### PR TITLE
feat(remap transform): add `sha3` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
@@ -399,6 +399,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
@@ -410,6 +411,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bloom"
@@ -2190,6 +2197,12 @@ dependencies = [
  "tempfile",
  "tokio",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -4505,6 +4518,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5734,6 +5759,7 @@ dependencies = [
  "serde_yaml",
  "sha-1 0.9.1",
  "sha2",
+ "sha3",
  "smpl_jwt",
  "snafu",
  "stream-cancel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,7 +5678,6 @@ dependencies = [
  "db-key",
  "derivative 1.0.4",
  "derive_is_enum_variant",
- "digest 0.9.0",
  "dirs 3.0.1",
  "elastic_responses",
  "evmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,7 @@ k8s-openapi = { version = "0.9", features = ["v1_15"], optional = true }
 portpicker = "0.1.0"
 sha-1 = "0.9"
 sha2 = "0.9"
+sha3 = "0.9"
 md-5 = "0.9"
 hex = "0.4.2"
 chrono-tz = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,6 @@ sha3 = "0.9"
 md-5 = "0.9"
 hex = "0.4.2"
 chrono-tz = "0.5.3"
-digest = "0.9"
 
 # For WASM
 vector-wasm = { path = "lib/vector-wasm", optional = true }

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -507,8 +507,9 @@ mod tests {
     use super::*;
     use crate::mapping::query::function::{
         ContainsFn, DowncaseFn, FormatTimestampFn, Md5Fn, NowFn, ParseJsonFn, ParseTimestampFn,
-        Sha1Fn, Sha2Fn, SliceFn, StripAnsiEscapeCodesFn, StripWhitespaceFn, ToBooleanFn, ToFloatFn,
-        ToIntegerFn, ToStringFn, ToTimestampFn, TokenizeFn, TruncateFn, UpcaseFn, UuidV4Fn,
+        Sha1Fn, Sha2Fn, Sha3Fn, SliceFn, StripAnsiEscapeCodesFn, StripWhitespaceFn, ToBooleanFn,
+        ToFloatFn, ToIntegerFn, ToStringFn, ToTimestampFn, TokenizeFn, TruncateFn, UpcaseFn,
+        UuidV4Fn,
     };
 
     #[test]
@@ -1107,6 +1108,16 @@ mod tests {
                     Box::new(Sha2Fn::new(
                         Box::new(QueryPath::from("foo")),
                         Some("SHA-224"),
+                    )),
+                ))]),
+            ),
+            (
+                r#".foo = sha3(.foo, variant = "SHA3-224")"#,
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "foo".to_string(),
+                    Box::new(Sha3Fn::new(
+                        Box::new(QueryPath::from("foo")),
+                        Some("SHA3-224"),
                     )),
                 ))]),
             ),

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -114,6 +114,7 @@ build_signatures! {
     md5 => Md5Fn,
     sha1 => Sha1Fn,
     sha2 => Sha2Fn,
+    sha3 => Sha3Fn,
     now => NowFn,
     truncate => TruncateFn,
     parse_json => ParseJsonFn,

--- a/src/mapping/query/function/sha2.rs
+++ b/src/mapping/query/function/sha2.rs
@@ -55,11 +55,6 @@ impl Function for Sha2Fn {
     }
 }
 
-#[inline(always)]
-fn encode<T: Digest>(value: &[u8]) -> String {
-    hex::encode(T::digest(value))
-}
-
 impl TryFrom<ArgumentList> for Sha2Fn {
     type Error = String;
 
@@ -69,6 +64,11 @@ impl TryFrom<ArgumentList> for Sha2Fn {
 
         Ok(Self { query, variant })
     }
+}
+
+#[inline]
+fn encode<T: Digest>(value: &[u8]) -> String {
+    hex::encode(T::digest(value))
 }
 
 #[cfg(test)]

