### PR TITLE
feat(remap transform): add `format_timestamp` function

### DIFF
--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -506,9 +506,9 @@ pub fn parse(input: &str) -> Result<Mapping> {
 mod tests {
     use super::*;
     use crate::mapping::query::function::{
-        DowncaseFn, Md5Fn, NowFn, ParseJsonFn, ParseTimestampFn, Sha1Fn, StripWhitespaceFn,
-        ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn, TruncateFn, UpcaseFn,
-        UuidV4Fn,
+        DowncaseFn, FormatTimestampFn, Md5Fn, NowFn, ParseJsonFn, ParseTimestampFn, Sha1Fn,
+        StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn,
+        TruncateFn, UpcaseFn, UuidV4Fn,
     };
 
     #[test]
@@ -1143,6 +1143,16 @@ mod tests {
                 Mapping::new(vec![Box::new(Assignment::new(
                     "foo".to_string(),
                     Box::new(UuidV4Fn::new()),
+                ))]),
+            ),
+            (
+                r#".foo = format_timestamp("500", "%s")"#,
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(FormatTimestampFn::new(
+                        Box::new(Literal::from(Value::from("500"))),
+                        "%s",
+                    )),
                 ))]),
             ),
         ];

--- a/src/mapping/query/function/format_timestamp.rs
+++ b/src/mapping/query/function/format_timestamp.rs
@@ -1,0 +1,119 @@
+use super::prelude::*;
+use chrono::format::{strftime::StrftimeItems, Item};
+use chrono::{DateTime, Utc};
+
+#[derive(Debug)]
+pub(in crate::mapping) struct FormatTimestampFn {
+    query: Box<dyn Function>,
+    format: Box<dyn Function>,
+}
+
+impl FormatTimestampFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(query: Box<dyn Function>, format: &str) -> Self {
+        let format = Box::new(Literal::from(Value::from(format)));
+
+        Self { query, format }
+    }
+}
+
+impl Function for FormatTimestampFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let format = match self.format.execute(ctx)? {
+            Value::Bytes(b) => String::from_utf8_lossy(&b).into_owned(),
+            v => unexpected_type!(v),
+        };
+
+        self.query
+            .execute(ctx)
+            .map(|v| match v {
+                Value::Timestamp(ts) => ts,
+                _ => unexpected_type!(v),
+            })
+            .and_then(|ts| try_format(&ts, &format))
+            .map(Value::from)
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Timestamp(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "format",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for FormatTimestampFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let format = arguments.required("format")?;
+
+        Ok(Self { query, format })
+    }
+}
+
+fn try_format(dt: &DateTime<Utc>, format: &str) -> Result<String> {
+    let items = StrftimeItems::new(format)
+        .map(|item| match item {
+            Item::Error => Err("invalid format".to_owned()),
+            _ => Ok(item),
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(dt.format_with_items(items.into_iter()).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+    use chrono::TimeZone;
+
+    #[test]
+    fn format_timestamp() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                FormatTimestampFn::new(Box::new(Path::from(vec![vec!["foo"]])), "%s"),
+            ),
+            (
+                Event::from(""),
+                Err("invalid format".to_owned()),
+                FormatTimestampFn::new(
+                    Box::new(Literal::from(Value::from(Utc.timestamp(10, 0)))),
+                    "%Q INVALID",
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("10")),
+                FormatTimestampFn::new(
+                    Box::new(Literal::from(Value::from(Utc.timestamp(10, 0)))),
+                    "%s",
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("1970-01-01T00:00:10+00:00")),
+                FormatTimestampFn::new(
+                    Box::new(Literal::from(Value::from(Utc.timestamp(10, 0)))),
+                    "%+",
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -95,6 +95,7 @@ build_signatures! {
     now => NowFn,
     truncate => TruncateFn,
     parse_json => ParseJsonFn,
+    format_timestamp => FormatTimestampFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -446,3 +446,21 @@
       "j.equals" = "10"
       "k.equals" = "20"
       "l.equals" = "30"
+
+[transforms.remap_function_format_timestamp]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = format_timestamp(to_timestamp(.foo), format = "%+")
+  """
+[[tests]]
+  name = "remap_function_format_timestamp"
+  [tests.input]
+    insert_at = "remap_function_format_timestamp"
+    type = "log"
+    [tests.input.log_fields]
+      foo = 10
+  [[tests.outputs]]
+    extract_from = "remap_function_format_timestamp"
+    [[tests.outputs.conditions]]
+      "a.equals" = "1970-01-01T00:00:10+00:00"


### PR DESCRIPTION
```rust
.foo = format_timestamp(to_timestamp(.foo), "%s")
```

closes #3742 