### PR TITLE
fix(elasticsearch sink): refresh AWS credentials when required

### DIFF
--- a/src/sinks/util/rusoto.rs
+++ b/src/sinks/util/rusoto.rs
@@ -22,7 +22,7 @@ use rusoto_signature::{SignedRequest, SignedRequestPayload};
 use rusoto_sts::{StsAssumeRoleSessionCredentialsProvider, StsClient};
 use snafu::{ResultExt, Snafu};
 use std::{
-    io,
+    fmt, io,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -48,6 +48,20 @@ pub enum AwsCredentialsProvider {
     Default(AutoRefreshingProvider<ChainProvider>),
     Role(AutoRefreshingProvider<StsAssumeRoleSessionCredentialsProvider>),
     Static(StaticProvider),
+}
+
+impl fmt::Debug for AwsCredentialsProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Default(_) => "default",
+            Self::Role(_) => "role",
+            Self::Static(_) => "static",
+        };
+
+        f.debug_tuple("AwsCredentialsProvider")
+            .field(&name)
+            .finish()
+    }
 }
 
 impl AwsCredentialsProvider {


### PR DESCRIPTION
Closes #2815 

Credentials checked and refreshed if required on each `finish_signer` function call.
Currently working as blocking operation, for unblocking we need change `HttpSink::build_request` to async. (Submit as other PR before or after this PR?)

Also added `assume_role` option. In docs looks like:
![Screenshot from 2020-06-18 17-38-49](https://user-images.githubusercontent.com/2633065/85034749-1048d300-b18b-11ea-8e59-b1792e874356.png)