### PR TITLE
feat(remap): support resolving program to "any" value

### DIFF
--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -16,7 +16,7 @@ pub use error::{Error, RemapError};
 pub use expression::{Expr, Expression};
 pub use function::{Function, Parameter};
 pub use operator::Operator;
-pub use program::Program;
+pub use program::{Program, TypeConstraint};
 pub use runtime::Runtime;
 pub use type_def::TypeDef;
 pub use value::Value;
@@ -240,18 +240,13 @@ mod tests {
         ];
 
         for (script, compile_expected, runtime_expected) in cases {
-            let accept = TypeDef {
-                fallible: true,
-                kind: value::Kind::all(),
-            };
-
             let program = Program::new(
                 script,
                 &[
                     Box::new(test_functions::RegexPrinter),
                     Box::new(test_functions::EnumValidator),
                 ],
-                accept,
+                None,
             );
 
             assert_eq!(

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -54,6 +54,26 @@ impl fmt::Display for ResolvesToError {
     }
 }
 
+/// The constraint applied to the result of a program.
+pub struct TypeConstraint {
+    /// The type definition constraint for the program.
+    pub type_def: TypeDef,
+
+    /// If set to `true`, then a program that can return "any" value is
+    /// considered to be valid.
+    ///
+    /// Note that the configured `type_def.kind` value still holds when a
+    /// program returns anything other than any.
+    ///
+    /// Meaning, if a program returns a boolean or a string, and the constraint
+    /// is set to return a float, and `allow_any` is set to `true`, the
+    /// constraint will fail.
+    ///
+    /// However, for the same configuration, if the program returns "any" value,
+    /// the constraint holds, unless `allow_any` is set to `false`.
+    pub allow_any: bool,
+}
+
 /// The program to execute.
 ///
 /// This object is passed to [`Runtime::execute`](crate::Runtime::execute).
@@ -69,7 +89,7 @@ impl Program {
     pub fn new(
         source: &str,
         function_definitions: &[Box<dyn Function>],
-        expected_result: TypeDef,
+        constraint: Option<TypeConstraint>,
     ) -> Result<Self, RemapError> {
         let pairs = parser::Parser::parse(parser::Rule::program, source)
             .map_err(|s| E::Parser(s.to_string()))
@@ -84,24 +104,29 @@ impl Program {
 
         let expressions = parser.pairs_to_expressions(pairs).map_err(RemapError)?;
 
-        let mut type_defs = expressions
-            .iter()
-            .map(|e| e.type_def(&parser.compiler_state))
-            .collect::<Vec<_>>();
+        // optional type constraint checking
+        if let Some(constraint) = constraint {
+            let mut type_defs = expressions
+                .iter()
+                .map(|e| e.type_def(&parser.compiler_state))
+                .collect::<Vec<_>>();
 
-        let computed_result = type_defs.pop().unwrap_or(TypeDef {
-            fallible: true,
-            kind: value::Kind::Null,
-        });
+            let program_def = type_defs.pop().unwrap_or(TypeDef {
+                fallible: true,
+                kind: value::Kind::Null,
+            });
 
-        if !expected_result.contains(&computed_result) {
-            return Err(RemapError::from(E::from(Error::ResolvesTo(
-                ResolvesToError(expected_result, computed_result),
-            ))));
-        }
+            if !constraint.type_def.contains(&program_def) {
+                if !program_def.kind.is_all() || !constraint.allow_any {
+                    return Err(RemapError::from(E::from(Error::ResolvesTo(
+                        ResolvesToError(constraint.type_def, program_def),
+                    ))));
+                }
+            }
 
-        if !expected_result.is_fallible() && type_defs.iter().any(TypeDef::is_fallible) {
-            return Err(RemapError::from(E::from(Error::Fallible)));
+            if !constraint.type_def.is_fallible() && type_defs.iter().any(TypeDef::is_fallible) {
+                return Err(RemapError::from(E::from(Error::Fallible)));
+            }
         }
 
         Ok(Self { expressions })
@@ -119,40 +144,97 @@ mod tests {
         use value::Kind;
 
         let cases = vec![
-            (".foo", TypeDef { fallible: true, ..Default::default()}, Ok(())),
-
+            (
+                ".foo",
+                None,
+                Ok(()),
+            ),
+            // "any" value is allowed
+            (
+                ".foo",
+                Some(TypeConstraint {
+                    type_def: TypeDef {
+                        fallible: true,
+                        kind: Kind::Boolean,
+                    },
+                    allow_any: true,
+                }),
+                Ok(()),
+            ),
+            // "any" value is allowed, but resolves to non-allowed kind
+            (
+                "42",
+                Some(TypeConstraint {
+                    type_def: TypeDef {
+                        fallible: false,
+                        kind: Kind::Boolean,
+                    },
+                    allow_any: true,
+                }),
+                Err("expected to resolve to boolean value, but instead resolves to integer value"),
+            ),
+            // "any" value is disallowed, and resolves to any
+            (
+                ".foo",
+                Some(TypeConstraint {
+                    type_def: TypeDef {
+                        fallible: true,
+                        kind: Kind::Boolean,
+                    },
+                    allow_any: false,
+                }),
+                Err("expected to resolve to boolean value, but instead resolves to any value"),
+            ),
             // The final expression is infallible, but the first one isn't, so
             // this isn't allowed.
             (
                 ".foo\ntrue",
-                TypeDef { fallible: false, ..Default::default()},
-                Err("expected to be infallible, but is not".to_owned()),
+                Some(TypeConstraint {
+                    type_def: TypeDef {
+                        fallible: false,
+                        ..Default::default()
+                    },
+                    allow_any: false,
+                }),
+                Err("expected to be infallible, but is not"),
             ),
             (
                 ".foo",
-                TypeDef::default(),
-                Err("expected to resolve to any value, but instead resolves to an error, or any value".to_owned()),
+                Some(TypeConstraint {
+                    type_def: TypeDef {
+                        fallible: false,
+                        ..Default::default()
+                    },
+                    allow_any: false,
+                }),
+                Err("expected to resolve to any value, but instead resolves to an error, or any value"),
             ),
             (
                 ".foo",
-                TypeDef {
-                    fallible: false,
-                    kind: Kind::Bytes,
-                },
-                Err("expected to resolve to string value, but instead resolves to an error, or any value".to_owned()),
+                Some(TypeConstraint {
+                    type_def: TypeDef {
+                        fallible: false,
+                        kind: Kind::Bytes,
+                    },
+                    allow_any: false,
+                }),
+                Err("expected to resolve to string value, but instead resolves to an error, or any value"),
             ),
             (
                 "false || 2",
-                TypeDef {
-                    fallible: false,
-                    kind: Kind::Bytes | Kind::Float,
-                },
-                Err("expected to resolve to string or float values, but instead resolves to integer or boolean values".to_owned()),
+                Some(TypeConstraint {
+                    type_def: TypeDef {
+                        fallible: false,
+                        kind: Kind::Bytes | Kind::Float,
+                    },
+                    allow_any: false,
+                }),
+                Err("expected to resolve to string or float values, but instead resolves to integer or boolean values"),
             ),
         ];
 
-        for (source, expected_result, expect) in cases {
-            let program = Program::new(source, &[], expected_result)
+        for (source, constraint, expect) in cases {
+            let program = Program::new(source, &[], constraint)
                 .map(|_| ())
                 .map_err(|e| {
                     e.source()
@@ -160,7 +242,7 @@ mod tests {
                         .unwrap()
                 });
 
-            assert_eq!(program, expect);
+            assert_eq!(program, expect.map_err(ToOwned::to_owned));
         }
     }
 }

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -4,7 +4,7 @@ use crate::{
     internal_events::RemapConditionExecutionFailed,
     Event,
 };
-use remap::{value, Program, RemapError, Runtime, TypeDef, Value};
+use remap::{value, Program, RemapError, Runtime, TypeConstraint, TypeDef, Value};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
@@ -21,12 +21,15 @@ impl_generate_config_from_default!(RemapConfig);
 #[typetag::serde(name = "remap")]
 impl ConditionConfig for RemapConfig {
     fn build(&self) -> crate::Result<Box<dyn Condition>> {
-        let expected_result = TypeDef {
-            fallible: true,
-            kind: value::Kind::Boolean,
+        let constraint = TypeConstraint {
+            allow_any: false,
+            type_def: TypeDef {
+                fallible: true,
+                kind: value::Kind::Boolean,
+            },
         };
 
-        let program = Program::new(&self.source, &crate::remap::FUNCTIONS, expected_result)
+        let program = Program::new(&self.source, &crate::remap::FUNCTIONS, Some(constraint))
             .map_err(|e| e.to_string())?;
 
         Ok(Box::new(Remap { program }))


### PR DESCRIPTION
As suggested by @FungusHumungus in https://github.com/timberio/vector/pull/4902#issuecomment-727569570.

This PR introduces the option to accept a program that resolves to "any", but only if it's final expression isn't defined to resolve to anything other than any.

That is to say, if I configure my program such that it has to resolve to a boolean, and is not allowed to resolve to any then this happens:

```rust
true // ok
.foo // error: resolves to any, not boolean
42   // error: resolves to integer, not boolean
```

If instead I were to keep the boolean constraint, but also allow resolving to any, then this changes:

```rust
true // ok
.foo // ok
42   // error: resolves to integer, not boolean
```

This will become useful when we want to use remap in string templates, e.g:

```rust
"foo {{ .bar }}" // ok, the caller of the program should make sure to coerce `.bar` to a string, or error
"foo {{ true }}" // error, a boolean isn't a string, so we can warn about this at compile-time
```

The advantage to this is such that we keep the templating logic simple, as we don't require the user to always use `to_string` when referencing a path: `"foo {{ to_string(.bar) }}"`.

_note, in the last example of `"foo {{ true }}"`, the program can still be configured to also allow boolean values, and coerce manually, depending on how strict we want to be in string templates_

---

Once we have the option to pass field types through Vector pipelines, we can refine this further, as we'd potentially know that `.foo` resolves to a boolean.