### PR TITLE
fix(pulsar sink): Move healtcheck consumer creation to boxed future

### DIFF
--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -169,19 +169,14 @@ fn encode_event(item: Event, enc: Encoding) -> crate::Result<Vec<u8>> {
 
 fn healthcheck(config: PulsarSinkConfig, pulsar: Pulsar) -> super::Healthcheck {
     Box::new(future::lazy(move || {
-        let consumer = pulsar
+        pulsar
             .consumer()
             .with_topic(&config.topic)
             .with_consumer_name("Healthcheck")
             .with_subscription_type(SubType::Shared)
             .with_subscription("HealthSubscription")
             .build::<String>()
-            .wait()
-            .expect("Pulsar healthcheck consumer failed to be created");
-
-        consumer
-            .take(1)
-            .collect()
+            .and_then(|consumer| consumer.take(1).collect())
             .map(|_| ())
             .map_err(|err| err.into())
     }))

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -67,7 +67,7 @@ inventory::submit! {
 impl SinkConfig for PulsarSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
         let sink = PulsarSink::new(self.clone(), cx.acker(), cx.exec())?;
-        let hc = healthcheck(self, &sink.pulsar)?;
+        let hc = healthcheck(self.clone(), sink.pulsar.clone());
         Ok((Box::new(sink), hc))
     }
 
@@ -167,23 +167,24 @@ fn encode_event(item: Event, enc: Encoding) -> crate::Result<Vec<u8>> {
     Ok(data)
 }
 
-fn healthcheck(config: &PulsarSinkConfig, pulsar: &Pulsar) -> crate::Result<super::Healthcheck> {
-    let consumer = pulsar
-        .consumer()
-        .with_topic(&config.topic)
-        .with_consumer_name("Healthcheck")
-        .with_subscription_type(SubType::Shared)
-        .with_subscription("HealthSubscription")
-        .build::<String>()
-        .wait()?;
+fn healthcheck(config: PulsarSinkConfig, pulsar: Pulsar) -> super::Healthcheck {
+    Box::new(future::lazy(move || {
+        let consumer = pulsar
+            .consumer()
+            .with_topic(&config.topic)
+            .with_consumer_name("Healthcheck")
+            .with_subscription_type(SubType::Shared)
+            .with_subscription("HealthSubscription")
+            .build::<String>()
+            .wait()
+            .expect("Pulsar healthcheck consumer failed to be created");
 
-    Ok(Box::new(
         consumer
             .take(1)
             .collect()
             .map(|_| ())
-            .map_err(|err| err.into()),
-    ))
+            .map_err(|err| err.into())
+    }))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
closes #2475 

I'm not actually able to recreate the users error. Perhaps we can get @KannarFr to give this branch a try?