### PR TITLE
fix: Fix the Kafka TLS key parameter handling

### DIFF
--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -42,10 +42,10 @@ impl KafkaTlsConfig {
             client.set("ssl.certificate.location", pathbuf_to_string(&path)?);
         }
         if let Some(ref path) = self.options.key_path {
-            client.set("ssl.keystore.location", pathbuf_to_string(&path)?);
+            client.set("ssl.key.location", pathbuf_to_string(&path)?);
         }
         if let Some(ref pass) = self.options.key_pass {
-            client.set("ssl.keystore.password", pass);
+            client.set("ssl.key.password", pass);
         }
         Ok(())
     }

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -352,6 +352,8 @@ mod integration_test {
     }
 
     const TEST_CA: &str = "tests/data/Vector_CA.crt";
+    const TEST_CRT: &str = "tests/data/localhost.crt";
+    const TEST_KEY: &str = "tests/data/localhost.key";
 
     #[test]
     fn kafka_happy_path_tls() {
@@ -361,6 +363,24 @@ mod integration_test {
                 enabled: Some(true),
                 options: TlsOptions {
                     ca_path: Some(TEST_CA.into()),
+                    ..Default::default()
+                },
+            }),
+            None,
+        );
+    }
+
+    #[test]
+    fn kafka_happy_path_tls_with_key() {
+        kafka_happy_path(
+            "localhost:9091",
+            Some(KafkaTlsConfig {
+                enabled: Some(true),
+                options: TlsOptions {
+                    ca_path: Some(TEST_CA.into()),
+                    // Dummy key, not actually checked by server
+                    crt_path: Some(TEST_CRT.into()),
+                    key_path: Some(TEST_KEY.into()),
                     ..Default::default()
                 },
             }),


### PR DESCRIPTION
Closes #2638 

When enabling a TLS/SSL client key, the parameter passed to the
librdkafka client library was "ssl.keystore.location". This is the the
wrong setting, it should be "ssl.key.location".

This fix affects the kafka sink and source.

Signed-off-by: Bruce Guenter <bruce@timber.io>