### PR TITLE
feat(remap): support query/assignment of object root

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -41,7 +41,8 @@ operator_not            = { "!" }
 
 // Paths -----------------------------------------------------------------------
 
-path             = ${ ("." ~ path_segment)+ }
+path             = ${ path_root | ("." ~ path_segment)+ }
+path_root        = ${ ". " }
 path_segment     = ${ (path_field | path_coalesce) ~ path_index* }
 path_field       = ${ ident | string }
 path_coalesce    = !{ "(" ~ path_field ~ ("|" ~ path_field)+ ~ ")" }

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -93,6 +93,7 @@ impl fmt::Display for Rule {
             path_field,
             path_index,
             path_index_inner,
+            path_root,
             path_segment,
             primary,
             program,

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -237,6 +237,7 @@ mod tests {
             (r#"null || false"#, Ok(()), Ok(false.into())),
             (r#"false || null"#, Ok(()), Ok(().into())),
             (r#"null || "foo""#, Ok(()), Ok("foo".into())),
+            (r#". = "bar""#, Ok(()), Ok("bar".into())),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {
@@ -251,11 +252,11 @@ mod tests {
 
             assert_eq!(
                 program.as_ref().map(|_| ()).map_err(|e| e.to_string()),
-                compile_expected.map_err(|e| e.to_string())
+                compile_expected.map_err(|e: &str| e.to_string())
             );
 
-            if program.is_err() {
-                return;
+            if program.is_err() && compile_expected.is_err() {
+                continue;
             }
 
             let program = program.unwrap();
@@ -266,7 +267,7 @@ mod tests {
                 .execute(&mut event, &program)
                 .map_err(|e| e.to_string());
 
-            assert_eq!(result, runtime_expected.map_err(|e| e.to_string()));
+            assert_eq!(result, runtime_expected.map_err(|e: &str| e.to_string()));
         }
     }
 

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -116,12 +116,12 @@ impl Program {
                 kind: value::Kind::Null,
             });
 
-            if !constraint.type_def.contains(&program_def) {
-                if !program_def.kind.is_all() || !constraint.allow_any {
-                    return Err(RemapError::from(E::from(Error::ResolvesTo(
-                        ResolvesToError(constraint.type_def, program_def),
-                    ))));
-                }
+            if !constraint.type_def.contains(&program_def)
+                && (!program_def.kind.is_all() || !constraint.allow_any)
+            {
+                return Err(RemapError::from(E::from(Error::ResolvesTo(
+                    ResolvesToError(constraint.type_def, program_def),
+                ))));
             }
 
             if !constraint.type_def.is_fallible() && type_defs.iter().any(TypeDef::is_fallible) {

--- a/src/event/log_event.rs
+++ b/src/event/log_event.rs
@@ -92,6 +92,11 @@ impl LogEvent {
         self.fields.is_empty()
     }
 
+    #[instrument(level = "trace", skip(self))]
+    pub fn as_map(&self) -> &BTreeMap<String, Value> {
+        &self.fields
+    }
+
     #[instrument(level = "trace", skip(self, lookup), fields(lookup = %lookup), err)]
     fn entry(&mut self, lookup: Lookup) -> crate::Result<Entry<String, Value>> {
         trace!("Seeking to entry.");


### PR DESCRIPTION
This change enables assigning to, or fetching the root of an event.

This is now possible:

```rust
. = .foo   // will error if .foo isn't a map
$foo = .   // stores a map value containing the root fields and their values
```

I had to hack the parser rules a bit to make this work, and have useable error messages. That is to say, technically, you can write:

```rust
.foo= "bar" // equal to:
.foo = "bar"
```

Compared to:

```rust
.= .foo  // parser expects a space after a root `.`
. = .foo // ok
```

I'll probably circle back to this in the future to see if we can make it properly parse `.` and `.foo` without requiring the space, and without creating confusing error messages, but I deemed the `.= .foo` syntax enough of an outlier that I'm happy to commit this as-is.

If others feel differently, I'm happy to keep this PR open until that issue is resolved, though.

closes #5009.