### PR TITLE
chore: Add Rust 2018 edition tag to .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,3 +2,4 @@
 # Not stable yet.
 # indent_style = "Block"
 reorder_imports = true
+edition = "2018"


### PR DESCRIPTION
Some editors use `rustfmt` directly instead of `cargo fmt`, which
requires explicitly indicating which Rust edition the project is using.

Signed-off-by: Bruce Guenter <bruce@timber.io>