### PR TITLE
Fix readme flog install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 To start, you'll need `rustup` installed, along with the `rustfmt-preview` and
 `clippy-preview` components installed.
 
-For testing, I use the `flog` tool (`brew install flog`) to generate a 100MB
+For testing, I use the `flog` tool (`brew tap mingrammer/flog && brew install flog`) to generate a 100MB
 file of sample data used by the test harness:
 
 ```


### PR DESCRIPTION
I was curious about flog, but I couldnt find it on brew. So I added the tap instructions