### PR TITLE
fix(config): `enoding.only_fields` should properly handle parent keys

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -18,7 +18,6 @@ mod util;
 
 pub use metric::Metric;
 pub(crate) use util::log::PathComponent;
-#[cfg(any(feature = "transforms-grok_parser", feature = "transforms-tokenizer"))]
 pub(crate) use util::log::PathIter;
 
 pub mod proto {

--- a/src/event/util/log/path_iter.rs
+++ b/src/event/util/log/path_iter.rs
@@ -1,12 +1,13 @@
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use std::{mem, str::Chars};
 
 lazy_static! {
     static ref FAST_RE: Regex = Regex::new(r"\A\w+(\.\w+)*\z").unwrap();
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum PathComponent {
     /// For example, in "a.b[0].c[2]" the keys are "a", "b", and "c".
     Key(String),

--- a/src/sinks/util/encoding.rs
+++ b/src/sinks/util/encoding.rs
@@ -29,7 +29,7 @@
 //       `Encoder` that defines some `encode` function which this config then calls internally as
 //       part of it's own (yet to be written) `encode() -> Vec<u8>` function.
 
-use crate::{event::Value, Event, Result};
+use crate::{event::{Value, PathIter}, Event, Result};
 use serde::de::{MapAccess, Visitor};
 use serde::{
     de::{self, DeserializeOwned, Deserializer, IntoDeserializer},
@@ -156,11 +156,24 @@ pub trait EncodingConfiguration<E> {
                 Event::Log(log_event) => {
                     let to_remove = log_event
                         .keys()
-                        .filter(|f| {
+                        .filter(|field| {
+                            let field_path = PathIter::new(field).collect::<Vec<_>>();
                             !only_fields
                                 .iter()
-                                // TODO: This is a hack for #2407, #2410 should fix this fully.
-                                .any(|only| f.starts_with(&(only.to_string() + "[")) || only == f)
+                                .any(|only| {
+                                    if only == field {
+                                        true // fastpath
+                                    } else {
+                                        // TODO: This is a hack for #2407, #2410 should fix this fully.
+                                        // This is *slow*.
+                                        let only_path = PathIter::new(only);
+                                        if field_path.starts_with(&only_path.collect::<Vec<_>>()[..]) {
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    }
+                                })
                         })
                         .collect::<VecDeque<_>>();
                     for removal in to_remove {

--- a/src/sinks/util/encoding.rs
+++ b/src/sinks/util/encoding.rs
@@ -159,6 +159,7 @@ pub trait EncodingConfiguration<E> {
                         .filter(|f| {
                             !only_fields
                                 .iter()
+                                // TODO: This is a hack for #2407, #2410 should fix this fully.
                                 .any(|only| f.starts_with(&(only.to_string() + "[")) || only == f)
                         })
                         .collect::<VecDeque<_>>();

--- a/src/sinks/util/encoding.rs
+++ b/src/sinks/util/encoding.rs
@@ -156,9 +156,11 @@ pub trait EncodingConfiguration<E> {
                 Event::Log(log_event) => {
                     let to_remove = log_event
                         .keys()
-                        .filter(|f|
-                            !only_fields.iter().any(|only| f.starts_with(&(only.to_string() + "[")) || only == f)
-                        )
+                        .filter(|f| {
+                            !only_fields
+                                .iter()
+                                .any(|only| f.starts_with(&(only.to_string() + "[")) || only == f)
+                        })
                         .collect::<VecDeque<_>>();
                     for removal in to_remove {
                         log_event.remove(&Atom::from(removal));

--- a/src/sinks/util/encoding.rs
+++ b/src/sinks/util/encoding.rs
@@ -495,7 +495,7 @@ mod tests {
 
     const TOML_EXCEPT_FIELD: &str = r#"
         encoding.codec = "Snoot"
-        encoding.except_fields = ["Doop"]
+        encoding.except_fields = ["a.b.c", "b", "c[0].y"]
     "#;
     #[test]
     fn test_except() {
@@ -504,12 +504,23 @@ mod tests {
         let mut event = Event::new_empty_log();
         {
             let log = event.as_mut_log();
-            log.insert("Doop", 1);
-            log.insert("Beep", 1);
+            log.insert("a", 1);
+            log.insert("a.b", 1);
+            log.insert("a.b.c", 1);
+            log.insert("a.b.d", 1);
+            log.insert("b[0]", 1);
+            log.insert("b[1].x", 1);
+            log.insert("c[0].x", 1);
+            log.insert("c[0].y", 1);
         }
         config.encoding.apply_rules(&mut event);
-        assert!(!event.as_mut_log().contains(&Atom::from("Doop")));
-        assert!(event.as_mut_log().contains(&Atom::from("Beep")));
+        assert!(!event.as_mut_log().contains(&Atom::from("a.b.c")));
+        assert!(!event.as_mut_log().contains(&Atom::from("b")));
+        assert!(!event.as_mut_log().contains(&Atom::from("b[1].x")));
+        assert!(!event.as_mut_log().contains(&Atom::from("c[0].y")));
+
+        assert!(event.as_mut_log().contains(&Atom::from("a.b.d")));
+        assert!(event.as_mut_log().contains(&Atom::from("c[0].x")));
     }
 
     const TOML_ONLY_FIELD: &str = r#"


### PR DESCRIPTION
Closes https://github.com/timberio/vector/issues/2407

Does not address https://github.com/timberio/vector/issues/2410. Future work is required there. Related to https://github.com/timberio/vector/issues/2414