### PR TITLE
perf: add fast path and caching api to event insert

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -18,7 +18,7 @@ mod util;
 
 pub use metric::Metric;
 pub(crate) use util::log::PathComponent;
-#[cfg(feature = "transform-grok_parser")]
+#[cfg(feature = "transforms-grok_parser")]
 pub(crate) use util::log::PathIter;
 
 pub mod proto {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -17,7 +17,9 @@ pub mod metric;
 mod util;
 
 pub use metric::Metric;
-pub(crate) use util::log::{PathComponent, PathIter};
+pub(crate) use util::log::PathComponent;
+#[cfg(feature = "transform-grok_parser")]
+pub(crate) use util::log::PathIter;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/event.proto.rs"));

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -17,6 +17,7 @@ pub mod metric;
 mod util;
 
 pub use metric::Metric;
+pub(crate) use util::log::{PathComponent, PathIter};
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/event.proto.rs"));
@@ -120,6 +121,13 @@ impl LogEvent {
         V: Into<Value>,
     {
         util::log::insert(&mut self.fields, key.as_ref(), value.into())
+    }
+
+    pub fn insert_path<V>(&mut self, key: Vec<PathComponent>, value: V) -> Option<Value>
+    where
+        V: Into<Value>,
+    {
+        util::log::insert_path(&mut self.fields, key, value.into())
     }
 
     pub fn insert_flat<K, V>(&mut self, key: K, value: V)

--- a/src/event/util/log/insert.rs
+++ b/src/event/util/log/insert.rs
@@ -6,6 +6,14 @@ pub fn insert(fields: &mut BTreeMap<String, Value>, path: &str, value: Value) ->
     map_insert(fields, PathIter::new(path).peekable(), value)
 }
 
+pub fn insert_path(
+    fields: &mut BTreeMap<String, Value>,
+    path: Vec<PathComponent>,
+    value: Value,
+) -> Option<Value> {
+    map_insert(fields, path.into_iter().peekable(), value)
+}
+
 fn map_insert<I>(
     fields: &mut BTreeMap<String, Value>,
     mut path_iter: Peekable<I>,

--- a/src/event/util/log/mod.rs
+++ b/src/event/util/log/mod.rs
@@ -8,13 +8,13 @@ mod path_iter;
 mod remove;
 
 pub(self) use super::Value;
-pub(self) use path_iter::{PathComponent, PathIter};
+pub(crate) use path_iter::{PathComponent, PathIter};
 
 pub use all_fields::all_fields;
 pub use contains::contains;
 pub use get::get;
 pub use get_mut::get_mut;
-pub use insert::insert;
+pub use insert::{insert, insert_path};
 pub use keys::keys;
 pub use remove::remove;
 

--- a/src/event/util/log/path_iter.rs
+++ b/src/event/util/log/path_iter.rs
@@ -1,4 +1,10 @@
+use lazy_static::lazy_static;
+use regex::Regex;
 use std::{mem, str::Chars};
+
+lazy_static! {
+    static ref FAST_RE: Regex = Regex::new(r"\A\w+(\.\w+)*\z").unwrap();
+}
 
 #[derive(Debug, PartialEq)]
 pub enum PathComponent {
@@ -12,13 +18,15 @@ pub enum PathComponent {
 
 /// Iterator over components of paths specified in form "a.b[0].c[2]".
 pub struct PathIter<'a> {
+    path: &'a str,
     chars: Chars<'a>,
-    state: PathIterState,
+    state: PathIterState<'a>,
 }
 
 impl<'a> PathIter<'a> {
     pub fn new(path: &'a str) -> PathIter {
         PathIter {
+            path,
             chars: path.chars(),
             state: Default::default(),
         }
@@ -28,8 +36,9 @@ impl<'a> PathIter<'a> {
 /// The parsing is implemented using a state machine.
 /// The idea of using Rust enums to model states is taken from
 /// https://hoverbear.org/blog/rust-state-machine-pattern/ .
-enum PathIterState {
-    Empty,
+enum PathIterState<'a> {
+    Start,
+    Fast(std::str::Split<'a, char>),
     Key(String),
     KeyEscape(String), // escape mode inside keys entered into after `\` character
     Index(usize),
@@ -40,25 +49,40 @@ enum PathIterState {
     Invalid,
 }
 
-impl Default for PathIterState {
-    fn default() -> PathIterState {
-        PathIterState::Empty
+impl PathIterState<'_> {
+    fn is_start(&self) -> bool {
+        match self {
+            Self::Start => true,
+            _ => false,
+        }
+    }
+}
+
+impl<'a> Default for PathIterState<'a> {
+    fn default() -> PathIterState<'a> {
+        PathIterState::Start
     }
 }
 
 impl<'a> Iterator for PathIter<'a> {
     type Item = PathComponent;
+
     fn next(&mut self) -> Option<Self::Item> {
+        use PathIterState::*;
+
+        if self.state.is_start() && FAST_RE.is_match(self.path) {
+            self.state = Fast(self.path.split('.'));
+        }
+
         let mut res = None;
         loop {
             if let Some(res) = res {
                 return res;
             }
 
-            use PathIterState::*;
             let c = self.chars.next();
             self.state = match mem::take(&mut self.state) {
-                Empty => match c {
+                Start => match c {
                     Some('.') | Some('[') | Some(']') | None => Invalid,
                     Some('\\') => KeyEscape(String::new()),
                     Some(c) => Key(c.to_string()),
@@ -120,6 +144,10 @@ impl<'a> Iterator for PathIter<'a> {
                 Invalid => {
                     res = Some(Some(PathComponent::Invalid));
                     End
+                }
+                Fast(mut iter) => {
+                    res = Some(iter.next().map(|s| PathComponent::Key(s.to_string())));
+                    Fast(iter)
                 }
             }
         }

--- a/src/event/util/log/path_iter.rs
+++ b/src/event/util/log/path_iter.rs
@@ -6,7 +6,7 @@ lazy_static! {
     static ref FAST_RE: Regex = Regex::new(r"\A\w+(\.\w+)*\z").unwrap();
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum PathComponent {
     /// For example, in "a.b[0].c[2]" the keys are "a", "b", and "c".
     Key(String),


### PR DESCRIPTION
There are two separate changes here:

1. Adding a fast path to the `path_iter` parser. We check for "simple" inputs (i.e. no array indexes or escaping) and skip the whole parser in those cases.

2. Providing a second `insert_path` API that lets components cache parsed paths and use them directly. The `grok_parser` transform was updated to use this.

Together, these add about ~27% more throughput to an example grok-based pipeline.