### PR TITLE
fix: clean up debian user creation and unit file

### DIFF
--- a/distribution/debian/scripts/preinst
+++ b/distribution/debian/scripts/preinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-adduser --force-badname --system --home /nonexistent --no-create-home --quiet vector || true
+adduser --system --group --no-create-home --quiet vector
 
 mkdir -p /var/lib/vector
-chown -R vector /var/lib/vector
+chown -R vector:vector /var/lib/vector

--- a/distribution/systemd/vector.service
+++ b/distribution/systemd/vector.service
@@ -7,7 +7,7 @@ Requires=network-online.target
 [Service]
 User=vector
 Group=vector
-ExecStart=/opt/vector/bin/vector --config=/etc/vector/vector.toml
+ExecStart=/usr/bin/vector
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=no
 StandardOutput=syslog


### PR DESCRIPTION
Some small fixes and cleanups from setting up the test infrastructure:

1. Remove `--force-badname` and `--home` args from `adduser` call in `preinst`. As far as I can tell, these are not necessary and don't do anything useful for us.
2. Pass `--group` flag to `adduser`. This ensures a `vector` group is created alongside the `vector` user, which is normally disabled by the `--system` flag.
3. Drop `|| true` from the `adduser` call. The command will already exit successfully if the user already exists, so it's already idempotent without this.
4. Add `vector` group to the `chown` of `/var/lib/vector`
5. Set the `ExecStart` to the actual location of the vector binary that [we specify](https://github.com/timberio/vector/blob/089bb5a2a4fbc8fa1522781b0982a9a9ca58e479/Cargo.toml#L20)
6. Drop the `--config` arg from `ExecStart` since we now default that to the same location (#900)