### PR TITLE
chore(config): Add documentation for enabling auto-concurrency mode

### DIFF
--- a/docs/reference.cue
+++ b/docs/reference.cue
@@ -425,6 +425,7 @@ _values: {
 		enabled: bool
 
 		if enabled {
+			auto_concurrency:           bool | *true
 			in_flight_limit:            uint8 | *5
 			rate_limit_duration_secs:   uint8
 			rate_limit_num:             uint16

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -204,9 +204,14 @@ components: sinks: [Name=string]: {
 						examples: []
 						options: {
 							in_flight_limit: {
-								common:      true
-								description: "The maximum number of in-flight requests allowed at any given time."
-								required:    false
+								common: true
+								if sinks[Name].features.send.request.auto_concurrency {
+									description: "The maximum number of in-flight requests allowed at any given time, or \"auto\" to allow Vector to automatically set the limit based on current network and service conditions."
+								}
+								if !sinks[Name].features.send.request.auto_concurrency {
+									description: "The maximum number of in-flight requests allowed at any given time."
+								}
+								required: false
 								type: uint: {
 									default: sinks[Name].features.send.request.in_flight_limit
 									unit:    "requests"

--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -203,6 +203,34 @@ components: sinks: [Name=string]: {
 					type: object: {
 						examples: []
 						options: {
+							auto_concurrency: {
+								common:      false
+								description: "Configure the auto-concurrency algorithms. These values have been tuned by optimizing simulated results. In general you should not need to adjust these."
+								required:    false
+								type: object: {
+									examples: []
+									options: {
+										decrease_ratio: {
+											common:      false
+											description: "The fraction of the current value to set the new concurrency limit when decreasing the limit. Valid values are greater than 0 and less than 1. Smaller values cause the algorithm to scale back rapidly when latency increases. Note that the new limit is rounded down after applying this ratio."
+											required:    false
+											type: float: default: 0.9
+										}
+										ewma_alpha: {
+											common:      false
+											description: "The auto-concurrency algorithm uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with the current RTT. This value controls how heavily new measurements are weighted compared to older ones. Valid values are greater than 0 and less than 1. Smaller values cause this reference to adjust more slowly, which may be useful if a service has unusually high response variability."
+											required:    false
+											type: float: default: 0.7
+										}
+										rtt_threshold_ratio: {
+											common:      false
+											description: "When comparing the past RTT average to the current measurements, we ignore changes that are less than this ratio higher than the past RTT. Valid values are greater than or equal to 0. Larger values cause the algorithm to ignore larger increases in the RTT."
+											required:    false
+											type: float: default: 0.05
+										}
+									}
+								}
+							}
 							in_flight_limit: {
 								common: true
 								if sinks[Name].features.send.request.auto_concurrency {

--- a/docs/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/docs/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -39,6 +39,7 @@ components: sinks: aws_cloudwatch_logs: {
 			}
 			request: {
 				enabled:                    true
+				auto_concurrency:           false
 				in_flight_limit:            5
 				rate_limit_duration_secs:   1
 				rate_limit_num:             5


### PR DESCRIPTION
Add a note to the sink metadata about the auto-concurrency setting for `request.in_flight_limit`. As far as I can determine, this is available for all sinks for which `request` is enabled except for `aws_cloudwatch_logs` which has its own service structure.

Signed-off-by: Bruce Guenter <bruce@timber.io>