### PR TITLE
enhancement(splunk_hec source): Add instrumentation

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -15,6 +15,7 @@ mod lua;
 #[cfg(feature = "sources-prometheus")]
 mod prometheus;
 mod regex;
+#[cfg(any(feature = "sources-splunk_hec", feature = "sinks-splunk_hec"))]
 mod splunk_hec;
 mod stdin;
 mod syslog;
@@ -44,7 +45,8 @@ pub use self::lua::*;
 #[cfg(feature = "sources-prometheus")]
 pub use self::prometheus::*;
 pub use self::regex::*;
-pub use self::splunk_hec::*;
+#[cfg(any(feature = "sources-splunk_hec", feature = "sinks-splunk_hec"))]
+pub(crate) use self::splunk_hec::*;
 pub use self::stdin::*;
 pub use self::syslog::*;
 pub use self::tcp::*;

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -2,6 +2,8 @@ use super::InternalEvent;
 use metrics::counter;
 use serde_json::Error;
 
+pub use self::source::*;
+
 #[derive(Debug)]
 pub struct SplunkEventSent {
     pub byte_size: usize,

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -1,4 +1,5 @@
 use super::InternalEvent;
+use crate::sources::splunk_hec::ApiError;
 use metrics::counter;
 use serde_json::Error;
 
@@ -30,7 +31,7 @@ pub struct SplunkEventEncodeError {
 impl InternalEvent for SplunkEventEncodeError {
     fn emit_logs(&self) {
         error!(
-            message = "Error encoding Splunk HEC event to json",
+            message = "error encoding Splunk HEC event to json.",
             error = ?self.error,
             rate_limit_secs = 30,
         );
@@ -40,6 +41,74 @@ impl InternalEvent for SplunkEventEncodeError {
         counter!(
             "encode_errors", 1,
             "component_kind" => "sink",
+            "component_type" => "splunk_hec",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct SplunkHECEventReceived;
+
+impl InternalEvent for SplunkHECEventReceived {
+    fn emit_logs(&self) {
+        trace!(message = "received one event.");
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "events_processed", 1,
+            "component_kind" => "source",
+            "component_type" => "splunk_hec",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct SplunkHECRequestReceived<'a> {
+    pub path: &'a str,
+}
+
+impl<'a> InternalEvent for SplunkHECRequestReceived<'a> {
+    fn emit_logs(&self) {
+        debug!(message = "received one request.", %self.path, rate_limit_secs = 10);
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "request_received", 1,
+            "component_kind" => "source",
+            "component_type" => "splunk_hec",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct SplunkHECRequestBodyInvalid {
+    pub error: std::io::Error,
+}
+
+impl InternalEvent for SplunkHECRequestBodyInvalid {
+    fn emit_logs(&self) {
+        error!(message = "invalid request body.",%self.error, rate_limit_secs = 10);
+    }
+
+    fn emit_metrics(&self) {}
+}
+
+#[derive(Debug)]
+pub struct SplunkHECRequestError {
+    pub error: ApiError,
+}
+
+impl InternalEvent for SplunkHECRequestError {
+    fn emit_logs(&self) {
+        error!(message = "error processing request.",%self.error, rate_limit_secs = 10);
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "request_errors", 1,
+            "component_kind" => "source",
             "component_type" => "splunk_hec",
         );
     }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -1,5 +1,4 @@
 use super::InternalEvent;
-use crate::sources::splunk_hec::ApiError;
 use metrics::counter;
 use serde_json::Error;
 
@@ -46,70 +45,76 @@ impl InternalEvent for SplunkEventEncodeError {
     }
 }
 
-#[derive(Debug)]
-pub struct SplunkHECEventReceived;
+#[cfg(feature = "sources-splunk_hec")]
+mod source {
+    use super::*;
+    use crate::sources::splunk_hec::ApiError;
 
-impl InternalEvent for SplunkHECEventReceived {
-    fn emit_logs(&self) {
-        trace!(message = "received one event.");
+    #[derive(Debug)]
+    pub struct SplunkHECEventReceived;
+
+    impl InternalEvent for SplunkHECEventReceived {
+        fn emit_logs(&self) {
+            trace!(message = "received one event.");
+        }
+
+        fn emit_metrics(&self) {
+            counter!(
+                "events_processed", 1,
+                "component_kind" => "source",
+                "component_type" => "splunk_hec",
+            );
+        }
     }
 
-    fn emit_metrics(&self) {
-        counter!(
-            "events_processed", 1,
-            "component_kind" => "source",
-            "component_type" => "splunk_hec",
-        );
-    }
-}
-
-#[derive(Debug)]
-pub struct SplunkHECRequestReceived<'a> {
-    pub path: &'a str,
-}
-
-impl<'a> InternalEvent for SplunkHECRequestReceived<'a> {
-    fn emit_logs(&self) {
-        debug!(message = "received one request.", %self.path, rate_limit_secs = 10);
+    #[derive(Debug)]
+    pub struct SplunkHECRequestReceived<'a> {
+        pub path: &'a str,
     }
 
-    fn emit_metrics(&self) {
-        counter!(
-            "request_received", 1,
-            "component_kind" => "source",
-            "component_type" => "splunk_hec",
-        );
-    }
-}
+    impl<'a> InternalEvent for SplunkHECRequestReceived<'a> {
+        fn emit_logs(&self) {
+            debug!(message = "received one request.", %self.path, rate_limit_secs = 10);
+        }
 
-#[derive(Debug)]
-pub struct SplunkHECRequestBodyInvalid {
-    pub error: std::io::Error,
-}
-
-impl InternalEvent for SplunkHECRequestBodyInvalid {
-    fn emit_logs(&self) {
-        error!(message = "invalid request body.",%self.error, rate_limit_secs = 10);
+        fn emit_metrics(&self) {
+            counter!(
+                "request_received", 1,
+                "component_kind" => "source",
+                "component_type" => "splunk_hec",
+            );
+        }
     }
 
-    fn emit_metrics(&self) {}
-}
-
-#[derive(Debug)]
-pub struct SplunkHECRequestError {
-    pub error: ApiError,
-}
-
-impl InternalEvent for SplunkHECRequestError {
-    fn emit_logs(&self) {
-        error!(message = "error processing request.",%self.error, rate_limit_secs = 10);
+    #[derive(Debug)]
+    pub struct SplunkHECRequestBodyInvalid {
+        pub error: std::io::Error,
     }
 
-    fn emit_metrics(&self) {
-        counter!(
-            "request_errors", 1,
-            "component_kind" => "source",
-            "component_type" => "splunk_hec",
-        );
+    impl InternalEvent for SplunkHECRequestBodyInvalid {
+        fn emit_logs(&self) {
+            error!(message = "invalid request body.",%self.error, rate_limit_secs = 10);
+        }
+
+        fn emit_metrics(&self) {}
+    }
+
+    #[derive(Debug)]
+    pub struct SplunkHECRequestError {
+        pub error: ApiError,
+    }
+
+    impl InternalEvent for SplunkHECRequestError {
+        fn emit_logs(&self) {
+            error!(message = "error processing request.",%self.error, rate_limit_secs = 10);
+        }
+
+        fn emit_metrics(&self) {
+            counter!(
+                "request_errors", 1,
+                "component_kind" => "source",
+                "component_type" => "splunk_hec",
+            );
+        }
     }
 }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -6,7 +6,7 @@ use serde_json::Error;
 pub(crate) use self::source::*;
 
 #[derive(Debug)]
-pub struct SplunkEventSent {
+pub(crate) struct SplunkEventSent {
     pub byte_size: usize,
 }
 
@@ -26,7 +26,7 @@ impl InternalEvent for SplunkEventSent {
 }
 
 #[derive(Debug)]
-pub struct SplunkEventEncodeError {
+pub(crate) struct SplunkEventEncodeError {
     pub error: Error,
 }
 
@@ -55,7 +55,7 @@ mod source {
     use metrics::counter;
 
     #[derive(Debug)]
-    pub struct SplunkHECEventReceived;
+    pub(crate) struct SplunkHECEventReceived;
 
     impl InternalEvent for SplunkHECEventReceived {
         fn emit_logs(&self) {
@@ -72,7 +72,7 @@ mod source {
     }
 
     #[derive(Debug)]
-    pub struct SplunkHECRequestReceived<'a> {
+    pub(crate) struct SplunkHECRequestReceived<'a> {
         pub path: &'a str,
     }
 
@@ -95,7 +95,7 @@ mod source {
     }
 
     #[derive(Debug)]
-    pub struct SplunkHECRequestBodyInvalid {
+    pub(crate) struct SplunkHECRequestBodyInvalid {
         pub error: std::io::Error,
     }
 
@@ -112,7 +112,7 @@ mod source {
     }
 
     #[derive(Debug)]
-    pub struct SplunkHECRequestError {
+    pub(crate) struct SplunkHECRequestError {
         pub(crate) error: ApiError,
     }
 

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -629,7 +629,7 @@ fn raw_event(
 }
 
 #[derive(Clone, Copy, Debug, Snafu)]
-pub enum ApiError {
+pub(crate) enum ApiError {
     MissingAuthorization,
     InvalidAuthorization,
     UnsupportedEncoding,


### PR DESCRIPTION
Closes #3205 

### Open questions

- [x] `bytes_processed` would require introducing a wrapper for `trait Read` to sum up used bytes, so it isn't practical. Instead we can emit `bytes_received`, but is this useful? (No.)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
