### PR TITLE
Allow `require`ing additional scripts in lua transforms

### DIFF
--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -39,7 +39,7 @@ fn add_fields(c: &mut Criterion) {
             b.iter_with_setup(
                 || {
                     let source = format!("event['{}'] = '{}'", key, value);
-                    transforms::lua::Lua::new(&source).unwrap()
+                    transforms::lua::Lua::new(&source, vec![]).unwrap()
                 },
                 |transform| {
                     for _ in 0..num_events {
@@ -92,7 +92,7 @@ fn field_filter(c: &mut Criterion) {
                         event = nil
                       end
                     "#;
-                    transforms::lua::Lua::new(&source).unwrap()
+                    transforms::lua::Lua::new(&source, vec![]).unwrap()
                 },
                 |transform| {
                     let num = (0..num_events)


### PR DESCRIPTION
Nothing too fancy here. It allows users to set an additional set of directories to search for lua scripts in and then adds those to lua's search path.

`require` is smart and only loads/parses a single file one time (much like ruby's `require`), so there shouldn't be much overhead in re-executing the `require` on each run of the script.
(I am slightly concerned about how the interface I made for these transforms doesn't really allow for doing any run-only-once setup work, but internally memoizing in setup functions like this does seem viable).

I pushed towards getting [this fancy nginx/apache log parsing script](https://github.com/mozilla-services/lua_sandbox_extensions/blob/51aabb8f672ea7323d45f7b8cf0a0bd171258d74/lpeg/modules/lpeg/common_log_format.lua) working, but hit a couple of barriers and ran out of time. The script relies on a native extension (`lpeg`), which causes some issues. I was able to compile/install the extension with `luarocks`, but because rlua compiles its own lua, there were some mismatches (search paths and version ABI issues) preventing it from working with that installation. `rlua` does allow using the system lua installation instead, but that seems like it'd require users to build `vector` from source for everything to work out properly. I'm not sure what the best way to handle native extensions is, but one additional option is building some common extensions and shipping them alongside (or linked into) vector by default.