### PR TITLE
enhancement(humio_logs sink): add text encoding

### DIFF
--- a/.meta/sinks/humio_logs.toml
+++ b/.meta/sinks/humio_logs.toml
@@ -63,6 +63,6 @@ description = "The optional host to send Humio logs to."
 
 <%= render("_partials/fields/_encoding_options.toml",
   namespace: "sinks.humio_logs.options",
-  encodings: ["json"],
+  encodings: ["json", "text"],
   default: "json"
 ) %>

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -6429,8 +6429,9 @@ require('custom_module')
     # * optional
     # * default: "json"
     # * type: string
-    # * must be: "json" (if supplied)
+    # * enum: "json" or "text"
     codec = "json"
+    codec = "text"
 
     # Prevent the sink from encoding the specified labels.
     #

--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -34,11 +34,15 @@ inventory::submit! {
 pub enum Encoding {
     #[derivative(Default)]
     Json,
+    Text,
 }
 
 impl Into<splunk_hec::Encoding> for Encoding {
     fn into(self) -> splunk_hec::Encoding {
-        splunk_hec::Encoding::Json
+        match self {
+            Encoding::Json => splunk_hec::Encoding::Json,
+            Encoding::Text => splunk_hec::Encoding::Text,
+        }
     }
 }
 

--- a/website/docs/reference/sinks/humio_logs.md
+++ b/website/docs/reference/sinks/humio_logs.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-04-24"
+last_modified_on: "2020-04-27"
 delivery_guarantee: "at_least_once"
 component_title: "Humio Logs"
 description: "The Vector `humio_logs` sink batches `log` events to Humio via the HEC API."
@@ -316,8 +316,8 @@ Configures the encoding specific sink behavior.
 <Field
   common={true}
   defaultValue={"json"}
-  enumValues={{"json":"Each event is encoded into JSON and the payload is represented as a JSON array."}}
-  examples={["json"]}
+  enumValues={{"json":"Each event is encoded into JSON and the payload is represented as a JSON array.","text":"Each event is encoded into text via the `message` key and the payload is new line delimited."}}
+  examples={["json","text"]}
   groups={[]}
   name={"codec"}
   path={"encoding"}


### PR DESCRIPTION
We already support this in the `splunk_hec` sink, so it's just a matter of passing the option through. 

Closes #2084 
