### PR TITLE
feat(file source): favor older files and allow configuring greedier reads

### DIFF
--- a/.metadata.toml
+++ b/.metadata.toml
@@ -189,6 +189,28 @@ will buffer lines into a single event before flushing, regardless of whether \
 or not it has seen a line indicating the start of a new message.\
 """
 
+[sources.file.options.max_read_bytes]
+type = "int"
+default = 2048
+null = true
+unit = "bytes"
+description = """\
+An approximate limit on the amount of data read from a single file at a given \
+time.\
+"""
+
+[sources.file.options.oldest_first]
+type = "bool"
+default = false
+null = true
+description = """\
+By default, the file source will try to share read capacity fairly between all \
+the files that it is currently tailing. Depending on your file rotation \
+strategy, log file organization, and throughput patterns, it could be better \
+for the file source to focus on draining the oldest files it's aware of before \
+moving on to read data from younger files. This flag enables that behavior.\
+"""
+
 # ------------------------------------------------------------------------------
 # sources.journald
 # ------------------------------------------------------------------------------

--- a/.metadata.toml
+++ b/.metadata.toml
@@ -204,11 +204,8 @@ type = "bool"
 default = false
 null = true
 description = """\
-By default, the file source will try to share read capacity fairly between all \
-the files that it is currently tailing. Depending on your file rotation \
-strategy, log file organization, and throughput patterns, it could be better \
-for the file source to focus on draining the oldest files it's aware of before \
-moving on to read data from younger files. This flag enables that behavior.\
+Instead of balancing read capacity fairly across all watched files, prioritize \
+draining the oldest files before moving on to read data from younger files.\
 """
 
 # ------------------------------------------------------------------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "scan_fmt 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -96,6 +96,14 @@
   # * unit: bytes
   max_line_bytes = 102400
 
+  # An approximate limit on the amount of data read from a single file at a given
+  # time.
+  # 
+  # * optional
+  # * default: 2048
+  # * unit: bytes
+  max_read_bytes = 2048
+
   # When present, Vector will aggregate multiple lines into a single event, using
   # this pattern as the indicator that the previous lines should be flushed and a
   # new event started. The pattern will be matched against entire lines as a
@@ -113,6 +121,17 @@
   # * default: 1000
   # * unit: milliseconds
   multi_line_timeout = 1000
+
+  # By default, the file source will try to share read capacity fairly between
+  # all the files that it is currently tailing. Depending on your file rotation
+  # strategy, log file organization, and throughput patterns, it could be better
+  # for the file source to focus on draining the oldest files it's aware of
+  # before moving on to read data from younger files. This flag enables that
+  # behavior.
+  # 
+  # * optional
+  # * default: false
+  oldest_first = false
 
   # When `true` Vector will read from the beginning of new files, when `false`
   # Vector will only read new data added to the file.

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -122,12 +122,9 @@
   # * unit: milliseconds
   multi_line_timeout = 1000
 
-  # By default, the file source will try to share read capacity fairly between
-  # all the files that it is currently tailing. Depending on your file rotation
-  # strategy, log file organization, and throughput patterns, it could be better
-  # for the file source to focus on draining the oldest files it's aware of
-  # before moving on to read data from younger files. This flag enables that
-  # behavior.
+  # Instead of balancing read capacity fairly across all watched files,
+  # prioritize draining the oldest files before moving on to read data from
+  # younger files.
   # 
   # * optional
   # * default: false

