### PR TITLE
fix(elasticsearch sink): `host` is not required when provider is AWS

### DIFF
--- a/.meta/sinks/elasticsearch.toml
+++ b/.meta/sinks/elasticsearch.toml
@@ -26,8 +26,8 @@ description = "The `doc_type` for your index data. This is only relevant for Ela
 [sinks.elasticsearch.options.host]
 type = "string"
 examples = ["http://10.24.32.122:9000"]
-null = false
-description = "The host of your Elasticsearch cluster. This should be the full URL as shown in the example."
+null = true
+description = """The host of your Elasticsearch cluster. This should be the full URL as shown in the example. This is required if the `provider` is not `"aws"`"""
 
 [sinks.elasticsearch.options.index]
 type = "string"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2233,13 +2233,6 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The host of your Elasticsearch cluster. This should be the full URL as shown
-  # in the example.
-  # 
-  # * required
-  # * type: string
-  host = "http://10.24.32.122:9000"
-
   # The `doc_type` for your index data. This is only relevant for Elasticsearch
   # <= 6.X. If you are using >= 7.0 you do not need to set this option since
   # Elasticsearch has removed it.
@@ -2255,6 +2248,14 @@ end
   # * default: true
   # * type: bool
   healthcheck = true
+
+  # The host of your Elasticsearch cluster. This should be the full URL as shown
+  # in the example. This is required if the `provider` is not `"aws"`
+  # 
+  # * optional
+  # * no default
+  # * type: string
+  host = "http://10.24.32.122:9000"
 
   # Index name to write events to.
   # 

--- a/docs/usage/configuration/sinks/elasticsearch.md
+++ b/docs/usage/configuration/sinks/elasticsearch.md
@@ -32,7 +32,6 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
 [sinks.my_sink_id]
   type = "elasticsearch" # must be: "elasticsearch"
   inputs = ["my-source-id"]
