### PR TITLE
fix(loki sink): Drop the batch byte size limit

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -2,15 +2,16 @@
 titleOnly: true
 
 types:
-  - chore # An internal change this is not observable by users.
-  - docs # Any user observable documentation change.
-  - enhancement # Any user observable enhancement to an existing feature.
-  - feat # Any user observable new feature, such as a new platform, source, transform, or sink.
-  - fix # Any user observable bug fix.
-  - perf # Any user observable performance improvment.
-  - status # A status change to a Vector component.
+  - chore               # An internal change this is not observable by users.
+  - docs                # Any user observable documentation change.
+  - enhancement         # Any user observable enhancement to an existing feature.
+  - feat                # Any user observable new feature, such as a new platform, source, transform, or sink.
+  - fix                 # Any user observable bug fix.
+  - perf                # Any user observable performance improvment.
+  - status              # A status change to a Vector component.
 
 scopes:
+
   - new source
   - new transform
   - new sink

--- a/.meta/sinks/loki.toml.erb
+++ b/.meta/sinks/loki.toml.erb
@@ -27,7 +27,7 @@ write_to_description = "[Loki][urls.loki]"
 
 <%= render("_partials/fields/_component_options.toml", type: "sink", name: "loki") %>
 
-<%= render("_partials/fields/_batch_options.toml", namespace: "sinks.loki.options", common: false, max_bytes: 10490000, max_events: 100000, timeout_secs: 1) %>
+<%= render("_partials/fields/_batch_options.toml", namespace: "sinks.loki.options", common: false, max_bytes: nil, max_events: 100000, timeout_secs: 1) %>
 
 <%= render(
   "_partials/fields/_buffer_options.toml",

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -8041,14 +8041,6 @@ require('custom_module')
   #
 
   [sinks.loki.batch]
-    # The maximum size of a batch, in bytes, before it is flushed.
-    #
-    # * optional
-    # * default: 10490000
-    # * type: uint
-    # * unit: bytes
-    max_bytes = 10490000
-
     # The maximum size of a batch, in events, before it is flushed.
     #
     # * optional

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -81,12 +81,10 @@ impl SinkConfig for LokiConfig {
         }
 
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
-        let batch_settings = self.batch.use_size_as_bytes()?.get_settings_or_default(
-            BatchSettings::default()
-                .bytes(bytesize::mib(10u64))
-                .events(100_000)
-                .timeout(1),
-        );
+        let batch_settings = self
+            .batch
+            .use_size_as_bytes()?
+            .get_settings_or_default(BatchSettings::default().events(100_000).timeout(1));
         let tls = TlsSettings::from_options(&self.tls)?;
 
         let sink = BatchedHttpSink::new(

--- a/website/docs/reference/sinks/loki.md
+++ b/website/docs/reference/sinks/loki.md
@@ -77,7 +77,6 @@ The Vector `loki` sink
   auth.user = "${LOKI_USERNAME}" # required, required when strategy = "basic"
 
   # Batch
-  batch.max_bytes = 10490000 # optional, default, bytes
   batch.max_events = 100000 # optional, default, events
   batch.timeout_secs = 1 # optional, default, seconds
 
@@ -260,29 +259,6 @@ Configures the sink batching behavior.
 
 
 <Fields filters={false}>
-<Field
-  common={true}
-  defaultValue={10490000}
-  enumValues={null}
-  examples={[10490000]}
-  groups={[]}
-  name={"max_bytes"}
-  path={"batch"}
-  relevantWhen={null}
-  required={false}
-  templateable={false}
-  type={"uint"}
-  unit={"bytes"}
-  warnings={[]}
-  >
-
-#### max_bytes
-
-The maximum size of a batch, in bytes, before it is flushed.
-
-
-
-</Field>
 <Field
   common={true}
   defaultValue={100000}


### PR DESCRIPTION
The batch size for the Loki sink cannot be calculated before the request
is generated, and the buffer in use ignores the byte size limit, so drop
the default byte size limit from the code and documentation.

Signed-off-by: Bruce Guenter <bruce@timber.io>