### PR TITLE
enhancement(observability): More debug info on more HTTP requests

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -26,6 +26,8 @@ pub enum HttpError {
     BuildTlsConnector { source: TlsError },
     #[snafu(display("Failed to build HTTPS connector"))]
     MakeHttpsConnector { source: openssl::error::ErrorStack },
+    #[snafu(display("Failed to make HTTP(S) request"))]
+    CallRequest { source: hyper::Error },
 }
 
 pub type HttpClientFuture = <HttpClient as Service<http::Request<Body>>>::Future;
@@ -74,8 +76,8 @@ where
         })
     }
 
-    pub async fn send(&mut self, request: Request<B>) -> crate::Result<http::Response<Body>> {
-        self.call(request).await.map_err(Into::into)
+    pub async fn send(&mut self, request: Request<B>) -> Result<http::Response<Body>, HttpError> {
+        self.call(request).await.context(CallRequest)
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -76,7 +76,7 @@ where
         })
     }
 
-    fn call_internal(
+    pub fn send(
         &self,
         mut request: Request<B>,
     ) -> BoxFuture<'static, Result<http::Response<Body>, HttpError>> {
@@ -114,10 +114,6 @@ where
 
         Box::pin(fut)
     }
-
-    pub async fn send(&self, request: Request<B>) -> Result<http::Response<Body>, HttpError> {
-        self.call_internal(request).await
-    }
 }
 
 impl<B> Service<Request<B>> for HttpClient<B>
