### PR TITLE
fix(loki sink): Set a proper default for the batch buffer initialization

### DIFF
--- a/.meta/sinks/loki.toml.erb
+++ b/.meta/sinks/loki.toml.erb
@@ -27,7 +27,7 @@ write_to_description = "[Loki][urls.loki]"
 
 <%= render("_partials/fields/_component_options.toml", type: "sink", name: "loki") %>
 
-<%= render("_partials/fields/_batch_options.toml", namespace: "sinks.loki.options", common: false, max_bytes: 10490000, max_events: nil, timeout_secs: 1) %>
+<%= render("_partials/fields/_batch_options.toml", namespace: "sinks.loki.options", common: false, max_bytes: 10490000, max_events: 100000, timeout_secs: 1) %>
 
 <%= render(
   "_partials/fields/_buffer_options.toml",

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -8060,10 +8060,10 @@ require('custom_module')
     # The maximum size of a batch, in events, before it is flushed.
     #
     # * optional
-    # * no default
+    # * default: 100000
     # * type: uint
     # * unit: events
-    max_events = 1000
+    max_events = 100000
 
     # The maximum age of a batch before it is flushed.
     #

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -84,6 +84,7 @@ impl SinkConfig for LokiConfig {
         let batch_settings = self.batch.use_size_as_bytes()?.get_settings_or_default(
             BatchSettings::default()
                 .bytes(bytesize::mib(10u64))
+                .events(100_000)
                 .timeout(1),
         );
         let tls = TlsSettings::from_options(&self.tls)?;

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -1,5 +1,5 @@
 ---
-last_modified_on: "2020-06-25"
+last_modified_on: "2020-07-10"
 delivery_guarantee: "at_least_once"
 component_title: "Loki"
 description: "The Vector `loki` sink batches `log` events to Loki."
@@ -78,7 +78,7 @@ The Vector `loki` sink
 
   # Batch
   batch.max_bytes = 10490000 # optional, default, bytes
-  batch.max_events = 1000 # optional, no default, events
+  batch.max_events = 100000 # optional, default, events
   batch.timeout_secs = 1 # optional, default, seconds
 
   # Buffer
@@ -285,9 +285,9 @@ The maximum size of a batch, in bytes, before it is flushed.
 </Field>
 <Field
   common={true}
-  defaultValue={null}
+  defaultValue={100000}
   enumValues={null}
-  examples={[1000]}
+  examples={[100000]}
   groups={[]}
   name={"max_events"}
   path={"batch"}


### PR DESCRIPTION
The loki sink uses VecBuffer but did not set a default for the maximum number of events. When unset, the default number of events is `usize::max_value()`. Further, VecBuffer creates an array based on this maximum number of events. This causes a run time error due to the vector size being too large for memory.

Closes #3006 

This shows one of the defects in the current batch buffer workings—each sink has to ensure that the batch buffer has the right default(s) size set (either bytes or events) instead of the buffer itself making that assurance. This should be moved into each buffer, but that is beyond the scope of this fix.