### PR TITLE
fix(security): Load verify certificates from default paths

### DIFF
--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -90,6 +90,8 @@ pub enum TlsError {
     AddCertToStore { source: ErrorStack },
     #[snafu(display("Error setting up the verification certificate: {}", source))]
     SetVerifyCert { source: ErrorStack },
+    #[snafu(display("Error setting up the default verification paths: {}", source))]
+    SetDefaultVerifyPaths { source: ErrorStack },
     #[snafu(display("PKCS#12 parse failed: {}", source))]
     ParsePkcs12 { source: ErrorStack },
     #[snafu(display("TCP bind failed: {}", source))]

--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -1,7 +1,8 @@
 use super::{
     AddCertToStore, AddExtraChainCert, CaStackPush, DerExportError, FileOpenFailed, FileReadFailed,
     MaybeTls, NewCaStack, NewStoreBuilder, ParsePkcs12, Pkcs12Error, PrivateKeyParseError, Result,
-    SetCertificate, SetPrivateKey, SetVerifyCert, TlsError, TlsIdentityError, X509ParseError,
+    SetCertificate, SetDefaultVerifyPaths, SetPrivateKey, SetVerifyCert, TlsError,
+    TlsIdentityError, X509ParseError,
 };
 use openssl::{
     pkcs12::{ParsedPkcs12, Pkcs12},
@@ -132,6 +133,10 @@ impl TlsSettings {
                 .context(SetVerifyCert)?;
         } else {
             debug!("Fetching system root certs.");
+
+            context
+                .set_default_verify_paths()
+                .context(SetDefaultVerifyPaths)?;
 
             #[cfg(windows)]
             load_windows_certs(context).unwrap();


### PR DESCRIPTION
When no TLS authorities are configured, add a call to explicitly set the
paths to the verify certificates to the defaults. This will read the
environment variables set by openssl_probe earlier in the program in
case the certificates are not in the location hard-coded into the
openssl library.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #3868 