### PR TITLE
fix(windows platform): Update tokio signal to avoid unnecessary shutdowns.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "gimli 0.21.0",
  "log",
  "regalloc",
- "smallvec 1.4.2",
+ "smallvec",
  "target-lexicon",
  "thiserror",
 ]
@@ -699,7 +699,7 @@ source = "git+https://github.com/bytecodealliance/lucet.git?rev=b1863dacc8c92c11
 dependencies = [
  "cranelift-codegen",
  "log",
- "smallvec 1.4.2",
+ "smallvec",
  "target-lexicon",
 ]
 
@@ -1169,7 +1169,7 @@ dependencies = [
  "bytes 0.5.6",
  "hashbag",
  "slab",
- "smallvec 1.4.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -2530,7 +2530,7 @@ dependencies = [
  "metrics-observer-prometheus",
  "metrics-observer-yaml",
  "metrics-util",
- "parking_lot 0.10.2",
+ "parking_lot",
  "quanta",
 ]
 
@@ -2966,38 +2966,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.6.2",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "rustc_version",
- "smallvec 0.6.13",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3010,7 +2984,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
@@ -3725,7 +3699,7 @@ checksum = "7c03092d79e0fd610932d89ed53895a38c0dd3bcd317a0046e69940de32f1d95"
 dependencies = [
  "log",
  "rustc-hash",
- "smallvec 1.4.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -4405,15 +4379,6 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
@@ -4922,25 +4887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
- "lazy_static",
- "log",
- "mio",
- "num_cpus",
- "parking_lot 0.9.0",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
-]
-
-[[package]]
 name = "tokio-retry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4961,33 +4907,6 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
-dependencies = [
- "futures 0.1.29",
- "libc",
- "mio",
- "mio-uds",
- "signal-hook-registry",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures 0.1.29",
 ]
 
 [[package]]
@@ -5243,7 +5162,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.4.2",
+ "smallvec",
  "thread_local",
  "tracing-core 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-log",
@@ -5566,7 +5485,6 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tokio-retry",
- "tokio-signal",
  "tokio-test",
  "tokio-util",
  "tokio01-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,9 @@ prometheus-parser = { path = "lib/prometheus-parser", optional = true }
 # Tokio / Futures
 futures01 = { package = "futures", version = "0.1.25" }
 futures = { version = "0.3", default-features = false, features = ["compat", "io-compat"] }
-tokio = { version = "0.2.13", features = ["blocking", "fs", "io-std", "macros", "rt-core", "rt-threaded", "uds", "sync"] }
+tokio = { version = "0.2.13", features = ["blocking", "fs", "signal", "io-std", "macros", "rt-core", "rt-threaded", "uds", "sync"] }
 tokio-openssl = "0.4.0"
 tokio-retry = "0.2.0"
-tokio-signal = "0.2.7"
 tokio-util = { version = "0.3.1", features = ["codec"] }
 async-trait = "0.1"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
         emit!(VectorStarted);
         tokio::spawn(heartbeat::heartbeat());
 
