### PR TITLE
enhancement(remap): accept array of arguments for function parameters

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -23,9 +23,13 @@ group    =  { "(" ~ expression ~ ")" }
 
 // Function Calls --------------------------------------------------------------
 
-call      = ${ ident ~ "(" ~ arguments? ~ ")"  }
-arguments = !{ argument ~ ("," ~ argument)* }
-argument  =  { (ident ~ "=")? ~ (expression | regex) }
+call           = ${ ident ~ "(" ~ arguments? ~ ")"  }
+arguments      = !{ argument ~ ("," ~ argument)* }
+argument       =  { (ident ~ "=")? ~ (argument_array | argument_value) }
+argument_value = _{ (expression | regex) }
+
+// Similar to `array`, but also accepts regex patterns.
+argument_array =  { "[" ~ NEWLINE* ~ (argument_value ~ "," ~ NEWLINE*)* ~ argument_value? ~ NEWLINE* ~ "]" }
 
 // Operations ------------------------------------------------------------------
 

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -76,6 +76,8 @@ impl fmt::Display for Rule {
         rules_str![
             addition,
             argument,
+            argument_array,
+            argument_value,
             arguments,
             array,
             assignment,

--- a/lib/remap-lang/src/expression/array.rs
+++ b/lib/remap-lang/src/expression/array.rs
@@ -1,6 +1,8 @@
 use crate::{state, value, Expr, Expression, Object, Result, TypeDef, Value};
+use std::fmt;
+use std::iter::IntoIterator;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Array {
     expressions: Vec<Expr>,
 }
@@ -8,6 +10,21 @@ pub struct Array {
 impl Array {
     pub fn new(expressions: Vec<Expr>) -> Self {
         Self { expressions }
+    }
+}
+
+impl fmt::Debug for Array {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.expressions.fmt(f)
+    }
+}
+
+impl IntoIterator for Array {
+    type Item = Expr;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.expressions.into_iter()
     }
 }
 

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -112,7 +112,7 @@ impl Function {
                     )
                     .into(),
                 ),
-                Argument::Regex(_) => argument,
+                Argument::Regex(_) | Argument::Array(_) => argument,
             };
 
             list.insert(param.keyword, argument);

--- a/lib/remap-lang/src/expression/literal.rs
+++ b/lib/remap-lang/src/expression/literal.rs
@@ -1,7 +1,14 @@
 use crate::{state, Expression, Object, Result, TypeDef, Value};
