### PR TITLE
fix(journald source): Fix typo in metrics name

### DIFF
--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -12,7 +12,7 @@ impl InternalEvent for JournaldEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("event_processed", 1,
+        counter!("events_processed", 1,
                  "component_kind" => "source",
                  "component_name" => "journald",
         );


### PR DESCRIPTION
Signed-off-by: Bruce Guenter <bruce@timber.io>

Looks like we missed this typo @lukesteensen. Thanks to @fanatid for pointing this out.

What do others think about defining constants for these common strings to make typos harder in the future?