### PR TITLE
Add Integer/Float/Boolean types to ValueKind and the event protocol

### DIFF
--- a/proto/event.proto
+++ b/proto/event.proto
@@ -19,6 +19,9 @@ message Value {
   oneof kind {
     bytes raw_bytes = 1;
     google.protobuf.Timestamp timestamp = 2;
+    int64 integer = 4;
+    double float = 5;
+    bool boolean = 6;
   }
   bool explicit = 3;
 }


### PR DESCRIPTION
Ref issue #406 this pull adds support for the three new types (int, float, and bool). I have a couple of questions on the details:

1. Did I do the numbering correctly in the protobuf schema, or should explicit have been renumbered as well?
2. Should the floating point type be named "float" like I did, "number" (like JavaScript), or something else?
3. Are there tests for the protocol that I missed? I didn't see any.