### PR TITLE
Switch to jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1130,25 @@ dependencies = [
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -3232,6 +3256,7 @@ dependencies = [
  "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leveldb 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3480,6 +3505,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -3519,6 +3545,8 @@ dependencies = [
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum jemalloc-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bef0d4ce37578dfd80b466e3d8324bd9de788e249f1accebb0c472ea4b52bdc"
+"checksum jemallocator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c2b69163a3cf2d0fffcd4e1b57921bc6d8fb97ec27f2aeef00562abdaf4ffe2a"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ headers = "0.2.1"
 rdkafka = { version = "0.20.0", optional = true }
 hostname = "0.1.5"
 seahash = "3.0.6"
+jemallocator = "0.3.0"
 
 [build-dependencies]
 prost-build = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ extern crate tokio_trace;
 #[macro_use]
 extern crate prost_derive;
 
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 pub mod buffers;
 pub mod bytes;
 pub mod metrics;


### PR DESCRIPTION
Impact on `master`:
```
group                                         after                                   before
-----                                         -----                                   ------
batch/gzip 10mb with 2mb batches              1.00    421.2±1.92ms    22.6 MB/sec     1.01    423.4±4.72ms    22.5 MB/sec
batch/no compression 10mb with 2mb batches    1.00      6.0±0.23ms  1585.0 MB/sec     1.16      7.0±0.21ms  1368.6 MB/sec
buffers/in-memory                             1.00    158.2±5.62ms    60.3 MB/sec     1.14    180.1±6.08ms    53.0 MB/sec
buffers/on-disk                               1.09    453.6±4.19ms    21.0 MB/sec     1.00   417.9±28.87ms    22.8 MB/sec
buffers/on-disk (low limit)                   1.01  1528.2±166.40ms     6.2 MB/sec    1.00  1516.1±161.82ms     6.3 MB/sec
complex                                       1.00  1331.2±18.86ms        ? B/sec     1.49  1983.7±39.81ms        ? B/sec
http/http_gzip                                1.00  1628.0±17.18ms     5.9 MB/sec     1.01  1641.0±17.32ms     5.8 MB/sec
http/http_no_compression                      1.00  708.7±223.65ms    13.5 MB/sec     1.05  746.3±222.79ms    12.8 MB/sec
interconnected                                1.00    188.7±7.86ms   101.1 MB/sec     1.24    234.3±1.60ms    81.4 MB/sec
pipe                                          1.00    162.7±2.89ms    58.6 MB/sec     1.15    187.2±2.75ms    50.9 MB/sec
pipe_with_huge_lines                          1.01   831.8±33.89ms   229.3 MB/sec     1.00   822.8±41.91ms   231.8 MB/sec
pipe_with_many_writers                        1.00    147.7±0.70ms    64.6 MB/sec     1.21    178.1±6.24ms    53.5 MB/sec
pipe_with_tiny_lines                          1.00    111.6±2.77ms   874.9 KB/sec     1.40    156.0±3.92ms   626.0 KB/sec
transforms                                    1.00    317.2±2.13ms    33.1 MB/sec     1.11    350.7±6.73ms    29.9 MB/sec
```

Impact on #308:

```
batch/gzip 10mb with 2mb batches              1.00    418.0±1.72ms    22.8 MB/sec    1.05   437.0±20.17ms    21.8 MB/sec
batch/no compression 10mb with 2mb batches    1.00      5.4±0.22ms  1756.7 MB/sec    1.28      6.9±0.07ms  1374.1 MB/sec
buffers/in-memory                             1.00    471.7±1.77ms    20.2 MB/sec    1.26    592.2±7.35ms    16.1 MB/sec
buffers/on-disk                               1.00   623.4±32.49ms    15.3 MB/sec    1.02   636.2±17.24ms    15.0 MB/sec
buffers/on-disk (low limit)                   1.00       2.4±0.27s     3.9 MB/sec    1.04       2.5±0.28s     3.8 MB/sec
complex                                       1.00  1716.6±63.00ms        ? B/sec    1.27       2.2±0.09s        ? B/sec
http/http_gzip                                1.00       6.2±0.09s  1583.9 KB/sec    1.00       6.2±0.09s  1579.8 KB/sec
http/http_no_compression                      1.00  1012.8±40.26ms     9.4 MB/sec    1.13  1143.2±50.84ms     8.3 MB/sec
interconnected                                1.00   448.5±21.76ms    42.5 MB/sec    1.47   658.5±55.38ms    29.0 MB/sec
pipe                                          1.00    471.2±3.84ms    20.2 MB/sec    1.25    589.7±7.52ms    16.2 MB/sec
pipe_with_huge_lines                          1.05   816.1±27.88ms   233.7 MB/sec    1.00   775.3±11.63ms   246.0 MB/sec
pipe_with_many_writers                        1.00    151.8±1.66ms    62.8 MB/sec    1.03    157.0±4.89ms    60.7 MB/sec
pipe_with_tiny_lines                          1.00    431.8±3.01ms   226.2 KB/sec    1.25   538.0±11.03ms   181.5 KB/sec
transforms                                    1.00   416.3±18.71ms    25.2 MB/sec    1.37    572.0±9.88ms    18.3 MB/sec
```


This adds 5mb to the binary size, bumping it up to 30mb total.