### PR TITLE
enhancement(remap): support enum variants for function arguments

### DIFF
--- a/lib/remap-lang/src/expression/argument.rs
+++ b/lib/remap-lang/src/expression/argument.rs
@@ -1,0 +1,88 @@
+use crate::{
+    expression, expression::Error as E, state, value, Expr, Expression, Object, Result, TypeDef,
+    Value,
+};
+
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
+pub enum Error {
+    #[error(r#"invalid value type (got "{0}")"#)]
+    Invalid(value::Kind),
+}
+
+#[derive(Clone)]
+pub struct Argument {
+    expression: Box<Expr>,
+    ident: &'static str,
+    keyword: &'static str,
+    validator: fn(&Value) -> bool,
+
+    // used for error messages
+    function_ident: &'static str,
+}
+
+impl std::fmt::Debug for Argument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Argument")
+            .field("expression", &self.expression)
+            .field("ident", &self.ident)
+            .field("keyword", &self.keyword)
+            .field("validator", &"fn(&Value) -> bool".to_owned())
+            .finish()
+    }
+}
+
+impl Argument {
+    pub fn new(
+        expression: Box<Expr>,
+        ident: &'static str,
+        keyword: &'static str,
+        validator: fn(&Value) -> bool,
+        function_ident: &'static str,
+    ) -> Self {
+        Self {
+            expression,
+            ident,
+            keyword,
+            validator,
+            function_ident,
+        }
+    }
+
+    /// Consume the argument, returning its inner expression.
+    ///
+    /// Doing this will prevent the argument runtime check from running, but
+    /// gives you access to the underlying concrete `Expr` type at compile-time.
+    pub fn into_expr(self) -> Expr {
+        *self.expression
+    }
+}
+
+impl Expression for Argument {
+    fn execute(
+        &self,
+        state: &mut state::Program,
+        object: &mut dyn Object,
+    ) -> Result<Option<Value>> {
+        let value = match self.expression.execute(state, object)? {
+            Some(value) => value,
+            None => return Ok(None),
+        };
+
+        if !(self.validator)(&value) {
+            return Err(E::Function(
+                self.function_ident.to_owned(),
+                expression::function::Error::Argument(
+                    self.keyword.to_owned(),
+                    Error::Invalid(value.kind()),
+                ),
+            )
+            .into());
+        }
+
+        Ok(Some(value))
+    }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.expression.type_def(state)
+    }
+}

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -7,6 +7,10 @@ impl Literal {
     pub fn boxed(self) -> Box<dyn Expression> {
         Box::new(self)
     }
+
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
 }
 
 impl<T: Into<Value>> From<T> for Literal {

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -86,10 +86,7 @@ impl ArgumentList {
         keyword: &str,
         variants: &'static [&'static str],
     ) -> Result<Option<String>> {
-        let expr = self
-            .optional(keyword)
-            .map(|v| Expr::try_from(v))
-            .transpose()?;
+        let expr = self.optional(keyword).map(Expr::try_from).transpose()?;
 
         let argument = match expr {
             Some(expr) => expression::Argument::try_from(expr)?,
@@ -105,7 +102,7 @@ impl ArgumentList {
         if variants.contains(&variant.as_str()) {
             Ok(Some(variant))
         } else {
-            Err(Error::UnknownEnumVariant(variant.to_owned(), &variants).into())
+            Err(Error::UnknownEnumVariant(variant, &variants).into())
         }
     }
 

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -1,5 +1,5 @@
-use crate::{Expression, Result, Value};
-use core::convert::TryInto;
+use crate::{expression, Expr, Expression, Result, Value};
+use core::convert::{TryFrom, TryInto};
 use std::collections::HashMap;
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
@@ -12,6 +12,9 @@ pub enum Error {
 
     #[error(r#"missing required argument "{0}""#)]
     Required(String),
+
+    #[error("unknown enum variant: {0}, must be one of: {}", .1.join(", "))]
+    UnknownEnumVariant(String, &'static [&'static str]),
 }
 
 #[derive(Copy, Clone)]
@@ -51,26 +54,68 @@ impl ArgumentList {
         self.0.remove(keyword)
     }
 
+    pub fn required(&mut self, keyword: &str) -> Result<Argument> {
+        self.optional(keyword)
+            .ok_or_else(|| Error::Required(keyword.to_owned()).into())
+    }
+
     pub fn optional_expr(&mut self, keyword: &str) -> Result<Option<Box<dyn Expression>>> {
         self.optional(keyword)
             .map(|v| v.try_into().map_err(Into::into))
             .transpose()
     }
 
-    pub fn required(&mut self, keyword: &str) -> Result<Argument> {
-        self.0
-            .remove(keyword)
+    pub fn required_expr(&mut self, keyword: &str) -> Result<Box<dyn Expression>> {
+        self.optional_expr(keyword)?
             .ok_or_else(|| Error::Required(keyword.to_owned()).into())
     }
 
-    pub fn required_expr(&mut self, keyword: &str) -> Result<Box<dyn Expression>> {
-        self.required(keyword)
-            .and_then(|v| v.try_into().map_err(Into::into))
+    pub fn optional_regex(&mut self, keyword: &str) -> Result<Option<regex::Regex>> {
+        self.optional(keyword)
+            .map(|v| v.try_into().map_err(Into::into))
+            .transpose()
     }
 
     pub fn required_regex(&mut self, keyword: &str) -> Result<regex::Regex> {
-        self.required(keyword)
-            .and_then(|v| v.try_into().map_err(Into::into))
+        self.optional_regex(keyword)?
+            .ok_or_else(|| Error::Required(keyword.to_owned()).into())
+    }
+
+    pub fn optional_enum(
+        &mut self,
+        keyword: &str,
+        variants: &'static [&'static str],
+    ) -> Result<Option<String>> {
+        let expr = self
+            .optional(keyword)
+            .map(|v| Expr::try_from(v))
+            .transpose()?;
+
+        let argument = match expr {
+            Some(expr) => expression::Argument::try_from(expr)?,
+            None => return Ok(None),
+        };
+
+        let variant = expression::Literal::try_from(argument.into_expr())?
+            .as_value()
+            .clone()
+            .try_string()
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())?;
+
+        if variants.contains(&variant.as_str()) {
+            Ok(Some(variant))
+        } else {
+            Err(Error::UnknownEnumVariant(variant.to_owned(), &variants).into())
+        }
+    }
+
+    pub fn required_enum(
+        &mut self,
+        keyword: &str,
+        variants: &'static [&'static str],
+    ) -> Result<String> {
+        self.optional_enum(keyword, variants)?
+            .ok_or_else(|| Error::Required(keyword.to_owned()).into())
     }
 
     pub fn keywords(&self) -> Vec<&'static str> {
