### PR TITLE
enhancement(lua transform): Allow iterating over event fields

### DIFF
--- a/docs/usage/configuration/transforms/lua.md
+++ b/docs/usage/configuration/transforms/lua.md
@@ -185,6 +185,19 @@ Vector provides a `search_dirs` option that allows you to specify absolute
 paths that will searched when using the [Lua `require`
 function][urls.lua_require].
 
+### Iterate over fields
+
+To iterate over all fields of an `event` use the `pairs` method.  For example:
+
+```lua
+# Remove all fields where the value is "-"
+for f,v in pairs(event) do
+  if v == "-" then
+    event[f] = nil
+  end
+end
+```
+
 ## Troubleshooting
 
 The best place to start with troubleshooting is to check the


### PR DESCRIPTION
Make it possible to use `pairs(event)` to iterate over all fields of an event.

For example:
```lua
# Remove all fields where the value is "-"
for f,v in pairs(event) do
  if v == "-" then
    event[f] = nil
  end
end
```

This code will only compile after rlua takes in kyren/rlua#152 as the `__pairs` meta-method is currently not exposed.

This commit fixes #528.