### PR TITLE
enhancement(buffers): Add lz4 compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytecount"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92204551573580e078dc80017f36a213eb77a0450e4ddd8cfa0f3f2d1f0178f"
+
+[[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +323,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 dependencies = [
  "ppv-lite86",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1b4d380e1bab994591a24c2bdd1b054f64b60bef483a8c598c7c345bc3bbe"
+dependencies = [
+ "error-chain",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -894,6 +913,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 dependencies = [
+ "backtrace",
  "version_check 0.1.5",
 ]
 
@@ -1956,6 +1976,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c94a9f09a60017f373020cc93d4291db4cd92b0db64ff25927f27d09dc23d5"
+dependencies = [
+ "libc",
+ "lz4-sys",
+ "skeptic",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ab022822e9331c58d373acdd6b98085bace058ac6837b8266f213a2fccdafe"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,6 +2841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef52fac62d0ea7b9b4dc7da092aa64ea7ec3d90af6679422d3d7e0e14b6ee15"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "pulsar"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,6 +3578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+ "serde",
 ]
 
 [[package]]
@@ -3702,6 +3753,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d3e7f23bad2d6694e0f46f5e470ec27eb07b8f3e8b309a4b0dc17501928b9f2"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "skeptic"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6fb8ed853fdc19ce09752d63f3a2e5b5158aeb261520cd75eb618bd60305165"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob 0.2.11",
+ "pulldown-cmark",
+ "serde_json",
+ "tempdir",
+ "walkdir",
 ]
 
 [[package]]
@@ -3998,6 +4065,16 @@ checksum = "0328783c46b98ea9e2747a49761313f483cf7bba40e51d6f0b05bf31b988d578"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.4",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -5051,6 +5128,7 @@ dependencies = [
  "listenfd",
  "logfmt",
  "lru",
+ "lz4",
  "matches",
  "maxminddb",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ openssl = "0.10.26"
 openssl-probe = "0.1.2"
 string_cache = "0.7.3"
 flate2 = "1.0.6"
+lz4 = "1.23.1"
 structopt = "0.3.13"
 indexmap = {version = "1.0.2", features = ["serde-1"]}
 http = "0.1.14"


### PR DESCRIPTION
Related with #1411. I crated this draft for discussion.

[lz4](https://crates.io/crates/lz4) crate is outdated (last release was at Nov 28, 2018. Recently new maintainer was introduced -- https://github.com/bozaro/lz4-rs/issues/52. Looks like transfer is still in progress.

I was interesting in `ffi` so made changes in own fork: https://github.com/fanatid/lz4-rs/commits/master -- but publish something same under new name is not wise solution.

Not sure how handle this situation.