### PR TITLE
enhancement(prometheus source): Add TLS and authentication options

### DIFF
--- a/docs/reference/components/sources/prometheus.cue
+++ b/docs/reference/components/sources/prometheus.cue
@@ -31,6 +31,13 @@ components: sources: prometheus: {
 					ssl: "optional"
 				}
 			}
+			tls: {
+				enabled:                true
+				can_enable:             false
+				can_verify_certificate: true
+				can_verify_hostname:    true
+				enabled_default:        false
+			}
 		}
 		multiline: enabled: false
 	}

--- a/docs/reference/components/sources/prometheus.cue
+++ b/docs/reference/components/sources/prometheus.cue
@@ -76,6 +76,52 @@ components: sources: prometheus: {
 				unit:    "seconds"
 			}
 		}
+		auth: {
+			common:      false
+			description: "Options for the authentication strategy."
+			required:    false
+			warnings: []
+			type: object: {
+				examples: []
+				options: {
+					password: {
+						description: "The basic authentication password."
+						required:    true
+						warnings: []
+						type: string: {
+							examples: ["${PROMETHEUS_PASSWORD}", "password"]
+						}
+					}
+					strategy: {
+						description: "The authentication strategy to use."
+						required:    true
+						warnings: []
+						type: string: {
+							enum: {
+								basic:  "The [basic authentication strategy](\(urls.basic_auth))."
+								bearer: "The bearer token authentication strategy."
+							}
+						}
+					}
+					token: {
+						description: "The token to use for bearer authentication"
+						required:    true
+						warnings: []
+						type: string: {
+							examples: ["${API_TOKEN}", "xyz123"]
+						}
+					}
+					user: {
+						description: "The basic authentication user name."
+						required:    true
+						warnings: []
+						type: string: {
+							examples: ["${PROMETHEUS_USERNAME}", "username"]
+						}
+					}
+				}
+			}
+		}
 	}
 
 	output: metrics: {

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -261,6 +261,7 @@ mod test {
             PrometheusConfig {
                 endpoints: vec![format!("http://{}", in_addr)],
                 scrape_interval_secs: 1,
+                tls: None,
             },
         );
         config.add_sink(


### PR DESCRIPTION
Closes #3797 
Supercedes #4878 

The `auth` config metadata is shared with the Clickhouse sink. Some better way of sharing that stanza would be good, but I am unclear what is the best option for that.