### PR TITLE
fix(tests): Fix uptime_metrics GraphQL/API tests

### DIFF
--- a/graphql/subscriptions/uptime_metrics.graphql
+++ b/graphql/subscriptions/uptime_metrics.graphql
@@ -1,5 +1,5 @@
-subscription UptimeMetricsSubscription($interval: Int!) {
-  uptimeMetrics(interval: $interval) {
+subscription UptimeMetricsSubscription {
+  uptimeMetrics {
     seconds
   }
 }


### PR DESCRIPTION
Closes #4175 (hopefully.)

Test with:

```bash
RUST_TEST_THREADS=X cargo test --test api -- --nocapture
```

Where 'X' is the number of threads to test. CI was balking at `1`; my local machine panicked with `2`. If both pass, it probably works.

Signed-off-by: Lee Benson <lee@leebenson.com>