### PR TITLE
enhancement(observability): API batch support + tests

### DIFF
--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -1706,6 +1706,45 @@
                 }
               ],
               "deprecationReason": null,
+              "description": "Component events processed metrics, received in batches containing metrics over `interval`",
+              "isDeprecated": false,
+              "name": "componentEventsProcessedTotalBatch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentEventsProcessedTotal",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
               "description": "Bytes processed metrics",
               "isDeprecated": false,
               "name": "bytesProcessedTotal",
@@ -1768,6 +1807,45 @@
                 }
               ],
               "deprecationReason": null,
+              "description": "Component bytes processed metrics, received in batches containing metrics over `interval`",
+              "isDeprecated": false,
+              "name": "componentBytesProcessedTotalBatch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentBytesProcessedTotal",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
               "description": "Total error metrics",
               "isDeprecated": false,
               "name": "errorsTotal",
@@ -1809,6 +1887,45 @@
                   "kind": "OBJECT",
                   "name": "ComponentErrorsTotal",
                   "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Component errors metrics, received in batches containing metrics over `interval`",
+              "isDeprecated": false,
+              "name": "componentErrorsTotalBatch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentErrorsTotal",
+                      "ofType": null
+                    }
+                  }
                 }
               }
             },

--- a/lib/vector-api-client/graphql/subscriptions/component_bytes_processed_total_batch.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_bytes_processed_total_batch.graphql
@@ -1,0 +1,8 @@
+subscription ComponentBytesProcessedTotalBatchSubscription($interval: Int!) {
+    componentBytesProcessedTotalBatch(interval: $interval) {
+        name
+        metric {
+            bytesProcessedTotal
+        }
+    }
+}

--- a/lib/vector-api-client/graphql/subscriptions/component_events_processed_total_batch.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_events_processed_total_batch.graphql
@@ -1,0 +1,8 @@
+subscription ComponentEventsProcessedTotalBatchSubscription($interval: Int!) {
+    componentEventsProcessedTotalBatch(interval: $interval) {
+        name
+        metric {
+            eventsProcessedTotal
+        }
+    }
+}

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -143,7 +143,7 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         self.start::<ComponentEventsProcessedTotalBatchSubscription>(&request_body)
     }
 
-    /// Executes a components events processed total metrics subscription
+    /// Executes a components bytes processed total metrics subscription
     fn component_bytes_processed_total_subscription(
         &self,
         interval: i64,
@@ -155,7 +155,7 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         self.start::<ComponentBytesProcessedTotalSubscription>(&request_body)
     }
 
-    /// Executes a components events processed total metrics subscription
+    /// Executes a components bytes processed total metrics subscription
     fn component_bytes_processed_total_batch_subscription(
         &self,
         interval: i64,

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -33,6 +33,16 @@ pub struct EventsProcessedTotalSubscription;
 )]
 pub struct ComponentEventsProcessedTotalSubscription;
 
+/// ComponentEventsProcessedTotalSubscription contains metrics on the number of events
+/// that have been processed by a Vector instance, against a specific component
+#[derive(GraphQLQuery, Debug, Copy, Clone)]
+#[graphql(
+    schema_path = "graphql/schema.json",
+    query_path = "graphql/subscriptions/component_events_processed_total_batch.graphql",
+    response_derives = "Debug"
+)]
+pub struct ComponentEventsProcessedTotalBatchSubscription;
+
 /// ComponentBytesProcessedTotalSubscription contains metrics on the number of bytes
 /// that have been processed by a Vector instance, against a specific component
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
@@ -42,6 +52,16 @@ pub struct ComponentEventsProcessedTotalSubscription;
     response_derives = "Debug"
 )]
 pub struct ComponentBytesProcessedTotalSubscription;
+
+/// ComponentBytesProcessedTotalSubscription contains metrics on the number of bytes
+/// that have been processed by a Vector instance, against a specific component
+#[derive(GraphQLQuery, Debug, Copy, Clone)]
+#[graphql(
+    schema_path = "graphql/schema.json",
+    query_path = "graphql/subscriptions/component_bytes_processed_total_batch.graphql",
+    response_derives = "Debug"
+)]
+pub struct ComponentBytesProcessedTotalBatchSubscription;
 
 /// Extension methods for metrics subscriptions
 pub trait MetricsSubscriptionExt {
@@ -60,11 +80,23 @@ pub trait MetricsSubscriptionExt {
         interval: i64,
     ) -> crate::BoxedSubscription<ComponentEventsProcessedTotalSubscription>;
 
+    /// Executes a components events processed total metrics batch subscription
+    fn component_events_processed_total_batch_subscription(
+        &self,
+        interval: i64,
+    ) -> crate::BoxedSubscription<ComponentEventsProcessedTotalBatchSubscription>;
+
     /// Executes a components bytes processed total metrics subscription
     fn component_bytes_processed_total_subscription(
         &self,
         interval: i64,
     ) -> crate::BoxedSubscription<ComponentBytesProcessedTotalSubscription>;
+
+    /// Executes a components bytes processed total metrics batch subscription
+    fn component_bytes_processed_total_batch_subscription(
+        &self,
+        interval: i64,
+    ) -> crate::BoxedSubscription<ComponentBytesProcessedTotalBatchSubscription>;
 }
 
 impl MetricsSubscriptionExt for crate::SubscriptionClient {
@@ -99,6 +131,18 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         self.start::<ComponentEventsProcessedTotalSubscription>(&request_body)
     }
 
