### PR TITLE
chore: Racy buffering tests correction

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,4 +75,6 @@
 
 /src/event/merge.rs @MOZGIII
 
+/tests/buffering.rs @MOZGIII
+
 /website/ @binarylogic

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -241,6 +241,15 @@ pub fn wait_for_tcp(addr: SocketAddr) {
     wait_for(|| std::net::TcpStream::connect(addr).is_ok())
 }
 
+pub fn wait_for_atomic_usize<T, F>(val: T, unblock: F)
+where
+    T: AsRef<AtomicUsize>,
+    F: Fn(usize) -> bool,
+{
+    let val = val.as_ref();
+    wait_for(|| unblock(val.load(Ordering::SeqCst)))
+}
+
 pub fn shutdown_on_idle(runtime: Runtime) {
     block_on(
         runtime

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -5,12 +5,9 @@ use prost::Message;
 use tempfile::tempdir;
 use tracing::trace;
 use vector::event;
-use vector::test_util::{
-    self, block_on, next_addr, random_lines, receive, runtime, send_lines, shutdown_on_idle,
-    wait_for_tcp,
-};
+use vector::test_util::{self, next_addr, runtime, shutdown_on_idle};
 use vector::topology::{self, config};
-use vector::{buffers::BufferConfig, runtime, sinks, sources};
+use vector::{buffers::BufferConfig, runtime, sinks};
 
 mod support;
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -16,6 +16,11 @@ fn terminate_gracefully(mut rt: runtime::Runtime, topology: topology::RunningTop
     test_util::shutdown_on_idle(rt);
 }
 
+fn terminate_abruptly(rt: runtime::Runtime, topology: topology::RunningTopology) {
+    rt.shutdown_now().wait().unwrap();
+    drop(topology);
+}
+
 #[test]
 fn test_buffering() {
     test_util::trace_init();
@@ -69,7 +74,10 @@ fn test_buffering() {
     // mock.
     test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
 
-    terminate_gracefully(rt, topology);
+    // Give the topology some time to process the received data and simulate
+    // a crash.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    terminate_abruptly(rt, topology);
 
     // Then run vector again with a sink that accepts events now. It should
     // send all of the events from the first run.
@@ -169,7 +177,10 @@ fn test_max_size() {
     // mock.
     test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
 
-    terminate_gracefully(rt, topology);
+    // Give the topology some time to process the received data and simulate
+    // a crash.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    terminate_abruptly(rt, topology);
 
     // Then run vector again with a sink that accepts events now. It should
     // send all of the events from the first run that fit in the limited buffer
@@ -307,7 +318,10 @@ fn test_reclaim_disk_space() {
     // mock.
     test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
 
-    terminate_gracefully(rt, topology);
+    // Give the topology some time to process the received data and simulate
+    // a crash.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    terminate_abruptly(rt, topology);
 
     let before_disk_size: u64 = compute_disk_size(&data_dir);
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -5,7 +5,7 @@ use prost::Message;
 use tempfile::tempdir;
 use tracing::trace;
 use vector::event;
-use vector::test_util::{self, next_addr, runtime, shutdown_on_idle};
+use vector::test_util::{self, next_addr, shutdown_on_idle};
 use vector::topology::{self, config};
 use vector::{buffers::BufferConfig, runtime, sinks};
 
@@ -46,7 +46,7 @@ fn test_buffering() {
         config
     };
 
-    let mut rt = runtime();
+    let mut rt = test_util::runtime();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
@@ -83,7 +83,7 @@ fn test_buffering() {
         config
     };
 
-    let mut rt = runtime();
+    let mut rt = test_util::runtime();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
@@ -150,7 +150,7 @@ fn test_max_size() {
         config
     };
 
-    let mut rt = runtime();
+    let mut rt = test_util::runtime();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
@@ -186,7 +186,7 @@ fn test_max_size() {
         config
     };
 
-    let mut rt = runtime();
+    let mut rt = test_util::runtime();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
@@ -288,7 +288,7 @@ fn test_reclaim_disk_space() {
         config
     };
 
-    let mut rt = runtime();
+    let mut rt = test_util::runtime();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -231,6 +231,7 @@ fn test_max_size_resume() {
     };
     config.global.data_dir = Some(data_dir.clone());
 
+    // Use a multi-thread runtime here.
     let mut rt = runtime::Runtime::new().unwrap();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -12,6 +12,8 @@ use vector::{buffers::BufferConfig, runtime, sinks, sources};
 
 #[test]
 fn test_buffering() {
+    vector::test_util::trace_init();
+
     let data_dir = tempdir().unwrap();
     let data_dir = data_dir.path().to_path_buf();
 
@@ -97,6 +99,8 @@ fn test_buffering() {
 
 #[test]
 fn test_max_size() {
+    vector::test_util::trace_init();
+
     let data_dir = tempdir().unwrap();
     let data_dir = data_dir.path().to_path_buf();
 
@@ -185,6 +189,8 @@ fn test_max_size() {
 
 #[test]
 fn test_max_size_resume() {
+    vector::test_util::trace_init();
+
     let data_dir = tempdir().unwrap();
     let data_dir = data_dir.path().to_path_buf();
 
@@ -246,6 +252,8 @@ fn test_max_size_resume() {
 #[test]
 #[ignore]
 fn test_reclaim_disk_space() {
+    vector::test_util::trace_init();
+
     let data_dir = tempdir().unwrap();
     let data_dir = data_dir.path().to_path_buf();
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -1,114 +1,119 @@
 #![cfg(feature = "leveldb")]
 
-use futures01::Future;
+use futures01::{Future, Sink, Stream};
 use prost::Message;
 use tempfile::tempdir;
+use tracing::trace;
 use vector::event::{self, Event};
 use vector::test_util::{
-    block_on, next_addr, random_lines, receive, runtime, send_lines, shutdown_on_idle, wait_for_tcp,
+    self, block_on, next_addr, random_lines, receive, runtime, send_lines, shutdown_on_idle,
+    wait_for_tcp,
 };
 use vector::topology::{self, config};
 use vector::{buffers::BufferConfig, runtime, sinks, sources};
 
+mod support;
+
 #[test]
 fn test_buffering() {
-    vector::test_util::trace_init();
+    test_util::trace_init();
 
     let data_dir = tempdir().unwrap();
     let data_dir = data_dir.path().to_path_buf();
+    trace!(message = "Test data dir", ?data_dir);
 
-    let num_lines: usize = 10;
+    let num_events: usize = 10;
     let line_length = 100;
     let max_size = 10_000;
+    let expected_events_count = num_events * 2;
 
     assert!(
-        line_length * num_lines * 2 <= max_size,
+        line_length * expected_events_count <= max_size,
         "Test parameters are invalid, this test implies  that all lines will fit
         into the buffer, but the buffer is not big enough"
     );
 
-    let in_addr = next_addr();
-    let out_addr = next_addr();
-
-    // Run vector while sink server is not running, and then shut it down
-    // without server ever coming online.
-    let mut config = config::Config::empty();
-    config.add_source(
-        "in",
-        sources::socket::SocketConfig::make_tcp_config(in_addr),
-    );
-    config.add_sink(
-        "out",
-        &["in"],
-        sinks::socket::SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
-    );
-    config.sinks["out"].buffer = BufferConfig::Disk {
-        max_size,
-        when_full: Default::default(),
+    // Run vector with a dead sink, and then shut it down without sink ever
+    // accepting any data.
+    let (in_tx, source_config, source_event_counter) = support::source_with_event_counter();
+    let sink_config = support::sink_dead();
+    let config = {
+        let mut config = config::Config::empty();
+        config.add_source("in", source_config);
+        config.add_sink("out", &["in"], sink_config);
+        config.sinks["out"].buffer = BufferConfig::Disk {
+            max_size,
+            when_full: Default::default(),
+        };
+        config.global.data_dir = Some(data_dir.clone());
+        config
     };
-    config.global.data_dir = Some(data_dir.clone());
 
     let mut rt = runtime();
 
     let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
-    wait_for_tcp(in_addr);
 
-    let input_lines = random_lines(line_length)
-        .take(num_lines)
-        .collect::<Vec<_>>();
-    let send = send_lines(in_addr, input_lines.clone().into_iter());
-    rt.block_on(send).unwrap();
+    let (input_events, input_events_stream) =
+        test_util::random_events_with_stream(line_length, num_events);
+    let send = in_tx
+        .sink_map_err(|err| panic!(err))
+        .send_all(input_events_stream);
+    let _ = rt.block_on(send).unwrap();
 
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    rt.shutdown_now().wait().unwrap();
-    drop(topology);
-
-    let in_addr = next_addr();
-    let out_addr = next_addr();
-
-    // Start sink server, then run vector again. It should send all of the lines
-    // from the first run.
-    let mut config = config::Config::empty();
-    config.add_source(
-        "in",
-        sources::socket::SocketConfig::make_tcp_config(in_addr),
-    );
-    config.add_sink(
-        "out",
-        &["in"],
-        sinks::socket::SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
-    );
-    config.sinks["out"].buffer = BufferConfig::Disk {
-        max_size,
-        when_full: Default::default(),
-    };
-    config.global.data_dir = Some(data_dir);
-
-    let mut rt = runtime();
-
-    let output_lines = receive(&out_addr);
-
-    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
-
-    wait_for_tcp(in_addr);
-
-    let input_lines2 = random_lines(line_length)
-        .take(num_lines)
-        .collect::<Vec<_>>();
-    let send = send_lines(in_addr, input_lines2.clone().into_iter());
-    rt.block_on(send).unwrap();
-
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    // A race caused by `rt.block_on(send).unwrap()` is handled here. For some
+    // reason, at times less events than were sent actually arrive to the
+    // `source`.
+    // We mitigate that by waiting on the event counter provided by our source
+    // mock.
+    test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
 
     rt.block_on(topology.stop()).unwrap();
-
     shutdown_on_idle(rt);
 
-    let output_lines = output_lines.wait();
-    assert_eq!(num_lines * 2, output_lines.len());
-    assert_eq!(input_lines, &output_lines[..num_lines]);
-    assert_eq!(input_lines2, &output_lines[num_lines..]);
+    // Then run vector again with a sink that accepts events now. It should
+    // send all of the events from the first run.
+    let (in_tx, source_config, source_event_counter) = support::source_with_event_counter();
+    let (mut out_rx, sink_config) = support::sink(expected_events_count + 100);
+    let config = {
+        let mut config = config::Config::empty();
+        config.add_source("in", source_config);
+        config.add_sink("out", &["in"], sink_config);
+        config.sinks["out"].buffer = BufferConfig::Disk {
+            max_size,
+            when_full: Default::default(),
+        };
+        config.global.data_dir = Some(data_dir.clone());
+        config
+    };
+
+    let mut rt = runtime();
+
+    let (topology, _crash) = topology::start(config, &mut rt, false).unwrap();
+
+    let (input_events2, input_events_stream) =
+        test_util::random_events_with_stream(line_length, num_events);
+
+    let send = in_tx
+        .sink_map_err(|err| panic!(err))
+        .send_all(input_events_stream);
+    let _ = rt.block_on(send).unwrap();
+
+    // A race caused by `rt.block_on(send).unwrap()` is handled here. For some
+    // reason, at times less events than were sent actually arrive to the
+    // `source`.
+    // We mitigate that by waiting on the event counter provided by our source
+    // mock.
+    test_util::wait_for_atomic_usize(source_event_counter, |x| x == num_events);
+
+    rt.block_on(topology.stop()).unwrap();
+    shutdown_on_idle(rt);
+
+    out_rx.close();
+    let output_events = out_rx.collect().wait().unwrap();
+
+    assert_eq!(expected_events_count, output_events.len());
+    assert_eq!(input_events, &output_events[..num_events]);
+    assert_eq!(input_events2, &output_events[num_events..]);
 }
 
 #[test]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -238,8 +238,10 @@ impl SinkConfig for MockSinkConfig {
             .sender
             .clone()
             .unwrap()
-            .stream_ack(cx.acker())
-            .sink_map_err(|e| error!("Error sending in sink {}", e));
+            .sink_map_err(
+                |error| error!(message = "Ingesting an event failed at mock sink", %error),
+            )
+            .stream_ack(cx.acker());
         let healthcheck = match self.healthy {
             true => future::ok(()),
             false => future::err(HealthcheckError::Unhealthy.into()),

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -27,18 +27,16 @@ use vector::topology::config::{
 };
 use vector::transforms::Transform;
 
-pub fn sink() -> (Receiver<Event>, MockSinkConfig<Sender<Event>>) {
-    sink_with_buffer_size(10)
-}
-
-pub fn sink_with_buffer_size(size: usize) -> (Receiver<Event>, MockSinkConfig<Sender<Event>>) {
-    let (tx, rx) = futures01::sync::mpsc::channel(size);
+pub fn sink(channel_size: usize) -> (Receiver<Event>, MockSinkConfig<Sender<Event>>) {
+    let (tx, rx) = futures01::sync::mpsc::channel(channel_size);
     let sink = MockSinkConfig::new(tx, true);
     (rx, sink)
 }
 
-pub fn sink_failing_healthcheck() -> (Receiver<Event>, MockSinkConfig<Sender<Event>>) {
-    let (tx, rx) = futures01::sync::mpsc::channel(10);
+pub fn sink_failing_healthcheck(
+    channel_size: usize,
+) -> (Receiver<Event>, MockSinkConfig<Sender<Event>>) {
+    let (tx, rx) = futures01::sync::mpsc::channel(channel_size);
     let sink = MockSinkConfig::new(tx, false);
     (rx, sink)
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -68,6 +68,8 @@ pub struct MockSourceConfig {
     receiver: Arc<Mutex<Option<Receiver<Event>>>>,
     #[serde(skip)]
     event_counter: Option<Arc<AtomicUsize>>,
+    #[serde(skip)]
+    data_type: Option<DataType>,
 }
 
 impl MockSourceConfig {
@@ -75,6 +77,7 @@ impl MockSourceConfig {
         Self {
             receiver: Arc::new(Mutex::new(Some(receiver))),
             event_counter: None,
+            data_type: Some(DataType::Any),
         }
     }
 
@@ -85,7 +88,12 @@ impl MockSourceConfig {
         Self {
             receiver: Arc::new(Mutex::new(Some(receiver))),
             event_counter: Some(event_counter),
+            data_type: Some(DataType::Any),
         }
+    }
+
+    pub fn set_data_type(&mut self, data_type: DataType) {
+        self.data_type = Some(data_type)
     }
 }
 
@@ -120,7 +128,7 @@ impl SourceConfig for MockSourceConfig {
     }
 
     fn output_type(&self) -> DataType {
-        DataType::Any
+        self.data_type.clone().unwrap()
     }
 
     fn source_type(&self) -> &'static str {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,8 @@
+// Using a shared mod like this is probably not the best idea, since we have to
+// disable the `dead_code` lint, as we don't need all of the helpers from here
+// all over the place.
+#![allow(dead_code)]
+
 use futures01::{
     future,
     sink::Sink,
@@ -10,6 +15,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,
 };
+use tracing::{error, info};
 use vector::event::{self, metric::MetricValue, Event, Value};
 use vector::shutdown::ShutdownSignal;
 use vector::sinks::{util::SinkExt, Healthcheck, RouterSink};

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -51,6 +51,13 @@ pub fn source() -> (Sender<Event>, MockSourceConfig) {
     (tx, source)
 }
 
+pub fn source_with_event_counter() -> (Sender<Event>, MockSourceConfig, Arc<AtomicUsize>) {
+    let event_counter = Arc::new(AtomicUsize::new(0));
+    let (tx, rx) = futures01::sync::mpsc::channel(0);
+    let source = MockSourceConfig::new_with_event_counter(rx, event_counter.clone());
+    (tx, source, event_counter)
+}
+
 pub fn transform(suffix: &str, increase: f64) -> MockTransformConfig {
     MockTransformConfig::new(suffix.to_owned(), increase)
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -256,6 +256,7 @@ enum HealthcheckError {
     Unhealthy,
 }
 
+#[typetag::serialize(name = "mock")]
 impl<T> SinkConfig for MockSinkConfig<T>
 where
     T: Sink<SinkItem = Event> + std::fmt::Debug + Clone + Send + 'static,
@@ -281,10 +282,6 @@ where
 
     fn sink_type(&self) -> &'static str {
         "mock"
-    }
-
-    fn typetag_name(&self) -> &'static str {
-        unimplemented!("not intended for use in real configs")
     }
 
     fn typetag_deserialize(&self) {

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -1,8 +1,6 @@
 mod support;
 
-use crate::support::{
-    sink, sink_failing_healthcheck, sink_with_buffer_size, source, transform, MockSourceConfig,
-};
+use crate::support::{sink, sink_failing_healthcheck, source, transform, MockSourceConfig};
 use futures01::{
     future, future::Future, sink::Sink, stream::iter_ok, stream::Stream, sync::mpsc::SendError,
     sync::oneshot,
@@ -21,14 +19,14 @@ use vector::topology::config::Config;
 fn basic_config() -> Config {
     let mut config = Config::empty();
     config.add_source("in1", source().1);
-    config.add_sink("out1", &["in1"], sink().1);
+    config.add_sink("out1", &["in1"], sink(10).1);
     config
 }
 
 fn basic_config_with_sink_failing_healthcheck() -> Config {
     let mut config = Config::empty();
     config.add_source("in1", source().1);
-    config.add_sink("out1", &["in1"], sink_failing_healthcheck().1);
+    config.add_sink("out1", &["in1"], sink_failing_healthcheck(10).1);
     config
 }
 
@@ -50,7 +48,7 @@ fn topology_shutdown_while_active() {
 
     let source1 = MockSourceConfig::new_with_event_counter(rx, source_event_counter);
     let transform1 = transform(" transformed", 0.0);
-    let (out1, sink1) = sink_with_buffer_size(10);
+    let (out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -101,7 +99,7 @@ fn topology_shutdown_while_active() {
 fn topology_source_and_sink() {
     let mut rt = runtime();
     let (in1, source1) = source();
-    let (out1, sink1) = sink();
+    let (out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -125,7 +123,7 @@ fn topology_multiple_sources() {
     let mut rt = runtime();
     let (in1, source1) = source();
     let (in2, source2) = source();
-    let (out1, sink1) = sink();
+    let (out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -157,8 +155,8 @@ fn topology_multiple_sources() {
 fn topology_multiple_sinks() {
     let mut rt = runtime();
     let (in1, source1) = source();
-    let (out1, sink1) = sink();
-    let (out2, sink2) = sink();
+    let (out1, sink1) = sink(10);
+    let (out2, sink2) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -187,7 +185,7 @@ fn topology_transform_chain() {
     let (in1, source1) = source();
     let transform1 = transform(" first", 0.0);
     let transform2 = transform(" second", 0.0);
-    let (out1, sink1) = sink();
+    let (out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -214,7 +212,7 @@ fn topology_remove_one_source() {
     let mut rt = runtime();
     let (in1, source1) = source();
     let (in2, source2) = source();
-    let (_out1, sink1) = sink();
+    let (_out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -223,7 +221,7 @@ fn topology_remove_one_source() {
 
     let (mut topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
-    let (out1, sink1) = sink();
+    let (out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source().1);
@@ -248,8 +246,8 @@ fn topology_remove_one_source() {
 fn topology_remove_one_sink() {
     let mut rt = runtime();
     let (in1, source1) = source();
-    let (out1, sink1) = sink();
-    let (out2, sink2) = sink();
+    let (out1, sink1) = sink(10);
+    let (out2, sink2) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -260,7 +258,7 @@ fn topology_remove_one_sink() {
 
     let mut config = Config::empty();
     config.add_source("in1", source().1);
-    config.add_sink("out1", &["in1"], sink().1);
+    config.add_sink("out1", &["in1"], sink(10).1);
 
     assert!(topology.reload_config_and_respawn(config, &mut rt, false));
 
@@ -284,7 +282,7 @@ fn topology_remove_one_transform() {
     let (in1, source1) = source();
     let transform1 = transform(" transformed", 0.0);
     let transform2 = transform(" transformed", 0.0);
-    let (out1, sink1) = sink();
+    let (out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -299,7 +297,7 @@ fn topology_remove_one_transform() {
     let mut config = Config::empty();
     config.add_source("in1", source().1);
     config.add_transform("t2", &["in1"], transform2);
-    config.add_sink("out1", &["t2"], sink().1);
+    config.add_sink("out1", &["t2"], sink(10).1);
 
     assert!(topology.reload_config_and_respawn(config, &mut rt, false));
 
@@ -317,7 +315,7 @@ fn topology_remove_one_transform() {
 fn topology_swap_source() {
     let mut rt = runtime();
     let (in1, source1) = source();
-    let (out1v1, sink1v1) = sink();
+    let (out1v1, sink1v1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -326,7 +324,7 @@ fn topology_swap_source() {
     let (mut topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
     let (in2, source2) = source();
-    let (out1v2, sink1v2) = sink();
+    let (out1v2, sink1v2) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in2", source2);
@@ -356,7 +354,7 @@ fn topology_swap_sink() {
     trace_init();
     let mut rt = runtime();
     let (in1, source1) = source();
-    let (out1, sink1) = sink();
+    let (out1, sink1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -364,7 +362,7 @@ fn topology_swap_sink() {
 
     let (mut topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
-    let (out2, sink2) = sink();
+    let (out2, sink2) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source().1);
@@ -390,7 +388,7 @@ fn topology_swap_transform() {
     let mut rt = runtime();
     let (in1, source1) = source();
     let transform1 = transform(" transformed", 0.0);
-    let (out1v1, sink1v1) = sink();
+    let (out1v1, sink1v1) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source1);
@@ -400,7 +398,7 @@ fn topology_swap_transform() {
     let (mut topology, _crash) = topology::start(config, &mut rt, false).unwrap();
 
     let transform2 = transform(" replaced", 0.0);
-    let (out1v2, sink1v2) = sink();
+    let (out1v2, sink1v2) = sink(10);
 
     let mut config = Config::empty();
     config.add_source("in1", source().1);
@@ -427,7 +425,7 @@ fn topology_swap_transform_is_atomic() {
     let mut rt = runtime();
     let (in1, source1) = source();
     let transform1v1 = transform(" transformed", 0.0);
-    let (out1, sink1) = sink();
+    let (out1, sink1) = sink(10);
 
     let running = Arc::new(AtomicBool::new(true));
     let run_control = running.clone();
@@ -468,7 +466,7 @@ fn topology_swap_transform_is_atomic() {
     let mut config = Config::empty();
     config.add_source("in1", source().1);
     config.add_transform("t1", &["in1"], transform1v2);
-    config.add_sink("out1", &["t1"], sink().1);
+    config.add_sink("out1", &["t1"], sink(10).1);
 
     assert!(topology.reload_config_and_respawn(config, &mut rt, false));
     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -521,6 +519,6 @@ fn topology_healthcheck_run_for_changes_on_reload() {
     let (mut topology, _crash) = topology::start(config, &mut rt, false).unwrap();
     let mut config = Config::empty();
     config.add_source("in1", source().1);
-    config.add_sink("out2", &["in1"], sink_failing_healthcheck().1);
+    config.add_sink("out2", &["in1"], sink_failing_healthcheck(10).1);
     assert!(topology.reload_config_and_respawn(config, &mut rt, true) == false);
 }

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate tracing;
-
-pub mod support;
+mod support;
 
 use crate::support::{
     sink, sink_failing_healthcheck, sink_with_buffer_size, source, transform, MockSourceConfig,


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->

Closes #2102.

This solved the issue with racy buffer checking tests.
This, in turn, should fix our nightly builds! :tada: 