### PR TITLE
chore(operations): Support conditionally rebuilding the docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 *
-!scripts
+!scripts/Gemfile
+!scripts/Gemfile.lock
+!scripts/ci-docker-images/verifier-nixos/Gemfile
 !rust-toolchain

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 _latest_version := $(shell scripts/version.sh true)
 _version := $(shell scripts/version.sh)
 export USE_CONTAINER ?= docker
+export REBUILD_CONTAINER_IMAGE ?= true
 
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 _latest_version := $(shell scripts/version.sh true)
 _version := $(shell scripts/version.sh)
 export USE_CONTAINER ?= docker
-export REBUILD_CONTAINER_IMAGE ?= true
 
 
 help:

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -28,14 +28,13 @@ fi
 #
 
 DOCKER=${USE_CONTAINER:-docker}
-DOCKER_PRIVILEGED=${DOCKER_PRIVILEGED:-false}
 tag="$1"
 image="timberiodev/vector-$tag:latest"
 
 #
 # (Re)Build
 #
-if ! $DOCKER inspect $image >/dev/null 2>&1 || [ "$REBUILD_CONTAINER_IMAGE" == true ]
+if ! $DOCKER inspect $image >/dev/null 2>&1 || [ "${REBUILD_CONTAINER_IMAGE:-true}" == true ]
 then
   $DOCKER build \
     --file scripts/ci-docker-images/$tag/Dockerfile \
@@ -60,7 +59,7 @@ fi
 # pass `--privileged`. One use case is to register `binfmt`
 # handlers in order to run builders for ARM architectures
 # using `qemu-user`.
-if [ "$DOCKER_PRIVILEGED" == "true" ]; then
+if [ "${DOCKER_PRIVILEGED:-false}" == true ]; then
   docker_flags+=("--privileged")
 fi
 

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -9,8 +9,6 @@
 
 set -eou pipefail
 
-DOCKER=${USE_CONTAINER:-docker}
-
 #
 # Requirements
 #
@@ -29,18 +27,25 @@ fi
 # Variables
 #
 
+DOCKER=${USE_CONTAINER:-docker}
 DOCKER_PRIVILEGED=${DOCKER_PRIVILEGED:-false}
 tag="$1"
 image="timberiodev/vector-$tag:latest"
 
 #
+# (Re)Build
+#
+if ! $DOCKER inspect $image >/dev/null 2>&1 || [ "$REBUILD_CONTAINER_IMAGE" == true ]
+then
+  $DOCKER build \
+    --file scripts/ci-docker-images/$tag/Dockerfile \
+    --tag $image \
+    .
+fi
+
+#
 # Execute
 #
-
-$DOCKER build \
-  -t $image \
-  -f scripts/ci-docker-images/$tag/Dockerfile \
-  .
 
 # Set flags for "docker run".
 # The `--rm` flag is used to delete containers on exit.


### PR DESCRIPTION
This compares the build time of the (Docker) image to be run with the `Dockerfile` it was generated from, and only rebuilds if the image is older. This prevents superfluous rebuilds when running things like `make generate`.

Signed-off-by: Bruce Guenter <bruce@timber.io>