### PR TITLE
fix(statsd source): Fixup statsd shutdown

### DIFF
--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -320,6 +320,7 @@ fn timely_shutdown_socket_unix() {
 
 #[test]
 fn timely_shutdown_splunk_hec() {
+    vector::test_util::trace_init();
     test_timely_shutdown(source_vector(
         r#"
     type = "splunk_hec"
@@ -329,15 +330,18 @@ fn timely_shutdown_splunk_hec() {
 
 #[test]
 fn timely_shutdown_statsd() {
+    vector::test_util::trace_init();
     test_timely_shutdown(source_vector(
         r#"
     type = "statsd"
+    mode = "tcp"
     address = "${VECTOR_TEST_ADDRESS}""#,
     ));
 }
 
 #[test]
 fn timely_shutdown_syslog_tcp() {
+    vector::test_util::trace_init();
     test_timely_shutdown(source_vector(
         r#"
         type = "syslog"


### PR DESCRIPTION
Fixup a problem from https://github.com/timberio/vector/pull/4557/ where the test was not updated.