@@ -135,7 +131,7 @@ where
     }
 
     fn call(&mut self, request: Request<B>) -> Self::Future {
-        self.call_internal(request)
+        self.send(request)
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -27,7 +27,7 @@ pub struct HttpClient<B = Body> {
 
 impl<B> HttpClient<B>
 where
-    B: HttpBody + Send + 'static,
+    B: fmt::Debug + HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: Into<crate::Error>,
 {
@@ -70,7 +70,7 @@ where
 
 impl<B> Service<Request<B>> for HttpClient<B>
 where
-    B: HttpBody + Send + 'static,
+    B: fmt::Debug + HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: Into<crate::Error>,
 {
@@ -91,16 +91,25 @@ where
                 .insert("User-Agent", self.user_agent.clone());
         }
 
-        debug!(message = "Sending request.", uri = %request.uri(), method = %request.method());
+        debug!(
+            message = "Sending HTTP request.",
+            uri = %request.uri(),
+            method = %request.method(),
+            version = ?request.version(),
+            headers = ?request.headers(),
+            body = ?request.body(),
+        );
 
         let response = self.client.request(request);
 
         let fut = async move {
             let res = response.await?;
             debug!(
-                    message = "Response.",
-                    status = ?res.status(),
+                    message = "HTTP response.",
+                    status = %res.status(),
                     version = ?res.version(),
+                    headers = ?res.headers(),
+                    body = ?res.body(),
             );
             Ok(res)
         }

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -76,7 +76,7 @@ impl InternalEvent for ApacheMetricsErrorResponse<'_> {
 
 #[derive(Debug)]
 pub struct ApacheMetricsHttpError<'a> {
-    pub error: hyper::Error,
+    pub error: crate::Error,
     pub url: &'a str,
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -78,7 +78,7 @@ impl InternalEvent for PrometheusErrorResponse {
 
 #[derive(Debug)]
 pub struct PrometheusHttpError {
-    pub error: hyper::Error,
+    pub error: crate::Error,
     pub url: http::Uri,
 }
 

--- a/src/kubernetes/api_watcher.rs
+++ b/src/kubernetes/api_watcher.rs
@@ -135,7 +135,7 @@ pub mod invocation {
         #[snafu(display("error during the HTTP request"))]
         Request {
             /// The error that API client returned.
-            source: crate::Error,
+            source: crate::http::HttpError,
         },
 
         /// Returned when the HTTP response has a bad status.

--- a/src/kubernetes/client/mod.rs
+++ b/src/kubernetes/client/mod.rs
@@ -19,7 +19,10 @@
 //!   The reference implementation on preparing the in-cluster config.
 //!
 
-use crate::{http::HttpClient, tls::TlsSettings};
+use crate::{
+    http::{HttpClient, HttpError},
+    tls::TlsSettings,
+};
 use http::{
     header::{self, HeaderValue},
     uri, Request, Response, Uri,
@@ -78,7 +81,10 @@ impl Client {
     }
 
     /// Alters a request according to the client configuration and sends it.
-    pub async fn send<B: Into<Body>>(&mut self, req: Request<B>) -> crate::Result<Response<Body>> {
+    pub async fn send<B: Into<Body>>(
+        &mut self,
+        req: Request<B>,
+    ) -> Result<Response<Body>, HttpError> {
         let req = self.prepare_request(req);
         self.inner.send(req).await
     }

--- a/src/rusoto/mod.rs
+++ b/src/rusoto/mod.rs
@@ -1,4 +1,4 @@
-use crate::tls::MaybeTlsSettings;
+use crate::{http::HttpError, tls::MaybeTlsSettings};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::StreamExt;
@@ -186,7 +186,7 @@ impl<T> HttpClient<T> {
 
 impl<T> DispatchSignedRequest for HttpClient<T>
 where
-    T: Service<Request<RusotoBody>, Response = Response<Body>, Error = hyper::Error>
+    T: Service<Request<RusotoBody>, Response = Response<Body>, Error = HttpError>
         + Clone
         + Send
         + 'static,

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -280,7 +280,7 @@ impl AzureMonitorLogsSink {
     }
 }
 
-async fn healthcheck(sink: AzureMonitorLogsSink, mut client: HttpClient) -> crate::Result<()> {
+async fn healthcheck(sink: AzureMonitorLogsSink, client: HttpClient) -> crate::Result<()> {
     let request = sink.build_request(vec![]).await?.map(Body::from);
 
     let res = client.send(request).await?;

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -141,7 +141,7 @@ impl HttpSink for ClickhouseConfig {
     }
 }
 
-async fn healthcheck(mut client: HttpClient, config: ClickhouseConfig) -> crate::Result<()> {
+async fn healthcheck(client: HttpClient, config: ClickhouseConfig) -> crate::Result<()> {
     // TODO: check if table exists?
     let uri = format!("{}/?query=SELECT%201", config.endpoint);
     let mut request = Request::get(uri).body(Body::empty()).unwrap();

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -251,7 +251,7 @@ impl HttpSink for DatadogLogsTextService {
 
 /// The healthcheck is performed by sending an empty request to Datadog and checking
 /// the return.
-async fn healthcheck<T, O>(sink: T, mut client: HttpClient) -> crate::Result<()>
+async fn healthcheck<T, O>(sink: T, client: HttpClient) -> crate::Result<()>
 where
     T: HttpSink<Output = Vec<O>>,
 {

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -254,7 +254,7 @@ fn build_uri(host: &str, endpoint: &'static str) -> crate::Result<Uri> {
     Ok(uri)
 }
 
-async fn healthcheck(config: DatadogConfig, mut client: HttpClient) -> crate::Result<()> {
+async fn healthcheck(config: DatadogConfig, client: HttpClient) -> crate::Result<()> {
     let uri = format!("{}/api/v1/validate", config.get_endpoint())
         .parse::<Uri>()
         .context(UriParseError)?;

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -424,7 +424,7 @@ impl ElasticSearchCommon {
     }
 }
 
-async fn healthcheck(mut client: HttpClient, common: ElasticSearchCommon) -> crate::Result<()> {
+async fn healthcheck(client: HttpClient, common: ElasticSearchCommon) -> crate::Result<()> {
     let mut builder = Request::get(format!("{}/_cluster/health", common.base_url));
 
     match &common.credentials {
@@ -830,7 +830,7 @@ mod integration_tests {
         let uri = format!("{}/_flush", common.base_url);
         let request = Request::post(uri).body(Body::empty()).unwrap();
 
-        let mut client =
+        let client =
             HttpClient::new(common.tls_settings.clone()).expect("Could not build client to flush");
         let response = client.send(request).await?;
         match response.status() {

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -233,7 +233,7 @@ impl GcsSink {
         Ok(VectorSink::Sink(Box::new(sink)))
     }
 
-    async fn healthcheck(mut self) -> crate::Result<()> {
+    async fn healthcheck(self) -> crate::Result<()> {
         let uri = self.base_url.parse::<Uri>()?;
         let mut request = http::Request::head(uri).body(Body::empty())?;
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -1,7 +1,7 @@
 use super::{healthcheck_response, GcpAuthConfig, GcpCredentials, Scope};
 use crate::{
     config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
-    http::{HttpClient, HttpClientFuture},
+    http::{HttpClient, HttpClientFuture, HttpError},
     serde::to_string,
     sinks::{
         util::{
@@ -251,7 +251,7 @@ impl GcsSink {
 
 impl Service<RequestWrapper> for GcsSink {
     type Response = Response<Body>;
-    type Error = hyper::Error;
+    type Error = HttpError;
     type Future = HttpClientFuture;
 
     fn poll_ready(&mut self, _: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -1,4 +1,7 @@
-use crate::sinks::HealthcheckError;
+use crate::{
+    http::{HttpClient, HttpError},
+    sinks::HealthcheckError,
+};
 use futures::StreamExt;
 use goauth::scopes::Scope;
 use goauth::{
@@ -35,11 +38,13 @@ enum GcpError {
     #[snafu(display("Failed to get OAuth token text"))]
     GetTokenBytes { source: hyper::Error },
     #[snafu(display("Failed to get implicit GCP token"))]
-    GetImplicitToken { source: hyper::Error },
+    GetImplicitToken { source: crate::Error },
     #[snafu(display("Failed to parse OAuth token JSON"))]
     TokenFromJson { source: TokenErr },
     #[snafu(display("Failed to parse OAuth token JSON text"))]
     TokenJsonFromStr { source: serde_json::Error },
+    #[snafu(display("Failed to build HTTP client"))]
+    BuildHttpClient { source: HttpError },
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -73,8 +78,9 @@ async fn get_token_implicit() -> Result<Token, GcpError> {
         .body(hyper::Body::empty())
         .unwrap();
 
-    let res = hyper::Client::new()
-        .request(req)
+    let res = HttpClient::new(None)
+        .context(BuildHttpClient)?
+        .send(req)
         .await
         .context(GetImplicitToken)?;
 

--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -38,7 +38,7 @@ enum GcpError {
     #[snafu(display("Failed to get OAuth token text"))]
     GetTokenBytes { source: hyper::Error },
     #[snafu(display("Failed to get implicit GCP token"))]
-    GetImplicitToken { source: crate::Error },
+    GetImplicitToken { source: HttpError },
     #[snafu(display("Failed to parse OAuth token JSON"))]
     TokenFromJson { source: TokenErr },
     #[snafu(display("Failed to parse OAuth token JSON text"))]

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -187,7 +187,7 @@ impl HttpSink for PubsubSink {
 }
 
 async fn healthcheck(
-    mut client: HttpClient,
+    client: HttpClient,
     uri: Uri,
     creds: Option<GcpCredentials>,
 ) -> crate::Result<()> {

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -248,7 +248,7 @@ fn remap_severity(severity: Value) -> Value {
     Value::Integer(n)
 }
 
-async fn healthcheck(mut client: HttpClient, sink: StackdriverSink) -> crate::Result<()> {
+async fn healthcheck(client: HttpClient, sink: StackdriverSink) -> crate::Result<()> {
     let request = sink.build_request(vec![]).await?.map(Body::from);
 
     let response = client.send(request).await?;

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -124,7 +124,7 @@ impl HoneycombConfig {
     }
 }
 
-async fn healthcheck(config: HoneycombConfig, mut client: HttpClient) -> crate::Result<()> {
+async fn healthcheck(config: HoneycombConfig, client: HttpClient) -> crate::Result<()> {
     let req = config
         .build_request(Vec::new())
         .await?

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -247,11 +247,7 @@ impl HttpSink for HttpSinkConfig {
     }
 }
 
-async fn healthcheck(
-    uri: UriSerde,
-    auth: Option<Auth>,
-    mut client: HttpClient,
-) -> crate::Result<()> {
+async fn healthcheck(uri: UriSerde, auth: Option<Auth>, client: HttpClient) -> crate::Result<()> {
     let uri = build_uri(uri);
     let mut request = Request::head(&uri).body(Body::empty()).unwrap();
 

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -261,7 +261,7 @@ impl LogdnaConfig {
     }
 }
 
-async fn healthcheck(config: LogdnaConfig, mut client: HttpClient) -> crate::Result<()> {
+async fn healthcheck(config: LogdnaConfig, client: HttpClient) -> crate::Result<()> {
     let uri = config.build_uri("");
 
     let req = Request::post(uri).body(hyper::Body::empty()).unwrap();

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -198,7 +198,7 @@ impl HttpSink for LokiConfig {
     }
 }
 
-async fn healthcheck(config: LokiConfig, mut client: HttpClient) -> crate::Result<()> {
+async fn healthcheck(config: LokiConfig, client: HttpClient) -> crate::Result<()> {
     let uri = format!("{}ready", config.endpoint);
 
     let mut req = http::Request::get(uri).body(hyper::Body::empty()).unwrap();

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -328,15 +328,17 @@ mod integration_tests {
     use crate::{
         config::SinkContext,
         event::{Metric, MetricValue},
+        http::HttpClient,
     };
     use futures::{stream, task::Poll};
-    use hyper::Client;
     use serde_json::Value;
     use std::{pin::Pin, task::Context};
     use tokio::time::Duration;
 
     #[tokio::test]
     async fn prometheus_scrapes_metrics() {
+        crate::test_util::trace_init();
+
         let start = Utc::now().timestamp();
         let address = "127.0.0.1:9101";
 
@@ -374,8 +376,9 @@ mod integration_tests {
         let request = Request::post(uri)
             .body(Body::empty())
             .expect("Error creating request.");
-        let result = Client::new()
-            .request(request)
+        let result = HttpClient::new(None)
+            .unwrap()
+            .send(request)
             .await
             .expect("Could not fetch query");
         let result = hyper::body::to_bytes(result.into_body())

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -105,7 +105,7 @@ impl SinkConfig for RemoteWriteConfig {
     }
 }
 
-async fn healthcheck(endpoint: Uri, mut client: HttpClient) -> crate::Result<()> {
+async fn healthcheck(endpoint: Uri, client: HttpClient) -> crate::Result<()> {
     let request = http::Request::get(endpoint)
         .body(hyper::Body::empty())
         .unwrap();
@@ -167,10 +167,10 @@ impl tower::Service<Vec<Metric>> for RemoteWriteService {
             .header("Content-Type", "application/x-protobuf")
             .body(body.into())
             .unwrap();
-        let mut client = self.client.clone();
+        let client = self.client.clone();
 
         Box::pin(async move {
-            let response = client.call(request).await?;
+            let response = client.send(request).await?;
             let (parts, body) = response.into_parts();
             let body = hyper::body::to_bytes(body).await?;
             Ok(hyper::Response::from_parts(parts, body))

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -59,7 +59,7 @@ impl GenerateConfig for SematextMetricsConfig {
     }
 }
 
-async fn healthcheck(endpoint: String, mut client: HttpClient) -> Result<()> {
+async fn healthcheck(endpoint: String, client: HttpClient) -> Result<()> {
     let uri = format!("{}/health", endpoint);
 
     let request = Request::get(uri)

--- a/src/sinks/splunk_hec.rs
+++ b/src/sinks/splunk_hec.rs
@@ -242,7 +242,7 @@ enum HealthcheckError {
     QueuesFull,
 }
 
-pub async fn healthcheck(config: HecSinkConfig, mut client: HttpClient) -> crate::Result<()> {
+pub async fn healthcheck(config: HecSinkConfig, client: HttpClient) -> crate::Result<()> {
     let uri = build_uri(&config.endpoint, "/services/collector/health/1.0")
         .context(super::UriParseError)?;
 

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -268,6 +268,7 @@ impl MetadataClient {
             .client
             .send(req)
             .await
+            .map_err(crate::Error::from)
             .and_then(|res| match res.status() {
                 StatusCode::OK => Ok(res),
                 status_code => Err(UnexpectedHTTPStatusError {
@@ -417,6 +418,7 @@ impl MetadataClient {
             .client
             .send(req)
             .await
+            .map_err(crate::Error::from)
             .and_then(|res| match res.status() {
                 StatusCode::OK => Ok(res),
                 status_code => Err(UnexpectedHTTPStatusError {


### PR DESCRIPTION
The `HttpClient` framework in vector is a wrapper for `hyper::Client`. It provides debug information for all requests and responses. This change enhances that information and rewrites all non-testing uses of `hyper::Client` to use `HttpClient` instead.

Closes #4272

AFAICT there is one remaining use of `hyper::Client` in the statsd source self-tests, but it was a little messier to convert and I have spent enough time on this already. Additionally, we use `reqwest` for many tests, and these uses are not covered by this change. If adding debugging for these uses or any other non-hyper client is desired, I suggest opening up a follow-up issue to this.