### PR TITLE
enhancement(file source): Add `FileOpen` gauge

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -199,6 +199,9 @@ where
             let mut global_bytes_read: usize = 0;
             let mut maxed_out_reading_single_file = false;
             for (&file_id, watcher) in &mut fp_map {
+                self.emitter
+                    .emit_file_open(&watcher.path, watcher.open_since);
+
                 if !watcher.should_read() {
                     continue;
                 }

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -27,6 +27,7 @@ pub struct FileWatcher {
     is_dead: bool,
     last_read_attempt: Instant,
     last_read_success: Instant,
+    pub open_since: Instant,
 }
 
 impl FileWatcher {
@@ -93,6 +94,7 @@ impl FileWatcher {
             is_dead: false,
             last_read_attempt: ts,
             last_read_success: ts,
+            open_since: Instant::now(),
         })
     }
 

--- a/lib/file-source/src/internal_events.rs
+++ b/lib/file-source/src/internal_events.rs
@@ -1,5 +1,6 @@
 use std::io::Error;
 use std::path::Path;
+use std::time::Instant;
 
 /// Every internal event in this crate has a coresponding
 /// method in this trait which should emit the event.
@@ -7,6 +8,8 @@ pub trait FileSourceInternalEvents: Send + 'static {
     fn emit_file_added(&self, path: &Path);
 
     fn emit_file_resumed(&self, path: &Path, file_position: u64);
+
+    fn emit_file_open(&self, path: &Path, since: Instant);
 
     fn emit_file_watch_failed(&self, path: &Path, error: Error);
 


### PR DESCRIPTION
Closes #3516

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
