### PR TITLE
Simple benchmarks of a few topologies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "approx"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,6 +28,37 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -42,6 +81,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,11 +106,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-stats 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools-num 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion-stats"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -92,6 +200,28 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "csv"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "elastic_responses"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +230,26 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -161,6 +311,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "http"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +378,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools-num"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -397,6 +578,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pest_derive"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +652,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -503,6 +704,14 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +738,7 @@ dependencies = [
  "approx 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic_responses 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -549,6 +759,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +775,14 @@ dependencies = [
 name = "ryu"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "scopeguard"
@@ -602,6 +825,16 @@ dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -677,6 +910,21 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +933,57 @@ dependencies = [
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-scoped"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "thread_local"
@@ -878,6 +1177,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1213,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "want"
@@ -948,6 +1272,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,18 +1295,33 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f71f10b5c4946a64aad7b8cf65e3406cd3da22fc448595991d22423cf6db67b4"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
+"checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
+"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c47d2b548c5647e1a436dc0cb78d4ebf51b6bf7ab101ed76662828bdd4d3a24a"
+"checksum criterion-plot 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6e649d6aacdbbdb94ec659561a309a71336fc5655ed408f3afd28df2fc0c4f4f"
+"checksum criterion-stats 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff43cac80562f91ead0b617c1be74edf350adfaa195809d355de98dfc8f9237d"
 "checksum crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3486aefc4c0487b9cb52372c97df0a48b8c249514af1ee99703bf70d2f2ceda1"
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
+"checksum csv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d54f6b0fd69128a2894b1a3e57af5849a0963c1cc77b165d30b896e40296452"
+"checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elastic_responses 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5783170dca235427b4b9899dcb2e94242c0a578f43ed205d70ee9bd82331f0"
+"checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
+"checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fern 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "57915fe00a83af935983eb2d00b0ecc62419c4741b28c207ecbf98fd4a1b94c8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -982,11 +1329,14 @@ dependencies = [
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd33bafe2e6370e6c8eb0cf1b8c5f93390b90acde7e9b03723f166b28b648ed"
+"checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "24f58e8c2d8e886055c3ead7b28793e1455270b5fb39650984c224bc538ba581"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum hyper 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2f60ae467ef4fc5eba9a34d31648c9c8ed902faf45a217f6734ce9ea64779ac7"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+"checksum itertools-num 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
@@ -1009,6 +1359,8 @@ dependencies = [
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
+"checksum pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc"
+"checksum pest_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3294f437119209b084c797604295f40227cffa35c57220b1e99a6ff3bf8ee4"
 "checksum phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b"
 "checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
@@ -1017,22 +1369,27 @@ dependencies = [
 "checksum protobuf 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "671a9cce836bd3635b40b2b0a72783481755ee988c493891f4e974b45264cc9d"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
+"checksum simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e95345f185d5adeb8ec93459d2dc99654e294cc6ccf5b75414d8ea262de9a13"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
@@ -1043,7 +1400,15 @@ dependencies = [
 "checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
 "checksum string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea1eee654ef80933142157fdad9dd8bc43cf7c74e999e369263496f04ff4da"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6e93c78d23cc61aa245a8acd2c4a79c4d7fa7fb5c3ca90d5737029f043a84895"
@@ -1061,16 +1426,21 @@ dependencies = [
 "checksum tokio-uds 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df195376b43508f01570bacc73e13a1de0854dc59e79d1ec09913e8db6dd2a70"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 "checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ string_cache = "0.7.3"
 
 [dev-dependencies]
 approx = "0.3.0"
+criterion = "0.2.5"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,576 @@
+extern crate approx;
+extern crate criterion;
+extern crate futures;
+extern crate rand;
+extern crate router;
+extern crate tokio;
+
+use criterion::{criterion_group, criterion_main, Benchmark, Criterion, Throughput};
+
+use approx::{__assert_approx, assert_relative_eq, relative_eq};
+use futures::{future, Future, Sink, Stream};
+use router::topology::{self, config};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::codec::{BytesCodec, FramedRead, FramedWrite, LinesCodec};
+use tokio::net::{TcpListener, TcpStream};
+
+static NEXT_PORT: AtomicUsize = AtomicUsize::new(1234);
+fn next_addr() -> SocketAddr {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    let port = NEXT_PORT.fetch_add(1, Ordering::AcqRel) as u16;
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
+}
+
+fn benchmark_simple_pipe(c: &mut Criterion) {
+    let num_lines: usize = 100_000;
+    let line_size: usize = 100;
+
+    let in_addr = next_addr();
+    let out_addr = next_addr();
+
+    c.bench(
+        "pipe",
+        Benchmark::new("pipe", move |b| {
+            b.iter_with_setup(
+                || {
+                    let mut topology = config::Config::empty();
+                    topology.add_source("in", config::Source::Splunk { address: in_addr });
+                    topology.add_sink("out", &["in"], config::Sink::Splunk { address: out_addr });
+                    let (server, trigger) = topology::build(topology);
+
+                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+                    let output_lines = count_lines(&out_addr, &rt.executor());
+
+                    rt.spawn(server);
+                    while let Err(_) = std::net::TcpStream::connect(in_addr) {}
+
+                    (rt, trigger, output_lines)
+                },
+                |(mut rt, trigger, output_lines)| {
+                    let send = send_lines(in_addr, random_lines(line_size).take(num_lines));
+                    rt.block_on(send).unwrap();
+
+                    drop(trigger);
+
+                    rt.shutdown_on_idle().wait().unwrap();
+                    assert_eq!(num_lines, output_lines.wait().unwrap());
+                },
+            );
+        })
+        .sample_size(4)
+        .noise_threshold(0.05)
+        .throughput(Throughput::Bytes((num_lines * line_size) as u32)),
+    );
+}
+
+fn benchmark_simple_pipe_with_tiny_lines(c: &mut Criterion) {
+    let num_lines: usize = 100_000;
+    let line_size: usize = 1;
+
+    let in_addr = next_addr();
+    let out_addr = next_addr();
+
+    c.bench(
+        "pipe_with_tiny_lines",
+        Benchmark::new("pipe_with_tiny_lines", move |b| {
+            b.iter_with_setup(
+                || {
+                    let mut topology = config::Config::empty();
+                    topology.add_source("in", config::Source::Splunk { address: in_addr });
+                    topology.add_sink("out", &["in"], config::Sink::Splunk { address: out_addr });
+                    let (server, trigger) = topology::build(topology);
+
+                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+                    let output_lines = count_lines(&out_addr, &rt.executor());
+
+                    rt.spawn(server);
+                    while let Err(_) = std::net::TcpStream::connect(in_addr) {}
+
+                    (rt, trigger, output_lines)
+                },
+                |(mut rt, trigger, output_lines)| {
+                    let send = send_lines(in_addr, random_lines(line_size).take(num_lines));
+                    rt.block_on(send).unwrap();
+
+                    drop(trigger);
+
+                    rt.shutdown_on_idle().wait().unwrap();
+                    assert_eq!(num_lines, output_lines.wait().unwrap());
+                },
+            );
+        })
+        .sample_size(4)
+        .noise_threshold(0.05)
+        .throughput(Throughput::Bytes((num_lines * line_size) as u32)),
+    );
+}
+
+fn benchmark_simple_pipe_with_huge_lines(c: &mut Criterion) {
+    let num_lines: usize = 2_000;
+    let line_size: usize = 100_000;
+
+    let in_addr = next_addr();
+    let out_addr = next_addr();
+
+    c.bench(
+        "pipe_with_huge_lines",
+        Benchmark::new("pipe_with_huge_lines", move |b| {
+            b.iter_with_setup(
+                || {
+                    let mut topology = config::Config::empty();
+                    topology.add_source("in", config::Source::Splunk { address: in_addr });
+                    topology.add_sink("out", &["in"], config::Sink::Splunk { address: out_addr });
+                    let (server, trigger) = topology::build(topology);
+
+                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+                    let output_lines = count_lines(&out_addr, &rt.executor());
+
+                    rt.spawn(server);
+                    while let Err(_) = std::net::TcpStream::connect(in_addr) {}
+
+                    (rt, trigger, output_lines)
+                },
+                |(mut rt, trigger, output_lines)| {
+                    let send = send_lines(in_addr, random_lines(line_size).take(num_lines));
+                    rt.block_on(send).unwrap();
+
+                    drop(trigger);
+
+                    rt.shutdown_on_idle().wait().unwrap();
+                    assert_eq!(num_lines, output_lines.wait().unwrap());
+                },
+            );
+        })
+        .sample_size(4)
+        .noise_threshold(0.05)
+        .throughput(Throughput::Bytes((num_lines * line_size) as u32)),
+    );
+}
+
+fn benchmark_simple_pipe_with_many_writers(c: &mut Criterion) {
+    let num_lines: usize = 10_000;
+    let line_size: usize = 100;
+    let num_writers: usize = 10;
+
+    let in_addr = next_addr();
+    let out_addr = next_addr();
+
+    c.bench(
+        "pipe_with_many_writers",
+        Benchmark::new("pipe_with_many_writers", move |b| {
+            b.iter_with_setup(
+                || {
+                    let mut topology = config::Config::empty();
+                    topology.add_source("in", config::Source::Splunk { address: in_addr });
+                    topology.add_sink("out", &["in"], config::Sink::Splunk { address: out_addr });
+                    let (server, trigger) = topology::build(topology);
+
+                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+                    let output_lines = count_lines(&out_addr, &rt.executor());
+
+                    rt.spawn(server);
+                    while let Err(_) = std::net::TcpStream::connect(in_addr) {}
+
+                    (rt, trigger, output_lines)
+                },
+                |(mut rt, trigger, output_lines)| {
+                    let sends = (0..num_writers)
+                        .map(|_| {
+                            let send = send_lines(in_addr, random_lines(line_size).take(num_lines));
+                            futures::sync::oneshot::spawn(send, &rt.executor())
+                        })
+                        .collect::<Vec<_>>();
+
+                    rt.block_on(future::join_all(sends)).unwrap();
+
+                    drop(trigger);
+
+                    rt.shutdown_on_idle().wait().unwrap();
+                    assert_eq!(num_lines * num_writers, output_lines.wait().unwrap());
+                },
+            );
+        })
+        .sample_size(4)
+        .noise_threshold(0.05)
+        .throughput(Throughput::Bytes(
+            (num_lines * line_size * num_writers) as u32,
+        )),
+    );
+}
+
+fn benchmark_interconnected(c: &mut Criterion) {
+    let num_lines: usize = 100_000;
+    let line_size: usize = 100;
+
+    let in_addr1 = next_addr();
+    let in_addr2 = next_addr();
+    let out_addr1 = next_addr();
+    let out_addr2 = next_addr();
+
+    c.bench(
+        "interconnected",
+        Benchmark::new("interconnected", move |b| {
+            b.iter_with_setup(
+                || {
+                    let mut topology = config::Config::empty();
+                    topology.add_source("in1", config::Source::Splunk { address: in_addr1 });
+                    topology.add_source("in2", config::Source::Splunk { address: in_addr2 });
+                    topology.add_sink(
+                        "out1",
+                        &["in1", "in2"],
+                        config::Sink::Splunk { address: out_addr1 },
+                    );
+                    topology.add_sink(
+                        "out2",
+                        &["in1", "in2"],
+                        config::Sink::Splunk { address: out_addr2 },
+                    );
+                    let (server, trigger) = topology::build(topology);
+
+                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+                    let output_lines1 = count_lines(&out_addr1, &rt.executor());
+                    let output_lines2 = count_lines(&out_addr2, &rt.executor());
+
+                    rt.spawn(server);
+                    while let Err(_) = std::net::TcpStream::connect(in_addr1) {}
+                    while let Err(_) = std::net::TcpStream::connect(in_addr2) {}
+
+                    (rt, trigger, output_lines1, output_lines2)
+                },
+                |(mut rt, trigger, output_lines1, output_lines2)| {
+                    let send1 = send_lines(in_addr1, random_lines(line_size).take(num_lines));
+                    let send2 = send_lines(in_addr2, random_lines(line_size).take(num_lines));
+                    let sends = vec![send1, send2];
+                    rt.block_on(future::join_all(sends)).unwrap();
+
+                    drop(trigger);
+
+                    rt.shutdown_on_idle().wait().unwrap();
+                    assert_eq!(num_lines * 2, output_lines1.wait().unwrap());
+                    assert_eq!(num_lines * 2, output_lines2.wait().unwrap());
+                },
+            );
+        })
+        .sample_size(4)
+        .noise_threshold(0.05)
+        .throughput(Throughput::Bytes((num_lines * line_size * 2) as u32)),
+    );
+}
+
+fn benchmark_transforms(c: &mut Criterion) {
+    let num_lines: usize = 100_000;
+    let line_size: usize = 100;
+
+    let in_addr = next_addr();
+    let out_addr = next_addr();
+
+    c.bench(
+        "transforms",
+        Benchmark::new("transforms", move |b| {
+            b.iter_with_setup(
+                || {
+                    let mut topology = config::Config::empty();
+                    topology.add_source("in", config::Source::Splunk { address: in_addr });
+                    topology.add_transform(
+                        "parser",
+                        &["in"],
+                        config::Transform::RegexParser {
+                            regex: r"status=(?P<status>\d+)".to_string(),
+                        },
+                    );
+                    topology.add_transform(
+                        "filter",
+                        &["parser"],
+                        config::Transform::FieldFilter {
+                            field: "status".to_string(),
+                            value: "404".to_string(),
+                        },
+                    );
+                    topology.add_sink(
+                        "out",
+                        &["filter"],
+                        config::Sink::Splunk { address: out_addr },
+                    );
+                    let (server, trigger) = topology::build(topology);
+                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+                    let output_lines = count_lines(&out_addr, &rt.executor());
+
+                    rt.spawn(server);
+                    while let Err(_) = std::net::TcpStream::connect(in_addr) {}
+
+                    (rt, trigger, output_lines)
+                },
+                |(mut rt, trigger, output_lines)| {
+                    let send = send_lines(
+                        in_addr,
+                        random_lines(line_size)
+                            .map(|l| l + "status=404")
+                            .take(num_lines),
+                    );
+                    rt.block_on(send).unwrap();
+
+                    drop(trigger);
+
+                    rt.shutdown_on_idle().wait().unwrap();
+                    assert_eq!(num_lines, output_lines.wait().unwrap());
+                },
+            );
+        })
+        .sample_size(4)
+        .noise_threshold(0.05)
+        .throughput(Throughput::Bytes(
+            (num_lines * (line_size + "status=404".len())) as u32,
+        )),
+    );
+}
+
+fn benchmark_complex(c: &mut Criterion) {
+    let num_lines: usize = 100_000;
+
+    let in_addr1 = next_addr();
+    let in_addr2 = next_addr();
+    let out_addr_all = next_addr();
+    let out_addr_sampled = next_addr();
+    let out_addr_200 = next_addr();
+    let out_addr_404 = next_addr();
+    let out_addr_500 = next_addr();
+
+    c.bench(
+        "complex",
+        Benchmark::new("complex", move |b| {
+            b.iter_with_setup(
+                || {
+                    let mut topology = config::Config::empty();
+                    topology.add_source("in1", config::Source::Splunk { address: in_addr1 });
+                    topology.add_source("in2", config::Source::Splunk { address: in_addr2 });
+                    topology.add_transform(
+                        "parser",
+                        &["in1", "in2"],
+                        config::Transform::RegexParser {
+                            regex: r"status=(?P<status>\d+)".to_string(),
+                        },
+                    );
+                    topology.add_transform(
+                        "filter_200",
+                        &["parser"],
+                        config::Transform::FieldFilter {
+                            field: "status".to_string(),
+                            value: "200".to_string(),
+                        },
+                    );
+                    topology.add_transform(
+                        "filter_404",
+                        &["parser"],
+                        config::Transform::FieldFilter {
+                            field: "status".to_string(),
+                            value: "404".to_string(),
+                        },
+                    );
+                    topology.add_transform(
+                        "filter_500",
+                        &["parser"],
+                        config::Transform::FieldFilter {
+                            field: "status".to_string(),
+                            value: "500".to_string(),
+                        },
+                    );
+                    topology.add_transform(
+                        "sampler",
+                        &["parser"],
+                        config::Transform::Sampler {
+                            rate: 10,
+                            pass_list: vec![],
+                        },
+                    );
+                    topology.add_sink(
+                        "out_all",
+                        &["parser"],
+                        config::Sink::Splunk {
+                            address: out_addr_all,
+                        },
+                    );
+                    topology.add_sink(
+                        "out_sampled",
+                        &["sampler"],
+                        config::Sink::Splunk {
+                            address: out_addr_sampled,
+                        },
+                    );
+                    topology.add_sink(
+                        "out_200",
+                        &["filter_200"],
+                        config::Sink::Splunk {
+                            address: out_addr_200,
+                        },
+                    );
+                    topology.add_sink(
+                        "out_404",
+                        &["filter_404"],
+                        config::Sink::Splunk {
+                            address: out_addr_404,
+                        },
+                    );
+                    topology.add_sink(
+                        "out_500",
+                        &["filter_500"],
+                        config::Sink::Splunk {
+                            address: out_addr_500,
+                        },
+                    );
+                    let (server, trigger) = topology::build(topology);
+                    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+                    let output_lines_all = count_lines(&out_addr_all, &rt.executor());
+                    let output_lines_sampled = count_lines(&out_addr_sampled, &rt.executor());
+                    let output_lines_200 = count_lines(&out_addr_200, &rt.executor());
+                    let output_lines_404 = count_lines(&out_addr_404, &rt.executor());
+                    let output_lines_500 = count_lines(&out_addr_500, &rt.executor());
+
+                    rt.spawn(server);
+                    while let Err(_) = std::net::TcpStream::connect(in_addr1) {}
+                    while let Err(_) = std::net::TcpStream::connect(in_addr2) {}
+
+                    (
+                        rt,
+                        trigger,
+                        output_lines_all,
+                        output_lines_sampled,
+                        output_lines_200,
+                        output_lines_404,
+                        output_lines_500,
+                    )
+                },
+                |(
+                    mut rt,
+                    trigger,
+                    output_lines_all,
+                    output_lines_sampled,
+                    output_lines_200,
+                    output_lines_404,
+                    output_lines_500,
+                )| {
+                    use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
+
+                    // One sender generates pure random lines
+                    let send1 = send_lines(in_addr1, random_lines(100).take(num_lines));
+                    let send1 = futures::sync::oneshot::spawn(send1, &rt.executor());
+
+                    // The other includes either status=200 or status=404
+                    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+                    let send2 = send_lines(
+                        in_addr2,
+                        random_lines(100)
+                            .map(move |mut l| {
+                                let status = if rng.gen_bool(0.5) { "200" } else { "404" };
+                                l += "status=";
+                                l += status;
+                                l
+                            })
+                            .take(num_lines),
+                    );
+                    let send2 = futures::sync::oneshot::spawn(send2, &rt.executor());
+                    let sends = vec![send1, send2];
+                    rt.block_on(future::join_all(sends)).unwrap();
+
+                    drop(trigger);
+
+                    rt.shutdown_on_idle().wait().unwrap();
+
+                    let output_lines_all = output_lines_all.wait().unwrap();
+                    let output_lines_sampled = output_lines_sampled.wait().unwrap();
+                    let output_lines_200 = output_lines_200.wait().unwrap();
+                    let output_lines_404 = output_lines_404.wait().unwrap();
+                    let output_lines_500 = output_lines_500.wait().unwrap();
+
+                    assert_eq!(output_lines_all, num_lines * 2);
+                    assert_relative_eq!(
+                        output_lines_sampled as f32 / num_lines as f32,
+                        0.2,
+                        epsilon = 0.01
+                    );
+                    assert!(output_lines_200 > 0);
+                    assert!(output_lines_404 > 0);
+                    assert_eq!(output_lines_200 + output_lines_404, num_lines);
+                    assert_eq!(output_lines_500, 0);
+                },
+            );
+        })
+        .sample_size(2),
+    );
+}
+
+criterion_group!(
+    benches,
+    benchmark_simple_pipe,
+    benchmark_simple_pipe_with_tiny_lines,
+    benchmark_simple_pipe_with_huge_lines,
+    benchmark_simple_pipe_with_many_writers,
+    benchmark_interconnected,
+    benchmark_transforms,
+    benchmark_complex,
+);
+criterion_main!(benches);
+
+fn random_lines(size: usize) -> impl Iterator<Item = String> {
+    use rand::distributions::Alphanumeric;
+    use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
+
+    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+
+    std::iter::repeat(()).map(move |_| {
+        rng.sample_iter(&Alphanumeric)
+            .take(size)
+            .collect::<String>()
+    })
+}
+
+fn send_lines(
+    addr: SocketAddr,
+    lines: impl Iterator<Item = String>,
+) -> impl Future<Item = (), Error = ()> {
+    let lines = futures::stream::iter_ok::<_, ()>(lines);
+
+    TcpStream::connect(&addr)
+        .map_err(|e| panic!("{:}", e))
+        .and_then(|socket| {
+            let out =
+                FramedWrite::new(socket, LinesCodec::new()).sink_map_err(|e| panic!("{:?}", e));
+
+            lines
+                .forward(out)
+                .map(|(_source, sink)| sink)
+                .and_then(|sink| {
+                    // This waits for FIN from the server so we don't start shutting it down before it's fully received the test data
+                    let socket = sink.into_inner().into_inner();
+                    socket.shutdown(std::net::Shutdown::Write).unwrap();
+                    FramedRead::new(socket, BytesCodec::new())
+                        .for_each(|_| Ok(()))
+                        .map_err(|e| panic!("{:}", e))
+                })
+        })
+}
+
+fn count_lines(
+    addr: &SocketAddr,
+    executor: &tokio::runtime::TaskExecutor,
+) -> impl Future<Item = usize, Error = ()> {
+    let listener = TcpListener::bind(addr).unwrap();
+
+    let lines = listener
+        .incoming()
+        .take(1)
+        .map(|socket| FramedRead::new(socket, LinesCodec::new()))
+        .flatten()
+        .map_err(|e| panic!("{:?}", e))
+        .fold(0, |n, _| future::ok(n + 1));
+
+    futures::sync::oneshot::spawn(lines, executor)
+}


### PR DESCRIPTION
Closes #39.

These take about a minute to run on my main development machine, which seems like a decent compromise between thoroughness and iteration speed. Their speed can be tweaked with `num_lines` or `sample_size` (to change either how much data a single benchmark handles or how many times the benchmark is run).

I focused on a few topologies that I expect to have different bottlenecks or be impacted by different types code changes. Let me know if there are any other setups that you think are worth including in here.

One thing that's not in here that I think is probably worth trying at some point: Having some benchmarks with artificial sinks/sources that don't use the network (e.g. a random line generator sink) and use those to detect changes that would otherwise be hidden behind network bottlenecks (or even just the noise of using the network).

The code in these is not super pretty. If you see any easy wins on how to clean them up at all, I would love that feedback.

These are not the purest benchmarks in the world (e.g. the harness itself takes up resources, and the network traffic between the harness and the system-under-test might be a bottleneck at times), but it seems decent enough to identify significant changes in either direction.


Instructions for using this thing:
`cargo bench` will run it (and report the time difference between the previous run of `cargo bench`).

After `cargo install`ing `critcmp`, it can be used to compare non-consecutive run:
```
cargo bench --bench bench -- --save-baseline before
# Make changes that impact performance
cargo bench --bench bench -- --save-baseline after
critcmp before after --list
```
(An example of this in action in #53.)

It also seems like we're off to a very good start with our performance. `pipe` (100 byte lines) is doing `16.1 MB/sec`, and `pipe_with_huge_lines` (100kb lines) is getting `288.4 MB/sec`.