### PR TITLE
Only rerun the build script if proto/events.proto changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo:rerun-if-changed=proto/event.proto");
     prost_build::compile_protos(&["proto/event.proto"], &["proto/"]).unwrap();
     built::write_built_file().unwrap();
 }


### PR DESCRIPTION
By default, the build script is run if any source changes. This change
scopes it to just the one source file that it uses, which speeds up some
incremental changes (to benchmarks, for example).