### PR TITLE
enhancement(observability): Batch events processed total

### DIFF
--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -249,16 +249,16 @@ pub fn component_counter_metrics_batch(
     get_metrics_sorted_batch(interval).map(move |m| {
         m.into_iter()
             .filter(filter_fn)
-            .filter_map(|m| match m.tag_value("component_name") {
-                Some(name) => match m.value {
+            .filter_map(|m| {
+                let component_name = m.tag_value("component_name")?;
+                match m.value {
                     MetricValue::Counter { value }
-                        if cache.insert(name, value).unwrap_or(0.00) < value =>
+                        if cache.insert(component_name, value).unwrap_or(0.00) < value =>
                     {
                         Some(m)
                     }
                     _ => None,
-                },
-                _ => None,
+                }
             })
             .collect()
     })


### PR DESCRIPTION
Adds a new `componentEventsProcessedTotalBatch` subscription, to introduce the option of receiving an array of payloads over `interval` alongside individual streams. 

@sghall brought this to my attention as potentially useful for the web UI, where it might be less expensive to update state atomically against a single `interval` vs. every stream, which can be numerous.

It also has the side-effect of shaving off a few bytes from the total payload, not repeating the typical ` { data { ... } }` setup.

## Example

Previously, we had this:

```gql
subscription {
  componentEventsProcessedTotal(interval:1000) {
    name
    metric {
      eventsProcessedTotal
    }
  }
}
```

Which returned individual payloads, like:

```json
{
  "data": {
    "componentEventsProcessedTotal": {
      "metric": {
        "eventsProcessedTotal": 52488
      },
      "name": "gen7"
    }
  }
}
```

This still exists, but now we also have:

```gql
subscription {
  componentEventsProcessedTotalBatch(interval:1000) {
    name
    metric {
      eventsProcessedTotal
    }
  }
}
```

Which returns _all_ metrics within the `interval` period as an array:

```json
{
  "data": {
    "componentEventsProcessedTotalBatch": [
      {
        "metric": {
          "eventsProcessedTotal": 55078
        },
        "name": "gen4"
      },
      {
        "metric": {
          "eventsProcessedTotal": 55078
        },
        "name": "gen7"
      },
      {
        "metric": {
          "eventsProcessedTotal": 55078
        },
        "name": "gen1"
      },
      {
        "metric": {
          "eventsProcessedTotal": 55078
        },
        "name": "gen5"
      },
      {
        "metric": {
          "eventsProcessedTotal": 55078
        },
        "name": "gen1_add_field"
      },
      {
        "metric": {
          "eventsProcessedTotal": 110156
        },
        "name": "out"
      }
    ]
  }
}
```

---

@sghall, if you like this approach, I'll roll it out to the other subscriptions separately.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
