### PR TITLE
Disable some clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default, clippy::needless_pass_by_value)]
+
 pub mod record;
 pub mod sinks;
 pub mod sources;


### PR DESCRIPTION
Both of us have checked in code running afoul of both of these checks recently, and they've all been false positives in my book, so I'd like to silence them.

The current [`new_without_default`](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default) failure is from [`ElasticsearchSink::new`](https://github.com/timberio/router/blob/39680bc779b685b2863572d580132b4c6279017e/src/sinks/elasticsearch.rs#L96), and I don't think we really care about it having a default.

The [`needless_pass_by_value`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value) warnings are from https://github.com/timberio/router/blob/39680bc779b685b2863572d580132b4c6279017e/src/topology/builder.rs#L95-L106, but I explicitly want those methods to only take ownership of their input, since future variants of those enums might not contain only `Copy` values. (Note that `build_transform` _doesn't_ trigger this because it does have non-Copy variants).

