### PR TITLE
enhancement(logplex source): Add instrumentation

### DIFF
--- a/src/internal_events/logplex.rs
+++ b/src/internal_events/logplex.rs
@@ -1,0 +1,51 @@
+use super::InternalEvent;
+use metrics::counter;
+
+#[derive(Debug)]
+pub struct HerokuLogplexRequestReceived<'a> {
+    pub msg_count: usize,
+    pub frame_id: &'a str,
+    pub drain_token: &'a str,
+}
+
+impl<'a> InternalEvent for HerokuLogplexRequestReceived<'a> {
+    fn emit_logs(&self) {
+        info!(
+            message = "handling logplex request.",
+            msg_count = %self.msg_count,
+            frame_id = %self.frame_id,
+            drain_token = %self.drain_token,
+            rate_limit_secs = 10
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("requests_received", 1,
+            "component_kind" => "source",
+            "component_type" => "logplex",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct HerokuLogplexRequestReadError {
+    pub error: std::io::Error,
+}
+
+impl InternalEvent for HerokuLogplexRequestReadError {
+    fn emit_logs(&self) {
+        error!(
+            message = "error reading request body.",
+            error = ?self.error,
+            rate_limit_secs = 10
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "request_read_errors", 1,
+            "component_kind" => "source",
+            "component_type" => "logplex",
+        );
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -13,6 +13,7 @@ mod json;
 mod kafka;
 #[cfg(feature = "sources-kubernetes-logs")]
 mod kubernetes_logs;
+mod logplex;
 #[cfg(feature = "transforms-lua")]
 mod lua;
 #[cfg(feature = "sources-prometheus")]
@@ -48,6 +49,7 @@ pub use self::json::*;
 pub use self::kafka::*;
 #[cfg(feature = "sources-kubernetes-logs")]
 pub use self::kubernetes_logs::*;
+pub use self::logplex::*;
 #[cfg(feature = "transforms-lua")]
 pub use self::lua::*;
 #[cfg(feature = "sources-prometheus")]


### PR DESCRIPTION
Closes #3202 

### Open questions

- [x] If we add `HerokuLogplexEventReceived` we would count one event twice since #3264 added `HTTPEventsReceived` to a shared code that `logplex` source uses. 
To fix this, I propose moving `emit!(HTTPEventsReceived)` from here https://github.com/timberio/vector/blob/547c8ad6ac6ad4fa21dbf3a70f6b18570704bed6/src/sources/util/http.rs#L90-L93 to here https://github.com/timberio/vector/blob/547c8ad6ac6ad4fa21dbf3a70f6b18570704bed6/src/sources/http.rs#L58 And also removing this label https://github.com/timberio/vector/blob/547c8ad6ac6ad4fa21dbf3a70f6b18570704bed6/src/internal_events/http.rs#L51 so to make it clear these errors are aggregated from multiple types of sources.
 ref. https://github.com/timberio/vector/issues/3247#issuecomment-667732800 (Edit.  #2660 will solve this)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
