### PR TITLE
feat(processing): add "remap" condition type

### DIFF
--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -6,9 +6,6 @@ pub enum Error {
     #[error("parser error: {0}")]
     Parser(String),
 
-    #[error("invalid escape char: {0}")]
-    EscapeChar(char),
-
     #[error("unexpected token sequence")]
     Rule(#[from] Rule),
 

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -46,7 +46,7 @@ pub enum Error {
     Variable(#[from] variable::Error),
 }
 
-pub trait Expression: Send + std::fmt::Debug {
+pub trait Expression: Send + Sync + std::fmt::Debug {
     fn execute(&self, state: &mut State, object: &mut dyn Object) -> Result<Option<Value>>;
 }
 

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -91,7 +91,7 @@ impl TryInto<Box<dyn Expression>> for Argument {
     }
 }
 
-pub trait Function: std::fmt::Debug {
+pub trait Function: std::fmt::Debug + Sync + CloneFunction {
     /// The identifier by which the function can be called.
     fn identifier(&self) -> &'static str;
 
@@ -115,5 +115,24 @@ pub trait Function: std::fmt::Debug {
     /// resolved `Value` type is checked against the parameter properties.
     fn parameters(&self) -> &'static [Parameter] {
         &[]
+    }
+}
+
+pub trait CloneFunction {
+    fn clone_function(&self) -> Box<dyn Function>;
+}
+
+impl<T> CloneFunction for T
+where
+    T: Function + Clone + 'static,
+{
+    fn clone_function(&self) -> Box<dyn Function> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn Function> {
+    fn clone(&self) -> Self {
+        self.clone_function()
     }
 }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -172,7 +172,7 @@ mod tests {
         ];
 
         for (script, result) in cases {
-            let program = Program::new(script, vec![])
+            let program = Program::new(script, &[])
                 .map_err(|e| {
                     println!("{}", &e);
                     e

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -12,8 +12,8 @@ use std::str::FromStr;
 
 #[derive(pest_derive::Parser)]
 #[grammar = "../grammar.pest"]
-pub(super) struct Parser {
-    pub function_definitions: Vec<Box<dyn Fn>>,
+pub(super) struct Parser<'a> {
+    pub function_definitions: &'a [Box<dyn Fn>],
 }
 
 type R = Rule;
@@ -54,7 +54,7 @@ macro_rules! operation_fns {
     );
 }
 
-impl Parser {
+impl Parser<'_> {
     /// Converts the set of known "root" rules into boxed [`Expression`] trait
     /// objects.
     pub(crate) fn pairs_to_expressions(&self, pairs: Pairs<R>) -> Result<Vec<Expr>> {

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -316,10 +316,7 @@ impl Parser<'_> {
                     'n' => escaped_chars.push('\n'),
                     't' => escaped_chars.push('\t'),
                     '"' => escaped_chars.push('"'),
-                    // This isn't reachable currently due to the explicit list of
-                    // allowed escape chars in our parser grammar. However, if that
-                    // changes then we might need to rely on this error.
-                    _ => return Err(Error::EscapeChar(c)),
+                    _ => return Err(e(Rule::char)),
                 }
                 is_escaped = false;
             } else if c == '\\' {

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -13,7 +13,7 @@ pub struct Program {
 }
 
 impl Program {
-    pub fn new(source: &str, function_definitions: Vec<Box<dyn Function>>) -> Result<Self> {
+    pub fn new(source: &str, function_definitions: &[Box<dyn Function>]) -> Result<Self> {
         let pairs = parser::Parser::parse(parser::Rule::program, source)
             .map_err(|s| Error::Parser(s.to_string()))?;
 

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub mod check_fields;
 pub mod is_log;
 pub mod is_metric;
+pub mod remap;
 
 pub use check_fields::CheckFieldsConfig;
 

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -1,0 +1,180 @@
+use crate::{
+    conditions::{Condition, ConditionConfig, ConditionDescription},
+    Event,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+pub struct RemapConfig {
+    source: String,
+}
+
+inventory::submit! {
+    ConditionDescription::new::<RemapConfig>("remap")
+}
+
+impl_generate_config_from_default!(RemapConfig);
+
+#[typetag::serde(name = "remap")]
+impl ConditionConfig for RemapConfig {
+    fn build(&self) -> crate::Result<Box<dyn Condition>> {
+        // TODO(jean): move this to into a global "immutable functions" array.
+        use crate::remap::*;
+        let functions: Vec<Box<dyn remap::Function>> = vec![
+            Box::new(Split),
+            Box::new(ToString),
+            Box::new(ToInt),
+            Box::new(ToFloat),
+            Box::new(ToBool),
+            Box::new(ToTimestamp),
+            Box::new(Upcase),
+            Box::new(Downcase),
+            Box::new(UuidV4),
+            Box::new(Sha1),
+            Box::new(Md5),
+            Box::new(Now),
+            Box::new(FormatTimestamp),
+            Box::new(Contains),
+            Box::new(StartsWith),
+            Box::new(EndsWith),
+            Box::new(Slice),
+            Box::new(Tokenize),
+            Box::new(Sha2),
+            Box::new(Sha3),
+            Box::new(ParseDuration),
+            Box::new(FormatNumber),
+            Box::new(ParseUrl),
+            Box::new(Ceil),
+            Box::new(Floor),
+            Box::new(Round),
+            Box::new(ParseSyslog),
+            Box::new(ParseTimestamp),
+            Box::new(ParseJson),
+            Box::new(Truncate),
+            Box::new(StripWhitespace),
+            Box::new(StripAnsiEscapeCodes),
+        ];
+
+        let program = remap::Program::new(&self.source, functions)?;
+
+        Ok(Box::new(Remap { program }))
+    }
+}
+
+//------------------------------------------------------------------------------
+
+pub struct Remap {
+    program: remap::Program,
+}
+
+impl Remap {
+    fn execute(&self, event: &Event) -> remap::Result<Option<remap::Value>> {
+        // TODO(jean): This clone exists until remap-lang has an "immutable"
+        // mode.
+        //
+        // For now, mutability in reduce "remap ends-when conditions" is
+        // allowed, but it won't mutate the original event, since we cloned it
+        // here.
+        //
+        // Having first-class immutability support in the language allows for
+        // more performance (one less clone), and boot-time errors when a
+        // program wants to mutate its events.
+        remap::Runtime::default().execute(&mut event.clone(), &self.program)
+    }
+}
+
+impl Condition for Remap {
+    fn check(&self, event: &Event) -> bool {
+        self.execute(&event)
+            .ok()
+            .flatten()
+            .map(|value| match value {
+                remap::Value::Boolean(boolean) => boolean,
+                _ => false,
+            })
+            .unwrap_or(false)
+    }
+
+    fn check_with_context(&self, event: &Event) -> Result<(), String> {
+        self.execute(event)
+            .map_err(|err| format!("source execution failed: {}", err))?
+            .ok_or("source execution resolved to no value".into())
+            .and_then(|value| match value {
+                remap::Value::Boolean(v) if v => Ok(()),
+                remap::Value::Boolean(v) if !v => Err("source execution resolved to false".into()),
+                _ => Err("source execution resolved to non-boolean value".into()),
+            })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::log_event;
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<RemapConfig>();
+    }
+
+    #[test]
+    fn check_remap() {
+        let checks = vec![
+            (
+                log_event![],   // event
+                "true == true", // source
+                Ok(()),         // build result
+                Ok(()),         // check result
+            ),
+            (
+                log_event!["foo" => true, "bar" => false],
+                ".bar || .foo",
+                Ok(()),
+                Ok(()),
+            ),
+            (
+                log_event![],
+                "true == false",
+                Ok(()),
+                Err("source execution resolved to false"),
+            ),
+            (
+                log_event![],
+                "",
+                Ok(()),
+                Err("source execution resolved to no value"),
+            ),
+            (
+                log_event!["foo" => "string"],
+                ".foo",
+                Ok(()),
+                Err("source execution resolved to non-boolean value"),
+            ),
+            (
+                log_event![],
+                ".",
+                Err(
+                    "parser error:  --> 1:2\n  |\n1 | .\n  |  ^---\n  |\n  = expected path_segment",
+                ),
+                Ok(()),
+            ),
+        ];
+
+        for (event, source, build, check) in checks {
+            let source = source.to_owned();
+            let config = RemapConfig { source };
+
+            assert_eq!(
+                config.build().map(|_| ()).map_err(|e| e.to_string()),
+                build.map_err(|e| e.to_string())
+            );
+
+            if let Ok(cond) = config.build() {
+                assert_eq!(
+                    cond.check_with_context(&event),
+                    check.map_err(|e| e.to_string())
+                );
+            }
+        }
+    }
+}

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -18,43 +18,7 @@ impl_generate_config_from_default!(RemapConfig);
 #[typetag::serde(name = "remap")]
 impl ConditionConfig for RemapConfig {
     fn build(&self) -> crate::Result<Box<dyn Condition>> {
-        // TODO(jean): move this to into a global "immutable functions" array.
-        use crate::remap::*;
-        let functions: Vec<Box<dyn remap::Function>> = vec![
-            Box::new(Split),
-            Box::new(ToString),
-            Box::new(ToInt),
-            Box::new(ToFloat),
-            Box::new(ToBool),
-            Box::new(ToTimestamp),
-            Box::new(Upcase),
-            Box::new(Downcase),
-            Box::new(UuidV4),
-            Box::new(Sha1),
-            Box::new(Md5),
-            Box::new(Now),
-            Box::new(FormatTimestamp),
-            Box::new(Contains),
-            Box::new(StartsWith),
-            Box::new(EndsWith),
-            Box::new(Slice),
-            Box::new(Tokenize),
-            Box::new(Sha2),
-            Box::new(Sha3),
-            Box::new(ParseDuration),
-            Box::new(FormatNumber),
-            Box::new(ParseUrl),
-            Box::new(Ceil),
-            Box::new(Floor),
-            Box::new(Round),
-            Box::new(ParseSyslog),
-            Box::new(ParseTimestamp),
-            Box::new(ParseJson),
-            Box::new(Truncate),
-            Box::new(StripWhitespace),
-            Box::new(StripAnsiEscapeCodes),
-        ];
-
+        let functions: Vec<Box<dyn remap::Function>> = crate::remap::FUNCTIONS.clone();
         let program = remap::Program::new(&self.source, functions)?;
 
         Ok(Box::new(Remap { program }))

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -42,6 +42,8 @@ impl Remap {
         // Having first-class immutability support in the language allows for
         // more performance (one less clone), and boot-time errors when a
         // program wants to mutate its events.
+        //
+        // see: https://github.com/timberio/vector/issues/4744
         remap::Runtime::default().execute(&mut event.clone(), &self.program)
     }
 }

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -18,8 +18,7 @@ impl_generate_config_from_default!(RemapConfig);
 #[typetag::serde(name = "remap")]
 impl ConditionConfig for RemapConfig {
     fn build(&self) -> crate::Result<Box<dyn Condition>> {
-        let functions: Vec<Box<dyn remap::Function>> = crate::remap::FUNCTIONS.clone();
-        let program = remap::Program::new(&self.source, functions)?;
+        let program = remap::Program::new(&self.source, &crate::remap::FUNCTIONS)?;
 
         Ok(Box::new(Remap { program }))
     }

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -37,3 +37,27 @@ impl InternalEvent for RemapFailedMapping {
         counter!("processing_errors_total", 1, "error_type" => "failed_mapping");
     }
 }
+
+#[derive(Debug, Copy, Clone)]
+pub struct RemapConditionExecutionFailed;
+
+impl InternalEvent for RemapConditionExecutionFailed {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Remap condition execution failed.",
+            rate_limit_secs = 120
+        )
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct RemapConditionNonBooleanReturned;
+
+impl InternalEvent for RemapConditionNonBooleanReturned {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Remap condition non-boolean value returned.",
+            rate_limit_secs = 120
+        )
+    }
+}

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -1,7 +1,7 @@
 use super::round_to_precision;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Ceil;
 
 impl Function for Ceil {

--- a/src/remap/function/contains.rs
+++ b/src/remap/function/contains.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Contains;
 
 impl Function for Contains {

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -1,7 +1,7 @@
 use remap::prelude::*;
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Del;
 
 impl Function for Del {

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -1,7 +1,7 @@
 use remap::prelude::*;
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Downcase;
 
 impl Function for Downcase {

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct EndsWith;
 
 impl Function for EndsWith {

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -1,7 +1,7 @@
 use super::round_to_precision;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Floor;
 
 impl Function for Floor {

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use remap::prelude::*;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct FormatNumber;
 
 impl Function for FormatNumber {

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -2,7 +2,7 @@ use chrono::format::{strftime::StrftimeItems, Item};
 use chrono::{DateTime, Utc};
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct FormatTimestamp;
 
 impl Function for FormatTimestamp {

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Md5;
 
 impl Function for Md5 {

--- a/src/remap/function/now.rs
+++ b/src/remap/function/now.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Now;
 
 impl Function for Now {

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -1,7 +1,7 @@
 use remap::prelude::*;
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct OnlyFields;
 
 impl Function for OnlyFields {

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -32,7 +32,7 @@ lazy_static! {
     .collect();
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ParseDuration;
 
 impl Function for ParseDuration {

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ParseJson;
 
 impl Function for ParseJson {

--- a/src/remap/function/parse_syslog.rs
+++ b/src/remap/function/parse_syslog.rs
@@ -3,7 +3,7 @@ use remap::prelude::*;
 use std::collections::BTreeMap;
 use syslog_loose::{IncompleteDate, Message, ProcId};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ParseSyslog;
 
 impl Function for ParseSyslog {

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -1,7 +1,7 @@
 use crate::types::Conversion;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ParseTimestamp;
 
 impl Function for ParseTimestamp {

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::iter::FromIterator;
 use url::Url;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ParseUrl;
 
 impl Function for ParseUrl {

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -1,7 +1,7 @@
 use super::round_to_precision;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Round;
 
 impl Function for Round {

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Sha1;
 
 impl Function for Sha1 {

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -1,7 +1,7 @@
 use remap::prelude::*;
 use sha2::{Digest, Sha224, Sha256, Sha384, Sha512, Sha512Trunc224, Sha512Trunc256};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Sha2;
 
 impl Function for Sha2 {

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -1,7 +1,7 @@
 use remap::prelude::*;
 use sha3::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Sha3;
 
 impl Function for Sha3 {

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Slice;
 
 impl Function for Slice {

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -1,7 +1,7 @@
 use remap::prelude::*;
 use std::convert::{TryFrom, TryInto};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Split;
 
 impl Function for Split {

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct StartsWith;
 
 impl Function for StartsWith {

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct StripAnsiEscapeCodes;
 
 impl Function for StripAnsiEscapeCodes {

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct StripWhitespace;
 
 impl Function for StripWhitespace {

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -1,7 +1,7 @@
 use crate::types::Conversion;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ToBool;
 
 impl Function for ToBool {

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -1,7 +1,7 @@
 use crate::types::Conversion;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ToFloat;
 
 impl Function for ToFloat {

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -1,7 +1,7 @@
 use crate::types::Conversion;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ToInt;
 
 impl Function for ToInt {

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ToString;
 
 impl Function for ToString {

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -2,7 +2,7 @@ use crate::types::Conversion;
 use chrono::{TimeZone, Utc};
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ToTimestamp;
 
 impl Function for ToTimestamp {

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -1,7 +1,7 @@
 use crate::transforms::util::tokenize;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Tokenize;
 
 impl Function for Tokenize {

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -1,6 +1,6 @@
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Truncate;
 
 impl Function for Truncate {

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -1,7 +1,7 @@
 use remap::prelude::*;
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Upcase;
 
 impl Function for Upcase {

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use remap::prelude::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct UuidV4;
 
 impl Function for UuidV4 {

--- a/src/remap/mod.rs
+++ b/src/remap/mod.rs
@@ -1,3 +1,51 @@
 pub(crate) mod function;
 
 pub use function::*;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    // List of immutable functions that can be loaded into a remap-lang program.
+    pub(crate) static ref FUNCTIONS: Vec<Box<dyn remap::Function>> = vec![
+        Box::new(Split),
+        Box::new(ToString),
+        Box::new(ToInt),
+        Box::new(ToFloat),
+        Box::new(ToBool),
+        Box::new(ToTimestamp),
+        Box::new(Upcase),
+        Box::new(Downcase),
+        Box::new(UuidV4),
+        Box::new(Sha1),
+        Box::new(Md5),
+        Box::new(Now),
+        Box::new(FormatTimestamp),
+        Box::new(Contains),
+        Box::new(StartsWith),
+        Box::new(EndsWith),
+        Box::new(Slice),
+        Box::new(Tokenize),
+        Box::new(Sha2),
+        Box::new(Sha3),
+        Box::new(ParseDuration),
+        Box::new(FormatNumber),
+        Box::new(ParseUrl),
+        Box::new(Ceil),
+        Box::new(Floor),
+        Box::new(Round),
+        Box::new(ParseSyslog),
+        Box::new(ParseTimestamp),
+        Box::new(ParseJson),
+        Box::new(Truncate),
+        Box::new(StripWhitespace),
+        Box::new(StripAnsiEscapeCodes),
+    ];
+
+    // List of both mutable, and immutable functions that can be loaded into a
+    // remap-lang program.
+    pub(crate) static ref FUNCTIONS_MUT: Vec<Box<dyn remap::Function>> = {
+        let mut vec: Vec<Box<dyn remap::Function>> = vec![Box::new(Del), Box::new(OnlyFields)];
+
+        vec.extend(FUNCTIONS.clone());
+        vec
+    };
+}

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -77,7 +77,7 @@ impl GenerateConfig for AwsKinesisFirehoseConfig {
 mod tests {
     use super::*;
     use crate::{
-        event::{Event, LogEvent},
+        event::Event,
         log_event,
         test_util::{collect_ready, next_addr, wait_for_tcp},
     };

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -54,8 +54,9 @@ macro_rules! assert_downcast_matches {
 #[macro_export]
 macro_rules! log_event {
     ($($key:expr => $value:expr),*  $(,)?) => {
+        #[allow(unused_variables)]
         {
-            let mut event = Event::Log(LogEvent::default());
+            let mut event = crate::event::Event::Log(crate::event::LogEvent::default());
             let log = event.as_mut_log();
             $(
                 log.insert($key, $value);

--- a/src/transforms/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/transforms/aws_cloudwatch_logs_subscription_parser.rs
@@ -161,7 +161,7 @@ struct AwsCloudWatchLogEvent {
 #[cfg(test)]
 mod test {
     use super::{AwsCloudwatchLogsSubscriptionParser, AwsCloudwatchLogsSubscriptionParserConfig};
-    use crate::{event::Event, event::LogEvent, log_event, transforms::Transform};
+    use crate::{event::Event, log_event, transforms::Transform};
     use chrono::{TimeZone, Utc};
     use pretty_assertions::assert_eq;
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -49,47 +49,10 @@ pub struct Remap {
 
 impl Remap {
     pub fn new(config: RemapConfig) -> crate::Result<Remap> {
-        // TODO: move this into a constant?
-        use crate::remap::*;
-        let definitions: Vec<Box<dyn remap::Function>> = vec![
-            Box::new(Split),
-            Box::new(Del),
-            Box::new(OnlyFields),
-            Box::new(ToString),
-            Box::new(ToInt),
-            Box::new(ToFloat),
-            Box::new(ToBool),
-            Box::new(ToTimestamp),
-            Box::new(Upcase),
-            Box::new(Downcase),
-            Box::new(UuidV4),
-            Box::new(Sha1),
-            Box::new(Md5),
-            Box::new(Now),
-            Box::new(FormatTimestamp),
-            Box::new(Contains),
-            Box::new(StartsWith),
-            Box::new(EndsWith),
-            Box::new(Slice),
-            Box::new(Tokenize),
-            Box::new(Sha2),
-            Box::new(Sha3),
-            Box::new(ParseDuration),
-            Box::new(FormatNumber),
-            Box::new(ParseUrl),
-            Box::new(Ceil),
-            Box::new(Floor),
-            Box::new(Round),
-            Box::new(ParseSyslog),
-            Box::new(ParseTimestamp),
-            Box::new(ParseJson),
-            Box::new(Truncate),
-            Box::new(StripWhitespace),
-            Box::new(StripAnsiEscapeCodes),
-        ];
+        let functions: Vec<Box<dyn remap::Function>> = crate::remap::FUNCTIONS_MUT.clone();
 
         Ok(Remap {
-            program: Program::new(&config.source, definitions)?,
+            program: Program::new(&config.source, functions)?,
             drop_on_err: config.drop_on_err,
         })
     }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -49,10 +49,8 @@ pub struct Remap {
 
 impl Remap {
     pub fn new(config: RemapConfig) -> crate::Result<Remap> {
-        let functions: Vec<Box<dyn remap::Function>> = crate::remap::FUNCTIONS_MUT.clone();
-
         Ok(Remap {
-            program: Program::new(&config.source, functions)?,
+            program: Program::new(&config.source, &crate::remap::FUNCTIONS_MUT)?,
             drop_on_err: config.drop_on_err,
         })
     }

--- a/tests/behavior/transforms/reduce.toml
+++ b/tests/behavior/transforms/reduce.toml
@@ -259,3 +259,86 @@
       "mins.equals" = 5
       "maxs.equals" = 7
       "timestamp_end.exists" = true
+
+##------------------------------------------------------------------------------
+
+[transforms.ends_when_remap]
+  inputs = []
+  type = "reduce"
+  group_by = ["request_id"]
+
+  [transforms.ends_when_remap.ends_when]
+    "type" = "remap"
+    "source" = """
+        .test_end_message == true
+    """
+
+[[tests]]
+  name = "reduce_ends_when_remap"
+
+  [[tests.inputs]]
+    insert_at = "ends_when_remap"
+    type = "log"
+    [tests.inputs.log_fields]
+      request_id = "1"
+      counter = 1
+
+  [[tests.inputs]]
+    insert_at = "ends_when_remap"
+    type = "log"
+    [tests.inputs.log_fields]
+      request_id = "1"
+      counter = 3
+
+  [[tests.inputs]]
+    insert_at = "ends_when_remap"
+    type = "log"
+    [tests.inputs.log_fields]
+      request_id = "2"
+      counter = 5
+
+  [[tests.inputs]]
+    insert_at = "ends_when_remap"
+    type = "log"
+    [tests.inputs.log_fields]
+      request_id = "1"
+      counter = 2
+      test_end_message = true
+
+  [[tests.inputs]]
+    insert_at = "ends_when_remap"
+    type = "log"
+    [tests.inputs.log_fields]
+      request_id = "1"
+      counter = 7
+
+  [[tests.inputs]]
+    insert_at = "ends_when_remap"
+    type = "log"
+    [tests.inputs.log_fields]
+      request_id = "2"
+      counter = 2
+      test_end_message = true
+
+  [[tests.inputs]]
+    insert_at = "ends_when_remap"
+    type = "log"
+    [tests.inputs.log_fields]
+      request_id = "3"
+      counter = 5
+      test_end_message = true
+
+  [[tests.outputs]]
+    extract_from = "ends_when_remap"
+    [[tests.outputs.conditions]]
+      "request_id.equals" = "1"
+      "counter.equals" = 6
+      "timestamp_end.exists" = true
+    [[tests.outputs.conditions]]
+      "request_id.equals" = "2"
+      "counter.equals" = 7
+      "test_end_message.exists" = true
+    [[tests.outputs.conditions]]
+      "request_id.equals" = "3"
+      "counter.equals" = 5
+      "test_end_message.exists" = true


### PR DESCRIPTION
This PR builds on top of #4695 and #4709.

It adds a new **condition** trait implementation, named **remap**. This allows one to use remap-lang expressions to determine _some kind of event-based condition_.

These conditionals are currently used in the following transforms:

* Reduce [`ends_when`](https://vector.dev/docs/reference/transforms/reduce/#ends_when)
* Filter [`condition`](https://vector.dev/docs/reference/transforms/filter/#condition)
* Swimlane [`lanes`](https://vector.dev/docs/reference/transforms/swimlanes/#lanes)

closes #4572
closes #4643
partially solves #4574, although some more changes to the `reduce` transform are needed first.

## Examples

After this PR, one can write the following:

```toml
[transforms.reduce]
	type = "reduce"

	ends_when.type = "remap"
	ends_when.source = """
		.message == "done"
	"""

[transforms.swimlanes]
	type = "swimlanes"

	lanes.foo.type = "remap"
	lanes.foo.source = """
		.lane_id > 12 && contains(.message, "foo")
	"""

[transforms.filter]
	type = "filter"

	condition.type = "remap"
	condition.source = """
		if .foo == true {
			.bar == "bar" || to_bool(.maybe_bool, false)
		} else {
			starts_with(strip_whitespace(.baz), "baz")
		}
	"""
```

## Naming Things

I can't say I'm a fan of the "remap" name, but I'm not sure what else to name it. I feel like we must in some ways acknowledge the language used in this condition type, so that people can look up the language documentation to know what to do, but "remap" implies you can mutate the event, which isn't the case in this context.

I don't want to bikeshed the name too much, as we can change it before we ship the next version of Vector, but if there's a strong consensus for a specific name, I'm happy to change it in this PR.

## Non-Boolean Expressions

Currently, only expressions that resolve to a boolean value can result in `true`, any other value is `false` by default.

This means if you write:

```javascript
false || "yes"
```

This will always resolve to `false`.

We can't warn about this oddity at boot-time because `"yes"` can also be resolved through an event path (e.g. `false || .foo`). If `.foo` resolves to a boolean value for some events, but for others it resolves to a string, then the ones that resolve to a string will always result in a `false` condition.

There are a few potential solutions:

1. Do nothing. Document this behaviour. The current implementation makes sense, even if it might be confusing in some cases.
2. Implicitly call `to_bool` on the final expression. This allows `"yes"` to resolve to `true`, however, this feels like a bit too much magic to me (and on a technical level becomes more complicated, as the `to_bool` function might not be loaded in all situations). People can of course always call `false || to_bool(.foo)` themselves.
3. Update the `trait Condition` to support failing certain conditions. This seems like the least desired solution (especially if this can't be toggled on/of), as it can cause conditionals to fail, which would probably mean we'd have to drop the event, and it has performance implications.
4. Trigger an internal event if a non-boolean value is encountered. This might be a nice way for people to be aware of the "problem". However, it might not always be a problem, but an expected situation, in which case the logging noise might be considered annoying.

I'm leaning towards (1) as the only sensible solution, as long as we document this well. I could see (4) working as well, but I'm worried about the logging noise it might produce (even if it's rate-limited). We could provide a config option to disable logging the specific event.

## Performance And Mutation

Another improvement I'd like to defer to an issue (https://github.com/timberio/vector/issues/4744) (but which we should tackle soon) is the need for cloning the event (performance), and the fact that we don't explicitly reject mutation in this context (user experience).

That is to say, this source currently parses and runs as a conditional:

```javascript
.foo = true
```

The assignment expression resolves to the value assigned to the target, which in this case is `true`. However, the assignment itself will _not_ mutate the original event, since we cloned it before providing it to the language runtime.

The reason for this is that the language implementation requires all its expressions to take a `&mut Event`, whereas the `Condition` trait takes a `&Event`. This all makes perfect sense in isolation, but it conflicts when we want to use the two together.

The/A solution is to provide for a way to run programs immutably _(aside: see "naming things")_, which would allow for the language parser to return an error when Vector boots if a mutable expression (e.g. path assignments, or mutating functions) is present in the source. We'd introduce an `ExpressionMut` trait, and allow a program to parse sources either mutably or immutably.

This would:

* remove the need for cloning the event (better performance)
* provide boot-time errors when a source tries to assign values to event paths
* rejects loading mutating functions into the program, making it impossible to run functions such as `del` and `only_fields`

Perhaps there are other solutions we can consider here. I'll create an issue to discuss potential solutions.