### PR TITLE
enhancement(aws_cloudwatch_logs sink): add assume_role

### DIFF
--- a/.meta/links.toml
+++ b/.meta/links.toml
@@ -24,6 +24,7 @@ aws_cw_metrics_service_limits = "https://docs.aws.amazon.com/en_pv/AmazonCloudWa
 aws_cw_metrics_regions = "https://docs.aws.amazon.com/general/latest/gr/rande.html#cw_region"
 aws_elasticsearch = "https://aws.amazon.com/elasticsearch-service/"
 aws_elasticsearch_regions = "https://docs.aws.amazon.com/general/latest/gr/rande.html#elasticsearch-service-regions"
+aws_iam_role = "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html"
 aws_kinesis_data_streams = "https://aws.amazon.com/kinesis/data-streams/"
 aws_kinesis_data_firehose = "https://aws.amazon.com/kinesis/data-firehose/"
 aws_kinesis_partition_key = "https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecordsRequestEntry.html#Streams-Type-PutRecordsRequestEntry-PartitionKey"

--- a/.meta/sinks/aws_cloudwatch_logs.toml
+++ b/.meta/sinks/aws_cloudwatch_logs.toml
@@ -70,6 +70,13 @@ common = true
 default = true
 description = "Dynamically create a [log stream][urls.aws_cw_logs_stream_name] if it does not already exist."
 
+[sinks.aws_cloudwatch_logs.options.assume_role]
+type = "string"
+common = false
+examples = ["arn:aws:iam::123456789098:role/my_role"]
+required = false
+description = "The ARN of an [IAM role][urls.aws_iam_role] to assume at startup."
+
 [[sinks.aws_cloudwatch_logs.output.examples]]
 label = "Generic"
 body = """\

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,6 +2677,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_sts"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,6 +4175,7 @@ dependencies = [
  "rusoto_kinesis 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_logs 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_sts 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4667,6 +4681,7 @@ dependencies = [
 "checksum rusoto_kinesis 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f88609598b24779b268f47c0d19780cf4865b0cbccd9f677bae75f7f7c5d4dcb"
 "checksum rusoto_logs 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "691f665f2ae401d4fddaac8d6a33c3e7c388e93494242ea937ebdddf9961f7f6"
 "checksum rusoto_s3 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6c840fca030950caf0c9bea89eb35311aa5b01c0341fb0aaf28d347b5c416d7"
+"checksum rusoto_sts 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e8cdff317625611de545e91b80a883a7d6fb1cf2d772f64abaf83c0925fa0ff"
 "checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ rusoto_cloudwatch = "0.41.0"
 rusoto_kinesis = "0.41.0"
 rusoto_credential = "0.41.1"
 rusoto_firehose = "0.41.0"
+rusoto_sts = "0.41.0"
 
 # Tower
 tower = "0.1.1"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1522,6 +1522,13 @@ end
   stream_name = "%Y-%m-%d"
   stream_name = "stream-name"
 
+  # The ARN of an IAM role to assume at startup.
+  #
+  # * optional
+  # * no default
+  # * type: string
+  assume_role = "arn:aws:iam::123456789098:role/my_role"
+
   # Dynamically create a log group if it does not already exist. This will ignore
   # `create_missing_stream` directly after creating the group and will create the
   # first stream.

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -796,7 +796,7 @@ mod integration_tests {
         request.log_group_name = GROUP_NAME.into();
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client = create_client(region, resolver).unwrap();
+        let client = create_client(region, None, resolver).unwrap();
 
         let response = rt.block_on(client.get_log_events(request)).unwrap();
 
@@ -846,7 +846,7 @@ mod integration_tests {
         request.log_group_name = group_name;
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client = create_client(region, resolver).unwrap();
+        let client = create_client(region, None, resolver).unwrap();
 
         let response = rt.block_on(client.get_log_events(request)).unwrap();
 
@@ -901,7 +901,7 @@ mod integration_tests {
         request.log_group_name = group_name.into();
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client = create_client(region, resolver).unwrap();
+        let client = create_client(region, None, resolver).unwrap();
 
         let response = rt.block_on(client.get_log_events(request)).unwrap();
 
@@ -1028,7 +1028,7 @@ mod integration_tests {
         let mut rt = Runtime::single_threaded().unwrap();
         let resolver = Resolver::new(Vec::new(), rt.executor()).unwrap();
 
-        let client = create_client(region, resolver).unwrap();
+        let client = create_client(region, None, resolver).unwrap();
 
         let req = CreateLogGroupRequest {
             log_group_name: GROUP_NAME.into(),

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -927,7 +927,7 @@ mod integration_tests {
             endpoint: "http://localhost:6000".into(),
         };
 
-        let client = create_client(region.clone(), resolver).unwrap();
+        let client = create_client(region.clone(), None, resolver).unwrap();
         ensure_group(region);
 
         let config = CloudwatchLogsSinkConfig {

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -71,6 +71,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
   stream_name = "{{ instance_id }}" # example
 
   # OPTIONAL - General
+  assume_role = "arn:aws:iam::123456789098:role/my_role" # example, no default
   create_missing_group = true # default
   create_missing_stream = true # default
   healthcheck = true # default
@@ -112,6 +113,28 @@ import Fields from '@site/src/components/Fields';
 import Field from '@site/src/components/Field';
 
 <Fields filters={true}>
+
+
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={["arn:aws:iam::123456789098:role/my_role"]}
+  name={"assume_role"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  >
+
+### assume_role
+
+The ARN of an [IAM role][urls.aws_iam_role] to assume at startup.
+
+
+</Field>
 
 
 <Field
@@ -784,5 +807,6 @@ You can read more about the complete syntax in the
 [urls.aws_cw_logs_group_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 [urls.aws_cw_logs_regions]: https://docs.aws.amazon.com/general/latest/gr/rande.html#cwl_region
 [urls.aws_cw_logs_stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+[urls.aws_iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 [urls.new_aws_cloudwatch_logs_sink_issue]: https://github.com/timberio/vector/issues/new?labels=sink%3A+aws_cloudwatch_logs
 [urls.strptime_specifiers]: https://docs.rs/chrono/0.3.1/chrono/format/strftime/index.html


### PR DESCRIPTION
This is a minimal implementation of allowing the Cloudwatch Logs sink to assume a given IAM role at startup. I've tested it manually but couldn't come up with a good-enough-to-be-worth-the-effort automated test.

This would be useful functionality for all our AWS-based components, but we can address that in a follow-up change.