### PR TITLE
fix: Handle templates with invalid strftime elements

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,6 +4,7 @@ use approx::assert_relative_eq;
 use futures01::future;
 use rand::distributions::{Alphanumeric, Uniform};
 use rand::prelude::*;
+use std::convert::TryFrom;
 use vector::event::Event;
 use vector::test_util::{
     block_on, count_receive, next_addr, send_lines, shutdown_on_idle, wait_for_tcp,
@@ -626,7 +627,7 @@ fn bench_elasticsearch_index(c: &mut Criterion) {
                         .as_mut_log()
                         .insert(event::log_schema().timestamp_key().clone(), Utc::now());
 
-                    (Template::from("index-%Y.%m.%d"), event)
+                    (Template::try_from("index-%Y.%m.%d").unwrap(), event)
                 },
                 |(index, event)| index.render(&event),
             )
@@ -643,7 +644,7 @@ fn bench_elasticsearch_index(c: &mut Criterion) {
                         .as_mut_log()
                         .insert(event::log_schema().timestamp_key().clone(), Utc::now());
 
-                    (Template::from("index"), event)
+                    (Template::try_from("index").unwrap(), event)
                 },
                 |(index, event)| index.render(&event),
             )

--- a/benches/files.rs
+++ b/benches/files.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use criterion::{criterion_group, Benchmark, Criterion, Throughput};
 use futures01::{sink::Sink, stream::Stream, Future};
+use std::convert::TryInto;
 use std::path::PathBuf;
 use tempfile::tempdir;
 use tokio01::codec::{BytesCodec, FramedWrite};
