### PR TITLE
enhancement(observability): Added batch subscriptions for component bytes and errors

### DIFF
--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -1706,6 +1706,45 @@
                 }
               ],
               "deprecationReason": null,
+              "description": "Component events processed metrics, received in batches containing metrics over `interval`",
+              "isDeprecated": false,
+              "name": "componentEventsProcessedTotalBatch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentEventsProcessedTotal",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
               "description": "Bytes processed metrics",
               "isDeprecated": false,
               "name": "bytesProcessedTotal",
@@ -1768,6 +1807,45 @@
                 }
               ],
               "deprecationReason": null,
+              "description": "Component bytes processed metrics, received in batches containing metrics over `interval`",
+              "isDeprecated": false,
+              "name": "componentBytesProcessedTotalBatch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentBytesProcessedTotal",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
               "description": "Total error metrics",
               "isDeprecated": false,
               "name": "errorsTotal",
@@ -1809,6 +1887,45 @@
                   "kind": "OBJECT",
                   "name": "ComponentErrorsTotal",
                   "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Component errors metrics, received in batches containing metrics over `interval`",
+              "isDeprecated": false,
+              "name": "componentErrorsTotalBatch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentErrorsTotal",
+                      "ofType": null
+                    }
+                  }
                 }
               }
             },

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -125,13 +125,11 @@ impl MetricsSubscription {
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentBytesProcessedTotal>> {
-        component_counter_metrics_batch(interval, &|m| m.name == "processed_bytes_total").map(
-            |m| {
-                m.into_iter()
-                    .map(ComponentBytesProcessedTotal::new)
-                    .collect()
-            },
-        )
+        component_counter_metrics_batch(interval, &|m| m.name == "processed_bytes_total").map(|m| {
+            m.into_iter()
+                .map(ComponentBytesProcessedTotal::new)
+                .collect()
+        })
     }
 
     /// Total error metrics
@@ -158,13 +156,8 @@ impl MetricsSubscription {
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentErrorsTotal>> {
-        component_counter_metrics_batch(interval, &|m| m.name.ends_with("_errors_total")).map(
-            |m| {
-                m.into_iter()
-                    .map(ComponentErrorsTotal::new)
-                    .collect()
-            },
-        )
+        component_counter_metrics_batch(interval, &|m| m.name.ends_with("_errors_total"))
+            .map(|m| m.into_iter().map(ComponentErrorsTotal::new).collect())
     }
 
     /// All metrics

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -120,6 +120,20 @@ impl MetricsSubscription {
             .map(ComponentBytesProcessedTotal::new)
     }
 
+    /// Component bytes processed metrics, received in batches containing metrics over `interval`
+    async fn component_bytes_processed_total_batch(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = Vec<ComponentBytesProcessedTotal>> {
+        component_counter_metrics_batch(interval, &|m| m.name == "processed_bytes_total").map(
+            |m| {
+                m.into_iter()
+                    .map(ComponentBytesProcessedTotal::new)
+                    .collect()
+            },
+        )
+    }
+
     /// Total error metrics
     async fn errors_total(
         &self,
@@ -137,6 +151,20 @@ impl MetricsSubscription {
     ) -> impl Stream<Item = ComponentErrorsTotal> {
         component_counter_metrics(interval, &|m| m.name.ends_with("_errors_total"))
             .map(ComponentErrorsTotal::new)
+    }
+
+    /// Component errors metrics, received in batches containing metrics over `interval`
+    async fn component_errors_total_batch(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = Vec<ComponentErrorsTotal>> {
+        component_counter_metrics_batch(interval, &|m| m.name.ends_with("_errors_total")).map(
+            |m| {
+                m.into_iter()
+                    .map(ComponentErrorsTotal::new)
+                    .collect()
+            },
+        )
     }
 
     /// All metrics


### PR DESCRIPTION
This PR is targeting https://github.com/timberio/vector/pull/4958.  I branched off of there and added the batch subscriptions for component bytes total and component errors total.  I'll wait for that to clear and then get this one in after review.

cc @leebenson 
I added the other subscriptions based off the pattern for the events.  I tested these out today locally in the app and they work great.  Comparing `vector top` (using the non-batched versions) and the batched data in the app looks to line up perfectly. Performance in the app with these subscriptions is much better.

**Note:** I regenerated the schema here.  Wasn't sure if I should do that.


