### PR TITLE
Type checking v0.1

### DIFF
--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -12,7 +12,7 @@ pub struct BlackholeSink {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct BlackholeConfig {
-    print_amount: usize,
+    pub print_amount: usize,
 }
 
 #[typetag::serde(name = "blackhole")]

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -173,6 +173,8 @@ pub fn build_pieces(config: &super::Config) -> Result<(Pieces, Vec<String>), Vec
 
     if config.contains_cycle() {
         errors.push(format!("Configured topology contains a cycle"));
+    } else if let Err(type_errors) = config.typecheck() {
+        errors.extend(type_errors);
     }
 
     if errors.is_empty() {

--- a/src/topology/config.rs
+++ b/src/topology/config.rs
@@ -17,9 +17,19 @@ pub struct Config {
     pub transforms: IndexMap<String, TransformOuter>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum DataType {
+    Log,
+    Metric,
+}
+
 #[typetag::serde(tag = "type")]
 pub trait SourceConfig: core::fmt::Debug {
     fn build(&self, out: mpsc::Sender<Record>) -> Result<sources::Source, String>;
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -37,6 +47,10 @@ pub trait SinkConfig: core::fmt::Debug {
         &self,
         acker: crate::buffers::Acker,
     ) -> Result<(sinks::RouterSink, sinks::Healthcheck), String>;
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -49,6 +63,14 @@ pub struct TransformOuter {
 #[typetag::serde(tag = "type")]
 pub trait TransformConfig: core::fmt::Debug {
     fn build(&self) -> Result<Box<dyn transforms::Transform>, String>;
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn output_type(&self) -> DataType {
+        DataType::Log
+    }
 }
 
 // Helper methods for programming contstruction during tests
@@ -111,6 +133,10 @@ impl Config {
 
     pub fn contains_cycle(&self) -> bool {
         validation::contains_cycle(self)
+    }
+
+    pub fn typecheck(&self) -> Result<(), Vec<String>> {
+        validation::typecheck(self)
     }
 }
 

--- a/src/topology/config/validation.rs
+++ b/src/topology/config/validation.rs
@@ -1,5 +1,109 @@
-use crate::topology::Config;
-use std::collections::HashSet;
+use crate::topology::{config::DataType, Config};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone)]
+enum Node {
+    Source {
+        ty: DataType,
+    },
+    Transform {
+        in_ty: DataType,
+        out_ty: DataType,
+        inputs: Vec<String>,
+    },
+    Sink {
+        ty: DataType,
+        inputs: Vec<String>,
+    },
+}
+
+pub fn typecheck(config: &Config) -> Result<(), Vec<String>> {
+    let mut nodes = HashMap::new();
+
+    // TODO: validate that node names are unique across sources/transforms/sinks?
+    for (name, config) in config.sources.iter() {
+        nodes.insert(
+            name,
+            Node::Source {
+                ty: config.output_type(),
+            },
+        );
+    }
+
+    for (name, config) in config.transforms.iter() {
+        nodes.insert(
+            name,
+            Node::Transform {
+                in_ty: config.inner.input_type(),
+                out_ty: config.inner.output_type(),
+                inputs: config.inputs.clone(),
+            },
+        );
+    }
+
+    for (name, config) in config.sinks.iter() {
+        nodes.insert(
+            name,
+            Node::Sink {
+                ty: config.inner.input_type(),
+                inputs: config.inputs.clone(),
+            },
+        );
+    }
+
+    let paths = config
+        .sinks
+        .keys()
+        .flat_map(|node| paths(&nodes, node, Vec::new()))
+        .collect::<Vec<_>>();
+
+    let mut errors = Vec::new();
+
+    for path in paths {
+        for pair in path.windows(2) {
+            let (x, y) = (&pair[0], &pair[1]);
+            if nodes.get(x).is_none() || nodes.get(y).is_none() {
+                continue;
+            }
+            match (nodes[&x].clone(), nodes[&y].clone()) {
+                (Node::Source { ty: ty1 }, Node::Sink { ty: ty2, .. })
+                | (Node::Source { ty: ty1 }, Node::Transform { in_ty: ty2, .. })
+                | (Node::Transform { out_ty: ty1, .. }, Node::Transform { in_ty: ty2, .. })
+                | (Node::Transform { out_ty: ty1, .. }, Node::Sink { ty: ty2, .. }) => {
+                    if ty1 != ty2 {
+                        errors.push(format!(
+                            "Data type mismatch between {} ({:?}) and {} ({:?})",
+                            x, ty1, y, ty2
+                        ));
+                    }
+                }
+                (Node::Sink { .. }, _) | (_, Node::Source { .. }) => unreachable!(),
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        errors.sort();
+        errors.dedup();
+        Err(errors)
+    }
+}
+
+fn paths(nodes: &HashMap<&String, Node>, node: &String, mut path: Vec<String>) -> Vec<Vec<String>> {
+    path.push(node.clone());
+    match nodes.get(node).clone() {
+        Some(Node::Source { .. }) | None => {
+            path.reverse();
+            vec![path]
+        }
+        Some(Node::Transform { inputs, .. }) | Some(Node::Sink { inputs, .. }) => inputs
+            .iter()
+            .flat_map(|input| paths(nodes, input, path.clone()))
+            .collect(),
+    }
+}
 
 // Modified version of Kahn's topological sort algorithm that ignores the actual sorted output and
 // only cares if the sort was possible (i.e. whether or not there was a cycle in the input graph).
@@ -50,7 +154,7 @@ pub fn contains_cycle(config: &Config) -> bool {
 
 #[cfg(test)]
 mod test {
-    use super::contains_cycle;
+    use super::{contains_cycle, typecheck};
     use crate::topology::Config;
 
     #[test]
@@ -127,5 +231,64 @@ mod test {
         .unwrap();
 
         assert_eq!(false, contains_cycle(&acyclic));
+    }
+
+    #[test]
+    fn detects_type_mismatches() {
+        // Define a "minimal" Metric-typed sink so our example config can trigger a type error. As
+        // soon as we've actually implemented a Metric-typed sink or transform, we can get rid of
+        // this and just use one of those.
+        // TODO: remove all this once we have an actual non-Log component
+        use crate::{
+            buffers::Acker,
+            sinks::{
+                blackhole::{BlackholeConfig, BlackholeSink},
+                Healthcheck, RouterSink,
+            },
+            topology::config::DataType,
+        };
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Deserialize, Serialize, Debug)]
+        pub struct MetricsSinkConfig;
+
+        #[typetag::serde(name = "metrics_sink")]
+        impl crate::topology::config::SinkConfig for MetricsSinkConfig {
+            fn build(&self, acker: Acker) -> Result<(RouterSink, Healthcheck), String> {
+                Ok((
+                    Box::new(BlackholeSink::new(
+                        BlackholeConfig { print_amount: 1 },
+                        acker,
+                    )),
+                    Box::new(futures::future::ok(())),
+                ))
+            }
+
+            fn input_type(&self) -> DataType {
+                DataType::Metric
+            }
+        }
+        // End of stuff to delete
+
+        let badly_typed = Config::load(
+            r#"
+            [sources.in]
+            type = "tcp"
+            address = "127.0.0.1:1235"
+
+            [sinks.out]
+            type = "metrics_sink"
+            inputs = ["in"]
+          "#
+            .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            Err(vec![
+                "Data type mismatch between in (Log) and out (Metric)".into()
+            ]),
+            typecheck(&badly_typed)
+        );
     }
 }


### PR DESCRIPTION
This is super minimal and won't actually do anything right now (because everything is still typed as `Log` everywhere), but it shows the basic algorithm and how it can integrate with sources/transforms/sinks.

First, it introduces `DataType` as a super minimal enum of `Log` and `Metric` types. This is meant to be expanded significantly in the future to include things like metric subtypes, tracking specific fields in a log record, etc. I don't love the name and it might change as we expand it.

Next, it adds `fn {input,output}_type(&self) -> DataType` to the source, transform, and sink config traits. For now they're all give a default implementation of `Log`, but this gives us a place to customize the type per component with access to the configuration (e.g. we can look at the `fields` config of an `AddFields` transform and use that info when constructing its type).

Finally, it adds the actual type checking implementation. It first generates all the paths of data through the topology, then walks each of those paths checking that the preceding node's outgoing type matches the following node's incoming type. Right now it's equivalent to validating each edge of the graph, but having all the paths materialized means we can easily expand it to propagate type information through the graph (i.e. remembering which fields were added by node N-2 and earlier).

The next step is to convert `Record` into `enum Event { LogRecord, Metric }` and change the implementation of things like statsd and prometheus to actually use the `Metric` type. I also have a good idea of how we can combine the type checking and cycle checking stages into one that would be simpler and more helpful (described in #321).

I spent some time investigating whether we could use this type information in topology building to avoid the `Event` enum and just define sources/sinks/transforms directly in terms of the data type they support, but it seemed like that would require a large reworking of topology building. It also seems like it would fail to capture some of the more structural type information we want to use (e.g. log fields), so it's not clear there'd be a big benefit outside of implementation cleanliness.

Closes #235 (We should maybe split out some of the more advanced ideas there into their own issues)