### PR TITLE
feat(file source): allow aggregating multiple lines into one event

### DIFF
--- a/.metadata.toml
+++ b/.metadata.toml
@@ -167,6 +167,28 @@ The number of bytes to skip ahead (or ignore) when generating a unique \
 fingerprint. This is helpful if all files share a common header.\
 """
 
+[sources.file.options.message_start_indicator]
+type = "string"
+null = true
+examples = ["^(INFO|ERROR)"]
+description = """\
+When present, Vector will aggregate multiple lines into a single event, using \
+this pattern as the indicator that the previous lines should be flushed and \
+a new event started. The pattern will be matched against entire lines as \
+a regular expression, so remember to anchor as appropriate.\
+"""
+
+[sources.file.options.multi_line_timeout]
+type = "int"
+default = 1000
+null = true
+unit = "milliseconds"
+description = """\
+When `message_start_indicator` is present, this sets the amount of time Vector \
+will buffer lines into a single event before flushing, regardless of whether \
+or not it has seen a line indicating the start of a new message.\
+"""
+
 # ------------------------------------------------------------------------------
 # sources.journald
 # ------------------------------------------------------------------------------

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -96,6 +96,24 @@
   # * unit: bytes
   max_line_bytes = 102400
 
+  # When present, Vector will aggregate multiple lines into a single event, using
+  # this pattern as the indicator that the previous lines should be flushed and a
+  # new event started. The pattern will be matched against entire lines as a
+  # regular expression, so remember to anchor as appropriate.
+  # 
+  # * optional
+  # * no default
+  message_start_indicator = "^(INFO|ERROR)"
+
+  # When `message_start_indicator` is present, this sets the amount of time
+  # Vector will buffer lines into a single event before flushing, regardless of
+  # whether or not it has seen a line indicating the start of a new message.
+  # 
+  # * optional
+  # * default: 1000
+  # * unit: milliseconds
+  multi_line_timeout = 1000
+
   # When `true` Vector will read from the beginning of new files, when `false`
   # Vector will only read new data added to the file.
   # 

--- a/docs/usage/configuration/sources/file.md
+++ b/docs/usage/configuration/sources/file.md
@@ -40,6 +40,8 @@ The `file` source ingests data through one or more local files and outputs [`log
   glob_minimum_cooldown = 1000 # default, milliseconds
   ignore_older = 86400 # no default, seconds
   max_line_bytes = 102400 # default, bytes
+  message_start_indicator = "^(INFO|ERROR)" # no default
+  multi_line_timeout = 1000 # default, milliseconds
   start_at_beginning = false # default
   
   # OPTIONAL - Context
@@ -66,6 +68,8 @@ The `file` source ingests data through one or more local files and outputs [`log
   glob_minimum_cooldown = <int>
   ignore_older = <int>
   max_line_bytes = <int>
+  message_start_indicator = "<string>"
+  multi_line_timeout = <int>
   start_at_beginning = <bool>
 
   # OPTIONAL - Context
@@ -137,6 +141,24 @@ The `file` source ingests data through one or more local files and outputs [`log
   # * unit: bytes
   max_line_bytes = 102400
 
+  # When present, Vector will aggregate multiple lines into a single event, using
+  # this pattern as the indicator that the previous lines should be flushed and a
+  # new event started. The pattern will be matched against entire lines as a
+  # regular expression, so remember to anchor as appropriate.
+  # 
+  # * optional
+  # * no default
+  message_start_indicator = "^(INFO|ERROR)"
+
+  # When `message_start_indicator` is present, this sets the amount of time
+  # Vector will buffer lines into a single event before flushing, regardless of
+  # whether or not it has seen a line indicating the start of a new message.
+  # 
+  # * optional
+  # * default: 1000
+  # * unit: milliseconds
+  multi_line_timeout = 1000
+
   # When `true` Vector will read from the beginning of new files, when `false`
   # Vector will only read new data added to the file.
   # 
@@ -207,6 +229,8 @@ The `file` source ingests data through one or more local files and outputs [`log
 | `glob_minimum_cooldown` | `int` | Delay between file discovery calls. This controls the interval at which Vector searches for files. See [Auto Discovery](#auto-discovery) and [Globbing](#globbing) for more info.<br />`default: 1000` `unit: milliseconds` |
 | `ignore_older` | `int` | Ignore files with a data modification date that does not exceed this age. See [File Rotation](#file-rotation) for more info.<br />`no default` `example: 86400` `unit: seconds` |
 | `max_line_bytes` | `int` | The maximum number of a bytes a line can contain before being discarded. This protects against malformed lines or tailing incorrect files.<br />`default: 102400` `unit: bytes` |
+| `message_start_indicator` | `string` | When present, Vector will aggregate multiple lines into a single event, using this pattern as the indicator that the previous lines should be flushed and a new event started. The pattern will be matched against entire lines as a regular expression, so remember to anchor as appropriate.<br />`no default` `example: "^(INFO|ERROR)"` |
+| `multi_line_timeout` | `int` | When `message_start_indicator` is present, this sets the amount of time Vector will buffer lines into a single event before flushing, regardless of whether or not it has seen a line indicating the start of a new message.<br />`default: 1000` `unit: milliseconds` |
 | `start_at_beginning` | `bool` | When `true` Vector will read from the beginning of new files, when `false` Vector will only read new data added to the file. See [Read Position](#read-position) for more info.<br />`default: false` |
 | **OPTIONAL** - Context | | |
 | `file_key` | `string` | The key name added to each event with the full path of the file. See [Context](#context) for more info.<br />`default: "file"` |

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -116,6 +116,24 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * unit: bytes
   max_line_bytes = 102400
 
+  # When present, Vector will aggregate multiple lines into a single event, using
+  # this pattern as the indicator that the previous lines should be flushed and a
+  # new event started. The pattern will be matched against entire lines as a
+  # regular expression, so remember to anchor as appropriate.
+  # 
+  # * optional
+  # * no default
+  message_start_indicator = "^(INFO|ERROR)"
+
+  # When `message_start_indicator` is present, this sets the amount of time
+  # Vector will buffer lines into a single event before flushing, regardless of
+  # whether or not it has seen a line indicating the start of a new message.
+  # 
+  # * optional
+  # * default: 1000
+  # * unit: milliseconds
+  multi_line_timeout = 1000
+
   # When `true` Vector will read from the beginning of new files, when `false`
   # Vector will only read new data added to the file.
   # 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -183,8 +183,8 @@ pub fn file_source(
     Box::new(future::lazy(move || {
         info!(message = "Starting file server.", ?include, ?exclude);
 
-        // TODO: channel sizing?
-        let (tx, rx) = futures::sync::mpsc::channel(100); // create channel to send down, wrap agg around rx, forward to out
+        // sizing here is just a guess
+        let (tx, rx) = futures::sync::mpsc::channel(100);
 
         let messages: Box<dyn Stream<Item = (Bytes, String), Error = ()> + Send> =
             if let Some(msi) = message_start_indicator {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -262,7 +262,7 @@ impl<T: Stream<Item = (Bytes, String), Error = ()>> Stream for LineAgg<T> {
                     continue;
                 }
                 Ok(Async::NotReady) => return Ok(Async::NotReady),
-                Err(e) => panic!(e),
+                Err(()) => return Err(()),
             };
 
             if let Some(buffered) = self.buffers.remove(&src) {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -285,7 +285,6 @@ impl<T: Stream<Item = (Bytes, String), Error = ()>> Stream for LineAgg<T> {
                 Ok(Async::Ready(None)) => {
                     // start flushing all existing data, stop polling inner
                     self.draining = Some(self.buffers.drain().map(|(k, v)| (v, k)).collect());
-                    continue;
                 }
                 Ok(Async::NotReady) => {
                     // check for keys that have hit their timeout

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -29,7 +29,7 @@ pub struct FileConfig {
     pub glob_minimum_cooldown: u64, // millis
     pub fingerprinting: FingerprintingConfig,
     pub message_start_indicator: Option<String>,
-    pub multi_line_timeout: Option<u64>, // millis? TODO: decide
+    pub multi_line_timeout: u64, // millis
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -79,7 +79,7 @@ impl Default for FileConfig {
             data_dir: None,
             glob_minimum_cooldown: 1000, // millis
             message_start_indicator: None,
-            multi_line_timeout: None, // millis
+            multi_line_timeout: 1000, // millis
         }
     }
 }
@@ -170,7 +170,7 @@ pub fn file_source(
     let include = config.include.clone();
     let exclude = config.exclude.clone();
     let message_start_indicator = config.message_start_indicator.clone();
-    let multi_line_timeout = config.multi_line_timeout.unwrap_or(1000); // TODO: 1s default?
+    let multi_line_timeout = config.multi_line_timeout;
     Box::new(future::lazy(move || {
         info!(message = "Starting file server.", ?include, ?exclude);
 
@@ -1106,7 +1106,7 @@ mod tests {
         let config = file::FileConfig {
             include: vec![dir.path().join("*")],
             message_start_indicator: Some("INFO".into()),
-            multi_line_timeout: Some(25), // less than 50 in sleep()
+            multi_line_timeout: 25, // less than 50 in sleep()
             ..test_default_file_config(&dir)
         };
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -213,7 +213,7 @@ pub fn file_source(
             let dispatcher = dispatcher;
             dispatcher::with_default(&dispatcher, || {
                 span.in_scope(|| {
-                    file_server.run(tx.sink_map_err(|_| ()), shutdown_rx);
+                    file_server.run(tx.sink_map_err(drop), shutdown_rx);
                 })
             });
         });


### PR DESCRIPTION
Closes #388 

This provides a mechanism in the file source for aggregating multiple lines from a given file into a single event. The user provides a `message_start_indicator`, which is a regex that we match against each line from the underlying file tailer. If the regex matches, we consider that line the beginning of a new event. If it doesn't, we add that line to a buffer keyed on the file name the line was read from. We also provide a timeout to prevent data from buffering indefinitely.

For example, if you set `message_start_indicator` to `^INFO`, the following would result in two events instead of five:

```
INFO 2019-08-21T10:29:34.971Z UTC Exception in thread "main" java.lang.NullPointerException
        at com.example.foo.Bar.getTitle(Bar.java:16)
        at com.example.foo.Baz.getBarTitles(Baz.java:25)
        at com.example.foo.Boot.main(Boot.java:14)
INFO 2019-08-21T10:29:35.156Z UTC starting download of /my/file.gz
```

I went back and forth a few times on the best way to implement this (see comment [here](https://github.com/timberio/vector/issues/388#issuecomment-524138026)). In the end, I went with the stream adapter because it was much less invasive to the underlying file source and gave good options for flushing on close, timeouts, etc. With some additional work to make it more generic, it can also be reused for other sources.