-  host = "http://10.24.32.122:9000"
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="vector.toml (advanced)" %}
@@ -41,11 +40,11 @@ The `elasticsearch` sink [batches](#buffers-and-batches) [`log`][docs.data-model
   # REQUIRED - General
   type = "elasticsearch" # must be: "elasticsearch"
   inputs = ["my-source-id"]
-  host = "http://10.24.32.122:9000"
   
   # OPTIONAL - General
   doc_type = "_doc" # default
   healthcheck = true # default
+  host = "http://10.24.32.122:9000" # no default
   index = "vector-%Y-%m-%d" # default
   provider = "default" # default, enum: "default" or "aws"
   region = "us-east-1" # no default
@@ -196,9 +195,9 @@ Enables/disables the sink healthcheck upon start. See [Health Checks](#health-ch
 
 ### host
 
-`required` `type: string` `example: "http://10.24.32.122:9000"`
+`optional` `no default` `type: string` `example: "http://10.24.32.122:9000"`
 
-The host of your Elasticsearch cluster. This should be the full URL as shown in the example.
+The host of your Elasticsearch cluster. This should be the full URL as shown in the example. This is required if the `provider` is not `"aws"`
 
 ### index
 

--- a/docs/usage/configuration/specification.md
+++ b/docs/usage/configuration/specification.md
@@ -2253,13 +2253,6 @@ end
   # * type: [string]
   inputs = ["my-source-id"]
 
-  # The host of your Elasticsearch cluster. This should be the full URL as shown
-  # in the example.
-  # 
-  # * required
-  # * type: string
-  host = "http://10.24.32.122:9000"
-
   # The `doc_type` for your index data. This is only relevant for Elasticsearch
   # <= 6.X. If you are using >= 7.0 you do not need to set this option since
   # Elasticsearch has removed it.
@@ -2275,6 +2268,14 @@ end
   # * default: true
   # * type: bool
   healthcheck = true
+
+  # The host of your Elasticsearch cluster. This should be the full URL as shown
+  # in the example. This is required if the `provider` is not `"aws"`
+  # 
+  # * optional
+  # * no default
+  # * type: string
+  host = "http://10.24.32.122:9000"
 
   # Index name to write events to.
   # 

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -31,7 +31,7 @@ use tower::ServiceBuilder;
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ElasticSearchConfig {
-    pub host: String,
+    pub host: Option<String>,
     pub index: Option<String>,
     pub doc_type: Option<String>,
     pub id_key: Option<String>,
@@ -68,7 +68,7 @@ pub struct ElasticSearchBasicAuthConfig {
     pub user: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Provider {
     Default,
@@ -99,7 +99,7 @@ impl SinkConfig for ElasticSearchConfig {
 }
 
 struct ElasticSearchCommon {
-    host: String,
+    base_url: String,
     authorization: Option<String>,
     region: Option<Region>,
     credentials: Option<AwsCredentials>,
@@ -110,6 +110,8 @@ struct ElasticSearchCommon {
 enum ParseError {
     #[snafu(display("Invalid host {:?}: {:?}", host, source))]
     InvalidHost { host: String, source: InvalidUri },
+    #[snafu(display("Default provider requires a configured host"))]
+    DefaultRequiresHost,
     #[snafu(display("AWS provider requires a configured region"))]
     AWSRequiresRegion,
     #[snafu(display("Could not create AWS credentials provider: {:?}", source))]
@@ -120,12 +122,6 @@ enum ParseError {
 
 impl ElasticSearchCommon {
     fn parse_config(config: &ElasticSearchConfig) -> crate::Result<Self> {
-        // Test the configured host, but ignore the result
-        let uri = format!("{}/_test", config.host);
-        uri.parse::<Uri>().with_context(|| InvalidHost {
-            host: config.host.clone(),
-        })?;
-
         let authorization = config.basic_auth.as_ref().map(|auth| {
             let token = format!("{}:{}", auth.user, auth.password);
             format!("Basic {}", base64::encode(token.as_bytes()))
@@ -137,13 +133,35 @@ impl ElasticSearchCommon {
             Err(error) => return Err(error.into()),
         };
 
-        let credentials = match config.provider.as_ref().unwrap_or(&Provider::Default) {
+        let provider = config.provider.unwrap_or(Provider::Default);
+
+        let base_url = match provider {
+            Provider::Default => match config.host {
+                Some(ref host) => host.clone(),
+                None => return Err(ParseError::DefaultRequiresHost.into()),
+            },
+            Provider::Aws => match region {
+                None => return Err(ParseError::AWSRequiresRegion.into()),
+                Some(ref region) => match region {
+                    // Adapted from rusoto_core::signature::build_hostname, which is unfortunately not pub
+                    Region::Custom { endpoint, .. } if endpoint.contains("://") => endpoint.clone(),
+                    Region::Custom { endpoint, .. } => format!("https://{}", endpoint),
+                    Region::CnNorth1 | Region::CnNorthwest1 => {
+                        format!("https://es.{}.amazonaws.com.cn", region.name())
+                    }
+                    _ => format!("https://es.{}.amazonaws.com", region.name()),
+                },
+            },
+        };
+
+        // Test the configured host, but ignore the result
+        let uri = format!("{}/_test", base_url);
+        uri.parse::<Uri>()
+            .with_context(|| InvalidHost { host: &base_url })?;
+
+        let credentials = match provider {
             Provider::Default => None,
             Provider::Aws => {
-                if region.is_none() {
-                    return Err(ParseError::AWSRequiresRegion.into());
-                }
-
                 let provider =
                     DefaultCredentialsProvider::new().context(AWSCredentialsProviderFailed)?;
 
@@ -160,7 +178,7 @@ impl ElasticSearchCommon {
         let tls_settings = TlsSettings::from_options(&config.tls)?;
 
         Ok(Self {
-            host: config.host.clone(),
+            base_url,
             authorization,
             region,
             credentials,
@@ -169,7 +187,7 @@ impl ElasticSearchCommon {
     }
 
     fn request_builder(&self, method: Method, path: &str) -> (Uri, http::request::Builder) {
-        let uri = format!("{}{}", self.host, path);
+        let uri = format!("{}{}", self.base_url, path);
         let uri = uri.parse::<Uri>().unwrap(); // Already tested that this parses above.
         let mut builder = Request::builder();
         builder.method(method);
@@ -392,7 +410,7 @@ fn maybe_set_id(key: Option<impl AsRef<str>>, doc: &mut serde_json::Value, event
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Event;
+    use crate::{assert_downcast_matches, Event};
     use serde_json::json;
 
     #[test]
@@ -437,15 +455,52 @@ mod tests {
         assert_eq!(json!({}), action);
     }
 
+    fn parse_config(input: &str) -> crate::Result<ElasticSearchCommon> {
+        let config: ElasticSearchConfig = toml::from_str(input).unwrap();
+        ElasticSearchCommon::parse_config(&config)
+    }
+
+    fn parse_config_err(input: &str) -> crate::Error {
+        // ElasticSearchCommon doesn't impl Debug, so can't just unwrap_err
+        match parse_config(input) {
+            Ok(_) => panic!("Mis-parsed invalid config"),
+            Err(err) => err,
+        }
+    }
+
+    #[test]
+    fn host_is_required_for_default() {
+        let err = parse_config_err(r#"provider = "default""#);
+        assert_downcast_matches!(err, ParseError, ParseError::DefaultRequiresHost);
+    }
+
+    #[test]
+    fn host_is_not_required_for_aws() {
+        let result = parse_config(
+            r#"
+                provider = "aws"
+                region = "us-east-1"
+            "#,
+        );
+        // If not running in an AWS context, this will fail with a
+        // credentials error, but that is valid too.
+        match result {
+            Ok(_) => (),
+            Err(err) => assert_downcast_matches!(err, ParseError, ParseError::AWSCredentialsGenerateFailed { .. }),
+        }
+    }
+
     #[test]
     fn region_is_not_required_for_default() {
-        let input = r#"
-            host = "https://example.com"
-        "#;
+        let common = parse_config(r#"host = "https://example.com""#).unwrap();
 
-        let config: ElasticSearchConfig = toml::from_str(input).unwrap();
-        let common = ElasticSearchCommon::parse_config(&config).unwrap();
         assert_eq!(None, common.region);
+    }
+
+    #[test]
+    fn region_is_required_for_aws() {
+        let err = parse_config_err(r#"provider = "aws""#);
+        assert_downcast_matches!(err, ParseError, ParseError::AWSRequiresRegion { .. });
     }
 }
 
@@ -472,13 +527,14 @@ mod integration_tests {
     fn structures_events_correctly() {
         let index = gen_index();
         let config = ElasticSearchConfig {
-            host: "http://localhost:9200".into(),
+            host: Some("http://localhost:9200".into()),
             index: Some(index.clone()),
             doc_type: Some("log_lines".into()),
             id_key: Some("my_id".into()),
             compression: Some(Compression::None),
             ..config()
         };
+        let common = ElasticSearchCommon::parse_config(&config).expect("Config error");
 
         let (sink, _hc) = config.build(Acker::Null).unwrap();
 
@@ -494,10 +550,10 @@ mod integration_tests {
         block_on(pump).unwrap();
 
         // make sure writes all all visible
-        block_on(flush(&config)).unwrap();
+        block_on(flush(&common)).unwrap();
 
         let response = reqwest::Client::new()
-            .get(&format!("{}/{}/_search", config.host, index))
+            .get(&format!("{}/{}/_search", common.base_url, index))
             .json(&json!({
                 "query": { "query_string": { "query": "*" } }
             }))
@@ -527,7 +583,7 @@ mod integration_tests {
     #[test]
     fn insert_events_over_http() {
         run_insert_tests(ElasticSearchConfig {
-            host: "http://localhost:9200".into(),
+            host: Some("http://localhost:9200".into()),
             doc_type: Some("log_lines".into()),
             compression: Some(Compression::None),
             ..config()
@@ -537,7 +593,7 @@ mod integration_tests {
     #[test]
     fn insert_events_over_https() {
         run_insert_tests(ElasticSearchConfig {
-            host: "https://localhost:9201".into(),
+            host: Some("https://localhost:9201".into()),
             doc_type: Some("log_lines".into()),
             compression: Some(Compression::None),
             tls: Some(TlsOptions {
@@ -550,11 +606,9 @@ mod integration_tests {
 
     #[test]
     fn insert_events_on_aws() {
-        let url = "http://localhost:4571";
         run_insert_tests(ElasticSearchConfig {
-            host: url.into(),
             provider: Some(Provider::Aws),
-            region: RegionOrEndpoint::with_endpoint(url.into()),
+            region: RegionOrEndpoint::with_endpoint("http://localhost:4571".into()),
             ..config()
         });
     }
@@ -562,6 +616,7 @@ mod integration_tests {
     fn run_insert_tests(mut config: ElasticSearchConfig) {
         let index = gen_index();
         config.index = Some(index.clone());
+        let common = ElasticSearchCommon::parse_config(&config).expect("Config error");
 
         let (sink, healthcheck) = config.build(Acker::Null).expect("Building config failed");
 
@@ -573,7 +628,7 @@ mod integration_tests {
         let _ = block_on(pump).expect("Sending events failed");
 
         // make sure writes all all visible
-        block_on(flush(&config)).expect("Flushing writes failed");
+        block_on(flush(&common)).expect("Flushing writes failed");
 
         let mut test_ca = Vec::<u8>::new();
         File::open("tests/data/Vector_CA.crt")
@@ -588,7 +643,7 @@ mod integration_tests {
             .expect("Could not build HTTP client");
 
         let response = client
-            .get(&format!("{}/{}/_search", config.host, index))
+            .get(&format!("{}/{}/_search", common.base_url, index))
             .json(&json!({
                 "query": { "query_string": { "query": "*" } }
             }))
@@ -612,12 +667,11 @@ mod integration_tests {
         format!("test-{}", random_string(10).to_lowercase())
     }
 
-    fn flush(config: &ElasticSearchConfig) -> impl Future<Item = (), Error = crate::Error> {
-        let uri = format!("{}/_flush", config.host);
+    fn flush(common: &ElasticSearchCommon) -> impl Future<Item = (), Error = crate::Error> {
+        let uri = format!("{}/_flush", common.base_url);
         let request = Request::post(uri).body(Body::empty()).unwrap();
 
-        let common = ElasticSearchCommon::parse_config(config).expect("Config error");
-        https_client(common.tls_settings)
+        https_client(common.tls_settings.clone())
             .expect("Could not build client to flush")
             .request(request)
             .map_err(|source| dbg!(source).into())

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -438,12 +438,9 @@ mod tests {
     }
 
     #[test]
-    fn region_is_not_required() {
+    fn region_is_not_required_for_default() {
         let input = r#"
             host = "https://example.com"
-            doc_type = "_doc"
-            index = "my-jobs"
-            compression = "none"
         "#;
 
         let config: ElasticSearchConfig = toml::from_str(input).unwrap();


### PR DESCRIPTION
The elasticsearch has a `host` configuration setting that was non-optional, but the AWS provider does not actually require it as it can be worked out from either the region or endpoint settings. This change fixes this extraneous requirement.

Fixes #1162 