### PR TITLE
Add basic structured record type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,21 @@ pub mod sinks;
 pub mod sources;
 pub mod transforms;
 
+#[derive(PartialEq, Debug)]
+pub struct Record {
+    line: String,
+    timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+impl Record {
+    pub fn new_from_line(line: String) -> Self {
+        Record {
+            line,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+}
+
 pub fn setup_logger() {
     fern::Dispatch::new()
         .format(|out, message, record| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ extern crate tokio;
 use futures::{Future, Sink, Stream};
 use log::{error, info};
 use prometheus::{opts, register_counter, Encoder, TextEncoder, __register_counter};
-use regex::bytes::RegexSet;
+use regex::RegexSet;
 use router::{sinks, sources, transforms};
 use std::net::SocketAddr;
 use stream_cancel::Tripwire;
@@ -99,7 +99,7 @@ fn comcast(
     let exceptions = RegexSet::new(&["(very )?important"]).unwrap();
     let sampler = transforms::Sampler::new(10, exceptions);
     let sampled = splunk_in
-        .filter(move |record| sampler.filter(record.as_bytes()))
+        .filter(move |record| sampler.filter(record))
         .inspect(move |_| counter.inc());
 
     let splunk_out = sinks::splunk::raw_tcp(out_addr)

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -10,6 +10,7 @@ use serde_json::{json, Value};
 use std::{marker::PhantomData, mem};
 use tokio::executor::DefaultExecutor;
 use uuid::Uuid;
+use Record;
 
 pub trait Document {
     type Body: Serialize;
@@ -47,6 +48,30 @@ impl<T: Serialize> Document for T {
 
     fn body(&self) -> Self::Body {
         json!({ "msg": self })
+    }
+}
+
+impl Document for Record {
+    type Body = serde_json::Value;
+
+    fn app_id(&self) -> &str {
+        "12345"
+    }
+
+    fn id(&self) -> Uuid {
+        Uuid::new_v4()
+    }
+
+    fn ty(&self) -> &str {
+        "log_lines"
+    }
+
+    fn dt(&self) -> Date<Utc> {
+        Utc::today()
+    }
+
+    fn body(&self) -> Self::Body {
+        json!({ "msg": self.line })
     }
 }
 

--- a/src/sinks/splunk.rs
+++ b/src/sinks/splunk.rs
@@ -5,11 +5,16 @@ use futures::{future, Future, Sink};
 use tokio::codec::{FramedWrite, LinesCodec};
 use tokio::net::TcpStream;
 
+use Record;
+
 pub fn raw_tcp(
     addr: SocketAddr,
-) -> impl Future<Item = impl Sink<SinkItem = String, SinkError = io::Error>, Error = io::Error> {
+) -> impl Future<Item = impl Sink<SinkItem = Record, SinkError = io::Error>, Error = io::Error> {
     // lazy so that we don't actually try to connect until the future is polled
     future::lazy(move || {
-        TcpStream::connect(&addr).map(|socket| FramedWrite::new(socket, LinesCodec::new()))
+        TcpStream::connect(&addr).map(|socket| {
+            FramedWrite::new(socket, LinesCodec::new())
+                .with(|record: Record| Ok(record.line))
+        })
     })
 }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -2,10 +2,12 @@ use futures::Stream;
 use log::error;
 use tokio::codec::{FramedRead, LinesCodec};
 use tokio::io::AsyncRead;
+use Record;
 
 pub mod splunk;
 
-pub fn reader_source<T: AsyncRead>(inner: T) -> impl Stream<Item = String, Error = ()> {
+pub fn reader_source<T: AsyncRead>(inner: T) -> impl Stream<Item = Record, Error = ()> {
     FramedRead::new(inner, LinesCodec::new_with_max_length(100 * 1024))
+        .map(Record::new_from_line)
         .map_err(|e| error!("error reading source: {:?}", e))
 }


### PR DESCRIPTION
This is suuuper basic, but at least gets `String` out of the signatures everywhere. I'm going to let #38 (parsing) drive the need for more fields on this thing.

Closes #37 