### PR TITLE
feat(remap transform): add `slice` function

### DIFF
--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -507,8 +507,8 @@ mod tests {
     use super::*;
     use crate::mapping::query::function::{
         ContainsFn, DowncaseFn, FormatTimestampFn, Md5Fn, NowFn, ParseJsonFn, ParseTimestampFn,
-        Sha1Fn, StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn,
-        TruncateFn, UpcaseFn, UuidV4Fn,
+        Sha1Fn, SliceFn, StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn,
+        ToTimestampFn, TruncateFn, UpcaseFn, UuidV4Fn,
     };
 
     #[test]
@@ -1164,6 +1164,13 @@ mod tests {
                         "BAR",
                         true,
                     )),
+                ))]),
+            ),
+            (
+                r#".foo = slice(.foo, 0, 1)"#,
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(SliceFn::new(Box::new(QueryPath::from("foo")), 0, Some(1))),
                 ))]),
             ),
         ];

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -31,7 +31,7 @@ macro_rules! unexpected_type {
 }
 
 macro_rules! required {
-    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+) => {
+    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+ $(,)?) => {
         match $fn.execute($ctx)? {
             $($pattern => $then,)+
             v => unexpected_type!(v),
@@ -40,7 +40,7 @@ macro_rules! required {
 }
 
 macro_rules! optional {
-    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+) => {
+    ($ctx:expr, $fn:expr, $($pattern:pat => $then:expr),+ $(,)?) => {
         $fn.as_ref()
             .map(|v| v.execute($ctx))
             .transpose()?

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -118,6 +118,7 @@ build_signatures! {
     parse_json => ParseJsonFn,
     format_timestamp => FormatTimestampFn,
     contains => ContainsFn,
+    slice => SliceFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -43,32 +43,22 @@ impl Function for SliceFn {
                 start += len;
             }
 
-            let mut end = match end {
-                Some(end) => *end,
+            let end = match *end {
+                Some(end) if end < 0 => end + len,
+                Some(end) => end,
                 None => len,
             };
 
-            if end < 0 {
-                end += len;
-            }
-
-            if start < 0 || start >= len {
-                return Err(format!(
+            match () {
+                _ if start < 0 || start >= len => Err(format!(
                     "'start' must be between '{}' and '{}'",
                     -len,
                     len - 1
-                ));
+                )),
+                _ if end > len => Err(format!("'end' must not be greater than '{}'", len)),
+                _ if end <= start => Err("'end' must be greater than 'start'".to_owned()),
+                _ => Ok(start as usize..end as usize),
             }
-
-            if end > len {
-                return Err(format!("'end' must not be greater than '{}'", len));
-            }
-
-            if end <= start {
-                return Err("'end' must be greater than 'start'".to_owned());
-            }
-
-            Ok(start as usize..end as usize)
         };
 
         match self.query.execute(ctx)? {

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -25,8 +25,8 @@ impl Function for SliceFn {
     fn execute(&self, ctx: &Event) -> Result<Value> {
         let range = |len: i64| {
             let start = match required!(ctx, self.start, Value::Integer(v) => v) {
-                i if i < 0 => i + len,
-                i => i,
+                start if start < 0 => start + len,
+                start => start,
             };
 
             let end = match optional!(ctx, self.end, Value::Integer(v) => v) {

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -1,0 +1,269 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct SliceFn {
+    query: Box<dyn Function>,
+    start: Box<dyn Function>,
+    end: Option<Box<dyn Function>>,
+}
+
+impl SliceFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(
+        query: Box<dyn Function>,
+        start: isize,
+        end: Option<isize>,
+    ) -> Self {
+        let start = Box::new(Literal::from(Value::from(start as i64)));
+        let end = end.map(|i| Box::new(Literal::from(Value::from(i as i64))) as _);
+
+        Self { query, start, end }
+    }
+}
+
+impl Function for SliceFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let mut start = match self.start.execute(ctx)? {
+            Value::Integer(v) => v,
+            v => unexpected_type!(v),
+        };
+
+        let end = &self
+            .end
+            .as_ref()
+            .map(|v| v.execute(ctx))
+            .transpose()?
+            .map(|v| match v {
+                Value::Integer(v) => v,
+                v => unexpected_type!(v),
+            });
+
+        let mut range = |len: i64| {
+            if start < 0 {
+                start += len;
+            }
+
+            let mut end = match end {
+                Some(end) => *end,
+                None => len,
+            };
+
+            if end < 0 {
+                end += len;
+            }
+
+            if start < 0 || start >= len {
+                return Err(format!(
+                    "'start' must be between '{}' and '{}'",
+                    -len,
+                    len - 1
+                ));
+            }
+
+            if end > len {
+                return Err(format!("'end' must not be greater than '{}'", len));
+            }
+
+            if end <= start {
+                return Err("'end' must be greater than 'start'".to_owned());
+            }
+
+            Ok(start as usize..end as usize)
+        };
+
+        match self.query.execute(ctx)? {
+            Value::Bytes(v) => range(v.len() as i64)
+                .map(|range| v.slice(range))
+                .map(Value::from),
+            Value::Array(mut v) => range(v.len() as i64)
+                .map(|range| v.drain(range).collect::<Vec<_>>())
+                .map(Value::from),
+            v => unexpected_type!(v),
+        }
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Bytes(_) | Value::Array(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "start",
+                accepts: |v| matches!(v, Value::Integer(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "end",
+                accepts: |v| matches!(v, Value::Integer(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for SliceFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let start = arguments.required("start")?;
+        let end = arguments.optional("end");
+
+        Ok(Self { query, start, end })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn bytes() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Ok(Value::from("foo")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 0, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("oo")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 1, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("o")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 2, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("oo")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), -2, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("docious")),
+                SliceFn::new(
+                    Box::new(Literal::from(Value::from(
+                        "Supercalifragilisticexpialidocious",
+                    ))),
+                    -7,
+                    None,
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("cali")),
+                SliceFn::new(
+                    Box::new(Literal::from(Value::from(
+                        "Supercalifragilisticexpialidocious",
+                    ))),
+                    5,
+                    Some(9),
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+
+    #[test]
+    fn array() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Ok(Value::from(vec![0, 1, 2])),
+                SliceFn::new(Box::new(Literal::from(Value::from(vec![0, 1, 2]))), 0, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(vec![1, 2])),
+                SliceFn::new(Box::new(Literal::from(Value::from(vec![0, 1, 2]))), 1, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(vec![1, 2])),
+                SliceFn::new(
+                    Box::new(Literal::from(Value::from(vec![0, 1, 2]))),
+                    -2,
+                    None,
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("docious".bytes().collect::<Vec<_>>())),
+                SliceFn::new(
+                    Box::new(Literal::from(Value::from(
+                        "Supercalifragilisticexpialidocious"
+                            .bytes()
+                            .collect::<Vec<_>>(),
+                    ))),
+                    -7,
+                    None,
+                ),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("cali".bytes().collect::<Vec<_>>())),
+                SliceFn::new(
+                    Box::new(Literal::from(Value::from(
+                        "Supercalifragilisticexpialidocious"
+                            .bytes()
+                            .collect::<Vec<_>>(),
+                    ))),
+                    5,
+                    Some(9),
+                ),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+
+    #[test]
+    fn errors() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                SliceFn::new(Box::new(Path::from(vec![vec!["foo"]])), 0, None),
+            ),
+            (
+                Event::from(""),
+                Err("'start' must be between '-3' and '2'".to_owned()),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 3, None),
+            ),
+            (
+                Event::from(""),
+                Err("'start' must be between '-3' and '2'".to_owned()),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), -4, None),
+            ),
+            (
+                Event::from(""),
+                Err("'end' must not be greater than '3'".to_owned()),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 0, Some(4)),
+            ),
+            (
+                Event::from(""),
+                Err("'end' must be greater than 'start'".to_owned()),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 2, Some(2)),
+            ),
+            (
+                Event::from(""),
+                Err("'end' must be greater than 'start'".to_owned()),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 2, Some(1)),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/slice.rs
+++ b/src/mapping/query/function/slice.rs
@@ -50,13 +50,11 @@ impl Function for SliceFn {
             };
 
             match () {
-                _ if start < 0 || start >= len => Err(format!(
-                    "'start' must be between '{}' and '{}'",
-                    -len,
-                    len - 1
-                )),
-                _ if end > len => Err(format!("'end' must not be greater than '{}'", len)),
-                _ if end <= start => Err("'end' must be greater than 'start'".to_owned()),
+                _ if start < 0 || start > len => {
+                    Err(format!("'start' must be between '{}' and '{}'", -len, len))
+                }
+                _ if end < start => Err("'end' must be greater or equal to 'start'".to_owned()),
+                _ if end > len => Ok(start as usize..len as usize),
                 _ => Ok(start as usize..end as usize),
             }
         };
@@ -132,6 +130,26 @@ mod tests {
                 Event::from(""),
                 Ok(Value::from("oo")),
                 SliceFn::new(Box::new(Literal::from(Value::from("foo"))), -2, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 3, None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 2, Some(2)),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("foo")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 0, Some(4)),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("oo")),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 1, Some(5)),
             ),
             (
                 Event::from(""),
@@ -227,27 +245,17 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Err("'start' must be between '-3' and '2'".to_owned()),
-                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 3, None),
+                Err("'start' must be between '-3' and '3'".to_owned()),
+                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 4, None),
             ),
             (
                 Event::from(""),
-                Err("'start' must be between '-3' and '2'".to_owned()),
+                Err("'start' must be between '-3' and '3'".to_owned()),
                 SliceFn::new(Box::new(Literal::from(Value::from("foo"))), -4, None),
             ),
             (
                 Event::from(""),
-                Err("'end' must not be greater than '3'".to_owned()),
-                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 0, Some(4)),
-            ),
-            (
-                Event::from(""),
-                Err("'end' must be greater than 'start'".to_owned()),
-                SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 2, Some(2)),
-            ),
-            (
-                Event::from(""),
-                Err("'end' must be greater than 'start'".to_owned()),
+                Err("'end' must be greater or equal to 'start'".to_owned()),
                 SliceFn::new(Box::new(Literal::from(Value::from("foo"))), 2, Some(1)),
             ),
         ];

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -489,3 +489,28 @@
       "b.equals" = true
       "c.equals" = false
       "d.equals" = true
+
+[transforms.remap_function_slice]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = slice(.foo + .bar, 1)
+    .b = slice(.foo + .bar, 0, 1)
+    .c = slice(.foo + .bar, start = -2)
+    .d = slice(.foo + .bar, start = 1, end = -1)
+  """
+[[tests]]
+  name = "remap_function_slice"
+  [tests.input]
+    insert_at = "remap_function_slice"
+    type = "log"
+    [tests.input.log_fields]
+      foo = "foo"
+      bar = "bar"
+  [[tests.outputs]]
+    extract_from = "remap_function_slice"
+    [[tests.outputs.conditions]]
+      "a.equals" = "oobar"
+      "b.equals" = "f"
+      "c.equals" = "ar"
+      "d.equals" = "ooba"


### PR DESCRIPTION
```rust
.foo = "foo"
.bar = "bar"

.a = slice(.foo + .bar, 1) // oobar
.b = slice(.foo + .bar, 0, 1) // f
.c = slice(.foo + .bar, start = -2) // ar
.d = slice(.foo + .bar, start = 1, end = -1) // ooba
```

Also works with arrays.

closes #3755  