### PR TITLE
perf(file source): Backoff reads to inactive files

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -215,6 +215,10 @@ impl FileServer {
             let mut global_bytes_read: usize = 0;
             let mut maxed_out_reading_single_file = false;
             for (&file_id, watcher) in &mut fp_map {
+                if !watcher.should_read() {
+                    continue;
+                }
+
                 let mut bytes_read: usize = 0;
                 while let Ok(sz) = watcher.read_line(&mut line_buffer, self.max_line_bytes) {
                     if sz > 0 {

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -5,7 +5,7 @@ use std::{
     io::{self, BufRead, Seek},
     path::PathBuf,
     thread,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 
 use crate::metadata_ext::PortableMetadataExt;
@@ -25,6 +25,8 @@ pub struct FileWatcher {
     devno: u64,
     inode: u64,
     is_dead: bool,
+    last_read_attempt: Option<Instant>,
+    last_read_success: Option<Instant>,
 }
 
 impl FileWatcher {
@@ -81,6 +83,8 @@ impl FileWatcher {
             devno: metadata.portable_dev(),
             inode: metadata.portable_ino(),
             is_dead: false,
+            last_read_attempt: None,
+            last_read_success: None,
         })
     }
 
@@ -131,17 +135,24 @@ impl FileWatcher {
     ///
     /// This function will attempt to read a new line from its file, blocking,
     /// up to some maximum but unspecified amount of time. `read_line` will open
-    /// a new file handler at need, transparently to the caller.
+    /// a new file handler as needed, transparently to the caller.
     pub fn read_line(&mut self, mut buffer: &mut Vec<u8>, max_size: usize) -> io::Result<usize> {
-        //ensure buffer is re-initialized
+        self.track_read_attempt();
+
+        // ensure buffer is re-initialized
         buffer.clear();
         let reader = &mut self.reader;
         let file_position = &mut self.file_position;
         match read_until_with_max_size(reader, file_position, b'\n', &mut buffer, max_size) {
             Ok(sz) => {
+                if sz > 0 {
+                    self.track_read_success()
+                }
+
                 if sz == 0 && !self.file_findable() {
                     self.set_dead();
                 }
+
                 Ok(sz)
             }
             Err(e) => {
@@ -149,6 +160,26 @@ impl FileWatcher {
                     self.set_dead();
                 }
                 Err(e)
+            }
+        }
+    }
+
+    fn track_read_attempt(&mut self) {
+        self.last_read_attempt = Some(Instant::now());
+    }
+
+    fn track_read_success(&mut self) {
+        self.last_read_success = Some(Instant::now());
+    }
+
+    pub fn should_read(&self) -> bool {
+        match (self.last_read_attempt, self.last_read_success) {
+            (None, None) => true,
+            (None, Some(_)) => panic!("success requires an attempt"),
+            (Some(attempt), None) => attempt.elapsed() > Duration::from_secs(10),
+            (Some(attempt), Some(success)) => {
+                success.elapsed() < Duration::from_secs(10)
+                    || attempt.elapsed() > Duration::from_secs(10)
             }
         }
     }

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -75,6 +75,13 @@ impl FileWatcher {
             (Box::new(reader), pos)
         };
 
+        let ts = metadata
+            .modified()
+            .ok()
+            .and_then(|mtime| mtime.elapsed().ok())
+            .and_then(|diff| Instant::now().checked_sub(diff))
+            .unwrap_or_else(Instant::now);
+
         Ok(FileWatcher {
             path,
             findable: true,
@@ -83,8 +90,8 @@ impl FileWatcher {
             devno: metadata.portable_dev(),
             inode: metadata.portable_ino(),
             is_dead: false,
-            last_read_attempt: Instant::now(),
-            last_read_success: Instant::now(),
+            last_read_attempt: ts.clone(),
+            last_read_success: ts,
         })
     }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1001,7 +1001,7 @@ mod tests {
         let config = file::FileConfig {
             include: vec![dir.path().join("*")],
             start_at_beginning: true,
-            ignore_older: Some(1000),
+            ignore_older: Some(5),
             ..test_default_file_config(&dir)
         };
 
@@ -1019,8 +1019,8 @@ mod tests {
 
         {
             // Set the modified times
-            let before = SystemTime::now() - Duration::from_secs(1010);
-            let after = SystemTime::now() - Duration::from_secs(990);
+            let before = SystemTime::now() - Duration::from_secs(8);
+            let after = SystemTime::now() - Duration::from_secs(2);
 
             let before_time = libc::timeval {
                 tv_sec: before


### PR DESCRIPTION
Ref #1466 

This implements a very simple per-file backoff that will prevent Vector from repeatedly issuing `read`s to files that have not seen activity in a while.

We track both the last read attempt and the last read that returned new data. If we've received new data in the last 10 seconds, we'll do the read. If we haven't received new data, we'll try again only if it's been more than 10 seconds since our last attempt.

These specific durations are chosen pretty arbitrarily, but should effectively move these inactive files out of the hot read loop without creating too large a gap for potentially missed data. I'm open to tightening or loosening them if anyone has opinions one way or the other.