### PR TITLE
fix(config)!: require encoding for console and file sinks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,6 +477,7 @@ jobs:
           name: Verify that the Vector service has started
           command: |
             sleep 5
+            sudo systemctl status vector
             sudo systemctl is-active vector
 
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,7 +477,7 @@ jobs:
           name: Verify that the Vector service has started
           command: |
             sleep 5
-            sudo systemctl status vector
+            sudo systemctl status vector --full
             sudo systemctl is-active vector
 
   #

--- a/.meta/sinks/console.toml
+++ b/.meta/sinks/console.toml
@@ -2,14 +2,14 @@
 buffer = false
 delivery_guarantee = "best_effort"
 egress_method = "streaming"
-encoodings = ["json", "text"]
+encodings = ["json", "text"]
 healthcheck = true
 input_types = ["log", "metric"]
 write_to_description = "[standard output streams][urls.standard_streams], such as `STDOUT` and `STDERR`"
 
 [sinks.console.options.target]
 type = "string"
-defaukt = "stdout"
+default = "stdout"
 null = false
 description = "The [standard stream][urls.standard_streams] to write to."
 

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -50,7 +50,7 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
                     sinks::file::FileSinkConfig {
                         path: output.into(),
                         idle_timeout_secs: None,
-                        encoding: None,
+                        encoding: sinks::file::Encoding::Text,
                     },
                 );
 

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2027,6 +2027,10 @@ end
 
 # Streams `log` and `metric` events to standard output streams, such as `STDOUT` and `STDERR`.
 [sinks.console]
+  #
+  # General
+  #
+
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `console`.
   # 
@@ -2042,20 +2046,33 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The standard stream to write to.
-  # 
-  # * required
-  # * type: string
-  # * enum: "stdout" or "stderr"
-  target = "stdout"
-  target = "stderr"
-
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   # * type: bool
   healthcheck = true
+
+  # The standard stream to write to.
+  # 
+  # * optional
+  # * default: "stdout"
+  # * type: string
+  # * enum: "stdout" or "stderr"
+  target = "stdout"
+  target = "stderr"
+
+  #
+  # requests
+  #
+
+  # The encoding format used to serialize the events before outputting.
+  # 
+  # * required
+  # * type: string
+  # * enum: "json" or "text"
+  encoding = "json"
+  encoding = "text"
 
 # Batches `metric` events to Datadog metrics service using HTTP API.
 [sinks.datadog_metrics]

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -22,5 +22,6 @@ data_dir = "/var/lib/vector"
 
 # Output data
 [sinks.out]
-  inputs = ["in"]
-  type   = "console"
+  inputs   = ["in"]
+  type     = "console"
+  encoding = "text"

--- a/docs/about/data-model/log.md
+++ b/docs/about/data-model/log.md
@@ -258,6 +258,7 @@ remove, or rename fields as desired.
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
+
 [assets.data-model-log]: ../../assets/data-model-log.svg
 [docs.configuration]: ../../usage/configuration
 [docs.data-model]: ../../about/data-model