+use std::fmt;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Literal(Value);
+
+impl fmt::Debug for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl Literal {
     pub fn boxed(self) -> Box<dyn Expression> {
@@ -10,6 +17,10 @@ impl Literal {
 
     pub fn as_value(&self) -> &Value {
         &self.0
+    }
+
+    pub fn into_value(self) -> Value {
+        self.0
     }
 }
 

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -36,13 +36,13 @@ pub enum Error {
     #[error(r#"expected regex argument, got array"#)]
     ArgumentRegexArray,
 
-    #[error(r#"expected array argument, got expression"#)]
+    #[error(r#"expected array literal argument, got expression"#)]
     ArgumentArrayExpr,
 
-    #[error(r#"expected array argument, got regex"#)]
+    #[error(r#"expected array literal argument, got regex"#)]
     ArgumentArrayRegex,
 
-    #[error(r#"expected expression or regex argument, got array"#)]
+    #[error(r#"expected expression or regex argument, got array literal"#)]
     ArgumentExprOrRegexArray,
 
     #[error(r#"missing required argument "{0}""#)]

--- a/lib/remap-lang/src/function.rs
+++ b/lib/remap-lang/src/function.rs
@@ -1,5 +1,5 @@
 use crate::{
-    expression::{self, Path},
+    expression::{self, Literal, Path},
     Expr, Expression, Result, Value,
 };
 use core::convert::{TryFrom, TryInto};
@@ -27,14 +27,29 @@ pub enum Error {
     #[error(r#"expected expression argument, got regex"#)]
     ArgumentExprRegex,
 
+    #[error(r#"expected expression argument, got array"#)]
+    ArgumentExprArray,
+
     #[error(r#"expected regex argument, got expression"#)]
     ArgumentRegexExpr,
+
+    #[error(r#"expected regex argument, got array"#)]
+    ArgumentRegexArray,
+
+    #[error(r#"expected array argument, got expression"#)]
+    ArgumentArrayExpr,
+
+    #[error(r#"expected array argument, got regex"#)]
+    ArgumentArrayRegex,
+
+    #[error(r#"expected expression or regex argument, got array"#)]
+    ArgumentExprOrRegexArray,
 
     #[error(r#"missing required argument "{0}""#)]
     Required(String),
 
     #[error("unknown enum variant: {0}, must be one of: {}", .1.join(", "))]
-    UnknownEnumVariant(String, &'static [&'static str]),
+    UnknownEnumVariant(String, Vec<&'static str>),
 }
 
 #[derive(Copy, Clone)]
@@ -101,7 +116,7 @@ impl ArgumentList {
             .ok_or_else(|| Error::Required(keyword.to_owned()).into())
     }
 
-    pub fn optional_literal(&mut self, keyword: &str) -> Result<Option<expression::Literal>> {
+    pub fn optional_literal(&mut self, keyword: &str) -> Result<Option<Literal>> {
         let expr = self.optional(keyword).map(Expr::try_from).transpose()?;
 
         let argument = match expr {
@@ -109,11 +124,11 @@ impl ArgumentList {
             None => return Ok(None),
         };
 
-        let variant = expression::Literal::try_from(argument.into_expr())?;
+        let variant = Literal::try_from(argument.into_expr())?;
         Ok(Some(variant))
     }
 
-    pub fn required_literal(&mut self, keyword: &str) -> Result<expression::Literal> {
+    pub fn required_literal(&mut self, keyword: &str) -> Result<Literal> {
         self.optional_literal(keyword)?
             .ok_or_else(|| Error::Required(keyword.to_owned()).into())
     }
@@ -121,31 +136,14 @@ impl ArgumentList {
     pub fn optional_enum(
         &mut self,
         keyword: &str,
-        variants: &'static [&'static str],
+        variants: &[&'static str],
     ) -> Result<Option<String>> {
-        match self.optional_literal(keyword)? {
-            None => Ok(None),
-            Some(variant) => {
-                let variant = variant
-                    .as_value()
-                    .clone()
-                    .try_bytes()
-                    .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())?;
-
-                if variants.contains(&variant.as_str()) {
-                    Ok(Some(variant))
-                } else {
-                    Err(Error::UnknownEnumVariant(variant, &variants).into())
-                }
-            }
-        }
+        self.optional_literal(keyword)?
+            .map(|lit| literal_to_enum_variant(lit, variants))
+            .transpose()
     }
 
-    pub fn required_enum(
-        &mut self,
-        keyword: &str,
-        variants: &'static [&'static str],
-    ) -> Result<String> {
+    pub fn required_enum(&mut self, keyword: &str, variants: &[&'static str]) -> Result<String> {
         self.optional_enum(keyword, variants)?
             .ok_or_else(|| Error::Required(keyword.to_owned()).into())
     }
@@ -164,6 +162,61 @@ impl ArgumentList {
             .ok_or_else(|| Error::Required(keyword.to_owned()).into())
     }
 
+    pub fn optional_array(&mut self, keyword: &str) -> Result<Option<Vec<Argument>>> {
+        self.optional(keyword)
+            .map(|v| v.try_into().map_err(Into::into))
+            .transpose()
+    }
+
+    pub fn required_array(&mut self, keyword: &str) -> Result<Vec<Argument>> {
+        self.optional_array(keyword)?
+            .ok_or_else(|| Error::Required(keyword.to_owned()).into())
+    }
+
+    pub fn optional_enum_list(
+        &mut self,
+        keyword: &str,
+        variants: &[&'static str],
+    ) -> Result<Option<Vec<String>>> {
+        self.optional_array(keyword)?
+            .map(|array| {
+                array
+                    .into_iter()
+                    .map(|arg| {
+                        let expr = Expr::try_from(arg)?;
+
+                        Literal::try_from(expr).map_err(Into::into)
+                    })
+                    .map(|lit: Result<Literal>| literal_to_enum_variant(lit?, variants))
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()
+    }
+
+    pub fn required_enum_list(
+        &mut self,
+        keyword: &str,
+        variants: &[&'static str],
+    ) -> Result<Vec<String>> {
+        self.optional_enum_list(keyword, variants)?
+            .ok_or_else(|| Error::Required(keyword.to_owned()).into())
+    }
+
+    pub fn optional_expr_or_regex(&mut self, keyword: &str) -> Result<Option<Argument>> {
+        self.optional(keyword)
+            .map(|arg| match arg {
+                Argument::Array(_) => Err(Error::ArgumentExprOrRegexArray),
+                _ => Ok(arg),
+            })
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    pub fn required_expr_or_regex(&mut self, keyword: &str) -> Result<Argument> {
+        self.optional_expr_or_regex(keyword)?
+            .ok_or_else(|| Error::Required(keyword.to_owned()).into())
+    }
+
     pub fn keywords(&self) -> Vec<&'static str> {
         self.0.keys().copied().collect::<Vec<_>>()
     }
@@ -173,10 +226,24 @@ impl ArgumentList {
     }
 }
 
+fn literal_to_enum_variant(literal: Literal, variants: &[&'static str]) -> Result<String> {
+    let variant = literal
+        .into_value()
+        .try_bytes()
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())?;
+
+    if variants.contains(&variant.as_str()) {
+        Ok(variant)
+    } else {
+        Err(Error::UnknownEnumVariant(variant, variants.to_owned()).into())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Argument {
     Expression(Expr),
     Regex(regex::Regex),
+    Array(Vec<Argument>),
 }
 
 impl<T: Into<Expr>> From<T> for Argument {
@@ -191,6 +258,12 @@ impl From<regex::Regex> for Argument {
     }
 }
 
+impl From<Vec<Argument>> for Argument {
+    fn from(args: Vec<Argument>) -> Self {
+        Argument::Array(args)
+    }
+}
+
 impl TryFrom<Argument> for Expr {
     type Error = Error;
 
@@ -198,6 +271,7 @@ impl TryFrom<Argument> for Expr {
         match arg {
             Argument::Expression(expr) => Ok(expr),
             Argument::Regex(_) => Err(Error::ArgumentExprRegex),
+            Argument::Array(_) => Err(Error::ArgumentExprArray),
         }
     }
 }
@@ -209,6 +283,7 @@ impl TryFrom<Argument> for Box<dyn Expression> {
         match arg {
             Argument::Expression(expr) => Ok(Box::new(expr) as _),
             Argument::Regex(_) => Err(Error::ArgumentExprRegex),
+            Argument::Array(_) => Err(Error::ArgumentExprArray),
         }
     }
 }
@@ -220,6 +295,19 @@ impl TryFrom<Argument> for regex::Regex {
         match arg {
             Argument::Regex(regex) => Ok(regex),
             Argument::Expression(_) => Err(Error::ArgumentRegexExpr),
+            Argument::Array(_) => Err(Error::ArgumentRegexArray),
+        }
+    }
+}
+
+impl TryFrom<Argument> for Vec<Argument> {
+    type Error = Error;
+
+    fn try_from(arg: Argument) -> std::result::Result<Self, Self::Error> {
+        match arg {
+            Argument::Array(args) => Ok(args),
+            Argument::Regex(_) => Err(Error::ArgumentArrayRegex),
+            Argument::Expression(_) => Err(Error::ArgumentArrayExpr),
         }
     }
 }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -121,7 +121,7 @@ mod tests {
             (
                 r#"enum_validator("baz")"#,
                 Err("remap error: function error: unknown enum variant: baz, must be one of: foo, bar"),
-                Ok("valid: baz".into()),
+                Ok(().into()),
             ),
             (r#"false || true"#, Ok(()), Ok(true.into())),
             (r#"false || false"#, Ok(()), Ok(false.into())),
@@ -210,7 +210,7 @@ mod tests {
                     .foo = ["foo", "bar"]
                     array_printer(.foo)
                 "#,
-                Err("remap error: function error: expected array argument, got expression"),
+                Err("remap error: function error: expected array literal argument, got expression"),
                 Ok(().into()),
             ),
         ];

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -2,7 +2,7 @@
 pub use crate::{expression, function, state, value};
 
 // commonly used top-level crate types
-pub use crate::{Error, Expression, Function, Object, Result, TypeDef, Value};
+pub use crate::{Error, Expr, Expression, Function, Object, Result, TypeDef, Value};
 
 // commonly used expressions
 pub use crate::expression::{Literal, Noop, Path, Variable};

--- a/src/remap/function/replace.rs
+++ b/src/remap/function/replace.rs
@@ -35,7 +35,7 @@ impl Function for Replace {
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
         let value = arguments.required_expr("value")?;
-        let pattern = arguments.required("pattern")?;
+        let pattern = arguments.required_expr_or_regex("pattern")?;
         let with = arguments.required_expr("with")?;
         let count = arguments.optional_expr("count")?;
 
@@ -108,6 +108,7 @@ impl Expression for ReplaceFn {
 
                 Ok(replaced)
             }
+            Argument::Array(_) => unreachable!(),
         }
     }
 
@@ -124,6 +125,7 @@ impl Expression for ReplaceFn {
         let pattern_def = match &self.pattern {
             Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::Bytes)),
             Argument::Regex(_) => None, // regex is a concrete infallible type
+            Argument::Array(_) => unreachable!(),
         };
 
         self.value

--- a/src/remap/function/split.rs
+++ b/src/remap/function/split.rs
@@ -31,7 +31,7 @@ impl Function for Split {
 
     fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
         let value = arguments.required_expr("value")?;
-        let pattern = arguments.required("pattern")?;
+        let pattern = arguments.required_expr_or_regex("pattern")?;
         let limit = arguments.optional_expr("limit")?;
 
         Ok(Box::new(SplitFn {
@@ -77,6 +77,7 @@ impl Expression for SplitFn {
                     .collect::<Vec<_>>()
                     .into()
             }
+            Argument::Array(_) => unreachable!(),
         };
 
         Ok(value)
@@ -94,6 +95,7 @@ impl Expression for SplitFn {
         let pattern_def = match &self.pattern {
             Argument::Expression(expr) => Some(expr.type_def(state).fallible_unless(Kind::Bytes)),
             Argument::Regex(_) => None, // regex is a concrete infallible type
+            Argument::Array(_) => unreachable!(),
         };
 
         self.value


### PR DESCRIPTION
This PR adds support for providing a list of arguments for a single function parameter.


```rust
my_func(values = ["foo", /bar/, true])
```

It should be noted that these _differ_ from expression-based arrays, which already support passing in a `Value::Array`:

```rust
.foo = ["foo", "bar", true]
my_func(values = .foo)

// or

my_func(values = ["foo", "bar", true])
```

That is to say, the former supports mixing expressions and **regex patterns**, whereas the  latter only supports expressions.

The reason for this is that Remap does not support using regex patterns as expressions, as we have no (acceptable) way of representing them as a `Value`.

So, this works:

```rust
.baz = "baz"
.foobar = ["foo", "bar"]
my_func(value = .baz)
my_func(value = /foo/)
my_func(values = .foobar)
my_func(values = [/foo/, /bar/])
my_func(values = [/foo/, /bar/, .baz])
```

This does not:

```rust
.baz = /baz/ 			// ERROR: expected expression
.baz = [/baz/, "bar"] 	// ERROR: expected expression
```

It should be noted that this is unlikely to ever really cause any confusion/issues, but we definitely will want to document this behaviour.

---

Additionally, the PR also supports requiring a list of enum variants for a given function parameter:

```rust
my_func(variants = ["foo", "qux"])
// remap error: function error: unknown enum variant: qux, must be one of: foo, bar, baz
```

This feature will be used in a follow-up PR implementing #5221.

closes #5220 