### PR TITLE
On-disk buffering acking proposal

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -163,6 +163,9 @@ impl<T: Document> ElasticsearchSink<T> {
                         .map_err(|e| format!("response error: {:?}", e))
                 })
                 .and_then(|response| {
+                    for record_id in records_that_succeeded(response) {
+                        ack_chan.unbounded_send(record_id);
+                    }
                     // TODO: use the response to build a new body for retries that include
                     // only the failed items
                     if response.is_err() {

--- a/src/sinks/splunk.rs
+++ b/src/sinks/splunk.rs
@@ -136,7 +136,9 @@ impl Sink for TcpSink {
 }
 
 pub fn raw_tcp(addr: SocketAddr) -> super::RouterSink {
-    Box::new(TcpSink::new(addr).with(|record: Record| Ok(record.line)))
+    Box::new(TcpSink::new(addr)
+             .simple_ack(ack_chan)
+             .with(|record: Record| Ok(record.line)))
 }
 
 pub fn tcp_healthcheck(addr: SocketAddr) -> super::Healthcheck {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -61,7 +61,7 @@ pub fn build(
 
         let buffer = sink.buffer.build(&config.data_dir, &name);
 
-        let (tx, rx) = match buffer {
+        let (tx, rx, ack_chan) = match buffer {
             Err(error) => {
                 errors.push(format!("Sink \"{}\": {}", name, error));
                 continue;
@@ -71,7 +71,7 @@ pub fn build(
 
         add_connections(sink.inputs, tx);
 
-        match sink.inner.build() {
+        match sink.inner.build(ack_chan) {
             Err(error) => {
                 errors.push(format!("Sink \"{}\": {}", name, error));
             }

--- a/src/topology/config.rs
+++ b/src/topology/config.rs
@@ -30,7 +30,7 @@ pub struct SinkOuter {
 
 #[typetag::serde(tag = "type")]
 pub trait SinkConfig: core::fmt::Debug {
-    fn build(&self) -> Result<(sinks::RouterSink, sinks::Healthcheck), String>;
+    fn build(&self, ack_chan: mpsc::UnboundedSender<usize>) -> Result<(sinks::RouterSink, sinks::Healthcheck), String>;
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This is a sketch of one way to implement sink->buffer acking.

In short, a sink receives a unique per-record id (aka the levedb key) along with the record, and after successfully writing the record downstream, the sink sends the record's id a channel back to the buffer. The buffer reads this channel and deletes the corresponding record from the database.

I'd be very interested in any other ideas of how to do this.

Some problems this will help us solve:
- The S3 sink will read records out of its buffer but might not send them to S3 for minutes (or possibly longer), and we don't want to delete the records from the buffer until they've been sent.
- Elasticsearch and Splunk HEC, can be slow, have partial failures, etc., and it'd be nice to not delete records from the on-disk buffer until the downstream system has fully accepted them.
- Some of the sink combinators (e.g. `with` and `forward`) do some internal buffering, which currently causes the on-disk buffer to think that a record has made it to the sink before it actually has (causing it to delete the on-disk record prematurely).