### PR TITLE
fix(kafka sink): Run entire healthcheck lazily

### DIFF
--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -209,9 +209,11 @@ impl Sink for KafkaSink {
 }
 
 fn healthcheck(config: KafkaSinkConfig) -> super::Healthcheck {
-    let consumer: BaseConsumer = config.to_rdkafka().unwrap().create().unwrap();
+    let client = config.to_rdkafka().unwrap();
 
     let check = future::lazy(move || {
+        let consumer: BaseConsumer = client.create().unwrap();
+
         tokio::task::block_in_place(|| {
             consumer
                 .fetch_metadata(Some(&config.topic), Duration::from_secs(3))


### PR DESCRIPTION
Signed-off-by: Lucio Franco <luciofranco14@gmail.com>
