### PR TITLE
fix(journald source): Fix the journalctl start date to work across all timezones

### DIFF
--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -206,7 +206,7 @@ impl JournalSource for Journalctl {
             command.arg(format!("--after-cursor={}", cursor));
         } else {
             // journalctl --follow only outputs a few lines without a starting point
-            command.arg("--since=1970-01-01");
+            command.arg("--since=2000-01-01");
         }
 
         let mut child = command.spawn().context(JournalctlSpawn)?;


### PR DESCRIPTION
When running on a positive timezone, local midnight on 1970-01-01 ends
up being a negative number (in the Unix epoch). This causes journalctl
to flag a fatal error at startup on such systems.

By changing the start time to 2000-01-01, we avoid all timezone issues
while still capturing all longs since the beginning of the journal.

Fixes #1544 

Signed-off-by: Bruce Guenter <bruce@timber.io>