### PR TITLE
enhancement(prometheus source): Provide error context on parse error

### DIFF
--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -22,7 +22,7 @@ pub struct PrometheusParseError {
 
 impl InternalEvent for PrometheusParseError {
     fn emit_logs(&self) {
-        error!(message = "parsing error", error = %self.error);
+        error!("parsing error: {:?}", self.error);
     }
 
     fn emit_metrics(&self) {

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -56,6 +56,7 @@ fn parse_header(input: &str) -> Result<ParserHeader, ParserError> {
     if tokens.len() != 4 {
         return Err(ParserError::Malformed {
             s: "expected 4 tokens in TYPE string",
+            context: String::from(input),
         });
     }
 
@@ -110,6 +111,7 @@ fn parse_tags(input: &str) -> Result<BTreeMap<String, String>, ParserError> {
             None => {
                 return Err(ParserError::Malformed {
                     s: "expected 2 values separated by '='",
+                    context: String::from(input),
                 });
             }
             Some(equals) => {
@@ -144,6 +146,7 @@ fn parse_metric(input: &str) -> Result<ParserMetric, ParserError> {
         if parts.len() < 2 {
             return Err(ParserError::Malformed {
                 s: "expected at least 2 tokens in data line",
+                context: String::from(input),
             });
         };
 
@@ -165,6 +168,7 @@ fn parse_metric(input: &str) -> Result<ParserMetric, ParserError> {
         if parts.len() < 2 {
             return Err(ParserError::Malformed {
                 s: "expected at least 2 tokens in data line",
+                context: String::from(input),
             });
         };
         let name = parts[0];
@@ -337,6 +341,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                     if v.len() < 2 {
                         return Err(ParserError::Malformed {
                             s: "expected histogram name suffix",
+                            context: String::from(line),
                         });
                     }
                     let (name, suffix) = (v[1], v[0]);
@@ -365,6 +370,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                             } else {
                                 return Err(ParserError::Malformed {
                                     s: "expected \"le\" tag in histogram bucket",
+                                    context: String::from(line),
                                 });
                             }
                         }
@@ -377,6 +383,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                         _ => {
                             return Err(ParserError::Malformed {
                                 s: "unknown histogram name suffix",
+                                context: String::from(line),
                             });
                         }
                     }
@@ -442,6 +449,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                             } else {
                                 return Err(ParserError::Malformed {
                                     s: "expected \"quantile\" tag in summary bucket",
+                                    context: String::from(line),
                                 });
                             }
                         }
@@ -454,6 +462,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
                         _ => {
                             return Err(ParserError::Malformed {
                                 s: "unknown summary name suffix",
+                                context: String::from(line),
                             });
                         }
                     }
@@ -492,6 +501,7 @@ pub fn parse(packet: &str) -> Result<Vec<Metric>, ParserError> {
 pub enum ParserError {
     Malformed {
         s: &'static str,
+        context: String,
     },
     UnknownMetricType {
         s: String,


### PR DESCRIPTION
Closes #3274

While investigating a Prometheus Source parse error (#3090), the only feedback given by vector was 'Malformed'

This patch logs more of the error context object, and adds the line on which the error occurs to this object. I found this was necessary to track down the exact issue fixed in #3090 - I think this will be useful in the future too.

This shouldn't block any of the changes discussed in https://github.com/timberio/vector/issues/3160 - it also doesn't address them

Before:
```
Jul 16 11:52:13.222 ERROR source{name=rabbitin type=prometheus}: vector::internal_events::prometheus: parsing error error=Malformed
```

After:
```
Jul 16 11:30:04.398 ERROR source{name=rabbitin type=prometheus}: vector::internal_events::prometheus: parsing error: Malformed { s: "expected 2 values separated by \'=\'", context: "registry=\"default\",content_type=\"text/plain; version=0.0.4\",encoding=\"identity\"" }
```

Signed-off-by: Adam Casey <acasey23@bloomberg.net>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
