### PR TITLE
Make splunk to use record host field

### DIFF
--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -117,7 +117,7 @@ pub fn receive_lines_with_count(
     (futures::sync::oneshot::spawn(lines, executor), count)
 }
 
-pub fn wait_for(f: impl Fn() -> bool) {
+pub fn wait_for(mut f: impl FnMut() -> bool) {
     let wait = std::time::Duration::from_millis(5);
     let limit = std::time::Duration::from_secs(5);
     let mut attempts = 0;


### PR DESCRIPTION
This fix ended up having some behavior consequences, hence the separate PR from #269.

The end result here is that the splunk sink will look first for the `host_field` configuration, then any explicitly set `"host"` field in the structured data, and then fall back the the built in `host` field on the record. It will also fall back in the case that `host_field` is set but these is no value in that field.

Does that sound sane to everyone? /cc @binarylogic 

Something else we might want to do is a less case-sensitive lookup for the default `"host"` field.