### PR TITLE
enhancement(log_to_metric transform): Add `namespace` option

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -496,8 +496,9 @@ _values: {
 }
 
 #MetricEvent: {
-	kind: "incremental" | "absolute"
-	name: string
+	kind:       "incremental" | "absolute"
+	name:       string
+	namespace?: string
 	tags: [Name=string]: string
 	timestamp?: string
 	close({counter: #MetricEventCounter}) |

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -75,7 +75,7 @@ components: transforms: log_to_metric: {
 						warnings: []
 						type: string: {
 							examples: ["service"]
-							default:      string
+							default:      null
 							templateable: true
 						}
 					}
@@ -143,9 +143,10 @@ components: transforms: log_to_metric: {
 			configuration: {
 				metrics: [
 					{
-						type:  "counter"
-						field: "status"
-						name:  "response_total"
+						type:      "counter"
+						field:     "status"
+						name:      "response_total"
+						namespace: "service"
 						tags: {
 							status: "{{status}}"
 							host:   "{{host}}"
@@ -159,8 +160,9 @@ components: transforms: log_to_metric: {
 				status:  200
 			}
 			output: [{metric: {
-				kind: "incremental"
-				name: "response_total"
+				kind:      "incremental"
+				name:      "response_total"
+				namespace: "service"
 				tags: {
 					status: "200"
 					host:   "10.22.11.222"
@@ -347,8 +349,9 @@ components: transforms: log_to_metric: {
 			configuration: {
 				metrics: [
 					{
-						type:  "set"
-						field: "remote_addr"
+						type:      "set"
+						field:     "remote_addr"
+						namespace: "{{branch}}"
 						tags: {
 							host: "{{host}}"
 						}
@@ -359,10 +362,12 @@ components: transforms: log_to_metric: {
 				host:        "10.22.11.222"
 				message:     "Sent 200 in 54.2ms"
 				remote_addr: "233.221.232.22"
+				branch:      "dev"
 			}
 			output: [{metric: {
-				kind: "incremental"
-				name: "remote_addr"
+				kind:      "incremental"
+				name:      "remote_addr"
+				namespace: "dev"
 				tags: {
 					host: "10.22.11.222"
 				}

--- a/docs/reference/components/transforms/log_to_metric.cue
+++ b/docs/reference/components/transforms/log_to_metric.cue
@@ -68,6 +68,17 @@ components: transforms: log_to_metric: {
 							templateable: true
 						}
 					}
+					namespace: {
+						description: "The namespace of the metric."
+						required:    false
+						common:      true
+						warnings: []
+						type: string: {
+							examples: ["service"]
+							default:      string
+							templateable: true
+						}
+					}
 					tags: {
 						description: "Key/value pairs representing [metric tags][docs.data-model.metric#tags]."
 						required:    false

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -830,6 +830,7 @@ mod reload_tests {
             metrics: vec![MetricConfig::Gauge(GaugeConfig {
                 field: "message".to_string(),
                 name: None,
+                namespace: None,
                 tags: None,
             })],
         };


### PR DESCRIPTION
Ref. #3896 

Updates transforms to expose `namespace` field. Only `log_to_metric` transform needed to be changed. 

Adds `namespace` option to `log_to_metric` transform which is templateable and sets `namespace` field of created metric.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
