### PR TITLE
fix: rate_limit_num for GCP pubsub and cloud_storage was wrong

### DIFF
--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -123,7 +123,7 @@ enum GcsStorageClass {
 lazy_static! {
     static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
         in_flight_limit: InFlightLimit::Fixed(25),
-        rate_limit_num: Some(25),
+        rate_limit_num: Some(1000),
         ..Default::default()
     };
 }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -60,6 +60,13 @@ inventory::submit! {
     SinkDescription::new::<PubsubConfig>("gcp_pubsub")
 }
 
+lazy_static::lazy_static! {
+    static ref REQUEST_DEFAULTS: TowerRequestConfig = TowerRequestConfig {
+        rate_limit_num: Some(100),
+        ..Default::default()
+    };
+}
+
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_pubsub")]
 impl SinkConfig for PubsubConfig {


### PR DESCRIPTION
The default value for rate_limit_num for the gcp_pubsub and
gcp_cloud_storage sinks was much lower than the documentation.

Signed-off-by: Bruce Guenter <bruce@timber.io>