### PR TITLE
enhancement(elasticsearch sink): Add `timeout` query parameter

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -211,7 +211,8 @@ fn es(
         .unwrap_or(&HashMap::default())
         .clone();
 
-    let mut path_query = url::form_urlencoded::Serializer::new(String::from("/_bulk"));
+    let path = format!("/_bulk?timeout={}s", request.timeout.as_secs());
+    let mut path_query = url::form_urlencoded::Serializer::new(path);
     if let Some(ref query) = config.query {
         for (p, v) in query {
             path_query.append_pair(&p[..], &v[..]);


### PR DESCRIPTION
This is done to ensure that Vector does not timeout before Elasticsearch
to help prevent orphaned requests.

Closes #1866 

Signed-off-by: Bruce Guenter <bruce@timber.io>