### PR TITLE
fix(aws_cloudwatch_logs sink): Make throttling errors retryable

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -550,6 +550,14 @@ impl RetryLogic for CloudwatchRetryLogic {
                     true
                 }
 
+                RusotoError::Unknown(res)
+                    if rusoto_core::proto::json::Error::parse(&res)
+                        .filter(|err| err.typ.as_str() == "ThrottlingException")
+                        .is_some() =>
+                {
+                    true
+                }
+
                 _ => false,
             },
 


### PR DESCRIPTION
Closes #2740 

Based on https://docs.rs/rusoto_logs/0.41.0/src/rusoto_logs/generated.rs.html#2722-2767 & https://docs.rs/rusoto_core/0.41.0/src/rusoto_core/proto/json/error.rs.html#5-34

[PutLogEventsError](https://docs.rs/rusoto_logs/0.41.0/rusoto_logs/enum.PutLogEventsError.html) have limited number of errors and throttling error stored in [RusotoError::Unknown](https://docs.rs/rusoto_core/0.41.0/rusoto_core/enum.RusotoError.html#variant.Unknown).

`rusoto_core::proto::json::Error::parse` is not documented, but I used it for parsing [BufferedHttpResponse](https://docs.rs/rusoto_core/0.41.0/rusoto_core/request/struct.BufferedHttpResponse.html).