### PR TITLE
fix(prometheus sink): Fix output timestamp

### DIFF
--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -391,6 +391,7 @@ pub mod test_util {
 
     pub(crate) async fn onboarding_v1(endpoint: &str) -> String {
         let database = next_database();
+        query_v1(endpoint, &format!("drop database {}", database)).await;
         let status = query_v1(endpoint, &format!("create database {}", database))
             .await
             .status();

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -13,7 +13,7 @@ pub(super) trait MetricCollector {
 
     fn emit(
         &mut self,
-        timestamp: i64,
+        timestamp_millis: i64,
         name: &str,
         suffix: &str,
         value: f64,
@@ -35,7 +35,7 @@ pub(super) trait MetricCollector {
             &metric.name,
         );
         let name = &name;
-        let timestamp = metric.timestamp.map(|t| t.timestamp()).unwrap_or(0);
+        let timestamp = metric.timestamp.map(|t| t.timestamp_millis()).unwrap_or(0);
 
         if metric.kind.is_absolute() {
             let tags = &metric.tags;
@@ -197,7 +197,7 @@ impl MetricCollector for StringCollector {
 
     fn emit(
         &mut self,
-        _timestamp: i64,
+        _timestamp_millis: i64,
         name: &str,
         suffix: &str,
         value: f64,
@@ -313,7 +313,7 @@ impl MetricCollector for TimeSeries {
 
     fn emit(
         &mut self,
-        timestamp: i64,
+        timestamp_millis: i64,
         name: &str,
         suffix: &str,
         value: f64,
@@ -323,7 +323,10 @@ impl MetricCollector for TimeSeries {
         self.buffer
             .entry(Self::make_labels(tags, name, suffix, extra))
             .or_default()
-            .push(proto::Sample { value, timestamp });
+            .push(proto::Sample {
+                value,
+                timestamp: timestamp_millis,
+            });
     }
 }
 

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -205,7 +205,8 @@ mod integration_tests {
         Event,
     };
     use futures::stream;
-    use std::ops::Range;
+    use serde_json::Value;
+    use std::{collections::HashMap, ops::Range};
 
     const HTTP_URL: &str = "http://localhost:8086";
     const HTTPS_URL: &str = "https://localhost:8087";
@@ -233,29 +234,91 @@ mod integration_tests {
             }),
             ..Default::default()
         };
-        let events = create_events(0..10);
+        let events = create_events(0..5, |n| n * 11.0);
 
         let (sink, _) = config.build(cx).await.expect("error building config");
-        sink.run(stream::iter(events)).await.unwrap();
+        sink.run(stream::iter(events.clone())).await.unwrap();
 
-        let result = query_v1(url, &format!("show series on {}", database)).await;
-        let text = result.text().await.unwrap();
-        let result: serde_json::Value =
-            serde_json::from_str(&text).expect("error when parsing InfluxDB response JSON");
+        let result = query(url, &format!("show series on {}", database)).await;
 
         let values = &result["results"][0]["series"][0]["values"];
-        assert_eq!(values.as_array().unwrap().len(), 10);
+        assert_eq!(values.as_array().unwrap().len(), 5);
+
+        for event in events {
+            let metric = event.into_metric();
+            let result = query(
+                url,
+                &format!(r#"SELECT * FROM "{}".."{}""#, database, &metric.name),
+            )
+            .await;
+
+            let metrics = decode_metrics(&result["results"][0]["series"][0]);
+            assert_eq!(metrics.len(), 1);
+            let output = &metrics[0];
+
+            match metric.value {
+                MetricValue::Gauge { value } => {
+                    assert_eq!(output["value"], Value::Number((value as u32).into()))
+                }
+                _ => panic!("Unhandled metric value, fix the test"),
+            }
+            for (tag, value) in metric.tags.unwrap() {
+                assert_eq!(output[&tag], Value::String(value.into()));
+            }
+            let timestamp = strip_timestamp(
+                metric
+                    .timestamp
+                    .unwrap()
+                    .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+                    .to_string(),
+            );
+            assert_eq!(output["time"], Value::String(timestamp.into()));
+        }
 
         cleanup_v1(url, &database).await;
     }
 
-    fn create_events(range: Range<i32>) -> Vec<Event> {
-        range.map(create_event).collect()
+    async fn query(url: &str, query: &str) -> Value {
+        let result = query_v1(url, query).await;
+        let text = result.text().await.unwrap();
+        serde_json::from_str(&text).expect("error when parsing InfluxDB response JSON")
     }
 
-    fn create_event(i: i32) -> Event {
+    // InfluxDB strips off trailing zeros in
+    fn strip_timestamp(timestamp: String) -> String {
+        let strip_one = || format!("{}Z", &timestamp[..timestamp.len() - 2]);
+        match timestamp {
+            _ if timestamp.ends_with("0Z") => strip_timestamp(strip_one()),
+            _ if timestamp.ends_with(".Z") => strip_one(),
+            _ => timestamp,
+        }
+    }
+
+    fn decode_metrics(data: &Value) -> Vec<HashMap<String, Value>> {
+        let data = data.as_object().expect("Data is not an object");
+        let columns = data["columns"].as_array().expect("Columns is not an array");
+        let values = data["values"].as_array().expect("Values is not an array");
+        values
+            .into_iter()
+            .map(|values| {
+                columns
+                    .into_iter()
+                    .zip(values.as_array().unwrap().into_iter())
+                    .map(|(column, value)| (column.as_str().unwrap().to_owned(), value.clone()))
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn create_events(name_range: Range<i32>, value: impl Fn(f64) -> f64) -> Vec<Event> {
+        name_range
+            .map(move |num| create_event(format!("metric_{}", num), value(num as f64)))
+            .collect()
+    }
+
+    fn create_event(name: String, value: f64) -> Event {
         Event::Metric(Metric {
-            name: format!("gauge-{}", i),
+            name,
             namespace: None,
             timestamp: Some(chrono::Utc::now()),
             tags: Some(
@@ -267,7 +330,7 @@ mod integration_tests {
                 .collect(),
             ),
             kind: MetricKind::Absolute,
-            value: MetricValue::Gauge { value: i as f64 },
+            value: MetricValue::Gauge { value },
         })
     }
 }

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -263,7 +263,7 @@ mod integration_tests {
                 _ => panic!("Unhandled metric value, fix the test"),
             }
             for (tag, value) in metric.tags.unwrap() {
-                assert_eq!(output[&tag], Value::String(value.into()));
+                assert_eq!(output[&tag], Value::String(value));
             }
             let timestamp = strip_timestamp(
                 metric
@@ -272,7 +272,7 @@ mod integration_tests {
                     .format("%Y-%m-%dT%H:%M:%S%.3fZ")
                     .to_string(),
             );
-            assert_eq!(output["time"], Value::String(timestamp.into()));
+            assert_eq!(output["time"], Value::String(timestamp));
         }
 
         cleanup_v1(url, &database).await;
@@ -297,13 +297,14 @@ mod integration_tests {
     fn decode_metrics(data: &Value) -> Vec<HashMap<String, Value>> {
         let data = data.as_object().expect("Data is not an object");
         let columns = data["columns"].as_array().expect("Columns is not an array");
-        let values = data["values"].as_array().expect("Values is not an array");
-        values
-            .into_iter()
+        data["values"]
+            .as_array()
+            .expect("Values is not an array")
+            .iter()
             .map(|values| {
                 columns
-                    .into_iter()
-                    .zip(values.as_array().unwrap().into_iter())
+                    .iter()
+                    .zip(values.as_array().unwrap().iter())
                     .map(|(column, value)| (column.as_str().unwrap().to_owned(), value.clone()))
                     .collect()
             })


### PR DESCRIPTION
The output timestamp is expressed in milliseconds since the UNIX epoch, and we were sending seconds since. This scales the output properly.

Closes #5110 