### PR TITLE
feat(reduce transform): add "starts_when" option

### DIFF
--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -153,9 +153,12 @@ pub struct Reduce {
 
 impl Reduce {
     fn new(config: &ReduceConfig) -> crate::Result<Self> {
+        if config.ends_when.is_some() && config.starts_when.is_some() {
+            return Err("only one of `ends_when` and `starts_when` can be provided".into());
+        }
+
         let ends_when = config.ends_when.as_ref().map(|c| c.build()).transpose()?;
         let starts_when = config.starts_when.as_ref().map(|c| c.build()).transpose()?;
-
         let group_by = config.group_by.clone().into_iter().collect();
 
         Ok(Reduce {

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -41,6 +41,7 @@ pub struct ReduceConfig {
     /// An optional condition that determines when an event is the end of a
     /// reduce.
     pub ends_when: Option<AnyCondition>,
+    pub starts_when: Option<AnyCondition>,
 }
 
 inventory::submit! {
@@ -147,15 +148,13 @@ pub struct Reduce {
     merge_strategies: IndexMap<String, MergeStrategy>,
     reduce_merge_states: HashMap<Discriminant, ReduceState>,
     ends_when: Option<Box<dyn Condition>>,
+    starts_when: Option<Box<dyn Condition>>,
 }
 
 impl Reduce {
     fn new(config: &ReduceConfig) -> crate::Result<Self> {
-        let ends_when = if let Some(ends_conf) = &config.ends_when {
-            Some(ends_conf.build()?)
-        } else {
-            None
-        };
+        let ends_when = config.ends_when.as_ref().map(|c| c.build()).transpose()?;
+        let starts_when = config.starts_when.as_ref().map(|c| c.build()).transpose()?;
 
         let group_by = config.group_by.clone().into_iter().collect();
 
@@ -166,6 +165,7 @@ impl Reduce {
             merge_strategies: config.merge_strategies.clone(),
             reduce_merge_states: HashMap::new(),
             ends_when,
+            starts_when,
         })
     }
 
@@ -189,6 +189,17 @@ impl Reduce {
             .drain()
             .for_each(|(_, s)| output.push(Event::from(s.flush())));
     }
+
+    fn push_or_new_reduce_state(&mut self, event: LogEvent, discriminant: Discriminant) {
+        match self.reduce_merge_states.entry(discriminant) {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(ReduceState::new(event, &self.merge_strategies));
+            }
+            hash_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().add_event(event, &self.merge_strategies);
+            }
+        }
+    }
 }
 
 impl Transform for Reduce {
@@ -200,6 +211,12 @@ impl Transform for Reduce {
     }
 
     fn transform_into(&mut self, output: &mut Vec<Event>, event: Event) {
+        let starts_here = self
+            .starts_when
+            .as_ref()
+            .map(|c| c.check(&event))
+            .unwrap_or(false);
+
         let ends_here = self
             .ends_when
             .as_ref()
@@ -209,24 +226,24 @@ impl Transform for Reduce {
         let event = event.into_log();
         let discriminant = Discriminant::from_log_event(&event, &self.group_by);
 
-        if ends_here {
-            output.push(Event::from(
-                if let Some(mut state) = self.reduce_merge_states.remove(&discriminant) {
-                    state.add_event(event, &self.merge_strategies);
-                    state.flush()
-                } else {
-                    ReduceState::new(event, &self.merge_strategies).flush()
-                },
-            ));
-        } else {
-            match self.reduce_merge_states.entry(discriminant) {
-                hash_map::Entry::Vacant(entry) => {
-                    entry.insert(ReduceState::new(event, &self.merge_strategies));
-                }
-                hash_map::Entry::Occupied(mut entry) => {
-                    entry.get_mut().add_event(event, &self.merge_strategies);
-                }
+        if starts_here {
+            if let Some(state) = self.reduce_merge_states.remove(&discriminant) {
+                output.push(state.flush().into());
             }
+
+            self.push_or_new_reduce_state(event, discriminant)
+        } else if ends_here {
+            output.push(match self.reduce_merge_states.remove(&discriminant) {
+                Some(mut state) => {
+                    state.add_event(event, &self.merge_strategies);
+                    state.flush().into()
+                }
+                None => ReduceState::new(event, &self.merge_strategies)
+                    .flush()
+                    .into(),
+            })
+        } else {
+            self.push_or_new_reduce_state(event, discriminant)
         }
 
         emit!(ReduceEventProcessed);

--- a/tests/behavior/transforms/reduce.toml
+++ b/tests/behavior/transforms/reduce.toml
@@ -268,8 +268,8 @@
   group_by = ["request_id"]
 
   [transforms.ends_when_remap.ends_when]
-    "type" = "remap"
-    "source" = """
+    type = "remap"
+    source = """
         .test_end_message == true
     """
 
@@ -342,3 +342,289 @@
       "request_id.equals" = "3"
       "counter.equals" = 5
       "test_end_message.exists" = true
+
+##------------------------------------------------------------------------------
+
+[transforms.ruby_exception]
+    inputs = []
+    type = "reduce"
+    merge_strategies.message = "concat_newline"
+    starts_when.type = "remap"
+    starts_when.source = "match(.message, /^\\w.*/)"
+
+[[tests]]
+  name = "reduce_ruby_exception"
+
+  [[tests.inputs]]
+    insert_at = "ruby_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "Started GET \"/\" for 127.0.0.1 at 2012-03-10 14:28:14 +0100"
+
+  [[tests.inputs]]
+    insert_at = "ruby_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)"
+
+  [[tests.inputs]]
+    insert_at = "ruby_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "  from foobar.rb:6:in `bar'"
+
+  [[tests.inputs]]
+    insert_at = "ruby_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "  from foobar.rb:2:in `foo'"
+
+  [[tests.inputs]]
+    insert_at = "ruby_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "  from foobar.rb:9:in `<main>'"
+
+  [[tests.inputs]]
+    insert_at = "ruby_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "Started GET \"/\" for 127.0.0.1 at 2012-03-11 14:28:14 +0100"
+
+  [[tests.outputs]]
+    extract_from = "ruby_exception"
+    [[tests.outputs.conditions]]
+      "message.equals" = "Started GET \"/\" for 127.0.0.1 at 2012-03-10 14:28:14 +0100"
+    [[tests.outputs.conditions]]
+      "message.equals" = "foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)\n  from foobar.rb:6:in `bar'\n  from foobar.rb:2:in `foo'\n  from foobar.rb:9:in `<main>'"
+
+##------------------------------------------------------------------------------
+
+[transforms.line_continuation]
+    inputs = []
+    type = "reduce"
+    merge_strategies.message = "concat"
+    ends_when.type = "remap"
+    ends_when.source = """!ends_with(strip_whitespace(.message), "\\\\")"""
+
+[[tests]]
+  name = "reduce_line_continuation"
+
+  [[tests.inputs]]
+    insert_at = "line_continuation"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "First-line"
+
+  [[tests.inputs]]
+    insert_at = "line_continuation"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "Second line\\"
+
+  [[tests.inputs]]
+    insert_at = "line_continuation"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "more second line\\     "
+
+  [[tests.inputs]]
+    insert_at = "line_continuation"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "end of second line"
+
+  [[tests.inputs]]
+    insert_at = "line_continuation"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "third line"
+
+  [[tests.outputs]]
+    extract_from = "line_continuation"
+    [[tests.outputs.conditions]]
+      "message.equals" = "First-line"
+    [[tests.outputs.conditions]]
+      "message.equals" = "Second line\\ more second line\\      end of second line"
+    [[tests.outputs.conditions]]
+      "message.equals" = "third line"
+
+##------------------------------------------------------------------------------
+
+[transforms.line_termination]
+    inputs = []
+    type = "reduce"
+    merge_strategies.message = "concat"
+    ends_when.type = "remap"
+    ends_when.source = """ends_with(strip_whitespace(.message), ";")"""
+
+[[tests]]
+  name = "reduce_line_termination"
+
+  [[tests.inputs]]
+    insert_at = "line_termination"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "first line;"
+
+  [[tests.inputs]]
+    insert_at = "line_termination"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "second line"
+
+  [[tests.inputs]]
+    insert_at = "line_termination"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "more of the second line"
+
+  [[tests.inputs]]
+    insert_at = "line_termination"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "end of second line;         "
+
+  [[tests.inputs]]
+    insert_at = "line_termination"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "third line;"
+
+  [[tests.outputs]]
+    extract_from = "line_termination"
+    [[tests.outputs.conditions]]
+      "message.equals" = "first line;"
+    [[tests.outputs.conditions]]
+      "message.equals" = "second line more of the second line end of second line;         "
+    [[tests.outputs.conditions]]
+      "message.equals" = "third line;"
+
+##------------------------------------------------------------------------------
+
+[transforms.log_stream]
+    inputs = []
+    type = "reduce"
+    merge_strategies.message = "concat"
+    starts_when.type = "remap"
+    starts_when.source = "match(.message, /^<\\d\\d> /)"
+
+[[tests]]
+  name = "reduce_log_stream"
+
+  [[tests.inputs]]
+    insert_at = "log_stream"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "<12> first line "
+
+  [[tests.inputs]]
+    insert_at = "log_stream"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = " more of the first line"
+
+  [[tests.inputs]]
+    insert_at = "log_stream"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "<22> second line"
+
+  [[tests.inputs]]
+    insert_at = "log_stream"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "<17> third line"
+
+  [[tests.inputs]]
+    insert_at = "log_stream"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "<99> fourth line"
+
+  [[tests.outputs]]
+    extract_from = "log_stream"
+    [[tests.outputs.conditions]]
+      "message.equals" = "<12> first line   more of the first line"
+    [[tests.outputs.conditions]]
+      "message.equals" = "<22> second line"
+    [[tests.outputs.conditions]]
+      "message.equals" = "<17> third line"
+
+##------------------------------------------------------------------------------
+
+[transforms.java_exception]
+    inputs = []
+    type = "reduce"
+    merge_strategies.message = "concat_newline"
+    starts_when.type = "remap"
+    starts_when.source = "match(.message, /^\\d{4}-\\d{2}-\\d{2} .+/)"
+
+[[tests]]
+  name = "reduce_java_exception"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "2020-10-19 04:34:15,389 - org.apache.skywalking.oap.server.starter.OAPServerBootstrap -571727 [main] ERROR [] - method [HEAD], host [http://localhost:9200], URI [/], status line [HTTP/1.1 503 Service Unavailable]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "org.elasticsearch.ElasticsearchStatusException: method [HEAD], host [http://localhost:9200], URI [/], status line [HTTP/1.1 503 Service Unavailable]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "at org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:625) ~[elasticsearch-rest-high-level-client-6.3.2.jar:6.3.2]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:535) ~[elasticsearch-rest-high-level-client-6.3.2.jar:6.3.2]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "at org.elasticsearch.client.RestHighLevelClient.ping(RestHighLevelClient.java:275) ~[elasticsearch-rest-high-level-client-6.3.2.jar:6.3.2]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "Caused by: org.elasticsearch.client.ResponseException: method [HEAD], host [http://localhost:9200], URI [/], status line [HTTP/1.1 503 Service Unavailable]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "... 7 more"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "Caused by: org.elasticsearch.client.ResponseException: method [HEAD], host [http://localhost:9200], URI [/], status line [HTTP/1.1 503 Service Unavailable]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]"
+
+  [[tests.inputs]]
+    insert_at = "java_exception"
+    type = "log"
+    [tests.inputs.log_fields]
+      message = "2020-10-19 05:34:15,389 - org.apache.skywalking.oap.server.starter.OAPServerBootstrap -571727 [main] ERROR [] - method [HEAD], host [http://localhost:9200], URI [/], status line [HTTP/1.1 503 Service Unavailable]"
+
+  [[tests.outputs]]
+    extract_from = "java_exception"
+    [[tests.outputs.conditions]]
+      "message.starts_with" = "2020-10-19 04:34:15,389"
+      "message.ends_with" = "\nat java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]"


### PR DESCRIPTION
Similar to the existing `ends_when` option, but starts a new reduce operation when this option triggers, as opposed to ending a reduce operation when `ends_when` triggers.

Currently, if both options are provided, ~~`starts_when` takes precedence~~ a boot-time error is triggered.

I also added a bunch of behaviour tests that validate the examples provided in #4574 work as expected.

closes #4574.