### PR TITLE
enhancement: Beautify reports of conflicting `Resource` usage

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap; // IndexMap preserves insertion order, allowing us to ou
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Display, Formatter};
 use std::fs::DirBuilder;
 use std::hash::Hash;
 use std::net::SocketAddr;
@@ -266,7 +267,7 @@ impl Resource {
     /// From given components returns all that have a resource conflict with any other component.
     pub fn conflicts<K: Eq + Hash + Clone>(
         components: impl IntoIterator<Item = (K, Vec<Resource>)>,
-    ) -> HashSet<K> {
+    ) -> HashMap<Resource, HashSet<K>> {
         let mut resource_map = HashMap::<Resource, HashSet<K>>::new();
         let mut unspecified = Vec::new();
 
@@ -299,17 +300,25 @@ impl Resource {
             }
         }
 
+        resource_map.retain(|_, components| components.len() > 1);
+
         resource_map
-            .into_iter()
-            .filter(|(_, components)| components.len() > 1)
-            .flat_map(|(_, components)| components)
-            .collect()
     }
 }
 
 impl From<SocketAddr> for Resource {
     fn from(addr: SocketAddr) -> Self {
         Self::Port(addr)
+    }
+}
+
+impl Display for Resource {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Resource::Port(address) => write!(fmt, "{}", address),
+            Resource::SystemFdOffset(offset) => write!(fmt, "systemfd {}th socket", offset + 1),
+            Resource::Stdin => write!(fmt, "stdin"),
+        }
     }
 }
 
@@ -568,11 +577,18 @@ mod test {
 #[cfg(all(test, feature = "sources-stdin", feature = "sinks-console"))]
 mod resource_tests {
     use super::{load_from_str, Resource};
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::net::{Ipv4Addr, SocketAddr};
 
     fn localhost(port: u16) -> Resource {
         SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port).into()
+    }
+
+    fn hashmap(conflicts: Vec<(Resource, Vec<&str>)>) -> HashMap<Resource, HashSet<&str>> {
+        conflicts
+            .into_iter()
+            .map(|(key, values)| (key, values.into_iter().collect()))
+            .collect()
     }
 
     #[test]
@@ -583,7 +599,7 @@ mod resource_tests {
             ("sink_2", vec![localhost(2)]),
         ];
         let conflicting = Resource::conflicts(components);
-        assert_eq!(conflicting, HashSet::new());
+        assert_eq!(conflicting, HashMap::new());
     }
 
     #[test]
@@ -594,7 +610,10 @@ mod resource_tests {
             ("sink_2", vec![localhost(2)]),
         ];
         let conflicting = Resource::conflicts(components);
-        assert_eq!(conflicting, vec!["sink_1", "sink_2"].into_iter().collect());
+        assert_eq!(
+            conflicting,
+            hashmap(vec![(localhost(2), vec!["sink_1", "sink_2"])])
+        );
     }
 
     #[test]
@@ -607,7 +626,10 @@ mod resource_tests {
         let conflicting = Resource::conflicts(components);
         assert_eq!(
             conflicting,
-            vec!["sink_0", "sink_1", "sink_2"].into_iter().collect()
+            hashmap(vec![
+                (localhost(0), vec!["sink_0", "sink_1"]),
+                (localhost(2), vec!["sink_1", "sink_2"])
+            ])
         );
     }
 
@@ -621,7 +643,7 @@ mod resource_tests {
             ),
         ];
         let conflicting = Resource::conflicts(components);
-        assert_eq!(conflicting, HashSet::new());
+        assert_eq!(conflicting, HashMap::new());
     }
 
     #[test]
@@ -634,7 +656,10 @@ mod resource_tests {
             ),
         ];
         let conflicting = Resource::conflicts(components);
-        assert_eq!(conflicting, vec!["sink_0", "sink_1"].into_iter().collect());
+        assert_eq!(
+            conflicting,
+            hashmap(vec![(localhost(0), vec!["sink_0", "sink_1"])])
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -316,7 +316,7 @@ impl Display for Resource {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Resource::Port(address) => write!(fmt, "{}", address),
-            Resource::SystemFdOffset(offset) => write!(fmt, "systemfd {}th socket", offset + 1),
+            Resource::SystemFdOffset(offset) => write!(fmt, "systemd {}th socket", offset + 1),
             Resource::Stdin => write!(fmt, "stdin"),
         }
     }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -61,15 +61,15 @@ pub fn check_resources(config: &Config) -> Result<(), Vec<String>> {
     if conflicting_componenets.is_empty() {
         Ok(())
     } else {
-        let conflicting_componenets = conflicting_componenets
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<_>>();
-        let error = format!(
-            "Multiple components own the same resource. Conflicting components: {}.",
-            conflicting_componenets.join(", ")
-        );
-        Err(vec![error])
+        Err(conflicting_componenets
+            .into_iter()
+            .map(|(resource, components)| {
+                format!(
+                    "Resource `{}` is claimed by multiple components: {:?}",
+                    resource, components
+                )
+            })
+            .collect())
     }
 }
 

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -263,9 +263,11 @@ where
     let s: &'de str = Deserialize::deserialize(des)?;
     match s {
         "systemd" => Ok(0),
-        s if s.starts_with("systemd#") => {
-            Ok(s[8..].parse::<usize>().map_err(de::Error::custom)? - 1)
-        }
+        s if s.starts_with("systemd#") => s[8..]
+            .parse::<usize>()
+            .map_err(de::Error::custom)?
+            .checked_sub(1)
+            .ok_or_else(|| de::Error::custom("systemd indices start from 1, found 0")),
         _ => Err(de::Error::custom("must start with \"systemd\"")),
     }
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -236,7 +236,10 @@ impl RunningTopology {
                     .chain(add_source)
                     .map(|(key, value)| ((false, key), value)),
             ),
-        );
+        )
+        .into_iter()
+        .flat_map(|(_, components)| components)
+        .collect::<HashSet<_>>();
         let wait_for_sinks = conflicts
             .into_iter()
             .filter(|&(existing_sink, _)| existing_sink)


### PR DESCRIPTION
Closes #4826 

Regular vector run:
```
Nov 16 00:16:38.850 ERROR vector::cli: Configuration error. error=Resource `systemd 2th socket` is claimed by multiple components: {"in2", "in4"}
Nov 16 00:16:38.850 ERROR vector::cli: Configuration error. error=Resource `127.0.0.1:8126` is claimed by multiple components: {"out2", "out3", "in3"}
Nov 16 00:16:38.850 ERROR vector::cli: Configuration error. error=Resource `stdin` is claimed by multiple components: {"in6", "in7"}
```

`validate`
```
x Resource `127.0.0.1:8126` is claimed by multiple components: {"out2", "out3", "in3"}
x Resource `stdin` is claimed by multiple components: {"in6", "in7"}
x Resource `systemd 2th socket` is claimed by multiple components: {"in2", "in4"}
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
