### PR TITLE
enhancement(sinks): add compression option for aws sinks

### DIFF
--- a/.meta/sinks/aws_cloudwatch_logs.toml.erb
+++ b/.meta/sinks/aws_cloudwatch_logs.toml.erb
@@ -53,6 +53,13 @@ write_to_description = "[Amazon Web Service's CloudWatch Logs service][urls.aws_
   encodings: ["json", "text"]
 ) %>
 
+<%= render("_partials/fields/_compression_options.toml",
+  namespace: "sinks.aws_cloudwatch_logs.options",
+  options: {
+    "default" => "none"
+  }
+) %>
+
 [sinks.aws_cloudwatch_logs.options.group_name]
 type = "string"
 common = true

--- a/.meta/sinks/aws_cloudwatch_metrics.toml.erb
+++ b/.meta/sinks/aws_cloudwatch_metrics.toml.erb
@@ -28,6 +28,13 @@ write_to_description = "[Amazon Web Service's CloudWatch Metrics service][urls.a
 
 <%= render("_partials/fields/_component_options.toml", type: "sink", name: "aws_cloudwatch_metrics") %>
 
+<%= render("_partials/fields/_compression_options.toml",
+  namespace: "sinks.aws_cloudwatch_metrics.options",
+  options: {
+    "default" => "none"
+  }
+) %>
+
 [sinks.aws_cloudwatch_metrics.options.namespace]
 type = "string"
 common = true

--- a/.meta/sinks/aws_kinesis_firehose.toml.erb
+++ b/.meta/sinks/aws_kinesis_firehose.toml.erb
@@ -56,6 +56,13 @@ write_to_description = "[Amazon Web Service's Kinesis Data Firehose][urls.aws_ki
   encodings: ["json", "text"]
 ) %>
 
+<%= render("_partials/fields/_compression_options.toml",
+  namespace: "sinks.aws_kinesis_firehose.options",
+  options: {
+    "default" => "none"
+  }
+) %>
+
 [sinks.aws_kinesis_firehose.options.stream_name]
 type = "string"
 common = true

--- a/.meta/sinks/aws_kinesis_streams.toml.erb
+++ b/.meta/sinks/aws_kinesis_streams.toml.erb
@@ -56,6 +56,13 @@ write_to_description = "[Amazon Web Service's Kinesis Data Stream service][urls.
   encodings: ["json", "text"]
 ) %>
 
+<%= render("_partials/fields/_compression_options.toml",
+  namespace: "sinks.aws_kinesis_streams.options",
+  options: {
+    "default" => "none"
+  }
+) %>
+
 [sinks.aws_kinesis_streams.options.partition_key_field]
 type = "string"
 common = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "async-trait",
  "base64 0.12.0",
  "bytes 0.5.4",
+ "flate2",
  "futures 0.3.4",
  "hmac",
  "http 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ metrics-core = "0.5.2"
 metrics-runtime = "0.13.0"
 
 # Aws
-rusoto_core = { version = "0.44.0", optional = true }
+rusoto_core = { version = "0.44.0", features = ["encoding"], optional = true }
 rusoto_s3 = { version = "0.44.0", optional = true }
 rusoto_logs = { version = "0.44.0", optional = true }
 rusoto_cloudwatch = { version = "0.44.0", optional = true }

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -2862,6 +2862,16 @@ require('custom_module')
   # * type: string
   assume_role = "arn:aws:iam::123456789098:role/my_role"
 
+  # The compression strategy used to compress the encoded event data before
+  # transmission.
+  #
+  # * optional
+  # * default: "none"
+  # * type: string
+  # * enum: "none" or "gzip"
+  compression = "none"
+  compression = "gzip"
+
   # Dynamically create a log group if it does not already exist. This will ignore
   # `create_missing_stream` directly after creating the group and will create the
   # first stream.
@@ -3118,6 +3128,16 @@ require('custom_module')
   # * type: string
   assume_role = "arn:aws:iam::123456789098:role/my_role"
 
+  # The compression strategy used to compress the encoded event data before
+  # transmission.
+  #
+  # * optional
+  # * default: "none"
+  # * type: string
+  # * enum: "none" or "gzip"
+  compression = "none"
+  compression = "gzip"
+
   # Custom endpoint for use with AWS-compatible services. Providing a value for
   # this option will make `region` moot.
   #
