### PR TITLE
feat(remap transform): add `contains` function

### DIFF
--- a/src/event/value.rs
+++ b/src/event/value.rs
@@ -202,6 +202,13 @@ impl Value {
         }
     }
 
+    pub fn as_boolean(&self) -> Option<bool> {
+        match &self {
+            Value::Boolean(v) => Some(*v),
+            _ => None,
+        }
+    }
+
     pub fn kind(&self) -> &str {
         match self {
             Value::Bytes(_) => "string",

--- a/src/event/value.rs
+++ b/src/event/value.rs
@@ -202,13 +202,6 @@ impl Value {
         }
     }
 
-    pub fn as_boolean(&self) -> Option<bool> {
-        match &self {
-            Value::Boolean(v) => Some(*v),
-            _ => None,
-        }
-    }
-
     pub fn kind(&self) -> &str {
         match self {
             Value::Bytes(_) => "string",

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -506,8 +506,8 @@ pub fn parse(input: &str) -> Result<Mapping> {
 mod tests {
     use super::*;
     use crate::mapping::query::function::{
-        DowncaseFn, FormatTimestampFn, Md5Fn, NowFn, ParseJsonFn, ParseTimestampFn, Sha1Fn,
-        StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn,
+        ContainsFn, DowncaseFn, FormatTimestampFn, Md5Fn, NowFn, ParseJsonFn, ParseTimestampFn,
+        Sha1Fn, StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn,
         TruncateFn, UpcaseFn, UuidV4Fn,
     };
 
@@ -1152,6 +1152,17 @@ mod tests {
                     Box::new(FormatTimestampFn::new(
                         Box::new(Literal::from(Value::from("500"))),
                         "%s",
+                    )),
+                ))]),
+            ),
+            (
+                r#".foo = contains(.foo, substring = "BAR", case_sensitive = true)"#,
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(ContainsFn::new(
+                        Box::new(QueryPath::from("foo")),
+                        "BAR",
+                        true,
                     )),
                 ))]),
             ),

--- a/src/mapping/query/function/contains.rs
+++ b/src/mapping/query/function/contains.rs
@@ -1,0 +1,155 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct ContainsFn {
+    query: Box<dyn Function>,
+    substring: Box<dyn Function>,
+    case_sensitive: Option<Box<dyn Function>>,
+}
+
+impl ContainsFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        query: Box<dyn Function>,
+        substring: &str,
+        case_sensitive: bool,
+    ) -> Self {
+        let substring = Box::new(Literal::from(Value::from(substring)));
+        let case_sensitive = Some(Box::new(Literal::from(Value::from(case_sensitive))) as _);
+
+        Self {
+            query,
+            substring,
+            case_sensitive,
+        }
+    }
+}
+
+impl Function for ContainsFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let substring = match self.substring.execute(ctx)? {
+            Value::Bytes(v) => String::from_utf8_lossy(&v).into_owned(),
+            v => unexpected_type!(v),
+        };
+
+        let value = match self.query.execute(ctx)? {
+            Value::Bytes(v) => String::from_utf8_lossy(&v).into_owned(),
+            v => unexpected_type!(v),
+        };
+
+        let contains = value.contains(&substring)
+            || self
+                .case_sensitive
+                .as_ref()
+                .map(|v| v.execute(ctx))
+                .transpose()?
+                .and_then(|v| v.as_boolean())
+                .iter()
+                .filter(|&case_sensitive| !case_sensitive)
+                .any(|_| value.to_lowercase().contains(&substring.to_lowercase()));
+
+        Ok(Value::from(contains))
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "substring",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "case_sensitive",
+                accepts: |v| matches!(v, Value::Boolean(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for ContainsFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let substring = arguments.required("substring")?;
+        let case_sensitive = arguments.optional("case_sensitive");
+
+        Ok(Self {
+            query,
+            substring,
+            case_sensitive,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn contains() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                ContainsFn::new(Box::new(Path::from(vec![vec!["foo"]])), "", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foo"))), "bar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foo"))), "foobar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foo"))), "foo", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foobar"))), "oba", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foobar"))), "foo", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foobar"))), "bar", false),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("fooBAR"))), "BAR", true),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(false)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foobar"))), "BAR", true),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(true)),
+                ContainsFn::new(Box::new(Literal::from(Value::from("foobar"))), "BAR", false),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -96,6 +96,7 @@ build_signatures! {
     truncate => TruncateFn,
     parse_json => ParseJsonFn,
     format_timestamp => FormatTimestampFn,
+    contains => ContainsFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -30,6 +30,27 @@ macro_rules! unexpected_type {
     };
 }
 
