### PR TITLE
enhancement: Add SASL to kafka

### DIFF
--- a/.meta/_partials/fields/_kafka_options.toml.erb
+++ b/.meta/_partials/fields/_kafka_options.toml.erb
@@ -26,3 +26,39 @@ examples = [
 description = """\
 The options and their values. Accepts `string` values.
 """
+
+[<%= namespace %>.sasl]
+type = "table"
+category = "SASL"
+common = false
+description = "Options for SASL/SCRAM authentication support."
+
+[<%= namespace %>.sasl.children.enabled]
+type = "bool"
+common = true
+description = "Enable SASL/SCRAM authentication to the remote."
+
+[<%= namespace %>.sasl.children.username]
+type = "string"
+common = true
+examples = ["username"]
+description = "The Kafka SASL/SCRAM authentication username."
+
+[<%= namespace %>.sasl.children.password]
+type = "string"
+common = true
+examples = ["password"]
+description = "The Kafka SASL/SCRAM authentication password."
+
+[<%= namespace %>.sasl.children.mechanism]
+type = "string"
+common = true
+examples = ["SCRAM-SHA-256", "SCRAM-SHA-512"]
+description = "The Kafka SASL/SCRAM mechanisms."
+
+<%= render("_partials/fields/_tls_connector_options.toml",
+  namespace: namespace,
+  can_enable: true,
+  can_verify_certificate: false,
+  can_verify_hostname: false
+) %>

--- a/.meta/sinks/kafka.toml.erb
+++ b/.meta/sinks/kafka.toml.erb
@@ -60,13 +60,6 @@ randomly generated. If the field does not exist on the log, a blank value \
 will be used.\
 """
 
-<%= render("_partials/fields/_tls_connector_options.toml",
-  namespace: "sinks.kafka.options",
-  can_enable: true,
-  can_verify_certificate: false,
-  can_verify_hostname: false
-) %>
-
 [sinks.kafka.options.topic]
 type = "string"
 common = true

--- a/.meta/sources/kafka.toml.erb
+++ b/.meta/sources/kafka.toml.erb
@@ -26,13 +26,6 @@ through_description = "[Kafka][urls.kafka]"
   namespace: "sources.kafka.options"
 ) %>
 
-<%= render("_partials/fields/_tls_connector_options.toml",
-  namespace: "sources.kafka.options",
-  can_enable: true,
-  can_verify_certificate: false,
-  can_verify_hostname: false
-) %>
-
 [sources.kafka.options.topics]
 type = "[string]"
 common = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ leveldb = { git = "https://github.com/timberio/leveldb", optional = true, defaul
 db-key = "0.0.5"
 headers = "0.2.1"
 headers03 = { package = "headers", version = "0.3" }
-rdkafka = { version = "0.23.1", features = ["libz", "ssl", "zstd"], optional = true }
+rdkafka = { version = "0.23.1", features = ["libz", "ssl", "zstd", "gssapi"], optional = true }
 hostname = "0.1.5"
 seahash = { version = "3.0.6", optional = true }
 jemallocator = { version = "0.3.0", optional = true }

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -654,6 +654,41 @@ dns_servers = ["0.0.0.0:53"]
     "socket.send.buffer.bytes" = "100"
 
   #
+  # SASL
+  #
+
+  [sources.kafka.sasl]
+    # Enable SASL/SCRAM authentication to the remote.
+    #
+    # * optional
+    # * no default
+    # * type: bool
+    enabled = true
+    enabled = false
+
+    # The Kafka SASL/SCRAM mechanisms.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    mechanism = "SCRAM-SHA-256"
+    mechanism = "SCRAM-SHA-512"
+
+    # The Kafka SASL/SCRAM authentication password.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    password = "password"
+
+    # The Kafka SASL/SCRAM authentication username.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    username = "username"
+
+  #
   # TLS
   #
 
@@ -7459,6 +7494,41 @@ require('custom_module')
     "client.id" = "${ENV_VAR}"
     "fetch.error.backoff.ms" = "1000"
     "socket.send.buffer.bytes" = "100"
+
+  #
+  # SASL
+  #
+
+  [sinks.kafka.sasl]
+    # Enable SASL/SCRAM authentication to the remote.
+    #
+    # * optional
+    # * no default
+    # * type: bool
+    enabled = true
+    enabled = false
+
+    # The Kafka SASL/SCRAM mechanisms.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    mechanism = "SCRAM-SHA-256"
+    mechanism = "SCRAM-SHA-512"
+
+    # The Kafka SASL/SCRAM authentication password.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    password = "password"
+
+    # The Kafka SASL/SCRAM authentication username.
+    #
+    # * optional
+    # * no default
+    # * type: string
+    username = "username"
 
   #
   # TLS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -463,16 +463,21 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://:9092,SSL://:9091
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,SSL://localhost:9091
+      KAFKA_LISTENERS: PLAINTEXT://:9091,SSL://:9092,SASL_PLAINTEXT://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9091,SSL://localhost:9092,SASL_PLAINTEXT://localhost:9093
       KAFKA_SSL_KEYSTORE_LOCATION: /certs/localhost.p12
       KAFKA_SSL_KEYSTORE_PASSWORD: NOPASS
       KAFKA_SSL_TRUSTSTORE_LOCATION: /certs/localhost.p12
       KAFKA_SSL_TRUSTSTORE_PASSWORD: NOPASS
       KAFKA_SSL_KEY_PASSWORD: NOPASS
       KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: none
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
     volumes:
       - ./tests/data/localhost.p12:/certs/localhost.p12:ro
+      - ./tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
   pulsar:
     image: apachepulsar/pulsar
     command: bin/pulsar standalone

--- a/scripts/environment/definition.nix
+++ b/scripts/environment/definition.nix
@@ -57,6 +57,7 @@ scope@{ pkgs ? import <nixpkgs> {} }:
     rustup
     pkg-config
     openssl
+    cyrus_sasl
     protobuf
     ruby_2_7
     nodejs

--- a/scripts/environment/definition.nix
+++ b/scripts/environment/definition.nix
@@ -38,45 +38,45 @@ scope@{ pkgs ? import <nixpkgs> {} }:
 
   packages = with pkgs; [
     # Core CLI tools
-    dnsutils
-    curl
     bash
-    nix
-    direnv
-    binutils
-    remarshal
-    libiconv
-    tzdata
-    jq
-    stdenv
     bashInteractive
+    binutils
+    curl
+    direnv
+    dnsutils
+    jq
+    libiconv
+    nix
+    remarshal
+    stdenv
+    tzdata
     # Build Env
-    git
+    autoconf
     cacert
     cmake
-    rustup
-    pkg-config
-    openssl
     cyrus_sasl
+    git
+    gnumake
+    nodejs
+    openssl
+    perl
+    pkg-config
     protobuf
     ruby_2_7
-    nodejs
-    perl
-    yarn
-    snappy
-    gnumake
-    autoconf
+    rustup
     shellcheck
+    snappy
+    yarn
     # Container tools
     docker
     docker-compose
     # Wasm
     llvmPackages.libclang
   ] ++ (if stdenv.isDarwin then [
-    darwin.cf-private
     darwin.apple_sdk.frameworks.CoreServices
     darwin.apple_sdk.frameworks.Security
     darwin.apple_sdk.frameworks.SecurityFoundation
+    darwin.cf-private
   ] else [
     # Build
     gcc
@@ -84,8 +84,8 @@ scope@{ pkgs ? import <nixpkgs> {} }:
     # Testing
     systemd
     # Container tools
+    linuxHeaders
     podman
     podman-compose
-    linuxHeaders
   ]);
 }

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -23,35 +23,69 @@ pub(crate) enum KafkaCompression {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct KafkaAuthConfig {
+    pub sasl: Option<KafkaSaslConfig>,
+    pub tls: Option<KafkaTlsConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct KafkaSaslConfig {
+    pub enabled: Option<bool>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub mechanism: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct KafkaTlsConfig {
     pub enabled: Option<bool>,
     #[serde(flatten)]
     pub options: TlsOptions,
 }
 
-impl KafkaTlsConfig {
+impl KafkaAuthConfig {
     pub(crate) fn apply(&self, client: &mut ClientConfig) -> crate::Result<()> {
-        client.set(
-            "security.protocol",
-            if self.enabled() { "ssl" } else { "plaintext" },
-        );
-        if let Some(ref path) = self.options.ca_file {
-            client.set("ssl.ca.location", pathbuf_to_string(&path)?);
-        }
-        if let Some(ref path) = self.options.crt_file {
-            client.set("ssl.certificate.location", pathbuf_to_string(&path)?);
-        }
-        if let Some(ref path) = self.options.key_file {
-            client.set("ssl.key.location", pathbuf_to_string(&path)?);
-        }
-        if let Some(ref pass) = self.options.key_pass {
-            client.set("ssl.key.password", pass);
-        }
-        Ok(())
-    }
+        let sasl_enabled = self.sasl.as_ref().and_then(|s| s.enabled).unwrap_or(false);
+        let tls_enabled = self.tls.as_ref().and_then(|s| s.enabled).unwrap_or(false);
 
-    pub(crate) fn enabled(&self) -> bool {
-        self.enabled.unwrap_or(false)
+        let protocol = match (sasl_enabled, tls_enabled) {
+            (false, false) => "plaintext",
+            (false, true) => "ssl",
+            (true, false) => "sasl_plaintext",
+            (true, true) => "sasl_ssl",
+        };
+        client.set("security.protocol", protocol);
+
+        if sasl_enabled {
+            let sasl = self.sasl.as_ref().unwrap();
+            if let Some(username) = &sasl.username {
+                client.set("sasl.username", username);
+            }
+            if let Some(password) = &sasl.password {
+                client.set("sasl.password", password);
+            }
+            if let Some(mechanism) = &sasl.mechanism {
+                client.set("sasl.mechanism", mechanism);
+            }
+        }
+
+        if tls_enabled {
+            let tls = self.tls.as_ref().unwrap();
+            if let Some(path) = &tls.options.ca_file {
+                client.set("ssl.ca.location", pathbuf_to_string(&path)?);
+            }
+            if let Some(path) = &tls.options.crt_file {
+                client.set("ssl.certificate.location", pathbuf_to_string(&path)?);
+            }
+            if let Some(path) = &tls.options.key_file {
+                client.set("ssl.key.location", pathbuf_to_string(&path)?);
+            }
+            if let Some(pass) = &tls.options.key_pass {
+                client.set("ssl.key.password", pass);
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/tests/data/kafka_server_jaas.conf
+++ b/tests/data/kafka_server_jaas.conf
@@ -1,0 +1,6 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin"
+  user_admin="admin";
+};

--- a/website/docs/reference/sinks/kafka.md
+++ b/website/docs/reference/sinks/kafka.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-02"
+last_modified_on: "2020-06-24"
 delivery_guarantee: "at_least_once"
 component_title: "Kafka"
 description: "The Vector `kafka` sink streams `log` events to Apache Kafka via the Kafka protocol."
@@ -96,6 +96,12 @@ Kafka][urls.kafka] via the [Kafka protocol][urls.kafka_protocol].
   encoding.except_fields = ["timestamp", "message", "host"] # optional, no default
   encoding.only_fields = ["timestamp", "message", "host"] # optional, no default
   encoding.timestamp_format = "rfc3339" # optional, default
+
+  # SASL
+  sasl.enabled = true # optional, no default
+  sasl.mechanism = "SCRAM-SHA-256" # optional, no default
+  sasl.password = "password" # optional, no default
+  sasl.username = "username" # optional, no default
 
   # TLS
   tls.ca_file = "/path/to/certificate_authority.crt" # optional, no default
@@ -510,6 +516,123 @@ The options and their values. Accepts `string` values.
 Local message timeout.
 
 
+
+</Field>
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  groups={[]}
+  name={"sasl"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  warnings={[]}
+  >
+
+### sasl
+
+Options for SASL/SCRAM authentication support.
+
+
+<Fields filters={false}>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"enabled"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### enabled
+
+Enable SASL/SCRAM authentication to the remote.
+
+
+
+</Field>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["SCRAM-SHA-256","SCRAM-SHA-512"]}
+  groups={[]}
+  name={"mechanism"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### mechanism
+
+The Kafka SASL/SCRAM mechanisms.
+
+
+
+</Field>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["password"]}
+  groups={[]}
+  name={"password"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### password
+
+The Kafka SASL/SCRAM authentication password.
+
+
+
+</Field>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["username"]}
+  groups={[]}
+  name={"username"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### username
+
+The Kafka SASL/SCRAM authentication username.
+
+
+
+</Field>
+</Fields>
 
 </Field>
 <Field

--- a/website/docs/reference/sources/kafka.md
+++ b/website/docs/reference/sources/kafka.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-02"
+last_modified_on: "2020-06-24"
 delivery_guarantee: "at_least_once"
 component_title: "Kafka"
 description: "The Vector `kafka` source ingests data through Kafka and outputs `log` events."
@@ -78,6 +78,12 @@ ingests data through [Kafka][urls.kafka] and outputs
   librdkafka_options."client.id" = "${ENV_VAR}" # example
   librdkafka_options."fetch.error.backoff.ms" = "1000" # example
   librdkafka_options."socket.send.buffer.bytes" = "100" # example
+
+  # SASL
+  sasl.enabled = true # optional, no default
+  sasl.mechanism = "SCRAM-SHA-256" # optional, no default
+  sasl.password = "password" # optional, no default
+  sasl.username = "username" # optional, no default
 
   # TLS
   tls.ca_file = "/path/to/certificate_authority.crt" # optional, no default
@@ -278,6 +284,123 @@ details.
 #### `[field-name]`
 
 The options and their values. Accepts `string` values.
+
+
+
+</Field>
+</Fields>
+
+</Field>
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={[]}
+  groups={[]}
+  name={"sasl"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"table"}
+  unit={null}
+  warnings={[]}
+  >
+
+### sasl
+
+Options for SASL/SCRAM authentication support.
+
+
+<Fields filters={false}>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[true,false]}
+  groups={[]}
+  name={"enabled"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"bool"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### enabled
+
+Enable SASL/SCRAM authentication to the remote.
+
+
+
+</Field>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["SCRAM-SHA-256","SCRAM-SHA-512"]}
+  groups={[]}
+  name={"mechanism"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### mechanism
+
+The Kafka SASL/SCRAM mechanisms.
+
+
+
+</Field>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["password"]}
+  groups={[]}
+  name={"password"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### password
+
+The Kafka SASL/SCRAM authentication password.
+
+
+
+</Field>
+<Field
+  common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={["username"]}
+  groups={[]}
+  name={"username"}
+  path={"sasl"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+#### username
+
+The Kafka SASL/SCRAM authentication username.
 
 
 


### PR DESCRIPTION
Previous attempt -- #1276 

Should we add integration tests for this?

One important thing here is that `librdkafka` silently ignore build flags (like `--enable-ssl` / `--enable-gssapi`), so clients can get not working binaries (see #2834 as example). Possible solution that `librdkafka` will throw error on `./configure` step, but we too far from this. Developers and contributors also can have not working sasl right now if not install `cyrus-sasl-devel` (or similar package).

Edit: `librdkafka` master branch fail on `./configure` if thing is not present, but this not included in any release yet (https://github.com/edenhill/librdkafka/commit/d38de95b210022736f9d6df2eaf050386ea83ec0)