### PR TITLE
Serialize timestamps as timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +3392,7 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3741,6 +3751,7 @@ dependencies = [
 "checksum prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9787d1977ea72e8066d58e46ae66100324a2815e677897fe78dfe54958f48252"
 "checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
 "checksum prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5644c57d56bc085f9570e113495c1f08d7185beca700dcc296cb4672f380a679"
+"checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
 "checksum protobuf 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3959be8d6250192f80ef056c0a4aaaeaff8a25e904e6e7a0f5285cb1a061835f"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quanta 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd25291023477d6f6d60e7ec4bb0883ab20dd628edb95ad7dec25531ed590d23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = "1.0.33"
 # Prost
 prost = "0.5"
 prost-derive = "0.5"
+prost-types = "0.5"
 
 # External libs
 derivative = "1.0"

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
+
 package event.proto;
 
 message EventWrapper {
@@ -14,13 +16,11 @@ message Log {
 }
 
 message Value {
-  bytes data = 1;
-  bool explicit = 2;
-  enum Kind {
-    Bytes = 0;
-    Timestamp = 1;
+  oneof kind {
+    bytes raw_bytes = 1;
+    google.protobuf.Timestamp timestamp = 2;
   }
-  Kind kind = 3;
+  bool explicit = 3;
 }
 
 message Metric {


### PR DESCRIPTION
Digging into the disk buffer performance issues, it turned out that our protobuf serialization is actually quite slow. There are a handful of annoying reasons for this, and it's definitely not the only bottleneck for disk buffering, but one of the most straightforward issues was the way we write out timestamps as strings. This fixes that and gives us a pretty reasonable performance gain.

There are some backward incompatible changes in `event.proto` here, but I think we're still at the point where that shouldn't bother anyone.