### PR TITLE
fix(gcp provider): sync token request

### DIFF
--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -1,5 +1,5 @@
 use crate::sinks::HealthcheckError;
-use futures01::{Future, Stream};
+use futures::stream::StreamExt;
 use goauth::scopes::Scope;
 use goauth::{
     auth::{JwtClaims, Token, TokenErr},
@@ -12,7 +12,6 @@ use smpl_jwt::Jwt;
 use snafu::{ResultExt, Snafu};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tokio01::timer::Interval;
 
 pub mod cloud_storage;
 pub mod pubsub;
@@ -51,13 +50,23 @@ pub struct GcpAuthConfig {
 
 impl GcpAuthConfig {
     pub fn make_credentials(&self, scope: Scope) -> crate::Result<Option<GcpCredentials>> {
-        let gap = std::env::var("GOOGLE_APPLICATION_CREDENTIALS").ok();
-        let creds_path = self.credentials_path.as_ref().or_else(|| gap.as_ref());
-        Ok(match (&creds_path, &self.api_key) {
-            (Some(path), _) => Some(GcpCredentials::from_file(path, scope)?),
-            (None, Some(_)) => None,
-            (None, None) => Some(GcpCredentials::new_implicit(scope)?),
+        let this = self.clone();
+        // We can not run new Runtime in thread which already used by other Runtime.
+        // Without new thread we get error: `default Tokio timer already set for execution context`
+        std::thread::spawn(|| {
+            let mut rt = crate::runtime::Runtime::single_threaded().unwrap();
+            rt.block_on_std(async move {
+                let gap = std::env::var("GOOGLE_APPLICATION_CREDENTIALS").ok();
+                let creds_path = this.credentials_path.as_ref().or_else(|| gap.as_ref());
+                Ok(match (&creds_path, &this.api_key) {
+                    (Some(path), _) => Some(GcpCredentials::from_file(path, scope).await?),
+                    (None, Some(_)) => None,
+                    (None, None) => Some(GcpCredentials::new_implicit(scope).await?),
+                })
+            })
         })
+        .join()
+        .expect("Runtime thread error")
     }
 }
 
@@ -68,54 +77,35 @@ pub struct GcpCredentials {
     token: Arc<RwLock<Token>>,
 }
 
-fn get_token_implicit() -> Result<Token, GcpError> {
-    std::thread::spawn(|| {
-        let mut rt = crate::runtime::Runtime::single_threaded().unwrap();
-        rt.block_on_std(async {
-            let req = http::Request::get(SERVICE_ACCOUNT_TOKEN_URL)
-                .header("Metadata-Flavor", "Google")
-                .body(hyper::Body::empty())
-                .unwrap();
+async fn get_token_implicit() -> Result<Token, GcpError> {
+    let req = http::Request::get(SERVICE_ACCOUNT_TOKEN_URL)
+        .header("Metadata-Flavor", "Google")
+        .body(hyper::Body::empty())
+        .unwrap();
 
-            let res = hyper::Client::new()
-                .request(req)
-                .await
-                .context(GetImplicitToken)?;
+    let res = hyper::Client::new()
+        .request(req)
+        .await
+        .context(GetImplicitToken)?;
 
-            let body = res.into_body();
-            let bytes = hyper::body::to_bytes(body).await.context(GetTokenBytes)?;
+    let body = res.into_body();
+    let bytes = hyper::body::to_bytes(body).await.context(GetTokenBytes)?;
 
-            // Token::from_str is irresponsible and may panic!
-            match serde_json::from_slice::<Token>(&bytes) {
-                Ok(token) => Ok(token),
-                Err(error) => Err(match serde_json::from_slice::<TokenErr>(&bytes) {
-                    Ok(error) => GcpError::TokenFromJson { source: error },
-                    Err(_) => GcpError::TokenJsonFromStr { source: error },
-                }),
-            }
-        })
-    })
-    .join()
-    .expect("Runtime thread error")
-}
-
-fn get_token_with_creds_blocking(
-    jwt: Jwt<JwtClaims>,
-    credentials: Credentials,
-) -> Result<Token, GoErr> {
-    std::thread::spawn(move || {
-        let mut rt = crate::runtime::Runtime::single_threaded().unwrap();
-        rt.block_on_std(async move { goauth::get_token(&jwt, &credentials).await })
-    })
-    .join()
-    .expect("Runtime thread error")
+    // Token::from_str is irresponsible and may panic!
+    match serde_json::from_slice::<Token>(&bytes) {
+        Ok(token) => Ok(token),
+        Err(error) => Err(match serde_json::from_slice::<TokenErr>(&bytes) {
+            Ok(error) => GcpError::TokenFromJson { source: error },
+            Err(_) => GcpError::TokenJsonFromStr { source: error },
+        }),
+    }
 }
 
 impl GcpCredentials {
-    fn from_file(path: &str, scope: Scope) -> crate::Result<Self> {
+    async fn from_file(path: &str, scope: Scope) -> crate::Result<Self> {
         let creds = Credentials::from_file(path).context(InvalidCredentials1)?;
         let jwt = make_jwt(&creds, &scope)?;
-        let token = get_token_with_creds_blocking(jwt, creds.clone()).context(GetToken)?;
+        let token = goauth::get_token(&jwt, &creds).await.context(GetToken)?;
         Ok(Self {
             creds: Some(creds),
             scope,
@@ -123,8 +113,8 @@ impl GcpCredentials {
         })
     }
 
-    fn new_implicit(scope: Scope) -> crate::Result<Self> {
-        let token = get_token_implicit()?;
+    async fn new_implicit(scope: Scope) -> crate::Result<Self> {
+        let token = get_token_implicit().await?;
         Ok(Self {
             creds: None,
             scope,
@@ -140,34 +130,33 @@ impl GcpCredentials {
             .insert(AUTHORIZATION, value.parse().unwrap());
     }
 
-    fn regenerate_token(&self) -> crate::Result<()> {
+    async fn regenerate_token(&self) -> crate::Result<()> {
         let token = match &self.creds {
             Some(creds) => {
                 let jwt = make_jwt(creds, &self.scope).unwrap(); // Errors caught above
-                get_token_with_creds_blocking(jwt, creds.clone())?
+                goauth::get_token(&jwt, creds).await?
             }
-            None => get_token_implicit()?,
+            None => get_token_implicit().await?,
         };
         *self.token.write().unwrap() = token;
         Ok(())
     }
 
     pub fn spawn_regenerate_token(&self) {
-        let interval = self.token.read().unwrap().expires_in() as u64 / 2;
-        let copy = self.clone();
-        let renew_task = Interval::new_interval(Duration::from_secs(interval))
-            .for_each(move |_instant| {
+        let this = self.clone();
+
+        let period = this.token.read().unwrap().expires_in() as u64 / 2;
+        let interval = tokio::time::interval(Duration::from_secs(period));
+        let task = interval.for_each(move |_| {
+            let this = this.clone();
+            async move {
                 debug!("Renewing GCP authentication token");
-                if let Err(error) = copy.regenerate_token() {
+                if let Err(error) = this.regenerate_token().await {
                     error!(message = "Failed to update GCP authentication token", %error);
                 }
-                Ok(())
-            })
-            .map_err(
-                |error| error!(message = "GCP authentication token regenerate interval failed", %error),
-            );
-
-        tokio01::spawn(renew_task);
+            }
+        });
+        tokio::spawn(task);
     }
 }
 


### PR DESCRIPTION
Thought how I can solve #2977 and realized that gcp sinks broken after #2964.

This was not caught by tests by 2 reasons:
1) Tests still create sinks / healthchecks outside runtime (and then move with `async move {`).
2) Even if objects was created in right place we do not test token generation. https://github.com/timberio/vector/blob/25d0aa1855938b549e9cfa42c38c6a22f7951c60/src/sinks/gcp/pubsub.rs#L117-L121

Currently with simple config:
```toml
data_dir = "/home/kirill/tmp/vector-tests/data/shared"

[sources.in]
  type = "socket"
  address = "127.0.0.1:1514"
  mode = "tcp"

[sinks.out]
  inputs = ["in"]
  type = "gcp_pubsub"
  project = "testproject"
  topic = "qwerty"
```

an error will be thrown:
```
thread 'main' panicked at 'default Tokio reactor already set for execution context', /home/kirill/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-reactor-0.1.11/src/lib.rs:223:9
```

If we start used `crate::runtime::Runtime` instead `tokio_compat::runtime::current_thread::Runtime`:
```
thread 'main' panicked at 'default Tokio timer already set for execution context', /home/kirill/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-timer-0.2.12/src/timer/handle.rs:86:9
```

As solution, we can create runtime in new thread.