### PR TITLE
fix(startup): Fix 101 exit code on `api.enabled = true`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -184,6 +184,8 @@ impl Application {
         let mut config_paths = self.config.config_paths;
 
         let opts = self.opts;
+
+        #[cfg(feature = "api")]
         let api_config = self.config.api;
 
         rt.block_on(async move {

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,24 +183,25 @@ impl Application {
 
         let mut config_paths = self.config.config_paths;
 
-        #[cfg(feature = "api")]
-        // assigned to prevent the API terminating when falling out of scope
-        let _api = if self.config.api.enabled {
-            emit!(ApiStarted {
-                addr: self.config.api.bind.unwrap(),
-                playground: self.config.api.playground
-            });
-
-            Some(api::Server::start(self.config.api))
-        } else {
-            None
-        };
-
         let opts = self.opts;
+        let api_config = self.config.api;
 
         rt.block_on(async move {
             emit!(VectorStarted);
             tokio::spawn(heartbeat::heartbeat());
+
+            #[cfg(feature = "api")]
+            // assigned to prevent the API terminating when falling out of scope
+            let _api = if api_config.enabled {
+                emit!(ApiStarted {
+                    addr: api_config.bind.unwrap(),
+                    playground: api_config.playground
+                });
+
+                Some(api::Server::start(api_config))
+            } else {
+                None
+            };
 
             let signals = signal::signals();
             tokio::pin!(signals);


### PR DESCRIPTION
Fixes the 101 exit code caused by adding `api.enabled = true` to `vector.toml`, due to the server being started outside of the tokio runtime.

Moved the API startup into the `rt.block_on()` block.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
