### PR TITLE
feat(file source): make fingerprinting strategy configurable

### DIFF
--- a/.metadata.toml
+++ b/.metadata.toml
@@ -77,16 +77,6 @@ description = """\
 The key name added to each event with the full path of the file.\
 """
 
-[sources.file.options.fingerprint_bytes]
-type = "int"
-default = 256
-null = false
-unit = "bytes"
-description = """\
-The number of bytes read off the head of the file to generate a unique \
-fingerprint.\
-"""
-
 [sources.file.options.glob_minimum_cooldown]
 type = "int"
 default = 1000
@@ -117,16 +107,6 @@ description = """\
 Ignore files with a data modification date that does not exceed this age.\
 """
 
-[sources.file.options.ignored_header_bytes]
-type = "int"
-default = 0
-null = false
-unit = "bytes"
-description = """\
-The number of bytes to skipe ahead (or ignore) when generating a unique \
-fingerprint. This is helpful if all files share a common header.\
-"""
-
 [sources.file.options.max_line_bytes]
 type = "int"
 unit = "bytes"
@@ -145,6 +125,46 @@ default = false
 description = """\
 When `true` Vector will read from the beginning of new files, when \
 `false` Vector will only read new data added to the file.\
+"""
+
+[sources.file.options.fingerprinting]
+type = "table"
+null = true
+description = """\
+Configuration for how the file source should identify files.\
+"""
+
+[sources.file.options.fingerprinting.options.strategy]
+type = "string"
+enum = ["checksum", "device_and_inode"]
+default = "checksum"
+null = true
+description = """\
+Whether to use the content of a file to differentiate it (`checksum`) or the \
+storage device and inode (`device_and_inode`). Depending on your log rotation \
+strategy, one may be a better fit than the other.\
+"""
+
+[sources.file.options.fingerprinting.options.fingerprint_bytes]
+type = "int"
+default = 256
+null = false
+unit = "bytes"
+relevant_when = {strategy = "checksum"}
+description = """\
+The number of bytes read off the head of the file to generate a unique \
+fingerprint.\
+"""
+
+[sources.file.options.fingerprinting.options.ignored_header_bytes]
+type = "int"
+default = 0
+null = false
+unit = "bytes"
+relevant_when = {strategy = "checksum"}
+description = """\
+The number of bytes to skip ahead (or ignore) when generating a unique \
+fingerprint. This is helpful if all files share a common header.\
 """
 
 # ------------------------------------------------------------------------------

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -73,14 +73,6 @@
   # * no default
   data_dir = "/var/lib/vector"
 
-  # The number of bytes read off the head of the file to generate a unique
-  # fingerprint.
-  # 
-  # * optional
-  # * default: 256
-  # * unit: bytes
-  fingerprint_bytes = 256
-
   # Delay between file discovery calls. This controls the interval at which
   # Vector searches for files.
   # 
@@ -95,14 +87,6 @@
   # * no default
   # * unit: seconds
   ignore_older = 86400
-
-  # The number of bytes to skipe ahead (or ignore) when generating a unique
-  # fingerprint. This is helpful if all files share a common header.
-  # 
-  # * optional
-  # * default: 0
-  # * unit: bytes
-  ignored_header_bytes = 0
 
   # The maximum number of a bytes a line can contain before being discarded. This
   # protects against malformed lines or tailing incorrect files.
@@ -134,6 +118,37 @@
   # * optional
   # * default: "host"
   host_key = "host"
+
+  #
+  # Fingerprinting
+  #
+
+  [sources.file.fingerprinting]
+    # Whether to use the content of a file to differentiate it (`checksum`) or the
+    # storage device and inode (`device_and_inode`). Depending on your log rotation
+    # strategy, one may be a better fit than the other.
+    # 
+    # * optional
+    # * default: "checksum"
+    # * enum: "checksum" or "device_and_inode"
+    strategy = "checksum"
+    strategy = "device_and_inode"
+
+    # The number of bytes read off the head of the file to generate a unique
+    # fingerprint.
+    # 
+    # * optional
+    # * default: 256
+    # * unit: bytes
+    fingerprint_bytes = 256
+
+    # The number of bytes to skip ahead (or ignore) when generating a unique
+    # fingerprint. This is helpful if all files share a common header.
+    # 
+    # * optional
+    # * default: 0
+    # * unit: bytes
+    ignored_header_bytes = 0
 
 [sources.journald]
   # The component type

