### PR TITLE
fix(remap): unescape forward slash in regex

### DIFF
--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -267,7 +267,12 @@ impl Parser<'_> {
     fn regex_from_pair(&self, pair: Pair<R>) -> Result<Regex> {
         let mut inner = pair.into_inner();
 
-        let pattern = inner.next().ok_or(e(R::regex_inner))?.as_str();
+        let pattern = inner
+            .next()
+            .ok_or(e(R::regex_inner))?
+            .as_str()
+            .replace("\\/", "/");
+
         let (x, i, m) = inner
             .next()
             .map(|flags| {
@@ -283,7 +288,7 @@ impl Parser<'_> {
             })
             .unwrap_or_default();
 
-        RegexBuilder::new(pattern)
+        RegexBuilder::new(&pattern)
             .case_insensitive(i)
             .multi_line(m)
             .ignore_whitespace(x)


### PR DESCRIPTION
Rust's `regex` crate takes its regex as a string, such as:

```rust
regex::Regex::new("hello / world")
```

In Remap, a regex is surrounded by forward slashes, which requires forward slashes inside the regex to be escaped:

```javascript
match(.foo, /hello \/ world/)
```

Before, we'd pass the entire value `hello \/ world` to `Regex::new` as a string, which would result in an error, since it doesn't accept escaped forward slashes.

This PR unescapes those slashes, so that the regex can be properly parsed by the `regex` crate.