### PR TITLE
fix(sinks): Treat all hyper::Error results as retriable

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -295,8 +295,8 @@ impl RetryLogic for ElasticSearchRetryLogic {
     type Error = hyper::Error;
     type Response = hyper::Response<Bytes>;
 
-    fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        error.is_connect() || error.is_closed()
+    fn is_retriable_error(&self, _error: &Self::Error) -> bool {
+        true
     }
 
     fn should_retry_response(&self, response: &Self::Response) -> RetryAction {

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -436,8 +436,8 @@ impl RetryLogic for GcsRetryLogic {
     type Error = hyper::Error;
     type Response = Response<Body>;
 
-    fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        error.is_connect() || error.is_closed()
+    fn is_retriable_error(&self, _error: &Self::Error) -> bool {
+        true
     }
 
     fn should_retry_response(&self, response: &Self::Response) -> RetryAction {

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -349,8 +349,8 @@ impl RetryLogic for HttpRetryLogic {
     type Error = hyper::Error;
     type Response = hyper::Response<Bytes>;
 
-    fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        error.is_connect() || error.is_closed()
+    fn is_retriable_error(&self, _error: &Self::Error) -> bool {
+        true
     }
 
     fn should_retry_response(&self, response: &Self::Response) -> RetryAction {


### PR DESCRIPTION
None the error conditions encoded within a [`hyper::Error`](https://docs.rs/hyper/0.13.8/hyper/struct.Error.html) indicate a rejection of the request. As such, they should all result in a retried request.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #4082 

This was discussed briefly in [discord](https://discordapp.com/channels/742820443487993987/746070604192415834/766050056389263360)