### PR TITLE
fix(Humio sink): Removing trailing slash from host parameter before constructing HEC URL

### DIFF
--- a/src/sinks/humio_logs.rs
+++ b/src/sinks/humio_logs.rs
@@ -65,7 +65,12 @@ impl SinkConfig for HumioLogsConfig {
 
 impl HumioLogsConfig {
     fn build_hec_config(&self) -> HecSinkConfig {
-        let host = self.host.clone().unwrap_or_else(|| HOST.to_string());
+        let mut host = self.host.clone().unwrap_or_else(|| HOST.to_string());
+
+        if host.ends_with('/') {
+            host.pop();
+        }
+
 
         HecSinkConfig {
             token: self.token.clone(),


### PR DESCRIPTION
This PR addresses https://github.com/timberio/vector/issues/2705 