### PR TITLE
enhancement: Extend `Resource` to sources 

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -590,10 +590,10 @@ mod resource_tests {
             r#"
         [sources.in0]
         type = "stdin"
-  
+
         [sources.in1]
         type = "stdin"
-  
+
         [sinks.out]
         type = "console"
         inputs = ["in0","in1"]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -259,6 +259,7 @@ inventory::collect!(TransformDescription);
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Resource {
     Port(u16),
+    SystemFdOffset(usize),
 }
 
 impl Resource {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -257,7 +257,7 @@ inventory::collect!(TransformDescription);
 /// Unique thing, like port, of which only one owner can be.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Resource {
-    Port(u16),
+    Port(SocketAddr),
     SystemFdOffset(usize),
     Stdin,
 }
@@ -268,8 +268,17 @@ impl Resource {
         components: impl IntoIterator<Item = (K, Vec<Resource>)>,
     ) -> HashSet<K> {
         let mut resource_map = HashMap::<Resource, HashSet<K>>::new();
+        let mut unspecified = Vec::new();
+
+        // Find equality based conflicts
         for (key, resources) in components {
             for resource in resources {
+                if let Resource::Port(address) = &resource {
+                    if address.ip().is_unspecified() {
+                        unspecified.push((key.clone(), address.port()));
+                    }
+                }
+
                 resource_map
                     .entry(resource)
                     .or_default()
@@ -277,17 +286,30 @@ impl Resource {
             }
         }
 
+        // Port with unspecified address will bind to all network interfaces
+        // so we have to check for all Port resources if they share the same
+        // port.
+        for (key, port) in unspecified {
+            for (resource, components) in resource_map.iter_mut() {
+                if let Resource::Port(address) = resource {
+                    if address.port() == port {
+                        components.insert(key.clone());
+                    }
+                }
+            }
+        }
+
         resource_map
             .into_iter()
-            .filter(|(_, componenets)| componenets.len() > 1)
-            .flat_map(|(_, componenets)| componenets)
+            .filter(|(_, components)| components.len() > 1)
+            .flat_map(|(_, components)| components)
             .collect()
     }
 }
 
 impl From<SocketAddr> for Resource {
     fn from(addr: SocketAddr) -> Self {
-        Self::Port(addr.port())
+        Self::Port(addr)
     }
 }
 
@@ -547,41 +569,72 @@ mod test {
 mod resource_tests {
     use super::{load_from_str, Resource};
     use std::collections::HashSet;
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    fn localhost(port: u16) -> Resource {
+        SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port).into()
+    }
 
     #[test]
     fn valid() {
-        let componenets = vec![
-            ("sink_0", vec![Resource::Port(0)]),
-            ("sink_1", vec![Resource::Port(1)]),
-            ("sink_2", vec![Resource::Port(2)]),
+        let components = vec![
+            ("sink_0", vec![localhost(0)]),
+            ("sink_1", vec![localhost(1)]),
+            ("sink_2", vec![localhost(2)]),
         ];
-        let conflicting = Resource::conflicts(componenets);
+        let conflicting = Resource::conflicts(components);
         assert_eq!(conflicting, HashSet::new());
     }
 
     #[test]
     fn conflicting_pair() {
-        let componenets = vec![
-            ("sink_0", vec![Resource::Port(0)]),
-            ("sink_1", vec![Resource::Port(2)]),
-            ("sink_2", vec![Resource::Port(2)]),
+        let components = vec![
+            ("sink_0", vec![localhost(0)]),
+            ("sink_1", vec![localhost(2)]),
+            ("sink_2", vec![localhost(2)]),
         ];
-        let conflicting = Resource::conflicts(componenets);
+        let conflicting = Resource::conflicts(components);
         assert_eq!(conflicting, vec!["sink_1", "sink_2"].into_iter().collect());
     }
 
     #[test]
     fn conflicting_multi() {
-        let componenets = vec![
-            ("sink_0", vec![Resource::Port(0)]),
-            ("sink_1", vec![Resource::Port(2), Resource::Port(0)]),
-            ("sink_2", vec![Resource::Port(2)]),
+        let components = vec![
+            ("sink_0", vec![localhost(0)]),
+            ("sink_1", vec![localhost(2), localhost(0)]),
+            ("sink_2", vec![localhost(2)]),
         ];
-        let conflicting = Resource::conflicts(componenets);
+        let conflicting = Resource::conflicts(components);
         assert_eq!(
             conflicting,
             vec!["sink_0", "sink_1", "sink_2"].into_iter().collect()
         );
+    }
+
+    #[test]
+    fn different_network_interface() {
+        let components = vec![
+            ("sink_0", vec![localhost(0)]),
+            (
+                "sink_1",
+                vec![SocketAddr::new(Ipv4Addr::new(127, 0, 0, 2).into(), 0).into()],
+            ),
+        ];
+        let conflicting = Resource::conflicts(components);
+        assert_eq!(conflicting, HashSet::new());
+    }
+
+    #[test]
+    fn unspecified_network_interface() {
+        let components = vec![
+            ("sink_0", vec![localhost(0)]),
+            (
+                "sink_1",
+                vec![SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0).into()],
+            ),
+        ];
+        let conflicting = Resource::conflicts(components);
+        assert_eq!(conflicting, vec!["sink_0", "sink_1"].into_iter().collect());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,7 @@ use snafu::{ResultExt, Snafu};
 use std::collections::{HashMap, HashSet};
 use std::fs::DirBuilder;
 use std::hash::Hash;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 pub mod api;
@@ -260,6 +261,7 @@ inventory::collect!(TransformDescription);
 pub enum Resource {
     Port(u16),
     SystemFdOffset(usize),
+    Stdin,
 }
 
 impl Resource {
@@ -282,6 +284,12 @@ impl Resource {
             .filter(|(_, componenets)| componenets.len() > 1)
             .flat_map(|(_, componenets)| componenets)
             .collect()
+    }
+}
+
+impl From<SocketAddr> for Resource {
+    fn from(addr: SocketAddr) -> Self {
+        Self::Port(addr.port())
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -161,6 +161,11 @@ pub trait SourceConfig: core::fmt::Debug + Send + Sync {
     fn output_type(&self) -> DataType;
 
     fn source_type(&self) -> &'static str;
+
+    /// Resources that the source is using.
+    fn resources(&self) -> Vec<Resource> {
+        Vec::new()
+    }
 }
 
 pub type SourceDescription = ComponentDescription<Box<dyn SourceConfig>>;
@@ -192,7 +197,7 @@ pub trait SinkConfig: core::fmt::Debug + Send + Sync {
 
     /// Resources that the sink is using.
     /// These resources shouldn't be used in the build method as that can result
-    /// in a build error. Only the sinks are constrained by this.
+    /// in a build error. Only sinks are constrained by this.
     fn resources(&self) -> Vec<Resource> {
         Vec::new()
     }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -47,12 +47,17 @@ pub fn check_shape(config: &Config) -> Result<(), Vec<String>> {
 }
 
 pub fn check_resources(config: &Config) -> Result<(), Vec<String>> {
-    let conflicting_componenets = Resource::conflicts(
-        config
-            .sinks
-            .iter()
-            .map(|(name, config)| (name, config.inner.resources())),
-    );
+    let source_resources = config
+        .sources
+        .iter()
+        .map(|(name, config)| (name, config.resources()));
+    let sink_resources = config
+        .sinks
+        .iter()
+        .map(|(name, config)| (name, config.inner.resources()));
+
+    let conflicting_componenets = Resource::conflicts(source_resources.chain(sink_resources));
+
     if conflicting_componenets.is_empty() {
         Ok(())
     } else {
@@ -61,7 +66,7 @@ pub fn check_resources(config: &Config) -> Result<(), Vec<String>> {
             .map(|s| s.as_str())
             .collect::<Vec<_>>();
         let error = format!(
-            "Multiple sinks own the same resource. Conflicting sinks: {}.",
+            "Multiple components own the same resource. Conflicting components: {}.",
             conflicting_componenets.join(", ")
         );
         Err(vec![error])

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -114,7 +114,7 @@ impl SinkConfig for PrometheusExporterConfig {
     }
 
     fn resources(&self) -> Vec<Resource> {
-        vec![Resource::Port(self.address.port())]
+        vec![self.address.into()]
     }
 }
 

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig, SourceDescription},
     shutdown::ShutdownSignal,
     tls::{MaybeTlsSettings, TlsConfig},
     Pipeline,
@@ -55,6 +55,10 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
 
     fn source_type(&self) -> &'static str {
         "aws_kinesis_firehose"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![self.address.into()]
     }
 }
 

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig,
+        SourceDescription,
     },
     event::{Event, Value},
     shutdown::ShutdownSignal,
@@ -111,6 +112,10 @@ impl SourceConfig for SimpleHttpConfig {
 
     fn source_type(&self) -> &'static str {
         "http"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![self.address.into()]
     }
 }
 

--- a/src/sources/logplex.rs
+++ b/src/sources/logplex.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig,
+        SourceDescription,
     },
     event::Event,
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
@@ -85,6 +86,10 @@ impl SourceConfig for LogplexConfig {
 
     fn source_type(&self) -> &'static str {
         "logplex"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![self.address.into()]
     }
 }
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -6,7 +6,8 @@ mod unix;
 use super::util::TcpSource;
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig,
+        SourceDescription,
     },
     shutdown::ShutdownSignal,
     tls::MaybeTlsSettings,
@@ -135,6 +136,15 @@ impl SourceConfig for SocketConfig {
 
     fn source_type(&self) -> &'static str {
         "socket"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        match self.mode.clone() {
+            Mode::Tcp(tcp) => vec![tcp.address.into()],
+            Mode::Udp(udp) => vec![udp.address.into()],
+            #[cfg(unix)]
+            Mode::Unix(_) => vec![],
+        }
     }
 }
 

--- a/src/sources/splunk_hec.rs
+++ b/src/sources/splunk_hec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, Resource, SourceConfig, SourceDescription},
     event::{Event, LogEvent, Value},
     internal_events::{
         SplunkHECEventReceived, SplunkHECRequestBodyInvalid, SplunkHECRequestError,
@@ -134,6 +134,10 @@ impl SourceConfig for SplunkConfig {
 
     fn source_type(&self) -> &'static str {
         "splunk_hec"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![self.address.into()]
     }
 }
 

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{self, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{self, GenerateConfig, GlobalOptions, Resource, SourceConfig, SourceDescription},
     internal_events::{StatsdEventReceived, StatsdInvalidRecord, StatsdSocketError},
     shutdown::ShutdownSignal,
     sources::util::{SocketListenAddr, TcpSource},
@@ -97,6 +97,15 @@ impl SourceConfig for StatsdConfig {
 
     fn source_type(&self) -> &'static str {
         "statsd"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        match self.clone() {
+            Self::Tcp(tcp) => vec![tcp.address.into()],
+            Self::Udp(udp) => vec![udp.address.into()],
+            #[cfg(unix)]
+            Self::Unix(_) => vec![],
+        }
     }
 }
 

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{log_schema, DataType, GlobalOptions, SourceConfig, SourceDescription},
+    config::{log_schema, DataType, GlobalOptions, Resource, SourceConfig, SourceDescription},
     event::Event,
     internal_events::{StdinEventReceived, StdinReadFailed},
     shutdown::ShutdownSignal,