@@ -84,19 +129,13 @@ impl ArgumentList {
 
 #[derive(Debug, Clone)]
 pub enum Argument {
-    Expression(Box<dyn Expression>),
+    Expression(Expr),
     Regex(regex::Regex),
 }
 
-impl From<Box<dyn Expression>> for Argument {
-    fn from(expr: Box<dyn Expression>) -> Self {
-        Argument::Expression(expr)
-    }
-}
-
-impl<T: Expression + 'static> From<Box<T>> for Argument {
-    fn from(expr: Box<T>) -> Self {
-        Argument::Expression(expr)
+impl<T: Into<Expr>> From<T> for Argument {
+    fn from(expr: T) -> Self {
+        Argument::Expression(expr.into())
     }
 }
 
@@ -106,22 +145,33 @@ impl From<regex::Regex> for Argument {
     }
 }
 
-impl TryInto<Box<dyn Expression>> for Argument {
+impl TryFrom<Argument> for Expr {
     type Error = Error;
 
-    fn try_into(self) -> std::result::Result<Box<dyn Expression>, Self::Error> {
-        match self {
+    fn try_from(arg: Argument) -> std::result::Result<Self, Self::Error> {
+        match arg {
             Argument::Expression(expr) => Ok(expr),
             Argument::Regex(_) => Err(Error::ArgumentExprRegex),
         }
     }
 }
 
-impl TryInto<regex::Regex> for Argument {
+impl TryFrom<Argument> for Box<dyn Expression> {
     type Error = Error;
 
-    fn try_into(self) -> std::result::Result<regex::Regex, Self::Error> {
-        match self {
+    fn try_from(arg: Argument) -> std::result::Result<Self, Self::Error> {
+        match arg {
+            Argument::Expression(expr) => Ok(Box::new(expr) as _),
+            Argument::Regex(_) => Err(Error::ArgumentExprRegex),
+        }
+    }
+}
+
+impl TryFrom<Argument> for regex::Regex {
+    type Error = Error;
+
+    fn try_from(arg: Argument) -> std::result::Result<Self, Self::Error> {
+        match arg {
             Argument::Regex(regex) => Ok(regex),
             Argument::Expression(_) => Err(Error::ArgumentRegexExpr),
         }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -133,67 +133,35 @@ mod tests {
     use crate::function::ArgumentList;
     use std::collections::HashMap;
 
-    #[derive(Debug, Clone)]
-    struct RegexPrinter;
-    impl Function for RegexPrinter {
-        fn identifier(&self) -> &'static str {
-            "regex_printer"
-        }
-
-        fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-            Ok(Box::new(RegexPrinterFn(arguments.required_regex("value")?)))
-        }
-
-        fn parameters(&self) -> &'static [Parameter] {
-            &[Parameter {
-                keyword: "value",
-                accepts: |_| true,
-                required: true,
-            }]
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct RegexPrinterFn(regex::Regex);
-    impl Expression for RegexPrinterFn {
-        fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
-            Ok(Some(format!("regex: {:?}", self.0).into()))
-        }
-
-        fn type_def(&self, _: &state::Compiler) -> TypeDef {
-            TypeDef::default()
-        }
-    }
-
     #[test]
     fn it_works() {
-        let cases: Vec<(&str, Result<Option<Value>>)> = vec![
-            (r#".foo = null || "bar""#, Ok(Some("bar".into()))),
-            (r#"$foo = null || "bar""#, Ok(Some("bar".into()))),
+        let cases = vec![
+            (r#".foo = null || "bar""#, Ok(()), Ok(Some("bar".into()))),
+            (r#"$foo = null || "bar""#, Ok(()), Ok(Some("bar".into()))),
             // (r#".foo == .bar"#, Ok(Some(Value::Boolean(false)))),
             (
                 r#".foo == .bar"#,
-                Err(
-                    expression::Error::Path(expression::path::Error::Missing("foo".to_owned()))
-                        .into(),
-                ),
+                Ok(()),
+                Err("remap error: path error: missing path: foo"),
             ),
-            (r#".foo = (null || "bar")"#, Ok(Some("bar".into()))),
-            (r#"!false"#, Ok(Some(true.into()))),
-            (r#"!!false"#, Ok(Some(false.into()))),
-            (r#"!!!true"#, Ok(Some(false.into()))),
-            (r#"if true { "yes" } else { "no" }"#, Ok(Some("yes".into()))),
+            (r#".foo = (null || "bar")"#, Ok(()), Ok(Some("bar".into()))),
+            (r#"!false"#, Ok(()), Ok(Some(true.into()))),
+            (r#"!!false"#, Ok(()), Ok(Some(false.into()))),
+            (r#"!!!true"#, Ok(()), Ok(Some(false.into()))),
+            (r#"if true { "yes" } else { "no" }"#, Ok(()), Ok(Some("yes".into()))),
             // (
             //     r#".a.b.(c | d) == .e."f.g"[2].(h | i)"#,
             //     Ok(Some(Value::Boolean(false))),
             // ),
-            ("$bar = true\n.foo = $bar", Ok(Some(Value::Boolean(true)))),
+            ("$bar = true\n.foo = $bar", Ok(()), Ok(Some(Value::Boolean(true)))),
             (
                 r#"{
                     $foo = "foo"
                     .foo = $foo + "bar"
                     .foo
                 }"#,
+                Ok(()),
+
                 Ok(Some("foobar".into())),
             ),
             (
@@ -202,57 +170,165 @@ mod tests {
                     false || (.foo = true) && true
                     .foo
                 "#,
+
+                Ok(()),
+
                 Ok(Some(true.into())),
             ),
-            (r#"if false { 1 }"#, Ok(None)),
-            (r#"if true { 1 }"#, Ok(Some(1.into()))),
-            (r#"if false { 1 } else { 2 }"#, Ok(Some(2.into()))),
-            (r#"if false { 1 } else if false { 2 }"#, Ok(None)),
-            (r#"if false { 1 } else if true { 2 }"#, Ok(Some(2.into()))),
+            (r#"if false { 1 }"#, Ok(()), Ok(None)),
+            (r#"if true { 1 }"#, Ok(()), Ok(Some(1.into()))),
+            (r#"if false { 1 } else { 2 }"#, Ok(()), Ok(Some(2.into()))),
+            (r#"if false { 1 } else if false { 2 }"#, Ok(()), Ok(None)),
+            (r#"if false { 1 } else if true { 2 }"#, Ok(()), Ok(Some(2.into()))),
             (
                 r#"if false { 1 } else if false { 2 } else { 3 }"#,
-                Ok(Some(3.into())),
+                Ok(()), Ok(Some(3.into())),
             ),
             (
                 r#"if false { 1 } else if true { 2 } else { 3 }"#,
-                Ok(Some(2.into())),
+                Ok(()), Ok(Some(2.into())),
             ),
             (
                 r#"if false { 1 } else if false { 2 } else if false { 3 }"#,
-                Ok(None),
+                Ok(()), Ok(None),
             ),
             (
                 r#"if false { 1 } else if false { 2 } else if true { 3 }"#,
-                Ok(Some(3.into())),
+                Ok(()), Ok(Some(3.into())),
             ),
             (
                 r#"if false { 1 } else if true { 2 } else if false { 3 } else { 4 }"#,
-                Ok(Some(2.into())),
+                Ok(()), Ok(Some(2.into())),
             ),
             (
                 r#"if false { 1 } else if false { 2 } else if false { 3 } else { 4 }"#,
-                Ok(Some(4.into())),
+                Ok(()), Ok(Some(4.into())),
             ),
             (
                 r#"regex_printer(/escaped\/forward slash/)"#,
-                Ok(Some("regex: escaped/forward slash".into())),
+                Ok(()), Ok(Some("regex: escaped/forward slash".into())),
+            ),
+            (
+                r#"enum_validator("foo")"#,
+                Ok(()),
+                Ok(Some("valid: foo".into())),
+            ),
+            (
+                r#"enum_validator("bar")"#,
+                Ok(()),
+                Ok(Some("valid: bar".into())),
+            ),
+            (
+                r#"enum_validator("baz")"#,
+                Err("remap error: function error: unknown enum variant: baz, must be one of: foo, bar"),
+                Ok(Some("valid: baz".into())),
             ),
         ];
 
-        for (script, expectation) in cases {
+        for (script, compile_expected, runtime_expected) in cases {
             let accept = TypeDef {
                 fallible: true,
                 optional: true,
                 constraint: value::Constraint::Any,
             };
 
-            let program = Program::new(script, &[Box::new(RegexPrinter)], accept).unwrap();
+            let program = Program::new(
+                script,
+                &[
+                    Box::new(test_functions::RegexPrinter),
+                    Box::new(test_functions::EnumValidator),
+                ],
+                accept,
+            );
+
+            assert_eq!(
+                program.as_ref().map(|_| ()).map_err(|e| e.to_string()),
+                compile_expected.map_err(|e| e.to_string())
+            );
+
+            if program.is_err() {
+                return;
+            }
+
+            let program = program.unwrap();
             let mut runtime = Runtime::new(state::Program::default());
             let mut event = HashMap::default();
 
-            let result = runtime.execute(&mut event, &program).map_err(|e| e.0);
+            let result = runtime
+                .execute(&mut event, &program)
+                .map_err(|e| e.to_string());
 
-            assert_eq!(expectation, result);
+            assert_eq!(result, runtime_expected.map_err(|e| e.to_string()));
+        }
+    }
+
+    mod test_functions {
+        use super::*;
+
+        #[derive(Debug, Clone)]
+        pub(super) struct EnumValidator;
+        impl Function for EnumValidator {
+            fn identifier(&self) -> &'static str {
+                "enum_validator"
+            }
+
+            fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
+                Ok(Box::new(EnumValidatorFn(
+                    arguments.required_enum("value", &["foo", "bar"])?,
+                )))
+            }
+
+            fn parameters(&self) -> &'static [Parameter] {
+                &[Parameter {
+                    keyword: "value",
+                    accepts: |_| true,
+                    required: true,
+                }]
+            }
+        }
+
+        #[derive(Debug, Clone)]
+        struct EnumValidatorFn(String);
+        impl Expression for EnumValidatorFn {
+            fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
+                Ok(Some(format!("valid: {}", self.0).into()))
+            }
+
+            fn type_def(&self, _: &state::Compiler) -> TypeDef {
+                TypeDef::default()
+            }
+        }
+
+        #[derive(Debug, Clone)]
+        pub(super) struct RegexPrinter;
+        impl Function for RegexPrinter {
+            fn identifier(&self) -> &'static str {
+                "regex_printer"
+            }
+
+            fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
+                Ok(Box::new(RegexPrinterFn(arguments.required_regex("value")?)))
+            }
+
+            fn parameters(&self) -> &'static [Parameter] {
+                &[Parameter {
+                    keyword: "value",
+                    accepts: |_| true,
+                    required: true,
+                }]
+            }
+        }
+
+        #[derive(Debug, Clone)]
+        struct RegexPrinterFn(regex::Regex);
+        impl Expression for RegexPrinterFn {
+            fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
+                Ok(Some(format!("regex: {:?}", self.0).into()))
+            }
+
+            fn type_def(&self, _: &state::Compiler) -> TypeDef {
+                TypeDef::default()
+            }
         }
     }
 }

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -258,10 +258,8 @@ impl Parser<'_> {
                 R::ident => ident = Some(pair.as_str().to_owned()),
                 R::regex => return Ok((ident, Argument::Regex(self.regex_from_pair(pair)?))),
                 _ => {
-                    return Ok((
-                        ident,
-                        Argument::Expression(Box::new(self.expression_from_pair(pair)?)),
-                    ))
+                    let expr = self.expression_from_pair(pair)?;
+                    return Ok((ident, Argument::Expression(expr)));
                 }
             }
         }

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -168,7 +168,7 @@ mod test {
         pattern_expression_infallible {
             expr: |_| ReplaceFn {
                 value: Literal::from("foo").boxed(),
-                pattern: Literal::from("foo").boxed().into(),
+                pattern: Literal::from("foo").into(),
                 with: Literal::from("foo").boxed(),
                 count: None,
             },
@@ -181,7 +181,7 @@ mod test {
         pattern_expression_fallible {
             expr: |_| ReplaceFn {
                 value: Literal::from("foo").boxed(),
-                pattern: Literal::from(10).boxed().into(),
+                pattern: Literal::from(10).into(),
                 with: Literal::from("foo").boxed(),
                 count: None,
             },
@@ -241,8 +241,8 @@ mod test {
                 map![],
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
-                    Box::new(Literal::from("a")).into(),
+                    Literal::from("I like apples and bananas").boxed(),
+                    Literal::from("a").into(),
                     "o",
                     None,
                 ),
@@ -251,8 +251,8 @@ mod test {
                 map![],
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
-                    Box::new(Literal::from("a")).into(),
+                    Literal::from("I like apples and bananas").boxed(),
+                    Literal::from("a").into(),
                     "o",
                     Some(-1),
                 ),
@@ -261,8 +261,8 @@ mod test {
                 map![],
                 Ok(Some("I like apples and bananas".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
-                    Box::new(Literal::from("a")).into(),
+                    Literal::from("I like apples and bananas").boxed(),
+                    Literal::from("a").into(),
                     "o",
                     Some(0),
                 ),
@@ -271,8 +271,8 @@ mod test {
                 map![],
                 Ok(Some("I like opples and bananas".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
-                    Box::new(Literal::from("a")).into(),
+                    Literal::from("I like apples and bananas").boxed(),
+                    Literal::from("a").into(),
                     "o",
                     Some(1),
                 ),
@@ -281,8 +281,8 @@ mod test {
                 map![],
                 Ok(Some("I like opples ond bananas".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
-                    Box::new(Literal::from("a")).into(),
+                    Literal::from("I like apples and bananas").boxed(),
+                    Literal::from("a").into(),
                     "o",
                     Some(2),
                 ),
@@ -307,7 +307,7 @@ mod test {
                 map![],
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
+                    Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
                     "o",
                     None,
@@ -317,7 +317,7 @@ mod test {
                 map![],
                 Ok(Some("I like opples ond bononos".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
+                    Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(-1),
@@ -327,7 +327,7 @@ mod test {
                 map![],
                 Ok(Some("I like apples and bananas".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
+                    Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(0),
@@ -337,7 +337,7 @@ mod test {
                 map![],
                 Ok(Some("I like opples and bananas".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
+                    Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(1),
@@ -347,7 +347,7 @@ mod test {
                 map![],
                 Ok(Some("I like opples ond bananas".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
+                    Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
                     "o",
                     Some(2),
@@ -373,8 +373,8 @@ mod test {
                 map![],
                 Ok(Some("I like biscuits and bananas".into())),
                 ReplaceFn::new(
-                    Box::new(Literal::from("I like apples and bananas")),
-                    Box::new(Literal::from("apples")).into(),
+                    Literal::from("I like apples and bananas").boxed(),
+                    Literal::from("apples").into(),
                     "biscuits",
                     None,
                 ),

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -1,6 +1,15 @@
 use remap::prelude::*;
 use sha2::{Digest, Sha224, Sha256, Sha384, Sha512, Sha512Trunc224, Sha512Trunc256};
 
+const VARIANTS: &[&str] = &[
+    "SHA-224",
+    "SHA-256",
+    "SHA-384",
+    "SHA-512",
+    "SHA-512/224",
+    "SHA-512/256",
+];
+
 #[derive(Clone, Copy, Debug)]
 pub struct Sha2;
 
@@ -10,16 +19,23 @@ impl Function for Sha2 {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "value",
-            accepts: |v| matches!(v, Value::String(_)),
-            required: true,
-        }]
+        &[
+            Parameter {
+                keyword: "value",
+                accepts: |v| matches!(v, Value::String(_)),
+                required: true,
+            },
+            Parameter {
+                keyword: "variant",
+                accepts: |v| matches!(v, Value::String(_)),
+                required: false,
+            },
+        ]
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
         let value = arguments.required_expr("value")?;
-        let variant = arguments.optional_expr("variant")?;
+        let variant = arguments.optional_enum("variant", &VARIANTS)?;
 
         Ok(Box::new(Sha2Fn { value, variant }))
     }
@@ -28,13 +44,13 @@ impl Function for Sha2 {
 #[derive(Debug, Clone)]
 struct Sha2Fn {
     value: Box<dyn Expression>,
-    variant: Option<Box<dyn Expression>>,
+    variant: Option<String>,
 }
 
 impl Sha2Fn {
     #[cfg(test)]
     fn new(value: Box<dyn Expression>, variant: Option<&str>) -> Self {
-        let variant = variant.map(|v| Box::new(Literal::from(v)) as _);
+        let variant = variant.map(|v| v.to_owned());
 
         Self { value, variant }
     }
@@ -47,22 +63,15 @@ impl Expression for Sha2Fn {
         object: &mut dyn Object,
     ) -> Result<Option<Value>> {
         let value = required!(state, object, self.value, Value::String(v) => v);
-        let variant = optional!(state, object, self.variant, Value::String(v) => v);
 
-        let hash = match variant.as_deref() {
-            Some(b"SHA-224") => encode::<Sha224>(&value),
-            Some(b"SHA-256") => encode::<Sha256>(&value),
-            Some(b"SHA-384") => encode::<Sha384>(&value),
-            Some(b"SHA-512") => encode::<Sha512>(&value),
-            Some(b"SHA-512/224") => encode::<Sha512Trunc224>(&value),
-            Some(b"SHA-512/256") | None => encode::<Sha512Trunc256>(&value),
-            Some(v) => {
-                return Err(format!(
-                    "unknown SHA-2 algorithm variant: '{}'",
-                    String::from_utf8_lossy(v)
-                )
-                .into())
-            }
+        let hash = match self.variant.as_deref() {
+            Some("SHA-224") => encode::<Sha224>(&value),
+            Some("SHA-256") => encode::<Sha256>(&value),
+            Some("SHA-384") => encode::<Sha384>(&value),
+            Some("SHA-512") => encode::<Sha512>(&value),
+            Some("SHA-512/224") => encode::<Sha512Trunc224>(&value),
+            Some("SHA-512/256") | None => encode::<Sha512Trunc256>(&value),
+            _ => unreachable!("enum invariant"),
         };
 
         Ok(Some(hash.into()))
@@ -72,12 +81,6 @@ impl Expression for Sha2Fn {
         self.value
             .type_def(state)
             .fallible_unless(value::Kind::String)
-            .merge_optional(
-                self.variant
-                    .as_ref()
-                    .map(|variant| variant.type_def(state).fallible_unless(value::Kind::String)),
-            )
-            .into_fallible(true) // unknown variant enum
             .with_constraint(value::Kind::String)
     }
 }
@@ -99,7 +102,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
+            def: TypeDef { constraint: String.into(), ..Default::default() },
         }
 
         value_non_string {
@@ -117,14 +120,6 @@ mod tests {
             },
             def: TypeDef { fallible: true, optional: true, constraint: String.into() },
         }
-
-        variant_fallible {
-            expr: |_| Sha2Fn {
-                value: Literal::from("foo").boxed(),
-                variant: Some(Variable::new("foo".to_string()).boxed()),
-            },
-            def: TypeDef { fallible: true, constraint: String.into(), ..Default::default() },
-        }
     ];
 
     #[test]
@@ -134,11 +129,6 @@ mod tests {
                 map![],
                 Err("path error: missing path: foo".into()),
                 Sha2Fn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map![],
-                Err("function call error: unknown SHA-2 algorithm variant: 'bar'".into()),
-                Sha2Fn::new(Box::new(Literal::from("foo")), Some("bar")),
             ),
             (
                 map!["foo": "foo"],

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -136,7 +136,7 @@ mod test {
         pattern_expression_infallible {
             expr: |_| SplitFn {
                 value: Literal::from("foo").boxed(),
-                pattern: Literal::from("foo").boxed().into(),
+                pattern: Literal::from("foo").into(),
                 limit: None,
             },
             def: TypeDef {
@@ -148,7 +148,7 @@ mod test {
         pattern_expression_fallible {
             expr: |_| SplitFn {
                 value: Literal::from("foo").boxed(),
-                pattern: Literal::from(10).boxed().into(),
+                pattern: Literal::from(10).into(),
                 limit: None,
             },
             def: TypeDef {


### PR DESCRIPTION
This is another improvement to the Remap language that moves one type of runtime errors to compile-time.

Specifically, this PR adds support for "enums" as function arguments.

As an example, this was possible before:

```rust
.variant = "SHA-512/INVALID"
sha2("my value", variant = .variant)
// ^ Runtime error: unknown SHA-2 algorithm variant
```

With this change, the variant has to be a literal string, and has to match the accepted enum variants. If it doesn't, the program won't compile:

```rust
.variant = "SHA-512/INVALID"
sha2("my value", variant = .variant)
// ^ Compiler error: unexpected expression, expected Literal, got Path

sha2("my value", variant = "SHA-512/INVALID")
// ^ Compiler error: unknown enum variant: SHA-512/INVALID, must be one of: SHA-224, SHA-256, <snip>
```

For now, the enum check logic requires enums to be strings, we can expand this to allow other values as well, but there's no need right now, so I wanted to start as simple as possible.

Aside from this change, the plumbing introduced to make this possible will also allow us to add other compile-time checks in the future.

For example, the `del` function currently works by providing a string `del(".foo")`, we want to use `del(.foo)`. With the changes in this PR, we can make it a compile-time error to provide anything other than a path as the function argument, without having to hard-code this function into the language grammar (as we did previously).