-        let mut signals = signal::signals();
+        let signals = signal::signals();
         tokio::pin!(signals);
         let mut sources_finished = topology.sources_finished().compat();
         let mut graceful_crash = graceful_crash.compat();

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,7 @@ fn main() {
         tokio::spawn(heartbeat::heartbeat());
 
         let mut signals = signal::signals();
+        tokio::pin!(signals);
         let mut sources_finished = topology.sources_finished().compat();
         let mut graceful_crash = graceful_crash.compat();
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,6 +1,4 @@
-use futures::{
-    FutureExt, Stream,
-};
+use futures::{FutureExt, Stream};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SignalTo {
@@ -15,8 +13,8 @@ pub enum SignalTo {
 /// Signals from OS/user.
 #[cfg(unix)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
-    use tokio::signal::unix::{signal, SignalKind};
     use futures::future::{select_all, BoxFuture};
+    use tokio::signal::unix::{signal, SignalKind};
 
     let mut sigint = signal(SignalKind::interrupt()).expect("Signal handlers should not panic.");
     let mut sigterm = signal(SignalKind::terminate()).expect("Signal handlers should not panic.");

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -34,6 +34,7 @@ pub fn signals() -> impl Stream<Item = SignalTo> {
 /// Signals from OS/user.
 #[cfg(windows)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
+    use futures::future::FutureExt;
     let ctrl_c = tokio::signal::ctrl_c();
 
     ctrl_c.map(|_| SignalTo::Shutdown).into_stream()

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,5 +1,4 @@
 use futures::{
-    future::{select_all, BoxFuture},
     FutureExt, Stream,
 };
 
@@ -17,6 +16,7 @@ pub enum SignalTo {
 #[cfg(unix)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
     use tokio::signal::unix::{signal, SignalKind};
+    use futures::future::{select_all, BoxFuture};
 
     let mut sigint = signal(SignalKind::interrupt()).expect("Signal handlers should not panic.");
     let mut sigterm = signal(SignalKind::terminate()).expect("Signal handlers should not panic.");

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -35,10 +35,11 @@ pub fn signals() -> impl Stream<Item = SignalTo> {
 #[cfg(windows)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
     use futures::future::FutureExt;
-    let ctrl_c = tokio::signal::ctrl_c();
 
     async_stream::stream! {
-        let signal = ctrl_c.map(|_| SignalTo::Shutdown).await;
-        yield signal;
+        loop {
+            let signal = tokio::signal::ctrl_c().map(|_| SignalTo::Shutdown).await;
+            yield signal;
+        }
     }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -37,5 +37,8 @@ pub fn signals() -> impl Stream<Item = SignalTo> {
     use futures::future::FutureExt;
     let ctrl_c = tokio::signal::ctrl_c();
 
-    ctrl_c.map(|_| SignalTo::Shutdown).into_stream()
+    async_stream::stream! {
+        let signal = ctrl_c.map(|_| SignalTo::Shutdown).await;
+        yield signal;
+    }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,4 +1,4 @@
-use futures::{compat::Stream01CompatExt, Stream, StreamExt, TryStreamExt};
+use futures::{compat::Stream01CompatExt, Stream, StreamExt, FutureExt, TryFutureExt, TryStreamExt};
 use futures01::{Future as Future01, Stream as Stream01};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -14,7 +14,7 @@ pub enum SignalTo {
 /// Signals from OS/user.
 #[cfg(unix)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
-    use tokio_signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
+    use tokio::signal::unix::{Signal, SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 
     let sigint = Signal::new(SIGINT).flatten_stream();
     let sigterm = Signal::new(SIGTERM).flatten_stream();
@@ -38,11 +38,9 @@ pub fn signals() -> impl Stream<Item = SignalTo> {
 /// Signals from OS/user.
 #[cfg(windows)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
-    let ctrl_c = tokio_signal::ctrl_c().flatten_stream();
+    let ctrl_c = tokio::signal::ctrl_c();
 
     ctrl_c
         .map(|_| SignalTo::Shutdown)
-        .compat()
         .into_stream()
-        .map(|result| result.expect("Shouldn't error"))
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,4 +1,7 @@
-use futures::{future::{select_all, BoxFuture}, Stream, FutureExt};
+use futures::{
+    future::{select_all, BoxFuture},
+    FutureExt, Stream,
+};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SignalTo {
@@ -13,7 +16,7 @@ pub enum SignalTo {
 /// Signals from OS/user.
 #[cfg(unix)]
 pub fn signals() -> impl Stream<Item = SignalTo> {
-    use tokio::signal::unix::{SignalKind, signal};
+    use tokio::signal::unix::{signal, SignalKind};
 
     let mut sigint = signal(SignalKind::interrupt()).expect("Signal handlers should not panic.");
     let mut sigterm = signal(SignalKind::terminate()).expect("Signal handlers should not panic.");
@@ -37,7 +40,5 @@ pub fn signals() -> impl Stream<Item = SignalTo> {
 pub fn signals() -> impl Stream<Item = SignalTo> {
     let ctrl_c = tokio::signal::ctrl_c();
 
-    ctrl_c
-        .map(|_| SignalTo::Shutdown)
-        .into_stream()
+    ctrl_c.map(|_| SignalTo::Shutdown).into_stream()
 }


### PR DESCRIPTION
This fixes the shutdown issue reported by @oktal today on Windows by upgrading to `tokio::signal`.

```rust
   Compiling vector v0.11.0 (C:\Users\ana\CLionProjects\vector)
    Finished dev [unoptimized + debuginfo] target(s) in 29.69s
     Running `target\debug\vector.exe --config .\vector.toml`
Sep 18 13:56:13.021  INFO vector: Log level "info" is enabled.
Sep 18 13:56:13.025  INFO vector: Loading configs. path=["vector.toml"]
Sep 18 13:56:13.041  INFO vector::sources::stdin: Capturing STDIN.
Sep 18 13:56:13.042  INFO vector::topology: Running healthchecks.
Sep 18 13:56:13.042  INFO vector::topology::builder: Healthcheck: Passed.
Sep 18 13:56:13.042  INFO vector::topology: Starting source "source0"
Sep 18 13:56:13.043  INFO vector::topology: Starting sink "sink0"
Sep 18 13:56:13.043  INFO vector: Vector has started. version="0.11.0" git_version="v0.9.0-702-g26cd7ae" released="Fri, 18 Sep 2020 17:28:57 +0000" arch="x86_64"
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SpawnError { is_shutdown: true }', C:\Users\ana\scoop\persist\rustup-msvc\.cargo\registry\src\github.com-1ecc629
9db9ec823\tokio-executor-0.1.10\src\global.rs:172:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Sep 18 13:56:13.045  INFO source{name=source0 type=stdin}: vector::sources::stdin: Finished sending
error: process didn't exit successfully: `target\debug\vector.exe --config .\vector.toml` (exit code: 101)
```