### PR TITLE
enhancement(file source): Enable skipping first N lines

### DIFF
--- a/.meta/sources/file.toml.erb
+++ b/.meta/sources/file.toml.erb
@@ -259,6 +259,7 @@ default = 0
 description = """\
 Number of first lines per file that should be skipped.\
 """
+relevant_when = {start_at_beginning = true}
 
 [sources.file.fields.log.fields.file]
 type = "string"

--- a/.meta/sources/file.toml.erb
+++ b/.meta/sources/file.toml.erb
@@ -252,6 +252,14 @@ If not specified, files will not be removed.\
 """
 warnings = [{visibility_level = "option", text = "Vector's process must have permission to delete files."}]
 
+[sources.file.options.skip_first_lines]
+type = "uint"
+common = false
+default = 0
+description = """\
+Number of first lines per file that should be skipped.\
+"""
+
 [sources.file.fields.log.fields.file]
 type = "string"
 examples = ["/var/log/nginx.log"]

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -219,6 +219,14 @@ dns_servers = ["0.0.0.0:53"]
   remove_after = 5
   remove_after = 60
 
+  # Number of first lines per file that should be skipped.
+  #
+  # * optional
+  # * default: 0
+  # * type: uint
+  # * relevant when start_at_beginning = true
+  skip_first_lines = 0
+
   # For files with a stored checkpoint at startup, setting this option to `true`
   # will tell Vector to read from the beginning of the file instead of the stored
   # checkpoint.

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -64,10 +64,10 @@ where
         self,
         mut chans: C,
         mut shutdown: impl Future + Unpin,
-    ) -> Result<Shutdown, <C as Sink<(Bytes, String)>>::Error>
+    ) -> Result<Shutdown, <C as Sink<(Bytes, String, u64)>>::Error>
     where
-        C: Sink<(Bytes, String)> + Unpin,
-        <C as Sink<(Bytes, String)>>::Error: std::error::Error,
+        C: Sink<(Bytes, String, u64)> + Unpin,
+        <C as Sink<(Bytes, String, u64)>>::Error: std::error::Error,
     {
         let mut line_buffer = Vec::new();
         let mut fingerprint_buffer = Vec::new();
@@ -213,6 +213,7 @@ where
                             lines.push((
                                 line_buffer.clone().into(),
                                 watcher.path.to_str().expect("not a valid path").to_owned(),
+                                file_id,
                             ));
                             line_buffer.clear();
                         }

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -269,6 +269,7 @@ pub fn file_source(
     let message_start_indicator = config.message_start_indicator.clone();
     let multi_line_timeout = config.multi_line_timeout;
     let skip_first_lines = config.skip_first_lines;
+    let start_at_beginning = config.start_at_beginning;
     Box::new(future::lazy(move || {
         info!(message = "Starting file server.", ?include, ?exclude);
 
@@ -277,7 +278,7 @@ pub fn file_source(
 
         // Skips first lines per file
         let skipped: Box<dyn Stream<Item = (Bytes, String, u64), Error = ()> + Send> =
-            if skip_first_lines > 0 {
+            if skip_first_lines > 0 && start_at_beginning {
                 let mut map = HashMap::new();
                 Box::new(rx.filter(move |&(_, _, file_id)| {
                     let entry = map.entry(file_id).or_insert(skip_first_lines);

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -563,7 +563,7 @@ draining the oldest files before moving on to read data from younger files.
   groups={[]}
   name={"remove_after"}
   path={null}
-  relevantWhen={null}
+  relevantWhen={{"start_at_beginning":true}}
   required={false}
   templateable={false}
   type={"uint"}

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-07-03"
+last_modified_on: "2020-07-07"
 delivery_guarantee: "best_effort"
 component_title: "File"
 description: "The Vector [`file`](#file) source ingests data through one or more local files and outputs `log` events."
@@ -74,6 +74,7 @@ ingests data through one or more local files and outputs
   include = ["/var/log/nginx/*.log"] # required
   max_line_bytes = 102400 # optional, default, bytes
   remove_after = 0 # optional, no default, seconds
+  skip_first_lines = 0 # optional, default, relevant when start_at_beginning = true
   start_at_beginning = false # optional, default
 
   # Context
@@ -563,7 +564,7 @@ draining the oldest files before moving on to read data from younger files.
   groups={[]}
   name={"remove_after"}
   path={null}
-  relevantWhen={{"start_at_beginning":true}}
+  relevantWhen={null}
   required={false}
   templateable={false}
   type={"uint"}
@@ -576,6 +577,29 @@ draining the oldest files before moving on to read data from younger files.
 Timeout from reaching `eof` after which file will be removed from filesystem,
 unless new data is written in the meantime. If not specified, files will not be
 removed.
+
+
+
+</Field>
+<Field
+  common={false}
+  defaultValue={0}
+  enumValues={null}
+  examples={[0]}
+  groups={[]}
+  name={"skip_first_lines"}
+  path={null}
+  relevantWhen={{"start_at_beginning":true}}
+  required={false}
+  templateable={false}
+  type={"uint"}
+  unit={null}
+  warnings={[]}
+  >
+
+### skip_first_lines
+
+Number of first lines per file that should be skipped.
 
 
 


### PR DESCRIPTION
Closes #2175

### Open questions
- [ ] This PR propagates `file_id` which is used to identify a file. It's need for this enhancement to function properly. But a similar enhancement `multiline` uses file path as an identifier which should break under certain file rotation strategies. 


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
