### PR TITLE
enhancement(remap): undefined path or variable return null

### DIFF
--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -44,9 +44,6 @@ pub enum Error {
 
     #[error("if-statement error")]
     IfStatement(#[from] if_statement::Error),
-
-    #[error("variable error")]
-    Variable(#[from] variable::Error),
 }
 
 pub trait Expression: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -42,10 +42,6 @@ mod tests {
     fn not() {
         let cases = vec![
             (
-                Err("path error".to_string()),
-                Not::new(Box::new(Path::from("foo").into())),
-            ),
-            (
                 Ok(false.into()),
                 Not::new(Box::new(Literal::from(true).into())),
             ),

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -49,10 +49,12 @@ impl Path {
 
 impl Expression for Path {
     fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        object
+        let value = object
             .find(&self.segments)
             .map_err(|e| E::from(Error::Resolve(e)))?
-            .ok_or_else(|| E::from(Error::Missing(self.as_string())).into())
+            .unwrap_or(Value::Null);
+
+        Ok(value)
     }
 
     /// A path resolves to `Any` by default, but the script might assign

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -1,11 +1,4 @@
-use super::Error as E;
 use crate::{state, Expression, Object, Result, TypeDef, Value};
-
-#[derive(thiserror::Error, Clone, Debug, PartialEq)]
-pub enum Error {
-    #[error("undefined variable: {0}")]
-    Undefined(String),
-}
 
 #[derive(Debug, Clone)]
 pub struct Variable {
@@ -28,10 +21,9 @@ impl Variable {
 
 impl Expression for Variable {
     fn execute(&self, state: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
-        state
-            .variable(&self.ident)
-            .cloned()
-            .ok_or_else(|| E::from(Error::Undefined(self.ident.to_owned())).into())
+        let value = state.variable(&self.ident).cloned().unwrap_or(Value::Null);
+
+        Ok(value)
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -142,7 +142,12 @@ mod tests {
             (
                 r#".foo == .bar"#,
                 Ok(()),
-                Err("remap error: path error: missing path: foo"),
+                Ok(true.into()),
+            ),
+            (
+                r#"if "foo" { "bar" }"#,
+                Ok(()),
+                Err(r#"remap error: value error: expected "boolean", got "string""#),
             ),
             (r#".foo = (null || "bar")"#, Ok(()), Ok("bar".into())),
             (r#"!false"#, Ok(()), Ok(true.into())),

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -448,20 +448,4 @@ impl Value {
             _ => self == rhs,
         }
     }
-
-    /// Returns [`Value::Bytes`], lossy converting any other variant.
-    pub fn as_string_lossy(&self) -> Self {
-        use Value::*;
-
-        match self {
-            s @ Bytes(_) => s.clone(), // cloning a Bytes is cheap
-            Integer(v) => Value::from(format!("{}", v)),
-            Float(v) => Value::from(format!("{}", v)),
-            Boolean(v) => Value::from(format!("{}", v)),
-            Map(_) => Value::from(""),
-            Array(_) => Value::from(""),
-            Timestamp(v) => Value::from(v.to_string()),
-            Null => Value::from(""),
-        }
-    }
 }

--- a/src/remap/function/ceil.rs
+++ b/src/remap/function/ceil.rs
@@ -125,11 +125,6 @@ mod tests {
     fn ceil() {
         let cases = vec![
             (
-                map![],
-                Err("path error: missing path: foo".into()),
-                CeilFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
                 map!["foo": 1234.2],
                 Ok(1235.0.into()),
                 CeilFn::new(Box::new(Path::from("foo")), None),

--- a/src/remap/function/contains.rs
+++ b/src/remap/function/contains.rs
@@ -120,11 +120,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                ContainsFn::new(Box::new(Path::from("foo")), "", false),
-            ),
-            (
-                map![],
                 Ok(false.into()),
                 ContainsFn::new(Box::new(Literal::from("foo")), "bar", false),
             ),

--- a/src/remap/function/downcase.rs
+++ b/src/remap/function/downcase.rs
@@ -60,18 +60,11 @@ mod tests {
 
     #[test]
     fn downcase() {
-        let cases = vec![
-            (
-                map![],
-                Err("path error: missing path: foo".into()),
-                DowncaseFn::new(Box::new(Path::from("foo"))),
-            ),
-            (
-                map!["foo": "FOO 2 bar"],
-                Ok(Value::from("foo 2 bar")),
-                DowncaseFn::new(Box::new(Path::from("foo"))),
-            ),
-        ];
+        let cases = vec![(
+            map!["foo": "FOO 2 bar"],
+            Ok(Value::from("foo 2 bar")),
+            DowncaseFn::new(Box::new(Path::from("foo"))),
+        )];
 
         let mut state = state::Program::default();
 

--- a/src/remap/function/ends_with.rs
+++ b/src/remap/function/ends_with.rs
@@ -161,11 +161,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                EndsWithFn::new(Box::new(Path::from("foo")), "", false),
-            ),
-            (
-                map![],
                 Ok(false.into()),
                 EndsWithFn::new(Box::new(Literal::from("bar")), "foo", false),
             ),

--- a/src/remap/function/floor.rs
+++ b/src/remap/function/floor.rs
@@ -125,11 +125,6 @@ mod tests {
     fn floor() {
         let cases = vec![
             (
-                map![],
-                Err("path error: missing path: foo".into()),
-                FloorFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
                 map!["foo": 1234.2],
                 Ok(1234.0.into()),
                 FloorFn::new(Box::new(Path::from("foo")), None),

--- a/src/remap/function/format_number.rs
+++ b/src/remap/function/format_number.rs
@@ -231,11 +231,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                FormatNumberFn::new(Box::new(Path::from("foo")), None, None, None),
-            ),
-            (
-                map![],
                 Ok("1234.567".into()),
                 FormatNumberFn::new(Box::new(Literal::from(1234.567)), None, None, None),
             ),

--- a/src/remap/function/format_timestamp.rs
+++ b/src/remap/function/format_timestamp.rs
@@ -113,11 +113,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                FormatTimestampFn::new(Box::new(Path::from("foo")), "%s"),
-            ),
-            (
-                map![],
                 Err("function call error: invalid format".into()),
                 FormatTimestampFn::new(
                     Box::new(Literal::from(Value::from(Utc.timestamp(10, 0)))),

--- a/src/remap/function/match.rs
+++ b/src/remap/function/match.rs
@@ -97,11 +97,6 @@ mod tests {
     fn r#match() {
         let cases = vec![
             (
-                map![],
-                Err("path error: missing path: foo".into()),
-                MatchFn::new(Box::new(Path::from("foo")), Regex::new("").unwrap()),
-            ),
-            (
                 map!["foo": "foobar"],
                 Ok(false.into()),
                 MatchFn::new(Box::new(Path::from("foo")), Regex::new("\\s\\w+").unwrap()),

--- a/src/remap/function/md5.rs
+++ b/src/remap/function/md5.rs
@@ -76,18 +76,11 @@ mod tests {
 
     #[test]
     fn md5() {
-        let cases = vec![
-            (
-                map![],
-                Err("path error: missing path: foo".into()),
-                Md5Fn::new(Box::new(Path::from("foo"))),
-            ),
-            (
-                map!["foo": "foo"],
-                Ok(Value::from("acbd18db4cc2f85cedef654fccc4a4d8")),
-                Md5Fn::new(Box::new(Path::from("foo"))),
-            ),
-        ];
+        let cases = vec![(
+            map!["foo": "foo"],
+            Ok(Value::from("acbd18db4cc2f85cedef654fccc4a4d8")),
+            Md5Fn::new(Box::new(Path::from("foo"))),
+        )];
 
         let mut state = state::Program::default();
 

--- a/src/remap/function/parse_duration.rs
+++ b/src/remap/function/parse_duration.rs
@@ -189,11 +189,6 @@ mod tests {
             ),
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                ParseDurationFn::new(Box::new(Path::from("foo")), "s"),
-            ),
-            (
-                map![],
                 Err("function call error: unable to parse duration: 'foo'".into()),
                 ParseDurationFn::new(Box::new(Literal::from("foo")), "µs"),
             ),

--- a/src/remap/function/parse_timestamp.rs
+++ b/src/remap/function/parse_timestamp.rs
@@ -212,11 +212,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                ParseTimestampFn::new("%a %b %e %T %Y", Box::new(Path::from("foo")), None),
-            ),
-            (
-                map![],
                 Ok(Value::Timestamp(
                     DateTime::parse_from_str(
                         "1983 Apr 13 12:09:14.274 +0000",

--- a/src/remap/function/round.rs
+++ b/src/remap/function/round.rs
@@ -125,11 +125,6 @@ mod tests {
     fn round() {
         let cases = vec![
             (
-                map![],
-                Err("path error: missing path: foo".into()),
-                RoundFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
                 map!["foo": 1234.2],
                 Ok(1234.0.into()),
                 RoundFn::new(Box::new(Path::from("foo")), None),

--- a/src/remap/function/sha1.rs
+++ b/src/remap/function/sha1.rs
@@ -76,18 +76,11 @@ mod tests {
 
     #[test]
     fn sha1() {
-        let cases = vec![
-            (
-                map![],
-                Err("path error: missing path: foo".into()),
-                Sha1Fn::new(Box::new(Path::from("foo"))),
-            ),
-            (
-                map!["foo": "foo"],
-                Ok(Value::from("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")),
-                Sha1Fn::new(Box::new(Path::from("foo"))),
-            ),
-        ];
+        let cases = vec![(
+            map!["foo": "foo"],
+            Ok(Value::from("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")),
+            Sha1Fn::new(Box::new(Path::from("foo"))),
+        )];
 
         let mut state = state::Program::default();
 

--- a/src/remap/function/sha2.rs
+++ b/src/remap/function/sha2.rs
@@ -122,11 +122,6 @@ mod tests {
     fn sha2() {
         let cases = vec![
             (
-                map![],
-                Err("path error: missing path: foo".into()),
-                Sha2Fn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
                 map!["foo": "foo"],
                 Ok("d58042e6aa5a335e03ad576c6a9e43b41591bfd2077f72dec9df7930e492055d".into()),
                 Sha2Fn::new(Box::new(Path::from("foo")), None),

--- a/src/remap/function/sha3.rs
+++ b/src/remap/function/sha3.rs
@@ -113,11 +113,6 @@ mod tests {
     fn sha3() {
         let cases = vec![
             (
-                map![],
-                Err("path error: missing path: foo".into()),
-                Sha3Fn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
                 map!["foo": "foo"],
                 Ok("4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7".into()),
                 Sha3Fn::new(Box::new(Path::from("foo")), None),

--- a/src/remap/function/slice.rs
+++ b/src/remap/function/slice.rs
@@ -282,11 +282,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                SliceFn::new(Box::new(Path::from("foo")), 0, None),
-            ),
-            (
-                map![],
                 Err(r#"function call error: "start" must be between "-3" and "3""#.into()),
                 SliceFn::new(Box::new(Literal::from("foo")), 4, None),
             ),

--- a/src/remap/function/starts_with.rs
+++ b/src/remap/function/starts_with.rs
@@ -159,11 +159,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                StartsWithFn::new(Box::new(Path::from("foo")), "", false),
-            ),
-            (
-                map![],
                 Ok(false.into()),
                 StartsWithFn::new(Box::new(Literal::from("foo")), "bar", false),
             ),

--- a/src/remap/function/strip_ansi_escape_codes.rs
+++ b/src/remap/function/strip_ansi_escape_codes.rs
@@ -80,11 +80,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                StripAnsiEscapeCodesFn::new(Box::new(Path::from("foo"))),
-            ),
-            (
-                map![],
                 Ok("foo bar".into()),
                 StripAnsiEscapeCodesFn::new(Box::new(Literal::from("foo bar"))),
             ),

--- a/src/remap/function/strip_whitespace.rs
+++ b/src/remap/function/strip_whitespace.rs
@@ -72,11 +72,6 @@ mod tests {
     fn strip_whitespace() {
         let cases = vec![
             (
-                map![],
-                Err("path error: missing path: foo".into()),
-                StripWhitespaceFn::new(Box::new(Path::from("foo"))),
-            ),
-            (
                 map!["foo": ""],
                 Ok("".into()),
                 StripWhitespaceFn::new(Box::new(Path::from("foo"))),

--- a/src/remap/function/to_bool.rs
+++ b/src/remap/function/to_bool.rs
@@ -195,13 +195,8 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                ToBoolFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map![],
                 Ok(Value::Boolean(true)),
-                ToBoolFn::new(Box::new(Path::from("foo")), Some(Value::Boolean(true))),
+                ToBoolFn::new(Literal::from(vec![0]).boxed(), Some(true.into())),
             ),
             (
                 map!["foo": "true"],

--- a/src/remap/function/to_float.rs
+++ b/src/remap/function/to_float.rs
@@ -195,13 +195,8 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                ToFloatFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map![],
                 Ok(Value::Float(10.0)),
-                ToFloatFn::new(Box::new(Path::from("foo")), Some(Value::Float(10.0))),
+                ToFloatFn::new(Literal::from(vec![0]).boxed(), Some(10.0.into())),
             ),
             (
                 map!["foo": "20.5"],

--- a/src/remap/function/to_int.rs
+++ b/src/remap/function/to_int.rs
@@ -195,13 +195,8 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                ToIntFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map![],
                 Ok(Value::Integer(10)),
-                ToIntFn::new(Box::new(Path::from("foo")), Some(10.into())),
+                ToIntFn::new(Literal::from(vec![0]).boxed(), Some(10.into())),
             ),
             (
                 map!["foo": "20"],

--- a/src/remap/function/to_timestamp.rs
+++ b/src/remap/function/to_timestamp.rs
@@ -213,11 +213,6 @@ mod tests {
         let cases = vec![
             (
                 map![],
-                Err("path error: missing path: foo".into()),
-                ToTimestampFn::new(Box::new(Path::from("foo")), None),
-            ),
-            (
-                map![],
                 Ok(Utc.timestamp(10, 0).into()),
                 ToTimestampFn::new(Box::new(Path::from("foo")), Some(10.into())),
             ),

--- a/src/remap/function/upcase.rs
+++ b/src/remap/function/upcase.rs
@@ -73,18 +73,11 @@ mod tests {
 
     #[test]
     fn upcase() {
-        let cases = vec![
-            (
-                map![],
-                Err("path error: missing path: foo".into()),
-                UpcaseFn::new(Box::new(Path::from("foo"))),
-            ),
-            (
-                map!["foo": "foo 2 bar"],
-                Ok(Value::from("FOO 2 BAR")),
-                UpcaseFn::new(Box::new(Path::from("foo"))),
-            ),
-        ];
+        let cases = vec![(
+            map!["foo": "foo 2 bar"],
+            Ok(Value::from("FOO 2 BAR")),
+            UpcaseFn::new(Box::new(Path::from("foo"))),
+        )];
 
         let mut state = state::Program::default();
 


### PR DESCRIPTION
This changes path resolution to resolve to `null` if the path cannot be found, instead of returning a runtime error. The same applies to variables.

I also removed a lot of useless function tests that were really testing the `Path` expression, instead of the function itself.

ref #4947.