### PR TITLE
fix(file source): only sleep when backing off

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -566,7 +566,7 @@ fn scale(bytes: u64) -> String {
     let mut bytes = bytes as f32;
     let mut i = 0;
     while bytes > 1000.0 && i <= 3 {
-        bytes = bytes / 1000.0;
+        bytes /= 1000.0;
         i += 1;
     }
     format!("{:.3}{}/sec", bytes, units[i])


### PR DESCRIPTION
This adds instrumentation around where the file source is spending its time. The ratio of time spent across various segments is reported as a debug log, so it's easily enabled with `LOG=info,file_source=debug`. The output looks roughly like the following:

```
{"checkpointing": 0.00042231457, "discovery": 0.0002874473, "other": 0.00043339972, "reading": 0.012727213, "sending": 0.98606783, "sleeping": 0.000062016334}
```

As part of adding that instrumentation, I found that it was spending a meaningful amount of time sleeping when it should not have been. It turns out this was due to calling `delay_for` with a zero duration and the fact that tokio timers only have millisecond resolution. This lead to us sleeping for a millisecond when we should not have been sleeping at all.