### PR TITLE
enhancement(remap): add support for literal arrays

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -17,7 +17,7 @@ if_statement = { "if" ~ boolean_expr ~ block ~ ("else if" ~ boolean_expr ~ block
 // Primary ---------------------------------------------------------------------
 
 primary  =  { value | variable | path | group }
-value    =  { string | float | integer | boolean | null }
+value    =  { string | float | integer | boolean | null | array }
 variable = ${ "$" ~ ident ~ path_index* ~ ("." ~ path_segments)?  }
 group    =  { "(" ~ expression ~ ")" }
 
@@ -66,6 +66,7 @@ path_index_inner =  { ("0" | ASCII_NONZERO_DIGIT) ~ ASCII_DIGIT* }
 null    =  { "null" }
 boolean =  { "true" | "false" }
 string  = ${ "\"" ~ string_inner ~ "\"" }
+array   =  { "[" ~ NEWLINE* ~ (expression ~ "," ~ NEWLINE*)* ~ expression? ~ NEWLINE* ~ "]" }
 integer = ${ "-"? ~ ("0" | ASCII_NONZERO_DIGIT) ~ ASCII_DIGIT* }
 float   = ${
     "-"?

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -77,6 +77,7 @@ impl fmt::Display for Rule {
             addition,
             argument,
             arguments,
+            array,
             assignment,
             block,
             boolean,

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 
 mod argument;
 mod arithmetic;
+mod array;
 mod assignment;
 mod block;
 pub(crate) mod function;
@@ -15,6 +16,7 @@ mod variable;
 
 pub use argument::Argument;
 pub use arithmetic::Arithmetic;
+pub use array::Array;
 pub use assignment::{Assignment, Target};
 pub use block::Block;
 pub use function::Function;
@@ -127,7 +129,9 @@ macro_rules! expression_dispatch {
 }
 
 expression_dispatch![
+    Argument,
     Arithmetic,
+    Array,
     Assignment,
     Block,
     Function,
@@ -137,7 +141,6 @@ expression_dispatch![
     Not,
     Path,
     Variable,
-    Argument,
 ];
 
 impl<T: Into<Value>> From<T> for Expr {

--- a/lib/remap-lang/src/expression/array.rs
+++ b/lib/remap-lang/src/expression/array.rs
@@ -1,0 +1,101 @@
+use crate::{state, value, Expr, Expression, Object, Result, TypeDef, Value};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Array {
+    expressions: Vec<Expr>,
+}
+
+impl Array {
+    pub fn new(expressions: Vec<Expr>) -> Self {
+        Self { expressions }
+    }
+}
+
+impl Expression for Array {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        self.expressions
+            .iter()
+            .map(|expr| expr.execute(state, object))
+            .collect::<Result<Vec<_>>>()
+            .map(Value::Array)
+    }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        let fallible = self
+            .expressions
+            .iter()
+            .map(|e| e.type_def(state))
+            .any(|d| d.is_fallible());
+
+        TypeDef {
+            fallible,
+            kind: value::Kind::Array,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        expression::{Arithmetic, Literal},
+        test_type_def,
+        value::Kind,
+        Operator,
+    };
+
+    test_type_def![
+        no_expression {
+            expr: |_| Array::new(vec![]),
+            def: TypeDef {
+                fallible: false,
+                kind: Kind::Array,
+            },
+        }
+
+        one_expression {
+            expr: |_| Array::new(vec![Literal::from(true).into()]),
+            def: TypeDef { kind: Kind::Array, ..Default::default() },
+        }
+
+        multiple_expressions {
+            expr: |_| Array::new(vec![
+                        Literal::from("foo").into(),
+                        Literal::from(true).into(),
+                        Literal::from(1234).into(),
+            ]),
+            def: TypeDef { kind: Kind::Array, ..Default::default() },
+        }
+
+        last_one_fallible {
+            expr: |_| Array::new(vec![
+                        Literal::from(true).into(),
+                        Arithmetic::new(
+                          Box::new(Literal::from(12).into()),
+                          Box::new(Literal::from(true).into()),
+                          Operator::Multiply,
+                        ).into(),
+            ]),
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Array,
+            },
+        }
+
+        any_fallible {
+            expr: |_| Array::new(vec![
+                        Literal::from(true).into(),
+                        Arithmetic::new(
+                          Box::new(Literal::from(12).into()),
+                          Box::new(Literal::from(true).into()),
+                          Operator::Multiply,
+                        ).into(),
+                        Literal::from(vec![1]).into(),
+            ]),
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Array,
+            },
+        }
+    ];
+}

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -180,6 +180,19 @@ mod tests {
                 Err(r#"remap error: parser error: paths in variable assignment not supported. Use "$foo" without ".[0]""#),
                 Ok(().into()),
             ),
+            (r#"["foo", "bar", "baz"]"#, Ok(()), Ok(vec!["foo", "bar", "baz"].into())),
+            (
+                r#"
+                    .foo = [
+                        "foo",
+                        5,
+                        ["bar"],
+                    ]
+                    .foo
+                "#,
+                Ok(()),
+                Ok(vec!["foo".into(), 5.into(), Value::Array(vec!["bar".into()])].into()),
+            ),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {


### PR DESCRIPTION
Add support for literal arrays:

```rust
.foo = ["foo", 5, ["bar"]]
```

closes #5219