### PR TITLE
Flush the write batch when it grows past a threshold

### DIFF
--- a/src/buffers/disk.rs
+++ b/src/buffers/disk.rs
@@ -40,6 +40,7 @@ pub struct Writer {
     offset: Arc<AtomicUsize>,
     notifier: Arc<AtomicTask>,
     writebatch: Writebatch<Key>,
+    batch_size: usize,
 }
 
 // Writebatch isn't Send, but the leveldb docs explicitly say that it's okay to share across threads
@@ -52,6 +53,7 @@ impl Clone for Writer {
             offset: Arc::clone(&self.offset),
             notifier: Arc::clone(&self.notifier),
             writebatch: Writebatch::new(),
+            batch_size: 0,
         }
     }
 }
@@ -70,27 +72,44 @@ impl Sink for Writer {
         let key = self.offset.fetch_add(1, Ordering::Relaxed);
 
         self.writebatch.put(Key(key), &value);
+        self.batch_size += 1;
+
+        if self.batch_size >= 100 {
+            self.write_batch();
+        }
 
         Ok(AsyncSink::Ready)
     }
 
     fn poll_complete(&mut self) -> Result<Async<()>, Self::SinkError> {
-        // TODO: should we periodically flush after N records are in the write batch?
         // This doesn't write all the way through to disk and doesn't need to be wrapped
         // with `blocking`. (It does get written to a memory mapped table that will be
         // flushed even in the case of a process crash.)
-        self.db
-            .write(WriteOptions::new(), &self.writebatch)
-            .unwrap();
-        self.writebatch = Writebatch::new();
-        self.notifier.notify();
+        if self.batch_size > 0 {
+            self.write_batch();
+        }
 
         Ok(Async::Ready(()))
     }
 }
 
+impl Writer {
+    fn write_batch(&mut self) {
+        self.db
+            .write(WriteOptions::new(), &self.writebatch)
+            .unwrap();
+        self.writebatch = Writebatch::new();
+        self.batch_size = 0;
+        self.notifier.notify();
+    }
+}
+
 impl Drop for Writer {
     fn drop(&mut self) {
+        if self.batch_size > 0 {
+            self.write_batch();
+        }
+
         // We need to wake up the reader so it can return None if there are no more writers
         self.notifier.notify();
     }
@@ -205,6 +224,7 @@ pub fn open(path: &std::path::Path) -> (Writer, Reader) {
         notifier: Arc::clone(&notifier),
         offset: Arc::new(AtomicUsize::new(tail)),
         writebatch: Writebatch::new(),
+        batch_size: 0,
     };
     let reader = Reader {
         db: Arc::clone(&db),


### PR DESCRIPTION
This is faster, and it reduces the window in which a crash could lose data.
In the benchmark, the writer was often writing all 100,000 lines in a single batch (which means the incoming TCP buffer was getting filled as fast as it was being read from, so `poll_complete` was never getting called.)

Before:
```
buffers/on-disk         time:   [297.87 ms 312.80 ms 321.52 ms]                         
                        thrpt:  [29.661 MiB/s 30.488 MiB/s 32.016 MiB/s]
```

After:
```
buffers/on-disk         time:   [264.64 ms 269.95 ms 273.65 ms]                         
                        thrpt:  [34.851 MiB/s 35.327 MiB/s 36.036 MiB/s]
                        change: [-16.493% -13.144% -9.3463%] (p = 0.01 < 0.05)
                        Performance has improved.
```