### PR TITLE
enhancement(file source): Option to remove file after some time of reaching `eof`

### DIFF
--- a/.meta/sources/file.toml.erb
+++ b/.meta/sources/file.toml.erb
@@ -240,6 +240,17 @@ Instead of balancing read capacity fairly across all watched files, prioritize \
 draining the oldest files before moving on to read data from younger files.\
 """
 
+[sources.file.options.remove_after]
+type = "uint"
+unit = "seconds"
+common = false
+examples = [0, 5, 60]
+description = """\
+Timeout from reaching `eof` after which file will be removed from filesystem, \
+unless new data is written in the meantime. \
+If not specified, files will not be removed.\
+"""
+
 [sources.file.fields.log.fields.file]
 type = "string"
 examples = ["/var/log/nginx.log"]

--- a/.meta/sources/file.toml.erb
+++ b/.meta/sources/file.toml.erb
@@ -250,6 +250,7 @@ Timeout from reaching `eof` after which file will be removed from filesystem, \
 unless new data is written in the meantime. \
 If not specified, files will not be removed.\
 """
+warnings = [{visibility_level = "option", text = "Vector's process must have permission to delete files."}]
 
 [sources.file.fields.log.fields.file]
 type = "string"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -207,6 +207,18 @@ dns_servers = ["0.0.0.0:53"]
   # * unit: bytes
   max_line_bytes = 102400
 
+  # Timeout from reaching `eof` after which file will be removed from filesystem,
+  # unless new data is written in the meantime. If not specified, files will not
+  # be removed.
+  #
+  # * optional
+  # * no default
+  # * type: uint
+  # * unit: seconds
+  remove_after = 0
+  remove_after = 5
+  remove_after = 60
+
   # For files with a stored checkpoint at startup, setting this option to `true`
   # will tell Vector to read from the beginning of the file instead of the stored
   # checkpoint.

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -8,10 +8,10 @@ use futures::{
 use glob::glob;
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
-use std::fs::{self, File};
+use std::fs::{self, remove_file, File};
 use std::io::{self, Read, Seek, Write};
 use std::path::{Path, PathBuf};
-use std::time;
+use std::time::{self, Duration};
 use tokio::time::delay_for;
 use tracing::field;
 
@@ -37,9 +37,10 @@ where
     pub ignore_before: Option<time::SystemTime>,
     pub max_line_bytes: usize,
     pub data_dir: PathBuf,
-    pub glob_minimum_cooldown: time::Duration,
+    pub glob_minimum_cooldown: Duration,
     pub fingerprinter: Fingerprinter,
     pub oldest_first: bool,
+    pub remove_after: Option<Duration>,
 }
 
 /// `FileServer` as Source
@@ -216,6 +217,23 @@ where
                             line_buffer.clear();
                         }
                     } else {
+                        // Should the file be removed
+                        if let Some(grace_period) = self.remove_after {
+                            if watcher.last_read_success().elapsed() >= grace_period {
+                                // Try to remove
+                                match remove_file(&watcher.path) {
+                                    Ok(()) => {
+                                        info!(message = "Log file deleted.", path = ?watcher.path);
+                                        watcher.set_dead();
+                                    }
+                                    Err(error) => {
+                                        // We will try again after some time.
+                                        warn!(message = "Failed deleting log file.",path = ?watcher.path, ?error);
+                                    }
+                                }
+                            }
+                        }
+
                         break;
                     }
                     if bytes_read > self.max_read_bytes {
@@ -270,7 +288,7 @@ where
             // all of these requirements.
             match block_on(select(
                 shutdown,
-                delay_for(time::Duration::from_millis(backoff as u64)),
+                delay_for(Duration::from_millis(backoff as u64)),
             )) {
                 Either::Left((_, _)) => return Ok(Shutdown),
                 Either::Right((_, future)) => shutdown = future,

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -228,7 +228,7 @@ where
                                     }
                                     Err(error) => {
                                         // We will try again after some time.
-                                        warn!(message = "Failed deleting log file.",path = ?watcher.path, ?error);
+                                        warn!(message = "Failed deleting log file.",path = ?watcher.path, ?error, rate_limit_secs = 1);
                                     }
                                 }
                             }

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -180,6 +180,10 @@ impl FileWatcher {
         self.last_read_success = Instant::now();
     }
 
+    pub fn last_read_success(&self) -> Instant {
+        self.last_read_success
+    }
+
     pub fn should_read(&self) -> bool {
         self.last_read_success.elapsed() < Duration::from_secs(10)
             || self.last_read_attempt.elapsed() > Duration::from_secs(10)

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -92,6 +92,7 @@ pub struct FileConfig {
     pub multiline: Option<MultilineConfig>,
     pub max_read_bytes: usize,
     pub oldest_first: bool,
+    pub remove_after: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -181,6 +182,7 @@ impl Default for FileConfig {
             multiline: None,
             max_read_bytes: 2048,
             oldest_first: false,
+            remove_after: None,
         }
     }
 }
