### PR TITLE
Add tokenizer transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stackvector 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1531,16 @@ name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "5.0.0-beta2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lexical-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2579,6 +2600,19 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "stackvector"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "static_assertions"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stream-cancel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,6 +3411,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,6 +3496,7 @@ dependencies = [
  "leveldb 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.0.0-beta2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3500,6 +3543,11 @@ dependencies = [
 [[package]]
 name = "version_check"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3759,6 +3807,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum leveldb 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8438a36a31c982ac399c4477d7e3c62cc7a6bf91bb6f42837b7e1033359fcbad"
 "checksum leveldb-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a4e97b4e1ee52602c3af5f47c1959e9f349217a41f1510fe4a8ac02ce3dc818"
+"checksum lexical-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e82e023e062f1d25f807ad182008fba1b46538e999f908a08cc0c29e084462e"
 "checksum libc 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "113dacd5d2dd5dcf7800449b3c3115957db1b6452a4c5bb3447e81087f23e53f"
 "checksum libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
 "checksum libm 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cfcefbd3a8aad4c0552fa150c28291becc386b1b056988493517875e987e99e3"
@@ -3789,6 +3838,7 @@ dependencies = [
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum nom 5.0.0-beta2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfa215de9f747c2b3290ceee185976eb6ffc936087e19d810b57ba3ff85ae28c"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "107b9be86cd2481930688277b675b0114578227f034674726605b8a482d8baf8"
@@ -3903,6 +3953,8 @@ dependencies = [
 "checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum stackvector 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c049c77bf85fbc036484c97b008276d539d9ebff9dfbde37b632ebcd5b8746b6"
+"checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum stream-cancel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d62fea0968935ec8eedcf671b2738bf49c58e133db968097c301d32e32eaedf"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
@@ -3979,6 +4031,7 @@ dependencies = [
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
@@ -3987,6 +4040,7 @@ dependencies = [
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum webpki 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f7e1cd7900a3a6b65a3e8780c51a3e6b59c0e2c55c6dc69578c288d69f7d082"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ rlua = "0.16.3"
 num_cpus = "1.10.0"
 bytesize = "1.0.0"
 grok = "1.0.0"
+nom = "5.0.0-beta2"
 
 [build-dependencies]
 prost-build = "0.4.0"

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -9,6 +9,7 @@ pub mod lua;
 pub mod regex_parser;
 pub mod remove_fields;
 pub mod sampler;
+pub mod tokenizer;
 
 pub trait Transform: Send {
     fn transform(&self, event: Event) -> Option<Event>;

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -1,0 +1,236 @@
+use super::Transform;
+use crate::event::{self, Event};
+use nom::{
+    branch::alt,
+    bytes::complete::{escaped, is_not, tag},
+    character::complete::{one_of, space0},
+    combinator::{all_consuming, rest, verify},
+    multi::many0,
+    sequence::{delimited, terminated},
+};
+use serde::{Deserialize, Serialize};
+use std::str;
+use string_cache::DefaultAtom as Atom;
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct TokenizerConfig {
+    pub field_names: Vec<Atom>,
+    pub field: Option<Atom>,
+    pub drop_field: bool,
+}
+
+#[typetag::serde(name = "tokenizer")]
+impl crate::topology::config::TransformConfig for TokenizerConfig {
+    fn build(&self) -> Result<Box<dyn Transform>, String> {
+        let field = if let Some(field) = &self.field {
+            field
+        } else {
+            &event::MESSAGE
+        };
+
+        // don't drop the source field if it's getting overwritten by a parsed value
+        let drop_field = self.drop_field && !self.field_names.iter().any(|f| f == field);
+
+        Ok(Box::new(Tokenizer::new(
+            self.field_names.clone(),
+            field.clone(),
+            drop_field,
+        )))
+    }
+}
+
+pub struct Tokenizer {
+    field_names: Vec<Atom>,
+    field: Atom,
+    drop_field: bool,
+}
+
+impl Tokenizer {
+    pub fn new(field_names: Vec<Atom>, field: Atom, drop_field: bool) -> Self {
+        Self {
+            field_names,
+            field,
+            drop_field,
+        }
+    }
+}
+
+impl Transform for Tokenizer {
+    fn transform(&self, mut event: Event) -> Option<Event> {
+        let value = event.as_log().get(&self.field).map(|s| s.to_string_lossy());
+
+        if let Some(value) = &value {
+            for (name, value) in self.field_names.iter().zip(parse(value).into_iter()) {
+                event
+                    .as_mut_log()
+                    .insert_explicit(name.clone(), value.as_bytes().into());
+            }
+            if self.drop_field {
+                event.as_mut_log().remove(&self.field);
+            }
+        } else {
+            debug!(
+                message = "Field does not exist.",
+                field = self.field.as_ref(),
+            );
+        };
+
+        Some(event)
+    }
+}
+
+pub fn parse(input: &str) -> Vec<&str> {
+    let simple = is_not::<_, _, (&str, nom::error::ErrorKind)>(" \t[\"");
+    let string = delimited(
+        tag("\""),
+        escaped(is_not("\"\\"), '\\', one_of("\"\\")),
+        tag("\""),
+    );
+    let bracket = delimited(
+        tag("["),
+        escaped(is_not("]\\"), '\\', one_of("]\\")),
+        tag("]"),
+    );
+
+    // fall back to returning the rest of the input, if any
+    let remainder = verify(rest, |s: &str| s.len() > 0);
+    let field = alt((bracket, string, simple, remainder));
+
+    all_consuming(many0(terminated(field, space0)))(input)
+        .expect("parser should always succeed")
+        .1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+    use super::TokenizerConfig;
+    use crate::{topology::config::TransformConfig, Event};
+
+    #[test]
+    fn basic() {
+        assert_eq!(parse("foo"), &["foo"]);
+    }
+
+    #[test]
+    fn multiple() {
+        assert_eq!(parse("foo bar"), &["foo", "bar"]);
+    }
+
+    #[test]
+    fn more_space() {
+        assert_eq!(parse("foo\t bar"), &["foo", "bar"]);
+    }
+
+    #[test]
+    fn quotes() {
+        assert_eq!(parse(r#"foo "bar baz""#), &["foo", r#"bar baz"#]);
+    }
+
+    #[test]
+    fn escaped_quotes() {
+        assert_eq!(
+            parse(r#"foo "bar \" \" baz""#),
+            &["foo", r#"bar \" \" baz"#],
+        );
+    }
+
+    #[test]
+    fn unclosed_quotes() {
+        assert_eq!(parse(r#"foo "bar"#), &["foo", "\"bar"],);
+    }
+
+    #[test]
+    fn brackets() {
+        assert_eq!(parse("[foo.bar = baz] quux"), &["foo.bar = baz", "quux"],);
+    }
+
+    #[test]
+    fn escaped_brackets() {
+        assert_eq!(
+            parse(r#"[foo " [[ \] "" bar] baz"#),
+            &[r#"foo " [[ \] "" bar"#, "baz"],
+        );
+    }
+
+    #[test]
+    fn unclosed_brackets() {
+        assert_eq!(parse("foo [bar"), &["foo", "[bar"],);
+    }
+
+    #[test]
+    fn truncated_field() {
+        assert_eq!(
+            parse("foo bar[baz]: quux"),
+            &["foo", "bar", "baz", ":", "quux"]
+        );
+        assert_eq!(parse("foo bar[baz quux"), &["foo", "bar", "[baz quux"]);
+    }
+
+    #[test]
+    fn from_fuzzing() {
+        assert_eq!(parse("").len(), 0);
+        assert_eq!(parse("f] bar"), &["f]", "bar"]);
+        assert_eq!(parse("f\" bar"), &["f", "\" bar"]);
+        assert_eq!(parse("f[f bar"), &["f", "[f bar"]);
+        assert_eq!(parse("f\"f bar"), &["f", "\"f bar"]);
+        assert_eq!(parse("[][x"), &["", "[x"]);
+        assert_eq!(parse("x[][x"), &["x", "", "[x"]);
+    }
+
+    #[test]
+    fn tokenizer_adds_parsed_field_to_event() {
+        let event = Event::from("1234 5678");
+        let parser = TokenizerConfig {
+            field_names: vec!["status".into(), "time".into()],
+            field: None,
+            ..Default::default()
+        }
+        .build()
+        .unwrap();
+
+        let event = parser.transform(event).unwrap();
+
+        assert_eq!(event.as_log()[&"status".into()], "1234".into());
+        assert_eq!(event.as_log()[&"time".into()], "5678".into());
+        assert!(event.as_log().get(&"message".into()).is_some());
+    }
+
+    #[test]
+    fn tokenizer_does_drop_parsed_field() {
+        let event = Event::from("1234 5678");
+        let parser = TokenizerConfig {
+            field_names: vec!["status".into(), "time".into()],
+            field: Some("message".into()),
+            drop_field: true,
+        }
+        .build()
+        .unwrap();
+
+        let event = parser.transform(event).unwrap();
+
+        let log = event.into_log();
+        assert_eq!(log[&"status".into()], "1234".into());
+        assert_eq!(log[&"time".into()], "5678".into());
+        assert!(log.get(&"message".into()).is_none());
+    }
+
+    #[test]
+    fn tokenizer_does_not_drop_same_name_parsed_field() {
+        let event = Event::from("1234 yes");
+        let parser = TokenizerConfig {
+            field_names: vec!["status".into(), "message".into()],
+            field: Some("message".into()),
+            drop_field: true,
+        }
+        .build()
+        .unwrap();
+
+        let event = parser.transform(event).unwrap();
+
+        let log = event.into_log();
+        assert_eq!(log[&"status".into()], "1234".into());
+        assert_eq!(log[&"message".into()], "yes".into());
+    }
+}


### PR DESCRIPTION
This adds a simple tokenizer-like parsing transform. It splits an incoming string into whitespace-, double quote-, and bracket-delimited fields. Those fields are then zipped with a configured list of field names to produce the key-value pairs that get added to the event.

We should probably have a better name than `fields` for the list of field names/keys in the config.