### PR TITLE
enhancement(console sink): Add "text" encoding for metrics

### DIFF
--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -247,11 +247,14 @@ impl Display for Metric {
                 write_word(fmt, tag).and_then(|()| write!(fmt, "={:?}", value))
             })?;
         }
-        write!(fmt, "}}")?;
-        match self.kind {
-            MetricKind::Absolute => write!(fmt, " = "),
-            MetricKind::Incremental => write!(fmt, " + "),
-        }?;
+        write!(
+            fmt,
+            "}} {} ",
+            match self.kind {
+                MetricKind::Absolute => '=',
+                MetricKind::Incremental => '+',
+            }
+        )?;
         match &self.value {
             MetricValue::Counter { value } => write!(fmt, "{}", value),
             MetricValue::Gauge { value } => write!(fmt, "{}", value),
@@ -265,10 +268,10 @@ impl Display for Metric {
             } => {
                 write!(
                     fmt,
-                    "{}",
+                    "{} ",
                     match statistic {
-                        StatisticKind::Histogram => "histogram ",
-                        StatisticKind::Summary => "summary ",
+                        StatisticKind::Histogram => "histogram",
+                        StatisticKind::Summary => "summary",
                     }
                 )?;
                 write_list(

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -173,7 +173,7 @@ mod test {
         });
         assert_eq!(
             r#"{"name":"foos","timestamp":"2018-11-14T08:09:10.000000011Z","tags":{"Key3":"Value3","key1":"value1","key2":"value2"},"kind":"incremental","counter":{"value":100.0}}"#,
-            encode_event(event, &EncodingConfig::from(Encoding::Text)).unwrap()
+            encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
         );
     }
 
@@ -190,7 +190,7 @@ mod test {
         });
         assert_eq!(
             r#"{"name":"users","timestamp":null,"tags":null,"kind":"incremental","set":{"values":["bob"]}}"#,
-            encode_event(event, &EncodingConfig::from(Encoding::Text)).unwrap()
+            encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
         );
     }
 
@@ -209,7 +209,7 @@ mod test {
         });
         assert_eq!(
             r#"{"name":"glork","timestamp":null,"tags":null,"kind":"incremental","distribution":{"values":[10.0],"sample_rates":[1],"statistic":"histogram"}}"#,
-            encode_event(event, &EncodingConfig::from(Encoding::Text)).unwrap()
+            encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
         );
     }
 }

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -15,17 +15,13 @@ use tokio::io::{self, AsyncWriteExt};
 
 use super::streaming_sink::{self, StreamingSink};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug, Derivative, Deserialize, Serialize)]
+#[derivative(Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Target {
+    #[derivative(Default)]
     Stdout,
     Stderr,
-}
-
-impl Default for Target {
-    fn default() -> Self {
-        Target::Stdout
-    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -89,7 +85,10 @@ fn encode_event(
                 Ok(s)
             }
         },
-        Event::Metric(metric) => serde_json::to_string(&metric),
+        Event::Metric(metric) => match encoding.codec() {
+            Encoding::Json => serde_json::to_string(&metric),
+            Encoding::Text => Ok(format!("{}", metric)),
+        },
     }
 }
 

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -212,4 +212,21 @@ mod test {
             encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
         );
     }
+
+    #[test]
+    fn encodes_metric_text() {
+        let event = Event::Metric(Metric {
+            name: "users".into(),
+            timestamp: None,
+            tags: None,
+            kind: MetricKind::Incremental,
+            value: MetricValue::Set {
+                values: vec!["bob".into()].into_iter().collect(),
+            },
+        });
+        assert_eq!(
+            "users{} + bob",
+            encode_event(event, &EncodingConfig::from(Encoding::Text)).unwrap()
+        );
+    }
 }


### PR DESCRIPTION
The text encoding is modelled after the Prometheus text format, though
using just one line for each output rather than multiple lines for
things like histograms.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #1266