### PR TITLE
enhancement: Add events for starting, stopping, and reloading

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -17,6 +17,7 @@ mod kubernetes_logs;
 mod logplex;
 #[cfg(feature = "transforms-lua")]
 mod lua;
+mod process;
 #[cfg(feature = "sources-prometheus")]
 mod prometheus;
 mod regex;
@@ -57,6 +58,7 @@ pub use self::kubernetes_logs::*;
 pub use self::logplex::*;
 #[cfg(feature = "transforms-lua")]
 pub use self::lua::*;
+pub use self::process::*;
 #[cfg(feature = "sources-prometheus")]
 pub use self::prometheus::*;
 pub use self::regex::*;

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -1,0 +1,63 @@
+use super::InternalEvent;
+use metrics::counter;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct VectorStarted;
+
+impl InternalEvent for VectorStarted {
+    fn emit_logs(&self) {
+        info!(
+            target: "vector",
+            message = "Vector is starting.",
+            version = built_info::PKG_VERSION,
+            git_version = built_info::GIT_VERSION.unwrap_or(""),
+            released = built_info::BUILT_TIME_UTC,
+            arch = built_info::CFG_TARGET_ARCH
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("vector_started_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct VectorReloaded<'a> {
+    pub config_paths: &'a [PathBuf],
+}
+
+impl InternalEvent for VectorReloaded<'_> {
+    fn emit_logs(&self) {
+        info!(
+            target: "vector",
+            message = "Vector is reloading.",
+            path = ?self.config_paths
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("vector_reloaded_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct VectorStopped;
+
+impl InternalEvent for VectorStopped {
+    fn emit_logs(&self) {
+        info!(
+            target: "vector",
+            message = "Vector is stopping."
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("vector_stopped_total", 1);
+    }
+}
+
+#[allow(unused)]
+mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -9,7 +9,7 @@ impl InternalEvent for VectorStarted {
     fn emit_logs(&self) {
         info!(
             target: "vector",
-            message = "Vector is starting.",
+            message = "Vector has started.",
             version = built_info::PKG_VERSION,
             git_version = built_info::GIT_VERSION.unwrap_or(""),
             released = built_info::BUILT_TIME_UTC,
@@ -31,7 +31,7 @@ impl InternalEvent for VectorReloaded<'_> {
     fn emit_logs(&self) {
         info!(
             target: "vector",
-            message = "Vector is reloading.",
+            message = "Vector has reloaded.",
             path = ?self.config_paths
         );
     }
@@ -48,7 +48,7 @@ impl InternalEvent for VectorStopped {
     fn emit_logs(&self) {
         info!(
             target: "vector",
-            message = "Vector is stopping."
+            message = "Vector has stopped."
         );
     }
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -13,7 +13,7 @@ use futures01::{Future, Sink};
 use metrics_runtime::Controller;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use tokio::time::interval;
+use tokio::{select, time::interval};
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct InternalMetricsConfig;
@@ -47,15 +47,18 @@ impl SourceConfig for InternalMetricsConfig {
 async fn run(
     controller: Controller,
     mut out: Pipeline,
-    mut shutdown: ShutdownSignal,
+    shutdown: ShutdownSignal,
 ) -> Result<(), ()> {
     let mut interval = interval(Duration::from_secs(2)).map(|_| ());
+    let mut shutdown = shutdown.compat();
 
-    while let Some(()) = interval.next().await {
-        // Check for shutdown signal
-        if shutdown.poll().expect("polling shutdown").is_ready() {
-            break;
-        }
+    let mut run = true;
+    while run {
+        run = select! {
+            Some(()) = interval.next() => true,
+            _ = &mut shutdown => false,
+            else => false,
+        };
 
         let metrics = capture_metrics(&controller);
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -9,7 +9,7 @@ use futures::{
     future::{FutureExt, TryFutureExt},
     stream::StreamExt,
 };
-use futures01::{Future, Sink};
+use futures01::Sink;
 use metrics_runtime::Controller;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;


### PR DESCRIPTION
Closes #3448.

Added events emit:
- `Vector is starting.`
- `Vector is reloading.`
- `Vector is stopping.`

logs respectively. This differs from what it used to be, but it reflects the metrics and is more streamlined.

### Open questions

- [x] logs are emitted under fixed `target = "vector"` to avoid `vector::internal_events::process:` being logged as the call site. Haven't seen what's our stance on that. It should be possible to extend `emit!` macro to set target as the actual emit site, or is this the intended behavior? (Edit: it should be fine to use target for now)

- [x] Should we use lowercase `vector` ? (Edit: use `Vector` for emphasis) 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
