### PR TITLE
enhancement(file source): Add more instrumentation

### DIFF
--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -60,7 +60,7 @@ impl FileWatcher {
                 // the entire thing, so for now we simply refuse to read gzipped files for which we
                 // already have a stored file position from a previous run.
                 debug!(
-                    message = "Not re-reading gzipped file with existing stored offset",
+                    message = "not re-reading gzipped file with existing stored offset.",
                     ?path,
                     %file_position
                 );
@@ -242,7 +242,7 @@ fn read_until_with_max_size<R: BufRead + ?Sized>(
 
         if !discarding && buf.len() > max_size {
             warn!(
-                message = "Found line that exceeds max_line_bytes; discarding.",
+                message = "found line that exceeds max_line_bytes; discarding.",
                 rate_limit_secs = 30
             );
             discarding = true;

--- a/lib/file-source/src/internal_events.rs
+++ b/lib/file-source/src/internal_events.rs
@@ -1,0 +1,24 @@
+use std::io::Error;
+use std::path::Path;
+
+/// Every internal event in this crate has a coresponding
+/// method in this trait which should emit the event.
+pub trait FileSourceInternalEvents: Send + 'static {
+    fn emit_file_added(&self, path: &Path);
+
+    fn emit_file_resumed(&self, path: &Path, file_position: u64);
+
+    fn emit_file_watch_failed(&self, path: &Path, error: Error);
+
+    fn emit_file_unwatched(&self, path: &Path);
+
+    fn emit_file_deleted(&self, path: &Path);
+
+    fn emit_file_delete_failed(&self, path: &Path, error: Error);
+
+    fn emit_file_fingerprint_read_failed(&self, path: &Path, error: Error);
+
+    fn emit_file_fingerprint_failed(&self, path: &Path);
+
+    fn emit_file_checkpoint_write_failed(&self, error: Error);
+}

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -5,10 +5,12 @@ extern crate tracing;
 
 mod file_server;
 mod file_watcher;
+mod internal_events;
 mod metadata_ext;
 pub mod paths_provider;
 
 pub use self::file_server::{FileServer, Fingerprinter, Shutdown as FileServerShutdown};
+pub use self::internal_events::FileSourceInternalEvents;
 
 type FileFingerprint = u64;
 type FilePosition = u64;

--- a/src/internal_events/docker.rs
+++ b/src/internal_events/docker.rs
@@ -112,7 +112,7 @@ impl<'a> InternalEvent for DockerCommunicationError<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("communication_error", 1,
+        counter!("communication_errors", 1,
                  "component_kind" => "source",
                  "component_name" => "docker",
         );
@@ -136,7 +136,7 @@ impl<'a> InternalEvent for DockerContainerMetadataFetchFailed<'a> {
     }
 
     fn emit_metrics(&self) {
-        counter!("container_metadata_fetch_failed", 1,
+        counter!("container_metadata_fetch_errors", 1,
                  "component_kind" => "source",
                  "component_name" => "docker",
         );

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -11,7 +11,8 @@ impl InternalEvent for FileEventReceived<'_> {
     fn emit_logs(&self) {
         trace!(
             message = "received one event.",
-            %self.file,
+            file = %self.file,
+            byte_size = %self.byte_size
         );
     }
 

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -1,5 +1,8 @@
 use super::InternalEvent;
+use file_source::FileSourceInternalEvents;
 use metrics::counter;
+use std::io::Error;
+use std::path::Path;
 
 #[derive(Debug)]
 pub struct FileEventReceived<'a> {
@@ -27,5 +30,252 @@ impl InternalEvent for FileEventReceived<'_> {
             "component_kind" => "source",
             "component_type" => "file",
         );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileFingerprintFailed<'a> {
+    pub path: &'a Path,
+}
+
+impl<'a> InternalEvent for FileFingerprintFailed<'a> {
+    fn emit_logs(&self) {
+        warn!(
+            message = "currently ignoring file too small for fingerprinting.",
+            path = ?self.path,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "fingerprint_errors", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileFingerprintReadFailed<'a> {
+    pub path: &'a Path,
+    pub error: Error,
+}
+
+impl<'a> InternalEvent for FileFingerprintReadFailed<'a> {
+    fn emit_logs(&self) {
+        error!(
+            message = "failed reading file for fingerprinting.",
+            path = ?self.path,
+            error = ?self.error,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "fingerprint_read_errors", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileDeleteFailed<'a> {
+    pub path: &'a Path,
+    pub error: Error,
+}
+
+impl<'a> InternalEvent for FileDeleteFailed<'a> {
+    fn emit_logs(&self) {
+        warn!(
+            message = "failed in deleting file.",
+            path = ?self.path,
+            error = ?self.error,
+            rate_limit_secs = 1
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "file_delete_errors", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileDeleted<'a> {
+    pub path: &'a Path,
+}
+
+impl<'a> InternalEvent for FileDeleted<'a> {
+    fn emit_logs(&self) {
+        info!(
+            message = "file deleted.",
+            path = ?self.path,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "files_deleted", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileUnwatched<'a> {
+    pub path: &'a Path,
+}
+
+impl<'a> InternalEvent for FileUnwatched<'a> {
+    fn emit_logs(&self) {
+        info!(
+            message = "stopped watching file.",
+            path = ?self.path,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "files_unwatched", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileWatchFailed<'a> {
+    pub path: &'a Path,
+    pub error: Error,
+}
+
+impl<'a> InternalEvent for FileWatchFailed<'a> {
+    fn emit_logs(&self) {
+        error!(
+            message = "failed to watch file.",
+            path = ?self.path,
+            error = ?self.error
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "file_watch_errors", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileResumed<'a> {
+    pub path: &'a Path,
+    pub file_position: u64,
+}
+
+impl<'a> InternalEvent for FileResumed<'a> {
+    fn emit_logs(&self) {
+        info!(
+            message = "resuming to watch file.",
+            path = ?self.path,
+            file_position = %self.file_position
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "files_resumed", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileAdded<'a> {
+    pub path: &'a Path,
+}
+
+impl<'a> InternalEvent for FileAdded<'a> {
+    fn emit_logs(&self) {
+        info!(
+            message = "found new file to watch.",
+            path = ?self.path,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "files_added", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct FileCheckpointWriteFailed {
+    pub error: Error,
+}
+
+impl InternalEvent for FileCheckpointWriteFailed {
+    fn emit_logs(&self) {
+        warn!(message = "failed writing checkpoints.", error = ?self.error);
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "checkpoint_write_errors", 1,
+            "component_kind" => "source",
+            "component_type" => "file",
+        );
+    }
+}
+
+pub struct FileSourceInternalEventsEmitter;
+
+impl FileSourceInternalEvents for FileSourceInternalEventsEmitter {
+    fn emit_file_added(&self, path: &Path) {
+        emit!(FileAdded { path });
+    }
+
+    fn emit_file_resumed(&self, path: &Path, file_position: u64) {
+        emit!(FileResumed {
+            path,
+            file_position
+        });
+    }
+
+    fn emit_file_watch_failed(&self, path: &Path, error: Error) {
+        emit!(FileWatchFailed { path, error });
+    }
+
+    fn emit_file_unwatched(&self, path: &Path) {
+        emit!(FileUnwatched { path });
+    }
+
+    fn emit_file_deleted(&self, path: &Path) {
+        emit!(FileDeleted { path });
+    }
+
+    fn emit_file_delete_failed(&self, path: &Path, error: Error) {
+        emit!(FileDeleteFailed { path, error });
+    }
+
+    fn emit_file_fingerprint_read_failed(&self, path: &Path, error: Error) {
+        emit!(FileFingerprintReadFailed { path, error });
+    }
+
+    fn emit_file_fingerprint_failed(&self, path: &Path) {
+        emit!(FileFingerprintFailed { path });
+    }
+
+    fn emit_file_checkpoint_write_failed(&self, error: Error) {
+        emit!(FileCheckpointWriteFailed { error });
     }
 }

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -4,7 +4,6 @@ mod blackhole;
 #[cfg(feature = "sources-docker")]
 mod docker;
 mod elasticsearch;
-mod file;
 mod http;
 #[cfg(all(unix, feature = "sources-journald"))]
 mod journald;
@@ -82,3 +81,6 @@ macro_rules! emit {
         $crate::internal_events::emit($event);
     };
 }
+
+// Modules that require emit! macro so they need to be defined after the macro.
+mod file;

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     event::{self, Event},
-    internal_events::FileEventReceived,
+    internal_events::{FileEventReceived, FileSourceInternalEventsEmitter},
     shutdown::ShutdownSignal,
     topology::config::{DataType, GlobalOptions, SourceConfig, SourceDescription},
     trace::{current_span, Instrument},
@@ -252,6 +252,7 @@ pub fn file_source(
         fingerprinter: config.fingerprinting.clone().into(),
         oldest_first: config.oldest_first,
         remove_after: config.remove_after.map(Duration::from_secs),
+        emitter: FileSourceInternalEventsEmitter,
     };
 
     let file_key = config.file_key.clone();

--- a/src/sources/file/mod.rs
+++ b/src/sources/file/mod.rs
@@ -267,7 +267,7 @@ pub fn file_source(
     let message_start_indicator = config.message_start_indicator.clone();
     let multi_line_timeout = config.multi_line_timeout;
     Box::new(future::lazy(move || {
-        info!(message = "Starting file server.", ?include, ?exclude);
+        info!(message = "starting file server.", ?include, ?exclude);
 
         // sizing here is just a guess
         let (tx, rx) = futures01::sync::mpsc::channel(100);
@@ -298,10 +298,6 @@ pub fn file_source(
             messages
                 .map(move |(msg, file): (Bytes, String)| {
                     let _enter = span2.enter();
-                    emit!(FileEventReceived {
-                        file: &file,
-                        byte_size: msg.len(),
-                    });
                     create_event(msg, file, &host_key, &hostname, &file_key)
                 })
                 .forward(out.sink_map_err(|e| error!(%e)))
@@ -321,7 +317,7 @@ pub fn file_source(
         })
         .boxed()
         .compat()
-        .map_err(|error| error!(message="File server unexpectedly stopped.",%error))
+        .map_err(|error| error!(message="file server unexpectedly stopped.",%error))
     }))
 }
 
@@ -332,6 +328,11 @@ fn create_event(
     hostname: &Option<String>,
     file_key: &Option<String>,
 ) -> Event {
+    emit!(FileEventReceived {
+        file: &file,
+        byte_size: line.len(),
+    });
+
     let mut event = Event::from(line);
 
     // Add source type

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -6,7 +6,10 @@
 #![deny(missing_docs)]
 
 use crate::event::{self, Event};
-use crate::internal_events::{KubernetesLogsEventAnnotationFailed, KubernetesLogsEventReceived};
+use crate::internal_events::{
+    FileSourceInternalEventsEmitter, KubernetesLogsEventAnnotationFailed,
+    KubernetesLogsEventReceived,
+};
 use crate::kubernetes as k8s;
 use crate::{
     dns::Resolver,
@@ -203,6 +206,7 @@ impl Source {
             },
             oldest_first: false,
             remove_after: None,
+            emitter: FileSourceInternalEventsEmitter,
         };
 
         let (file_source_tx, file_source_rx) =

--- a/src/sources/kubernetes_logs/util.rs
+++ b/src/sources/kubernetes_logs/util.rs
@@ -1,5 +1,7 @@
 use bytes05::Bytes;
-use file_source::{paths_provider::PathsProvider, FileServer, FileServerShutdown};
+use file_source::{
+    paths_provider::PathsProvider, FileServer, FileServerShutdown, FileSourceInternalEvents,
+};
 use futures::future::{select, Either};
 use futures::{pin_mut, Sink};
 use std::convert::Infallible;
@@ -9,13 +11,14 @@ use tokio::task::spawn_blocking;
 
 /// A tiny wrapper around a [`FileServer`] that runs it as a [`spawn_blocking`]
 /// task.
-pub async fn run_file_server<PP, C, S>(
-    file_server: FileServer<PP>,
+pub async fn run_file_server<PP, E, C, S>(
+    file_server: FileServer<PP, E>,
     chans: C,
     shutdown: S,
 ) -> Result<FileServerShutdown, tokio::task::JoinError>
 where
     PP: PathsProvider + Send + 'static,
+    E: FileSourceInternalEvents,
     C: Sink<(Bytes, String)> + Unpin + Send + 'static,
     <C as Sink<(Bytes, String)>>::Error: Error + Send,
     S: Future + Unpin + Send + 'static,


### PR DESCRIPTION
Closes #3197.

Adds a API for emitting events from `file-source` crate, but also fixes `docker` internal event logs a bit that I added recently. 

### Open questions

- [x] Better name for `FileFingerprintFailed` considering that fingerprinting fails when the file is too small. (Edit: let's go with this name)

- [x] `kubernetes` source reuses `FileSourceInternalEventsEmitter` but it's not clear if that is necessary. `kubernetes` has lots of events on it's own so maybe these are just noise? Otherwise `kubernetes` could enrich this logs more, like parsing out pod/container to which it belongs. cc. @MOZGIII (Edit: leave it as is)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
