### PR TITLE
Improve error when TCP source can't bind to socket

### DIFF
--- a/src/sources/tcp.rs
+++ b/src/sources/tcp.rs
@@ -45,8 +45,7 @@ pub fn tcp(addr: SocketAddr, max_length: usize, out: mpsc::Sender<Record>) -> su
             Ok(listener) => listener,
             Err(err) => {
                 error!("Failed to bind to listener socket: {}", err);
-                let future: super::Source = Box::new(future::err(()));
-                return future;
+                return future::Either::B(future::err(()));
             }
         };
 
@@ -74,7 +73,7 @@ pub fn tcp(addr: SocketAddr, max_length: usize, out: mpsc::Sender<Record>) -> su
 
                 tokio::spawn(handler)
             });
-        Box::new(future)
+        future::Either::A(future)
     }))
 }
 


### PR DESCRIPTION
Before:
```
 INFO vector::topology: Starting sink out
 INFO vector::topology: Starting sink in
 INFO vector::topology: Starting sink sampler
thread 'tokio-runtime-worker-0' panicked at 'failed to bind to listener socket: Os { code: 98, kind: AddrInUse, message: "Address already in use" }', src/libcore/result.rs:997:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:39
   1: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:70
   2: std::panicking::default_hook::{{closure}}
             at src/libstd/sys_common/backtrace.rs:58
             at src/libstd/panicking.rs:200
   3: std::panicking::default_hook
             at src/libstd/panicking.rs:215
   4: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:478
   5: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:385
   6: rust_begin_unwind
             at src/libstd/panicking.rs:312
   7: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
   8: core::result::unwrap_failed
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libcore/macros.rs:16
   9: <core::result::Result<T, E>>::expect
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libcore/result.rs:825
  10: vector::sources::tcp::tcp::{{closure}}
             at src/sources/tcp.rs:44
  11: <futures::future::lazy::Lazy<F, R>>::get
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/lazy.rs:64
  12: <futures::future::lazy::Lazy<F, R> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/lazy.rs:82
  13: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/mod.rs:113
  14: <futures::future::select::Select<A, B> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/select.rs:48
  15: <futures::future::map::Map<A, F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/map.rs:30
  16: <futures::future::map_err::MapErr<A, F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/map_err.rs:30
  17: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/mod.rs:113
  18: futures::future::catch_unwind::<impl futures::future::Future for std::panic::AssertUnwindSafe<F>>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/catch_unwind.rs:49
  19: <futures::future::catch_unwind::CatchUnwind<F> as futures::future::Future>::poll::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/catch_unwind.rs:32
  20: std::panicking::try::do_call
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/panicking.rs:297
  21: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:92
  22: std::panicking::try
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/panicking.rs:276
  23: std::panic::catch_unwind
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/panic.rs:388
  24: <futures::future::catch_unwind::CatchUnwind<F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/catch_unwind.rs:32
  25: <futures::future::map_err::MapErr<A, F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/map_err.rs:30
  26: <futures::future::chain::Chain<A, B, C>>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/chain.rs:26
  27: <futures::future::flatten::Flatten<A> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/flatten.rs:44
  28: <futures::future::chain::Chain<A, B, C>>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/chain.rs:26
  29: <futures::future::or_else::OrElse<A, B, F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/or_else.rs:32
  30: <futures::sync::oneshot::Execute<F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/sync/oneshot.rs:589
  31: <alloc::boxed::Box<F> as futures::future::Future>::poll
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/future/mod.rs:113
  32: <futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/task_impl/mod.rs:326
  33: <futures::task_impl::Spawn<T>>::enter::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/task_impl/mod.rs:396
  34: futures::task_impl::std::set
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/task_impl/std/mod.rs:78
  35: <futures::task_impl::Spawn<T>>::enter
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/task_impl/mod.rs:396
  36: <futures::task_impl::Spawn<T>>::poll_fn_notify
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/task_impl/mod.rs:288
  37: <futures::task_impl::Spawn<T>>::poll_future_notify
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.1.25/src/task_impl/mod.rs:326
  38: tokio_threadpool::task::Task::run::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/task/mod.rs:145
  39: core::ops::function::FnOnce::call_once
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libcore/ops/function.rs:231
  40: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/panic.rs:309
  41: std::panicking::try::do_call
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/panicking.rs:297
  42: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:92
  43: std::panicking::try
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/panicking.rs:276
  44: std::panic::catch_unwind
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/panic.rs:388
  45: tokio_threadpool::task::Task::run
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/task/mod.rs:130
  46: tokio_threadpool::worker::Worker::run_task2
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:567
  47: tokio_threadpool::worker::Worker::run_task
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:459
  48: tokio_threadpool::worker::Worker::try_run_owned_task
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:390
  49: tokio_threadpool::worker::Worker::try_run_task
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:297
  50: tokio_threadpool::worker::Worker::run
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:241
  51: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.18/src/runtime/threadpool/builder.rs:349
  52: tokio_trace_core::dispatcher::with_default
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-trace-core-0.1.0/src/dispatcher.rs:54
  53: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.18/src/runtime/threadpool/builder.rs:348
  54: tokio_timer::timer::handle::with_default::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:94
  55: <std::thread::local::LocalKey<T>>::try_with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:299
  56: <std::thread::local::LocalKey<T>>::with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:245
  57: tokio_timer::timer::handle::with_default
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/timer/handle.rs:81
  58: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.18/src/runtime/threadpool/builder.rs:347
  59: tokio_timer::clock::clock::with_default::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:141
  60: <std::thread::local::LocalKey<T>>::try_with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:299
  61: <std::thread::local::LocalKey<T>>::with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:245
  62: tokio_timer::clock::clock::with_default
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.10/src/clock/clock.rs:124
  63: tokio::runtime::threadpool::builder::Builder::build::{{closure}}::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.18/src/runtime/threadpool/builder.rs:346
  64: tokio_reactor::with_default::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:237
  65: <std::thread::local::LocalKey<T>>::try_with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:299
  66: <std::thread::local::LocalKey<T>>::with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:245
  67: tokio_reactor::with_default
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.9/src/lib.rs:217
  68: tokio::runtime::threadpool::builder::Builder::build::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.1.18/src/runtime/threadpool/builder.rs:345
  69: tokio_threadpool::callback::Callback::call
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/callback.rs:22
  70: tokio_threadpool::worker::Worker::do_run::{{closure}}::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:127
  71: tokio_executor::global::with_default::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.7/src/global.rs:209
  72: <std::thread::local::LocalKey<T>>::try_with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:299
  73: <std::thread::local::LocalKey<T>>::with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:245
  74: tokio_executor::global::with_default
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-executor-0.1.7/src/global.rs:178
  75: tokio_threadpool::worker::Worker::do_run::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:125
  76: <std::thread::local::LocalKey<T>>::try_with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:299
  77: <std::thread::local::LocalKey<T>>::with
             at /rustc/2aa4c46cfdd726e97360c2734835aa3515e8c858/src/libstd/thread/local.rs:245
  78: tokio_threadpool::worker::Worker::do_run
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/worker/mod.rs:116
  79: tokio_threadpool::pool::Pool::spawn_thread::{{closure}}
             at /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-threadpool-0.1.13/src/pool/mod.rs:344
ERROR vector::topology: Unhandled error
 INFO vector: Shutting down
```

After:
```
 INFO vector::topology: Starting sink out
 INFO vector::topology: Starting sink sampler
 INFO vector::topology: Starting sink in
ERROR vector::sources::tcp: Failed to bind to listener socket: Address already in use (os error 98)
ERROR vector::topology: Unhandled error
 INFO vector: Shutting down
```