### PR TITLE
chore(observability): API not reachable error in `vector top`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,6 +2757,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
+]
+
+[[package]]
 name = "inotify"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6811,6 +6820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
+
+[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6985,6 +7000,7 @@ dependencies = [
  "hyper",
  "hyper-openssl",
  "indexmap",
+ "indoc",
  "inventory",
  "itertools 0.9.0",
  "jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ mongodb = { version = "1.1.1", optional = true }
 anyhow = { version = "1.0.28" }
 snap = { version = "1.0.1", optional = true }
 dyn-clone = "1.0.3"
+indoc = "1.0.3"
 
 # For WASM
 vector-wasm = { path = "lib/vector-wasm", optional = true }

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -3,6 +3,7 @@ use super::{
     metrics, state,
 };
 use crate::config;
+use indoc::indoc;
 use url::Url;
 use vector_api_client::{connect_subscription_client, gql::HealthQueryExt, Client};
 
@@ -31,7 +32,18 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
     match client.health_query().await {
         Ok(_) => (),
         _ => {
-            eprintln!("Vector API server not reachable. Have you enabled the API?");
+            eprintln!(
+                indoc! {"
+                    Vector API server isn't reachable ({}).
+                    
+                    Have you enabled the API?
+                    
+                    To enable the API, add the following to your `vector.toml` config file:
+    
+                    [api]
+                      enabled = true"},
+                url
+            );
             return exitcode::UNAVAILABLE;
         }
     }

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -35,11 +35,11 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
             eprintln!(
                 indoc! {"
                     Vector API server isn't reachable ({}).
-                    
+
                     Have you enabled the API?
-                    
+
                     To enable the API, add the following to your `vector.toml` config file:
-    
+
                     [api]
                       enabled = true"},
                 url


### PR DESCRIPTION
Updates the error message displayed when `vector top` cannot reach a remote GraphQL endpoint / a `{ health }` query fails:

```
Vector API server isn't reachable (http://127.0.0.1:8686/graphql).

Have you enabled the API?

To enable the API, add the following to your `vector.toml` config file:

[api]
  enabled = true
```

Context: https://github.com/timberio/vector/pull/5114#issuecomment-732094955

Introduces the `indoc!` macro for readability over explicit `\n` handling.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