--- a/docs/usage/configuration/sources/file.md
+++ b/docs/usage/configuration/sources/file.md
@@ -37,16 +37,20 @@ The `file` source ingests data through one or more local files and outputs [`log
   
   # OPTIONAL - General
   data_dir = "/var/lib/vector" # no default
-  fingerprint_bytes = 256 # default, bytes
   glob_minimum_cooldown = 1000 # default, milliseconds
   ignore_older = 86400 # no default, seconds
-  ignored_header_bytes = 0 # default, bytes
   max_line_bytes = 102400 # default, bytes
   start_at_beginning = false # default
   
   # OPTIONAL - Context
   file_key = "file" # default
   host_key = "host" # default
+  
+  # OPTIONAL - Fingerprinting
+  [sources.my_source_id.fingerprinting]
+    strategy = "checksum" # default, enum: "checksum" or "device_and_inode"
+    fingerprint_bytes = 256 # default, bytes, relevant when strategy = "checksum"
+    ignored_header_bytes = 0 # default, bytes, relevant when strategy = "checksum"
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (schema)" %}
@@ -59,16 +63,20 @@ The `file` source ingests data through one or more local files and outputs [`log
 
   # OPTIONAL - General
   data_dir = "<string>"
-  fingerprint_bytes = <int>
   glob_minimum_cooldown = <int>
   ignore_older = <int>
-  ignored_header_bytes = <int>
   max_line_bytes = <int>
   start_at_beginning = <bool>
 
   # OPTIONAL - Context
   file_key = "<string>"
   host_key = "<string>"
+
+  # OPTIONAL - Fingerprinting
+  [sources.<source-id>.fingerprinting]
+    strategy = {"checksum" | "device_and_inode"}
+    fingerprint_bytes = <int>
+    ignored_header_bytes = <int>
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (specification)" %}
@@ -106,14 +114,6 @@ The `file` source ingests data through one or more local files and outputs [`log
   # * no default
   data_dir = "/var/lib/vector"
 
-  # The number of bytes read off the head of the file to generate a unique
-  # fingerprint.
-  # 
-  # * optional
-  # * default: 256
-  # * unit: bytes
-  fingerprint_bytes = 256
-
   # Delay between file discovery calls. This controls the interval at which
   # Vector searches for files.
   # 
@@ -128,14 +128,6 @@ The `file` source ingests data through one or more local files and outputs [`log
   # * no default
   # * unit: seconds
   ignore_older = 86400
-
-  # The number of bytes to skipe ahead (or ignore) when generating a unique
-  # fingerprint. This is helpful if all files share a common header.
-  # 
-  # * optional
-  # * default: 0
-  # * unit: bytes
-  ignored_header_bytes = 0
 
   # The maximum number of a bytes a line can contain before being discarded. This
   # protects against malformed lines or tailing incorrect files.
@@ -167,6 +159,37 @@ The `file` source ingests data through one or more local files and outputs [`log
   # * optional
   # * default: "host"
   host_key = "host"
+
+  #
+  # Fingerprinting
+  #
+
+  [sources.file_source.fingerprinting]
+    # Whether to use the content of a file to differentiate it (`checksum`) or the
+    # storage device and inode (`device_and_inode`). Depending on your log rotation
+    # strategy, one may be a better fit than the other.
+    # 
+    # * optional
+    # * default: "checksum"
+    # * enum: "checksum" or "device_and_inode"
+    strategy = "checksum"
+    strategy = "device_and_inode"
+
+    # The number of bytes read off the head of the file to generate a unique
+    # fingerprint.
+    # 
+    # * optional
+    # * default: 256
+    # * unit: bytes
+    fingerprint_bytes = 256
+
+    # The number of bytes to skip ahead (or ignore) when generating a unique
+    # fingerprint. This is helpful if all files share a common header.
+    # 
+    # * optional
+    # * default: 0
+    # * unit: bytes
+    ignored_header_bytes = 0
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -181,15 +204,17 @@ The `file` source ingests data through one or more local files and outputs [`log
 | `include` | `[string]` | Array of file patterns to include. [Globbing](#globbing) is supported.<br />`required` `example: ["/var/log/nginx/*.log"]` |
 | **OPTIONAL** - General | | |
 | `data_dir` | `string` | The directory used to persist file checkpoint positions. By default, the global `data_dir` is used. Please make sure the Vector project has write permissions to this dir. See [Checkpointing](#checkpointing) for more info.<br />`no default` `example: "/var/lib/vector"` |
-| `fingerprint_bytes` | `int` | The number of bytes read off the head of the file to generate a unique fingerprint. See [File Identification](#file-identification) for more info.<br />`default: 256` `unit: bytes` |
 | `glob_minimum_cooldown` | `int` | Delay between file discovery calls. This controls the interval at which Vector searches for files. See [Auto Discovery](#auto-discovery) and [Globbing](#globbing) for more info.<br />`default: 1000` `unit: milliseconds` |
 | `ignore_older` | `int` | Ignore files with a data modification date that does not exceed this age. See [File Rotation](#file-rotation) for more info.<br />`no default` `example: 86400` `unit: seconds` |
-| `ignored_header_bytes` | `int` | The number of bytes to skipe ahead (or ignore) when generating a unique fingerprint. This is helpful if all files share a common header. See [File Identification](#file-identification) for more info.<br />`default: 0` `unit: bytes` |
 | `max_line_bytes` | `int` | The maximum number of a bytes a line can contain before being discarded. This protects against malformed lines or tailing incorrect files.<br />`default: 102400` `unit: bytes` |
 | `start_at_beginning` | `bool` | When `true` Vector will read from the beginning of new files, when `false` Vector will only read new data added to the file. See [Read Position](#read-position) for more info.<br />`default: false` |
 | **OPTIONAL** - Context | | |
 | `file_key` | `string` | The key name added to each event with the full path of the file. See [Context](#context) for more info.<br />`default: "file"` |
 | `host_key` | `string` | The key name added to each event representing the current host. See [Context](#context) for more info.<br />`default: "host"` |
+| **OPTIONAL** - Fingerprinting | | |
+| `fingerprinting.strategy` | `string` | Whether to use the content of a file to differentiate it (`checksum`) or the storage device and inode (`device_and_inode`). Depending on your log rotation strategy, one may be a better fit than the other.<br />`default: "checksum"` `enum: "checksum" or "device_and_inode"` |
+| `fingerprinting.fingerprint_bytes` | `int` | The number of bytes read off the head of the file to generate a unique fingerprint. Only relevant when strategy = "checksum" See [File Identification](#file-identification) for more info.<br />`default: 256` `unit: bytes` |
+| `fingerprinting.ignored_header_bytes` | `int` | The number of bytes to skip ahead (or ignore) when generating a unique fingerprint. This is helpful if all files share a common header. Only relevant when strategy = "checksum" See [File Identification](#file-identification) for more info.<br />`default: 0` `unit: bytes` |
 
 ## Examples
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -93,14 +93,6 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * no default
   data_dir = "/var/lib/vector"
 
-  # The number of bytes read off the head of the file to generate a unique
-  # fingerprint.
-  # 
-  # * optional
-  # * default: 256
-  # * unit: bytes
-  fingerprint_bytes = 256
-
   # Delay between file discovery calls. This controls the interval at which
   # Vector searches for files.
   # 
@@ -115,14 +107,6 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * no default
   # * unit: seconds
   ignore_older = 86400
-
-  # The number of bytes to skipe ahead (or ignore) when generating a unique
-  # fingerprint. This is helpful if all files share a common header.
-  # 
-  # * optional
-  # * default: 0
-  # * unit: bytes
-  ignored_header_bytes = 0
 
   # The maximum number of a bytes a line can contain before being discarded. This
   # protects against malformed lines or tailing incorrect files.
@@ -154,6 +138,37 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * optional
   # * default: "host"
   host_key = "host"
+
+  #
+  # Fingerprinting
+  #
+
+  [sources.file.fingerprinting]
+    # Whether to use the content of a file to differentiate it (`checksum`) or the
+    # storage device and inode (`device_and_inode`). Depending on your log rotation
+    # strategy, one may be a better fit than the other.
+    # 
+    # * optional
+    # * default: "checksum"
+    # * enum: "checksum" or "device_and_inode"
+    strategy = "checksum"
+    strategy = "device_and_inode"
+
+    # The number of bytes read off the head of the file to generate a unique
+    # fingerprint.
+    # 
+    # * optional
+    # * default: 256
+    # * unit: bytes
+    fingerprint_bytes = 256
+
+    # The number of bytes to skip ahead (or ignore) when generating a unique
+    # fingerprint. This is helpful if all files share a common header.
+    # 
+    # * optional
+    # * default: 0
+    # * unit: bytes
+    ignored_header_bytes = 0
 
 [sources.journald]
   # The component type

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -4,7 +4,8 @@ use futures::{stream, Future, Sink, Stream};
 use glob::{glob, Pattern};
 use std::collections::HashMap;
 use std::fs;
-use std::io::{self, Read, Seek};
+use std::io::{self, Read, Seek, Write};
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::RecvTimeoutError;
 use std::time;
@@ -26,10 +27,9 @@ pub struct FileServer {
     pub start_at_beginning: bool,
     pub ignore_before: Option<time::SystemTime>,
     pub max_line_bytes: usize,
-    pub fingerprint_bytes: usize,
-    pub ignored_header_bytes: usize,
     pub data_dir: PathBuf,
     pub glob_minimum_cooldown: time::Duration,
+    pub fingerprinter: Fingerprinter,
 }
 
 /// `FileServer` as Source
@@ -107,8 +107,9 @@ impl FileServer {
                             continue;
                         }
 
-                        if let Ok(file_id) =
-                            self.get_fingerprint_of_file(&path, &mut fingerprint_buffer)
+                        if let Ok(file_id) = self
+                            .fingerprinter
+                            .get_fingerprint_of_file(&path, &mut fingerprint_buffer)
                         {
                             if let Some(watcher) = fp_map.get_mut(&file_id) {
                                 // file fingerprint matches a watched file
@@ -247,21 +248,6 @@ impl FileServer {
             }
         }
     }
-
-    fn get_fingerprint_of_file(
-        &self,
-        path: &PathBuf,
-        buffer: &mut Vec<u8>,
-    ) -> Result<FileFingerprint, io::Error> {
-        let i = self.ignored_header_bytes as u64;
-        let b = self.fingerprint_bytes;
-        buffer.resize(b, 0u8);
-        let mut fp = fs::File::open(path)?;
-        fp.seek(io::SeekFrom::Start(i))?;
-        fp.read_exact(&mut buffer[..b])?;
-        let fingerprint = crc::crc64::checksum_ecma(&buffer[..b]);
-        Ok(fingerprint)
-    }
 }
 
 pub struct Checkpointer {
@@ -322,48 +308,123 @@ impl Checkpointer {
     }
 }
 
+#[derive(Clone)]
+pub enum Fingerprinter {
+    Checksum {
+        fingerprint_bytes: usize,
+        ignored_header_bytes: usize,
+    },
+    DevInode,
+}
+
+impl Fingerprinter {
+    fn get_fingerprint_of_file(
+        &self,
+        path: &PathBuf,
+        buffer: &mut Vec<u8>,
+    ) -> Result<FileFingerprint, io::Error> {
+        match *self {
+            Fingerprinter::DevInode => {
+                let metadata = fs::metadata(path)?;
+                let dev = metadata.dev();
+                let ino = metadata.ino();
+                buffer.clear();
+                buffer.write_all(&dev.to_be_bytes())?;
+                buffer.write_all(&ino.to_be_bytes())?;
+            }
+            Fingerprinter::Checksum {
+                ignored_header_bytes,
+                fingerprint_bytes,
+            } => {
+                let i = ignored_header_bytes as u64;
+                let b = fingerprint_bytes;
+                buffer.resize(b, 0u8);
+                let mut fp = fs::File::open(path)?;
+                fp.seek(io::SeekFrom::Start(i))?;
+                fp.read_exact(&mut buffer[..b])?;
+            }
+        }
+        let fingerprint = crc::crc64::checksum_ecma(&buffer[..]);
+        Ok(fingerprint)
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::{Checkpointer, FileFingerprint, FilePosition, FileServer};
-    use std::{fs, time};
+    use super::{Checkpointer, FileFingerprint, FilePosition, Fingerprinter};
+    use std::fs;
     use tempfile::tempdir;
 
     #[test]
-    fn test_fingerprinting() {
-        let data_dir = tempdir().unwrap();
-        let target_dir = tempdir().unwrap();
-        let file_server = FileServer {
-            include: vec![target_dir.path().to_owned()],
-            exclude: Vec::new(),
-            max_read_bytes: 10000,
-            start_at_beginning: true,
-            ignore_before: None,
-            max_line_bytes: 10000,
+    fn test_checksum_fingerprinting() {
+        let fingerprinter = Fingerprinter::Checksum {
             fingerprint_bytes: 256,
             ignored_header_bytes: 0,
-            data_dir: data_dir.path().to_owned(),
-            glob_minimum_cooldown: time::Duration::from_millis(5),
         };
 
+        let target_dir = tempdir().unwrap();
         let enough_data = vec![b'x'; 256];
         let not_enough_data = vec![b'x'; 199];
         let empty_path = target_dir.path().join("empty.log");
         let big_enough_path = target_dir.path().join("big_enough.log");
+        let duplicate_path = target_dir.path().join("duplicate.log");
         let not_big_enough_path = target_dir.path().join("not_big_enough.log");
         fs::write(&empty_path, &[]).unwrap();
         fs::write(&big_enough_path, &enough_data).unwrap();
+        fs::write(&duplicate_path, &enough_data).unwrap();
         fs::write(&not_big_enough_path, &not_enough_data).unwrap();
 
         let mut buf = Vec::new();
-        assert!(file_server
+        assert!(fingerprinter
             .get_fingerprint_of_file(&empty_path, &mut buf)
             .is_err());
-        assert!(file_server
+        assert!(fingerprinter
             .get_fingerprint_of_file(&big_enough_path, &mut buf)
             .is_ok());
-        assert!(file_server
+        assert!(fingerprinter
             .get_fingerprint_of_file(&not_big_enough_path, &mut buf)
             .is_err());
+        assert_eq!(
+            fingerprinter
+                .get_fingerprint_of_file(&big_enough_path, &mut buf)
+                .unwrap(),
+            fingerprinter
+                .get_fingerprint_of_file(&duplicate_path, &mut buf)
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_inode_fingerprinting() {
+        let fingerprinter = Fingerprinter::DevInode;
+
+        let target_dir = tempdir().unwrap();
+        let small_data = vec![b'x'; 1];
+        let medium_data = vec![b'x'; 256];
+        let empty_path = target_dir.path().join("empty.log");
+        let small_path = target_dir.path().join("small.log");
+        let medium_path = target_dir.path().join("medium.log");
+        let duplicate_path = target_dir.path().join("duplicate.log");
+        fs::write(&empty_path, &[]).unwrap();
+        fs::write(&small_path, &small_data).unwrap();
+        fs::write(&medium_path, &medium_data).unwrap();
+        fs::write(&duplicate_path, &medium_data).unwrap();
+
+        let mut buf = Vec::new();
+        assert!(fingerprinter
+            .get_fingerprint_of_file(&empty_path, &mut buf)
+            .is_ok());
+        assert!(fingerprinter
+            .get_fingerprint_of_file(&small_path, &mut buf)
+            .is_ok());
+        assert_ne!(
+            fingerprinter
+                .get_fingerprint_of_file(&medium_path, &mut buf)
+                .unwrap(),
+            fingerprinter
+                .get_fingerprint_of_file(&duplicate_path, &mut buf)
+                .unwrap()
+        );
     }
 
     #[test]

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -6,7 +6,8 @@ extern crate tracing;
 mod file_server;
 mod file_watcher;
 
-pub use self::file_server::FileServer;
+pub use self::file_server::{FileServer, Fingerprinter};
+
 type FileFingerprint = u64;
 type FilePosition = u64;
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -3,7 +3,7 @@ use crate::{
     topology::config::{DataType, GlobalOptions, SourceConfig},
 };
 use bytes::Bytes;
-use file_source::FileServer;
+use file_source::{FileServer, Fingerprinter};
 use futures::{future, sync::mpsc, Future, Sink};
 use serde::{Deserialize, Serialize};
 use std::fs::DirBuilder;
@@ -118,6 +118,11 @@ pub fn file_source(
         .map(|secs| SystemTime::now() - Duration::from_secs(secs));
     let glob_minimum_cooldown = Duration::from_millis(config.glob_minimum_cooldown);
 
+    let fingerprinter = Fingerprinter::Checksum {
+        fingerprint_bytes: config.fingerprint_bytes,
+        ignored_header_bytes: config.ignored_header_bytes,
+    };
+
     let file_server = FileServer {
         include: config.include.clone(),
         exclude: config.exclude.clone(),
@@ -125,10 +130,9 @@ pub fn file_source(
         start_at_beginning: config.start_at_beginning,
         ignore_before,
         max_line_bytes: config.max_line_bytes,
-        fingerprint_bytes: config.fingerprint_bytes,
-        ignored_header_bytes: config.ignored_header_bytes,
         data_dir,
         glob_minimum_cooldown: glob_minimum_cooldown,
+        fingerprinter,
     };
 
     let file_key = config.file_key.clone();


### PR DESCRIPTION
Closes #643 
Closes #737 

This provides an optional alternative file fingerprinting strategy (device and inode) that gracefully handles cases the checksumming strategy does not. 