### PR TITLE
enhancement: Add `ConnectionOpen` gauge

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -51,6 +51,8 @@ mod lua;
 mod metric_to_log;
 #[cfg(feature = "sources-mongodb_metrics")]
 mod mongodb_metrics;
+#[cfg(feature = "sources-socket")]
+mod open;
 mod process;
 #[cfg(feature = "sources-prometheus")]
 mod prometheus;
@@ -149,6 +151,8 @@ pub use self::logplex::*;
 pub use self::lua::*;
 #[cfg(feature = "transforms-metric_to_log")]
 pub(crate) use self::metric_to_log::*;
+#[cfg(feature = "sources-socket")]
+pub use self::open::*;
 pub use self::process::*;
 #[cfg(feature = "sources-prometheus")]
 pub use self::prometheus::*;

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -51,7 +51,6 @@ mod lua;
 mod metric_to_log;
 #[cfg(feature = "sources-mongodb_metrics")]
 mod mongodb_metrics;
-#[cfg(feature = "sources-socket")]
 mod open;
 mod process;
 #[cfg(feature = "sources-prometheus")]
@@ -151,7 +150,6 @@ pub use self::logplex::*;
 pub use self::lua::*;
 #[cfg(feature = "transforms-metric_to_log")]
 pub(crate) use self::metric_to_log::*;
-#[cfg(feature = "sources-socket")]
 pub use self::open::*;
 pub use self::process::*;
 #[cfg(feature = "sources-prometheus")]

