### PR TITLE
fix(config): support numbers in paths

### DIFF
--- a/src/event/lookup/test.rs
+++ b/src/event/lookup/test.rs
@@ -159,7 +159,8 @@ fn parse_artifact(path: impl AsRef<Path>) -> std::io::Result<String> {
     let mut buf = Vec::new();
     test_file.read_to_end(&mut buf)?;
     let string = String::from_utf8(buf).unwrap();
-    Ok(string.trim_end_matches('\n').to_owned())
+    // remove trailing newline introduced by editors
+    Ok(string.trim_end().to_owned())
 }
 
 // This test iterates over the `tests/data/fixtures/lookup` folder and ensures the lookup parsed,

--- a/src/event/lookup/test.rs
+++ b/src/event/lookup/test.rs
@@ -159,7 +159,7 @@ fn parse_artifact(path: impl AsRef<Path>) -> std::io::Result<String> {
     let mut buf = Vec::new();
     test_file.read_to_end(&mut buf)?;
     let string = String::from_utf8(buf).unwrap();
-    Ok(string)
+    Ok(string.trim_end_matches('\n').to_owned())
 }
 
 // This test iterates over the `tests/data/fixtures/lookup` folder and ensures the lookup parsed,

--- a/src/mapping/parser/grammar.pest
+++ b/src/mapping/parser/grammar.pest
@@ -20,7 +20,7 @@ lookup = { (path_segment | quoted_path_segment) ~ ("." ~ (path_segment | quoted_
 path_index =$ { "[" ~ inner_path_index ~ "]" }
 inner_path_index = { '0'..'9'+ }
 path_segment = ${ path_field_name ~ path_index* }
-path_field_name = { (ASCII_ALPHA | "_" | "-" )+ }
+path_field_name = { (ASCII_ALPHANUMERIC | "_" | "-" )+ }
 quoted_path_segment = ${ "\"" ~ inner_quoted_string ~ "\"" ~ path_index* }
 
 target_path = @{ ("." ~ (path_segment | quoted_path_segment))+ }

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -571,6 +571,13 @@ mod tests {
                 ))]),
             ),
             (
+                ".123 = 38",
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "123".to_string(),
+                    Box::new(Literal::from(Value::from(38))),
+                ))]),
+            ),
+            (
                 ".foo = \"bar\"",
                 Mapping::new(vec![Box::new(Assignment::new(
                     "foo".to_string(),

--- a/src/mapping/parser/mod.rs
+++ b/src/mapping/parser/mod.rs
@@ -564,6 +564,13 @@ mod tests {
     fn check_parser() {
         let cases = vec![
             (
+                ".v3ctor = \"bar\"",
+                Mapping::new(vec![Box::new(Assignment::new(
+                    "v3ctor".to_string(),
+                    Box::new(Literal::from(Value::from("bar"))),
+                ))]),
+            ),
+            (
                 ".foo = \"bar\"",
                 Mapping::new(vec![Box::new(Assignment::new(
                     "foo".to_string(),

--- a/tests/data/fixtures/lookup/numbers
+++ b/tests/data/fixtures/lookup/numbers
@@ -1,0 +1,1 @@
+p4th_wi7h.numb3r5


### PR DESCRIPTION
This adds support for numbers in path segments.

Number support in remap was never added — and never caught in tests as we always use path names such as `foo` and `a` — but since remap hasn't officially shipped yet, this wasn't an issue.

However, now that the remap parser is used for path lookup (#4066) in the Vector config file itself, it _is_ exposed publicly, and so this needs to be addressed.

Note that this _only_ fixes numbers in paths for the Lookup code. The new remap-lang crate (#4695) has its own grammar file and already supports numbers in paths. I'm working on unifying the two (and fixing quoted paths in lookup, re https://github.com/timberio/vector/pull/4277#issuecomment-707771117) in a separate PR, but this should at least unblock releasing v0.11.

fixes #4794.

---

It would be good for @Hoverbear to weigh in on the current test-suite for the new lookup code, and how certain we are the tests cover all previous ways one could write paths to access event fields within the Vector config file.

It might be that we only accidentally missed the lacking support for numbers, or it might be that we need to add more tests to make sure the current path parsing rules are backward compatible with v0.10.

The intent in remap was always to be conservative in which characters we allow in regular path notation (`.foo`), so that we keep our options open towards using the restricted characters for other use-cases in the language, while simultaneously allowing an escape-hatch using quoted paths (`."@foo"`)

After this PR, the allowed set of characters is:

```
("a".."z" | "A".."Z" | 0..9 | "_" | "-" )+
```

Which strikes a balance between being able to use regular paths as often as possible while not restricting ourselves too much in the parser.

Anything else requires the quoted path notation to work.

Given that the same parser is used both for remap-lang and the regular path lookup in Vector configs, the above rule applies to both situations, even though we can be more lenient in what we allow in regular paths in Vector configs (given that we're not actually parsing the remap language itself, but only the path rule).

Are we certain the above covers all previous use-cases of path-based lookup using the old `PathComponent` system? @Hoverbear did a great job adding a lot of test-cases, but it's unclear to me if these cases are based on all the path syntax we currently support in v0.10.

**edit** I found a couple of backward-breaking changes in `Lookup`. See: https://github.com/timberio/vector/issues/4794#issuecomment-718693677