### PR TITLE
fix(statsd sink): Handle Absolute kind for values other than Gauge.

### DIFF
--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -144,21 +144,18 @@ fn encode_event(event: Event, namespace: &str) -> Option<Vec<u8>> {
                 buf.push(format!("#{}", encode_tags(t)));
             };
         }
-        MetricValue::Gauge { value } => match metric.kind {
-            MetricKind::Incremental => {
-                buf.push(format!("{}:{:+}", metric.name, value));
-                buf.push("g".to_string());
-                if let Some(t) = &metric.tags {
-                    buf.push(format!("#{}", encode_tags(t)));
-                };
-            }
-            MetricKind::Absolute => {
-                buf.push(format!("{}:{}", metric.name, value));
-                buf.push("g".to_string());
-                if let Some(t) = &metric.tags {
-                    buf.push(format!("#{}", encode_tags(t)));
-                };
-            }
+        MetricValue::Gauge { value } => {
+            match metric.kind {
+                MetricKind::Incremental => 
+                    buf.push(format!("{}:{:+}", metric.name, value)),
+                MetricKind::Absolute => 
+                    buf.push(format!("{}:{}", metric.name, value))
+            };
+        
+            buf.push("g".to_string());
+            if let Some(t) = &metric.tags {
+                buf.push(format!("#{}", encode_tags(t)));
+            };
         },
         MetricValue::Distribution {
             values,

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -284,7 +284,7 @@ mod test {
             kind: MetricKind::Absolute,
             value: MetricValue::Counter { value: 1.5 },
         };
-        let event = Event::Metric(metric1.clone());
+        let event = Event::Metric(metric1);
         let frame = &encode_event(event, "").unwrap();
         // The statsd parser will parse the counter as Incremental,
         // so we can't compare it with the parsed value.

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -146,17 +146,15 @@ fn encode_event(event: Event, namespace: &str) -> Option<Vec<u8>> {
         }
         MetricValue::Gauge { value } => {
             match metric.kind {
-                MetricKind::Incremental => 
-                    buf.push(format!("{}:{:+}", metric.name, value)),
-                MetricKind::Absolute => 
-                    buf.push(format!("{}:{}", metric.name, value))
+                MetricKind::Incremental => buf.push(format!("{}:{:+}", metric.name, value)),
+                MetricKind::Absolute => buf.push(format!("{}:{}", metric.name, value)),
             };
-        
+
             buf.push("g".to_string());
             if let Some(t) = &metric.tags {
                 buf.push(format!("#{}", encode_tags(t)));
             };
-        },
+        }
         MetricValue::Distribution {
             values,
             sample_rates,


### PR DESCRIPTION
For the statsd sink if the Metric Kind was Absolute, it would only output values if the MetricValue was guage. The rest were ignored, code further along then prepended the namespace. This resulted in only the namespace being sent.

One possible fix could have been to make the internal metrics send Counters as an Incremental value. Theoretically perhaps this was the more correct fix? However, the Prometheus source, and possibly others would also need changing as this was also sending Absolute Counters.

The alternative is as I have done here, The statsd sink now only considers the Metric Kind if the Value is a Guage. For all other values it outputs the same regardless of the kind.

There are still same Values that the StatsD sink does not handle (AggregatedHistogram and AggregatedSummary), to avoid future confusion, I have added a warning if these types are sent to the StatsD sink.

This fixes #3488 