### PR TITLE
chore(operations): Use the rustup minimal profile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ install-rust: &install-rust
   run:
     name: Install Rust
     command: |
-      curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+      curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
 
 install-rust-windows: &install-rust-windows
   run:
@@ -20,6 +20,7 @@ install-rust-windows: &install-rust-windows
     shell: bash
     command: |
       curl https://sh.rustup.rs -sSf | sh -s -- -y \
+        --profile minimal \
         --default-toolchain stable \
         --default-host x86_64-pc-windows-msvc
       # see https://github.com/rust-lang/cargo/issues/2078
@@ -172,6 +173,7 @@ jobs:
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
             source $HOME/.cargo/env
+            rustup set profile minimal
             rustup install stable
             rustup default stable
 

--- a/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-aarch64-unknown-linux-musl/Dockerfile
@@ -257,7 +257,7 @@ ENV RUSTUP_HOME=$RUST_PREFIX/rustup
 ENV CARGO_HOME=$RUST_PREFIX/cargo
 COPY rust-toolchain /tmp
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sh -s -- -y --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
+  sh -s -- -y --profile minimal --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
 
 ARG CLANG_PREFIX

--- a/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
+++ b/scripts/ci-docker-images/builder-armv7-unknown-linux-musleabihf/Dockerfile
@@ -256,7 +256,7 @@ ENV RUSTUP_HOME=$RUST_PREFIX/rustup
 ENV CARGO_HOME=$RUST_PREFIX/cargo
 COPY rust-toolchain /tmp/
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sh -s -- -y --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
+  sh -s -- -y --profile minimal --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
 
 ARG CLANG_PREFIX

--- a/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
+++ b/scripts/ci-docker-images/builder-x86_64-unknown-linux-musl/Dockerfile
@@ -260,7 +260,7 @@ ENV RUSTUP_HOME=$RUST_PREFIX/rustup
 ENV CARGO_HOME=$RUST_PREFIX/cargo
 COPY rust-toolchain /tmp/
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sh -s -- -y --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
+  sh -s -- -y --profile minimal --default-toolchain $(cat /tmp/rust-toolchain) --target $TARGET
 ENV PATH="$RUSTUP_HOME/bin:$CARGO_HOME/bin:$PATH"
 
 RUN apt-get update && apt-get install -y llvm clang lld

--- a/scripts/ci-docker-images/checker/Dockerfile
+++ b/scripts/ci-docker-images/checker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 
 # Install Rust
 COPY rust-toolchain /tmp/
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $(cat /tmp/rust-toolchain)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $(cat /tmp/rust-toolchain)
 ENV PATH="$PATH:/root/.cargo/bin"
 RUN rustup component add rustfmt
 


### PR DESCRIPTION
By default, rustup installs clippy and the rust docs. These are not needed to build Vector or to run the docs generator, so use the "minimal" profile to skip downloading the extra bits.