### PR TITLE
Buffering benchmarking

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -582,10 +582,7 @@ criterion_group!(
     benchmark_transforms,
     benchmark_complex,
 );
-criterion_main!(
-    benches,
-    buffering::buffers,
-);
+criterion_main!(benches, buffering::buffers);
 
 fn random_lines(size: usize) -> impl Iterator<Item = String> {
     use rand::distributions::Alphanumeric;


### PR DESCRIPTION
```
buffers/in-memory       time:   [137.12 ms 139.93 ms 146.65 ms]                           
                        thrpt:  [65.030 MiB/s 68.151 MiB/s 69.550 MiB/s]
                        change: [-4.0163% -0.2877% +3.3885%] (p = 0.91 > 0.05)
                        No change in performance detected.
buffers/on-disk         time:   [439.08 ms 455.42 ms 467.70 ms]                         
                        thrpt:  [20.391 MiB/s 20.941 MiB/s 21.720 MiB/s]
                        change: [-9.3344% -4.4271% +0.9736%] (p = 0.20 > 0.05)
                        No change in performance detected.
```
On-disk being 30% the speed of in-memory seems not-bad.