### PR TITLE
feat(elasticsearch sink): Check for partial failures

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -4,14 +4,16 @@ use crate::{
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
         http::{BatchedHttpSink, HttpClient, HttpSink},
+        retries::{RetryAction, RetryLogic},
         BatchBytesConfig, Buffer, Compression, TowerRequestConfig,
     },
     template::Template,
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
+use bytes::Bytes;
 use futures01::Future;
-use http::{uri::InvalidUri, Uri};
+use http::{status::StatusCode, uri::InvalidUri, Uri};
 use hyper::{
     header::{HeaderName, HeaderValue},
     Body, Request,
@@ -21,7 +23,7 @@ use rusoto_core::signature::{SignedRequest, SignedRequestPayload};
 use rusoto_core::{DefaultCredentialsProvider, ProvideAwsCredentials, Region};
 use rusoto_credential::{AwsCredentials, CredentialsError};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use snafu::{ResultExt, Snafu};
 use std::collections::HashMap;
 use tower::Service;
@@ -100,8 +102,15 @@ impl SinkConfig for ElasticSearchConfig {
         let gzip = matches!(&self.compression, Some(Compression::Gzip) | None)
             && common.credentials.is_none();
 
-        let sink =
-            BatchedHttpSink::new(common, Buffer::new(gzip), request, batch, tls_settings, &cx);
+        let sink = BatchedHttpSink::with_retry_logic(
+            common,
+            Buffer::new(gzip),
+            ElasticSearchRetryLogic,
+            request,
+            batch,
+            tls_settings,
+            &cx,
+        );
 
         Ok((Box::new(sink), healthcheck))
     }
@@ -226,6 +235,45 @@ impl HttpSink for ElasticSearchCommon {
             }
 
             builder.body(events).unwrap()
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ElasticSearchRetryLogic;
+
+impl RetryLogic for ElasticSearchRetryLogic {
+    type Error = hyper::Error;
+    type Response = hyper::Response<Bytes>;
+
+    fn is_retriable_error(&self, error: &Self::Error) -> bool {
+        error.is_connect() || error.is_closed()
+    }
+
+    fn should_retry_response(&self, response: &Self::Response) -> RetryAction {
+        let status = response.status();
+
+        match status {
+            StatusCode::TOO_MANY_REQUESTS => RetryAction::Retry("Too many requests".into()),
+            StatusCode::NOT_IMPLEMENTED => {
+                RetryAction::DontRetry("endpoint not implemented".into())
+            }
+            _ if status.is_server_error() => RetryAction::Retry(
+                format!("{}: {}", status, String::from_utf8_lossy(response.body())).into(),
+            ),
+            _ if status.is_success() => {
+                let body = String::from_utf8_lossy(response.body());
+                match body.find("\"errors\":true") {
+                    Some(_) => match serde_json::from_str::<Value>(&body) {
+                        Err(_) => RetryAction::DontRetry(
+                            "some messages failed, and invalid response from elasticsearch".into(),
+                        ),
+                        Ok(_data) => RetryAction::DontRetry("some messages failed".into()),
+                    },
+                    None => RetryAction::Successful,
+                }
+            }
+            _ => RetryAction::DontRetry(format!("response status: {}", status)),
         }
     }
 }
@@ -375,7 +423,9 @@ fn maybe_set_id(key: Option<impl AsRef<str>>, doc: &mut serde_json::Value, event
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sinks::util::retries::RetryAction;
     use crate::Event;
+    use http::{Response, StatusCode};
     use serde_json::json;
 
     #[test]
@@ -413,6 +463,20 @@ mod tests {
 
         assert_eq!(json!({}), action);
     }
+
+    #[test]
+    fn handles_error_response() {
+        let json = "{\"took\":185,\"errors\":true,\"items\":[{\"index\":{\"_index\":\"test-hgw28jv10u\",\"_type\":\"log_lines\",\"_id\":\"3GhQLXEBE62DvOOUKdFH\",\"status\":400,\"error\":{\"type\":\"illegal_argument_exception\",\"reason\":\"mapper [message] of different type, current_type [long], merged_type [text]\"}}}]}";
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body(Bytes::from(json))
+            .unwrap();
+        let logic = ElasticSearchRetryLogic;
+        assert!(matches!(
+            logic.should_retry_response(&response),
+            RetryAction::DontRetry(_)
+        ));
+    }
 }
 
 #[cfg(test)]
@@ -427,7 +491,7 @@ mod integration_tests {
         topology::config::{SinkConfig, SinkContext},
         Event,
     };
-    use futures01::{Future, Sink};
+    use futures01::{Future, Sink, Stream};
     use hyper::{Body, Request};
     use serde_json::{json, Value};
     use std::fs::File;
@@ -490,38 +554,60 @@ mod integration_tests {
 
     #[test]
     fn insert_events_over_http() {
-        run_insert_tests(ElasticSearchConfig {
-            host: "http://localhost:9200".into(),
-            doc_type: Some("log_lines".into()),
-            compression: Some(Compression::None),
-            ..config()
-        });
+        run_insert_tests(
+            ElasticSearchConfig {
+                host: "http://localhost:9200".into(),
+                doc_type: Some("log_lines".into()),
+                compression: Some(Compression::None),
+                ..config()
+            },
+            false,
+        );
     }
 
     #[test]
     fn insert_events_over_https() {
-        run_insert_tests(ElasticSearchConfig {
-            host: "https://localhost:9201".into(),
-            doc_type: Some("log_lines".into()),
-            compression: Some(Compression::None),
-            tls: Some(TlsOptions {
-                ca_path: Some("tests/data/Vector_CA.crt".into()),
-                ..Default::default()
-            }),
-            ..config()
-        });
+        run_insert_tests(
+            ElasticSearchConfig {
+                host: "https://localhost:9201".into(),
+                doc_type: Some("log_lines".into()),
+                compression: Some(Compression::None),
+                tls: Some(TlsOptions {
+                    ca_path: Some("tests/data/Vector_CA.crt".into()),
+                    ..Default::default()
+                }),
+                ..config()
+            },
+            false,
+        );
     }
 
     #[test]
     fn insert_events_on_aws() {
-        run_insert_tests(ElasticSearchConfig {
-            auth: Some(ElasticSearchAuth::Aws),
-            host: "http://localhost:4571".into(),
-            ..config()
-        });
+        run_insert_tests(
+            ElasticSearchConfig {
+                auth: Some(ElasticSearchAuth::Aws),
+                host: "http://localhost:4571".into(),
+                ..config()
+            },
+            false,
+        );
     }
 
-    fn run_insert_tests(mut config: ElasticSearchConfig) {
+    #[test]
+    fn insert_events_with_failure() {
+        run_insert_tests(
+            ElasticSearchConfig {
+                host: "http://localhost:9200".into(),
+                doc_type: Some("log_lines".into()),
+                compression: Some(Compression::None),
+                ..config()
+            },
+            true,
+        );
+    }
+
+    fn run_insert_tests(mut config: ElasticSearchConfig, break_events: bool) {
         crate::test_util::trace_init();
         let mut rt = runtime();
 
@@ -535,9 +621,24 @@ mod integration_tests {
         rt.block_on(healthcheck).expect("Health check failed");
 
         let (input, events) = random_events_with_stream(100, 100);
-
-        let pump = sink.send_all(events);
-        let _ = rt.block_on(pump).expect("Sending events failed");
+        match break_events {
+            true => {
+                // Break all but the first event to simulate some kind of partial failure
+                let mut doit = false;
+                let pump = sink.send_all(events.map(move |mut event| {
+                    if doit {
+                        event.as_mut_log().insert("message", 1);
+                    }
+                    doit = true;
+                    event
+                }));
+                let _ = rt.block_on(pump).expect("Sending events failed");
+            }
+            false => {
+                let pump = sink.send_all(events);
+                let _ = rt.block_on(pump).expect("Sending events failed");
+            }
+        };
 
         // make sure writes all all visible
         rt.block_on(flush(cx.resolver(), &common))
@@ -565,14 +666,19 @@ mod integration_tests {
             .json::<elastic_responses::search::SearchResponse<Value>>()
             .unwrap();
 
-        assert_eq!(input.len() as u64, response.total());
-        let input = input
-            .into_iter()
-            .map(|rec| serde_json::to_value(&rec.into_log()).unwrap())
-            .collect::<Vec<_>>();
-        for hit in response.into_hits() {
-            let event = hit.into_document().unwrap();
-            assert!(input.contains(&event));
+        if break_events {
+            assert_ne!(input.len() as u64, response.total());
+        } else {
+            assert_eq!(input.len() as u64, response.total());
+
+            let input = input
+                .into_iter()
+                .map(|rec| serde_json::to_value(&rec.into_log()).unwrap())
+                .collect::<Vec<_>>();
+            for hit in response.into_hits() {
+                let event = hit.into_document().unwrap();
+                assert!(input.contains(&event));
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1865 

Do we want to raise the `warn!(message = "request is not retryable...")` in [retries.rs](https://github.com/timberio/vector/blob/bd025bbf5ff7177a504e9ce1931f9ea581512632/src/sinks/util/retries.rs#L109) to an `error!`?