### PR TITLE
perf(http sink): Increase rate_limit_num to its maximum

### DIFF
--- a/.meta/sinks/http.toml.erb
+++ b/.meta/sinks/http.toml.erb
@@ -34,7 +34,7 @@ write_to_description = "a generic [HTTP][urls.http] endpoint"
   common: true,
   in_flight_limit: 10,
   rate_limit_duration_secs: 1,
-  rate_limit_num: 1000,
+  rate_limit_num: 18446744073709551615,
   retry_initial_backoff_secs: 1,
   retry_max_duration_secs: 10,
   timeout_secs: 30

--- a/.meta/sinks/http.toml.erb
+++ b/.meta/sinks/http.toml.erb
@@ -34,7 +34,7 @@ write_to_description = "a generic [HTTP][urls.http] endpoint"
   common: true,
   in_flight_limit: 10,
   rate_limit_duration_secs: 1,
-  rate_limit_num: 18446744073709551615,
+  rate_limit_num: 9000000000000000000,
   retry_initial_backoff_secs: 1,
   retry_max_duration_secs: 10,
   timeout_secs: 30

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -73,7 +73,7 @@ lazy_static! {
     static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
         in_flight_limit: InFlightLimit::Fixed(10),
         timeout_secs: Some(30),
-        rate_limit_num: Some(10),
+        rate_limit_num: Some(u64::max_value()),
         ..Default::default()
     };
 }


### PR DESCRIPTION
Signed-off-by: Bruce Guenter <bruce@timber.io>

I started to write this by removing the default and then re-adding it to those sinks that were missing it, but realized that the only generic sink using these defaults is the http sink. So this ends up being quite trivial. I did find some broken defaults along the way, though.

Closes #3491 