### PR TITLE
enhancement(tag_cardinality_limit transform): Add internal events

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -43,6 +43,8 @@ mod splunk_hec;
 mod statsd;
 mod stdin;
 mod syslog;
+#[cfg(feature = "transforms-tag_cardinality_limit")]
+mod tag_cardinality_limit;
 mod tcp;
 mod unix;
 mod vector;
@@ -95,6 +97,8 @@ pub(crate) use self::splunk_hec::*;
 pub use self::statsd::*;
 pub use self::stdin::*;
 pub use self::syslog::*;
+#[cfg(feature = "transforms-tag_cardinality_limit")]
+pub(crate) use self::tag_cardinality_limit::*;
 pub use self::tcp::*;
 pub use self::unix::*;
 pub use self::vector::*;

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -1,0 +1,66 @@
+use super::InternalEvent;
+use metrics::counter;
+
+pub(crate) struct TagCardinalityLimitEventProcessed;
+
+impl InternalEvent for TagCardinalityLimitEventProcessed {
+    fn emit_logs(&self) {
+        trace!(message = "Processed one event.");
+    }
+
+    fn emit_metrics(&self) {
+        counter!("events_processed", 1,
+            "component_kind" => "transform",
+            "component_type" => "regex_parser",
+        );
+    }
+}
+
+pub(crate) struct TagCardinalityLimitRejectingEvent<'a> {
+    pub tag_key: &'a str,
+    pub tag_value: &'a str,
+}
+
+impl<'a> InternalEvent for TagCardinalityLimitRejectingEvent<'a> {
+    fn emit_logs(&self) {
+        error!(
+            message = "Event containing tag with new value after hitting configured 'value_limit'; discarding event",
+            tag_key = self.tag_key,
+            tag_value = self.tag_value,
+            rate_limit_secs = 10,
+        );
+    }
+
+    fn emit_metrics(&self) {}
+}
+
+pub(crate) struct TagCardinalityLimitRejectingTag<'a> {
+    pub tag_key: &'a str,
+    pub tag_value: &'a str,
+}
+
+impl<'a> InternalEvent for TagCardinalityLimitRejectingTag<'a> {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Rejecting tag after hitting configured 'value_limit'",
+            tag_key = self.tag_key,
+            tag_value = self.tag_value,
+            rate_limit_secs = 10,
+        );
+    }
+
+    fn emit_metrics(&self) {}
+}
+
+pub(crate) struct TagCardinalityLimitReachedLimit<'a> {
+    pub key: &'a str,
+}
+
+impl<'a> InternalEvent for TagCardinalityLimitReachedLimit<'a> {
+    fn emit_logs(&self) {
+        warn!(
+            "value_limit reached for key {}. New values for this key will be rejected",
+            key = self.key,
+        );
+    }
+}

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -11,7 +11,7 @@ impl InternalEvent for TagCardinalityLimitEventProcessed {
     fn emit_metrics(&self) {
         counter!("events_processed", 1,
             "component_kind" => "transform",
-            "component_type" => "regex_parser",
+            "component_type" => "tag_cardinality_limit",
         );
     }
 }
@@ -31,7 +31,12 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingEvent<'a> {
         );
     }
 
-    fn emit_metrics(&self) {}
+    fn emit_metrics(&self) {
+        counter!("tag_value_limit_exceeded", 1,
+            "component_kind" => "transform",
+            "component_type" => "tag_cardinality_limit",
+        );
+    }
 }
 
 pub(crate) struct TagCardinalityLimitRejectingTag<'a> {
@@ -49,18 +54,30 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingTag<'a> {
         );
     }
 
-    fn emit_metrics(&self) {}
+    fn emit_metrics(&self) {
+        counter!("tag_value_limit_exceeded", 1,
+            "component_kind" => "transform",
+            "component_type" => "tag_cardinality_limit",
+        );
+    }
 }
 
-pub(crate) struct TagCardinalityLimitReachedLimit<'a> {
+pub(crate) struct TagCardinalityValueLimitReached<'a> {
     pub key: &'a str,
 }
 