--- a/src/mapping/query/function/sha3.rs
+++ b/src/mapping/query/function/sha3.rs
@@ -1,0 +1,140 @@
+use super::prelude::*;
+use digest::DynDigest;
+use sha3::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512};
+
+#[derive(Debug)]
+pub(in crate::mapping) struct Sha3Fn {
+    query: Box<dyn Function>,
+    variant: Option<Box<dyn Function>>,
+}
+
+impl Sha3Fn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(query: Box<dyn Function>, variant: Option<&str>) -> Self {
+        let variant = variant.map(|v| Box::new(Literal::from(Value::from(v))) as _);
+
+        Self { query, variant }
+    }
+}
+
+impl Function for Sha3Fn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+
+        let variant = optional!(ctx, self.variant, Value::Bytes(v) => v)
+            .map(|v| String::from_utf8_lossy(&v).into_owned());
+
+        let mut digest: Box<dyn DynDigest> = match variant.as_deref() {
+            Some("SHA3-224") => Box::new(Sha3_224::new()),
+            Some("SHA3-256") => Box::new(Sha3_256::new()),
+            Some("SHA3-384") => Box::new(Sha3_384::new()),
+            Some("SHA3-512") | None => Box::new(Sha3_512::new()),
+            Some(v) => return Err(format!("unknown SHA-3 algorithm variant: '{}'", v)),
+        };
+
+        digest.update(&bytes);
+        let sha3 = hex::encode(digest.finalize());
+
+        Ok(Value::Bytes(sha3.into()))
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "variant",
+                accepts: |v| matches!(v, Value::Bytes(_)),
+                required: false,
+            },
+        ]
+    }
+}
+
+impl TryFrom<ArgumentList> for Sha3Fn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+        let variant = arguments.optional("variant");
+
+        Ok(Self { query, variant })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::query::path::Path;
+
+    #[test]
+    fn sha3() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Err("path .foo not found in event".to_owned()),
+                Sha3Fn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
+                Event::from(""),
+                Err("unknown SHA-3 algorithm variant: 'bar'".to_owned()),
+                Sha3Fn::new(Box::new(Literal::from(Value::from("foo"))), Some("bar")),
+            ),
+            (
+                {
+                    let mut event = Event::from("");
+                    event.as_mut_log().insert("foo", Value::from("foo"));
+                    event
+                },
+                Ok(Value::from(
+                    "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7",
+                )),
+                Sha3Fn::new(Box::new(Path::from(vec![vec!["foo"]])), None),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(
+                    "f4f6779e153c391bbd29c95e72b0708e39d9166c7cea51d1f10ef58a",
+                )),
+                Sha3Fn::new(Box::new(Literal::from(Value::from("foo"))), Some("SHA3-224")),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(
+                    "76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01",
+                )),
+                Sha3Fn::new(Box::new(Literal::from(Value::from("foo"))), Some("SHA3-256")),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(
+                    "665551928d13b7d84ee02734502b018d896a0fb87eed5adb4c87ba91bbd6489410e11b0fbcc06ed7d0ebad559e5d3bb5",
+                )),
+                Sha3Fn::new(Box::new(Literal::from(Value::from("foo"))), Some("SHA3-384")),
+            ),
+            (
+                Event::from(""),
+                Ok(Value::from(
+                    "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7",
+                )),
+                Sha3Fn::new(Box::new(Literal::from(Value::from("foo"))), Some("SHA3-512")),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unexpected value type: 'boolean'")]
+    fn invalid_type() {
+        let mut event = Event::from("");
+        event.as_mut_log().insert("foo", Value::Boolean(true));
+
+        let _ = Sha3Fn::new(Box::new(Path::from(vec![vec!["foo"]])), None).execute(&event);
+    }
+}

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -567,3 +567,27 @@
     [[tests.outputs.conditions]]
       "a.equals" = "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d"
       "b.equals" = "211adce11372368668b582f2a9420a2df7512856ff62f37b124b82d9f505b42f"
+
+[transforms.remap_function_sha3]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .a = sha3(.a)
+
+    if sha3(.b) == "03457d23880d7847fc3f58780dd58cda7237a7144ac6758e76d45cec0e06ba69440a855e913ef03790c618777f5b0ec25fc34c4b82d7538151745b120b4f8b37" {
+        .b = sha3(.a + .b + "baz")
+    }
+  """
+[[tests]]
+  name = "remap_function_sha3"
+  [tests.input]
+    insert_at = "remap_function_sha3"
+    type = "log"
+    [tests.input.log_fields]
+      a = "foo"
+      b = "bar"
+  [[tests.outputs]]
+    extract_from = "remap_function_sha3"
+    [[tests.outputs.conditions]]
+      "a.equals" = "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7"
+      "b.equals" = "dbae094156f1bf73d9f442f75eb01e52398eb667cd12ba1dcb95748fc0151880ea260310c1451570d60b37bef8655d01f62280e5e24e70cffe3a55c23c2d7351"


### PR DESCRIPTION
```rust
.a = sha3(.a)
.b = sha3(.b, variant = "SHA3-224")
```

Valid SHA-3 variants are the ones [listed here](https://en.wikipedia.org/wiki/SHA-3#Comparison_of_SHA_functions).

closes #3884 