### PR TITLE
enhancement!: Use `namespace` field in metric sinks

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -496,8 +496,9 @@ _values: {
 }
 
 #MetricEvent: {
-	kind: "incremental" | "absolute"
-	name: string
+	kind:       "incremental" | "absolute"
+	name:       string
+	namespace?: string
 	tags: [Name=string]: string
 	timestamp?: string
 	close({counter: #MetricEventCounter}) |

--- a/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -90,7 +90,6 @@ components: sinks: aws_cloudwatch_metrics: {
 
 	configuration: {
 		default_namespace: {
-			common: true
 			description: """
 				A [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Namespace) that will isolate different metrics from each other.
 				Used as a namespace for metrics that don't have it.

--- a/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -92,7 +92,7 @@ components: sinks: aws_cloudwatch_metrics: {
 		default_namespace: {
 			description: """
 				A [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Namespace) that will isolate different metrics from each other.
-				Used if a metric event doesn't have a namespace.
+				Used as a namespace for metrics that don't have it.
 				"""
 			required: true
 			warnings: []

--- a/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -89,9 +89,12 @@ components: sinks: aws_cloudwatch_metrics: {
 	}
 
 	configuration: {
-		namespace: {
-			description: "A [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Namespace) that will isolate different metrics from each other."
-			required:    true
+		default_namespace: {
+			description: """
+				A [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Namespace) that will isolate different metrics from each other.
+				Used if a metric event doesn't have a namespace.
+				"""
+			required: true
 			warnings: []
 			type: string: {
 				examples: ["service"]

--- a/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -90,6 +90,7 @@ components: sinks: aws_cloudwatch_metrics: {
 
 	configuration: {
 		default_namespace: {
+			common: true
 			description: """
 				A [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Namespace) that will isolate different metrics from each other.
 				Used as a namespace for metrics that don't have it.

--- a/docs/reference/components/sinks/datadog_metrics.cue
+++ b/docs/reference/components/sinks/datadog_metrics.cue
@@ -55,6 +55,19 @@ components: sinks: datadog_metrics: {
 	configuration: {
 		api_key:  sinks._datadog.configuration.api_key
 		endpoint: sinks._datadog.configuration.endpoint
+		default_namespace: {
+			common: true
+			description: """
+				Used as a namespace for metrics that don't have it.
+				A namespace will be prefixed to a metric's name.
+				"""
+			required: false
+			warnings: []
+			type: string: {
+				default: null
+				examples: ["service"]
+			}
+		}
 	}
 
 	input: {

--- a/docs/reference/components/sinks/datadog_metrics.cue
+++ b/docs/reference/components/sinks/datadog_metrics.cue
@@ -55,16 +55,6 @@ components: sinks: datadog_metrics: {
 	configuration: {
 		api_key:  sinks._datadog.configuration.api_key
 		endpoint: sinks._datadog.configuration.endpoint
-		namespace: {
-			common:      true
-			description: "A prefix that will be added to all metric names."
-			required:    false
-			warnings: []
-			type: string: {
-				default: null
-				examples: ["service"]
-			}
-		}
 	}
 
 	input: {

--- a/docs/reference/components/sinks/influxdb.cue
+++ b/docs/reference/components/sinks/influxdb.cue
@@ -65,7 +65,7 @@ components: sinks: _influxdb: {
 			}
 		}
 		namespace: {
-			description: "A prefix that will be added to all metric names."
+			description: "A prefix that will be added to all logs names."
 			groups: ["v1", "v2"]
 			required: true
 			warnings: []

--- a/docs/reference/components/sinks/influxdb.cue
+++ b/docs/reference/components/sinks/influxdb.cue
@@ -64,15 +64,6 @@ components: sinks: _influxdb: {
 				examples: ["http://localhost:8086/", "https://us-west-2-1.aws.cloud1.influxdata.com", "https://us-west-2-1.aws.cloud2.influxdata.com"]
 			}
 		}
-		namespace: {
-			description: "A prefix that will be added to all logs names."
-			groups: ["v1", "v2"]
-			required: true
-			warnings: []
-			type: string: {
-				examples: ["service"]
-			}
-		}
 		org: {
 			category:    "Auth"
 			description: "Specifies the destination organization for writes into InfluxDB 2."

--- a/docs/reference/components/sinks/influxdb_logs.cue
+++ b/docs/reference/components/sinks/influxdb_logs.cue
@@ -57,7 +57,17 @@ components: sinks: influxdb_logs: {
 		notices: []
 	}
 
-	configuration: sinks._influxdb.configuration
+	configuration: sinks._influxdb.configuration & {
+		namespace: {
+			description: "A prefix that will be added to all logs names."
+			groups: ["v1", "v2"]
+			required: true
+			warnings: []
+			type: string: {
+				examples: ["service"]
+			}
+		}
+	}
 
 	input: {
 		logs:    true

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -57,7 +57,21 @@ components: sinks: influxdb_metrics: {
 		notices: []
 	}
 
-	configuration: sinks._influxdb.configuration
+	configuration: sinks._influxdb.configuration & {
+		default_namespace: {
+			common: true
+			description: """
+				Used as a namespace for metrics that don't have it.
+				A namespace will be prefixed to a metric's name.
+				"""
+			required: false
+			warnings: []
+			type: string: {
+				default: null
+				examples: ["service"]
+			}
+		}
+	}
 
 	input: {
 		logs: false

--- a/docs/reference/components/sinks/influxdb_metrics.cue
+++ b/docs/reference/components/sinks/influxdb_metrics.cue
@@ -91,7 +91,9 @@ components: sinks: influxdb_metrics: {
 			_name:  "logins"
 			_value: 1.5
 			title:  "Counter"
-			configuration: {}
+			configuration: {
+				default_namespace: "service"
+			}
 			input: metric: {
 				kind: "incremental"
 				name: _name
@@ -102,7 +104,7 @@ components: sinks: influxdb_metrics: {
 					host: _host
 				}
 			}
-			output: "ns.\(_name),metric_type=counter,host=\(_host) value=\(_value) 1542182950000000011"
+			output: "service.\(_name),metric_type=counter,host=\(_host) value=\(_value) 1542182950000000011"
 		},
 		{
 			_host: _values.local_host
@@ -111,8 +113,9 @@ components: sinks: influxdb_metrics: {
 			notes: "For distributions with histogram, summary is computed."
 			configuration: {}
 			input: metric: {
-				kind: "incremental"
-				name: _name
+				kind:      "incremental"
+				name:      _name
+				namespace: "app"
 				distribution: {
 					values: [1.0, 5.0, 3.0]
 					sample_rates: [1, 2, 3]
@@ -122,17 +125,20 @@ components: sinks: influxdb_metrics: {
 					host: _host
 				}
 			}
-			output: "ns.\(_name),metric_type=distribution,host=\(_host) avg=3.333333,count=6,max=5,median=3,min=1,quantile_0.95=5,sum=20 1542182950000000011"
+			output: "app.\(_name),metric_type=distribution,host=\(_host) avg=3.333333,count=6,max=5,median=3,min=1,quantile_0.95=5,sum=20 1542182950000000011"
 		},
 		{
 			_host:  _values.local_host
 			_name:  "memory_rss"
 			_value: 1.5
 			title:  "Gauge"
-			configuration: {}
+			configuration: {
+				default_namespace: "service"
+			}
 			input: metric: {
-				kind: "absolute"
-				name: _name
+				kind:      "absolute"
+				name:      _name
+				namespace: "app"
 				gauge: {
 					value: _value
 				}
@@ -140,7 +146,7 @@ components: sinks: influxdb_metrics: {
 					host: _host
 				}
 			}
-			output: "ns.\(_name),metric_type=gauge,host=\(_host) value=\(_value) 1542182950000000011"
+			output: "app.\(_name),metric_type=gauge,host=\(_host) value=\(_value) 1542182950000000011"
 		},
 		{
 			_host: _values.local_host
@@ -160,7 +166,7 @@ components: sinks: influxdb_metrics: {
 					host: _host
 				}
 			}
-			output: "ns.\(_name),metric_type=histogram,host=\(_host) bucket_1=2i,bucket_2.1=5i,bucket_3=10i,count=17i,sum=46.2 1542182950000000011"
+			output: "\(_name),metric_type=histogram,host=\(_host) bucket_1=2i,bucket_2.1=5i,bucket_3=10i,count=17i,sum=46.2 1542182950000000011"
 		},
 		{
 			_host:  _values.local_host
@@ -178,7 +184,7 @@ components: sinks: influxdb_metrics: {
 					host: _host
 				}
 			}
-			output: "ns.\(_name),metric_type=set,host=\(_host) value=3 154218295000000001"
+			output: "\(_name),metric_type=set,host=\(_host) value=3 154218295000000001"
 		},
 		{
 			_host: _values.local_host
@@ -198,7 +204,7 @@ components: sinks: influxdb_metrics: {
 					host: _host
 				}
 			}
-			output: "ns.\(_name),metric_type=summary,host=\(_host) count=6i,quantile_0.01=1.5,quantile_0.5=2,quantile_0.99=3,sum=12.1 1542182950000000011"
+			output: "\(_name),metric_type=summary,host=\(_host) count=6i,quantile_0.01=1.5,quantile_0.5=2,quantile_0.99=3,sum=12.1 1542182950000000011"
 		},
 	]
 }

--- a/docs/reference/components/sinks/prometheus.cue
+++ b/docs/reference/components/sinks/prometheus.cue
@@ -99,10 +99,9 @@ components: sinks: prometheus: {
 				A namespace will be prefixed to a metric's name.
 				It should follow Prometheus [naming conventions](\(urls.prometheus_metric_naming)).
 				"""
-			required:    false
+			required:    true
 			warnings: []
 			type: string: {
-				default: null
 				examples: ["service"]
 			}
 		}

--- a/docs/reference/components/sinks/prometheus.cue
+++ b/docs/reference/components/sinks/prometheus.cue
@@ -92,9 +92,13 @@ components: sinks: prometheus: {
 				unit:    "seconds"
 			}
 		}
-		namespace: {
+		default_namespace: {
 			common:      true
-			description: "A prefix that will be added to all metric names.\nIt should follow Prometheus [naming conventions](\(urls.prometheus_metric_naming))."
+			description: """
+				Used as a namespace for metrics that don't have it.
+				A namespace will be prefixed to a metric's name.
+				It should follow Prometheus [naming conventions](\(urls.prometheus_metric_naming)).
+				"""
 			required:    false
 			warnings: []
 			type: string: {

--- a/docs/reference/components/sinks/prometheus.cue
+++ b/docs/reference/components/sinks/prometheus.cue
@@ -93,7 +93,6 @@ components: sinks: prometheus: {
 			}
 		}
 		default_namespace: {
-			common:      true
 			description: """
 				Used as a namespace for metrics that don't have it.
 				A namespace will be prefixed to a metric's name.

--- a/docs/reference/components/sinks/prometheus.cue
+++ b/docs/reference/components/sinks/prometheus.cue
@@ -132,11 +132,14 @@ components: sinks: prometheus: {
 
 	examples: [
 		{
-			_host:  _values.local_host
-			_name:  "logins"
-			_value: 1.5
-			title:  "Counter"
-			configuration: {}
+			_host:      _values.local_host
+			_name:      "logins"
+			_namespace: "service"
+			_value:     1.5
+			title:      "Counter"
+			configuration: {
+				default_namespace: _namespace
+			}
 			input: metric: {
 				kind: "incremental"
 				name: _name
@@ -148,20 +151,22 @@ components: sinks: prometheus: {
 				}
 			}
 			output: """
-				# HELP \(_name) \(_name)
-				# TYPE \(_name) counter
-				\(_name){host="\(_host)"} \(_value)
+				# HELP \(_namespace)_\(_name) \(_name)
+				# TYPE \(_namespace)_\(_name) counter
+				\(_namespace)_\(_name){host="\(_host)"} \(_value)
 				"""
 		},
 		{
-			_host:  _values.local_host
-			_name:  "memory_rss"
-			_value: 1.5
-			title:  "Gauge"
+			_host:      _values.local_host
+			_name:      "memory_rss"
+			_namespace: "app"
+			_value:     1.5
+			title:      "Gauge"
 			configuration: {}
 			input: metric: {
-				kind: "absolute"
-				name: _name
+				kind:      "absolute"
+				name:      _name
+				namespace: _namespace
 				gauge: {
 					value: _value
 				}
@@ -170,16 +175,17 @@ components: sinks: prometheus: {
 				}
 			}
 			output: """
-				# HELP \(_name) \(_name)
-				# TYPE \(_name) gauge
-				\(_name){host="\(_host)"} \(_value)
+				# HELP \(_namespace)_\(_name) \(_name)
+				# TYPE \(_namespace)_\(_name) gauge
+				\(_namespace)_\(_name){host="\(_host)"} \(_value)
 				"""
 		},
 		{
 			_host: _values.local_host
 			_name: "response_time_s"
 			title: "Histogram"
-			configuration: {}
+			configuration: {
+			}
 			input: metric: {
 				kind: "absolute"
 				name: _name

--- a/docs/reference/components/sinks/prometheus.cue
+++ b/docs/reference/components/sinks/prometheus.cue
@@ -93,14 +93,16 @@ components: sinks: prometheus: {
 			}
 		}
 		default_namespace: {
+			common:      true
 			description: """
 				Used as a namespace for metrics that don't have it.
 				A namespace will be prefixed to a metric's name.
 				It should follow Prometheus [naming conventions](\(urls.prometheus_metric_naming)).
 				"""
-			required:    true
+			required:    false
 			warnings: []
 			type: string: {
+				default: null
 				examples: ["service"]
 			}
 		}

--- a/docs/reference/components/sinks/sematext_metrics.cue
+++ b/docs/reference/components/sinks/sematext_metrics.cue
@@ -56,7 +56,17 @@ components: sinks: sematext_metrics: {
 		notices: []
 	}
 
-	configuration: sinks._sematext.configuration
+	configuration: sinks._sematext.configuration & {
+		default_namespace: {
+			common:      true
+			description: "Used as a namespace for metrics that don't have it."
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["service"]
+			}
+		}
+	}
 
 	input: {
 		logs: false

--- a/docs/reference/components/sinks/sematext_metrics.cue
+++ b/docs/reference/components/sinks/sematext_metrics.cue
@@ -78,14 +78,4 @@ components: sinks: sematext_metrics: {
 			summary:      false
 		}
 	}
-
-	how_it_works: {
-		metric_types: {
-			title: "Metric Namespaces"
-			body: """
-				All metrics are sent with a namespace. If no namespace is included with the metric, the metric name becomes
-				the namespace and the metric is named `value`.
-				"""
-		}
-	}
 }

--- a/docs/reference/components/sinks/sematext_metrics.cue
+++ b/docs/reference/components/sinks/sematext_metrics.cue
@@ -58,7 +58,6 @@ components: sinks: sematext_metrics: {
 
 	configuration: sinks._sematext.configuration & {
 		default_namespace: {
-			common:      true
 			description: "Used as a namespace for metrics that don't have it."
 			required:    true
 			warnings: []

--- a/docs/reference/components/sinks/statsd.cue
+++ b/docs/reference/components/sinks/statsd.cue
@@ -48,5 +48,19 @@ components: sinks: statsd: {
 		}
 	}
 
-	configuration: sinks.socket.configuration
+	configuration: sinks.socket.configuration & {
+		default_namespace: {
+			common: true
+			description: """
+				Used as a namespace for metrics that don't have it.
+				A namespace will be prefixed to a metric's name.
+				"""
+			required: false
+			warnings: []
+			type: string: {
+				default: null
+				examples: ["service"]
+			}
+		}
+	}
 }

--- a/docs/reference/components/sinks/statsd.cue
+++ b/docs/reference/components/sinks/statsd.cue
@@ -48,16 +48,5 @@ components: sinks: statsd: {
 		}
 	}
 
-	configuration: sinks.socket.configuration & {
-		namespace: {
-			common:      true
-			description: "A prefix that will be added to all metric names."
-			required:    false
-			warnings: []
-			type: string: {
-				default: null
-				examples: ["service"]
-			}
-		}
-	}
+	configuration: sinks.socket.configuration
 }

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -277,7 +277,6 @@ mod tests {
     use crate::event::metric::{Metric, MetricKind, MetricValue, StatisticKind};
     use chrono::offset::TimeZone;
     use pretty_assertions::assert_eq;
-    use rusoto_cloudwatch::PutMetricDataInput;
 
     #[test]
     fn generate_config() {
@@ -286,7 +285,7 @@ mod tests {
 
     fn config() -> CloudWatchMetricsSinkConfig {
         CloudWatchMetricsSinkConfig {
-            namespace: "vector".into(),
+            default_namespace: "vector".into(),
             region: RegionOrEndpoint::with_endpoint("local".to_owned()),
             ..Default::default()
         }
@@ -334,32 +333,29 @@ mod tests {
 
         assert_eq!(
             svc().encode_events(events),
-            PutMetricDataInput {
-                namespace: "vector".into(),
-                metric_data: vec![
-                    MetricDatum {
-                        metric_name: "exception_total".into(),
-                        value: Some(1.0),
-                        ..Default::default()
-                    },
-                    MetricDatum {
-                        metric_name: "bytes_out".into(),
-                        value: Some(2.5),
-                        timestamp: Some("2018-11-14T08:09:10.123Z".into()),
-                        ..Default::default()
-                    },
-                    MetricDatum {
-                        metric_name: "healthcheck".into(),
-                        value: Some(1.0),
-                        timestamp: Some("2018-11-14T08:09:10.123Z".into()),
-                        dimensions: Some(vec![Dimension {
-                            name: "region".into(),
-                            value: "local".into()
-                        }]),
-                        ..Default::default()
-                    },
-                ],
-            }
+            vec![
+                MetricDatum {
+                    metric_name: "exception_total".into(),
+                    value: Some(1.0),
+                    ..Default::default()
+                },
+                MetricDatum {
+                    metric_name: "bytes_out".into(),
+                    value: Some(2.5),
+                    timestamp: Some("2018-11-14T08:09:10.123Z".into()),
+                    ..Default::default()
+                },
+                MetricDatum {
+                    metric_name: "healthcheck".into(),
+                    value: Some(1.0),
+                    timestamp: Some("2018-11-14T08:09:10.123Z".into()),
+                    dimensions: Some(vec![Dimension {
+                        name: "region".into(),
+                        value: "local".into()
+                    }]),
+                    ..Default::default()
+                },
+            ]
         );
     }
 
@@ -376,14 +372,11 @@ mod tests {
 
         assert_eq!(
             svc().encode_events(events),
-            PutMetricDataInput {
-                namespace: "vector".into(),
-                metric_data: vec![MetricDatum {
-                    metric_name: "temperature".into(),
-                    value: Some(10.0),
-                    ..Default::default()
-                }],
-            }
+            vec![MetricDatum {
+                metric_name: "temperature".into(),
+                value: Some(10.0),
+                ..Default::default()
+            }]
         );
     }
 
@@ -404,15 +397,12 @@ mod tests {
 
         assert_eq!(
             svc().encode_events(events),
-            PutMetricDataInput {
-                namespace: "vector".into(),
-                metric_data: vec![MetricDatum {
-                    metric_name: "latency".into(),
-                    values: Some(vec![11.0, 12.0]),
-                    counts: Some(vec![100.0, 50.0]),
-                    ..Default::default()
-                }],
-            }
+            vec![MetricDatum {
+                metric_name: "latency".into(),
+                values: Some(vec![11.0, 12.0]),
+                counts: Some(vec![100.0, 50.0]),
+                ..Default::default()
+            }]
         );
     }
 
@@ -431,14 +421,11 @@ mod tests {
 
         assert_eq!(
             svc().encode_events(events),
-            PutMetricDataInput {
-                namespace: "vector".into(),
-                metric_data: vec![MetricDatum {
-                    metric_name: "users".into(),
-                    value: Some(2.0),
-                    ..Default::default()
-                }],
-            }
+            vec![MetricDatum {
+                metric_name: "users".into(),
+                value: Some(2.0),
+                ..Default::default()
+            }]
         );
     }
 }
@@ -458,7 +445,7 @@ mod integration_tests {
 
     fn config() -> CloudWatchMetricsSinkConfig {
         CloudWatchMetricsSinkConfig {
-            namespace: "vector".into(),
+            default_namespace: "vector".into(),
             region: RegionOrEndpoint::with_endpoint("http://localhost:4566".to_owned()),
             ..Default::default()
         }

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -523,7 +523,7 @@ mod integration_tests {
     async fn cloudwatch_metrics_namespace_partitioning() {
         let cx = SinkContext::new_test();
         let config = config();
-        let client = config.create_client(cx.resolver()).unwrap();
+        let client = config.create_client().unwrap();
         let sink = CloudWatchMetricsSvc::new(config, client, cx).unwrap();
 
         let mut events = Vec::new();

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -1,16 +1,19 @@
 use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
     dns::Resolver,
-    event::metric::{Metric, MetricKind, MetricValue},
+    event::{
+        metric::{Metric, MetricKind, MetricValue},
+        Event,
+    },
     rusoto::{self, RegionOrEndpoint},
     sinks::util::{
         retries::RetryLogic, BatchConfig, BatchSettings, Compression, MetricBuffer,
-        TowerRequestConfig,
+        PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer, TowerRequestConfig,
     },
 };
 use chrono::{DateTime, SecondsFormat, Utc};
 use futures::{future, future::BoxFuture, FutureExt};
-use futures01::Sink;
+use futures01::{stream::iter_ok, Sink};
 use lazy_static::lazy_static;
 use rusoto_cloudwatch::{
     CloudWatch, CloudWatchClient, Dimension, MetricDatum, PutMetricDataError, PutMetricDataInput,
@@ -31,7 +34,7 @@ pub struct CloudWatchMetricsSvc {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct CloudWatchMetricsSinkConfig {
-    pub namespace: String,
+    pub default_namespace: String,
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
     #[serde(default)]
@@ -87,7 +90,7 @@ impl CloudWatchMetricsSinkConfig {
             ..Default::default()
         };
         let request = PutMetricDataInput {
-            namespace: self.namespace.clone(),
+            namespace: self.default_namespace.clone(),
             metric_data: vec![datum],
         };
 
@@ -123,6 +126,7 @@ impl CloudWatchMetricsSvc {
         client: CloudWatchClient,
         cx: SinkContext,
     ) -> crate::Result<super::VectorSink> {
+        let default_namespace = config.default_namespace.clone();
         let batch = BatchSettings::default()
             .events(20)
             .timeout(1)
@@ -131,21 +135,26 @@ impl CloudWatchMetricsSvc {
 
         let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };
 
-        let sink = request
-            .batch_sink(
-                CloudWatchMetricsRetryLogic,
-                cloudwatch_metrics,
-                MetricBuffer::new(batch.size),
-                batch.timeout,
-                cx.acker(),
-            )
-            .sink_map_err(|error| error!(message = "CloudwatchMetrics sink error.", %error));
+        let svc = request.service(CloudWatchMetricsRetryLogic, cloudwatch_metrics);
+
+        let buffer = PartitionBuffer::new(MetricBuffer::new(batch.size));
+
+        let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
+            .sink_map_err(|error| error!(message = "Fatal CloudwatchMetrics sink error.", %error))
+            .with_flat_map(move |mut event: Event| {
+                let namespace = event
+                    .as_mut_metric()
+                    .namespace
+                    .take()
+                    .unwrap_or_else(|| default_namespace.clone());
+                iter_ok(Some(PartitionInnerBuffer::new(event, namespace)))
+            });
 
         Ok(super::VectorSink::Futures01Sink(Box::new(sink)))
     }
 
-    fn encode_events(&mut self, events: Vec<Metric>) -> PutMetricDataInput {
-        let metric_data: Vec<_> = events
+    fn encode_events(&mut self, events: Vec<Metric>) -> Vec<MetricDatum> {
+        events
             .into_iter()
             .filter_map(|event| {
                 let metric_name = event.name.to_string();
@@ -193,18 +202,11 @@ impl CloudWatchMetricsSvc {
                     },
                 }
             })
-            .collect();
-
-        let namespace = self.config.namespace.clone();
-
-        PutMetricDataInput {
-            namespace,
-            metric_data,
-        }
+            .collect()
     }
 }
 
-impl Service<Vec<Metric>> for CloudWatchMetricsSvc {
+impl Service<PartitionInnerBuffer<Vec<Metric>, String>> for CloudWatchMetricsSvc {
     type Response = ();
     type Error = RusotoError<PutMetricDataError>;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
@@ -213,11 +215,17 @@ impl Service<Vec<Metric>> for CloudWatchMetricsSvc {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, items: Vec<Metric>) -> Self::Future {
-        let input = self.encode_events(items);
-        if input.metric_data.is_empty() {
+    fn call(&mut self, items: PartitionInnerBuffer<Vec<Metric>, String>) -> Self::Future {
+        let (items, namespace) = items.into_parts();
+        let metric_data = self.encode_events(items);
+        if metric_data.is_empty() {
             return future::ready(Ok(())).boxed();
         }
+
+        let input = PutMetricDataInput {
+            namespace,
+            metric_data,
+        };
 
         debug!(message = "Sending data.", input = ?input);
         let client = self.client.clone();

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -191,7 +191,7 @@ mod test {
     fn encodes_counter() {
         let event = Event::Metric(Metric {
             name: "foos".into(),
-            namespace: None,
+            namespace: Some("vector".into()),
             timestamp: Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)),
             tags: Some(
                 vec![
@@ -206,7 +206,7 @@ mod test {
             value: MetricValue::Counter { value: 100.0 },
         });
         assert_eq!(
-            r#"{"name":"foos","timestamp":"2018-11-14T08:09:10.000000011Z","tags":{"Key3":"Value3","key1":"value1","key2":"value2"},"kind":"incremental","counter":{"value":100.0}}"#,
+            r#"{"name":"foos","namespace":"vector","timestamp":"2018-11-14T08:09:10.000000011Z","tags":{"Key3":"Value3","key1":"value1","key2":"value2"},"kind":"incremental","counter":{"value":100.0}}"#,
             encode_event(event, &EncodingConfig::from(Encoding::Json)).unwrap()
         );
     }

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -40,7 +40,6 @@ struct DatadogState {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DatadogConfig {
-    pub namespace: Option<String>,
     // Deprecated name
     #[serde(alias = "host")]
     pub endpoint: Option<String>,
@@ -225,12 +224,11 @@ impl DatadogSink {
 
         let body = match endpoint {
             DatadogEndpoint::Series => {
-                let input = encode_events(events, interval, self.config.namespace.as_deref());
+                let input = encode_events(events, interval);
                 serde_json::to_vec(&input).unwrap()
             }
             DatadogEndpoint::Distribution => {
-                let input =
-                    encode_distribution_events(events, interval, self.config.namespace.as_deref());
+                let input = encode_distribution_events(events, interval);
                 serde_json::to_vec(&input).unwrap()
             }
         };
@@ -338,16 +336,12 @@ fn stats(values: &[f64], counts: &[u32]) -> Option<DatadogStats> {
     })
 }
 
-fn encode_events(
-    events: Vec<Metric>,
-    interval: i64,
-    namespace: Option<&str>,
-) -> DatadogRequest<DatadogMetric> {
+fn encode_events(events: Vec<Metric>, interval: i64) -> DatadogRequest<DatadogMetric> {
     debug!(message = "Series.", count = events.len());
     let series = events
         .into_iter()
         .filter_map(|event| {
-            let fullname = encode_namespace(namespace, '.', &event.name);
+            let fullname = encode_namespace(event.namespace.as_deref(), '.', &event.name);
             let ts = encode_timestamp(event.timestamp);
             let tags = event.tags.clone().map(encode_tags);
             match event.kind {
@@ -451,13 +445,12 @@ fn encode_events(
 fn encode_distribution_events(
     events: Vec<Metric>,
     interval: i64,
-    namespace: Option<&str>,
 ) -> DatadogRequest<DatadogDistributionMetric> {
     debug!(message = "Distribution.", count = events.len());
     let series = events
         .into_iter()
         .filter_map(|event| {
-            let fullname = encode_namespace(namespace, '.', &event.name);
+            let fullname = encode_namespace(event.namespace.as_deref(), '.', &event.name);
             let ts = encode_timestamp(event.timestamp);
             let tags = event.tags.clone().map(encode_tags);
             match event.kind {
@@ -530,7 +523,6 @@ mod tests {
     async fn test_request() {
         let (sink, _cx) = load_sink::<DatadogConfig>(
             r#"
-            namespace = "test"
             api_key = "test"
         "#,
         )
@@ -549,7 +541,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "total".into(),
-                namespace: None,
+                namespace: Some("test".into()),
                 timestamp: None,
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -557,7 +549,7 @@ mod tests {
             },
             Metric {
                 name: "check".into(),
-                namespace: None,
+                namespace: Some("test".into()),
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Incremental,
@@ -565,7 +557,7 @@ mod tests {
             },
             Metric {
                 name: "unsupported".into(),
-                namespace: None,
+                namespace: Some("test".into()),
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Absolute,
@@ -603,7 +595,7 @@ mod tests {
         let events = vec![
             Metric {
                 name: "total".into(),
-                namespace: None,
+                namespace: Some("ns".into()),
                 timestamp: Some(ts()),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -611,7 +603,7 @@ mod tests {
             },
             Metric {
                 name: "check".into(),
-                namespace: None,
+                namespace: Some("ns".into()),
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Incremental,
@@ -619,14 +611,14 @@ mod tests {
             },
             Metric {
                 name: "unsupported".into(),
-                namespace: None,
+                namespace: Some("ns".into()),
                 timestamp: Some(ts()),
                 tags: Some(tags()),
                 kind: MetricKind::Absolute,
                 value: MetricValue::Counter { value: 1.0 },
             },
         ];
-        let input = encode_events(events, interval, Some("ns"));
+        let input = encode_events(events, interval);
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
@@ -655,7 +647,7 @@ mod tests {
                 value: MetricValue::Gauge { value: -1.1 },
             },
         ];
-        let input = encode_events(events, 60, Some(""));
+        let input = encode_events(events, 60);
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
@@ -676,7 +668,7 @@ mod tests {
                 values: vec!["alice".into(), "bob".into()].into_iter().collect(),
             },
         }];
-        let input = encode_events(events, 60, Some(""));
+        let input = encode_events(events, 60);
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
@@ -785,7 +777,7 @@ mod tests {
                 statistic: StatisticKind::Histogram,
             },
         }];
-        let input = encode_events(events, 60, Some(""));
+        let input = encode_events(events, 60);
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(
@@ -809,7 +801,7 @@ mod tests {
                 statistic: StatisticKind::Summary,
             },
         }];
-        let input = encode_distribution_events(events, 60, None);
+        let input = encode_distribution_events(events, 60);
         let json = serde_json::to_string(&input).unwrap();
 
         assert_eq!(

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -4,8 +4,8 @@ use crate::{
     http::HttpClient,
     sinks::{
         influxdb::{
-            encode_namespace, encode_timestamp, healthcheck, influx_line_protocol,
-            influxdb_settings, Field, InfluxDB1Settings, InfluxDB2Settings, ProtocolVersion,
+            encode_timestamp, healthcheck, influx_line_protocol, influxdb_settings, Field,
+            InfluxDB1Settings, InfluxDB2Settings, ProtocolVersion,
         },
         util::{
             encoding::{EncodingConfig, EncodingConfigWithDefault, EncodingConfiguration},
@@ -163,7 +163,12 @@ impl HttpSink for InfluxDBLogsSink {
         let mut event = event.into_log();
 
         // Measurement
-        let measurement = encode_namespace(Some(&self.namespace), '.', "vector");
+        let name = "vector";
+        let measurement = if self.namespace.is_empty() {
+            name.to_string()
+        } else {
+            format!("{}{}{}", self.namespace, '.', name)
+        };
 
         // Timestamp
         let timestamp = encode_timestamp(match event.remove(log_schema().timestamp_key()) {

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -8,6 +8,7 @@ use crate::{
             InfluxDB1Settings, InfluxDB2Settings, ProtocolVersion,
         },
         util::{
+            encode_namespace,
             encoding::{EncodingConfig, EncodingConfigWithDefault, EncodingConfiguration},
             http::{BatchedHttpSink, HttpSink},
             BatchConfig, BatchSettings, Buffer, Compression, TowerRequestConfig,
@@ -164,11 +165,11 @@ impl HttpSink for InfluxDBLogsSink {
 
         // Measurement
         let name = "vector";
-        let measurement = if self.namespace.is_empty() {
-            name.to_string()
-        } else {
-            format!("{}{}{}", self.namespace, '.', name)
-        };
+        let measurement = encode_namespace(
+            Some(self.namespace.as_str()).filter(|namespace| !namespace.is_empty()),
+            '.',
+            name,
+        );
 
         // Timestamp
         let timestamp = encode_timestamp(match event.remove(log_schema().timestamp_key()) {

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -406,7 +406,6 @@ mod tests {
             "ns.total,metric_type=counter value=1.5 1542182950000000011\n\
             ns.check,metric_type=counter,normal_tag=value,true_tag=true value=1 1542182950000000011"
         );
-        None
     }
 
     #[test]

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -589,7 +589,7 @@ mod tests {
             },
         }];
 
-        let line_protocols = encode_events(ProtocolVersion::V2, None, events, None, &[]);
+        let line_protocols = encode_events(ProtocolVersion::V2, events, None, None, &[]);
         let line_protocols: Vec<&str> = line_protocols.split('\n').collect();
         assert_eq!(line_protocols.len(), 1);
 

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -1,7 +1,7 @@
 pub mod logs;
 pub mod metrics;
 
-use crate::{http::HttpClient, sinks::util::encode_namespace};
+use crate::http::HttpClient;
 use chrono::{DateTime, Utc};
 use futures::FutureExt;
 use http::{StatusCode, Uri};

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -73,7 +73,7 @@ pub fn default_flush_period_secs() -> u64 {
 impl Default for PrometheusSinkConfig {
     fn default() -> Self {
         Self {
-            namespace: None,
+            default_namespace: None,
             address: default_address(),
             buckets: default_histogram_buckets(),
             quantiles: default_summary_quantiles(),

--- a/src/sinks/prometheus.rs
+++ b/src/sinks/prometheus.rs
@@ -616,7 +616,7 @@ mod tests {
             header,
             "# HELP vector_requests requests\n# TYPE vector_requests histogram\n".to_owned()
         );
-        assert_eq!(frame, "vector_requests_bucket{le=\"0\"} 0\nvector_requests_bucket{le=\"2.5\"} 6\nvector_requests_bucket{le=\"5\"} 8\nvector_requests_bucket{le=\"+Inf\"} 8\nvector_requests_sum 15\nrequests_count 8\n".to_owned());
+        assert_eq!(frame, "vector_requests_bucket{le=\"0\"} 0\nvector_requests_bucket{le=\"2.5\"} 6\nvector_requests_bucket{le=\"5\"} 8\nvector_requests_bucket{le=\"+Inf\"} 8\nvector_requests_sum 15\nvector_requests_count 8\n".to_owned());
     }
 
     #[test]

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -31,6 +31,7 @@ struct SematextMetricsService {
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 struct SematextMetricsConfig {
+    pub default_namespace: String,
     pub region: Option<Region>,
     pub endpoint: Option<String>,
     pub token: String,
@@ -48,6 +49,7 @@ impl GenerateConfig for SematextMetricsConfig {
     fn generate_config() -> toml::Value {
         toml::from_str(
             r#"region = "us"
+            default_namespace = "vector"
             token = "${SEMATEXT_TOKEN}""#,
         )
         .unwrap()
@@ -170,7 +172,7 @@ impl Service<Vec<Metric>> for SematextMetricsService {
     }
 
     fn call(&mut self, items: Vec<Metric>) -> Self::Future {
-        let input = encode_events(&self.config.token, items);
+        let input = encode_events(&self.config.token, &self.config.default_namespace, items);
         let body: Vec<u8> = input.into_bytes();
 
         self.inner.call(body)
@@ -190,22 +192,13 @@ fn create_build_request(
     }
 }
 
-/// Sematext takes the first part of the name as the namespace for the event.
-/// The rest of the name is the value label.
-/// If the name is not a '.' separated string, it will take the whole name as the
-/// namespace, and set the label value to 'value'.
-/// This probably should not happen if you want meaningful metrics in Sematext.
-fn split_event_name(name: &str) -> (String, String) {
-    match name.find('.') {
-        None => (name.into(), "value".into()),
-        Some(pos) => (name[0..pos].into(), name[pos + 1..].into()),
-    }
-}
-
-fn encode_events(token: &str, events: Vec<Metric>) -> String {
+fn encode_events(token: &str, default_namespace: &str, events: Vec<Metric>) -> String {
     let mut output = String::new();
     for event in events.into_iter() {
-        let (namespace, label) = split_event_name(&event.name);
+        let namespace = event
+            .namespace
+            .unwrap_or_else(|| default_namespace.to_string());
+        let label = event.name;
         let ts = encode_timestamp(event.timestamp);
 
         // Authentication in Sematext is by inserting the token as a tag.
@@ -266,8 +259,8 @@ mod tests {
     #[test]
     fn test_encode_counter_event() {
         let events = vec![Metric {
-            name: "jvm.pool.used".into(),
-            namespace: None,
+            name: "pool.used".into(),
+            namespace: Some("jvm".into()),
             timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)),
             tags: None,
             kind: MetricKind::Incremental,
@@ -276,7 +269,7 @@ mod tests {
 
         assert_eq!(
             "jvm,metric_type=counter,token=aaa pool.used=42 1597784400000000000",
-            encode_events("aaa", events)
+            encode_events("aaa", "ns", events)
         );
     }
 
@@ -292,8 +285,8 @@ mod tests {
         }];
 
         assert_eq!(
-            "used,metric_type=counter,token=aaa value=42 1597784400000000000",
-            encode_events("aaa", events)
+            "ns,metric_type=counter,token=aaa used=42 1597784400000000000",
+            encode_events("aaa", "ns", events)
         );
     }
 
@@ -301,16 +294,16 @@ mod tests {
     fn test_encode_counter_multiple_events() {
         let events = vec![
             Metric {
-                name: "jvm.pool.used".into(),
-                namespace: None,
+                name: "pool.used".into(),
+                namespace: Some("jvm".into()),
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)),
                 tags: None,
                 kind: MetricKind::Incremental,
                 value: MetricValue::Counter { value: 42.0 },
             },
             Metric {
-                name: "jvm.pool.committed".into(),
-                namespace: None,
+                name: "pool.committed".into(),
+                namespace: Some("jvm".into()),
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 1)),
                 tags: None,
                 kind: MetricKind::Incremental,
@@ -321,7 +314,7 @@ mod tests {
         assert_eq!(
             "jvm,metric_type=counter,token=aaa pool.used=42 1597784400000000000\n\
              jvm,metric_type=counter,token=aaa pool.committed=18874368 1597784400000000001",
-            encode_events("aaa", events)
+            encode_events("aaa", "ns", events)
         );
     }
 
@@ -330,6 +323,7 @@ mod tests {
         let (mut config, cx) = load_sink::<SematextMetricsConfig>(
             r#"
             region = "eu"
+            default_namespace = "ns"
             token = "atoken"
             batch.max_events = 1
             "#,
@@ -350,22 +344,22 @@ mod tests {
 
         // Make our test metrics.
         let metrics = vec![
-            ("os.swap.size", 324292.0),
-            ("os.network.tx", 42000.0),
-            ("os.network.rx", 54293.0),
-            ("process.count", 12.0),
-            ("process.uptime", 32423.0),
-            ("process.rss", 2342333.0),
-            ("jvm.pool.used", 18874368.0),
-            ("jvm.pool.committed", 18868584.0),
-            ("jvm.pool.max", 18874368.0),
+            ("os", "swap.size", 324292.0),
+            ("os", "network.tx", 42000.0),
+            ("os", "network.rx", 54293.0),
+            ("process", "count", 12.0),
+            ("process", "uptime", 32423.0),
+            ("process", "rss", 2342333.0),
+            ("jvm", "pool.used", 18874368.0),
+            ("jvm", "pool.committed", 18868584.0),
+            ("jvm", "pool.max", 18874368.0),
         ];
 
         let mut events = Vec::new();
-        for (i, (metric, val)) in metrics.iter().enumerate() {
+        for (i, (namespace, metric, val)) in metrics.iter().enumerate() {
             let event = Event::from(Metric {
                 name: metric.to_string(),
-                namespace: None,
+                namespace: Some(namespace.into()),
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, i as u32)),
                 tags: Some(
                     vec![("os.host".to_owned(), "somehost".to_owned())]

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -359,7 +359,7 @@ mod tests {
         for (i, (namespace, metric, val)) in metrics.iter().enumerate() {
             let event = Event::from(Metric {
                 name: metric.to_string(),
-                namespace: Some(namespace.into()),
+                namespace: Some(namespace.to_string()),
                 timestamp: Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, i as u32)),
                 tags: Some(
                     vec![("os.host".to_owned(), "somehost".to_owned())]

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -81,19 +81,14 @@ pub fn encode_event(mut event: Event, encoding: &EncodingConfig<Encoding>) -> Op
     .ok()
 }
 
-/// Joins namespace with name via delimiter if namespace is present and not empty.
+/// Joins namespace with name via delimiter if namespace is present.
 pub fn encode_namespace<'a>(
     namespace: Option<&str>,
     delimiter: char,
     name: impl Into<Cow<'a, str>>,
 ) -> String {
     let name = name.into();
-    match namespace {
-        Some(namespace) if namespace.is_empty() => {
-            warn!("Dropping empty namespace. This feature has been deprecated, and could be removed in the future.");
-            name.into_owned()
-        }
-        Some(namespace) => format!("{}{}{}", namespace, delimiter, name),
-        _ => name.into_owned(),
-    }
+    namespace
+        .map(|namespace| format!("{}{}{}", namespace, delimiter, name))
+        .unwrap_or_else(|| name.into_owned())
 }

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -251,7 +251,7 @@ mod test {
             &["in"],
             PrometheusSinkConfig {
                 address: out_addr,
-                default_namespace: "vector".into(),
+                default_namespace: Some("vector".into()),
                 buckets: vec![1.0, 2.0, 4.0],
                 quantiles: vec![],
                 flush_period_secs: 1,

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -251,7 +251,7 @@ mod test {
             &["in"],
             PrometheusSinkConfig {
                 address: out_addr,
-                namespace: Some("vector".into()),
+                default_namespace: "vector".into(),
                 buckets: vec![1.0, 2.0, 4.0],
                 quantiles: vec![],
                 flush_period_secs: 1,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -284,7 +284,7 @@ mod test {
             &["in"],
             PrometheusSinkConfig {
                 address: out_addr,
-                namespace: Some("vector".into()),
+                default_namespace: "vector".into(),
                 buckets: vec![1.0, 2.0, 4.0],
                 quantiles: vec![],
                 flush_period_secs: 1,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -284,7 +284,7 @@ mod test {
             &["in"],
             PrometheusSinkConfig {
                 address: out_addr,
-                default_namespace: "vector".into(),
+                default_namespace: Some("vector".into()),
                 buckets: vec![1.0, 2.0, 4.0],
                 quantiles: vec![],
                 flush_period_secs: 1,

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -46,7 +46,7 @@ const PROMETHEUS_SINK_CONFIG: &'static str = r#"
 
     [sinks.out]
         type = "prometheus"
-        namespace = "vector"
+        default_namespace = "vector"
         inputs = ["log_to_metric"]
         address = "${VECTOR_TEST_ADDRESS}"
         namespace = "service"

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -46,10 +46,9 @@ const PROMETHEUS_SINK_CONFIG: &'static str = r#"
 
     [sinks.out]
         type = "prometheus"
-        default_namespace = "vector"
+        default_namespace = "service"
         inputs = ["log_to_metric"]
         address = "${VECTOR_TEST_ADDRESS}"
-        namespace = "service"
 "#;
 
 fn source_config(source: &str) -> String {

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -46,6 +46,7 @@ const PROMETHEUS_SINK_CONFIG: &'static str = r#"
 
     [sinks.out]
         type = "prometheus"
+        namespace = "vector"
         inputs = ["log_to_metric"]
         address = "${VECTOR_TEST_ADDRESS}"
         namespace = "service"


### PR DESCRIPTION
Ref. #3896 
Closes #4722

Contains:
* Updates to usage of `namespace` in metric sinks. 
* Removes `namespace` option (breaking change) from:
    * `aws_cloudwatch_metrics` 
    * `datadog_metrics`
    * `influxdb_metrics`
    * `prometheus`
    * `statsd`
* Adds required `default_namespace` option to:
    * `aws_cloudwatch_metrics`
    * `sematext_metrics`
- [x] Adds optional `default_namespace` option to:
     - `datadog_metrics`
     - `influxdb_metrics`
     - `statsd`
     - [x] `prometheus`


    

### Todo

- [x] add integration tests for CloudWatch metrics to verify the namespace partitioning behavior.

### Open questions

- [x]  Not sure that we would want namespace be only partially integrated in the next release, so should we hold of merging this until then? EDIT: Everything is ready, so I'll go ahead with merger.

- [x] Open issue to change `influxdb_logs` option `namespace: String` to `namespace: Option<String>` EDIT: Since we are leaving meaning "empty String => None" in sources, it also fine for this to remain like this.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