@@ -60,6 +60,10 @@ impl SourceConfig for StdinConfig {
 
     fn source_type(&self) -> &'static str {
         "stdin"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![Resource::Stdin]
     }
 }
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -3,7 +3,8 @@ use super::util::{SocketListenAddr, TcpSource};
 use crate::sources::util::build_unix_source;
 use crate::{
     config::{
-        log_schema, DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription,
+        log_schema, DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig,
+        SourceDescription,
     },
     event::{Event, Value},
     internal_events::{SyslogEventReceived, SyslogUdpReadError, SyslogUdpUtf8Error},
@@ -132,6 +133,15 @@ impl SourceConfig for SyslogConfig {
 
     fn source_type(&self) -> &'static str {
         "syslog"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        match self.mode.clone() {
+            Mode::Tcp { address, .. } => vec![address.into()],
+            Mode::Udp { address } => vec![address.into()],
+            #[cfg(unix)]
+            Mode::Unix { .. } => vec![],
+        }
     }
 }
 

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::Resource,
     internal_events::{ConnectionOpen, OpenGauge, TcpSocketConnectionError},
     shutdown::ShutdownSignal,
     tls::{MaybeTlsIncomingStream, MaybeTlsListener, MaybeTlsSettings},
@@ -243,6 +244,15 @@ impl fmt::Display for SocketListenAddr {
 impl From<SocketAddr> for SocketListenAddr {
     fn from(addr: SocketAddr) -> Self {
         Self::SocketAddr(addr)
+    }
+}
+
+impl From<SocketListenAddr> for Resource {
+    fn from(addr: SocketListenAddr) -> Resource {
+        match addr {
+            SocketListenAddr::SocketAddr(addr) => Self::Port(addr.port()),
+            SocketListenAddr::SystemdFd(offset) => Self::SystemFdOffset(offset),
+        }
     }
 }
 

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -250,7 +250,7 @@ impl From<SocketAddr> for SocketListenAddr {
 impl From<SocketListenAddr> for Resource {
     fn from(addr: SocketListenAddr) -> Resource {
         match addr {
-            SocketListenAddr::SocketAddr(addr) => Self::Port(addr.port()),
+            SocketListenAddr::SocketAddr(addr) => addr.into(),
             SocketListenAddr::SystemdFd(offset) => Self::SystemFdOffset(offset),
         }
     }

--- a/src/sources/vector.rs
+++ b/src/sources/vector.rs
@@ -1,6 +1,6 @@
 use super::util::{SocketListenAddr, TcpSource};
 use crate::{
-    config::{DataType, GenerateConfig, GlobalOptions, SourceConfig, SourceDescription},
+    config::{DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig, SourceDescription},
     event::proto,
     internal_events::{VectorEventReceived, VectorProtoDecodeError},
     shutdown::ShutdownSignal,
@@ -72,6 +72,10 @@ impl SourceConfig for VectorConfig {
 
     fn source_type(&self) -> &'static str {
         "vector"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![self.address.into()]
     }
 }
 

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -5,7 +5,7 @@ use futures01::{future, sync::mpsc, Async, AsyncSink, Poll, Sink, StartSend, Str
 type RouterSink = Box<dyn Sink<SinkItem = Event, SinkError = ()> + 'static + Send>;
 
 pub struct Fanout {
-    sinks: Vec<(String, RouterSink)>,
+    sinks: Vec<(String, Option<RouterSink>)>,
     i: usize,
     control_channel: mpsc::UnboundedReceiver<ControlMessage>,
 }
@@ -13,7 +13,8 @@ pub struct Fanout {
 pub enum ControlMessage {
     Add(String, RouterSink),
     Remove(String),
-    Replace(String, RouterSink),
+    /// Will stop accepting events until Some with given name is replaced.
+    Replace(String, Option<RouterSink>),
 }
 
 pub type ControlChannel = mpsc::UnboundedSender<ControlMessage>;
@@ -37,23 +38,25 @@ impl Fanout {
             "Duplicate output name in fanout"
         );
 
-        self.sinks.push((name, sink));
+        self.sinks.push((name, Some(sink)));
     }
 
     fn remove(&mut self, name: &str) {
         let i = self.sinks.iter().position(|(n, _)| n == name);
         let i = i.expect("Didn't find output in fanout");
 
-        let (_name, mut removed) = self.sinks.remove(i);
+        let (_name, removed) = self.sinks.remove(i);
 
-        tokio::spawn(future::poll_fn(move || removed.close()).compat());
+        if let Some(mut removed) = removed {
+            tokio::spawn(future::poll_fn(move || removed.close()).compat());
+        }
 
         if self.i > i {
             self.i -= 1;
         }
     }
 
-    fn replace(&mut self, name: String, sink: RouterSink) {
+    fn replace(&mut self, name: String, sink: Option<RouterSink>) {
         if let Some((_, existing)) = self.sinks.iter_mut().find(|(n, _)| n == &name) {
             *existing = sink
         } else {
@@ -92,16 +95,18 @@ impl Fanout {
         for i in 0..self.sinks.len() {
             let (_name, sink) = &mut self.sinks[i];
 
-            let result = if close {
-                sink.close()
-            } else {
-                sink.poll_complete()
-            };
+            if let Some(sink) = sink {
+                let result = if close {
+                    sink.close()
+                } else {
+                    sink.poll_complete()
+                };
 
-            match result {
-                Ok(Async::Ready(())) => {}
-                Ok(Async::NotReady) => poll_result = Async::NotReady,
-                Err(()) => self.handle_sink_error(i)?,
+                match result {
+                    Ok(Async::Ready(())) => {}
+                    Ok(Async::NotReady) => poll_result = Async::NotReady,
+                    Err(()) => self.handle_sink_error(i)?,
+                }
             }
         }
 
@@ -122,18 +127,32 @@ impl Sink for Fanout {
 
         while self.i < self.sinks.len() - 1 {
             let (_name, sink) = &mut self.sinks[self.i];
-            match sink.start_send(item.clone()) {
-                Ok(AsyncSink::NotReady(item)) => return Ok(AsyncSink::NotReady(item)),
-                Ok(AsyncSink::Ready) => self.i += 1,
-                Err(()) => self.handle_sink_error(self.i)?,
+            if let Some(sink) = sink.as_mut() {
+                match sink.start_send(item.clone()) {
+                    Ok(AsyncSink::NotReady(item)) => return Ok(AsyncSink::NotReady(item)),
+                    Ok(AsyncSink::Ready) => self.i += 1,
+                    Err(()) => self.handle_sink_error(self.i)?,
+                }
+            } else {
+                // process_control_messages ended because control channel returned
+                // NotReady so it's fine to return NotReady here since the control
+                // channel will notify current task when it receives a message.
+                return Ok(AsyncSink::NotReady(item));
             }
         }
 
         let (_name, sink) = &mut self.sinks[self.i];
-        match sink.start_send(item) {
-            Ok(AsyncSink::NotReady(item)) => return Ok(AsyncSink::NotReady(item)),
-            Ok(AsyncSink::Ready) => self.i += 1,
-            Err(()) => self.handle_sink_error(self.i)?,
+        if let Some(sink) = sink.as_mut() {
+            match sink.start_send(item) {
+                Ok(AsyncSink::NotReady(item)) => return Ok(AsyncSink::NotReady(item)),
+                Ok(AsyncSink::Ready) => self.i += 1,
+                Err(()) => self.handle_sink_error(self.i)?,
+            }
+        } else {
+            // process_control_messages ended because control channel returned
+            // NotReady so it's fine to return NotReady here since the control
+            // channel will notify current task when it receives a message.
+            return Ok(AsyncSink::NotReady(item));
         }
 
         self.i = 0;
@@ -433,7 +452,7 @@ mod tests {
 
         let (tx_a2, rx_a2) = mpsc::unbounded();
         let tx_a2 = Box::new(tx_a2.sink_map_err(|_| unreachable!()));
-        fanout.replace("a".to_string(), tx_a2);
+        fanout.replace("a".to_string(), Some(tx_a2));
 
         let rec3 = Event::from("line 3".to_string());
         let _fanout = fanout.send(rec3.clone()).compat().await.unwrap();

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -744,7 +744,7 @@ mod reload_tests {
     use crate::sinks::prometheus::exporter::PrometheusExporterConfig;
     use crate::sources::generator::GeneratorConfig;
     use crate::sources::splunk_hec::SplunkConfig;
-    use crate::test_util::{next_addr, start_topology, trace_init, wait_for_tcp};
+    use crate::test_util::{next_addr, start_topology, wait_for_tcp};
     use crate::transforms::log_to_metric::{GaugeConfig, LogToMetricConfig, MetricConfig};
     use futures::{compat::Stream01CompatExt, StreamExt};
     use std::net::{SocketAddr, TcpListener};
@@ -918,10 +918,10 @@ mod reload_tests {
         old_config.add_sink(
             "out1",
             &[&"trans"],
-            PrometheusSinkConfig {
+            PrometheusExporterConfig {
                 address: address_0,
                 flush_period_secs: 1,
-                ..PrometheusSinkConfig::default()
+                ..PrometheusExporterConfig::default()
             },
         );
 
@@ -931,10 +931,10 @@ mod reload_tests {
         new_config.add_sink(
             "out1",
             &[&"trans"],
-            PrometheusSinkConfig {
+            PrometheusExporterConfig {
                 address: address_1,
                 flush_period_secs: 1,
-                ..PrometheusSinkConfig::default()
+                ..PrometheusExporterConfig::default()
             },
         );
 

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -122,7 +122,7 @@ fn test_timely_shutdown_with_sub(mut cmd: Command, sub: impl FnOnce(&mut Child))
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
         println!("{}", stdout);
-        panic!("Vector didn't exit successfully.");
+        panic!("Vector didn't exit successfully. Status: {}", output.status);
     }
 
     // Check if vector has shutdown in a reasonable time

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -88,6 +88,22 @@ fn vector_with(config_path: PathBuf, address: SocketAddr) -> Command {
     cmd
 }
 
+fn dbg_source_vector(source: &str) -> Command {
+    dbg_vector_with(create_file(source_config(source).as_str()), next_addr())
+}
+
+fn dbg_vector_with(config_path: PathBuf, address: SocketAddr) -> Command {
+    let mut cmd = Command::cargo_bin("vector").unwrap();
+    cmd.arg("-c")
+        .arg(config_path)
+        .arg("-v")
+        .env("VECTOR_DATA_DIR", create_directory())
+        .env("VECTOR_TEST_UNIX_PATH", temp_file())
+        .env("VECTOR_TEST_ADDRESS", format!("{}", address));
+
+    cmd
+}
+
 fn test_timely_shutdown(cmd: Command) {
     test_timely_shutdown_with_sub(cmd, |_| ());
 }
@@ -244,7 +260,7 @@ fn timely_shutdown_logplex() {
 
 #[test]
 fn timely_shutdown_docker() {
-    test_timely_shutdown(source_vector(r#"type = "docker""#));
+    test_timely_shutdown(dbg_source_vector(r#"type = "docker""#));
 }
 
 #[test]


### PR DESCRIPTION
Closes #4827

Also extends `Fanout` with ability to wait. With that we can shutdown sinks before building new pieces so the resources can be freely used in build methods. cc @lukesteensen 

Also notable extension is the introduction of `SystemFdOffset` and `Stdin` resources. Where with `Stdin`, we will enforce usage of only one `stdin` source, and while that technically is a breaking change, the usage of multiple `stdin` sources is similar to using same port for multiple sockets so it's more of a bug fix than that we are breaking something.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
