### PR TITLE
enhancement(remap): expressions no longer return an option

### DIFF
--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -27,9 +27,6 @@ pub use variable::Variable;
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum Error {
-    #[error("expected expression, got none")]
-    Missing,
-
     #[error("unexpected expression")]
     Unexpected(#[from] ExprError),
 
@@ -53,8 +50,7 @@ pub enum Error {
 }
 
 pub trait Expression: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
-    fn execute(&self, state: &mut state::Program, object: &mut dyn Object)
-        -> Result<Option<Value>>;
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value>;
     fn type_def(&self, state: &state::Compiler) -> TypeDef;
 }
 
@@ -94,7 +90,7 @@ macro_rules! expression_dispatch {
         }
 
         impl Expression for Expr {
-            fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+            fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
                 match self {
                     $(Expr::$expr(expression) => expression.execute(state, object)),+
                 }

--- a/lib/remap-lang/src/expression/argument.rs
+++ b/lib/remap-lang/src/expression/argument.rs
@@ -58,15 +58,8 @@ impl Argument {
 }
 
 impl Expression for Argument {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
-        let value = match self.expression.execute(state, object)? {
-            Some(value) => value,
-            None => return Ok(None),
-        };
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        let value = self.expression.execute(state, object)?;
 
         if !(self.validator)(&value) {
             return Err(E::Function(
@@ -79,7 +72,7 @@ impl Expression for Argument {
             .into());
         }
 
-        Ok(Some(value))
+        Ok(value)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -15,23 +15,13 @@ impl Arithmetic {
 }
 
 impl Expression for Arithmetic {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
-        let lhs = self
-            .lhs
-            .execute(state, object)?
-            .ok_or(super::Error::Missing)?;
-
-        let rhs = self
-            .rhs
-            .execute(state, object)?
-            .ok_or(super::Error::Missing)?;
-
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use Operator::*;
-        let result = match self.op {
+
+        let lhs = self.lhs.execute(state, object)?;
+        let rhs = self.rhs.execute(state, object)?;
+
+        match self.op {
             Multiply => lhs.try_mul(rhs),
             Divide => lhs.try_div(rhs),
             Add => lhs.try_add(rhs),
@@ -48,9 +38,8 @@ impl Expression for Arithmetic {
             GreaterOrEqual => lhs.try_ge(rhs),
             Less => lhs.try_lt(rhs),
             LessOrEqual => lhs.try_le(rhs),
-        };
-
-        result.map(Some).map_err(Into::into)
+        }
+        .map_err(Into::into)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -40,30 +40,21 @@ impl Assignment {
 }
 
 impl Expression for Assignment {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = self.value.execute(state, object)?;
 
-        match value {
-            None => Ok(None),
-            Some(value) => {
-                match &self.target {
-                    Target::Variable(variable) => {
-                        state
-                            .variables_mut()
-                            .insert(variable.ident().to_owned(), value.clone());
-                    }
-                    Target::Path(path) => object
-                        .insert(path.segments(), value.clone())
-                        .map_err(|e| E::Assignment(Error::PathInsertion(e)))?,
-                }
-
-                Ok(Some(value))
+        match &self.target {
+            Target::Variable(variable) => {
+                state
+                    .variables_mut()
+                    .insert(variable.ident().to_owned(), value.clone());
             }
+            Target::Path(path) => object
+                .insert(path.segments(), value.clone())
+                .map_err(|e| E::Assignment(Error::PathInsertion(e)))?,
         }
+
+        Ok(value)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -12,18 +12,12 @@ impl Block {
 }
 
 impl Expression for Block {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
-        let mut value = None;
-
-        for expr in &self.expressions {
-            value = expr.execute(state, object)?;
-        }
-
-        Ok(value)
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        self.expressions
+            .iter()
+            .map(|expr| expr.execute(state, object))
+            .last()
+            .unwrap_or(Ok(Value::Null))
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -16,8 +16,8 @@ impl Expression for Block {
         self.expressions
             .iter()
             .map(|expr| expr.execute(state, object))
-            .last()
-            .unwrap_or(Ok(Value::Null))
+            .collect::<Result<Vec<_>>>()
+            .map(|mut v| v.pop().unwrap_or(Value::Null))
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -126,11 +126,7 @@ impl Function {
 }
 
 impl Expression for Function {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         self.function.execute(state, object)
     }
 

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -29,15 +29,11 @@ impl IfStatement {
 }
 
 impl Expression for IfStatement {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         match self.conditional.execute(state, object)? {
-            Some(Value::Boolean(true)) => self.true_expression.execute(state, object),
-            Some(Value::Boolean(false)) | None => self.false_expression.execute(state, object),
-            Some(v) => Err(E::from(Error::from(value::Error::Expected(
+            Value::Boolean(true) => self.true_expression.execute(state, object),
+            Value::Boolean(false) => self.false_expression.execute(state, object),
+            v => Err(E::from(Error::from(value::Error::Expected(
                 value::Kind::Boolean,
                 v.kind(),
             )))

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -20,8 +20,8 @@ impl<T: Into<Value>> From<T> for Literal {
 }
 
 impl Expression for Literal {
-    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
-        Ok(Some(self.0.clone()))
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
+        Ok(self.0.clone())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -4,8 +4,8 @@ use crate::{state, Expression, Object, Result, TypeDef, Value};
 pub struct Noop;
 
 impl Expression for Noop {
-    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
-        Ok(None)
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
+        Ok(Value::Null)
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -19,13 +19,10 @@ impl Not {
 }
 
 impl Expression for Not {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
-        self.expression.execute(state, object).and_then(|opt| {
-            opt.map(|v| match v {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        self.expression
+            .execute(state, object)
+            .and_then(|v| match v {
                 Value::Boolean(b) => Ok(Value::Boolean(!b)),
                 _ => Err(E::from(Error::from(value::Error::Expected(
                     value::Kind::Boolean,
@@ -33,8 +30,6 @@ impl Expression for Not {
                 )))
                 .into()),
             })
-            .transpose()
-        })
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
@@ -59,11 +54,11 @@ mod tests {
                 Not::new(Box::new(Path::from("foo").into())),
             ),
             (
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 Not::new(Box::new(Literal::from(true).into())),
             ),
             (
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 Not::new(Box::new(Literal::from(false).into())),
             ),
             (

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -48,12 +48,11 @@ impl Path {
 }
 
 impl Expression for Path {
-    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         object
             .find(&self.segments)
             .map_err(|e| E::from(Error::Resolve(e)))?
             .ok_or_else(|| E::from(Error::Missing(self.as_string())).into())
-            .map(Some)
     }
 
     /// A path resolves to `Any` by default, but the script might assign

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -27,12 +27,11 @@ impl Variable {
 }
 
 impl Expression for Variable {
-    fn execute(&self, state: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
         state
             .variable(&self.ident)
             .cloned()
             .ok_or_else(|| E::from(Error::Undefined(self.ident.to_owned())).into())
-            .map(Some)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -136,24 +136,24 @@ mod tests {
     #[test]
     fn it_works() {
         let cases = vec![
-            (r#".foo = null || "bar""#, Ok(()), Ok(Some("bar".into()))),
-            (r#"$foo = null || "bar""#, Ok(()), Ok(Some("bar".into()))),
-            // (r#".foo == .bar"#, Ok(Some(Value::Boolean(false)))),
+            (r#".foo = null || "bar""#, Ok(()), Ok("bar".into())),
+            (r#"$foo = null || "bar""#, Ok(()), Ok("bar".into())),
+            // (r#".foo == .bar"#, Ok(Value::Boolean(false))),
             (
                 r#".foo == .bar"#,
                 Ok(()),
                 Err("remap error: path error: missing path: foo"),
             ),
-            (r#".foo = (null || "bar")"#, Ok(()), Ok(Some("bar".into()))),
-            (r#"!false"#, Ok(()), Ok(Some(true.into()))),
-            (r#"!!false"#, Ok(()), Ok(Some(false.into()))),
-            (r#"!!!true"#, Ok(()), Ok(Some(false.into()))),
-            (r#"if true { "yes" } else { "no" }"#, Ok(()), Ok(Some("yes".into()))),
+            (r#".foo = (null || "bar")"#, Ok(()), Ok("bar".into())),
+            (r#"!false"#, Ok(()), Ok(true.into())),
+            (r#"!!false"#, Ok(()), Ok(false.into())),
+            (r#"!!!true"#, Ok(()), Ok(false.into())),
+            (r#"if true { "yes" } else { "no" }"#, Ok(()), Ok("yes".into())),
             // (
             //     r#".a.b.(c | d) == .e."f.g"[2].(h | i)"#,
-            //     Ok(Some(Value::Boolean(false))),
+            //     Ok(Value::Boolean(false)),
             // ),
-            ("$bar = true\n.foo = $bar", Ok(()), Ok(Some(Value::Boolean(true)))),
+            ("$bar = true\n.foo = $bar", Ok(()), Ok(Value::Boolean(true))),
             (
                 r#"{
                     $foo = "foo"
@@ -162,7 +162,7 @@ mod tests {
                 }"#,
                 Ok(()),
 
-                Ok(Some("foobar".into())),
+                Ok("foobar".into()),
             ),
             (
                 r#"
@@ -173,55 +173,55 @@ mod tests {
 
                 Ok(()),
 
-                Ok(Some(true.into())),
+                Ok(true.into()),
             ),
-            (r#"if false { 1 }"#, Ok(()), Ok(None)),
-            (r#"if true { 1 }"#, Ok(()), Ok(Some(1.into()))),
-            (r#"if false { 1 } else { 2 }"#, Ok(()), Ok(Some(2.into()))),
-            (r#"if false { 1 } else if false { 2 }"#, Ok(()), Ok(None)),
-            (r#"if false { 1 } else if true { 2 }"#, Ok(()), Ok(Some(2.into()))),
+            (r#"if false { 1 }"#, Ok(()), Ok(Value::Null)),
+            (r#"if true { 1 }"#, Ok(()), Ok(1.into())),
+            (r#"if false { 1 } else { 2 }"#, Ok(()), Ok(2.into())),
+            (r#"if false { 1 } else if false { 2 }"#, Ok(()), Ok(Value::Null)),
+            (r#"if false { 1 } else if true { 2 }"#, Ok(()), Ok(2.into())),
             (
                 r#"if false { 1 } else if false { 2 } else { 3 }"#,
-                Ok(()), Ok(Some(3.into())),
+                Ok(()), Ok(3.into()),
             ),
             (
                 r#"if false { 1 } else if true { 2 } else { 3 }"#,
-                Ok(()), Ok(Some(2.into())),
+                Ok(()), Ok(2.into()),
             ),
             (
                 r#"if false { 1 } else if false { 2 } else if false { 3 }"#,
-                Ok(()), Ok(None),
+                Ok(()), Ok(Value::Null),
             ),
             (
                 r#"if false { 1 } else if false { 2 } else if true { 3 }"#,
-                Ok(()), Ok(Some(3.into())),
+                Ok(()), Ok(3.into()),
             ),
             (
                 r#"if false { 1 } else if true { 2 } else if false { 3 } else { 4 }"#,
-                Ok(()), Ok(Some(2.into())),
+                Ok(()), Ok(2.into()),
             ),
             (
                 r#"if false { 1 } else if false { 2 } else if false { 3 } else { 4 }"#,
-                Ok(()), Ok(Some(4.into())),
+                Ok(()), Ok(4.into()),
             ),
             (
                 r#"regex_printer(/escaped\/forward slash/)"#,
-                Ok(()), Ok(Some("regex: escaped/forward slash".into())),
+                Ok(()), Ok("regex: escaped/forward slash".into()),
             ),
             (
                 r#"enum_validator("foo")"#,
                 Ok(()),
-                Ok(Some("valid: foo".into())),
+                Ok("valid: foo".into()),
             ),
             (
                 r#"enum_validator("bar")"#,
                 Ok(()),
-                Ok(Some("valid: bar".into())),
+                Ok("valid: bar".into()),
             ),
             (
                 r#"enum_validator("baz")"#,
                 Err("remap error: function error: unknown enum variant: baz, must be one of: foo, bar"),
-                Ok(Some("valid: baz".into())),
+                Ok("valid: baz".into()),
             ),
         ];
 
@@ -290,8 +290,8 @@ mod tests {
         #[derive(Debug, Clone)]
         struct EnumValidatorFn(String);
         impl Expression for EnumValidatorFn {
-            fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
-                Ok(Some(format!("valid: {}", self.0).into()))
+            fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
+                Ok(format!("valid: {}", self.0).into())
             }
 
             fn type_def(&self, _: &state::Compiler) -> TypeDef {
@@ -322,8 +322,8 @@ mod tests {
         #[derive(Debug, Clone)]
         struct RegexPrinterFn(regex::Regex);
         impl Expression for RegexPrinterFn {
-            fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
-                Ok(Some(format!("regex: {:?}", self.0).into()))
+            fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
+                Ok(format!("regex: {:?}", self.0).into())
             }
 
             fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/runtime.rs
+++ b/lib/remap-lang/src/runtime.rs
@@ -16,14 +16,14 @@ impl Runtime {
         &mut self,
         object: &mut impl Object,
         program: &Program,
-    ) -> Result<Option<Value>, RemapError> {
+    ) -> Result<Value, RemapError> {
         let mut values = program
             .expressions
             .iter()
             .map(|expression| expression.execute(&mut self.state, object))
-            .collect::<crate::Result<Vec<Option<Value>>>>()
+            .collect::<crate::Result<Vec<Value>>>()
             .map_err(RemapError)?;
 
-        Ok(values.pop().flatten())
+        Ok(values.pop().unwrap_or(Value::Null))
     }
 }

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -46,11 +46,7 @@ impl CeilFn {
 }
 
 impl Expression for CeilFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -135,22 +131,22 @@ mod tests {
             ),
             (
                 map!["foo": 1234.2],
-                Ok(Some(1235.0.into())),
+                Ok(1235.0.into()),
                 CeilFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map![],
-                Ok(Some(1235.0.into())),
+                Ok(1235.0.into()),
                 CeilFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),
             ),
             (
                 map![],
-                Ok(Some(1234.into())),
+                Ok(1234.into()),
                 CeilFn::new(Box::new(Literal::from(Value::Integer(1234))), None),
             ),
             (
                 map![],
-                Ok(Some(1234.4.into())),
+                Ok(1234.4.into()),
                 CeilFn::new(
                     Box::new(Literal::from(Value::Float(1234.39429))),
                     Some(Box::new(Literal::from(1))),
@@ -158,7 +154,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(3.1416.into())),
+                Ok(3.1416.into()),
                 CeilFn::new(
                     Box::new(Literal::from(Value::Float(std::f64::consts::PI))),
                     Some(Box::new(Literal::from(4))),
@@ -166,9 +162,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(
-                    9876543210123456789098765432101234567890987654321.98766.into(),
-                )),
+                Ok(9876543210123456789098765432101234567890987654321.98766.into()),
                 CeilFn::new(
                     Box::new(Literal::from(
                         9876543210123456789098765432101234567890987654321.987654321,

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -56,7 +56,7 @@ impl Expression for CeilFn {
                             v@Value::Integer(_) => v
         );
 
-        Ok(res.into())
+        Ok(res)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/contains.rs
+++ b/src/remap/function/contains.rs
@@ -63,11 +63,7 @@ impl ContainsFn {
 }
 
 impl Expression for ContainsFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -84,7 +80,7 @@ impl Expression for ContainsFn {
                 .filter(|&case_sensitive| !case_sensitive)
                 .any(|_| value.to_lowercase().contains(&substring.to_lowercase()));
 
-        Ok(Some(contains.into()))
+        Ok(contains.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -120,47 +116,47 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 ContainsFn::new(Box::new(Literal::from("foo")), "bar", false),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 ContainsFn::new(Box::new(Literal::from("foo")), "foobar", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 ContainsFn::new(Box::new(Literal::from("foo")), "foo", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 ContainsFn::new(Box::new(Literal::from("foobar")), "oba", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 ContainsFn::new(Box::new(Literal::from("foobar")), "foo", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 ContainsFn::new(Box::new(Literal::from("foobar")), "bar", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 ContainsFn::new(Box::new(Literal::from("fooBAR")), "BAR", true),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 ContainsFn::new(Box::new(Literal::from("foobar")), "BAR", true),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 ContainsFn::new(Box::new(Literal::from("foobar")), "BAR", false),
             ),
         ];

--- a/src/remap/function/del.rs
+++ b/src/remap/function/del.rs
@@ -38,13 +38,13 @@ pub struct DelFn {
 }
 
 impl Expression for DelFn {
-    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         self.paths
             .iter()
             .map(Path::as_string)
             .for_each(|string| object.remove(&string, false));
 
-        Ok(None)
+        Ok(Value::Null)
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -37,19 +37,12 @@ impl DowncaseFn {
 }
 
 impl Expression for DowncaseFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         self.value
-            .execute(state, object)?
-            .map(String::try_from)
-            .transpose()?
+            .execute(state, object)
+            .and_then(|v| String::try_from(v).map_err(Into::into))
             .map(|v| v.to_lowercase())
             .map(Into::into)
-            .map(Ok)
-            .transpose()
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -75,7 +68,7 @@ mod tests {
             ),
             (
                 map!["foo": "FOO 2 bar"],
-                Ok(Some(Value::from("foo 2 bar"))),
+                Ok(Value::from("foo 2 bar")),
                 DowncaseFn::new(Box::new(Path::from("foo"))),
             ),
         ];

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -63,11 +63,7 @@ impl EndsWithFn {
 }
 
 impl Expression for EndsWithFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -84,7 +80,7 @@ impl Expression for EndsWithFn {
                 .filter(|&case_sensitive| !case_sensitive)
                 .any(|_| value.to_lowercase().ends_with(&substring.to_lowercase()));
 
-        Ok(Some(ends_with.into()))
+        Ok(ends_with.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -161,47 +157,47 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 EndsWithFn::new(Box::new(Literal::from("bar")), "foo", false),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 EndsWithFn::new(Box::new(Literal::from("bar")), "foobar", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 EndsWithFn::new(Box::new(Literal::from("bar")), "bar", false),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 EndsWithFn::new(Box::new(Literal::from("foobar")), "oba", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 EndsWithFn::new(Box::new(Literal::from("foobar")), "bar", false),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 EndsWithFn::new(Box::new(Literal::from("foobar")), "foo", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 EndsWithFn::new(Box::new(Literal::from("fooBAR")), "BAR", true),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 EndsWithFn::new(Box::new(Literal::from("foobar")), "BAR", true),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 EndsWithFn::new(Box::new(Literal::from("foobar")), "BAR", false),
             ),
         ];

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -46,11 +46,7 @@ impl FloorFn {
 }
 
 impl Expression for FloorFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -135,22 +131,22 @@ mod tests {
             ),
             (
                 map!["foo": 1234.2],
-                Ok(Some(1234.0.into())),
+                Ok(1234.0.into()),
                 FloorFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map![],
-                Ok(Some(1234.0.into())),
+                Ok(1234.0.into()),
                 FloorFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),
             ),
             (
                 map![],
-                Ok(Some(1234.into())),
+                Ok(1234.into()),
                 FloorFn::new(Box::new(Literal::from(Value::Integer(1234))), None),
             ),
             (
                 map![],
-                Ok(Some(1234.3.into())),
+                Ok(1234.3.into()),
                 FloorFn::new(
                     Box::new(Literal::from(Value::Float(1234.39429))),
                     Some(Box::new(Literal::from(1))),
@@ -158,7 +154,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(3.1415.into())),
+                Ok(3.1415.into()),
                 FloorFn::new(
                     Box::new(Literal::from(Value::Float(std::f64::consts::PI))),
                     Some(Box::new(Literal::from(4))),
@@ -166,9 +162,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(
-                    9876543210123456789098765432101234567890987654321.98765.into(),
-                )),
+                Ok(9876543210123456789098765432101234567890987654321.98765.into()),
                 FloorFn::new(
                     Box::new(Literal::from(
                         9876543210123456789098765432101234567890987654321.987654321,

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -56,7 +56,7 @@ impl Expression for FloorFn {
                             v@Value::Integer(_) => v
         );
 
-        Ok(res.into())
+        Ok(res)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -80,11 +80,7 @@ impl FormatNumberFn {
 }
 
 impl Expression for FormatNumberFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = required!(state, object, self.value,
             Value::Integer(v) => Decimal::from_i64(v),
             Value::Float(v) => Decimal::from_f64(v),
@@ -147,11 +143,9 @@ impl Expression for FormatNumberFn {
         }
 
         // Join results, using configured decimal separator.
-        Ok(Some(
-            parts
-                .join(&String::from_utf8_lossy(&decimal_separator[..]))
-                .into(),
-        ))
+        Ok(parts
+            .join(&String::from_utf8_lossy(&decimal_separator[..]))
+            .into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -235,22 +229,22 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("1234.567".into())),
+                Ok("1234.567".into()),
                 FormatNumberFn::new(Box::new(Literal::from(1234.567)), None, None, None),
             ),
             (
                 map![],
-                Ok(Some("1234.56".into())),
+                Ok("1234.56".into()),
                 FormatNumberFn::new(Box::new(Literal::from(1234.567)), Some(2), None, None),
             ),
             (
                 map![],
-                Ok(Some("1234,56".into())),
+                Ok("1234,56".into()),
                 FormatNumberFn::new(Box::new(Literal::from(1234.567)), Some(2), Some(","), None),
             ),
             (
                 map![],
-                Ok(Some("1 234,56".into())),
+                Ok("1 234,56".into()),
                 FormatNumberFn::new(
                     Box::new(Literal::from(1234.567)),
                     Some(2),
@@ -260,7 +254,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("11.222.333.444,567".into())),
+                Ok("11.222.333.444,567".into()),
                 FormatNumberFn::new(
                     Box::new(Literal::from(11222333444.56789)),
                     Some(3),
@@ -270,22 +264,22 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("100".into())),
+                Ok("100".into()),
                 FormatNumberFn::new(Box::new(Literal::from(100.0)), None, None, None),
             ),
             (
                 map![],
-                Ok(Some("100.00".into())),
+                Ok("100.00".into()),
                 FormatNumberFn::new(Box::new(Literal::from(100.0)), Some(2), None, None),
             ),
             (
                 map![],
-                Ok(Some("123".into())),
+                Ok("123".into()),
                 FormatNumberFn::new(Box::new(Literal::from(123.45)), Some(0), None, None),
             ),
             (
                 map![],
-                Ok(Some("12345.00".into())),
+                Ok("12345.00".into()),
                 FormatNumberFn::new(Box::new(Literal::from(12345)), Some(2), None, None),
             ),
         ];

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -49,15 +49,11 @@ impl FormatTimestampFn {
 }
 
 impl Expression for FormatTimestampFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let format = required!(state, object, self.format, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let ts = required!(state, object, self.value, Value::Timestamp(ts) => ts);
 
-        try_format(&ts, &format).map(Into::into).map(Some)
+        try_format(&ts, &format).map(Into::into)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -129,7 +125,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("10".into())),
+                Ok("10".into()),
                 FormatTimestampFn::new(
                     Box::new(Literal::from(Value::from(Utc.timestamp(10, 0)))),
                     "%s",
@@ -137,7 +133,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("1970-01-01T00:00:10+00:00".into())),
+                Ok("1970-01-01T00:00:10+00:00".into()),
                 FormatTimestampFn::new(
                     Box::new(Literal::from(Value::from(Utc.timestamp(10, 0)))),
                     "%+",

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -46,17 +46,13 @@ impl MatchFn {
 }
 
 impl Expression for MatchFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         required!(
             state, object, self.value,
 
             Value::String(b) => {
                 let value = String::from_utf8_lossy(&b);
-                Ok(Some(self.pattern.is_match(&value).into()))
+                Ok(self.pattern.is_match(&value).into())
             }
         )
     }
@@ -111,22 +107,16 @@ mod tests {
             ),
             (
                 map!["foo": "foobar"],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 MatchFn::new(Box::new(Path::from("foo")), Regex::new("\\s\\w+").unwrap()),
             ),
             (
                 map!["foo": "foo 2 bar"],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 MatchFn::new(
                     Box::new(Path::from("foo")),
                     Regex::new("foo \\d bar").unwrap(),
                 ),
-            ),
-            // `Noop` returns `Ok(None)`, which is passed-through
-            (
-                map![],
-                Ok(None),
-                MatchFn::new(Box::new(Noop), Regex::new("true").unwrap()),
             ),
         ];
 

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -36,19 +36,15 @@ impl Md5Fn {
 }
 
 impl Expression for Md5Fn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use md5::{Digest, Md5};
 
-        self.value.execute(state, object).map(|r| {
-            r.map(|v| match v.as_string_lossy() {
-                Value::String(bytes) => Value::String(hex::encode(Md5::digest(&bytes)).into()),
+        self.value
+            .execute(state, object)
+            .map(|v| match v.as_string_lossy() {
+                Value::String(b) => Value::String(hex::encode(Md5::digest(&b)).into()),
                 _ => unreachable!(),
             })
-        })
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -92,7 +88,7 @@ mod tests {
             ),
             (
                 map!["foo": "foo"],
-                Ok(Some(Value::from("acbd18db4cc2f85cedef654fccc4a4d8"))),
+                Ok(Value::from("acbd18db4cc2f85cedef654fccc4a4d8")),
                 Md5Fn::new(Box::new(Path::from("foo"))),
             ),
         ];

--- a/src/remap/function/now.rs
+++ b/src/remap/function/now.rs
@@ -18,8 +18,8 @@ impl Function for Now {
 struct NowFn;
 
 impl Expression for NowFn {
-    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
-        Ok(Some(Utc::now().into()))
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
+        Ok(Utc::now().into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/src/remap/function/only_fields.rs
+++ b/src/remap/function/only_fields.rs
@@ -38,7 +38,7 @@ pub struct OnlyFieldsFn {
 }
 
 impl Expression for OnlyFieldsFn {
-    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let paths = self.paths.iter().map(Path::as_string).collect::<Vec<_>>();
 
         object
@@ -47,7 +47,7 @@ impl Expression for OnlyFieldsFn {
             .filter(|k| paths.iter().find(|p| k.starts_with(p.as_str())).is_none())
             .for_each(|path| object.remove(&path, true));
 
-        Ok(None)
+        Ok(Value::Null)
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -79,11 +79,7 @@ impl ParseDurationFn {
 }
 
 impl Expression for ParseDurationFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -114,7 +110,7 @@ impl Expression for ParseDurationFn {
             .to_f64()
             .ok_or(format!("unable to format duration: '{}'", number))?;
 
-        Ok(Some(number.into()))
+        Ok(number.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -160,37 +156,37 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Ok(Some(0.5.into())),
+                Ok(0.5.into()),
                 ParseDurationFn::new(Box::new(Literal::from("30s")), "m"),
             ),
             (
                 map![],
-                Ok(Some(1.2.into())),
+                Ok(1.2.into()),
                 ParseDurationFn::new(Box::new(Literal::from("1200ms")), "s"),
             ),
             (
                 map![],
-                Ok(Some(100.0.into())),
+                Ok(100.0.into()),
                 ParseDurationFn::new(Box::new(Literal::from("100ms")), "ms"),
             ),
             (
                 map![],
-                Ok(Some(1.005.into())),
+                Ok(1.005.into()),
                 ParseDurationFn::new(Box::new(Literal::from("1005ms")), "s"),
             ),
             (
                 map![],
-                Ok(Some(0.0001.into())),
+                Ok(0.0001.into()),
                 ParseDurationFn::new(Box::new(Literal::from("100ns")), "ms"),
             ),
             (
                 map![],
-                Ok(Some(86400.0.into())),
+                Ok(86400.0.into()),
                 ParseDurationFn::new(Box::new(Literal::from("1d")), "s"),
             ),
             (
                 map![],
-                Ok(Some(1000000000.0.into())),
+                Ok(1000000000.0.into()),
                 ParseDurationFn::new(Box::new(Literal::from("1 s")), "ns"),
             ),
             (

--- a/src/remap/function/parse_json.rs
+++ b/src/remap/function/parse_json.rs
@@ -47,11 +47,7 @@ impl ParseJsonFn {
 }
 
 impl Expression for ParseJsonFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let to_json = |value| match value {
             Value::String(bytes) => serde_json::from_slice(&bytes)
                 .map(|v: serde_json::Value| {
@@ -155,22 +151,22 @@ mod tests {
         let cases = vec![
             (
                 map!["foo": "42"],
-                Ok(Some(42.into())),
+                Ok(42.into()),
                 ParseJsonFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": "\"hello\""],
-                Ok(Some("hello".into())),
+                Ok("hello".into()),
                 ParseJsonFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": r#"{"field":"value"}"#],
-                Ok(Some(map!["field": "value"].into())),
+                Ok(map!["field": "value"].into()),
                 ParseJsonFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": r#"{ INVALID }"#],
-                Ok(Some(42.into())),
+                Ok(42.into()),
                 ParseJsonFn::new(Box::new(Path::from("foo")), Some("42".into())),
             ),
             (

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -64,17 +64,12 @@ impl ParseTimestampFn {
 }
 
 impl Expression for ParseTimestampFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let format = self.format.execute(state, object);
 
         let to_timestamp = |value| match value {
             Value::String(_) => format
-                .clone()?
-                .ok_or_else(|| Error::from(function::Error::Required("format".to_owned())))
+                .clone()
                 .map(|v| format!("timestamp|{}", String::from_utf8_lossy(&v.unwrap_string())))?
                 .parse::<Conversion>()
                 .map_err(|e| format!("{}", e))?
@@ -222,14 +217,14 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(Value::Timestamp(
+                Ok(Value::Timestamp(
                     DateTime::parse_from_str(
                         "1983 Apr 13 12:09:14.274 +0000",
                         "%Y %b %d %H:%M:%S%.3f %z",
                     )
                     .unwrap()
                     .with_timezone(&Utc),
-                ))),
+                )),
                 ParseTimestampFn::new(
                     "%Y %b %d %H:%M:%S%.3f %z",
                     Box::new(Path::from("foo")),
@@ -242,22 +237,22 @@ mod tests {
                             .unwrap()
                             .with_timezone(&Utc),
                 ],
-                Ok(Some(
+                Ok(
                     DateTime::parse_from_rfc2822("Wed, 16 Oct 2019 12:00:00 +0000")
                         .unwrap()
                         .with_timezone(&Utc)
                         .into(),
-                )),
+                ),
                 ParseTimestampFn::new("%d/%m/%Y:%H:%M:%S %z", Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": "16/10/2019:12:00:00 +0000"],
-                Ok(Some(
+                Ok(
                     DateTime::parse_from_rfc2822("Wed, 16 Oct 2019 12:00:00 +0000")
                         .unwrap()
                         .with_timezone(&Utc)
                         .into(),
-                )),
+                ),
                 ParseTimestampFn::new("%d/%m/%Y:%H:%M:%S %z", Box::new(Path::from("foo")), None),
             ),
         ];

--- a/src/remap/function/parse_url.rs
+++ b/src/remap/function/parse_url.rs
@@ -40,18 +40,13 @@ impl ParseUrlFn {
 }
 
 impl Expression for ParseUrlFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         Url::parse(&String::from_utf8_lossy(&bytes))
             .map_err(|e| format!("unable to parse url: {}", e).into())
             .map(event::Value::from)
             .map(Into::into)
-            .map(Some)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -115,36 +110,32 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Ok(Some(
-                    map![
-                            "scheme": "https",
-                            "username": "",
-                            "password": "",
-                            "host": "vector.dev",
-                            "port": Value::Null,
-                            "path": "/",
-                            "query": map![],
-                            "fragment": Value::Null,
-                    ]
-                    .into(),
-                )),
+                Ok(map![
+                        "scheme": "https",
+                        "username": "",
+                        "password": "",
+                        "host": "vector.dev",
+                        "port": Value::Null,
+                        "path": "/",
+                        "query": map![],
+                        "fragment": Value::Null,
+                ]
+                .into()),
                 ParseUrlFn::new(Box::new(Literal::from("https://vector.dev"))),
             ),
             (
                 map![],
-                Ok(Some(
-                    map![
-                            "scheme": "ftp",
-                            "username": "foo",
-                            "password": "bar",
-                            "host": "vector.dev",
-                            "port": 4343,
-                            "path": "/foobar",
-                            "query": map!["hello": "world"],
-                            "fragment": "123",
-                    ]
-                    .into(),
-                )),
+                Ok(map![
+                        "scheme": "ftp",
+                        "username": "foo",
+                        "password": "bar",
+                        "host": "vector.dev",
+                        "port": 4343,
+                        "path": "/foobar",
+                        "query": map!["hello": "world"],
+                        "fragment": "123",
+                ]
+                .into()),
                 ParseUrlFn::new(Box::new(Literal::from(
                     "ftp://foo:bar@vector.dev:4343/foobar?hello=world#123",
                 ))),

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -72,11 +72,7 @@ impl ReplaceFn {
 }
 
 impl Expression for ReplaceFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let with = required!(state, object, self.with, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let count = optional!(state, object, self.count, Value::Integer(v) => v).unwrap_or(-1);
@@ -90,7 +86,7 @@ impl Expression for ReplaceFn {
                     _ => value,
                 };
 
-                Ok(Some(replaced.into()))
+                Ok(replaced.into())
             }
             Argument::Regex(regex) => {
                 let replaced = match count {
@@ -102,7 +98,7 @@ impl Expression for ReplaceFn {
                     _ => value.into(),
                 };
 
-                Ok(Some(replaced))
+                Ok(replaced)
             }
         }
     }
@@ -239,7 +235,7 @@ mod test {
         let cases = vec![
             (
                 map![],
-                Ok(Some("I like opples ond bononos".into())),
+                Ok("I like opples ond bononos".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     Literal::from("a").into(),
@@ -249,7 +245,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like opples ond bononos".into())),
+                Ok("I like opples ond bononos".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     Literal::from("a").into(),
@@ -259,7 +255,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like apples and bananas".into())),
+                Ok("I like apples and bananas".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     Literal::from("a").into(),
@@ -269,7 +265,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like opples and bananas".into())),
+                Ok("I like opples and bananas".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     Literal::from("a").into(),
@@ -279,7 +275,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like opples ond bananas".into())),
+                Ok("I like opples ond bananas".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     Literal::from("a").into(),
@@ -305,7 +301,7 @@ mod test {
         let cases = vec![
             (
                 map![],
-                Ok(Some("I like opples ond bononos".into())),
+                Ok("I like opples ond bononos".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
@@ -315,7 +311,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like opples ond bononos".into())),
+                Ok("I like opples ond bononos".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
@@ -325,7 +321,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like apples and bananas".into())),
+                Ok("I like apples and bananas".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
@@ -335,7 +331,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like opples and bananas".into())),
+                Ok("I like opples and bananas".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
@@ -345,7 +341,7 @@ mod test {
             ),
             (
                 map![],
-                Ok(Some("I like opples ond bananas".into())),
+                Ok("I like opples ond bananas".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     regex::Regex::new("a").unwrap().into(),
@@ -371,7 +367,7 @@ mod test {
         let cases = vec![
             (
                 map![],
-                Ok(Some("I like biscuits and bananas".into())),
+                Ok("I like biscuits and bananas".into()),
                 ReplaceFn::new(
                     Literal::from("I like apples and bananas").boxed(),
                     Literal::from("apples").into(),
@@ -381,7 +377,7 @@ mod test {
             ),
             (
                 map!["foo": "I like apples and bananas"],
-                Ok(Some("I like opples and bananas".into())),
+                Ok("I like opples and bananas".into()),
                 ReplaceFn::new(
                     Box::new(Path::from("foo")),
                     regex::Regex::new("a").unwrap().into(),
@@ -391,7 +387,7 @@ mod test {
             ),
             (
                 map!["foo": "I like [apples] and bananas"],
-                Ok(Some("I like biscuits and bananas".into())),
+                Ok("I like biscuits and bananas".into()),
                 ReplaceFn::new(
                     Box::new(Path::from("foo")),
                     regex::Regex::new("\\[apples\\]").unwrap().into(),

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -46,11 +46,7 @@ impl RoundFn {
 }
 
 impl Expression for RoundFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let precision =
             optional!(state, object, self.precision, Value::Integer(v) => v).unwrap_or(0);
         let res = required!(state, object, self.value,
@@ -135,22 +131,22 @@ mod tests {
             ),
             (
                 map!["foo": 1234.2],
-                Ok(Some(1234.0.into())),
+                Ok(1234.0.into()),
                 RoundFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map![],
-                Ok(Some(1235.0.into())),
+                Ok(1235.0.into()),
                 RoundFn::new(Box::new(Literal::from(Value::Float(1234.8))), None),
             ),
             (
                 map![],
-                Ok(Some(1234.into())),
+                Ok(1234.into()),
                 RoundFn::new(Box::new(Literal::from(Value::Integer(1234))), None),
             ),
             (
                 map![],
-                Ok(Some(1234.4.into())),
+                Ok(1234.4.into()),
                 RoundFn::new(
                     Box::new(Literal::from(Value::Float(1234.39429))),
                     Some(Box::new(Literal::from(1))),
@@ -158,7 +154,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(3.1416.into())),
+                Ok(3.1416.into()),
                 RoundFn::new(
                     Box::new(Literal::from(Value::Float(std::f64::consts::PI))),
                     Some(Box::new(Literal::from(4))),
@@ -166,9 +162,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(
-                    9876543210123456789098765432101234567890987654321.98765.into(),
-                )),
+                Ok(9876543210123456789098765432101234567890987654321.98765.into()),
                 RoundFn::new(
                     Box::new(Literal::from(
                         9876543210123456789098765432101234567890987654321.987654321,

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -56,7 +56,7 @@ impl Expression for RoundFn {
                             v@Value::Integer(_) => v
         );
 
-        Ok(res.into())
+        Ok(res)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -36,19 +36,15 @@ impl Sha1Fn {
 }
 
 impl Expression for Sha1Fn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use ::sha1::{Digest, Sha1};
 
-        self.value.execute(state, object).map(|r| {
-            r.map(|v| match v.as_string_lossy() {
-                Value::String(bytes) => Value::String(hex::encode(Sha1::digest(&bytes)).into()),
+        self.value
+            .execute(state, object)
+            .map(|v| match v.as_string_lossy() {
+                Value::String(b) => Value::String(hex::encode(Sha1::digest(&b)).into()),
                 _ => unreachable!(),
             })
-        })
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -92,9 +88,7 @@ mod tests {
             ),
             (
                 map!["foo": "foo"],
-                Ok(Some(Value::from(
-                    "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
-                ))),
+                Ok(Value::from("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")),
                 Sha1Fn::new(Box::new(Path::from("foo"))),
             ),
         ];

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -57,11 +57,7 @@ impl Sha2Fn {
 }
 
 impl Expression for Sha2Fn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = required!(state, object, self.value, Value::String(v) => v);
 
         let hash = match self.variant.as_deref() {
@@ -74,7 +70,7 @@ impl Expression for Sha2Fn {
             _ => unreachable!("enum invariant"),
         };
 
-        Ok(Some(hash.into()))
+        Ok(hash.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -132,51 +128,37 @@ mod tests {
             ),
             (
                 map!["foo": "foo"],
-                Ok(Some(
-                    "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d".into()
-                )),
+                Ok("d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d".into()),
                 Sha2Fn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map![],
-                Ok(Some(
-                    "0808f64e60d58979fcb676c96ec938270dea42445aeefcd3a4e6f8db".into()
-                )),
+                Ok("0808f64e60d58979fcb676c96ec938270dea42445aeefcd3a4e6f8db".into()),
                 Sha2Fn::new(Box::new(Literal::from("foo")), Some("SHA-224")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae".into()
-                )),
+                Ok("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae".into()),
                 Sha2Fn::new(Box::new(Literal::from("foo")), Some("SHA-256")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "98c11ffdfdd540676b1a137cb1a22b2a70350c9a44171d6b1180c6be5cbb2ee3f79d532c8a1dd9ef2e8e08e752a3babb".into()
-                )),
+                Ok("98c11ffdfdd540676b1a137cb1a22b2a70350c9a44171d6b1180c6be5cbb2ee3f79d532c8a1dd9ef2e8e08e752a3babb".into()),
                 Sha2Fn::new(Box::new(Literal::from("foo")), Some("SHA-384")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7".into()
-                )),
+                Ok("f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7".into()),
                 Sha2Fn::new(Box::new(Literal::from("foo")), Some("SHA-512")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "d68f258d37d670cfc1ec1001a0394784233f88f056994f9a7e5e99be".into()
-                )),
+                Ok("d68f258d37d670cfc1ec1001a0394784233f88f056994f9a7e5e99be".into()),
                 Sha2Fn::new(Box::new(Literal::from("foo")), Some("SHA-512/224")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d".into()
-                )),
+                Ok("d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d".into()),
                 Sha2Fn::new(Box::new(Literal::from("foo")), Some("SHA-512/256")),
             ),
         ];

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -50,11 +50,7 @@ impl Sha3Fn {
 }
 
 impl Expression for Sha3Fn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = required!(state, object, self.value, Value::String(v) => v);
 
         let hash = match self.variant.as_deref() {
@@ -65,7 +61,7 @@ impl Expression for Sha3Fn {
             _ => unreachable!("enum invariant"),
         };
 
-        Ok(Some(hash.into()))
+        Ok(hash.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -123,37 +119,27 @@ mod tests {
             ),
             (
                 map!["foo": "foo"],
-                Ok(Some(
-                    "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7".into()
-                )),
+                Ok("4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7".into()),
                 Sha3Fn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map![],
-                Ok(Some(
-                    "f4f6779e153c391bbd29c95e72b0708e39d9166c7cea51d1f10ef58a".into()
-                )),
+                Ok("f4f6779e153c391bbd29c95e72b0708e39d9166c7cea51d1f10ef58a".into()),
                 Sha3Fn::new(Box::new(Literal::from("foo")), Some("SHA3-224")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01".into()
-                )),
+                Ok("76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01".into()),
                 Sha3Fn::new(Box::new(Literal::from("foo")), Some("SHA3-256")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "665551928d13b7d84ee02734502b018d896a0fb87eed5adb4c87ba91bbd6489410e11b0fbcc06ed7d0ebad559e5d3bb5".into()
-                )),
+                Ok("665551928d13b7d84ee02734502b018d896a0fb87eed5adb4c87ba91bbd6489410e11b0fbcc06ed7d0ebad559e5d3bb5".into()),
                 Sha3Fn::new(Box::new(Literal::from("foo")), Some("SHA3-384")),
             ),
             (
                 map![],
-                Ok(Some(
-                    "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7".into()
-                )),
+                Ok("4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7".into()),
                 Sha3Fn::new(Box::new(Literal::from("foo")), Some("SHA3-512")),
             ),
         ];

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -55,11 +55,7 @@ impl SliceFn {
 }
 
 impl Expression for SliceFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let start = required!(state, object, self.start, Value::Integer(v) => v);
         let end = optional!(state, object, self.end, Value::Integer(v) => v);
 
@@ -89,12 +85,10 @@ impl Expression for SliceFn {
             state, object, self.value,
             Value::String(v) => range(v.len() as i64)
                 .map(|range| v.slice(range))
-                .map(Value::from)
-                .map(Some),
+                .map(Value::from),
             Value::Array(mut v) => range(v.len() as i64)
                 .map(|range| v.drain(range).collect::<Vec<_>>())
-                .map(Value::from)
-                .map(Some),
+                .map(Value::from),
         }
     }
 
@@ -162,47 +156,47 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Ok(Some("foo".into())),
+                Ok("foo".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 0, None),
             ),
             (
                 map![],
-                Ok(Some("oo".into())),
+                Ok("oo".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 1, None),
             ),
             (
                 map![],
-                Ok(Some("o".into())),
+                Ok("o".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 2, None),
             ),
             (
                 map![],
-                Ok(Some("oo".into())),
+                Ok("oo".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), -2, None),
             ),
             (
                 map![],
-                Ok(Some("".into())),
+                Ok("".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 3, None),
             ),
             (
                 map![],
-                Ok(Some("".into())),
+                Ok("".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 2, Some(2)),
             ),
             (
                 map![],
-                Ok(Some("foo".into())),
+                Ok("foo".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 0, Some(4)),
             ),
             (
                 map![],
-                Ok(Some("oo".into())),
+                Ok("oo".into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 1, Some(5)),
             ),
             (
                 map![],
-                Ok(Some("docious".into())),
+                Ok("docious".into()),
                 SliceFn::new(
                     Box::new(Literal::from("Supercalifragilisticexpialidocious")),
                     -7,
@@ -211,7 +205,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("cali".into())),
+                Ok("cali".into()),
                 SliceFn::new(
                     Box::new(Literal::from("Supercalifragilisticexpialidocious")),
                     5,
@@ -236,22 +230,22 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Ok(Some(vec![0, 1, 2].into())),
+                Ok(vec![0, 1, 2].into()),
                 SliceFn::new(Box::new(Literal::from(vec![0, 1, 2])), 0, None),
             ),
             (
                 map![],
-                Ok(Some(vec![1, 2].into())),
+                Ok(vec![1, 2].into()),
                 SliceFn::new(Box::new(Literal::from(vec![0, 1, 2])), 1, None),
             ),
             (
                 map![],
-                Ok(Some(vec![1, 2].into())),
+                Ok(vec![1, 2].into()),
                 SliceFn::new(Box::new(Literal::from(vec![0, 1, 2])), -2, None),
             ),
             (
                 map![],
-                Ok(Some("docious".into())),
+                Ok("docious".into()),
                 SliceFn::new(
                     Box::new(Literal::from("Supercalifragilisticexpialidocious")),
                     -7,
@@ -260,7 +254,7 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("cali".into())),
+                Ok("cali".into()),
                 SliceFn::new(
                     Box::new(Literal::from("Supercalifragilisticexpialidocious")),
                     5,

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -50,16 +50,12 @@ pub(crate) struct SplitFn {
 }
 
 impl Expression for SplitFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
         let limit: usize = self
             .limit
             .as_ref()
-            .and_then(|expr| expr.execute(state, object).transpose())
+            .map(|expr| expr.execute(state, object))
             .transpose()?
             .map(i64::try_from)
             .transpose()?
@@ -78,7 +74,7 @@ impl Expression for SplitFn {
             }
         };
 
-        Ok(Some(value))
+        Ok(value)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -63,11 +63,7 @@ impl StartsWithFn {
 }
 
 impl Expression for StartsWithFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let substring = {
             let bytes = required!(state, object, self.substring, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -84,7 +80,7 @@ impl Expression for StartsWithFn {
                 .filter(|&case_sensitive| !case_sensitive)
                 .any(|_| value.to_lowercase().starts_with(&substring.to_lowercase()));
 
-        Ok(Some(starts_with.into()))
+        Ok(starts_with.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -159,47 +155,47 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 StartsWithFn::new(Box::new(Literal::from("foo")), "bar", false),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 StartsWithFn::new(Box::new(Literal::from("foo")), "foobar", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 StartsWithFn::new(Box::new(Literal::from("foo")), "foo", false),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 StartsWithFn::new(Box::new(Literal::from("foobar")), "oba", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 StartsWithFn::new(Box::new(Literal::from("foobar")), "foo", false),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 StartsWithFn::new(Box::new(Literal::from("foobar")), "bar", false),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 StartsWithFn::new(Box::new(Literal::from("FOObar")), "FOO", true),
             ),
             (
                 map![],
-                Ok(Some(false.into())),
+                Ok(false.into()),
                 StartsWithFn::new(Box::new(Literal::from("foobar")), "FOO", true),
             ),
             (
                 map![],
-                Ok(Some(true.into())),
+                Ok(true.into()),
                 StartsWithFn::new(Box::new(Literal::from("foobar")), "FOO", false),
             ),
         ];

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -37,11 +37,7 @@ impl StripAnsiEscapeCodesFn {
 }
 
 impl Expression for StripAnsiEscapeCodesFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let bytes = required!(state, object, self.value, Value::String(v) => v);
 
         strip_ansi_escapes::strip(&bytes)
@@ -89,22 +85,22 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some("foo bar".into())),
+                Ok("foo bar".into()),
                 StripAnsiEscapeCodesFn::new(Box::new(Literal::from("foo bar"))),
             ),
             (
                 map![],
-                Ok(Some("foo bar".into())),
+                Ok("foo bar".into()),
                 StripAnsiEscapeCodesFn::new(Box::new(Literal::from("\x1b[3;4Hfoo bar"))),
             ),
             (
                 map![],
-                Ok(Some("foo bar".into())),
+                Ok("foo bar".into()),
                 StripAnsiEscapeCodesFn::new(Box::new(Literal::from("\x1b[46mfoo\x1b[0m bar"))),
             ),
             (
                 map![],
-                Ok(Some("foo bar".into())),
+                Ok("foo bar".into()),
                 StripAnsiEscapeCodesFn::new(Box::new(Literal::from("\x1b[=3lfoo bar"))),
             ),
         ];

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -36,14 +36,10 @@ impl StripWhitespaceFn {
 }
 
 impl Expression for StripWhitespaceFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = required!(state, object, self.value, Value::String(b) => String::from_utf8_lossy(&b).into_owned());
 
-        Ok(Some(value.trim().into()))
+        Ok(value.trim().into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -81,27 +77,27 @@ mod tests {
             ),
             (
                 map!["foo": ""],
-                Ok(Some("".into())),
+                Ok("".into()),
                 StripWhitespaceFn::new(Box::new(Path::from("foo"))),
             ),
             (
                 map!["foo": "     "],
-                Ok(Some("".into())),
+                Ok("".into()),
                 StripWhitespaceFn::new(Box::new(Path::from("foo"))),
             ),
             (
                 map!["foo": "hi there"],
-                Ok(Some("hi there".into())),
+                Ok("hi there".into()),
                 StripWhitespaceFn::new(Box::new(Path::from("foo"))),
             ),
             (
                 map!["foo": "           hi there        "],
-                Ok(Some("hi there".into())),
+                Ok("hi there".into()),
                 StripWhitespaceFn::new(Box::new(Path::from("foo"))),
             ),
             (
                 map!["foo": " \u{3000}\u{205F}\u{202F}\u{A0}\u{9} ❤❤ hi there ❤❤  \u{9}\u{A0}\u{202F}\u{205F}\u{3000} "],
-                Ok(Some("❤❤ hi there ❤❤".into())),
+                Ok("❤❤ hi there ❤❤".into()),
                 StripWhitespaceFn::new(Box::new(Path::from("foo"))),
             ),
         ];

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -47,11 +47,7 @@ impl ToBoolFn {
 }
 
 impl Expression for ToBoolFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use Value::*;
 
         let to_bool = |value| match value {
@@ -204,17 +200,17 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(Value::Boolean(true))),
+                Ok(Value::Boolean(true)),
                 ToBoolFn::new(Box::new(Path::from("foo")), Some(Value::Boolean(true))),
             ),
             (
                 map!["foo": "true"],
-                Ok(Some(Value::Boolean(true))),
+                Ok(Value::Boolean(true)),
                 ToBoolFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": 20],
-                Ok(Some(Value::Boolean(true))),
+                Ok(Value::Boolean(true)),
                 ToBoolFn::new(Box::new(Path::from("foo")), None),
             ),
         ];

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -47,11 +47,7 @@ impl ToFloatFn {
 }
 
 impl Expression for ToFloatFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use Value::*;
 
         let to_float = |value| match value {
@@ -204,17 +200,17 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(Value::Float(10.0))),
+                Ok(Value::Float(10.0)),
                 ToFloatFn::new(Box::new(Path::from("foo")), Some(Value::Float(10.0))),
             ),
             (
                 map!["foo": "20.5"],
-                Ok(Some(Value::Float(20.5))),
+                Ok(Value::Float(20.5)),
                 ToFloatFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": 20],
-                Ok(Some(Value::Float(20.0))),
+                Ok(Value::Float(20.0)),
                 ToFloatFn::new(Box::new(Path::from("foo")), None),
             ),
         ];

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -47,11 +47,7 @@ impl ToIntFn {
 }
 
 impl Expression for ToIntFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use Value::*;
 
         let to_int = |value| match value {
@@ -204,17 +200,17 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(Value::Integer(10))),
+                Ok(Value::Integer(10)),
                 ToIntFn::new(Box::new(Path::from("foo")), Some(10.into())),
             ),
             (
                 map!["foo": "20"],
-                Ok(Some(Value::Integer(20))),
+                Ok(Value::Integer(20)),
                 ToIntFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": 20.5],
-                Ok(Some(Value::Integer(20))),
+                Ok(Value::Integer(20)),
                 ToIntFn::new(Box::new(Path::from("foo")), None),
             ),
         ];

--- a/src/remap/function/to_string.rs
+++ b/src/remap/function/to_string.rs
@@ -46,11 +46,7 @@ impl ToStringFn {
 }
 
 impl Expression for ToStringFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let to_string = |value| match value {
             Value::String(_) => Ok(value),
             _ => Ok(value.as_string_lossy()),
@@ -189,17 +185,17 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(Value::from("default"))),
+                Ok(Value::from("default")),
                 ToStringFn::new(Box::new(Path::from("foo")), Some(Value::from("default"))),
             ),
             (
                 map!["foo": 20],
-                Ok(Some(Value::from("20"))),
+                Ok(Value::from("20")),
                 ToStringFn::new(Box::new(Path::from("foo")), None),
             ),
             (
                 map!["foo": 20.5],
-                Ok(Some(Value::from("20.5"))),
+                Ok(Value::from("20.5")),
                 ToStringFn::new(Box::new(Path::from("foo")), None),
             ),
         ];

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -64,11 +64,7 @@ impl ToTimestampFn {
 }
 
 impl Expression for ToTimestampFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         use Value::*;
 
         let to_timestamp = |value| match value {
@@ -222,12 +218,12 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(Utc.timestamp(10, 0).into())),
+                Ok(Utc.timestamp(10, 0).into()),
                 ToTimestampFn::new(Box::new(Path::from("foo")), Some(10.into())),
             ),
             (
                 map![],
-                Ok(Some(Utc.timestamp(10, 0).into())),
+                Ok(Utc.timestamp(10, 0).into()),
                 ToTimestampFn::new(
                     Box::new(Path::from("foo")),
                     Some(Utc.timestamp(10, 0).into()),
@@ -235,12 +231,12 @@ mod tests {
             ),
             (
                 map![],
-                Ok(Some(Value::Timestamp(Utc.timestamp(10, 0)))),
+                Ok(Value::Timestamp(Utc.timestamp(10, 0))),
                 ToTimestampFn::new(Box::new(Path::from("foo")), Some("10".into())),
             ),
             (
                 map!["foo": Utc.timestamp(10, 0)],
-                Ok(Some(Value::Timestamp(Utc.timestamp(10, 0)))),
+                Ok(Value::Timestamp(Utc.timestamp(10, 0))),
                 ToTimestampFn::new(Box::new(Path::from("foo")), None),
             ),
         ];

--- a/src/remap/function/tokenize.rs
+++ b/src/remap/function/tokenize.rs
@@ -37,11 +37,7 @@ impl TokenizeFn {
 }
 
 impl Expression for TokenizeFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -56,7 +52,7 @@ impl Expression for TokenizeFn {
             .collect::<Vec<_>>()
             .into();
 
-        Ok(Some(tokens))
+        Ok(tokens)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -89,7 +85,7 @@ mod tests {
     fn tokenize() {
         let cases = vec![(
                     map![],
-                    Ok(Some(vec![
+                    Ok(vec![
                             "217.250.207.207".into(),
                             Value::Null,
                             Value::Null,
@@ -98,7 +94,7 @@ mod tests {
                             "205".into(),
                             "11881".into(),
 
-                    ].into())),
+                    ].into()),
                     TokenizeFn::new(Box::new(Literal::from("217.250.207.207 - - [07/Sep/2020:16:38:00 -0400] \"DELETE /deliverables/next-generation/user-centric HTTP/1.1\" 205 11881"))),
                 )];
 

--- a/src/remap/function/truncate.rs
+++ b/src/remap/function/truncate.rs
@@ -66,11 +66,7 @@ impl TruncateFn {
 }
 
 impl Expression for TruncateFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         let mut value = {
             let bytes = required!(state, object, self.value, Value::String(v) => v);
             String::from_utf8_lossy(&bytes).into_owned()
@@ -104,7 +100,7 @@ impl Expression for TruncateFn {
             }
         }
 
-        Ok(Some(value.into()))
+        Ok(value.into())
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -194,7 +190,7 @@ mod tests {
         let cases = vec![
             (
                 map!["foo": "Super"],
-                Ok(Some("".into())),
+                Ok("".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(0.0)),
@@ -203,7 +199,7 @@ mod tests {
             ),
             (
                 map!["foo": "Super"],
-                Ok(Some("...".into())),
+                Ok("...".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(0.0)),
@@ -212,7 +208,7 @@ mod tests {
             ),
             (
                 map!["foo": "Super"],
-                Ok(Some("Super".into())),
+                Ok("Super".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(10.0)),
@@ -221,7 +217,7 @@ mod tests {
             ),
             (
                 map!["foo": "Super"],
-                Ok(Some("Super".into())),
+                Ok("Super".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(5.0)),
@@ -230,7 +226,7 @@ mod tests {
             ),
             (
                 map!["foo": "Supercalifragilisticexpialidocious"],
-                Ok(Some("Super".into())),
+                Ok("Super".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(5.0)),
@@ -239,7 +235,7 @@ mod tests {
             ),
             (
                 map!["foo": "♔♕♖♗♘♙♚♛♜♝♞♟"],
-                Ok(Some("♔♕♖♗♘♙...".into())),
+                Ok("♔♕♖♗♘♙...".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(6.0)),
@@ -248,7 +244,7 @@ mod tests {
             ),
             (
                 map!["foo": "Supercalifragilisticexpialidocious"],
-                Ok(Some("Super...".into())),
+                Ok("Super...".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(5.0)),
@@ -257,7 +253,7 @@ mod tests {
             ),
             (
                 map!["foo": "Supercalifragilisticexpialidocious"],
-                Ok(Some("Super".into())),
+                Ok("Super".into()),
                 TruncateFn::new(
                     Box::new(Path::from("foo")),
                     Box::new(Literal::from(5.0)),

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -37,19 +37,12 @@ impl UpcaseFn {
 }
 
 impl Expression for UpcaseFn {
-    fn execute(
-        &self,
-        state: &mut state::Program,
-        object: &mut dyn Object,
-    ) -> Result<Option<Value>> {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
         self.value
-            .execute(state, object)?
-            .map(String::try_from)
-            .transpose()?
+            .execute(state, object)
+            .and_then(|v| String::try_from(v).map_err(Into::into))
             .map(|v| v.to_uppercase())
             .map(Into::into)
-            .map(Ok)
-            .transpose()
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
@@ -88,7 +81,7 @@ mod tests {
             ),
             (
                 map!["foo": "foo 2 bar"],
-                Ok(Some(Value::from("FOO 2 BAR"))),
+                Ok(Value::from("FOO 2 BAR")),
                 UpcaseFn::new(Box::new(Path::from("foo"))),
             ),
         ];

--- a/src/remap/function/uuid_v4.rs
+++ b/src/remap/function/uuid_v4.rs
@@ -18,11 +18,11 @@ impl Function for UuidV4 {
 struct UuidV4Fn;
 
 impl Expression for UuidV4Fn {
-    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Option<Value>> {
+    fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
         let mut buf = [0; 36];
         let uuid = uuid::Uuid::new_v4().to_hyphenated().encode_lower(&mut buf);
 
-        Ok(Some(Bytes::copy_from_slice(uuid.as_bytes()).into()))
+        Ok(Bytes::copy_from_slice(uuid.as_bytes()).into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
@@ -51,7 +51,7 @@ mod tests {
     fn uuid_v4() {
         let mut state = state::Program::default();
         let mut object = map![];
-        let value = UuidV4Fn.execute(&mut state, &mut object).unwrap().unwrap();
+        let value = UuidV4Fn.execute(&mut state, &mut object).unwrap();
 
         assert!(matches!(&value, Value::String(_)));
 


### PR DESCRIPTION
This PR changes the expression trait `execute` function to return `Result<Value>` instead of the old `Result<Option<Value>>`.

This came up in multiple discussions, and with the infallible expressions RFC (#4840) stalled for now, removing the extra indirection makes things simpler to work with.

The user-facing implication is that an if-statement without an else block resolves to `null` if the conditional does not match. This was also discussed in several places and deemed to be an acceptable (or even good) trade-off.

E.g.:

```rust
// before
.foo = if false { "foo" } // .foo assignment is skipped

// after
.foo if false { "foo" } // .foo == null

// after, same result as before
if false { .foo = "foo" } //.foo assignment is skipped
```

_note: I'll be updating the `TypeDef` implementations in a follow-up PR (basically removing all references to `optional`)_