### PR TITLE
fix(observability): Fix host metrics in the API

### DIFF
--- a/src/api/schema/metrics/host.rs
+++ b/src/api/schema/metrics/host.rs
@@ -313,7 +313,7 @@ impl HostMetrics {
 fn filter_host_metric(metrics: &[Metric], name: &str) -> f64 {
     metrics
         .iter()
-        .find(|m| m.name == format!("host_{}", name))
+        .find(|m| matches!(&m.namespace, Some(n) if n == "host") && m.name == name)
         .map(|m| match m.value {
             MetricValue::Gauge { value } => value,
             MetricValue::Counter { value } => value,


### PR DESCRIPTION
Small fix for host metrics after #4833 to re-enable the following GraphQL API query:

```gql
{
  hostMetrics {
    memory {
      totalBytes
      freeBytes
      availableBytes
      activeBytes
      buffersBytes
      cachedBytes
      sharedBytes
      usedBytes
      inactiveBytes
      wiredBytes
    }
    swap {
      freeBytes
      totalBytes
      usedBytes
      swappedInBytesTotal
      swappedOutBytesTotal
    }
    cpu {
      cpuSecondsTotal
    }
    loadAverage {
      load1
      load5
    }
    network {
      receiveBytesTotal
      receiveErrsTotal
      receivePacketsTotal
      transmitBytesTotal
      transmitErrsTotal
      transmitPacketsDropTotal
      transmitPacketsTotal
    }
    filesystem {
      freeBytes
      totalBytes
      usedBytes
    }
    disk {
      readBytesTotal
      readsCompletedTotal
      writtenBytesTotal
      writesCompletedTotal
    }
  }
}
```

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
