### PR TITLE
chore(security): remove outdated security advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,4 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2020-0014", # Advisory for dev dependency of `trust-dns` for testing
-                         # dns servers.
     "RUSTSEC-2020-0002", # tracked in #1639
-    "RUSTSEC-2020-0001", # dev dependency only
 ]


### PR DESCRIPTION
Only remove ignored security advisories which not relevant anymore with current vector dependencies.
Related with https://github.com/timberio/vector/issues/2464