@@ -248,6 +250,7 @@ pub fn file_source(
         glob_minimum_cooldown,
         fingerprinter: config.fingerprinting.clone().into(),
         oldest_first: config.oldest_first,
+        remove_after: config.remove_after.map(Duration::from_secs),
     };
 
     let file_key = config.file_key.clone();

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -355,7 +355,7 @@ mod tests {
         event,
         shutdown::ShutdownSignal,
         sources::file,
-        test_util::{block_on, runtime, shutdown_on_idle},
+        test_util::{block_on, runtime, shutdown_on_idle, trace_init},
         topology::Config,
     };
     use futures01::{Future, Stream};
@@ -1485,5 +1485,50 @@ mod tests {
                 "hooray".into(),
             ]
         );
+    }
+
+    #[test]
+    fn remove_file() {
+        trace_init();
+        let n = 5;
+        let remove_after = 2;
+
+        let (tx, rx) = futures01::sync::mpsc::channel(2 * n);
+        let (trigger_shutdown, shutdown, _) = ShutdownSignal::new_wired();
+
+        let dir = tempdir().unwrap();
+        let config = file::FileConfig {
+            include: vec![dir.path().join("*")],
+            remove_after: Some(remove_after),
+            ..test_default_file_config(&dir)
+        };
+
+        let source = file::file_source(&config, config.data_dir.clone().unwrap(), shutdown, tx);
+        let mut rt = runtime();
+        rt.spawn(source);
+
+        let path = dir.path().join("file");
+        let mut file = File::create(&path).unwrap();
+
+        sleep(); // The files must be observed at their original lengths before writing to them
+
+        for i in 0..n {
+            writeln!(&mut file, "{}", i).unwrap();
+        }
+        std::mem::drop(file);
+
+        // Wait for remove grace period to end.
+        std::thread::sleep(Duration::from_secs(remove_after + 1));
+
+        drop(trigger_shutdown);
+        shutdown_on_idle(rt);
+
+        let received = wait_with_timeout(rx.collect());
+        assert_eq!(received.len(), n);
+
+        match File::open(&path) {
+            Ok(_) => panic!("File wasn't removed"),
+            Err(error) => assert_eq!(error.kind(), std::io::ErrorKind::NotFound),
+        }
     }
 }

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-05-21"
+last_modified_on: "2020-06-25"
 delivery_guarantee: "best_effort"
 component_title: "File"
 description: "The Vector [`file`](#file) source ingests data through one or more local files and outputs `log` events."
@@ -73,6 +73,7 @@ ingests data through one or more local files and outputs
   ignore_older = 86400 # optional, no default, seconds
   include = ["/var/log/nginx/*.log"] # required
   max_line_bytes = 102400 # optional, default, bytes
+  remove_after = 0 # optional, no default, seconds
   start_at_beginning = false # optional, default
 
   # Context
@@ -551,6 +552,31 @@ the buffered message is guaraneed to be flushed, even if incomplete.
 Instead of balancing read capacity fairly across all watched files, prioritize
 draining the oldest files before moving on to read data from younger files.
  See [File Read Order](#file-read-order) for more info.
+
+
+</Field>
+<Field
+  common={false}
+  defaultValue={null}
+  enumValues={null}
+  examples={[0,5,60]}
+  groups={[]}
+  name={"remove_after"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"uint"}
+  unit={"seconds"}
+  warnings={[]}
+  >
+
+### remove_after
+
+Timeout from reaching `eof` after which file will be removed from filesystem,
+unless new data is written in the meantime. If not specified, files will not be
+removed.
+
 
 
 </Field>

--- a/website/docs/reference/sources/file.md
+++ b/website/docs/reference/sources/file.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-25"
+last_modified_on: "2020-07-03"
 delivery_guarantee: "best_effort"
 component_title: "File"
 description: "The Vector [`file`](#file) source ingests data through one or more local files and outputs `log` events."
@@ -568,7 +568,7 @@ draining the oldest files before moving on to read data from younger files.
   templateable={false}
   type={"uint"}
   unit={"seconds"}
-  warnings={[]}
+  warnings={[{"visibility_level":"option","text":"Vector's process must have permission to delete files.","option_name":"remove_after"}]}
   >
 
 ### remove_after


### PR DESCRIPTION
Closes #2187.

Adds a `remove_after` option which is a timeout from reaching `eof` after which file will be removed from filesystem, unless new data is written in the meantime. If not specified, files will not be removed.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
