### PR TITLE
enhancement(remap): use path arguments for `del` and `only_field` functions

### DIFF
--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -75,7 +75,7 @@ impl Expression for Assignment {
             Target::Path(path) => state
                 .path_query_type(&path.as_string())
                 .cloned()
-                .expect("variable must be assigned via Assignment::new"),
+                .expect("path must be assigned via Assignment::new"),
         }
     }
 }

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -88,7 +88,7 @@ mod tests {
     test_type_def![
         variable {
             expr: |state: &mut state::Compiler| {
-                let target = Target::Variable("foo".to_owned());
+                let target = Target::Variable(Variable::new("foo".to_owned()));
                 let value = Box::new(Literal::from(true).into());
 
                 Assignment::new(target, value, state)
@@ -101,7 +101,7 @@ mod tests {
 
         path {
             expr: |state: &mut state::Compiler| {
-                let target = Target::Path(vec![vec!["foo".to_owned()]]);
+                let target = Target::Path(Path::from("foo"));
                 let value = Box::new(Literal::from("foo").into());
 
                 Assignment::new(target, value, state)

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -28,6 +28,23 @@ impl Path {
     pub(crate) fn new(segments: Vec<Vec<String>>) -> Self {
         Self { segments }
     }
+
+    pub fn segments(&self) -> &[Vec<String>] {
+        &self.segments
+    }
+
+    pub fn as_string(&self) -> String {
+        self.segments
+            .iter()
+            .map(|c| {
+                c.iter()
+                    .map(|p| p.replace(".", "\\."))
+                    .collect::<Vec<_>>()
+                    .join(".")
+            })
+            .collect::<Vec<_>>()
+            .join(".")
+    }
 }
 
 impl Expression for Path {
@@ -35,7 +52,7 @@ impl Expression for Path {
         object
             .find(&self.segments)
             .map_err(|e| E::from(Error::Resolve(e)))?
-            .ok_or_else(|| E::from(Error::Missing(segments_to_path(&self.segments))).into())
+            .ok_or_else(|| E::from(Error::Missing(self.as_string())).into())
             .map(Some)
     }
 
@@ -44,26 +61,13 @@ impl Expression for Path {
     /// understanding of the value kind the path contains.
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         state
-            .path_query_type(&segments_to_path(&self.segments))
+            .path_query_type(self.as_string())
             .cloned()
             .unwrap_or(TypeDef {
                 fallible: true,
                 ..Default::default()
             })
     }
-}
-
-pub(crate) fn segments_to_path(segments: &[Vec<String>]) -> String {
-    segments
-        .iter()
-        .map(|c| {
-            c.iter()
-                .map(|p| p.replace(".", "\\."))
-                .collect::<Vec<_>>()
-                .join(".")
-        })
-        .collect::<Vec<_>>()
-        .join(".")
 }
 
 #[cfg(test)]

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -20,6 +20,10 @@ impl Variable {
     pub fn boxed(self) -> Box<Self> {
         Box::new(self)
     }
+
+    pub fn ident(&self) -> &str {
+        &self.ident
+    }
 }
 
 impl Expression for Variable {

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -135,6 +135,20 @@ impl ArgumentList {
             .ok_or_else(|| Error::Required(keyword.to_owned()).into())
     }
 
+    pub fn optional_path(&mut self, keyword: &str) -> Result<Option<Path>> {
+        self.optional(keyword)
+            .map(Expr::try_from)
+            .transpose()?
+            .map(Path::try_from)
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub fn required_path(&mut self, keyword: &str) -> Result<Path> {
+        self.optional_path(keyword)?
+            .ok_or_else(|| Error::Required(keyword.to_owned()).into())
+    }
+
     pub fn keywords(&self) -> Vec<&'static str> {
         self.0.keys().copied().collect::<Vec<_>>()
     }

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -1,6 +1,26 @@
-use crate::{expression, Expr, Expression, Result, Value};
+use crate::{
+    expression::{self, Path},
+    Expr, Expression, Result, Value,
+};
 use core::convert::{TryFrom, TryInto};
 use std::collections::HashMap;
+
+// workaround for missing variable argument length.
+//
+// We'll come up with a nicer solution at some point. It took Rust five
+// years to support [0; 34].
+#[macro_export]
+macro_rules! generate_param_list {
+    (accepts = $accepts:expr, required = $required:expr, keywords = [$($k:literal),+ $(,)?] $(,)?) => (
+        &[
+            $(Parameter {
+                keyword: $k,
+                accepts: $accepts,
+                required: $required,
+            }),+
+        ]
+    );
+}
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -104,16 +104,16 @@ impl Parser<'_> {
     /// on the parser rule being processed.
     fn target_from_pair(&mut self, pair: Pair<R>) -> Result<Target> {
         match pair.as_rule() {
-            R::variable => Ok(Target::Variable(
+            R::variable => Ok(Target::Variable(Variable::new(
                 pair.into_inner()
                     .next()
                     .ok_or(e(R::variable))?
                     .as_str()
                     .to_owned(),
-            )),
-            R::path => Ok(Target::Path(
+            ))),
+            R::path => Ok(Target::Path(Path::new(
                 self.path_segments_from_pairs(pair.into_inner())?,
-            )),
+            ))),
             _ => Err(e(R::target)),
         }
     }

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -9,3 +9,9 @@ pub use crate::expression::{Literal, Noop, Path, Variable};
 
 // commonly used function types
 pub use crate::function::{Argument, ArgumentList, Parameter};
+
+// commonly used macros
+pub use crate::generate_param_list;
+
+// test helpers
+pub use crate::test_type_def;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -499,7 +499,8 @@ impl remap::Object for Event {
     }
 
     fn remove(&mut self, path: &str, compact: bool) {
-        self.as_mut_log().remove_prune(path, compact);
+        self.as_mut_log()
+            .remove_prune(path.trim_start_matches('.'), compact);
     }
 }
 

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -10,21 +10,13 @@ impl Function for Del {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        // workaround for missing variable argument length.
-        //
-        // We'll come up with a nicer solution at some point. It took Rust five
-        // years to support [0; 34].
-        macro_rules! set_variable_params {
-            ($($n:tt),+ $(,)?) => (
-                &[$(Parameter {
-                        keyword: stringify!($n),
-                        accepts: |v| matches!(v, Value::String(_)),
-                        required: false,
-                    }),+]
-            );
+        generate_param_list! {
+            accepts = |_| true,
+            required = false,
+            keywords = [
+                "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
+            ],
         }
-
-        set_variable_params!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -1,5 +1,4 @@
 use remap::prelude::*;
-use std::convert::TryFrom;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Del;
@@ -20,19 +19,14 @@ impl Function for Del {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        macro_rules! get_variable_params {
-            ($n:tt) => {{
-                let mut a = vec![];
-                for i in 1..=$n {
-                    if let Some(arg) = arguments.optional_expr(&format!("{}", i))? {
-                        a.push(arg)
-                    }
-                }
-                a
-            }};
-        }
+        let mut paths = vec![];
+        paths.push(arguments.required_path("1")?);
 
-        let paths = get_variable_params!(16);
+        for i in 2..=16 {
+            if let Some(path) = arguments.optional_path(&format!("{}", i))? {
+                paths.push(path)
+            }
+        }
 
         Ok(Box::new(DelFn { paths }))
     }
@@ -40,41 +34,21 @@ impl Function for Del {
 
 #[derive(Debug, Clone)]
 pub struct DelFn {
-    paths: Vec<Box<dyn Expression>>,
+    paths: Vec<Path>,
 }
 
 impl Expression for DelFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
-        let paths = self
-            .paths
+    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+        self.paths
             .iter()
-            .filter_map(|expr| expr.execute(state, object).transpose())
-            .map(|r| r.and_then(|v| Ok(String::try_from(v)?.trim_start_matches('.').to_owned())))
-            .collect::<Result<Vec<String>>>()?;
-
-        for path in paths {
-            object.remove(&path, false)
-        }
+            .map(Path::as_string)
+            .for_each(|string| object.remove(&string, false));
 
         Ok(None)
     }
 
-    fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        self.paths
-            .iter()
-            .fold(TypeDef::default(), |acc, expression| {
-                acc.merge(
-                    expression
-                        .type_def(state)
-                        .fallible_unless(value::Kind::String),
-                )
-            })
-            .with_constraint(value::Constraint::Any)
-            .into_optional(true)
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::default().into_optional(true)
     }
 }
 
@@ -82,15 +56,13 @@ impl Expression for DelFn {
 mod tests {
     use super::*;
 
-    remap::test_type_def![
-        value_string {
-            expr: |_| DelFn { paths: vec![Literal::from("foo").boxed()] },
-            def: TypeDef { optional: true, constraint: value::Constraint::Any, ..Default::default() },
-        }
-
-        fallible_expression {
-            expr: |_| DelFn { paths: vec![Variable::new("foo".to_owned()).boxed(), Literal::from("foo").boxed()] },
-            def: TypeDef { fallible: true, optional: true, constraint: value::Constraint::Any },
-        }
-    ];
+    test_type_def![static_type_def {
+        expr: |_| DelFn {
+            paths: vec![Path::from("foo")]
+        },
+        def: TypeDef {
+            optional: true,
+            ..Default::default()
+        },
+    }];
 }

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -1,5 +1,4 @@
 use remap::prelude::*;
-use std::convert::TryFrom;
 
 #[derive(Clone, Copy, Debug)]
 pub struct OnlyFields;
@@ -20,19 +19,14 @@ impl Function for OnlyFields {
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
-        macro_rules! get_variable_params {
-            ($n:tt) => {{
-                let mut a = vec![];
-                for i in 1..=$n {
-                    if let Some(arg) = arguments.optional_expr(&format!("{}", i))? {
-                        a.push(arg)
-                    }
-                }
-                a
-            }};
-        }
+        let mut paths = vec![];
+        paths.push(arguments.required_path("1")?);
 
-        let paths = get_variable_params!(16);
+        for i in 2..=16 {
+            if let Some(path) = arguments.optional_path(&format!("{}", i))? {
+                paths.push(path)
+            }
+        }
 
         Ok(Box::new(OnlyFieldsFn { paths }))
     }
@@ -40,21 +34,12 @@ impl Function for OnlyFields {
 
 #[derive(Debug, Clone)]
 pub struct OnlyFieldsFn {
-    paths: Vec<Box<dyn Expression>>,
+    paths: Vec<Path>,
 }
 
 impl Expression for OnlyFieldsFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
-        let paths = self
-            .paths
-            .iter()
-            .filter_map(|expr| expr.execute(state, object).transpose())
-            .map(|r| r.and_then(|v| Ok(String::try_from(v)?.trim_start_matches('.').to_owned())))
-            .collect::<Result<Vec<String>>>()?;
+    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+        let paths = self.paths.iter().map(Path::as_string).collect::<Vec<_>>();
 
         object
             .paths()
@@ -65,18 +50,8 @@ impl Expression for OnlyFieldsFn {
         Ok(None)
     }
 
-    fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        self.paths
-            .iter()
-            .fold(TypeDef::default(), |acc, expression| {
-                acc.merge(
-                    expression
-                        .type_def(state)
-                        .fallible_unless(value::Kind::String),
-                )
-            })
-            .with_constraint(value::Constraint::Any)
-            .into_optional(true)
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::default().into_optional(true)
     }
 }
 
@@ -84,15 +59,13 @@ impl Expression for OnlyFieldsFn {
 mod tests {
     use super::*;
 
-    remap::test_type_def![
-        value_string {
-            expr: |_| OnlyFieldsFn { paths: vec![Literal::from("foo").boxed()] },
-            def: TypeDef { optional: true, constraint: value::Constraint::Any, ..Default::default() },
-        }
-
-        fallible_expression {
-            expr: |_| OnlyFieldsFn { paths: vec![Variable::new("foo".to_owned()).boxed(), Literal::from("foo").boxed()] },
-            def: TypeDef { fallible: true, optional: true, constraint: value::Constraint::Any },
-        }
-    ];
+    test_type_def![static_type_def {
+        expr: |_| OnlyFieldsFn {
+            paths: vec![Path::from("foo")]
+        },
+        def: TypeDef {
+            optional: true,
+            ..Default::default()
+        },
+    }];
 }

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -10,21 +10,13 @@ impl Function for OnlyFields {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        // workaround for missing variable argument length.
-        //
-        // We'll come up with a nicer solution at some point. It took Rust five
-        // years to support [0; 34].
-        macro_rules! set_variable_params {
-            ($($n:tt),+ $(,)?) => (
-                &[$(Parameter {
-                        keyword: stringify!($n),
-                        accepts: |v| matches!(v, Value::String(_)),
-                        required: false,
-                    }),+]
-            );
+        generate_param_list! {
+            accepts = |_| true,
+            required = false,
+            keywords = [
+                "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
+            ],
         }
-
-        set_variable_params!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
     }
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {


### PR DESCRIPTION
Previously, when a function took some action on the path (as opposed to the value the path evaluated to), you'd write:

```rust
del(".foo")
only_fields(".foo.bar", ".baz")
```

If you provided anything other than a string expression, or if the string contained an invalid path (e.g. `".foo hello world"`), you'd get a runtime error.

With this change, you now write:

```rust
del(.foo)
del(.foo.bar, .baz)
```

These functions validate at compile-time that their arguments are "path expressions". Any other kind of expression is a compile-time error.

_PR is best reviewed per commit_

ref #4947