### PR TITLE
feat(remap transform): add `parse_url` function

### DIFF
--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -423,8 +423,10 @@ impl CheckFieldsPredicate for LengthEqualsPredicate {
         match event {
             Event::Log(l) => l.get(&self.target).map_or(false, |v| {
                 let len = match v {
+                    Value::Bytes(value) => value.len(),
                     Value::Array(value) => value.len(),
                     Value::Map(value) => value.len(),
+                    Value::Null => 0,
                     value => value.to_string_lossy().len(),
                 };
 

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -424,6 +424,7 @@ impl CheckFieldsPredicate for LengthEqualsPredicate {
             Event::Log(l) => l.get(&self.target).map_or(false, |v| {
                 let len = match v {
                     Value::Array(value) => value.len(),
+                    Value::Map(value) => value.len(),
                     value => value.to_string_lossy().len(),
                 };
 

--- a/src/event/value.rs
+++ b/src/event/value.rs
@@ -97,6 +97,15 @@ impl From<DateTime<Utc>> for Value {
     }
 }
 
+impl<T: Into<Value>> From<Option<T>> for Value {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            None => Value::Null,
+            Some(v) => v.into(),
+        }
+    }
+}
+
 impl From<f32> for Value {
     fn from(value: f32) -> Self {
         Value::Float(f64::from(value))

--- a/src/mapping/query/function/mod.rs
+++ b/src/mapping/query/function/mod.rs
@@ -125,6 +125,7 @@ build_signatures! {
     strip_ansi_escape_codes => StripAnsiEscapeCodesFn,
     parse_duration => ParseDurationFn,
     format_number => FormatNumberFn,
+    parse_url => ParseUrlFn,
 }
 
 /// A parameter definition accepted by a function.

--- a/src/mapping/query/function/parse_url.rs
+++ b/src/mapping/query/function/parse_url.rs
@@ -1,0 +1,129 @@
+use super::prelude::*;
+use std::collections::BTreeMap;
+use std::iter::FromIterator;
+use url::Url;
+
+#[derive(Debug)]
+pub(in crate::mapping) struct ParseUrlFn {
+    query: Box<dyn Function>,
+}
+
+impl ParseUrlFn {
+    #[cfg(test)]
+    pub(in crate::mapping) fn new(query: Box<dyn Function>) -> Self {
+        Self { query }
+    }
+}
+
+impl Function for ParseUrlFn {
+    fn execute(&self, ctx: &Event) -> Result<Value> {
+        let bytes = required!(ctx, self.query, Value::Bytes(v) => v);
+
+        Url::parse(&String::from_utf8_lossy(&bytes))
+            .map_err(|e| format!("unable to parse url: {}", e))
+            .map(Into::into)
+    }
+
+    fn parameters() -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            accepts: |v| matches!(v, Value::Bytes(_)),
+            required: true,
+        }]
+    }
+}
+
+impl TryFrom<ArgumentList> for ParseUrlFn {
+    type Error = String;
+
+    fn try_from(mut arguments: ArgumentList) -> Result<Self> {
+        let query = arguments.required("value")?;
+
+        Ok(Self { query })
+    }
+}
+
+impl From<Url> for Value {
+    fn from(url: Url) -> Self {
+        let mut map = BTreeMap::<&str, Value>::new();
+
+        map.insert("scheme", url.scheme().to_owned().into());
+        map.insert("username", url.username().to_owned().into());
+        map.insert("path", url.path().to_owned().into());
+        map.insert("password", url.password().map(ToOwned::to_owned).into());
+        map.insert("host", url.host_str().map(ToOwned::to_owned).into());
+        map.insert("port", url.port().map(|v| v as isize).into());
+        map.insert("fragment", url.fragment().map(ToOwned::to_owned).into());
+        map.insert(
+            "query",
+            url.query_pairs()
+                .into_owned()
+                .map(|(k, v)| (k, v.into()))
+                .collect::<BTreeMap<String, Value>>()
+                .into(),
+        );
+
+        Value::from_iter(map.into_iter().map(|(k, v)| (k.to_owned(), v)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! map {
+        () => (
+            Value::Map(BTreeMap::new())
+        );
+        ($($k:tt: $v:expr),+ $(,)?) => (
+            Value::from(vec![
+                $(($k.into(), $v.into())),+
+            ].into_iter().collect::<BTreeMap<String, Value>>())
+        );
+    }
+
+    #[test]
+    fn parse_duration() {
+        let cases = vec![
+            (
+                Event::from(""),
+                Ok(map![
+                    "scheme": "https",
+                    "username": "",
+                    "password": Value::Null,
+                    "host": "vector.dev",
+                    "port": Value::Null,
+                    "path": "/",
+                    "query": map![],
+                    "fragment": Value::Null,
+                ]),
+                ParseUrlFn::new(Box::new(Literal::from("https://vector.dev"))),
+            ),
+            (
+                Event::from(""),
+                Ok(map![
+                    "scheme": "ftp",
+                    "username": "foo",
+                    "password": "bar",
+                    "host": "vector.dev",
+                    "port": 4343,
+                    "path": "/foobar",
+                    "query": map!["hello": "world"],
+                    "fragment": "123",
+                ]),
+                ParseUrlFn::new(Box::new(Literal::from(
+                    "ftp://foo:bar@vector.dev:4343/foobar?hello=world#123",
+                ))),
+            ),
+            (
+                Event::from(""),
+                Err("unable to parse url: relative URL without a base".to_owned()),
+                ParseUrlFn::new(Box::new(Literal::from("INVALID"))),
+            ),
+        ];
+
+        for (input_event, exp, query) in cases {
+            assert_eq!(query.execute(&input_event), exp);
+        }
+    }
+}

--- a/src/mapping/query/function/parse_url.rs
+++ b/src/mapping/query/function/parse_url.rs
@@ -49,8 +49,14 @@ impl From<Url> for Value {
 
         map.insert("scheme", url.scheme().to_owned().into());
         map.insert("username", url.username().to_owned().into());
+        map.insert(
+            "password",
+            url.password()
+                .map(ToOwned::to_owned)
+                .unwrap_or_default()
+                .into(),
+        );
         map.insert("path", url.path().to_owned().into());
-        map.insert("password", url.password().map(ToOwned::to_owned).into());
         map.insert("host", url.host_str().map(ToOwned::to_owned).into());
         map.insert("port", url.port().map(|v| v as isize).into());
         map.insert("fragment", url.fragment().map(ToOwned::to_owned).into());
@@ -90,7 +96,7 @@ mod tests {
                 Ok(map![
                     "scheme": "https",
                     "username": "",
-                    "password": Value::Null,
+                    "password": "",
                     "host": "vector.dev",
                     "port": Value::Null,
                     "path": "/",

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -630,3 +630,29 @@
     extract_from = "remap_function_format_number"
     [[tests.outputs.conditions]]
       "a.equals" = "1.234,56"
+
+[transforms.remap_function_parse_url]
+  inputs = []
+  type = "remap"
+  mapping = """
+    .parts = parse_url(.url)
+  """
+[[tests]]
+  name = "remap_function_parse_url"
+  [tests.input]
+    insert_at = "remap_function_parse_url"
+    type = "log"
+    [tests.input.log_fields]
+      url = "https://master.vector.dev/docs/reference/transforms/merge/?hello=world#configuration"
+  [[tests.outputs]]
+    extract_from = "remap_function_parse_url"
+    [[tests.outputs.conditions]]
+      "parts.scheme.equals" = "https"
+      "parts.username.equals" = ""
+      "parts.password.equals" = "<null>"
+      "parts.host.equals" = "master.vector.dev"
+      "parts.port.equals" = "<null>"
+      "parts.path.equals" = "/docs/reference/transforms/merge/"
+      "parts.query.length_eq" = 1
+      "parts.query.hello.equals" = "world"
+      "parts.fragment.equals" = "configuration"

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -649,7 +649,7 @@
     [[tests.outputs.conditions]]
       "parts.scheme.equals" = "https"
       "parts.username.equals" = ""
-      "parts.password.equals" = "<null>"
+      "parts.password.equals" = ""
       "parts.host.equals" = "master.vector.dev"
       "parts.port.equals" = "<null>"
       "parts.path.equals" = "/docs/reference/transforms/merge/"


### PR DESCRIPTION
```rust
.url = parse_url("https://vector.dev")
```

```json
{
	"url": {
		"scheme": "https",
		"username": "",
		"password": null,
		"host": "vector.dev",
		"port": null,
		"path": "/",
		"query": {},
		"fragment": null,
	}
}
```

closes #3762
