### PR TITLE
Initial statsd source

### DIFF
--- a/configs/statsd_to_prom.toml
+++ b/configs/statsd_to_prom.toml
@@ -1,0 +1,18 @@
+[sources.in]
+type = "statsd"
+address = "127.0.0.1:6789"
+
+[sinks.out]
+type = "prometheus"
+inputs = ["in"]
+
+[[sinks.out.counters]]
+key = "foo"
+label = "foo"
+doc = "The Foos"
+parse_value = true
+
+[[sinks.out.gauges]]
+key = "bar"
+label = "bar"
+doc = "The Bar"

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -23,17 +23,17 @@ pub struct PrometheusSinkConfig {
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Counter {
-    key: Atom,
-    label: String,
-    doc: String,
-    parse_value: bool,
+    pub key: Atom,
+    pub label: String,
+    pub doc: String,
+    pub parse_value: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Gauge {
-    key: Atom,
-    label: String,
-    doc: String,
+    pub key: Atom,
+    pub label: String,
+    pub doc: String,
 }
 
 pub fn default_address() -> SocketAddr {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,6 +1,7 @@
 use futures::Future;
 
 pub mod file;
+pub mod statsd;
 pub mod stdin;
 pub mod syslog;
 pub mod tcp;

--- a/src/sources/statsd.rs
+++ b/src/sources/statsd.rs
@@ -1,0 +1,195 @@
+use crate::Record;
+use futures::{future, sync::mpsc, Future, Sink, Stream};
+use parser::parse;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use tokio::{
+    self,
+    codec::BytesCodec,
+    net::{UdpFramed, UdpSocket},
+};
+use tokio_trace::field;
+
+mod parser;
+
+#[derive(Debug, PartialEq)]
+pub enum Metric {
+    Counter {
+        name: String,
+        val: usize,
+        sampling: Option<f32>,
+    },
+    Timer {
+        name: String,
+        val: usize,
+        sampling: Option<f32>,
+    },
+    Gauge {
+        name: String,
+        val: usize,
+        direction: Option<Direction>,
+    },
+    Set {
+        name: String,
+        val: String,
+    },
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Direction {
+    Plus,
+    Minus,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct StatsdConfig {
+    address: SocketAddr,
+}
+
+#[typetag::serde(name = "statsd")]
+impl crate::topology::config::SourceConfig for StatsdConfig {
+    fn build(&self, out: mpsc::Sender<Record>) -> Result<super::Source, String> {
+        Ok(statsd(self.address.clone(), out))
+    }
+}
+
+fn statsd(addr: SocketAddr, out: mpsc::Sender<Record>) -> super::Source {
+    let out = out.sink_map_err(|e| error!("error sending metric: {:?}", e));
+
+    Box::new(
+        future::lazy(move || {
+            let socket = UdpSocket::bind(&addr).expect("failed to bind to udp listener socket");
+
+            info!(
+                message = "listening.",
+                addr = &field::display(addr),
+                r#type = "udp"
+            );
+
+            future::ok(socket)
+        })
+        .and_then(|socket| {
+            let metrics_in = UdpFramed::new(socket, BytesCodec::new())
+                .map(|(bytes, _sock)| {
+                    let packet = String::from_utf8_lossy(bytes.as_ref());
+                    let metrics = packet
+                        .lines()
+                        .map(parse)
+                        .filter_map(|res| res.map_err(|e| error!("{}", e)).ok())
+                        .map(Record::from)
+                        .collect::<Vec<_>>();
+                    futures::stream::iter_ok::<_, std::io::Error>(metrics)
+                })
+                .flatten()
+                .map_err(|e| error!("error reading datagram: {:?}", e));
+
+            metrics_in.forward(out).map(|_| info!("finished sending"))
+        }),
+    )
+}
+
+impl From<Metric> for Record {
+    fn from(metric: Metric) -> Record {
+        match metric {
+            Metric::Counter { name, val, .. } | Metric::Gauge { name, val, .. } => {
+                let mut record = Record::new_empty();
+                record.insert_explicit(name.into(), val.to_string().into());
+                record
+            }
+            _ => Record::from(format!("{:?}", metric)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::StatsdConfig;
+    use crate::{
+        sinks::prometheus::{Counter, Gauge, PrometheusSinkConfig},
+        test_util::{block_on, next_addr, shutdown_on_idle},
+        topology::{config, Topology},
+    };
+    use futures::Stream;
+    use std::{thread, time::Duration};
+
+    #[test]
+    fn test_statsd() {
+        let in_addr = next_addr();
+        let out_addr = next_addr();
+
+        let mut config = config::Config::empty();
+        config.add_source("in", StatsdConfig { address: in_addr });
+        config.add_sink(
+            "out",
+            &["in"],
+            PrometheusSinkConfig {
+                address: out_addr,
+                counters: vec![Counter {
+                    key: "foo".into(),
+                    label: "foo".into(),
+                    doc: "foo".into(),
+                    parse_value: true,
+                }],
+                gauges: vec![Gauge {
+                    key: "bar".into(),
+                    label: "bar".into(),
+                    doc: "bar".into(),
+                }],
+            },
+        );
+        let (mut topology, _warnings) = Topology::build(config).unwrap();
+
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+        topology.start(&mut rt);
+
+        let bind_addr = next_addr();
+        let socket = std::net::UdpSocket::bind(&bind_addr).unwrap();
+
+        for _ in 0..100 {
+            socket
+                .send_to(b"foo:1|c\nbar:42|g\nfoo:1|c\n", &in_addr)
+                .unwrap();
+            // Space things out slightly to try to avoid dropped packets
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        // Give packets some time to flow through
+        thread::sleep(Duration::from_millis(10));
+
+        let client = hyper::Client::new();
+        let response =
+            block_on(client.get(format!("http://{}/metrics", out_addr).parse().unwrap())).unwrap();
+        assert!(response.status().is_success());
+
+        let body = block_on(response.into_body().concat2()).unwrap();
+        let lines = std::str::from_utf8(&body)
+            .unwrap()
+            .lines()
+            .collect::<Vec<_>>();
+
+        let foo = lines
+            .iter()
+            .find(|s| s.starts_with("foo "))
+            .map(|s| s.split_whitespace().nth(1).unwrap())
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
+        let bar = lines
+            .iter()
+            .find(|s| s.starts_with("bar "))
+            .map(|s| s.split_whitespace().nth(1).unwrap())
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
+
+        assert_eq!(42, bar);
+        // packets get lost :(
+        assert!(foo % 2 == 0);
+        assert!(foo > 180);
+
+        // Shut down server
+        block_on(topology.stop()).unwrap();
+        shutdown_on_idle(rt);
+    }
+}

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -1,0 +1,227 @@
+use super::{Direction, Metric};
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::{
+    error, fmt,
+    num::{ParseFloatError, ParseIntError},
+};
+
+lazy_static! {
+    static ref WHITESPACE: Regex = Regex::new(r"\s+").unwrap();
+    static ref NONALPHANUM: Regex = Regex::new(r"[^a-zA-Z_\-0-9\.]").unwrap();
+}
+
+pub fn parse(packet: &str) -> Result<Metric, ParseError> {
+    let key_and_body = packet.splitn(2, ":").collect::<Vec<_>>();
+    if key_and_body.len() != 2 {
+        return Err(ParseError::Malformed(
+            "should be key and body with ':' separator",
+        ));
+    }
+    let (key, body) = (key_and_body[0], key_and_body[1]);
+
+    let parts = body.split("|").collect::<Vec<_>>();
+    if parts.len() < 2 {
+        return Err(ParseError::Malformed(
+            "body should have at least two pipe separated components",
+        ));
+    }
+    let metric_type = parts[1];
+
+    let metric = match metric_type {
+        "c" => Metric::Counter {
+            name: sanitize_key(key),
+            val: parts[0].parse()?,
+            sampling: if let Some(s) = parts.get(2) {
+                Some(parse_sampling(s)?)
+            } else {
+                None
+            },
+        },
+        "h" | "ms" => Metric::Timer {
+            name: sanitize_key(key),
+            val: parts[0].parse()?,
+            sampling: if let Some(s) = parts.get(2) {
+                Some(parse_sampling(s)?)
+            } else {
+                None
+            },
+        },
+        "g" => Metric::Gauge {
+            name: sanitize_key(key),
+            val: if parts[0]
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_digit())
+                .ok_or_else(|| ParseError::Malformed("empty first body component"))?
+            {
+                parts[0].parse()?
+            } else {
+                parts[0][1..].parse()?
+            },
+            direction: parse_direction(parts[0])?,
+        },
+        "s" => Metric::Set {
+            name: sanitize_key(key),
+            val: parts[0].into(),
+        },
+        other => return Err(ParseError::UnknownMetricType(other.into())),
+    };
+    Ok(metric)
+}
+
+fn parse_sampling(input: &str) -> Result<f32, ParseError> {
+    if input.chars().next() != Some('@') || input.len() < 2 {
+        return Err(ParseError::Malformed(
+            "expected '@'-prefixed sampling component",
+        ));
+    }
+
+    let num: f32 = input[1..].parse()?;
+    if num.is_sign_positive() {
+        Ok(num)
+    } else {
+        Err(ParseError::Malformed("sample rate can't be negative"))
+    }
+}
+
+fn parse_direction(input: &str) -> Result<Option<Direction>, ParseError> {
+    match input
+        .chars()
+        .next()
+        .ok_or_else(|| ParseError::Malformed("empty body component"))?
+    {
+        '+' => Ok(Some(Direction::Plus)),
+        '-' => Ok(Some(Direction::Minus)),
+        c if c.is_ascii_digit() => Ok(None),
+        _other => Err(ParseError::Malformed("invalid gauge value prefix")),
+    }
+}
+
+fn sanitize_key(key: &str) -> String {
+    let s = key.replace("/", "-");
+    let s = WHITESPACE.replace_all(&s, "_");
+    let s = NONALPHANUM.replace_all(&s, "");
+    s.into()
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ParseError {
+    Malformed(&'static str),
+    UnknownMetricType(String),
+    InvalidInteger(ParseIntError),
+    InvalidFloat(ParseFloatError),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            anything => write!(f, "Statsd parse error: {:?}", anything),
+        }
+    }
+}
+
+impl error::Error for ParseError {}
+
+impl From<ParseIntError> for ParseError {
+    fn from(e: ParseIntError) -> ParseError {
+        ParseError::InvalidInteger(e)
+    }
+}
+
+impl From<ParseFloatError> for ParseError {
+    fn from(e: ParseFloatError) -> ParseError {
+        ParseError::InvalidFloat(e)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{parse, sanitize_key, Direction, Metric};
+
+    #[test]
+    fn basic_counter() {
+        assert_eq!(
+            parse("foo:1|c"),
+            Ok(Metric::Counter {
+                name: "foo".into(),
+                val: 1,
+                sampling: None
+            }),
+        );
+    }
+
+    #[test]
+    fn sampled_counter() {
+        assert_eq!(
+            parse("bar:2|c|@0.1"),
+            Ok(Metric::Counter {
+                name: "bar".into(),
+                val: 2,
+                sampling: Some(0.1)
+            }),
+        );
+    }
+
+    #[test]
+    fn timer() {
+        assert_eq!(
+            parse("glork:320|ms|@0.1"),
+            Ok(Metric::Timer {
+                name: "glork".into(),
+                val: 320,
+                sampling: Some(0.1)
+            }),
+        );
+    }
+
+    #[test]
+    fn simple_gauge() {
+        assert_eq!(
+            parse("gaugor:333|g"),
+            Ok(Metric::Gauge {
+                name: "gaugor".into(),
+                val: 333,
+                direction: None
+            }),
+        );
+    }
+
+    #[test]
+    fn signed_gauge() {
+        assert_eq!(
+            parse("gaugor:-4|g"),
+            Ok(Metric::Gauge {
+                name: "gaugor".into(),
+                val: 4,
+                direction: Some(Direction::Minus)
+            }),
+        );
+        assert_eq!(
+            parse("gaugor:+10|g"),
+            Ok(Metric::Gauge {
+                name: "gaugor".into(),
+                val: 10,
+                direction: Some(Direction::Plus)
+            }),
+        );
+    }
+
+    #[test]
+    fn sets() {
+        assert_eq!(
+            parse("uniques:765|s"),
+            Ok(Metric::Set {
+                name: "uniques".into(),
+                val: "765".into(),
+            }),
+        );
+    }
+
+    #[test]
+    fn sanitizing_keys() {
+        assert_eq!("foo-bar-baz", sanitize_key("foo/bar/baz"));
+        assert_eq!("foo_bar_baz", sanitize_key("foo bar  baz"));
+        assert_eq!("foo.__bar_.baz", sanitize_key("foo. @& bar_$!#.baz"));
+    }
+}


### PR DESCRIPTION
This is a mostly real statsd protocol implementation and a little hack to get it partially working with our existing prometheus sink. I punted on introducing an actual `Record`-level metric type for now to avoid conflict with the structured data work.

What works:
* Accepting statsd counters, timers, gauges, and sets over udp
* Turning counters and gauges into something the prometheus sink understands and will aggregate

What's wonky:
* Metric types other than counters and gauges just get turned into "logs" in a dumb way
* The way counters and gauges get "serialized" into `Record`s and then parsed again by the prom sink

Next steps:
* Figure out the best way to pass metrics from source to sink for real. That could be replacing `Record` with `enum Event { LogRecord, Metric }`, but I'm also curious if type checking the config (i.e. #235) could let us avoid that and have actual typed components (it probably can, but need to see how much work it'd be).
* Figure out if these statsd metric types are the ones we want as our internal representation
* Actually support all of these metrics types in the prom sink
* Maybe not require pre-declaring all your metrics for the prom sink

Part of #64 

Refs https://github.com/aws/containers-roadmap/issues/699