### PR TITLE
fix(humio_logs sink): remove superfluous warning

### DIFF
--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -63,9 +63,6 @@ impl SinkConfig for HumioLogsConfig {
 
 impl HumioLogsConfig {
     fn build_hec_config(&self) -> HecSinkConfig {
-        if self.encoding.codec != Encoding::Json {
-            error!("Using an unsupported encoding for Humio");
-        }
         let host = self.host.clone().unwrap_or_else(|| HOST.to_string());
 
         HecSinkConfig {


### PR DESCRIPTION
Closes #2515 

I don't believe this warning serves any purpose, since unsupported encodings should not be representable as a `humio_logs::Encoding`.