--- a/src/internal_events/open.rs
+++ b/src/internal_events/open.rs
@@ -102,7 +102,7 @@ mod tests {
         let handles = (0..n)
             .map(|_| {
                 let gauge = gauge.clone();
-                let value = value.clone();
+                let value = Arc::clone(&value);
                 thread::spawn(move || {
                     let mut work = 0;
                     for _ in 0..m {

--- a/src/internal_events/open.rs
+++ b/src/internal_events/open.rs
@@ -93,7 +93,7 @@ mod tests {
 
     /// If this failes at any run, then the algorithm in `gauge_add` is faulty.
     #[test]
-    fn eventualy_consistent() {
+    fn eventually_consistent() {
         let n = 8;
         let m = 1000;
         let gauge = OpenGauge::new();

--- a/src/internal_events/open.rs
+++ b/src/internal_events/open.rs
@@ -1,0 +1,78 @@
+use super::InternalEvent;
+use metrics::gauge;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+#[derive(Debug)]
+pub struct ConnectionOpen {
+    pub count: usize,
+}
+
+impl InternalEvent for ConnectionOpen {
+    fn emit_metrics(&self) {
+        gauge!("open_connections", self.count as f64);
+    }
+}
+
+#[derive(Clone)]
+pub struct OpenGauge {
+    gauge: Arc<AtomicUsize>,
+}
+
+impl OpenGauge {
+    pub fn new() -> Self {
+        OpenGauge {
+            gauge: Arc::default(),
+        }
+    }
+
+    /// Increments and emits value once created.
+    /// Decrements and emits value once dropped.
+    pub fn open<E: Fn(usize)>(self, emitter: E) -> OpenToken<E> {
+        gauge_add(&self.gauge, 1, &emitter);
+        OpenToken {
+            gauge: self.gauge,
+            emitter,
+        }
+    }
+}
+
+pub struct OpenToken<E: Fn(usize)> {
+    gauge: Arc<AtomicUsize>,
+    emitter: E,
+}
+
+impl<E: Fn(usize)> Drop for OpenToken<E> {
+    fn drop(&mut self) {
+        gauge_add(&self.gauge, -1, &self.emitter);
+    }
+}
+
+/// If reporting gauges from multiple threads, they can end up in a wrong order
+/// resulting in having wrong value for a prolonged period of time.
+/// This function performs a synchronization procedure that corrects that.
+fn gauge_add(gauge: &AtomicUsize, add: isize, emitter: impl Fn(usize)) {
+    // Lock-free procedure with eventual consistency
+
+    // Initialize value and acquire older writes to gauge metric.
+    let mut value = gauge.load(Ordering::Acquire);
+    loop {
+        let new_value = (value as isize + add) as usize;
+        emitter(new_value);
+        // Try to update gauge to new value and releasing writes to gauge metric in the process.
+        // Otherwise acquire new writes to gauge metric.
+        let latest = gauge.compare_and_swap(value, new_value, Ordering::AcqRel);
+        if value == latest {
+            // Success
+            break;
+        }
+        // Try again with new value
+        value = latest;
+    }
+
+    // In the worst case scenario we will emit `n^2 / 2` times when there are `n` parallel
+    // updates in proggress. This scenario has higher chance of happening during shutdown.
+    // In most cases `n` will be small, and futher limited by the number of active threads.
+}

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -3,8 +3,9 @@ use crate::{
     dns::Resolver,
     emit,
     internal_events::{
-        TcpConnectionDisconnected, TcpConnectionEstablished, TcpConnectionFailed,
-        TcpConnectionShutdown, TcpEventSent, TcpFlushError,
+        ConnectionOpen, OpenGauge, OpenTokenDyn, TcpConnectionDisconnected,
+        TcpConnectionEstablished, TcpConnectionFailed, TcpConnectionShutdown, TcpEventSent,
+        TcpFlushError,
     },
     sinks::util::{
         encode_event, encoding::EncodingConfig, Encoding, SinkBuildError, StreamSinkOld,
@@ -184,7 +185,7 @@ pub struct TcpSink {
 enum TcpSinkState {
     Disconnected,
     Connecting(Box<dyn Future<Item = TcpOrTlsStream, Error = TcpError> + Send>),
-    Connected(TcpOrTlsStream01),
+    Connected(TcpOrTlsStream01, OpenTokenDyn),
     Backoff(Box<dyn Future<Item = (), Error = ()> + Send>),
 }
 
@@ -241,14 +242,20 @@ impl TcpSink {
                             peer_addr: connection.get_mut().peer_addr().ok(),
                         });
                         self.backoff = Self::fresh_backoff();
-                        TcpSinkState::Connected(CompatSink::new(connection))
+                        TcpSinkState::Connected(
+                            CompatSink::new(connection),
+                            OpenGauge::new()
+                                .open(Box::new(|count| emit!(ConnectionOpen { count }))),
+                        )
                     }
                     Err(error) => {
                         emit!(TcpConnectionFailed { error });
                         TcpSinkState::Backoff(self.next_delay01())
                     }
                 },
-                TcpSinkState::Connected(ref mut connection) => return Ok(Async::Ready(connection)),
+                TcpSinkState::Connected(ref mut connection, _) => {
+                    return Ok(Async::Ready(connection))
+                }
                 TcpSinkState::Backoff(ref mut delay) => match delay.poll() {
                     Ok(Async::NotReady) => return Ok(Async::NotReady),
                     Ok(Async::Ready(())) => TcpSinkState::Disconnected,

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -1,8 +1,9 @@
 use crate::{
     config::SinkContext,
     internal_events::{
-        UnixSocketConnectionEstablished, UnixSocketConnectionFailure, UnixSocketEventSent,
-        UnixSocketFlushFailed, UnixSocketSendFailed,
+        ConnectionOpen, OpenGauge, OpenTokenDyn, UnixSocketConnectionEstablished,
+        UnixSocketConnectionFailure, UnixSocketEventSent, UnixSocketFlushFailed,
+        UnixSocketSendFailed,
     },
     sinks::util::{encode_event, encoding::EncodingConfig, Encoding, StreamSinkOld},
     sinks::{Healthcheck, VectorSink},
@@ -115,7 +116,7 @@ type UnixSocket01 = CompatSink<UnixSocket, Bytes>;
 enum UnixSinkState {
     Disconnected,
     Creating(Box<dyn Future<Item = UnixSocket, Error = UnixSocketError> + Send>),
-    Open(UnixSocket01),
+    Open(UnixSocket01, OpenTokenDyn),
     Backoff(Box<dyn Future<Item = (), Error = ()> + Send>),
 }
 
@@ -151,7 +152,7 @@ impl UnixSink {
     fn poll_connection(&mut self) -> Poll01<&mut UnixSocket01, ()> {
         loop {
             self.state = match self.state {
-                UnixSinkState::Open(ref mut stream) => return Ok(Async::Ready(stream)),
+                UnixSinkState::Open(ref mut stream, _) => return Ok(Async::Ready(stream)),
                 UnixSinkState::Creating(ref mut connect_future) => match connect_future.poll() {
                     Ok(Async::NotReady) => return Ok(Async::NotReady),
                     Err(error) => {
@@ -166,7 +167,11 @@ impl UnixSink {
                             path: &self.connector.path,
                         });
                         self.backoff = Self::fresh_backoff();
-                        UnixSinkState::Open(CompatSink::new(socket))
+                        UnixSinkState::Open(
+                            CompatSink::new(socket),
+                            OpenGauge::new()
+                                .open(Box::new(|count| emit!(ConnectionOpen { count }))),
+                        )
                     }
                 },
                 UnixSinkState::Backoff(ref mut delay) => match delay.poll() {


### PR DESCRIPTION
Ref. #4505

Going with the simplicity, only one event was added for `tcp`/`unix` X `sink`/`source` connections. We can later split/enrich this event as needed. 

This event also covers other sources and sinks that use the shared code, more exactly this covers connections in: 
* `statsd` sink
* `socket` sink
* `vector` sink
* `papertrail` sink
* `syslog` source
* `vector` source
* `socket` source

There are two main problems that this PR addresses:
1. Cover all possible ways a connection can end. 
	- While the opening of a connection always has a single entry point, closing does not. 
	- This is solved by bundling, or tying in some other way, a token with the connection so that when the connection is dropped, the token is also and an event is emitted.

2. Unordered writes/emits to a gauge. 
	- In situations where we have a thread/future for every connection, just emitting current value of the gauge, noting that we are atomically modifying this value, can end with an older value of the gauge being emitted last which would then be reported as correct for an undetermined amount of time. 
	- To solve this, we have an algorithm which quickly reaches consistency, but which requires for the event to be emittable multiple times.   
	- An alternative would be to enforce sequentiality by using a lock, that would avoid the need for multiple emits, but it introduces locking for a quite a small thing.

cc. @binarylogic 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