+macro_rules! required {
+    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+) => {
+        match $fn.execute($ctx)? {
+            $($pattern => $then,)+
+            v => unexpected_type!(v),
+        }
+    }
+}
+
+macro_rules! optional {
+    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+) => {
+        $fn.as_ref()
+            .map(|v| v.execute($ctx))
+            .transpose()?
+            .map(|v| match v {
+                $($pattern => $then,)+
+                v => unexpected_type!(v),
+            })
+    }
+}
+
 macro_rules! build_signatures {
     ($($name:ident => $func:ident),* $(,)?) => {
         $(mod $name;)*

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -185,6 +185,47 @@
     [[tests.outputs.conditions]]
       "a.b\\.c.equals" = "baz"
 
+[transforms.remap_function_arguments]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = to_string(.in)
+    .b = to_string(value = .in)
+    .c = to_string(.in, 20)
+    .d = to_string(.in, default = 20)
+    .e = to_string(.nope, 20)
+    .f = to_string(.nope, default = 20)
+    .g = to_string(value = .in, default = 20)
+    .h = to_string(value = .in, 20)
+    .i = to_string(default = 20, .in)
+    .j = to_string(default = 20, value = .in)
+    .k = to_string(default = 20, value = .nope)
+    .l = to_string(default = .other, value = .nope)
+  """
+[[tests]]
+  name = "remap_function_arguments"
+  [tests.input]
+    insert_at = "remap_function_arguments"
+    type = "log"
+    [tests.input.log_fields]
+      in = 10
+      other = 30
+  [[tests.outputs]]
+    extract_from = "remap_function_arguments"
+    [[tests.outputs.conditions]]
+      "a.equals" = "10"
+      "b.equals" = "10"
+      "c.equals" = "10"
+      "d.equals" = "10"
+      "e.equals" = "20"
+      "f.equals" = "20"
+      "g.equals" = "10"
+      "h.equals" = "10"
+      "i.equals" = "10"
+      "j.equals" = "10"
+      "k.equals" = "20"
+      "l.equals" = "30"
+
 [transforms.remap_function_upcase]
   inputs = []
   type = "remap"
@@ -406,47 +447,6 @@
     [[tests.outputs.conditions]]
       "a.ends_with" = "Z"
 
-[transforms.remap_function_arguments]
-  inputs = []
-  type = "remap"
-  mapping = """
-    .a = to_string(.in)
-    .b = to_string(value = .in)
-    .c = to_string(.in, 20)
-    .d = to_string(.in, default = 20)
-    .e = to_string(.nope, 20)
-    .f = to_string(.nope, default = 20)
-    .g = to_string(value = .in, default = 20)
-    .h = to_string(value = .in, 20)
-    .i = to_string(default = 20, .in)
-    .j = to_string(default = 20, value = .in)
-    .k = to_string(default = 20, value = .nope)
-    .l = to_string(default = .other, value = .nope)
-  """
-[[tests]]
-  name = "remap_function_arguments"
-  [tests.input]
-    insert_at = "remap_function_arguments"
-    type = "log"
-    [tests.input.log_fields]
-      in = 10
-      other = 30
-  [[tests.outputs]]
-    extract_from = "remap_function_arguments"
-    [[tests.outputs.conditions]]
-      "a.equals" = "10"
-      "b.equals" = "10"
-      "c.equals" = "10"
-      "d.equals" = "10"
-      "e.equals" = "20"
-      "f.equals" = "20"
-      "g.equals" = "10"
-      "h.equals" = "10"
-      "i.equals" = "10"
-      "j.equals" = "10"
-      "k.equals" = "20"
-      "l.equals" = "30"
-
 [transforms.remap_function_format_timestamp]
   inputs = []
   type = "remap"
@@ -464,3 +464,28 @@
     extract_from = "remap_function_format_timestamp"
     [[tests.outputs.conditions]]
       "a.equals" = "1970-01-01T00:00:10+00:00"
+
+[transforms.remap_function_contains]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = contains(.foo, substring = .bar)
+    .b = contains(.bar, substring = "bar")
+    .c = contains(.bar, substring = "BAR", case_sensitive = true)
+    .d = contains(.bar, substring = "BAR", case_sensitive = false)
+  """
+[[tests]]
+  name = "remap_function_contains"
+  [tests.input]
+    insert_at = "remap_function_contains"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "foo"
+      bar = "bar"
+  [[tests.outputs]]
+    extract_from = "remap_function_contains"
+    [[tests.outputs.conditions]]
+      "a.equals" = false
+      "b.equals" = true
+      "c.equals" = false
+      "d.equals" = true


### PR DESCRIPTION
```rust
.foo = "FOO"
.bar = "bar"
.baz = contains(.bar, substring = .foo, case_sensitive = false)
```

This **does not** yet support regular expression patterns. This will be added later, as language-level support for regular expressions (or any non-Value argument types) has to be implemented first.

ref #4091
closes #3838 