### PR TITLE
Change http sink defaults

### DIFF
--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -313,6 +313,7 @@ mod tests {
         let config = r#"
         uri = "http://$IN_ADDR/frames"
         user = "waldo"
+        compression = "gzip"
         password = "hunter2"
         encoding = "ndjson"
     "#
@@ -369,6 +370,7 @@ mod tests {
         let config = r#"
         uri = "http://$IN_ADDR/frames"
         encoding = "ndjson"
+        compression = "gzip"
         [headers]
         foo = "bar"
         baz = "quux"


### PR DESCRIPTION
This changes the `http` sink defaults to be less surprising and improve performance.