### PR TITLE
Configure gzip for speed over size

### DIFF
--- a/src/sinks/util/buffer.rs
+++ b/src/sinks/util/buffer.rs
@@ -136,7 +136,7 @@ mod test {
             .collect::<Vec<Vec<u8>>>();
 
         assert!(output.len() > 1);
-        assert!(output.iter().map(|o| o.len()).sum::<usize>() < 50_000);
+        assert!(dbg!(output.iter().map(|o| o.len()).sum::<usize>()) < 51_000);
 
         let decompressed = output.into_iter().flat_map(|batch| {
             let mut decompressed = vec![];


### PR DESCRIPTION
Not a huge win, but it definitely helps:

```
batch/gzip 10mb with 2mb batches                                              
                        time:   [308.22 ms 308.38 ms 308.69 ms]
                        thrpt:  [30.894 MiB/s 30.925 MiB/s 30.941 MiB/s]
                 change:
                        time:   [-21.321% -21.156% -21.000%] (p = 0.00 < 0.05)
                        thrpt:  [+26.582% +26.833% +27.099%]
                        Performance has improved.

batch/gzip 10mb with 500kb batches                                            
                        time:   [365.51 ms 365.93 ms 366.47 ms]
                        thrpt:  [26.023 MiB/s 26.062 MiB/s 26.092 MiB/s]
                 change:
                        time:   [-5.9407% -5.6709% -5.4134%] (p = 0.00 < 0.05)
                        thrpt:  [+5.7233% +6.0118% +6.3159%]
                        Performance has improved.

partitioned_batch/gzip 10mb with 2mb batches                                  
                        time:   [397.30 ms 397.42 ms 397.62 ms]
                        thrpt:  [23.984 MiB/s 23.996 MiB/s 24.004 MiB/s]
                 change:
                        time:   [-0.4229% +0.1043% +0.4818%] (p = 0.73 > 0.05)
                        thrpt:  [-0.4795% -0.1041% +0.4247%]
                        No change in performance detected.

```

Also, it seems like gzip/deflate/zlib are just kinda slow in general (search `zlib` in https://github.com/inikep/lzbench#benchmarks), so maybe this is expected? We can add support for much better compression schemes for sinks like S3.