### PR TITLE
fix: (kubernetes source) Change `timestamp_key` back to `message_key`

### DIFF
--- a/src/sources/kubernetes/mod.rs
+++ b/src/sources/kubernetes/mod.rs
@@ -121,7 +121,7 @@ impl TimeFilter {
 fn remove_ending_newline(mut event: Event) -> Event {
     if let Some(Value::Bytes(msg)) = event
         .as_mut_log()
-        .get_mut(&event::log_schema().timestamp_key())
+        .get_mut(&event::log_schema().message_key())
     {
         if msg.ends_with(&['\n' as u8]) {
             msg.truncate(msg.len() - 1);

--- a/src/sources/kubernetes/test.rs
+++ b/src/sources/kubernetes/test.rs
@@ -112,7 +112,7 @@ spec:
         emptyDir: {}
       containers:
       - name: vector
-        image: ktff/vector-kube-watch-client:latest
+        image: ktff/vector-kube-newline-bug:latest
         imagePullPolicy: Always
         volumeMounts:
         - name: var-log


### PR DESCRIPTION
Field key in [this line](https://github.com/timberio/vector/blob/df8e103b937cc86d9ef12cf6b2638a4003f75b47/src/sources/kubernetes/mod.rs#L124) was accidentally changed in #1769 from message to timestamp. 

This was causing messages to retain newline at their ends. 

This was also causing kubernetes tests to fail.

PR changes this key back to message.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
