### PR TITLE
chore(deps): Bump async-graphql from 1.18.2 to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,33 +154,35 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "1.18.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4196945e3cedacf6e42e0e2efe97f5d9c9ca0bf973a674c58ca37720fa9091"
+checksum = "2c4ad0433b3b114db22303083b5fdbb43cdd3a7a7053cabb78dc1a77420a9be7"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
- "async-stream 0.2.1",
+ "async-graphql-value",
+ "async-stream",
  "async-trait",
+ "blocking 1.0.2",
  "bson",
  "bytes 0.5.6",
  "chrono",
  "chrono-tz",
  "fnv",
  "futures 0.3.5",
- "http 0.2.1",
- "httparse",
  "indexmap",
  "itertools 0.9.0",
  "log",
+ "lru 0.6.0",
  "multer",
+ "num-traits",
  "once_cell",
- "parking_lot",
+ "pin-project-lite",
  "regex",
  "serde",
  "serde_json",
- "slab",
  "spin",
+ "static_assertions",
  "tempfile",
  "thiserror",
  "tracing 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,25 +192,28 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "1.18.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5abf43fe40a9620458abd93178499aa336445abbd48fba8e25a1a8a7fd5415"
+checksum = "bc58814b6514bbf206ba7d27a3e4a7eea20b874549fafd2061610b98248d2de5"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
+ "darling",
  "itertools 0.9.0",
  "proc-macro-crate",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
+ "thiserror",
 ]
 
 [[package]]
 name = "async-graphql-parser"
