### PR TITLE
fix(aws_cloudwatch_logs sink): Drop excessive large events

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -307,7 +307,7 @@ impl CloudwatchLogsSvc {
             .map(|e| e.into_log())
             .filter_map(|e| {
                 self.encode_log(e)
-                    .map_err(|error| error!(message = "Could not encode event", %error))
+                    .map_err(|error| error!(message = "Could not encode event", %error, rate_limit_secs = 5))
                     .ok()
             })
             .filter(|e| age_range.contains(&e.timestamp))


### PR DESCRIPTION
AWS CloudWatch Logs has a fixed maximum event size of 256KiB. This
modifies the sink to drop all events that exceed that size once encoded
and generate an error.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #2742