@@ -48,7 +49,7 @@ fn benchmark_files_without_partitions(c: &mut Criterion) {
                     "out",
                     &["in"],
                     sinks::file::FileSinkConfig {
-                        path: output.into(),
+                        path: output.try_into().unwrap(),
                         idle_timeout_secs: None,
                         encoding: sinks::file::Encoding::Text.into(),
                     },

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -653,13 +653,14 @@ mod tests {
         test_util::runtime,
     };
     use std::collections::HashMap;
+    use std::convert::{TryFrom, TryInto};
     use string_cache::DefaultAtom as Atom;
 
     #[test]
     fn partition_static() {
         let event = Event::from("hello world");
-        let stream = Template::from("stream");
-        let group = "group".into();
+        let stream = Template::try_from("stream").unwrap();
+        let group = "group".try_into().unwrap();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
 
@@ -677,8 +678,8 @@ mod tests {
 
         event.as_mut_log().insert("log_stream", "stream");
 
-        let stream = Template::from("{{log_stream}}");
-        let group = "group".into();
+        let stream = Template::try_from("{{log_stream}}").unwrap();
+        let group = "group".try_into().unwrap();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
 
@@ -696,8 +697,8 @@ mod tests {
 
         event.as_mut_log().insert("log_stream", "stream");
 
-        let stream = Template::from("abcd-{{log_stream}}");
-        let group = "group".into();
+        let stream = Template::try_from("abcd-{{log_stream}}").unwrap();
+        let group = "group".try_into().unwrap();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
 
@@ -715,8 +716,8 @@ mod tests {
 
         event.as_mut_log().insert("log_stream", "stream");
 
-        let stream = Template::from("{{log_stream}}-abcd");
-        let group = "group".into();
+        let stream = Template::try_from("{{log_stream}}-abcd").unwrap();
+        let group = "group".try_into().unwrap();
 
         let (_event, key) = partition(event, &group, &stream).unwrap().into_parts();
 
@@ -732,8 +733,8 @@ mod tests {
     fn partition_no_key_event() {
         let event = Event::from("hello world");
 
-        let stream = Template::from("{{log_stream}}");
-        let group = "group".into();
+        let stream = Template::try_from("{{log_stream}}").unwrap();
+        let group = "group".try_into().unwrap();
 
         let stream_val = partition(event, &group, &stream);
 

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -23,7 +23,7 @@ use rusoto_s3::{
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::collections::BTreeMap;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use tower::{Service, ServiceBuilder};
 use tracing::field;
 use tracing_futures::{Instrument, Instrumented};
@@ -167,11 +167,12 @@ impl S3Sink {
         let filename_append_uuid = config.filename_append_uuid.unwrap_or(true);
         let batch = config.batch.unwrap_or(bytesize::mib(10u64), 300);
 
-        let key_prefix = if let Some(kp) = &config.key_prefix {
-            Template::from(kp.as_str())
-        } else {
-            Template::from("date=%F/")
-        };
+        let key_prefix = config
+            .key_prefix
+            .as_ref()
+            .map(String::as_str)
+            .unwrap_or("date=%F/");
+        let key_prefix = Template::try_from(key_prefix)?;
 
         let region = config.region.clone().try_into()?;
 
@@ -415,7 +416,7 @@ mod tests {
     #[test]
     fn s3_encode_event_text() {
         let message = "hello world".to_string();
-        let batch_time_format = Template::from("date=%F");
+        let batch_time_format = Template::try_from("date=%F").unwrap();
         let bytes = encode_event(
             message.clone().into(),
             &batch_time_format,
@@ -434,7 +435,7 @@ mod tests {
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("key", "value");
 
-        let batch_time_format = Template::from("date=%F");
+        let batch_time_format = Template::try_from("date=%F").unwrap();
         let bytes = encode_event(event, &batch_time_format, &Encoding::Ndjson.into()).unwrap();
 
         let (bytes, _) = bytes.into_parts();
@@ -450,7 +451,7 @@ mod tests {
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("key", "value");
 
-        let key_prefix = Template::from("{{ key }}");
+        let key_prefix = Template::try_from("{{ key }}").unwrap();
 
         let encoding_config = EncodingConfigWithDefault {
             codec: Encoding::Ndjson,

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -249,6 +249,7 @@ mod tests {
         },
     };
     use futures::stream;
+    use std::convert::TryInto;
 
     #[test]
     fn single_partition() {
@@ -257,7 +258,7 @@ mod tests {
         let template = temp_file();
 
         let config = FileSinkConfig {
-            path: template.clone().into(),
+            path: template.clone().try_into().unwrap(),
             idle_timeout_secs: None,
             encoding: Encoding::Text.into(),
         };
@@ -290,7 +291,7 @@ mod tests {
         trace!(message = "Template", %template);
 
         let config = FileSinkConfig {
-            path: template.clone().into(),
+            path: template.clone().try_into().unwrap(),
             idle_timeout_secs: None,
             encoding: Encoding::Text.into(),
         };

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         Healthcheck, RouterSink,
     },
-    template::Template,
+    template::{Template, TemplateError},
     tls::{TlsOptions, TlsSettings},
     topology::config::{DataType, SinkConfig, SinkContext, SinkDescription},
 };
@@ -26,8 +26,9 @@ use hyper::{
 };
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use tower::{Service, ServiceBuilder};
 use tracing::field;
 use uuid::Uuid;
@@ -172,6 +173,8 @@ enum HealthcheckError {
     UnknownBucket { bucket: String },
     #[snafu(display("Unknown status code: {}", status))]
     UnknownStatus { status: http::StatusCode },
+    #[snafu(display("key_prefix template parse error: {}", source))]
+    KeyPrefixTemplate { source: TemplateError },
 }
 
 impl GcsSink {
@@ -197,11 +200,12 @@ impl GcsSink {
 
         let batch = config.batch.unwrap_or(bytesize::mib(10u64), 300);
 
-        let key_prefix = if let Some(kp) = &config.key_prefix {
-            Template::from(kp.as_str())
-        } else {
-            Template::from("date=%F/")
-        };
+        let key_prefix = config
+            .key_prefix
+            .as_ref()
+            .map(String::as_str)
+            .unwrap_or("date=%F/");
+        let key_prefix = Template::try_from(key_prefix).context(KeyPrefixTemplate)?;
 
         let settings = self.settings.clone();
 
@@ -469,7 +473,7 @@ mod tests {
     #[test]
     fn gcs_encode_event_text() {
         let message = "hello world".to_string();
-        let batch_time_format = Template::from("date=%F");
+        let batch_time_format = Template::try_from("date=%F").unwrap();
         let bytes = encode_event(
             message.clone().into(),
             &batch_time_format,
@@ -488,7 +492,7 @@ mod tests {
         let mut event = Event::from(message.clone());
         event.as_mut_log().insert("key", "value");
 
-        let batch_time_format = Template::from("date=%F");
+        let batch_time_format = Template::try_from("date=%F").unwrap();
         let bytes = encode_event(event, &batch_time_format, &Encoding::Ndjson.into()).unwrap();
 
         let (bytes, _) = bytes.into_parts();

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -295,6 +295,7 @@ mod integration_tests {
     use crate::Event;
     use bytes::Bytes;
     use futures01::Sink;
+    use std::convert::TryFrom;
 
     #[test]
     fn text() {
@@ -312,7 +313,7 @@ mod integration_tests {
         let test_name = config.labels.get_mut("test_name").unwrap();
         assert_eq!(test_name.get_ref(), &Bytes::from("placeholder"));
 
-        *test_name = Template::from(stream.to_string());
+        *test_name = Template::try_from(stream.to_string()).unwrap();
 
         let (sink, _) = config.build(cx).unwrap();
 
@@ -349,7 +350,7 @@ mod integration_tests {
         let test_name = config.labels.get_mut("test_name").unwrap();
         assert_eq!(test_name.get_ref(), &Bytes::from("placeholder"));
 
-        *test_name = Template::from(stream.to_string());
+        *test_name = Template::try_from(stream.to_string()).unwrap();
 
         let (sink, _) = config.build(cx).unwrap();
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -13,6 +13,8 @@ use serde::{
     de::{self, Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
+use std::convert::TryFrom;
+use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
 use string_cache::DefaultAtom as Atom;
@@ -29,20 +31,53 @@ pub struct Template {
     has_fields: bool,
 }
 
-impl From<&str> for Template {
-    fn from(src: &str) -> Template {
-        Template {
-            src: src.into(),
-            src_bytes: src.into(),
-            has_ts: StrftimeItems::new(src).filter(is_dynamic).count() > 0,
-            has_fields: RE.is_match(src),
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TemplateError {
+    StrftimeError,
+}
+
+impl Error for TemplateError {}
+
+impl fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StrftimeError => write!(f, "Invalid strftime item"),
         }
     }
 }
 
-impl From<PathBuf> for Template {
-    fn from(p: PathBuf) -> Self {
-        Template::from(&*p.to_string_lossy())
+impl TryFrom<&str> for Template {
+    type Error = TemplateError;
+
+    fn try_from(src: &str) -> Result<Self, Self::Error> {
+        match StrftimeItems::new(src)
+            .filter(|item| matches!(item, Item::Error))
+            .count()
+        {
+            0 => Ok(Template {
+                src: src.into(),
+                src_bytes: src.into(),
+                has_ts: StrftimeItems::new(src).filter(is_dynamic).count() > 0,
+                has_fields: RE.is_match(src),
+            }),
+            _ => Err(TemplateError::StrftimeError),
+        }
+    }
+}
+
+impl TryFrom<PathBuf> for Template {
+    type Error = TemplateError;
+
+    fn try_from(p: PathBuf) -> Result<Self, Self::Error> {
+        Template::try_from(&*p.to_string_lossy())
+    }
+}
+
+impl TryFrom<String> for Template {
+    type Error = TemplateError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Template::try_from(s.as_str())
     }
 }
 
@@ -53,12 +88,6 @@ fn is_dynamic(item: &Item) -> bool {
         Item::Numeric(_, _) => true,
         Item::Space(_) | Item::OwnedSpace(_) => false,
         Item::Literal(_) | Item::OwnedLiteral(_) => false,
-    }
-}
-
-impl From<String> for Template {
-    fn from(s: String) -> Self {
-        Template::from(s.as_str())
     }
 }
 
@@ -163,7 +192,7 @@ impl<'de> Visitor<'de> for TemplateVisitor {
     where
         E: de::Error,
     {
-        Ok(Template::from(s))
+        Template::try_from(s).map_err(de::Error::custom)
     }
 }
 
@@ -185,10 +214,16 @@ mod tests {
 
     #[test]
     fn get_fields() {
-        let f1 = Template::from("{{ foo }}").get_fields().unwrap();
-        let f2 = Template::from("{{ foo }}-{{ bar }}").get_fields().unwrap();
-        let f3 = Template::from("nofield").get_fields();
-        let f4 = Template::from("%F").get_fields();
+        let f1 = Template::try_from("{{ foo }}")
+            .unwrap()
+            .get_fields()
+            .unwrap();
+        let f2 = Template::try_from("{{ foo }}-{{ bar }}")
+            .unwrap()
+            .get_fields()
+            .unwrap();
+        let f3 = Template::try_from("nofield").unwrap().get_fields();
+        let f4 = Template::try_from("%F").unwrap().get_fields();
 
         assert_eq!(f1, vec![Atom::from("foo")]);
         assert_eq!(f2, vec![Atom::from("foo"), Atom::from("bar")]);
@@ -198,16 +233,32 @@ mod tests {
 
     #[test]
     fn is_dynamic() {
-        assert_eq!(true, Template::from("/kube-demo/%F").is_dynamic());
-        assert_eq!(false, Template::from("/kube-demo/echo").is_dynamic());
-        assert_eq!(true, Template::from("/kube-demo/{{ foo }}").is_dynamic());
-        assert_eq!(true, Template::from("/kube-demo/{{ foo }}/%F").is_dynamic());
+        assert_eq!(
+            true,
+            Template::try_from("/kube-demo/%F").unwrap().is_dynamic()
+        );
+        assert_eq!(
+            false,
+            Template::try_from("/kube-demo/echo").unwrap().is_dynamic()
+        );
+        assert_eq!(
+            true,
+            Template::try_from("/kube-demo/{{ foo }}")
+                .unwrap()
+                .is_dynamic()
+        );
+        assert_eq!(
+            true,
+            Template::try_from("/kube-demo/{{ foo }}/%F")
+                .unwrap()
+                .is_dynamic()
+        );
     }
 
     #[test]
     fn render_static() {
         let event = Event::from("hello world");
-        let template = Template::from("foo");
+        let template = Template::try_from("foo").unwrap();
 
         assert_eq!(Ok(Bytes::from("foo")), template.render(&event))
     }
@@ -216,7 +267,7 @@ mod tests {
     fn render_dynamic() {
         let mut event = Event::from("hello world");
         event.as_mut_log().insert("log_stream", "stream");
-        let template = Template::from("{{log_stream}}");
+        let template = Template::try_from("{{log_stream}}").unwrap();
 
         assert_eq!(Ok(Bytes::from("stream")), template.render(&event))
     }
@@ -225,7 +276,7 @@ mod tests {
     fn render_dynamic_with_prefix() {
         let mut event = Event::from("hello world");
         event.as_mut_log().insert("log_stream", "stream");
-        let template = Template::from("abcd-{{log_stream}}");
+        let template = Template::try_from("abcd-{{log_stream}}").unwrap();
 
         assert_eq!(Ok(Bytes::from("abcd-stream")), template.render(&event))
     }
@@ -234,7 +285,7 @@ mod tests {
     fn render_dynamic_with_postfix() {
         let mut event = Event::from("hello world");
         event.as_mut_log().insert("log_stream", "stream");
-        let template = Template::from("{{log_stream}}-abcd");
+        let template = Template::try_from("{{log_stream}}-abcd").unwrap();
 
         assert_eq!(Ok(Bytes::from("stream-abcd")), template.render(&event))
     }
@@ -242,7 +293,7 @@ mod tests {
     #[test]
     fn render_dynamic_missing_key() {
         let event = Event::from("hello world");
-        let template = Template::from("{{log_stream}}-{{foo}}");
+        let template = Template::try_from("{{log_stream}}-{{foo}}").unwrap();
 
         assert_eq!(
             Err(vec![Atom::from("log_stream"), Atom::from("foo")]),
@@ -255,7 +306,7 @@ mod tests {
         let mut event = Event::from("hello world");
         event.as_mut_log().insert("foo", "bar");
         event.as_mut_log().insert("baz", "quux");
-        let template = Template::from("stream-{{foo}}-{{baz}}.log");
+        let template = Template::try_from("stream-{{foo}}-{{baz}}.log").unwrap();
 
         assert_eq!(
             Ok(Bytes::from("stream-bar-quux.log")),
@@ -268,7 +319,7 @@ mod tests {
         let mut event = Event::from("hello world");
         event.as_mut_log().insert("foo", "bar");
         event.as_mut_log().insert("baz", "quux");
-        let template = Template::from(r"{stream}{\{{}}}-{{foo}}-{{baz}}.log");
+        let template = Template::try_from(r"{stream}{\{{}}}-{{foo}}-{{baz}}.log").unwrap();
 
         assert_eq!(
             Ok(Bytes::from(r"{stream}{\{{}}}-bar-quux.log")),
@@ -285,7 +336,7 @@ mod tests {
             .as_mut_log()
             .insert(crate::event::log_schema().timestamp_key().clone(), ts);
 
-        let template = Template::from("abcd-%F");
+        let template = Template::try_from("abcd-%F").unwrap();
 
         assert_eq!(Ok(Bytes::from("abcd-2001-02-03")), template.render(&event))
     }
@@ -299,7 +350,7 @@ mod tests {
             .as_mut_log()
             .insert(crate::event::log_schema().timestamp_key().clone(), ts);
 
-        let template = Template::from("abcd-%F_%T");
+        let template = Template::try_from("abcd-%F_%T").unwrap();
 
         assert_eq!(
             Ok(Bytes::from("abcd-2001-02-03_04:05:06")),
@@ -317,7 +368,7 @@ mod tests {
             .as_mut_log()
             .insert(crate::event::log_schema().timestamp_key().clone(), ts);
 
-        let template = Template::from("{{ foo }}-%F_%T");
+        let template = Template::try_from("{{ foo }}-%F_%T").unwrap();
 
         assert_eq!(
             Ok(Bytes::from("butts-2001-02-03_04:05:06")),
@@ -335,7 +386,7 @@ mod tests {
             .as_mut_log()
             .insert(crate::event::log_schema().timestamp_key().clone(), ts);
 
-        let template = Template::from("nested {{ format }} %T");
+        let template = Template::try_from("nested {{ format }} %T").unwrap();
 
         assert_eq!(
             Ok(Bytes::from("nested 2001-02-03 04:05:06")),
@@ -353,11 +404,19 @@ mod tests {
             .as_mut_log()
             .insert(crate::event::log_schema().timestamp_key().clone(), ts);
 
-        let template = Template::from("nested {{ %F }} %T");
+        let template = Template::try_from("nested {{ %F }} %T").unwrap();
 
         assert_eq!(
             Ok(Bytes::from("nested foo 04:05:06")),
             template.render(&event)
         )
+    }
+
+    #[test]
+    fn strftime_error() {
+        assert_eq!(
+            Template::try_from("%E").unwrap_err(),
+            TemplateError::StrftimeError
+        );
     }
 }


### PR DESCRIPTION
Please make sure I did all the error handling correctly. There were a couple of cases where I guessed at the right error handling result.

Closes #2736 

Signed-off-by: Bruce Guenter <bruce@timber.io>