### PR TITLE
enhancement(elasticsearch sink): Add explicit AWS region

### DIFF
--- a/.meta/sinks/elasticsearch.toml.erb
+++ b/.meta/sinks/elasticsearch.toml.erb
@@ -105,6 +105,24 @@ relevant_when = {strategy = "basic"}
 required = true
 description = "The basic authentication user name."
 
+[sinks.elasticsearch.options.aws]
+type = "table"
+common = false
+description = "Options for the AWS connections."
+
+[sinks.elasticsearch.options.aws.children.region]
+type = "string"
+common = true
+examples = ["us-east-1"]
+relevant_when = {strategy = "aws"}
+required = false
+description = """\
+The [AWS region][urls.aws_regions] of the target service. \
+This defaults to the region named in the host parameter, \
+or the value of the `$AWS_REGION` or `$AWS_DEFAULT_REGION` environment \
+variables if that cannot be determined, or "us-east-1".\
+"""
+
 [sinks.elasticsearch.options.compression]
 type = "string"
 common = true

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -4559,6 +4559,22 @@ require('custom_module')
     user = "username"
 
   #
+  # AWS
+  #
+
+  [sinks.elasticsearch.aws]
+    # The AWS region of the target service. This defaults to the region named in
+    # the host parameter, or the value of the `$AWS_REGION` or
+    # `$AWS_DEFAULT_REGION` environment variables if that cannot be determined, or
+    # "us-east-1".
+    #
+    # * optional
+    # * no default
+    # * type: string
+    # * relevant when strategy = "aws"
+    region = "us-east-1"
+
+  #
   # Batch
   #
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -65,7 +65,9 @@ impl TryFrom<RegionOrEndpoint> for Region {
 /// Translate an endpoint URL into a Region
 pub fn region_from_endpoint(endpoint: &str) -> Result<Region, ParseError> {
     let uri = endpoint.parse::<Uri>().context(EndpointParseError)?;
-    let name = region_name_from_host(uri.host().unwrap_or(""))
+    let name = uri
+        .host()
+        .and_then(region_name_from_host)
         .unwrap_or_else(|| Region::default().name().into());
     let endpoint = strip_endpoint(&uri);
     Ok(Region::Custom { name, endpoint })

--- a/src/region.rs
+++ b/src/region.rs
@@ -65,29 +65,29 @@ impl TryFrom<RegionOrEndpoint> for Region {
 /// Translate an endpoint URL into a Region
 pub fn region_from_endpoint(endpoint: &str) -> Result<Region, ParseError> {
     let uri = endpoint.parse::<Uri>().context(EndpointParseError)?;
-    let name = region_name_from_host(uri.host().unwrap_or(""));
+    let name = region_name_from_host(uri.host().unwrap_or(""))
+        .unwrap_or_else(|| Region::default().name().into());
+    let endpoint = strip_endpoint(&uri);
+    Ok(Region::Custom { name, endpoint })
+}
 
-    // Reconstitute the endpoint from the URI, but strip off all path components
+/// Reconstitute the endpoint from the URI, but strip off all path components
+fn strip_endpoint(uri: &Uri) -> String {
     let pq_len = uri
         .path_and_query()
         .map(|pq| pq.as_str().len())
         .unwrap_or(1);
     let endpoint = uri.to_string();
-    let endpoint = endpoint[..endpoint.len() - pq_len].to_string();
-
-    Ok(Region::Custom { name, endpoint })
+    endpoint[..endpoint.len() - pq_len].to_string()
 }
 
-/// Translate a hostname into a custom region name
-fn region_name_from_host(host: &str) -> String {
-    // Find the first part of the domain name that matches a known region
-    for part in host.split('.') {
-        if let Ok(region) = Region::from_str(part) {
-            return region.name().into();
-        }
-    }
-    // Couldn't find a valid region, use the default
-    "custom".into()
+/// Translate a hostname into a region name by finding the first part of
+/// the domain name that matches a known region.
+fn region_name_from_host(host: &str) -> Option<String> {
+    host.split('.')
+        .filter_map(|part| Region::from_str(part).ok())
+        .map(|region| region.name().into())
+        .next()
 }
 
 #[cfg(test)]
@@ -133,7 +133,7 @@ mod tests {
         .unwrap();
 
         let expected_region = Region::Custom {
-            name: "custom".into(),
+            name: "us-east-1".into(),
             endpoint: "http://localhost:9000".into(),
         };
 
@@ -159,11 +159,28 @@ mod tests {
     }
 
     #[test]
+    fn extracts_region_name_from_host() {
+        assert_eq!(region_name_from_host("localhost"), None);
+        assert_eq!(
+            region_name_from_host("us-west-1.es.amazonaws.com"),
+            Some("us-west-1".into())
+        );
+        assert_eq!(
+            region_name_from_host("this-is-a-test.us-west-2.es.amazonaws.com"),
+            Some("us-west-2".into())
+        );
+        assert_eq!(
+            region_name_from_host("test.cn-north-1.es.amazonaws.com.cn"),
+            Some("cn-north-1".into())
+        );
+    }
+
+    #[test]
     fn region_from_endpoint_localhost() {
         assert_eq!(
             region_from_endpoint("http://localhost:9000").unwrap(),
             Region::Custom {
-                name: "custom".into(),
+                name: "us-east-1".into(),
                 endpoint: "http://localhost:9000".into()
             }
         );
@@ -190,7 +207,7 @@ mod tests {
         assert_eq!(
             region_from_endpoint("http://localhost:9000/path?query").unwrap(),
             Region::Custom {
-                name: "custom".into(),
+                name: "us-east-1".into(),
                 endpoint: "http://localhost:9000".into()
             }
         );

--- a/website/docs/reference/sinks/elasticsearch.md
+++ b/website/docs/reference/sinks/elasticsearch.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-05-01"
+last_modified_on: "2020-05-03"
 delivery_guarantee: "at_least_once"
 component_title: "Elasticsearch"
 description: "The Vector `elasticsearch` sink batches `log` events to Elasticsearch via the `_bulk` API endpoint."
@@ -79,6 +79,9 @@ endpoint][urls.elasticsearch_bulk].
   auth.password = "${ELASTICSEARCH_PASSWORD}" # required, required when strategy = "basic"
   auth.strategy = "aws" # required
   auth.user = "${ELASTICSEARCH_USERNAME}" # required, required when strategy = "basic"
+
+  # AWS
+  aws.region = "us-east-1" # optional, no default, relevant when strategy = "aws"
 
   # Batch
   batch.max_size = 10490000 # optional, default, bytes
@@ -211,6 +214,57 @@ The authentication strategy to use.
 #### user
 
 The basic authentication user name.
+
+
+
+</Field>
+</Fields>
+
+</Field>
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  groups={[]}
+  name={"aws"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  warnings={[]}
+  >
+
+### aws
+
+Options for the AWS connections.
+
+
+<Fields filters={false}>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["us-east-1"]}
+  groups={[]}
+  name={"region"}
+  path={"aws"}
+  relevantWhen={{"strategy":"aws"}}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### region
+
+The [AWS region][urls.aws_regions] of the target service. This defaults to the
+region named in the host parameter, or the value of the `$AWS_REGION` or
+`$AWS_DEFAULT_REGION` environment variables if that cannot be determined, or
+"us-east-1".
 
 
 
@@ -1326,6 +1380,7 @@ You can learn more about the complete syntax in the
 [urls.aws_credential_process]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
 [urls.aws_credentials_file]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [urls.aws_elasticsearch]: https://aws.amazon.com/elasticsearch-service/
+[urls.aws_regions]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
 [urls.basic_auth]: https://en.wikipedia.org/wiki/Basic_access_authentication
 [urls.elasticsearch]: https://www.elastic.co/products/elasticsearch
 [urls.elasticsearch_bulk]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html


### PR DESCRIPTION
Ref https://github.com/timberio/vector/pull/2412#issuecomment-618470561

This is the final part of the Elasticsearch sink AWS fix. It adds support for an explicit AWS region, and defaults (via the rusoto crate) to `$AWS_REGION`, `$AWS_DEFAULT_REGION`, or `"us-east-1"`.

The default region behavior is also extended to all other AWS sinks when configured using an endpoint. I don't think this should be a breaking change, but I'd like confirmation.