--- a/docs/usage/configuration/sinks/console.md
+++ b/docs/usage/configuration/sinks/console.md
@@ -23,26 +23,45 @@ The `console` sink [streams](#streaming) [`log`][docs.data-model.log] and [`metr
 {% code-tabs-item title="vector.toml (simple)" %}
 ```coffeescript
 [sinks.my_sink_id]
+  # REQUIRED - General
   type = "console" # must be: "console"
   inputs = ["my-source-id"]
-  target = "stdout" # enum: "stdout" or "stderr"
+  
+  # REQUIRED - requests
+  encoding = "json" # enum: "json" or "text"
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (advanced)" %}
 ```coffeescript
 [sinks.my_sink_id]
-  # REQUIRED
+  # REQUIRED - General
   type = "console" # must be: "console"
   inputs = ["my-source-id"]
-  target = "stdout" # enum: "stdout" or "stderr"
   
-  # OPTIONAL
+  # REQUIRED - requests
+  encoding = "json" # enum: "json" or "text"
+  
+  # OPTIONAL - General
   healthcheck = true # default
+  target = "stdout" # default, enum: "stdout" or "stderr"
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
 ## Options
+
+### encoding
+
+`required` `type: string`
+
+The encoding format used to serialize the events before outputting.
+
+The field is an enumeration and only accepts the following values:
+
+| Value | Description |
+|:------|:------------|
+| `"json"` | Each event is encoded into JSON and the payload is represented as a JSON array. |
+| `"text"` | Each event is encoded into text via the `message` key and the payload is new line delimited. |
 
 ### healthcheck
 
@@ -52,7 +71,7 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
 
 ### target
 
-`required` `type: string`
+`optional` `default: "stdout"` `type: string`
 
 The [standard stream][urls.standard_streams] to write to.
 
@@ -60,7 +79,7 @@ The field is an enumeration and only accepts the following values:
 
 | Value | Description |
 |:------|:------------|
-| `"stdout"` | Output will be written to [STDOUT][urls.stdout] |
+| `"stdout"` *(default)* | Output will be written to [STDOUT][urls.stdout] |
 | `"stderr"` | Output will be written to [STDERR][urls.stderr] |
 
 ## How It Works

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -2047,6 +2047,10 @@ end
 
 # Streams `log` and `metric` events to standard output streams, such as `STDOUT` and `STDERR`.
 [sinks.console]
+  #
+  # General
+  #
+
   # The component type. This is a required field that tells Vector which
   # component to use. The value _must_ be `console`.
   # 
@@ -2062,20 +2066,33 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The standard stream to write to.
-  # 
-  # * required
-  # * type: string
-  # * enum: "stdout" or "stderr"
-  target = "stdout"
-  target = "stderr"
-
   # Enables/disables the sink healthcheck upon start.
   # 
   # * optional
   # * default: true
   # * type: bool
   healthcheck = true
+
+  # The standard stream to write to.
+  # 
+  # * optional
+  # * default: "stdout"
+  # * type: string
+  # * enum: "stdout" or "stderr"
+  target = "stdout"
+  target = "stderr"
+
+  #
+  # requests
+  #
+
+  # The encoding format used to serialize the events before outputting.
+  # 
+  # * required
+  # * type: string
+  # * enum: "json" or "text"
+  encoding = "json"
+  encoding = "text"
 
 # Batches `metric` events to Datadog metrics service using HTTP API.
 [sinks.datadog_metrics]

--- a/docs/usage/configuration/transforms/coercer.md
+++ b/docs/usage/configuration/transforms/coercer.md
@@ -85,7 +85,7 @@ And the following configuration:
 [transforms.<transform-id>.types]
   bytes_in = "int"
   bytes_out = "int"
-  timestamp = "timestamp|%m/%d/%Y:%H:%M:%S %z"
+  timestamp = "timestamp|%d/%m/%Y:%H:%M:%S %z"
   status = "int"
 ```
 {% endcode-tabs-item %}

--- a/docs/usage/configuration/transforms/regex_parser.md
+++ b/docs/usage/configuration/transforms/regex_parser.md
@@ -121,7 +121,7 @@ And the following configuration:
 
 [transforms.<transform-id>.types]
   bytes_int = "int"
-  timestamp = "timestamp|%m/%d/%Y:%H:%M:%S %z"
+  timestamp = "timestamp|%d/%m/%Y:%H:%M:%S %z"
   status = "int"
   bytes_out = "int"
 ```

--- a/scripts/generate/templates/docs/usage/configuration/transforms/coercer.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/coercer.md.erb
@@ -42,7 +42,7 @@ And the following configuration:
 [transforms.<transform-id>.types]
   bytes_in = "int"
   bytes_out = "int"
-  timestamp = "timestamp|%m/%d/%Y:%H:%M:%S %z"
+  timestamp = "timestamp|%d/%m/%Y:%H:%M:%S %z"
   status = "int"
 ```
 {% endcode-tabs-item %}

--- a/scripts/generate/templates/docs/usage/configuration/transforms/regex_parser.md.erb
+++ b/scripts/generate/templates/docs/usage/configuration/transforms/regex_parser.md.erb
@@ -36,7 +36,7 @@ And the following configuration:
 
 [transforms.<transform-id>.types]
   bytes_int = "int"
-  timestamp = "timestamp|%m/%d/%Y:%H:%M:%S %z"
+  timestamp = "timestamp|%d/%m/%Y:%H:%M:%S %z"
   status = "int"
   bytes_out = "int"
 ```

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -94,10 +94,6 @@ impl LogEvent {
         self.fields.remove(key).map(|v| v.value)
     }
 
-    pub fn is_structured(&self) -> bool {
-        self.fields.iter().any(|(_, v)| v.explicit)
-    }
-
     pub fn insert_explicit(&mut self, key: Atom, value: ValueKind) {
         self.fields.insert(
             key,

--- a/src/sinks/file/file.rs
+++ b/src/sinks/file/file.rs
@@ -12,7 +12,7 @@ const BACKPRESSURE_BOUNDARY: usize = INITIAL_CAPACITY;
 #[derive(Debug)]
 pub struct File {
     state: State,
-    encoding: Option<Encoding>,
+    encoding: Encoding,
     buffer: BytesMut,
     codec: BytesDelimitedCodec,
 }
@@ -25,7 +25,7 @@ enum State {
 }
 
 impl File {
-    pub fn new(path: Bytes, encoding: Option<Encoding>) -> Self {
+    pub fn new(path: Bytes, encoding: Encoding) -> Self {
         let path = BytesPath(path);
 
         let fut = file::OpenOptions::new()
@@ -48,11 +48,11 @@ impl File {
     fn encode_event(&self, event: Event) -> Bytes {
         let log = event.into_log();
 
-        match (&self.encoding, log.is_structured()) {
-            (&Some(Encoding::Ndjson), _) | (None, true) => serde_json::to_vec(&log.unflatten())
+        match self.encoding {
+            Encoding::Ndjson => serde_json::to_vec(&log.unflatten())
                 .map(Bytes::from)
                 .expect("Unable to encode event as JSON."),
-            (&Some(Encoding::Text), _) | (None, false) => log
+            Encoding::Text => log
                 .get(&event::MESSAGE)
                 .map(|v| v.as_bytes())
                 .unwrap_or(Bytes::new()),
@@ -234,7 +234,7 @@ mod tests {
             .join("test.out");
 
         let b = Bytes::from(path.clone().to_str().unwrap().as_bytes());
-        let sink = File::new(b, Some(encoding));
+        let sink = File::new(b, encoding);
 
         let mut rt = crate::test_util::runtime();
         let pump = sink

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -19,7 +19,7 @@ use tokio::timer::Delay;
 pub struct FileSinkConfig {
     pub path: Template,
     pub idle_timeout_secs: Option<u64>,
-    pub encoding: Option<Encoding>,
+    pub encoding: Encoding,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
@@ -27,6 +27,12 @@ pub struct FileSinkConfig {
 pub enum Encoding {
     Text,
     Ndjson,
+}
+
+impl Default for Encoding {
+    fn default() -> Self {
+        Encoding::Text
+    }
 }
 
 #[typetag::serde(name = "file")]
@@ -51,7 +57,7 @@ impl SinkConfig for FileSinkConfig {
 #[derive(Debug, Default)]
 pub struct PartitionedFileSink {
     path: Template,
-    encoding: Option<Encoding>,
+    encoding: Encoding,
     idle_timeout_secs: u64,
     partitions: HashMap<Bytes, File>,
     last_accessed: HashMap<Bytes, Instant>,
@@ -191,7 +197,7 @@ mod tests {
         let config = FileSinkConfig {
             path: template.clone().into(),
             idle_timeout_secs: None,
-            encoding: None,
+            encoding: Encoding::Text,
         };
 
         let (sink, _) = config.build(Acker::Null).unwrap();
@@ -218,7 +224,7 @@ mod tests {
         let config = FileSinkConfig {
             path: template.clone().into(),
             idle_timeout_secs: None,
-            encoding: None,
+            encoding: Encoding::Text,
         };
 
         let (sink, _) = config.build(Acker::Null).unwrap();

--- a/src/topology/config/mod.rs
+++ b/src/topology/config/mod.rs
@@ -263,6 +263,7 @@ mod test {
       [sinks.out]
       type = "console"
       inputs = ["in"]
+      encoding = "json"
       "#,
         )
         .unwrap();

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -42,10 +42,11 @@ impl Transform for Coercer {
                 match conv.convert(value) {
                     Ok(converted) => log.insert_explicit(field.into(), converted),
                     Err(error) => {
-                        debug!(
+                        warn!(
                             message = "Could not convert types.",
                             field = &field[..],
                             %error,
+                            rate_limit_secs = 10,
                         );
                     }
                 }


### PR DESCRIPTION
Closes #1031 

There were a handful of small-ish issues preventing things from working the way our [coercer guide](https://docs.vector.dev/usage/configuration/transforms/coercer#examples) claims they should:

1. The example timestamp format string didn't match the example data
2. We weren't logging the failure to convert types from (1) at a level that's visible by default
3. We forgot the console and file sinks when fixing #806, so even when (1) and (2) were addressed the console sink wouldn't output the event
4. There were a couple of typos in the config metadata that gave them incorrect docs

This is a breaking change for both the console and file sinks, since the `encoding` field is no longer optional.

## Upgrade guide

1. If you're using the `console` sink add the `encoding` option:

    ```toml
    [sinks.print]
      type = "console"
      encoding = "json" # or text
    ```

2. If you're using the `file` sink add the `encoding` option:

    ```toml
    [sinks.file_out]
      type = "file"
      encoding = "ndjson" # or text
    ```