### PR TITLE
fix(rename_fields transform): Improve rename_fields table handling

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,3 +1,7 @@
+use indexmap::map::IndexMap;
+use serde::{Deserialize, Serialize};
+use string_cache::DefaultAtom as Atom;
+
 pub fn default_true() -> bool {
     true
 }
@@ -9,4 +13,33 @@ pub fn default_false() -> bool {
 pub fn to_string(value: impl serde::Serialize) -> String {
     let value = serde_json::to_value(value).unwrap();
     value.as_str().unwrap().into()
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum FieldsOrValue<V> {
+    Fields(Fields<V>),
+    Value(V),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Fields<V>(IndexMap<String, FieldsOrValue<V>>);
+
+impl<V: 'static> Fields<V> {
+    pub fn all_fields(self) -> impl Iterator<Item = (Atom, V)> {
+        self.0
+            .into_iter()
+            .map(|(k, v)| -> Box<dyn Iterator<Item = (Atom, V)>> {
+                match v {
+                    // boxing is used as a way to avoid incompatible types of the match arms
+                    FieldsOrValue::Value(v) => Box::new(std::iter::once((k.into(), v))),
+                    FieldsOrValue::Fields(f) => Box::new(
+                        f.all_fields()
+                            .into_iter()
+                            .map(move |(nested_k, v)| (format!("{}.{}", k, nested_k).into(), v)),
+                    ),
+                }
+            })
+            .flatten()
+    }
 }

--- a/src/transforms/rename_fields.rs
+++ b/src/transforms/rename_fields.rs
@@ -1,18 +1,17 @@
 use super::Transform;
 use crate::{
     event::Event,
+    serde::Fields,
     topology::config::{DataType, TransformConfig, TransformContext, TransformDescription},
 };
 use indexmap::map::IndexMap;
 use serde::{Deserialize, Serialize};
-use snafu::Snafu;
 use string_cache::DefaultAtom as Atom;
-use toml::value::Value as TomlValue;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RenameFieldsConfig {
-    pub fields: IndexMap<String, TomlValue>,
+    pub fields: Fields<String>,
 }
 
 pub struct RenameFields {
@@ -26,7 +25,13 @@ inventory::submit! {
 #[typetag::serde(name = "rename_fields")]
 impl TransformConfig for RenameFieldsConfig {
     fn build(&self, _exec: TransformContext) -> crate::Result<Box<dyn Transform>> {
-        Ok(Box::new(RenameFields::new(self.fields.clone())?))
+        Ok(Box::new(RenameFields::new(
+            self.fields
+                .clone()
+                .all_fields()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )?))
     }
 
     fn input_type(&self) -> DataType {
@@ -43,49 +48,8 @@ impl TransformConfig for RenameFieldsConfig {
 }
 
 impl RenameFields {
-    pub fn new(fields: IndexMap<String, TomlValue>) -> crate::Result<Self> {
-        Ok(RenameFields {
-            fields: fields
-                .into_iter()
-                .map(|kv| flatten(kv, None))
-                .collect::<crate::Result<_>>()?,
-        })
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Snafu)]
-enum FlattenError {
-    #[snafu(display(
-        "The key {:?} cannot be flattened. Is it a plain string or a `a.b.c` style map?",
-        key
-    ))]
-    CannotFlatten { key: String },
-}
-
-fn flatten(kv: (String, TomlValue), prequel: Option<String>) -> crate::Result<(Atom, Atom)> {
-    let (k, v) = kv;
-    match v {
-        TomlValue::String(s) => match prequel {
-            Some(prequel) => Ok((format!("{}.{}", prequel, k).into(), s.into())),
-            None => Ok((k.into(), s.into())),
-        },
-        TomlValue::Table(map) => {
-            if map.len() > 1 {
-                Err(Box::new(FlattenError::CannotFlatten { key: k }))
-            } else {
-                let sub_kv = map.into_iter().next().expect("Map of len 1 has no values");
-                let key = match prequel {
-                    Some(prequel) => format!("{}.{}", prequel, k),
-                    None => k,
-                };
-                flatten(sub_kv, Some(key))
-            }
-        }
-        TomlValue::Integer(_)
-        | TomlValue::Float(_)
-        | TomlValue::Boolean(_)
-        | TomlValue::Datetime(_)
-        | TomlValue::Array(_) => Err(Box::new(FlattenError::CannotFlatten { key: k })),
+    pub fn new(fields: IndexMap<Atom, Atom>) -> crate::Result<Self> {
+        Ok(RenameFields { fields })
     }
 }
 


### PR DESCRIPTION
We discovered some corner cases around table handling in rename fields.

As you can see our docs show you can use tables instead of quoted strings, but if you did this you might find errors or even dropped data.

![image](https://user-images.githubusercontent.com/130903/76692040-30a64600-660e-11ea-9f3c-eb567cdbaad3.png)

This PR adds more extensive support for this feature.