@@ -3196,6 +3216,16 @@ require('custom_module')
   # * no default
   # * type: string
   assume_role = "arn:aws:iam::123456789098:role/my_role"
+
+  # The compression strategy used to compress the encoded event data before
+  # transmission.
+  #
+  # * optional
+  # * default: "none"
+  # * type: string
+  # * enum: "none" or "gzip"
+  compression = "none"
+  compression = "gzip"
 
   # Custom endpoint for use with AWS-compatible services. Providing a value for
   # this option will make `region` moot.
@@ -3417,6 +3447,16 @@ require('custom_module')
   # * no default
   # * type: string
   assume_role = "arn:aws:iam::123456789098:role/my_role"
+
+  # The compression strategy used to compress the encoded event data before
+  # transmission.
+  #
+  # * optional
+  # * default: "none"
+  # * type: string
+  # * enum: "none" or "gzip"
+  compression = "none"
+  compression = "gzip"
 
   # Custom endpoint for use with AWS-compatible services. Providing a value for
   # this option will make `region` moot.

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -18,7 +18,7 @@ use chrono::{Duration, Utc};
 use futures::future::{FutureExt, TryFutureExt};
 use futures01::{stream::iter_ok, sync::oneshot, Async, Future, Poll, Sink};
 use lazy_static::lazy_static;