-version = "1.18.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef77d1893f105bac47c649f2f28bf22d3b2f257a6f21ac90144c1d13e8532715"
+checksum = "d79077561e3d93f905961a75cc4958660a21a8cf9471fa58b0156c7c2f17ea42"
 dependencies = [
+ "async-graphql-value",
  "pest",
  "pest_derive",
  "serde",
@@ -216,10 +221,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-graphql-warp"
-version = "1.18.1"
+name = "async-graphql-value"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19229af971dbee34b2956581505fdd1df85c81aef27f44c98560d6b527c4bddd"
+checksum = "c6e402ad33a8e9d657758a58d41d6bb1b7a47deac4ef647f789668654638bb82"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-warp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e473bb10b0a0ad2a26bef36728e5fa04ee095f738bde6b8abb312e46aa7e2c31"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -233,33 +248,12 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
-dependencies = [
- "async-stream-impl 0.2.1",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
 dependencies = [
- "async-stream-impl 0.3.0",
+ "async-stream-impl",
  "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
-dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.39",
 ]
 
 [[package]]
@@ -278,6 +272,12 @@ name = "async-task"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
+
+[[package]]
+name = "async-task"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
 name = "async-trait"
@@ -463,10 +463,24 @@ checksum = "d2468ff7bf85066b4a3678fede6fe66db31846d753ff0adfbfab2c6a6e81612b"
 dependencies = [
  "async-channel",
  "atomic-waker",
- "futures-lite",
+ "futures-lite 0.1.11",
  "once_cell",
  "parking 1.0.6",
  "waker-fn",
+]
+
+[[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task 4.0.2",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite 1.11.1",
+ "once_cell",
 ]
 
 [[package]]
@@ -551,16 +565,6 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -730,7 +734,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -1127,6 +1131,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac344c7efccb80cd25bc61b2170aec26f2f693fd40e765a539a1243db48c71"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "strsim 0.9.3",
+ "syn 1.0.39",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote 1.0.7",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -1642,6 +1681,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-lite"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381a7ad57b1bad34693f63f6f377e1abded7a9c85c9d3eb6771e11c60aaadab9"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking 2.0.0",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +1979,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
+ "ahash 0.3.8",
  "autocfg 1.0.1",
 ]
 
@@ -2331,6 +2386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2767,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 dependencies = [
  "hashbrown 0.6.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
+dependencies = [
+ "hashbrown 0.8.2",
 ]
 
 [[package]]
@@ -3155,7 +3225,7 @@ dependencies = [
  "log",
  "mime",
  "regex",
- "twoway 0.2.1",
+ "twoway",
 ]
 
 [[package]]
@@ -3163,24 +3233,6 @@ name = "multimap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
-
-[[package]]
-name = "multipart"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand 0.6.5",
- "safemem",
- "tempfile",
- "twoway 0.1.8",
-]
 
 [[package]]
 name = "native-tls"
@@ -4635,12 +4687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5016,8 +5062,8 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "620cbb3c6e34da57d3a248cda0cd01cd5848164dc062e764e65d06fe3ea7aed5"
 dependencies = [
- "async-task",
- "blocking",
+ "async-task 3.0.0",
+ "blocking 0.4.7",
  "concurrent-queue",
  "fastrand",
  "futures-io",
@@ -5210,6 +5256,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
@@ -5878,15 +5930,6 @@ dependencies = [
 
 [[package]]
 name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "twoway"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b40075910de3a912adbd80b5d8bad6ad10a23eeb1f5bf9d4006839e899ba5bc"
@@ -6124,7 +6167,7 @@ dependencies = [
  "async-compression",
  "async-graphql",
  "async-graphql-warp",
- "async-stream 0.3.0",
+ "async-stream",
  "async-trait",
  "atty",
  "base64 0.12.3",
@@ -6172,7 +6215,7 @@ dependencies = [
  "libz-sys",
  "listenfd",
  "logfmt",
- "lru",
+ "lru 0.4.3",
  "lucet-runtime",
  "lucet-wasi",
  "lucetc",
@@ -6385,7 +6428,6 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multipart",
  "pin-project",
  "scoped-tls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ goauth = { version = "0.7.1", optional = true }
 smpl_jwt = { version = "0.5.0", optional = true }
 
 # API
-async-graphql = { version = "1.18.2", optional = true }
-async-graphql-warp = { version = "1.18.1", optional = true }
+async-graphql = { version = "2.0.0", optional = true }
+async-graphql-warp = { version = "2.0.0", optional = true }
 
 # API client
 graphql_client = { version = "0.9.0", optional = true }

--- a/src/api/schema/gen.rs
+++ b/src/api/schema/gen.rs
@@ -104,7 +104,7 @@ fragment TypeRef on __Type {
 async fn main() {
     let schema = build_schema().finish();
     let res = schema.execute(INTROSPECTION_QUERY).await;
-    let json = serde_json::to_string_pretty(&async_graphql::http::GQLResponse(res)).unwrap();
+    let json = serde_json::to_string_pretty(&res).unwrap();
 
     fs::write("graphql/schema.json", format!("{}\n", json)).expect("Couldn't save schema file");
 }

--- a/src/api/schema/health.rs
+++ b/src/api/schema/health.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use tokio::stream::{Stream, StreamExt};
 use tokio::time::Duration;
 
-#[SimpleObject]
+#[derive(SimpleObject)]
 pub struct Heartbeat {
     utc: DateTime<Utc>,
 }
@@ -33,7 +33,7 @@ impl HealthSubscription {
     /// Heartbeat, containing the UTC timestamp of the last server-sent payload
     async fn heartbeat(
         &self,
-        #[arg(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = Heartbeat> {
         tokio::time::interval(Duration::from_millis(interval as u64)).map(|_| Heartbeat::new())
     }

--- a/src/api/schema/metrics.rs
+++ b/src/api/schema/metrics.rs
@@ -78,7 +78,8 @@ impl From<Metric> for BytesProcessed {
     }
 }
 
-#[Interface(field(name = "timestamp", type = "Option<DateTime<Utc>>"))]
+#[derive(Interface)]
+#[graphql(field(name = "timestamp", type = "Option<DateTime<Utc>>"))]
 pub enum MetricType {
     Uptime(Uptime),
     EventsProcessed(EventsProcessed),
@@ -93,7 +94,7 @@ impl MetricsSubscription {
     /// Metrics for how long the Vector instance has been running
     async fn uptime_metrics(
         &self,
-        #[arg(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = Uptime> {
         get_metrics(interval).filter_map(|m| match m.name.as_str() {
             "uptime_seconds" => Some(Uptime(m)),
@@ -115,7 +116,7 @@ impl MetricsSubscription {
     /// Bytes processed metrics
     async fn bytes_processed_metrics(
         &self,
-        #[arg(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = BytesProcessed> {
         get_metrics(interval).filter_map(|m| match m.name.as_str() {
             "bytes_processed" => Some(BytesProcessed(m)),
@@ -126,7 +127,7 @@ impl MetricsSubscription {
     /// All metrics
     async fn metrics(
         &self,
-        #[arg(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(IntRange(min = "100", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = MetricType> {
         get_metrics(interval).filter_map(|m| match m.name.as_str() {
             "uptime_seconds" => Some(MetricType::Uptime(m.into())),

--- a/src/api/schema/mod.rs
+++ b/src/api/schema/mod.rs
@@ -2,12 +2,12 @@ mod health;
 mod metrics;
 pub mod topology;
 
-use async_graphql::{EmptyMutation, GQLMergedObject, GQLMergedSubscription, Schema, SchemaBuilder};
+use async_graphql::{EmptyMutation, MergedObject, MergedSubscription, Schema, SchemaBuilder};
 
-#[derive(GQLMergedObject, Default)]
+#[derive(MergedObject, Default)]
 pub struct Query(health::HealthQuery, topology::TopologyQuery);
 
-#[derive(GQLMergedSubscription, Default)]
+#[derive(MergedSubscription, Default)]
 pub struct Subscription(health::HealthSubscription, metrics::MetricsSubscription);
 
 /// Build a new GraphQL schema, comprised of Query, Mutation and Subscription types

--- a/src/api/schema/topology.rs
+++ b/src/api/schema/topology.rs
@@ -9,7 +9,7 @@ use std::{
 const INVARIANT: &str =
     "It is an invariant for the API to be active but not have a TOPOLOGY. Please report this.";
 
-#[Enum]
+#[derive(Enum, Eq, PartialEq, Copy, Clone)]
 pub enum SourceOutputType {
     Any,
     Log,
@@ -145,8 +145,8 @@ impl Sink {
     }
 }
 
-#[Interface(field(name = "name", type = "String"))]
-#[derive(Clone)]
+#[derive(Clone, Interface)]
+#[graphql(field(name = "name", type = "String"))]
 pub enum Topology {
     Source(Source),
     Transform(Transform),


### PR DESCRIPTION
I upgraded `async-graphql` to `2.0.0` version, which provides better performance and easier to use API.

BTW:
I noticed that introspection query is used in `gen.rs` to obtain `SDL`, but in async-graphql `v2.0.0`, it can be obtained directly by calling the `Schema::sdl` function without starting the server. This might simplify the workflow (I'm not sure). 😁