--- a/docs/usage/configuration/sources/file.md
+++ b/docs/usage/configuration/sources/file.md
@@ -40,8 +40,10 @@ The `file` source ingests data through one or more local files and outputs [`log
   glob_minimum_cooldown = 1000 # default, milliseconds
   ignore_older = 86400 # no default, seconds
   max_line_bytes = 102400 # default, bytes
+  max_read_bytes = 2048 # default, bytes
   message_start_indicator = "^(INFO|ERROR)" # no default
   multi_line_timeout = 1000 # default, milliseconds
+  oldest_first = false # default
   start_at_beginning = false # default
   
   # OPTIONAL - Context
@@ -68,8 +70,10 @@ The `file` source ingests data through one or more local files and outputs [`log
   glob_minimum_cooldown = <int>
   ignore_older = <int>
   max_line_bytes = <int>
+  max_read_bytes = <int>
   message_start_indicator = "<string>"
   multi_line_timeout = <int>
+  oldest_first = <bool>
   start_at_beginning = <bool>
 
   # OPTIONAL - Context
@@ -141,6 +145,14 @@ The `file` source ingests data through one or more local files and outputs [`log
   # * unit: bytes
   max_line_bytes = 102400
 
+  # An approximate limit on the amount of data read from a single file at a given
+  # time.
+  # 
+  # * optional
+  # * default: 2048
+  # * unit: bytes
+  max_read_bytes = 2048
+
   # When present, Vector will aggregate multiple lines into a single event, using
   # this pattern as the indicator that the previous lines should be flushed and a
   # new event started. The pattern will be matched against entire lines as a
@@ -158,6 +170,17 @@ The `file` source ingests data through one or more local files and outputs [`log
   # * default: 1000
   # * unit: milliseconds
   multi_line_timeout = 1000
+
+  # By default, the file source will try to share read capacity fairly between
+  # all the files that it is currently tailing. Depending on your file rotation
+  # strategy, log file organization, and throughput patterns, it could be better
+  # for the file source to focus on draining the oldest files it's aware of
+  # before moving on to read data from younger files. This flag enables that
+  # behavior.
+  # 
+  # * optional
+  # * default: false
+  oldest_first = false
 
   # When `true` Vector will read from the beginning of new files, when `false`
   # Vector will only read new data added to the file.
@@ -229,8 +252,10 @@ The `file` source ingests data through one or more local files and outputs [`log
 | `glob_minimum_cooldown` | `int` | Delay between file discovery calls. This controls the interval at which Vector searches for files. See [Auto Discovery](#auto-discovery) and [Globbing](#globbing) for more info.<br />`default: 1000` `unit: milliseconds` |
 | `ignore_older` | `int` | Ignore files with a data modification date that does not exceed this age. See [File Rotation](#file-rotation) for more info.<br />`no default` `example: 86400` `unit: seconds` |
 | `max_line_bytes` | `int` | The maximum number of a bytes a line can contain before being discarded. This protects against malformed lines or tailing incorrect files.<br />`default: 102400` `unit: bytes` |
+| `max_read_bytes` | `int` | An approximate limit on the amount of data read from a single file at a given time.<br />`default: 2048` `unit: bytes` |
 | `message_start_indicator` | `string` | When present, Vector will aggregate multiple lines into a single event, using this pattern as the indicator that the previous lines should be flushed and a new event started. The pattern will be matched against entire lines as a regular expression, so remember to anchor as appropriate.<br />`no default` `example: "^(INFO\|ERROR)"` |
 | `multi_line_timeout` | `int` | When `message_start_indicator` is present, this sets the amount of time Vector will buffer lines into a single event before flushing, regardless of whether or not it has seen a line indicating the start of a new message.<br />`default: 1000` `unit: milliseconds` |
+| `oldest_first` | `bool` | By default, the file source will try to share read capacity fairly between all the files that it is currently tailing. Depending on your file rotation strategy, log file organization, and throughput patterns, it could be better for the file source to focus on draining the oldest files it's aware of before moving on to read data from younger files. This flag enables that behavior.<br />`default: false` |
 | `start_at_beginning` | `bool` | When `true` Vector will read from the beginning of new files, when `false` Vector will only read new data added to the file. See [Read Position](#read-position) for more info.<br />`default: false` |
 | **OPTIONAL** - Context | | |
 | `file_key` | `string` | The key name added to each event with the full path of the file. See [Context](#context) for more info.<br />`default: "file"` |

--- a/docs/usage/configuration/sources/file.md
+++ b/docs/usage/configuration/sources/file.md
@@ -171,12 +171,9 @@ The `file` source ingests data through one or more local files and outputs [`log
   # * unit: milliseconds
   multi_line_timeout = 1000
 
-  # By default, the file source will try to share read capacity fairly between
-  # all the files that it is currently tailing. Depending on your file rotation
-  # strategy, log file organization, and throughput patterns, it could be better
-  # for the file source to focus on draining the oldest files it's aware of
-  # before moving on to read data from younger files. This flag enables that
-  # behavior.
+  # Instead of balancing read capacity fairly across all watched files,
+  # prioritize draining the oldest files before moving on to read data from
+  # younger files.
   # 
   # * optional
   # * default: false
@@ -246,16 +243,16 @@ The `file` source ingests data through one or more local files and outputs [`log
 | **REQUIRED** - General | | |
 | `type` | `string` | The component type<br />`required` `must be: "file"` |
 | `exclude` | `[string]` | Array of file patterns to exclude. [Globbing](#globbing) is supported. *Takes precedence over the `include` option.*<br />`required` `example: ["/var/log/nginx/access.log"]` |
-| `include` | `[string]` | Array of file patterns to include. [Globbing](#globbing) is supported.<br />`required` `example: ["/var/log/nginx/*.log"]` |
+| `include` | `[string]` | Array of file patterns to include. [Globbing](#globbing) is supported. See [File Read Order](#file-read-order) and [File Rotation](#file-rotation) for more info.<br />`required` `example: ["/var/log/nginx/*.log"]` |
 | **OPTIONAL** - General | | |
 | `data_dir` | `string` | The directory used to persist file checkpoint positions. By default, the global `data_dir` is used. Please make sure the Vector project has write permissions to this dir. See [Checkpointing](#checkpointing) for more info.<br />`no default` `example: "/var/lib/vector"` |
 | `glob_minimum_cooldown` | `int` | Delay between file discovery calls. This controls the interval at which Vector searches for files. See [Auto Discovery](#auto-discovery) and [Globbing](#globbing) for more info.<br />`default: 1000` `unit: milliseconds` |
-| `ignore_older` | `int` | Ignore files with a data modification date that does not exceed this age. See [File Rotation](#file-rotation) for more info.<br />`no default` `example: 86400` `unit: seconds` |
+| `ignore_older` | `int` | Ignore files with a data modification date that does not exceed this age.<br />`no default` `example: 86400` `unit: seconds` |
 | `max_line_bytes` | `int` | The maximum number of a bytes a line can contain before being discarded. This protects against malformed lines or tailing incorrect files.<br />`default: 102400` `unit: bytes` |
 | `max_read_bytes` | `int` | An approximate limit on the amount of data read from a single file at a given time.<br />`default: 2048` `unit: bytes` |
 | `message_start_indicator` | `string` | When present, Vector will aggregate multiple lines into a single event, using this pattern as the indicator that the previous lines should be flushed and a new event started. The pattern will be matched against entire lines as a regular expression, so remember to anchor as appropriate.<br />`no default` `example: "^(INFO\|ERROR)"` |
 | `multi_line_timeout` | `int` | When `message_start_indicator` is present, this sets the amount of time Vector will buffer lines into a single event before flushing, regardless of whether or not it has seen a line indicating the start of a new message.<br />`default: 1000` `unit: milliseconds` |
-| `oldest_first` | `bool` | By default, the file source will try to share read capacity fairly between all the files that it is currently tailing. Depending on your file rotation strategy, log file organization, and throughput patterns, it could be better for the file source to focus on draining the oldest files it's aware of before moving on to read data from younger files. This flag enables that behavior.<br />`default: false` |
+| `oldest_first` | `bool` | Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from younger files. See [File Read Order](#file-read-order) for more info.<br />`default: false` |
 | `start_at_beginning` | `bool` | When `true` Vector will read from the beginning of new files, when `false` Vector will only read new data added to the file. See [Read Position](#read-position) for more info.<br />`default: false` |
 | **OPTIONAL** - Context | | |
 | `file_key` | `string` | The key name added to each event with the full path of the file. See [Context](#context) for more info.<br />`default: "file"` |
@@ -302,11 +299,11 @@ context. You can further parse the `"message"` key with a
 ### Auto Discovery
 
 Vector will continually look for new files matching any of your include
-patterns. The frequency is controlled via the `glob_minimum_cooldown` option. 
+patterns. The frequency is controlled via the `glob_minimum_cooldown` option.
 If a new file is added that matches any of the supplied patterns, Vector will
 begin tailing it. Vector maintains a unique list of files and will not tail a
 file more than once, even if it matches multiple patterns. You can read more
-about how we identify file in the [Identification](#file-identification)
+about how we identify files in the [Identification](#file-identification)
 section.
 
 ### Checkpointing
@@ -338,10 +335,11 @@ will be replaced before being evaluated.
 You can learn more in the [Environment Variables][docs.configuration.environment-variables]
 section.
 
-### File Deletions
+### File Deletion
 
-If a file is deleted Vector will flush the current buffer and stop tailing
-the file.
+When a watched file is deleted, Vector will maintain its open file handle and
+continue reading until it reaches EOF. When a file is no longer findable in the
+`includes` glob and the reader has reached EOF, that file's reader is discarded.
 
 ### File Identification
 
@@ -352,24 +350,56 @@ controlled via the `fingerprint_bytes` and `ignored_header_bytes` options.
 
 This strategy avoids the common pitfalls of using device and inode names since
 inode names can be reused across files. This enables Vector to [properly tail
-files in the event of rotation][docs.correctness].
+files across various rotation strategies][docs.correctness].
+
+### File Read Order
+
+By default, Vector attempts to allocate its read bandwidth fairly across all of
+the files it's currently watching. This prevents a single very busy file from
+starving other independent files from being read. In certain situations,
+however, this can lead to interleaved reads from files that should be read one
+after the other.
+
+For example, consider a service that logs to timestamped file, creating
+a new one at an interval and leaving the old one as-is. Under normal operation,
+Vector would follow writes as they happen to each file and there would be no
+interleaving. In an overload situation, however, Vector may pick up and begin
+tailing newer files before catching up to the latest writes from older files.
+This would cause writes from a single logical log stream to be interleaved in
+time and potentially slow down ingestion as a whole, since the fixed total read
+bandwidth is allocated across an increasing number of files.
+
+To address this type of situation, Vector provides the `oldest_first` flag. When
+set, Vector will not read from any file younger than the oldest file that it
+hasn't yet caught up to. In other words, Vector will continue reading from older
+files as long as there is more data to read. Only once it hits the end will it
+then move on to read from younger files.
+
+Whether or not to use the `oldest_first` flag depends on the organization of the
+logs you're configuring Vector to tail. If your `include` glob contains multiple
+independent logical log streams (e.g. nginx's `access.log` and `error.log`, or
+logs from multiple services), you are likely better off with the default
+behavior. If you're dealing with a single logical log stream or if you value
+per-stream ordering over fairness across streams, consider setting
+`oldest_first` to `true`.
 
 ### File Rotation
 
-Vector will follow files across rotations in the manner of tail, and because of
-the way Vector [identifies files](#file-identification), Vector will properly
-recognize newly rotated files regardless if you are using `copytruncate` or
-`create` directive. To ensure Vector handles rotated files properly we
-recommend:
+Vector supports tailing across a number of file rotation strategies. The default
+behavior of `logrotate` is simply to move the old log file and create a new one.
+This requires no special configuration of Vector, as it will maintain its open
+file handle to the rotated log until it has finished reading and it will find
+the newly created file normally.
 
-1. Ensure the `includes` paths include rotated files. For example, use
-   `/var/log/nginx*.log` to recognize `/var/log/nginx.2.log`.
-2. Use either the `copytruncate` or `create` directives when rotating files.
-   If historical data is compressed, or altered in any way, Vector will not be
-   able to properly identify the file.
-3. Only delete files when they have exceeded the `ignore_older` age. While
-   extremely rare, this ensures you do not delete data before Vector has a
-   chance to ingest it.
+A popular alternative strategy is `copytruncate`, in which `logrotate` will copy
+the old log file to a new location before truncating the original. Vector will
+also handle this well out of the box, but there are a couple configuration options
+that will help reduce the very small chance of missed data in some edge cases.
+We recommend a combination of `delaycompress` (if applicable) on the logrotate
+side and including the first rotated file in Vector's `include` option. This
+allows Vector to find the file after rotation, read it uncompressed to identify
+it, and then ensure it has all of the data, including any written in a gap
+between Vector's last read and the actual rotation event.
 
 ### Globbing
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -116,6 +116,14 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * unit: bytes
   max_line_bytes = 102400
 
+  # An approximate limit on the amount of data read from a single file at a given
+  # time.
+  # 
+  # * optional
+  # * default: 2048
+  # * unit: bytes
+  max_read_bytes = 2048
+
   # When present, Vector will aggregate multiple lines into a single event, using
   # this pattern as the indicator that the previous lines should be flushed and a
   # new event started. The pattern will be matched against entire lines as a
@@ -133,6 +141,17 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * default: 1000
   # * unit: milliseconds
   multi_line_timeout = 1000
+
+  # By default, the file source will try to share read capacity fairly between
+  # all the files that it is currently tailing. Depending on your file rotation
+  # strategy, log file organization, and throughput patterns, it could be better
+  # for the file source to focus on draining the oldest files it's aware of
+  # before moving on to read data from younger files. This flag enables that
+  # behavior.
+  # 
+  # * optional
+  # * default: false
+  oldest_first = false
 
   # When `true` Vector will read from the beginning of new files, when `false`
   # Vector will only read new data added to the file.

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -142,12 +142,9 @@ Vector package installs, generally located at `/etc/vector/vector.spec.yml`:
   # * unit: milliseconds
   multi_line_timeout = 1000
 
-  # By default, the file source will try to share read capacity fairly between
-  # all the files that it is currently tailing. Depending on your file rotation
-  # strategy, log file organization, and throughput patterns, it could be better
-  # for the file source to focus on draining the oldest files it's aware of
-  # before moving on to read data from younger files. This flag enables that
-  # behavior.
+  # Instead of balancing read capacity fairly across all watched files,
+  # prioritize draining the oldest files before moving on to read data from
+  # younger files.
   # 
   # * optional
   # * default: false

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.1.25"
 glob = "0.2.11"
 scan_fmt = "0.2.3"
 tracing = "0.1.2"
+indexmap = {version = "1.0.2", features = ["serde-1"]}
 
 [dev-dependencies]
 quickcheck = "0.6"

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -2,6 +2,7 @@ use crate::{file_watcher::FileWatcher, FileFingerprint, FilePosition};
 use bytes::Bytes;
 use futures::{stream, Future, Sink, Stream};
 use glob::{glob, Pattern};
+use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Read, Seek, Write};
@@ -55,7 +56,7 @@ impl FileServer {
         let mut line_buffer = Vec::new();
         let mut fingerprint_buffer = Vec::new();
 
-        let mut fp_map: HashMap<FileFingerprint, FileWatcher> = Default::default();
+        let mut fp_map: IndexMap<FileFingerprint, FileWatcher> = Default::default();
 
         let mut backoff_cap: usize = 1;
         let mut lines = Vec::new();

--- a/scripts/generate/templates/docs/usage/configuration/sources/file.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/sources/file.md.erb
@@ -49,11 +49,11 @@ context. You can further parse the `"message"` key with a
 ### Auto Discovery
 
 Vector will continually look for new files matching any of your include
-patterns. The frequency is controlled via the `glob_minimum_cooldown` option. 
+patterns. The frequency is controlled via the `glob_minimum_cooldown` option.
 If a new file is added that matches any of the supplied patterns, Vector will
 begin tailing it. Vector maintains a unique list of files and will not tail a
 file more than once, even if it matches multiple patterns. You can read more
-about how we identify file in the [Identification](#file-identification)
+about how we identify files in the [Identification](#file-identification)
 section.
 
 ### Checkpointing
@@ -65,10 +65,23 @@ the data directory which is specified via the
 [global `data_dir` option][docs.configuration.data-directory] but can be
 overridden via the `data_dir` option in the `file` sink directly.
 
-### File Deletions
+### File Rotation
 
-If a file is deleted Vector will flush the current buffer and stop tailing
-the file.
+Vector supports tailing across a number of file rotation strategies. The default
+behavior of `logrotate` is simply to move the old log file and create a new one.
+This requires no special configuration of Vector, as it will maintain its open
+file handle to the rotated log until it has finished reading and it will find
+the newly created file normally.
+
+A popular alternative strategy is `copytruncate`, in which `logrotate` will copy
+the old log file to a new location before truncating the original. Vector will
+also handle this well out of the box, but there are a couple configuration options
+that will help reduce the very small chance of missed data in some edge cases.
+We recommend a combination of `delaycompress` (if applicable) on the logrotate
+side and including the first rotated file in Vector's `include` option. This
+allows Vector to find the file after rotation, read it uncompressed to identify
+it, and then ensure it has all of the data, including any written in a gap
+between Vector's last read and the actual rotation event.
 
 ### File Identification
 
@@ -79,24 +92,13 @@ controlled via the `fingerprint_bytes` and `ignored_header_bytes` options.
 
 This strategy avoids the common pitfalls of using device and inode names since
 inode names can be reused across files. This enables Vector to [properly tail
-files in the event of rotation][docs.correctness].
+files across various rotation strategies][docs.correctness].
 
-### File Rotation
+### File Deletion
 
-Vector will follow files across rotations in the manner of tail, and because of
-the way Vector [identifies files](#file-identification), Vector will properly
-recognize newly rotated files regardless if you are using `copytruncate` or
-`create` directive. To ensure Vector handles rotated files properly we
-recommend:
-
-1. Ensure the `includes` paths include rotated files. For example, use
-   `/var/log/nginx*.log` to recognize `/var/log/nginx.2.log`.
-2. Use either the `copytruncate` or `create` directives when rotating files.
-   If historical data is compressed, or altered in any way, Vector will not be
-   able to properly identify the file.
-3. Only delete files when they have exceeded the `ignore_older` age. While
-   extremely rare, this ensures you do not delete data before Vector has a
-   chance to ingest it.
+When a watched file is deleted, Vector will maintain its open file handle and
+continue reading until it reaches EOF. When a file is no longer findable in the
+`includes` glob and the reader has reached EOF, that file's reader is discarded.
 
 ### Globbing
 
@@ -116,6 +118,37 @@ the `start_at_beginning` option to `true`.
 
 Previously discovered files will be [checkpointed](#checkpointing), and the
 read position will resume from the last checkpoint.
+
+### File Read Order
+
+By default, Vector attempts to allocate its read bandwidth fairly across all of
+the files it's currently watching. This prevents a single very busy file from
+starving other independent files from being read. In certain situations,
+however, this can lead to interleaved reads from files that should be read one
+after the other.
+
+For example, consider a service that logs to timestamped file, creating
+a new one at an interval and leaving the old one as-is. Under normal operation,
+Vector would follow writes as they happen to each file and there would be no
+interleaving. In an overload situation, however, Vector may pick up and begin
+tailing newer files before catching up to the latest writes from older files.
+This would cause writes from a single logical log stream to be interleaved in
+time and potentially slow down ingestion as a whole, since the fixed total read
+bandwidth is allocated across an increasing number of files.
+
+To address this type of situation, Vector provides the `oldest_first` flag. When
+set, Vector will not read from any file younger than the oldest file that it
+hasn't yet caught up to. In other words, Vector will continue reading from older
+files as long as there is more data to read. Only once it hits the end will it
+then move on to read from younger files.
+
+Whether or not to use the `oldest_first` flag depends on the organization of the
+logs you're configuring Vector to tail. If your `include` glob contains multiple
+independent logical log streams (e.g. nginx's `access.log` and `error.log`, or
+logs from multiple services), you are likely better off with the default
+behavior. If you're dealing with a single logical log stream or if you value
+per-stream ordering over fairness across streams, consider setting
+`oldest_first` to `true`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This is a small experiment for some tweaks that could help the case discussed in #763. It tries to be as noninvasive as possible while still hopefully addressing that use case. 

To recap, the theorized issue is with our "fair" file reading strategy. Right now, we read up to 2kb at a time from each file we're watching, iterating over them in a ~stable but effectively random order (`HashMap::iter`). This prevents one busy file from depriving others of read capacity, but is the opposite of what we want in certain file rotation setups where later files are simply created next to older files. In those cases, we want to prioritize the older file and it's actually better if we ignore the new file until the old one has been processed.

There are three parts to the strategy here, but I've only implemented two so far:

1. Maintain some notion of file age and read from the oldest files first. In this case, we switch from using a `HashMap` to using an `IndexMap` that preserves insertion order. This means that new files that appear while we're running will be read from after files that already existed. It's rough and doesn't account for file age for those that exist at startup, but it's a very minimal change.

2. Expose `max_read_bytes` to the user as an option. This determines how much we read from a single file before moving on to another. It was previously fixed at 2kb, but allowing users to increase it will let us spend more time reading from a single file before continuing to iterate through the rest.

3. TODO: Limit `global_bytes_read` per loop. This would introduce a conditional `break` in the loop over readable files based on the total amount read so far. This would mean that files later in the iteration order could get skipped if earlier files use up the entire read budget. If that limit is equal to `max_read_bytes`, we would exclusively read from the "oldest" file until we catch up (i.e. reach EOF).

The end result is that `max_read_bytes`/`global_bytes_read_limit` essentially gives you a "fairness" ratio and determines the degree to which older files can dominate read capacity over new ones. Using `IndexMap` instead of actually looking at timestamps makes it less precise but it's simpler and still pretty good. We could even check timestamps at startup and do the initial insertion in order if we thought that was worthwhile.

/cc @marcbowes @binarylogic 