-use rusoto_core::{request::BufferedHttpResponse, Region, RusotoError};
+use rusoto_core::{request::BufferedHttpResponse, RusotoError};
 use rusoto_logs::{
     CloudWatchLogs, CloudWatchLogsClient, CreateLogGroupError, CreateLogStreamError,
     DescribeLogGroupsRequest, DescribeLogStreamsError, InputLogEvent, PutLogEventsError,
@@ -260,8 +260,7 @@ impl CloudwatchLogsSvc {
         key: &CloudwatchKey,
         resolver: Resolver,
     ) -> crate::Result<Self> {
-        let region = config.region.clone().try_into()?;
-        let client = create_client(region, config.assume_role.clone(), resolver)?;
+        let client = create_client(config, resolver)?;
 
         let group_name = String::from_utf8_lossy(&key.group[..]).into_owned();
         let stream_name = String::from_utf8_lossy(&key.stream[..]).into_owned();
@@ -483,7 +482,7 @@ async fn healthcheck(config: CloudwatchLogsSinkConfig, resolver: Resolver) -> cr
     let group_name = String::from_utf8_lossy(&config.group_name.get_ref()[..]).into_owned();
     let expected_group_name = group_name.clone();
 
-    let client = create_client((&config.region).try_into()?, config.assume_role, resolver)?;
+    let client = create_client(&config, resolver)?;
 
     let request = DescribeLogGroupsRequest {
         limit: Some(1),
@@ -517,13 +516,13 @@ async fn healthcheck(config: CloudwatchLogsSinkConfig, resolver: Resolver) -> cr
 }
 
 fn create_client(
-    region: Region,
-    assume_role: Option<String>,
+    config: &CloudwatchLogsSinkConfig,
     resolver: Resolver,
 ) -> crate::Result<CloudWatchLogsClient> {
-    let http = rusoto::client(resolver)?;
-    let creds = rusoto::AwsCredentialsProvider::new(&region, assume_role)?;
-    Ok(CloudWatchLogsClient::new_with(http, creds, region))
+    let region = (&config.region).try_into()?;
+    let client = rusoto::client(resolver)?;
+    let creds = rusoto::AwsCredentialsProvider::new(&region, config.assume_role.clone())?;
+    Ok(CloudWatchLogsClient::new_with(client, creds, region))
 }
 
 #[derive(Debug, Clone)]
@@ -863,15 +862,10 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_log_event() {
         let mut rt = runtime();
-        let resolver = Resolver;
 
         let stream_name = gen_name();
 
-        let region = Region::Custom {
-            name: "localstack".into(),
-            endpoint: "http://localhost:6000".into(),
-        };
-        ensure_group(region.clone());
+        ensure_group();
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: Template::try_from(stream_name.as_str()).unwrap(),
@@ -901,10 +895,8 @@ mod integration_tests {
         request.log_group_name = GROUP_NAME.into();
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client = create_client(region, None, resolver).unwrap();
-
         let response = rt
-            .block_on_std(async move { client.get_log_events(request).await })
+            .block_on_std(async move { create_client_test().get_log_events(request).await })
             .unwrap();
 
         let events = response.events.unwrap();
@@ -920,15 +912,10 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_log_events_sorted() {
         let mut rt = runtime();
-        let resolver = Resolver;
 
         let stream_name = gen_name();
 
-        let region = Region::Custom {
-            name: "localstack".into(),
-            endpoint: "http://localhost:6000".into(),
-        };
-        ensure_group(region.clone());
+        ensure_group();
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: Template::try_from(stream_name.as_str()).unwrap(),
@@ -973,10 +960,8 @@ mod integration_tests {
         request.log_group_name = GROUP_NAME.into();
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client = create_client(region, None, resolver).unwrap();
-
         let response = rt
-            .block_on_std(async move { client.get_log_events(request).await })
+            .block_on_std(async move { create_client_test().get_log_events(request).await })
             .unwrap();
 
         let events = response.events.unwrap();
@@ -995,15 +980,9 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_out_of_range_timestamp() {
         let mut rt = runtime();
-        let resolver = Resolver;
 
         let stream_name = gen_name();
-
-        let region = Region::Custom {
-            name: "localstack".into(),
-            endpoint: "http://localhost:6000".into(),
-        };
-        ensure_group(region.clone());
+        ensure_group();
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: Template::try_from(stream_name.as_str()).unwrap(),
@@ -1057,10 +1036,8 @@ mod integration_tests {
         request.log_group_name = GROUP_NAME.into();
         request.start_time = Some((now - Duration::days(30)).timestamp_millis());
 
-        let client = create_client(region, None, resolver).unwrap();
-
         let response = rt
-            .block_on_std(async move { client.get_log_events(request).await })
+            .block_on_std(async move { create_client_test().get_log_events(request).await })
             .unwrap();
 
         let events = response.events.unwrap();
@@ -1076,15 +1053,9 @@ mod integration_tests {
     #[test]
     fn cloudwatch_dynamic_group_and_stream_creation() {
         let mut rt = runtime();
-        let resolver = Resolver;
 
         let group_name = gen_name();
         let stream_name = gen_name();
-
-        let region = Region::Custom {
-            name: "localstack".into(),
-            endpoint: "http://localhost:6000".into(),
-        };
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: Template::try_from(stream_name.as_str()).unwrap(),
@@ -1114,10 +1085,8 @@ mod integration_tests {
         request.log_group_name = group_name;
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client = create_client(region, None, resolver).unwrap();
-
         let response = rt
-            .block_on_std(async move { client.get_log_events(request).await })
+            .block_on_std(async move { create_client_test().get_log_events(request).await })
             .unwrap();
 
         let events = response.events.unwrap();
@@ -1133,16 +1102,11 @@ mod integration_tests {
     #[test]
     fn cloudwatch_insert_log_event_batched() {
         let mut rt = runtime();
-        let resolver = Resolver;
 
         let group_name = gen_name();
         let stream_name = gen_name();
 
-        let region = Region::Custom {
-            name: "localstack".into(),
-            endpoint: "http://localhost:6000".into(),
-        };
-        ensure_group(region.clone());
+        ensure_group();
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: Template::try_from(stream_name.as_str()).unwrap(),
@@ -1175,10 +1139,8 @@ mod integration_tests {
         request.log_group_name = group_name.into();
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client = create_client(region, None, resolver).unwrap();
-
         let response = rt
-            .block_on_std(async move { client.get_log_events(request).await })
+            .block_on_std(async move { create_client_test().get_log_events(request).await })
             .unwrap();
 
         let events = response.events.unwrap();
@@ -1195,17 +1157,10 @@ mod integration_tests {
     fn cloudwatch_insert_log_event_partitioned() {
         crate::test_util::trace_init();
         let mut rt = runtime();
-        let resolver = Resolver;
 
         let stream_name = gen_name();
 
-        let region = Region::Custom {
-            name: "localstack".into(),
-            endpoint: "http://localhost:6000".into(),
-        };
-
-        let client = create_client(region.clone(), None, resolver).unwrap();
-        ensure_group(region);
+        ensure_group();
 
         let config = CloudwatchLogsSinkConfig {
             group_name: Template::try_from(GROUP_NAME).unwrap(),
@@ -1248,9 +1203,8 @@ mod integration_tests {
         request.log_group_name = GROUP_NAME.into();
         request.start_time = Some(timestamp.timestamp_millis());
 
-        let client2 = client.clone();
         let response = rt
-            .block_on_std(async move { client2.get_log_events(request).await })
+            .block_on_std(async move { create_client_test().get_log_events(request).await })
             .unwrap();
         let events = response.events.unwrap();
         let output_lines = events
@@ -1273,7 +1227,7 @@ mod integration_tests {
         request.start_time = Some(timestamp.timestamp_millis());
 
         let response = rt
-            .block_on_std(async move { client.get_log_events(request).await })
+            .block_on_std(async move { create_client_test().get_log_events(request).await })
             .unwrap();
         let events = response.events.unwrap();
         let output_lines = events
@@ -1293,11 +1247,7 @@ mod integration_tests {
 
     #[test]
     fn cloudwatch_healthcheck() {
-        let region = Region::Custom {
-            name: "localstack".into(),
-            endpoint: "http://localhost:6000".into(),
-        };
-        ensure_group(region);
+        ensure_group();
 
         let config = CloudwatchLogsSinkConfig {
             stream_name: Template::try_from("test-stream").unwrap(),
@@ -1317,18 +1267,28 @@ mod integration_tests {
         rt.block_on_std(healthcheck(config, resolver)).unwrap();
     }
 
-    fn ensure_group(region: Region) {
-        let mut rt = runtime();
-        let resolver = Resolver;
-
-        let client = create_client(region, None, resolver).unwrap();
-
-        let req = CreateLogGroupRequest {
-            log_group_name: GROUP_NAME.into(),
-            ..Default::default()
+    fn create_client_test() -> CloudWatchLogsClient {
+        let region = Region::Custom {
+            name: "localstack".into(),
+            endpoint: "http://localhost:6000".into(),
         };
 
-        let _ = rt.block_on_std(async move { client.create_log_group(req).await });
+        let client = rusoto::client(Resolver).unwrap();
+        let creds = rusoto::AwsCredentialsProvider::new(&region, None).unwrap();
+        CloudWatchLogsClient::new_with(client, creds, region)
+    }
+
+    fn ensure_group() {
+        let mut rt = runtime();
+
+        let _ = rt.block_on_std(async move {
+            let client = create_client_test();
+            let req = CreateLogGroupRequest {
+                log_group_name: GROUP_NAME.into(),
+                ..Default::default()
+            };
+            client.create_log_group(req).await
+        });
     }
 
     fn gen_name() -> String {

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -528,8 +528,7 @@ fn create_client(
     let client = rusoto::client(resolver)?;
     let creds = rusoto::AwsCredentialsProvider::new(&region, config.assume_role.clone())?;
 
-    let client =
-        rusoto_core::Client::new_with_encoding(creds, client, config.compression.to_rusoto());
+    let client = rusoto_core::Client::new_with_encoding(creds, client, config.compression.into());
     Ok(CloudWatchLogsClient::new_with_client(client, region))
 }
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -58,9 +58,7 @@ inventory::submit! {
 #[typetag::serde(name = "aws_cloudwatch_metrics")]
 impl SinkConfig for CloudWatchMetricsSinkConfig {
     fn build(&self, cx: SinkContext) -> crate::Result<(super::RouterSink, super::Healthcheck)> {
-        let healthcheck = CloudWatchMetricsSvc::healthcheck(self.clone(), cx.resolver())
-            .boxed()
-            .compat();
+        let healthcheck = self.clone().healthcheck(cx.resolver()).boxed().compat();
         let sink = CloudWatchMetricsSvc::new(self.clone(), cx)?;
         Ok((sink, Box::new(healthcheck)))
     }
@@ -74,12 +72,52 @@ impl SinkConfig for CloudWatchMetricsSinkConfig {
     }
 }
 
+impl CloudWatchMetricsSinkConfig {
+    async fn healthcheck(self, resolver: Resolver) -> crate::Result<()> {
+        let client = self.create_client(resolver)?;
+
+        let datum = MetricDatum {
+            metric_name: "healthcheck".into(),
+            value: Some(1.0),
+            ..Default::default()
+        };
+        let request = PutMetricDataInput {
+            namespace: self.namespace.clone(),
+            metric_data: vec![datum],
+        };
+
+        client.put_metric_data(request).await.map_err(Into::into)
+    }
+
+    fn create_client(&self, resolver: Resolver) -> crate::Result<CloudWatchClient> {
+        let region = (&self.region).try_into()?;
+        let region = if cfg!(test) {
+            // Moto (used for mocking AWS) doesn't recognize 'custom' as valid region name
+            match region {
+                Region::Custom { endpoint, .. } => Region::Custom {
+                    name: "us-east-1".into(),
+                    endpoint,
+                },
+                _ => panic!("Only Custom regions are supported for CloudWatchClient testing"),
+            }
+        } else {
+            region
+        };
+
+        let client = rusoto::client(resolver)?;
+        let creds = rusoto::AwsCredentialsProvider::new(&region, self.assume_role.clone())?;
+
+        let client = rusoto_core::Client::new_with_encoding(creds, client, self.compression.into());
+        Ok(CloudWatchClient::new_with_client(client, region))
+    }
+}
+
 impl CloudWatchMetricsSvc {
     pub fn new(
         config: CloudWatchMetricsSinkConfig,
         cx: SinkContext,
     ) -> crate::Result<super::RouterSink> {
-        let client = Self::create_client(&config, cx.resolver())?;
+        let client = config.create_client(cx.resolver())?;
 
         let batch = config
             .batch
@@ -101,51 +139,6 @@ impl CloudWatchMetricsSvc {
             .sink_map_err(|e| error!("CloudwatchMetrics sink error: {}", e));
 
         Ok(Box::new(sink))
-    }
-
-    async fn healthcheck(
-        config: CloudWatchMetricsSinkConfig,
-        resolver: Resolver,
-    ) -> crate::Result<()> {
-        let client = Self::create_client(&config, resolver)?;
-
-        let datum = MetricDatum {
-            metric_name: "healthcheck".into(),
-            value: Some(1.0),
-            ..Default::default()
-        };
-        let request = PutMetricDataInput {
-            namespace: config.namespace.clone(),
-            metric_data: vec![datum],
-        };
-
-        client.put_metric_data(request).await.map_err(Into::into)
-    }
-
-    fn create_client(
-        config: &CloudWatchMetricsSinkConfig,
-        resolver: Resolver,
-    ) -> crate::Result<CloudWatchClient> {
-        let region = (&config.region).try_into()?;
-        let region = if cfg!(test) {
-            // Moto (used for mocking AWS) doesn't recognize 'custom' as valid region name
-            match region {
-                Region::Custom { endpoint, .. } => Region::Custom {
-                    name: "us-east-1".into(),
-                    endpoint,
-                },
-                _ => panic!("Only Custom regions are supported for CloudWatchClient testing"),
-            }
-        } else {
-            region
-        };
-
-        let client = rusoto::client(resolver)?;
-        let creds = rusoto::AwsCredentialsProvider::new(&region, config.assume_role.clone())?;
-
-        let client =
-            rusoto_core::Client::new_with_encoding(creds, client, config.compression.into());
-        Ok(CloudWatchClient::new_with_client(client, region))
     }
 
     fn encode_events(&mut self, events: Vec<Metric>) -> PutMetricDataInput {
@@ -288,7 +281,7 @@ mod tests {
     fn svc() -> CloudWatchMetricsSvc {
         let resolver = Resolver;
         let config = config();
-        let client = CloudWatchMetricsSvc::create_client(&config, resolver).unwrap();
+        let client = config.create_client(resolver).unwrap();
         CloudWatchMetricsSvc { client, config }
     }
 
@@ -452,7 +445,7 @@ mod integration_tests {
     fn cloudwatch_metrics_healthchecks() {
         let mut rt = runtime();
         let resolver = Resolver;
-        let _ = rt.block_on_std(CloudWatchMetricsSvc::healthcheck(config(), resolver));
+        let _ = rt.block_on_std(config().healthcheck(resolver));
     }
 
     #[test]

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -144,7 +144,7 @@ impl CloudWatchMetricsSvc {
         let creds = rusoto::AwsCredentialsProvider::new(&region, config.assume_role.clone())?;
 
         let client =
-            rusoto_core::Client::new_with_encoding(creds, client, config.compression.to_rusoto());
+            rusoto_core::Client::new_with_encoding(creds, client, config.compression.into());
         Ok(CloudWatchClient::new_with_client(client, region))
     }
 

--- a/src/sinks/aws_kinesis_firehose.rs
+++ b/src/sinks/aws_kinesis_firehose.rs
@@ -216,8 +216,7 @@ fn create_client(
     let client = rusoto::client(resolver)?;
     let creds = rusoto::AwsCredentialsProvider::new(&region, config.assume_role.clone())?;
 
-    let client =
-        rusoto_core::Client::new_with_encoding(creds, client, config.compression.to_rusoto());
+    let client = rusoto_core::Client::new_with_encoding(creds, client, config.compression.into());
     Ok(KinesisFirehoseClient::new_with_client(client, region))
 }
 

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -222,8 +222,7 @@ fn create_client(config: &KinesisSinkConfig, resolver: Resolver) -> crate::Resul
     let client = rusoto::client(resolver)?;
     let creds = rusoto::AwsCredentialsProvider::new(&region, config.assume_role.clone())?;
 
-    let client =
-        rusoto_core::Client::new_with_encoding(creds, client, config.compression.to_rusoto());
+    let client = rusoto_core::Client::new_with_encoding(creds, client, config.compression.into());
     Ok(KinesisClient::new_with_client(client, region))
 }
 

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -38,6 +38,15 @@ impl Compression {
             Self::Gzip => "log.gz",
         }
     }
+
+    #[cfg(feature = "rusoto_core")]
+    pub fn to_rusoto(&self) -> rusoto_core::encoding::ContentEncoding {
+        match self {
+            Self::None => rusoto_core::encoding::ContentEncoding::Identity,
+            // 6 is default, add Gzip level support to vector in future
+            Self::Gzip => rusoto_core::encoding::ContentEncoding::Gzip(None, 6),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -38,13 +38,15 @@ impl Compression {
             Self::Gzip => "log.gz",
         }
     }
+}
 
-    #[cfg(feature = "rusoto_core")]
-    pub fn to_rusoto(&self) -> rusoto_core::encoding::ContentEncoding {
-        match self {
-            Self::None => rusoto_core::encoding::ContentEncoding::Identity,
+#[cfg(feature = "rusoto_core")]
+impl From<Compression> for rusoto_core::encoding::ContentEncoding {
+    fn from(compression: Compression) -> Self {
+        match compression {
+            Compression::None => rusoto_core::encoding::ContentEncoding::Identity,
             // 6 is default, add Gzip level support to vector in future
-            Self::Gzip => rusoto_core::encoding::ContentEncoding::Gzip(None, 6),
+            Compression::Gzip => rusoto_core::encoding::ContentEncoding::Gzip(None, 6),
         }
     }
 }

--- a/website/docs/reference/sinks/aws_cloudwatch_logs.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_logs.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-29"
+last_modified_on: "2020-07-05"
 delivery_guarantee: "at_least_once"
 component_title: "AWS Cloudwatch Logs"
 description: "The Vector `aws_cloudwatch_logs` sink batches `log` events to Amazon Web Service's CloudWatch Logs service via the `PutLogEvents` API endpoint."
@@ -47,6 +47,7 @@ endpoint](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/A
   # General
   type = "aws_cloudwatch_logs" # required
   inputs = ["my-source-or-transform-id"] # required
+  compression = "none" # optional, default
   create_missing_group = true # optional, default
   create_missing_stream = true # optional, default
   group_name = "group-name" # required
@@ -67,6 +68,7 @@ endpoint](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/A
   type = "aws_cloudwatch_logs" # required
   inputs = ["my-source-or-transform-id"] # required
   assume_role = "arn:aws:iam::123456789098:role/my_role" # optional, no default
+  compression = "none" # optional, default
   create_missing_group = true # optional, default
   create_missing_stream = true # optional, default
   endpoint = "127.0.0.0:5000/path/to/service" # optional, no default, relevant when region = ""
@@ -338,6 +340,30 @@ The behavior when the buffer becomes full.
 
 </Field>
 </Fields>
+
+</Field>
+<Field
+  common={true}
+  defaultValue={"none"}
+  enumValues={{"none":"No compression.","gzip":"[Gzip][urls.gzip] standard DEFLATE compression."}}
+  examples={["none","gzip"]}
+  groups={[]}
+  name={"compression"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+### compression
+
+The compression strategy used to compress the encoded event data before
+transmission.
+
+
 
 </Field>
 <Field
@@ -1043,6 +1069,7 @@ You can learn more about the complete syntax in the
 [urls.aws_credentials_file]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [urls.aws_iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 [urls.aws_regions]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
+[urls.gzip]: https://www.gzip.org/
 [urls.iam_instance_profile]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 [urls.new_aws_cloudwatch_logs_sink_issue]: https://github.com/timberio/vector/issues/new?labels=sink%3A+aws_cloudwatch_logs
 [urls.strptime_specifiers]: https://docs.rs/chrono/0.4.11/chrono/format/strftime/index.html#specifiers

--- a/website/docs/reference/sinks/aws_cloudwatch_metrics.md
+++ b/website/docs/reference/sinks/aws_cloudwatch_metrics.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-05-21"
+last_modified_on: "2020-07-05"
 delivery_guarantee: "at_least_once"
 component_title: "AWS Cloudwatch Metrics"
 description: "The Vector `aws_cloudwatch_metrics` sink streams `metric` events to Amazon Web Service's CloudWatch Metrics service via the `PutMetricData` API endpoint."
@@ -45,6 +45,7 @@ endpoint](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_P
 [sinks.my_sink_id]
   type = "aws_cloudwatch_metrics" # required
   inputs = ["my-source-or-transform-id"] # required
+  compression = "none" # optional, default
   healthcheck = true # optional, default
   namespace = "service" # required
   region = "us-east-1" # required, required when endpoint = ""
@@ -59,6 +60,7 @@ endpoint](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_P
   type = "aws_cloudwatch_metrics" # required
   inputs = ["my-source-or-transform-id"] # required
   assume_role = "arn:aws:iam::123456789098:role/my_role" # optional, no default
+  compression = "none" # optional, default
   endpoint = "127.0.0.0:5000/path/to/service" # optional, no default, relevant when region = ""
   healthcheck = true # optional, default
   namespace = "service" # required
@@ -165,6 +167,30 @@ The maximum age of a batch before it is flushed.
 
 </Field>
 </Fields>
+
+</Field>
+<Field
+  common={true}
+  defaultValue={"none"}
+  enumValues={{"none":"No compression.","gzip":"[Gzip][urls.gzip] standard DEFLATE compression."}}
+  examples={["none","gzip"]}
+  groups={[]}
+  name={"compression"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+### compression
+
+The compression strategy used to compress the encoded event data before
+transmission.
+
+
 
 </Field>
 <Field
@@ -416,4 +442,5 @@ event-by-event basis. It does not batch data.
 [urls.aws_credentials_file]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [urls.aws_iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 [urls.aws_regions]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
+[urls.gzip]: https://www.gzip.org/
 [urls.iam_instance_profile]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html

--- a/website/docs/reference/sinks/aws_kinesis_firehose.md
+++ b/website/docs/reference/sinks/aws_kinesis_firehose.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-05-21"
+last_modified_on: "2020-07-05"
 delivery_guarantee: "at_least_once"
 component_title: "AWS Kinesis Firehose"
 description: "The Vector `aws_kinesis_firehose` sink batches `log` events to Amazon Web Service's Kinesis Data Firehose via the `PutRecordBatch` API endpoint."
@@ -47,6 +47,7 @@ endpoint](https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecord
   # General
   type = "aws_kinesis_firehose" # required
   inputs = ["my-source-or-transform-id"] # required
+  compression = "none" # optional, default
   healthcheck = true # optional, default
   region = "us-east-1" # required, required when endpoint = ""
   stream_name = "my-stream" # required
@@ -64,6 +65,7 @@ endpoint](https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecord
   type = "aws_kinesis_firehose" # required
   inputs = ["my-source-or-transform-id"] # required
   assume_role = "arn:aws:iam::123456789098:role/my_role" # optional, no default
+  compression = "none" # optional, default
   endpoint = "127.0.0.0:5000/path/to/service" # optional, no default, relevant when region = ""
   healthcheck = true # optional, default
   region = "us-east-1" # required, required when endpoint = ""
@@ -308,6 +310,30 @@ The behavior when the buffer becomes full.
 
 </Field>
 </Fields>
+
+</Field>
+<Field
+  common={true}
+  defaultValue={"none"}
+  enumValues={{"none":"No compression.","gzip":"[Gzip][urls.gzip] standard DEFLATE compression."}}
+  examples={["none","gzip"]}
+  groups={[]}
+  name={"compression"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+### compression
+
+The compression strategy used to compress the encoded event data before
+transmission.
+
+
 
 </Field>
 <Field
@@ -905,5 +931,6 @@ attempts and backoff rate with the [`retry_attempts`](#retry_attempts) and
 [urls.aws_iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 [urls.aws_kinesis_firehose]: https://aws.amazon.com/kinesis/data-firehose/
 [urls.aws_regions]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
+[urls.gzip]: https://www.gzip.org/
 [urls.iam_instance_profile]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 [urls.new_aws_kinesis_firehose_sink_issue]: https://github.com/timberio/vector/issues/new?labels=sink%3A+aws_kinesis_firehose

--- a/website/docs/reference/sinks/aws_kinesis_streams.md
+++ b/website/docs/reference/sinks/aws_kinesis_streams.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-05-21"
+last_modified_on: "2020-07-05"
 delivery_guarantee: "at_least_once"
 component_title: "AWS Kinesis Data Streams"
 description: "The Vector `aws_kinesis_streams` sink batches `log` events to Amazon Web Service's Kinesis Data Stream service via the `PutRecords` API endpoint."
@@ -47,6 +47,7 @@ endpoint](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords
   # General
   type = "aws_kinesis_streams" # required
   inputs = ["my-source-or-transform-id"] # required
+  compression = "none" # optional, default
   partition_key_field = "user_id" # optional, no default
   region = "us-east-1" # required, required when endpoint = ""
   stream_name = "my-stream" # required
@@ -64,6 +65,7 @@ endpoint](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords
   type = "aws_kinesis_streams" # required
   inputs = ["my-source-or-transform-id"] # required
   assume_role = "arn:aws:iam::123456789098:role/my_role" # optional, no default
+  compression = "none" # optional, default
   endpoint = "127.0.0.0:5000/path/to/service" # optional, no default, relevant when region = ""
   partition_key_field = "user_id" # optional, no default
   region = "us-east-1" # required, required when endpoint = ""
@@ -308,6 +310,30 @@ The behavior when the buffer becomes full.
 
 </Field>
 </Fields>
+
+</Field>
+<Field
+  common={true}
+  defaultValue={"none"}
+  enumValues={{"none":"No compression.","gzip":"[Gzip][urls.gzip] standard DEFLATE compression."}}
+  examples={["none","gzip"]}
+  groups={[]}
+  name={"compression"}
+  path={null}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"string"}
+  unit={null}
+  warnings={[]}
+  >
+
+### compression
+
+The compression strategy used to compress the encoded event data before
+transmission.
+
+
 
 </Field>
 <Field
@@ -951,5 +977,6 @@ attempts and backoff rate with the [`retry_attempts`](#retry_attempts) and
 [urls.aws_kinesis_split_shards]: https://docs.aws.amazon.com/streams/latest/dev/kinesis-using-sdk-java-resharding-split.html
 [urls.aws_kinesis_streams]: https://aws.amazon.com/kinesis/data-streams/
 [urls.aws_regions]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
+[urls.gzip]: https://www.gzip.org/
 [urls.iam_instance_profile]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 [urls.new_aws_kinesis_streams_sink_issue]: https://github.com/timberio/vector/issues/new?labels=sink%3A+aws_kinesis_streams


### PR DESCRIPTION
Close https://github.com/timberio/vector/issues/1411 (we will need create new issue for tracking lz4).

- Should we set `gzip` compression by default?
- S3 accept compressed and uncompressed logs. If logs compressed it's does not need compression request again, but if logs uncompressed it's can make sense (compress request body). Should we add extra option for such case?