### PR TITLE
feat(remap transform): add `strip_ansi_escape_codes` function

### DIFF
--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -507,8 +507,8 @@ mod tests {
     use super::*;
     use crate::mapping::query::function::{
         ContainsFn, DowncaseFn, FormatTimestampFn, Md5Fn, NowFn, ParseJsonFn, ParseTimestampFn,
-        Sha1Fn, SliceFn, StripWhitespaceFn, ToBooleanFn, ToFloatFn, ToIntegerFn, ToStringFn,
-        ToTimestampFn, TokenizeFn, TruncateFn, UpcaseFn, UuidV4Fn,
+        Sha1Fn, SliceFn, StripAnsiEscapeCodesFn, StripWhitespaceFn, ToBooleanFn, ToFloatFn,
+        ToIntegerFn, ToStringFn, ToTimestampFn, TokenizeFn, TruncateFn, UpcaseFn, UuidV4Fn,
     };
 
     #[test]
@@ -1178,6 +1178,15 @@ mod tests {
                 Mapping::new(vec![Box::new(Assignment::new(
                     "foo".to_string(),
                     Box::new(TokenizeFn::new(Box::new(QueryPath::from("foo")))),
+                ))]),
+            ),
+            (
+                ".foo = strip_ansi_escape_codes(.foo)",
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(StripAnsiEscapeCodesFn::new(Box::new(QueryPath::from(
+                        "foo",
+                    )))),
                 ))]),
             ),
         ];

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -120,6 +120,7 @@ build_signatures! {
     contains => ContainsFn,
     slice => SliceFn,
     tokenize => TokenizeFn,
+    strip_ansi_escape_codes => StripAnsiEscapeCodesFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/strip_ansi_escape_codes.rs
+++ b/src/mapping/query/function/strip_ansi_escape_codes.rs
@@ -1,0 +1,88 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct StripAnsiEscapeCodesFn {
+    query: Box<dyn Function>,
+}
+
+impl StripAnsiEscapeCodesFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(query: Box<dyn Function>) -> Self {
+        Self { query }
+    }
+}
+
+impl Function for StripAnsiEscapeCodesFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+
+        strip_ansi_escapes::strip(&bytes)
+            .map(Value::from)
+            .map_err(|e| e.to_string())
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            accepts: |v| matches!(v, Value::Bytes(_)),
+            required: true,
+        }]
+    }
+}
+
+impl TryFrom<ArgumentList> for StripAnsiEscapeCodesFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+
+        Ok(Self { query })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn contains() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_string()),
+                StripAnsiEscapeCodesFn::new(Box::new(Path::from(vec![vec!["foo"]]))),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("foo bar")),
+                StripAnsiEscapeCodesFn::new(Box::new(Literal::from(Value::from("foo bar")))),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("foo bar")),
+                StripAnsiEscapeCodesFn::new(Box::new(Literal::from(Value::from(
+                    "\x1b[3;4Hfoo bar",
+                )))),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("foo bar")),
+                StripAnsiEscapeCodesFn::new(Box::new(Literal::from(Value::from(
+                    "\x1b[46mfoo\x1b[0m bar",
+                )))),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from("foo bar")),
+                StripAnsiEscapeCodesFn::new(Box::new(Literal::from(Value::from(
+                    "\x1b[=3lfoo bar",
+                )))),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}


### PR DESCRIPTION
```rust
.foo = strip_ansi_escape_codes(.foo)
```

I didn't add a behaviour test, since [TOML doesn't support the `\e` escape character](https://github.com/toml-lang/toml/issues/715). I guess we could parse something similar to `<null>`, to make that work, but it didn't seem worth the investment for this one remap function (which is already tested in other ways).

closes #3754 