### PR TITLE
perf: start removing Atom from the hot path

### DIFF
--- a/src/event/discriminant.rs
+++ b/src/event/discriminant.rs
@@ -92,7 +92,7 @@ fn array_eq(this: &Vec<Value>, other: &Vec<Value>) -> bool {
         .all(|(first, second)| value_eq(first, second))
 }
 
-fn map_eq(this: &BTreeMap<Atom, Value>, other: &BTreeMap<Atom, Value>) -> bool {
+fn map_eq(this: &BTreeMap<String, Value>, other: &BTreeMap<String, Value>) -> bool {
     if this.len() != other.len() {
         return false;
     }
@@ -143,7 +143,7 @@ fn hash_array<H: Hasher>(hasher: &mut H, array: &Vec<Value>) {
     }
 }
 
-fn hash_map<H: Hasher>(hasher: &mut H, map: &BTreeMap<Atom, Value>) {
+fn hash_map<H: Hasher>(hasher: &mut H, map: &BTreeMap<String, Value>) {
     for (key, val) in map.iter() {
         hasher.write(key.as_bytes());
         hash_value(hasher, val);

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -106,24 +106,12 @@ impl LogEvent {
         util::log::get(&self.fields, key)
     }
 
-    pub fn get_flat(&self, key: &Atom) -> Option<&Value> {
-        self.fields.get(&key.to_string())
-    }
-
     pub fn get_mut(&mut self, key: &Atom) -> Option<&mut Value> {
         util::log::get_mut(&mut self.fields, key)
     }
 
-    pub fn get_flat_mut(&mut self, key: &Atom) -> Option<&mut Value> {
-        self.fields.get_mut(&key.to_string())
-    }
-
     pub fn contains(&self, key: &Atom) -> bool {
         util::log::contains(&self.fields, key)
-    }
-
-    pub fn contains_flat(&self, key: &Atom) -> bool {
-        self.fields.contains_key(&key.to_string())
     }
 
     pub fn insert<K, V>(&mut self, key: K, value: V) -> Option<Value>
@@ -150,16 +138,8 @@ impl LogEvent {
         util::log::remove(&mut self.fields, &key, prune)
     }
 
-    pub fn remove_flat(&mut self, key: &Atom) -> Option<Value> {
-        self.fields.remove(&key.to_string())
-    }
-
     pub fn keys<'a>(&'a self) -> impl Iterator<Item = String> + 'a {
         util::log::keys(&self.fields)
-    }
-
-    pub fn keys_flat<'a>(&'a self) -> impl Iterator<Item = &'a String> {
-        self.fields.keys()
     }
 
     pub fn all_fields<'a>(&'a self) -> impl Iterator<Item = (String, &'a Value)> + Serialize {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -44,7 +44,7 @@ pub enum Event {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct LogEvent {
-    fields: BTreeMap<Atom, Value>,
+    fields: BTreeMap<String, Value>,
 }
 
 impl Event {
@@ -107,7 +107,7 @@ impl LogEvent {
     }
 
     pub fn get_flat(&self, key: &Atom) -> Option<&Value> {
-        self.fields.get(key)
+        self.fields.get(&key.to_string())
     }
 
     pub fn get_mut(&mut self, key: &Atom) -> Option<&mut Value> {
@@ -115,7 +115,7 @@ impl LogEvent {
     }
 
     pub fn get_flat_mut(&mut self, key: &Atom) -> Option<&mut Value> {
-        self.fields.get_mut(key)
+        self.fields.get_mut(&key.to_string())
     }
 
     pub fn contains(&self, key: &Atom) -> bool {
@@ -123,7 +123,7 @@ impl LogEvent {
     }
 
     pub fn contains_flat(&self, key: &Atom) -> bool {
-        self.fields.contains_key(key)
+        self.fields.contains_key(&key.to_string())
     }
 
     pub fn insert<K, V>(&mut self, key: K, value: V) -> Option<Value>
@@ -136,7 +136,7 @@ impl LogEvent {
 
     pub fn insert_flat<K, V>(&mut self, key: K, value: V)
     where
-        K: Into<Atom>,
+        K: Into<String>,
         V: Into<Value>,
     {
         self.fields.insert(key.into(), value.into());
@@ -151,18 +151,18 @@ impl LogEvent {
     }
 
     pub fn remove_flat(&mut self, key: &Atom) -> Option<Value> {
-        self.fields.remove(key)
+        self.fields.remove(&key.to_string())
     }
 
-    pub fn keys<'a>(&'a self) -> impl Iterator<Item = Atom> + 'a {
+    pub fn keys<'a>(&'a self) -> impl Iterator<Item = String> + 'a {
         util::log::keys(&self.fields)
     }
 
-    pub fn keys_flat<'a>(&'a self) -> impl Iterator<Item = &'a Atom> {
+    pub fn keys_flat<'a>(&'a self) -> impl Iterator<Item = &'a String> {
         self.fields.keys()
     }
 