+    /// Executes a components events processed total batch metrics subscription
+    fn component_events_processed_total_batch_subscription(
+        &self,
+        interval: i64,
+    ) -> BoxedSubscription<ComponentEventsProcessedTotalBatchSubscription> {
+        let request_body = ComponentEventsProcessedTotalBatchSubscription::build_query(
+            component_events_processed_total_batch_subscription::Variables { interval },
+        );
+
+        self.start::<ComponentEventsProcessedTotalBatchSubscription>(&request_body)
+    }
+
     /// Executes a components events processed total metrics subscription
     fn component_bytes_processed_total_subscription(
         &self,
@@ -109,5 +153,17 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         );
 
         self.start::<ComponentBytesProcessedTotalSubscription>(&request_body)
+    }
+
+    /// Executes a components events processed total metrics subscription
+    fn component_bytes_processed_total_batch_subscription(
+        &self,
+        interval: i64,
+    ) -> BoxedSubscription<ComponentBytesProcessedTotalBatchSubscription> {
+        let request_body = ComponentBytesProcessedTotalBatchSubscription::build_query(
+            component_bytes_processed_total_batch_subscription::Variables { interval },
+        );
+
+        self.start::<ComponentBytesProcessedTotalBatchSubscription>(&request_body)
     }
 }

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -125,13 +125,11 @@ impl MetricsSubscription {
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentBytesProcessedTotal>> {
-        component_counter_metrics_batch(interval, &|m| m.name == "processed_bytes_total").map(
-            |m| {
-                m.into_iter()
-                    .map(ComponentBytesProcessedTotal::new)
-                    .collect()
-            },
-        )
+        component_counter_metrics_batch(interval, &|m| m.name == "processed_bytes_total").map(|m| {
+            m.into_iter()
+                .map(ComponentBytesProcessedTotal::new)
+                .collect()
+        })
     }
 
     /// Total error metrics
@@ -158,13 +156,8 @@ impl MetricsSubscription {
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentErrorsTotal>> {
-        component_counter_metrics_batch(interval, &|m| m.name.ends_with("_errors_total")).map(
-            |m| {
-                m.into_iter()
-                    .map(ComponentErrorsTotal::new)
-                    .collect()
-            },
-        )
+        component_counter_metrics_batch(interval, &|m| m.name.ends_with("_errors_total"))
+            .map(|m| m.into_iter().map(ComponentErrorsTotal::new).collect())
     }
 
     /// All metrics

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -120,6 +120,20 @@ impl MetricsSubscription {
             .map(ComponentBytesProcessedTotal::new)
     }
 
+    /// Component bytes processed metrics, received in batches containing metrics over `interval`
+    async fn component_bytes_processed_total_batch(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = Vec<ComponentBytesProcessedTotal>> {
+        component_counter_metrics_batch(interval, &|m| m.name == "processed_bytes_total").map(
+            |m| {
+                m.into_iter()
+                    .map(ComponentBytesProcessedTotal::new)
+                    .collect()
+            },
+        )
+    }
+
     /// Total error metrics
     async fn errors_total(
         &self,
@@ -137,6 +151,20 @@ impl MetricsSubscription {
     ) -> impl Stream<Item = ComponentErrorsTotal> {
         component_counter_metrics(interval, &|m| m.name.ends_with("_errors_total"))
             .map(ComponentErrorsTotal::new)
+    }
+
+    /// Component errors metrics, received in batches containing metrics over `interval`
+    async fn component_errors_total_batch(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = Vec<ComponentErrorsTotal>> {
+        component_counter_metrics_batch(interval, &|m| m.name.ends_with("_errors_total")).map(
+            |m| {
+                m.into_iter()
+                    .map(ComponentErrorsTotal::new)
+                    .collect()
+            },
+        )
     }
 
     /// All metrics

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -388,8 +388,169 @@ mod tests {
             map[&0].metric.events_processed_total,
             map[&1].metric.events_processed_total
         );
+    }
 
-        topology.sources_finished().await;
+    #[tokio::test]
+    #[allow(clippy::float_cmp)]
+    #[ignore]
+    /// Tests componentEventsProcessedTotalBatch returns increasing metrics, ordered by
+    /// source -> transform -> sink
+    async fn api_graphql_component_events_processed_total_batch() {
+        init_metrics();
+
+        let topology = from_str_config(
+            r#"
+            [api]
+              enabled = true
+
+            [sources.events_processed_total_batch_source]
+              type = "generator"
+              lines = ["Random line", "And another"]
+              batch_interval = 0.1
+
+            [sinks.events_processed_total_batch_sink]
+              # General
+              type = "blackhole"
+              inputs = ["events_processed_total_batch_source"]
+              print_amount = 100000
+        "#,
+        )
+        .await;
+
+        let server = api::Server::start(topology.config());
+        let client = new_subscription_client(server.addr()).await;
+        let subscription = client.component_events_processed_total_batch_subscription(500);
+
+        tokio::pin! {
+            let component_events_processed_total_batch = subscription.stream();
+        }
+
+        let data = component_events_processed_total_batch
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .data
+            .unwrap()
+            .component_events_processed_total_batch;
+
+        assert_eq!(data[0].name, "events_processed_total_batch_source");
+        assert_eq!(data[1].name, "events_processed_total_batch_sink");
+
+        assert_eq!(
+            data[0].metric.events_processed_total,
+            data[1].metric.events_processed_total
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::float_cmp)]
+    #[ignore]
+    /// Tests componentBytesProcessedTotal returns increasing metrics, ordered by
+    /// source -> transform -> sink
+    async fn api_graphql_component_bytes_processed_total() {
+        init_metrics();
+
+        let topology = from_str_config(
+            r#"
+            [api]
+              enabled = true
+
+            [sources.bytes_processed_total_source]
+              type = "generator"
+              lines = ["Random line", "And another"]
+              batch_interval = 0.1
+
+            [sinks.bytes_processed_total_sink]
+              # General
+              type = "blackhole"
+              inputs = ["bytes_processed_total_source"]
+              print_amount = 100000
+        "#,
+        )
+        .await;
+
+        let server = api::Server::start(topology.config());
+        let client = new_subscription_client(server.addr()).await;
+        let subscription = client.component_bytes_processed_total_subscription(500);
+
+        tokio::pin! {
+            let component_bytes_processed_total = subscription.stream();
+        }
+
+        // Results should be sorted by source -> sink, so we'll need to assert that
+        // order. The events generated should be the same in both cases
+        let mut map = HashMap::new();
+
+        for r in 0..=1 {
+            map.insert(
+                r,
+                component_bytes_processed_total
+                    .next()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .data
+                    .unwrap()
+                    .component_bytes_processed_total,
+            );
+        }
+
+        // Should only show byte totals on sinks
+        assert_eq!(map[&0].name, "bytes_processed_total_sink");
+        assert_eq!(map[&0].name, "bytes_processed_total_sink");
+
+        assert!(map[&0].metric.bytes_processed_total > 0.00);
+        assert!(map[&1].metric.bytes_processed_total > map[&0].metric.bytes_processed_total)
+    }
+
+    #[tokio::test]
+    #[allow(clippy::float_cmp)]
+    #[ignore]
+    /// Tests componentBytesProcessedTotalBatch returns increasing metrics, ordered by
+    /// source -> transform -> sink
+    async fn api_graphql_component_bytes_processed_total_batch() {
+        init_metrics();
+
+        let topology = from_str_config(
+            r#"
+            [api]
+              enabled = true
+
+            [sources.bytes_processed_total_batch_source]
+              type = "generator"
+              lines = ["Random line", "And another"]
+              batch_interval = 0.1
+
+            [sinks.bytes_processed_total_batch_sink]
+              # General
+              type = "blackhole"
+              inputs = ["bytes_processed_total_batch_source"]
+              print_amount = 100000
+        "#,
+        )
+        .await;
+
+        let server = api::Server::start(topology.config());
+        let client = new_subscription_client(server.addr()).await;
+        let subscription = client.component_bytes_processed_total_batch_subscription(500);
+
+        tokio::pin! {
+            let component_bytes_processed_total_batch = subscription.stream();
+        }
+
+        let data = component_bytes_processed_total_batch
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .data
+            .unwrap()
+            .component_bytes_processed_total_batch;
+
+        // Bytes are currently only relevant on sinks
+        assert_eq!(data[0].name, "bytes_processed_total_batch_sink");
+        assert!(data[0].metric.bytes_processed_total > 0.00);
     }
 
     #[tokio::test]
@@ -475,7 +636,6 @@ mod tests {
 
         // Await the join handle
         handle.await.unwrap();
-        topology.sources_finished().await;
     }
 
     #[tokio::test]
@@ -561,6 +721,5 @@ mod tests {
 
         // Await the join handle
         handle.await.unwrap();
-        topology.sources_finished().await;
     }
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -498,7 +498,7 @@ mod tests {
 
         // Should only show byte totals on sinks
         assert_eq!(map[&0].name, "bytes_processed_total_sink");
-        assert_eq!(map[&0].name, "bytes_processed_total_sink");
+        assert_eq!(map[&1].name, "bytes_processed_total_sink");
 
         assert!(map[&0].metric.bytes_processed_total > 0.00);
         assert!(map[&1].metric.bytes_processed_total > map[&0].metric.bytes_processed_total)


### PR DESCRIPTION
Follow-up to @sghall's #5002 to add support for `*Batch` subscriptions in the API client, and some tests to assert batching is happening as expected. I also realised I neglected to add a test for the previous `bytesProcessedTotal` and component variants, which have been added here.

No tests for error metrics yet, since those aren't typically thrown. Will probably tackle after #4925 is solved.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