-impl<'a> InternalEvent for TagCardinalityLimitReachedLimit<'a> {
+impl<'a> InternalEvent for TagCardinalityValueLimitReached<'a> {
     fn emit_logs(&self) {
         warn!(
             "value_limit reached for key {}. New values for this key will be rejected",
             key = self.key,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("value_limit_reached", 1,
+            "component_kind" => "transform",
+            "component_type" => "tag_cardinality_limit",
         );
     }
 }

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -2,8 +2,8 @@ use super::Transform;
 use crate::{
     config::{DataType, TransformConfig, TransformContext, TransformDescription},
     internal_events::{
-        TagCardinalityLimitEventProcessed, TagCardinalityLimitReachedLimit,
-        TagCardinalityLimitRejectingEvent, TagCardinalityLimitRejectingTag,
+        TagCardinalityLimitEventProcessed, TagCardinalityLimitRejectingEvent,
+        TagCardinalityLimitRejectingTag, TagCardinalityValueLimitReached,
     },
     Event,
 };
@@ -178,7 +178,7 @@ impl TagCardinalityLimit {
             tag_value_set.insert(value);
 
             if tag_value_set.len() == self.config.value_limit as usize {
-                emit!(TagCardinalityLimitReachedLimit { key });
+                emit!(TagCardinalityValueLimitReached { key });
             }
 
             true

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -1,6 +1,10 @@
 use super::Transform;
 use crate::{
     config::{DataType, TransformConfig, TransformContext, TransformDescription},
+    internal_events::{
+        TagCardinalityLimitEventProcessed, TagCardinalityLimitReachedLimit,
+        TagCardinalityLimitRejectingEvent, TagCardinalityLimitRejectingTag,
+    },
     Event,
 };
 use bloom::{BloomFilter, ASMS};
@@ -174,10 +178,7 @@ impl TagCardinalityLimit {
             tag_value_set.insert(value);
 
             if tag_value_set.len() == self.config.value_limit as usize {
-                warn!(
-                    "value_limit reached for key {}. New values for this key will be rejected",
-                    key
-                );
+                emit!(TagCardinalityLimitReachedLimit { key });
             }
 
             true
@@ -190,18 +191,17 @@ impl TagCardinalityLimit {
 
 impl Transform for TagCardinalityLimit {
     fn transform(&mut self, mut event: Event) -> Option<Event> {
+        emit!(TagCardinalityLimitEventProcessed);
         match event.as_mut_metric().tags {
             Some(ref mut tags_map) => {
                 match self.config.limit_exceeded_action {
                     LimitExceededAction::DropEvent => {
                         for (key, value) in tags_map {
                             if !self.try_accept_tag(key, Cow::Borrowed(value)) {
-                                info!(
-                                    message = "Rejecting Metric Event containing tag with new value after hitting configured 'value_limit'",
-                                    tag_key = key.as_str(),
-                                    tag_value = &value.as_str(),
-                                    rate_limit_secs = 10,
-                                );
+                                emit!(TagCardinalityLimitRejectingEvent {
+                                    tag_key: &key,
+                                    tag_value: &value,
+                                });
                                 return None;
                             }
                         }
@@ -210,13 +210,10 @@ impl Transform for TagCardinalityLimit {
                         let mut to_delete = Vec::new();
                         for (key, value) in tags_map.iter() {
                             if !self.try_accept_tag(key, Cow::Borrowed(value)) {
-                                info!(
-                                    message =
-                                        "Rejecting tag after hitting configured 'value_limit'",
-                                    tag_key = key.as_str(),
-                                    tag_value = value.as_str(),
-                                    rate_limit_secs = 10,
-                                );
+                                emit!(TagCardinalityLimitRejectingTag {
+                                    tag_key: &key,
+                                    tag_value: &value,
+                                });
                                 to_delete.push(key.clone());
                             }
                         }


### PR DESCRIPTION
Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #3409 

The two tag limiting events should emit metrics, but I am unsure what metric to emit. Limiting the tags is the whole purpose of this transform, so using `"processing_error"` doesn't seem to fit, but what then?