-    pub fn all_fields<'a>(&'a self) -> impl Iterator<Item = (Atom, &'a Value)> + Serialize {
+    pub fn all_fields<'a>(&'a self) -> impl Iterator<Item = (String, &'a Value)> + Serialize {
         util::log::all_fields(&self.fields)
     }
 
@@ -198,8 +198,8 @@ impl<K: Into<Atom>, V: Into<Value>> FromIterator<(K, V)> for LogEvent {
 
 /// Converts event into an iterator over top-level key/value pairs.
 impl IntoIterator for LogEvent {
-    type Item = (Atom, Value);
-    type IntoIter = std::collections::btree_map::IntoIter<Atom, Value>;
+    type Item = (String, Value);
+    type IntoIter = std::collections::btree_map::IntoIter<String, Value>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.fields.into_iter()
@@ -279,7 +279,7 @@ pub enum Value {
     Float(f64),
     Boolean(bool),
     Timestamp(DateTime<Utc>),
-    Map(BTreeMap<Atom, Value>),
+    Map(BTreeMap<String, Value>),
     Array(Vec<Value>),
     Null,
 }
@@ -357,8 +357,8 @@ impl From<f64> for Value {
     }
 }
 
-impl From<BTreeMap<Atom, Value>> for Value {
-    fn from(value: BTreeMap<Atom, Value>) -> Self {
+impl From<BTreeMap<String, Value>> for Value {
+    fn from(value: BTreeMap<String, Value>) -> Self {
         Value::Map(value)
     }
 }
@@ -465,11 +465,11 @@ fn timestamp_to_string(timestamp: &DateTime<Utc>) -> String {
 }
 
 fn decode_map(fields: BTreeMap<String, proto::Value>) -> Option<Value> {
-    let mut accum: BTreeMap<Atom, Value> = BTreeMap::new();
+    let mut accum: BTreeMap<String, Value> = BTreeMap::new();
     for (key, value) in fields {
         match decode_value(value) {
             Some(value) => {
-                accum.insert(Atom::from(key), value);
+                accum.insert(key, value);
             }
             None => return None,
         }
@@ -516,7 +516,7 @@ impl From<proto::EventWrapper> for Event {
                 let fields = proto
                     .fields
                     .into_iter()
-                    .filter_map(|(k, v)| decode_value(v).map(|value| (Atom::from(k), value)))
+                    .filter_map(|(k, v)| decode_value(v).map(|value| (k, value)))
                     .collect::<BTreeMap<_, _>>();
 
                 Event::Log(LogEvent { fields })
@@ -595,11 +595,11 @@ fn encode_value(value: Value) -> proto::Value {
     }
 }
 
-fn encode_map(fields: BTreeMap<Atom, Value>) -> proto::ValueMap {
+fn encode_map(fields: BTreeMap<String, Value>) -> proto::ValueMap {
     proto::ValueMap {
         fields: fields
             .into_iter()
-            .map(|(key, value)| (key.to_string(), encode_value(value)))
+            .map(|(key, value)| (key, encode_value(value)))
             .collect(),
     }
 }
@@ -812,11 +812,11 @@ mod test {
             all,
             vec![
                 (
-                    Atom::from("Ke$ha"),
+                    String::from("Ke$ha"),
                     "It's going down, I'm yelling timber".to_string()
                 ),
                 (
-                    Atom::from("Pitbull"),
+                    String::from("Pitbull"),
                     "The bigger they are, the harder they fall".to_string()
                 ),
             ]
@@ -837,9 +837,9 @@ mod test {
         assert_eq!(
             collected,
             vec![
-                (Atom::from("YRjhxXcg"), &Value::from("nw8iM5Jr")),
-                (Atom::from("lZDfzKIL"), &Value::from("tOVrjveM")),
-                (Atom::from("o9amkaRY"), &Value::from("pGsfG7Nr")),
+                (String::from("YRjhxXcg"), &Value::from("nw8iM5Jr")),
+                (String::from("lZDfzKIL"), &Value::from("tOVrjveM")),
+                (String::from("o9amkaRY"), &Value::from("pGsfG7Nr")),
             ]
         );
     }

--- a/src/event/util/log/contains.rs
+++ b/src/event/util/log/contains.rs
@@ -1,8 +1,8 @@
-use super::{Atom, PathComponent, PathIter, Value};
+use super::{PathComponent, PathIter, Value};
 use std::collections::BTreeMap;
 
 /// Checks whether a field specified by a given path is present.
-pub fn contains(fields: &BTreeMap<Atom, Value>, path: &str) -> bool {
+pub fn contains(fields: &BTreeMap<String, Value>, path: &str) -> bool {
     let mut path_iter = PathIter::new(path);
 
     match path_iter.next() {

--- a/src/event/util/log/get.rs
+++ b/src/event/util/log/get.rs
@@ -1,8 +1,8 @@
-use super::{Atom, PathComponent, PathIter, Value};
+use super::{PathComponent, PathIter, Value};
 use std::collections::BTreeMap;
 
 /// Returns a reference to a field value specified by the given path.
-pub fn get<'a>(fields: &'a BTreeMap<Atom, Value>, path: &str) -> Option<&'a Value> {
+pub fn get<'a>(fields: &'a BTreeMap<String, Value>, path: &str) -> Option<&'a Value> {
     let mut path_iter = PathIter::new(path);
 
     match path_iter.next() {

--- a/src/event/util/log/get_mut.rs
+++ b/src/event/util/log/get_mut.rs
@@ -1,8 +1,8 @@
-use super::{Atom, PathComponent, PathIter, Value};
+use super::{PathComponent, PathIter, Value};
 use std::collections::BTreeMap;
 
 /// Returns a mutable reference to field value specified by the given path.
-pub fn get_mut<'a>(fields: &'a mut BTreeMap<Atom, Value>, path: &str) -> Option<&'a mut Value> {
+pub fn get_mut<'a>(fields: &'a mut BTreeMap<String, Value>, path: &str) -> Option<&'a mut Value> {
     let mut path_iter = PathIter::new(path);
 
     match path_iter.next() {

--- a/src/event/util/log/insert.rs
+++ b/src/event/util/log/insert.rs
@@ -1,13 +1,13 @@
-use super::{Atom, PathComponent, PathIter, Value};
+use super::{PathComponent, PathIter, Value};
 use std::{collections::BTreeMap, iter::Peekable};
 
 /// Inserts field value using a path specified using `a.b[1].c` notation.
-pub fn insert(fields: &mut BTreeMap<Atom, Value>, path: &str, value: Value) -> Option<Value> {
+pub fn insert(fields: &mut BTreeMap<String, Value>, path: &str, value: Value) -> Option<Value> {
     map_insert(fields, PathIter::new(path).peekable(), value)
 }
 
 fn map_insert<I>(
-    fields: &mut BTreeMap<Atom, Value>,
+    fields: &mut BTreeMap<String, Value>,
     mut path_iter: Peekable<I>,
     value: Value,
 ) -> Option<Value>

--- a/src/event/util/log/keys.rs
+++ b/src/event/util/log/keys.rs
@@ -1,10 +1,10 @@
-use super::{all_fields, Atom, Value};
+use super::{all_fields, Value};
 use std::collections::BTreeMap;
 
 /// Iterates over all paths in form "a.b[0].c[1]" in alphabetical order.
 /// It is implemented as a wrapper around `all_fields` to reduce code
 /// duplication.
-pub fn keys<'a>(fields: &'a BTreeMap<Atom, Value>) -> impl Iterator<Item = Atom> + 'a {
+pub fn keys<'a>(fields: &'a BTreeMap<String, Value>) -> impl Iterator<Item = String> + 'a {
     all_fields(fields).map(|(k, _)| k)
 }
 
@@ -23,7 +23,7 @@ mod test {
         }));
         let expected: Vec<_> = vec!["field1", "field2", "field3"]
             .into_iter()
-            .map(|s| Atom::from(s))
+            .map(|s| String::from(s))
             .collect();
 
         let collected: Vec<_> = keys(&fields).collect();
@@ -52,7 +52,7 @@ mod test {
             "a.b.c",
         ]
         .into_iter()
-        .map(|s| Atom::from(s))
+        .map(|s| String::from(s))
         .collect();
 
         let collected: Vec<_> = keys(&fields).collect();

--- a/src/event/util/log/mod.rs
+++ b/src/event/util/log/mod.rs
@@ -7,7 +7,7 @@ mod keys;
 mod path_iter;
 mod remove;
 
-pub(self) use super::{Atom, Value};
+pub(self) use super::Value;
 pub(self) use path_iter::{PathComponent, PathIter};
 
 pub use all_fields::all_fields;
@@ -20,11 +20,11 @@ pub use remove::remove;
 
 #[cfg(test)]
 pub(self) mod test {
-    use super::{Atom, Value};
+    use super::Value;
     use serde_json::Value as JsonValue;
     use std::collections::BTreeMap;
 
-    pub fn fields_from_json(json_value: JsonValue) -> BTreeMap<Atom, Value> {
+    pub fn fields_from_json(json_value: JsonValue) -> BTreeMap<String, Value> {
         match Value::from(json_value) {
             Value::Map(map) => map,
             something => panic!("Expected a map, got {:?}", something),

--- a/src/event/util/log/path_iter.rs
+++ b/src/event/util/log/path_iter.rs
@@ -1,10 +1,9 @@
-use super::Atom;
 use std::{mem, str::Chars};
 
 #[derive(Debug, PartialEq)]
 pub enum PathComponent {
     /// For example, in "a.b[0].c[2]" the keys are "a", "b", and "c".
-    Key(Atom),
+    Key(String),
     /// For example, in "a.b[0].c[2]" the indexes are 0 and 2.
     Index(usize),
     /// Indicates that a parsing error occurred.

--- a/src/event/util/log/remove.rs
+++ b/src/event/util/log/remove.rs
@@ -1,11 +1,11 @@
-use super::{Atom, PathComponent, PathIter, Value};
+use super::{PathComponent, PathIter, Value};
 use std::{cmp::Ordering, collections::BTreeMap, iter::Peekable, mem};
 
 /// Removes field value specified by the given path and return its value.
 ///
 /// A special case worth mentioning: if there is a nested array and an item is removed
 /// from the middle of this array, then it is just replaced by `Value::Null`.
-pub fn remove(fields: &mut BTreeMap<Atom, Value>, path: &str, prune: bool) -> Option<Value> {
+pub fn remove(fields: &mut BTreeMap<String, Value>, path: &str, prune: bool) -> Option<Value> {
     remove_map(fields, PathIter::new(path).peekable(), prune).map(|(value, _)| value)
 }
 
@@ -37,7 +37,7 @@ fn remove_array(
 }
 
 fn remove_map(
-    fields: &mut BTreeMap<Atom, Value>,
+    fields: &mut BTreeMap<String, Value>,
     mut path: Peekable<PathIter>,
     prune: bool,
 ) -> Option<(Value, bool)> {

--- a/src/event/util/mod.rs
+++ b/src/event/util/mod.rs
@@ -1,3 +1,3 @@
 pub mod log;
 
-pub(self) use super::{Atom, Value};
+pub(self) use super::Value;

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -815,9 +815,9 @@ mod tests {
             assert_eq!(
                 received.as_log().keys().collect::<HashSet<_>>(),
                 vec![
-                    event::log_schema().host_key().clone(),
-                    event::log_schema().message_key().clone(),
-                    event::log_schema().timestamp_key().clone()
+                    event::log_schema().host_key().to_string(),
+                    event::log_schema().message_key().to_string(),
+                    event::log_schema().timestamp_key().to_string()
                 ]
                 .into_iter()
                 .collect::<HashSet<_>>()

--- a/src/types.rs
+++ b/src/types.rs
@@ -102,6 +102,19 @@ pub fn parse_conversion_map(
         .collect()
 }
 
+pub fn parse_conversion_map_no_atoms(
+    types: &HashMap<String, String>,
+) -> Result<HashMap<String, Conversion>, ConversionError> {
+    types
+        .iter()
+        .map(|(field, typename)| {
+            typename
+                .parse::<Conversion>()
+                .map(|conv| (field.to_string(), conv))
+        })
+        .collect()
+}
+
 #[derive(Debug, Eq, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display("Invalid boolean value {:?}", s))]


### PR DESCRIPTION
Ref #1891 

This removes `Atom` from our data model and the `grok_parser` transform. We can follow up with similar changes to other components, but this was sufficient for a ~15% throughput increase in a simple grok-heavy pipeline.

I also removed some unused methods `*_flat` that kept catching my eye for looking slow. Let me know if we should keep these around for any reason @a-rodin.