### PR TITLE
enhancement(log_to_metric transform): Improve error messages

### DIFF
--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -82,13 +82,13 @@ impl InternalEvent for LogToMetricRenderError {
     }
 }
 
-pub(crate) struct LogToMetricTemplateError {
+pub(crate) struct LogToMetricTemplateParseError {
     pub error: crate::template::TemplateError,
 }
 
-impl InternalEvent for LogToMetricTemplateError {
+impl InternalEvent for LogToMetricTemplateParseError {
     fn emit_logs(&self) {
-        warn!(message = "Failed to parse.", error = %self.error, rate_limit_secs = 30);
+        warn!(message = "Failed to parse template.", error = %self.error, rate_limit_secs = 30);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -1,5 +1,6 @@
 use super::InternalEvent;
 use metrics::counter;
+use std::num::ParseFloatError;
 use string_cache::DefaultAtom;
 
 pub(crate) struct LogToMetricEventProcessed;
@@ -23,7 +24,11 @@ pub(crate) struct LogToMetricFieldNotFound {
 
 impl InternalEvent for LogToMetricFieldNotFound {
     fn emit_logs(&self) {
-        warn!(message = "Field not found.", missing_field = ?self.field, rate_limit_sec = 30);
+        warn!(
+            message = "Field not found.",
+            missing_field = %self.field,
+            rate_limit_sec = 30
+        );
     }
 
     fn emit_metrics(&self) {
@@ -35,13 +40,19 @@ impl InternalEvent for LogToMetricFieldNotFound {
     }
 }
 
-pub(crate) struct LogToMetricParseError<'a> {
-    pub error: &'a str,
+pub(crate) struct LogToMetricParseFloatError {
+    pub field: DefaultAtom,
+    pub error: ParseFloatError,
 }
 
-impl<'a> InternalEvent for LogToMetricParseError<'a> {
+impl InternalEvent for LogToMetricParseFloatError {
     fn emit_logs(&self) {
-        warn!(message = "Failed to parse.", error = %self.error, rate_limit_secs = 30);
+        warn!(
+            message = "Failed to parse field as float.",
+            field = %self.field,
+            error = %self.error,
+            rate_limit_secs = 30
+        );
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -1,5 +1,6 @@
 use super::InternalEvent;
 use metrics::counter;
+use string_cache::DefaultAtom;
 
 pub(crate) struct LogToMetricEventProcessed;
 
@@ -16,11 +17,13 @@ impl InternalEvent for LogToMetricEventProcessed {
     }
 }
 
-pub(crate) struct LogToMetricFieldNotFound;
+pub(crate) struct LogToMetricFieldNotFound {
+    pub field: DefaultAtom,
+}
 
 impl InternalEvent for LogToMetricFieldNotFound {
     fn emit_logs(&self) {
-        warn!(message = "Field not found.", rate_limit_sec = 30);
+        warn!(message = "Field not found.", missing_field = ?self.field, rate_limit_sec = 30);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -64,13 +64,18 @@ impl InternalEvent for LogToMetricParseFloatError {
     }
 }
 
-pub(crate) struct LogToMetricRenderError {
-    pub error: String,
+pub(crate) struct LogToMetricTemplateRenderError {
+    pub missing_keys: Vec<String>,
 }
 
-impl InternalEvent for LogToMetricRenderError {
+impl InternalEvent for LogToMetricTemplateRenderError {
     fn emit_logs(&self) {
-        warn!(message = "Unable to render.", error = %self.error, rate_limit_secs = 30);
+        let error = format!("Keys {:?} do not exist on the event.", self.missing_keys);
+        warn!(
+            message = "Failed to render template.",
+            error = %error,
+            rate_limit_secs = 30
+        );
     }
 
     fn emit_metrics(&self) {

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -142,8 +142,15 @@ fn render_tags(
         Some(tags) => {
             let mut map = BTreeMap::new();
             for (name, value) in tags {
-                let tag = render_template(value, event)?;
-                map.insert(name.to_string(), tag);
+                match render_template(value, event) {
+                    Ok(tag) => {
+                        map.insert(name.to_string(), tag);
+                    }
+                    Err(TransformError::TemplateRenderError { missing_keys }) => {
+                        emit!(LogToMetricTemplateRenderError { missing_keys });
+                    }
+                    Err(other) => return Err(other),
+                }
             }
             if !map.is_empty() {
                 Some(map)


### PR DESCRIPTION
- Add field name to FieldNotFound error.
- Add field name and error detail to ParseFloatError.
- Clarify in TemplateError that we failed to parse a _template_.
- Previously, template rendering error prints "dropping event", this could be misleading because this transform tries many configs for each event, therefore other configs might successfully convert the event. Other errors in this transform do not have "dropping event".
- Fix render_tags silently ignores template rendering error. ~~I changed the code to return an error immediately, I'm not sure if this counts as a breaking change or not.~~ I emit a warning on missing keys error, and return on other errors (invalid template string in config).

Signed-off-by: Duy Do <juchiast@gmail.com>