### PR TITLE
enhancement(socket source): Add UNIX datagram mode

### DIFF
--- a/docs/reference/components/sources/socket.cue
+++ b/docs/reference/components/sources/socket.cue
@@ -99,9 +99,10 @@ components: sources: socket: {
 			warnings: []
 			type: string: {
 				enum: {
-					tcp:  "TCP Socket."
-					udp:  "UDP Socket."
-					unix: "Unix Domain Socket."
+					tcp:           "TCP socket."
+					udp:           "UDP socket."
+					unix_datagram: "Unix domain datagram socket."
+					unix_stream:   "Unix domain stream socket."
 				}
 			}
 		}

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -159,7 +159,7 @@ impl SourceConfig for SocketConfig {
 
 #[cfg(test)]
 mod test {
-    use super::{tcp::TcpConfig, udp::UdpConfig, Mode, SocketConfig};
+    use super::{tcp::TcpConfig, udp::UdpConfig, SocketConfig};
     use crate::{
         config::{log_schema, GlobalOptions, SinkContext, SourceConfig},
         shutdown::{ShutdownSignal, SourceShutdownCoordinator},
@@ -190,7 +190,7 @@ mod test {
     };
     #[cfg(unix)]
     use {
-        super::unix::UnixConfig,
+        super::{unix::UnixConfig, Mode},
         futures::SinkExt,
         std::path::PathBuf,
         tokio::{

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -24,13 +24,13 @@ pub struct UnixConfig {
     pub(super) mode: UnixMode,
 }
 
-#[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
 #[serde(rename_all = "lowercase")]
 pub enum UnixMode {
+    Datagram,
     #[derivative(Default)]
     Stream,
-    Datagram,
 }
 
 fn default_max_length() -> usize {
@@ -38,12 +38,12 @@ fn default_max_length() -> usize {
 }
 
 impl UnixConfig {
-    pub fn new(path: PathBuf) -> Self {
+    pub fn new(path: PathBuf, mode: UnixMode) -> Self {
         Self {
             path,
             max_length: default_max_length(),
             host_key: None,
-            mode: UnixMode::Stream,
+            mode,
         }
     }
 }

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -2,7 +2,7 @@ use crate::{
     event::Event,
     internal_events::{SocketEventReceived, SocketMode},
     shutdown::ShutdownSignal,
-    sources::{util::build_unix_source, Source},
+    sources::{util::build_unix_stream_source, Source},
     Pipeline,
 };
 use bytes::Bytes;
@@ -83,7 +83,7 @@ pub(super) fn unix_stream(
     shutdown: ShutdownSignal,
     out: Pipeline,
 ) -> Source {
-    build_unix_source(
+    build_unix_stream_source(
         path,
         LinesCodec::new_with_max_length(max_length),
         host_key,

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -20,17 +20,6 @@ pub struct UnixConfig {
     #[serde(default = "default_max_length")]
     pub max_length: usize,
     pub host_key: Option<String>,
-    #[serde(default)]
-    pub(super) mode: UnixMode,
-}
-
-#[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
-#[derivative(Default)]
-#[serde(rename_all = "lowercase")]
-pub enum UnixMode {
-    Datagram,
-    #[derivative(Default)]
-    Stream,
 }
 
 fn default_max_length() -> usize {
@@ -38,12 +27,11 @@ fn default_max_length() -> usize {
 }
 
 impl UnixConfig {
-    pub fn new(path: PathBuf, mode: UnixMode) -> Self {
+    pub fn new(path: PathBuf) -> Self {
         Self {
             path,
             max_length: default_max_length(),
             host_key: None,
-            mode,
         }
     }
 }

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -2,7 +2,10 @@ use crate::{
     event::Event,
     internal_events::{SocketEventReceived, SocketMode},
     shutdown::ShutdownSignal,
-    sources::{util::build_unix_stream_source, Source},
+    sources::{
+        util::{build_unix_datagram_source, build_unix_stream_source},
+        Source,
+    },
     Pipeline,
 };
 use bytes::Bytes;
@@ -73,7 +76,15 @@ pub(super) fn unix_datagram(
     shutdown: ShutdownSignal,
     out: Pipeline,
 ) -> Source {
-    unimplemented!()
+    build_unix_datagram_source(
+        path,
+        max_length,
+        host_key,
+        LinesCodec::new_with_max_length(max_length),
+        shutdown,
+        out,
+        build_event,
+    )
 }
 
 pub(super) fn unix_stream(

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -17,6 +17,17 @@ pub struct UnixConfig {
     #[serde(default = "default_max_length")]
     pub max_length: usize,
     pub host_key: Option<String>,
+    #[serde(default)]
+    pub(super) mode: UnixMode,
+}
+
+#[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
+#[derivative(Default)]
+#[serde(rename_all = "lowercase")]
+pub enum UnixMode {
+    #[derivative(Default)]
+    Stream,
+    Datagram,
 }
 
 fn default_max_length() -> usize {
@@ -29,12 +40,13 @@ impl UnixConfig {
             path,
             max_length: default_max_length(),
             host_key: None,
+            mode: UnixMode::Stream,
         }
     }
 }
 
 /**
-* Function to pass to build_unix_source, specific to the basic unix source.
+* Function to pass to build_unix_*_source, specific to the basic unix source.
 * Takes a single line of a received message and builds an Event object.
 **/
 fn build_event(host_key: &str, received_from: Option<Bytes>, line: &str) -> Option<Event> {
@@ -54,7 +66,17 @@ fn build_event(host_key: &str, received_from: Option<Bytes>, line: &str) -> Opti
     Some(event)
 }
 
-pub fn unix(
+pub(super) fn unix_datagram(
+    path: PathBuf,
+    max_length: usize,
+    host_key: String,
+    shutdown: ShutdownSignal,
+    out: Pipeline,
+) -> Source {
+    unimplemented!()
+}
+
+pub(super) fn unix_stream(
     path: PathBuf,
     max_length: usize,
     host_key: String,

--- a/src/sources/statsd/unix.rs
+++ b/src/sources/statsd/unix.rs
@@ -1,5 +1,6 @@
 use crate::{
-    shutdown::ShutdownSignal, sources::util::build_unix_source, sources::Source, Event, Pipeline,
+    shutdown::ShutdownSignal, sources::util::build_unix_stream_source, sources::Source, Event,
+    Pipeline,
 };
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
@@ -16,7 +17,7 @@ fn build_event(_: &str, _: Option<Bytes>, line: &str) -> Option<Event> {
 }
 
 pub fn statsd_unix(config: UnixConfig, shutdown: ShutdownSignal, out: Pipeline) -> Source {
-    build_unix_source(
+    build_unix_stream_source(
         config.path,
         LinesCodec::new(),
         String::new(),

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -1,6 +1,6 @@
 use super::util::{SocketListenAddr, TcpSource};
 #[cfg(unix)]
-use crate::sources::util::build_unix_source;
+use crate::sources::util::build_unix_stream_source;
 use crate::{
     config::{
         log_schema, DataType, GenerateConfig, GlobalOptions, Resource, SourceConfig,
@@ -116,7 +116,7 @@ impl SourceConfig for SyslogConfig {
             }
             Mode::Udp { address } => Ok(udp(address, self.max_length, host_key, shutdown, out)),
             #[cfg(unix)]
-            Mode::Unix { path } => Ok(build_unix_source(
+            Mode::Unix { path } => Ok(build_unix_stream_source(
                 path,
                 SyslogDecoder::new(self.max_length),
                 host_key,
@@ -329,7 +329,7 @@ fn resolve_year((month, _date, _hour, _min, _sec): IncompleteDate) -> i32 {
 }
 
 /**
-* Function to pass to build_unix_source, specific to the Unix mode of the syslog source.
+* Function to pass to build_unix_stream_source, specific to the Unix mode of the syslog source.
 * Handles the logic of parsing and decoding the syslog message format.
 **/
 // TODO: many more cases to handle:

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -3,8 +3,10 @@ mod http;
 pub mod multiline_config;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 mod tcp;
-#[cfg(all(unix, feature = "sources-utils-unix",))]
-mod unix;
+#[cfg(all(unix, feature = "sources-socket"))]
+mod unix_datagram;
+#[cfg(all(unix, feature = "sources-utils-unix"))]
+mod unix_stream;
 
 #[cfg(any(feature = "sources-http", feature = "sources-logplex"))]
 pub(crate) use self::http::add_query_parameters;
@@ -13,5 +15,7 @@ pub(crate) use self::http::{ErrorMessage, HttpSource, HttpSourceAuthConfig};
 pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 pub use tcp::{SocketListenAddr, TcpSource};
+#[cfg(all(unix, feature = "sources-socket",))]
+pub use unix_datagram::build_unix_datagram_source;
 #[cfg(all(unix, feature = "sources-utils-unix",))]
-pub use unix::{build_unix_datagram_source, build_unix_stream_source};
+pub use unix_stream::build_unix_stream_source;

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -14,4 +14,4 @@ pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 pub use tcp::{SocketListenAddr, TcpSource};
 #[cfg(all(unix, feature = "sources-utils-unix",))]
-pub use unix::build_unix_source;
+pub use unix::build_unix_stream_source;

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -14,4 +14,4 @@ pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 pub use tcp::{SocketListenAddr, TcpSource};
 #[cfg(all(unix, feature = "sources-utils-unix",))]
-pub use unix::build_unix_stream_source;
+pub use unix::{build_unix_datagram_source, build_unix_stream_source};

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -2,19 +2,84 @@ use crate::{
     async_read::VecAsyncReadExt,
     emit,
     event::Event,
-    internal_events::{ConnectionOpen, OpenGauge, UnixSocketError},
+    internal_events::{ConnectionOpen, OpenGauge, SocketMode, SocketReceiveError, UnixSocketError},
     shutdown::ShutdownSignal,
     sources::Source,
     Pipeline,
 };
-use bytes::Bytes;
-use futures::{compat::Sink01CompatExt, FutureExt, SinkExt, StreamExt};
+use bytes::{Bytes, BytesMut};
+use futures::{
+    compat::{Future01CompatExt, Sink01CompatExt},
+    FutureExt, SinkExt, StreamExt,
+};
 use futures01::Sink;
 use std::{future::ready, path::PathBuf};
-use tokio::net::{UnixListener, UnixStream};
+use tokio::net::{UnixDatagram, UnixListener, UnixStream};
 use tokio_util::codec::{Decoder, FramedRead};
 use tracing::field;
 use tracing_futures::Instrument;
+
+/// Returns a Source object corresponding to a Unix domain datagram
+/// socket.  Passing in different functions for build_event can allow
+/// for different source-specific logic (such as decoding syslog
+/// messages in the syslog source).
+pub fn build_unix_datagram_source<D, E>(
+    listen_path: PathBuf,
+    max_length: usize,
+    host_key: String,
+    mut decoder: D,
+    mut shutdown: ShutdownSignal,
+    out: Pipeline,
+    build_event: impl Fn(&str, Option<Bytes>, &str) -> Option<Event> + Clone + Send + Sync + 'static,
+) -> Source
+where
+    D: Decoder<Item = String, Error = E> + Clone + Send + 'static,
+    E: From<std::io::Error> + std::fmt::Debug + std::fmt::Display + Send,
+{
+    let mut out = out.sink_map_err(|error| error!(message = "Error sending line.", %error));
+
+    Box::pin(async move {
+        let mut socket =
+            UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
+        info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
+
+        let mut buf = BytesMut::with_capacity(max_length);
+        loop {
+            buf.resize(max_length, 0);
+            tokio::select! {
+                recv = socket.recv_from(&mut buf) => {
+                    let (byte_size, address) = recv.map_err(|error| {
+                        emit!(SocketReceiveError { error, mode: SocketMode::Unix })
+                    })?;
+
+                    let mut payload = buf.split_to(byte_size);
+
+                    let span = info_span!("datagram");
+                    let path = address.as_pathname().map(|e| e.to_owned()).map(|path| {
+                        span.record("peer_path", &field::debug(&path));
+                        path
+                    });
+
+                    let build_event = build_event.clone();
+                    let received_from: Option<Bytes> =
+                        path.map(|p| p.to_string_lossy().into_owned().into());
+
+                    while let Ok(Some(line)) = decoder.decode_eof(&mut payload) {
+                        if let Some(event) = build_event(&host_key, received_from.clone(), &line) {
+                            tokio::select! {
+                                result = out.send(event).compat() => {
+                                    out = result?;
+                                }
+                                _ = &mut shutdown => return Ok(()),
+                            }
+                        }
+                    }
+                }
+                _ = &mut shutdown => return Ok(()),
+            }
+        }
+    })
+}
 
 /// Returns a Source object corresponding to a Unix domain stream
 /// socket.  Passing in different functions for build_event can allow

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -16,12 +16,11 @@ use tokio_util::codec::{Decoder, FramedRead};
 use tracing::field;
 use tracing_futures::Instrument;
 
-/**
-* Returns a Source object corresponding to a Unix domain socket.  Passing in different functions
-* for build_event can allow for different source-specific logic (such as decoding syslog messages
-* in the syslog source).
-**/
-pub fn build_unix_source<D, E>(
+/// Returns a Source object corresponding to a Unix domain stream
+/// socket.  Passing in different functions for build_event can allow
+/// for different source-specific logic (such as decoding syslog
+/// messages in the syslog source).
+pub fn build_unix_stream_source<D, E>(
     listen_path: PathBuf,
     decoder: D,
     host_key: String,

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -61,12 +61,7 @@ where
 
                     while let Ok(Some(line)) = decoder.decode_eof(&mut payload) {
                         if let Some(event) = build_event(&host_key, received_from.clone(), &line) {
-                            tokio::select! {
-                                result = out.send(event).compat() => {
-                                    out = result?;
-                                }
-                                _ = &mut shutdown => return Ok(()),
-                            }
+                            out = out.send(event).compat().await?;
                         }
                     }
                 }

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -55,7 +55,6 @@ where
                         path
                     });
 
-                    let build_event = build_event.clone();
                     let received_from: Option<Bytes> =
                         path.map(|p| p.to_string_lossy().into_owned().into());
 

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -18,7 +18,7 @@ use tracing::field;
 /// socket.  Passing in different functions for build_event can allow
 /// for different source-specific logic (such as decoding syslog
 /// messages in the syslog source).
-pub fn build_unix_datagram_source<D, E>(
+pub fn build_unix_datagram_source<D>(
     listen_path: PathBuf,
     max_length: usize,
     host_key: String,
@@ -28,8 +28,8 @@ pub fn build_unix_datagram_source<D, E>(
     build_event: impl Fn(&str, Option<Bytes>, &str) -> Option<Event> + Clone + Send + Sync + 'static,
 ) -> Source
 where
-    D: Decoder<Item = String, Error = E> + Clone + Send + 'static,
-    E: From<std::io::Error> + std::fmt::Debug + std::fmt::Display + Send,
+    D: Decoder<Item = String> + Clone + Send + 'static,
+    D::Error: From<std::io::Error> + std::fmt::Debug + std::fmt::Display + Send,
 {
     let mut out = out.sink_map_err(|error| error!(message = "Error sending line.", %error));
 

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -1,0 +1,77 @@
+use crate::{
+    emit,
+    event::Event,
+    internal_events::{SocketMode, SocketReceiveError},
+    shutdown::ShutdownSignal,
+    sources::Source,
+    Pipeline,
+};
+use bytes::{Bytes, BytesMut};
+use futures::compat::Future01CompatExt;
+use futures01::Sink;
+use std::path::PathBuf;
+use tokio::net::UnixDatagram;
+use tokio_util::codec::Decoder;
+use tracing::field;
+
+/// Returns a Source object corresponding to a Unix domain datagram
+/// socket.  Passing in different functions for build_event can allow
+/// for different source-specific logic (such as decoding syslog
+/// messages in the syslog source).
+pub fn build_unix_datagram_source<D, E>(
+    listen_path: PathBuf,
+    max_length: usize,
+    host_key: String,
+    mut decoder: D,
+    mut shutdown: ShutdownSignal,
+    out: Pipeline,
+    build_event: impl Fn(&str, Option<Bytes>, &str) -> Option<Event> + Clone + Send + Sync + 'static,
+) -> Source
+where
+    D: Decoder<Item = String, Error = E> + Clone + Send + 'static,
+    E: From<std::io::Error> + std::fmt::Debug + std::fmt::Display + Send,
+{
+    let mut out = out.sink_map_err(|error| error!(message = "Error sending line.", %error));
+
+    Box::pin(async move {
+        let mut socket =
+            UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
+        info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
+
+        let mut buf = BytesMut::with_capacity(max_length);
+        loop {
+            buf.resize(max_length, 0);
+            tokio::select! {
+                recv = socket.recv_from(&mut buf) => {
+                    let (byte_size, address) = recv.map_err(|error| {
+                        emit!(SocketReceiveError { error, mode: SocketMode::Unix })
+                    })?;
+
+                    let mut payload = buf.split_to(byte_size);
+
+                    let span = info_span!("datagram");
+                    let path = address.as_pathname().map(|e| e.to_owned()).map(|path| {
+                        span.record("peer_path", &field::debug(&path));
+                        path
+                    });
+
+                    let build_event = build_event.clone();
+                    let received_from: Option<Bytes> =
+                        path.map(|p| p.to_string_lossy().into_owned().into());
+
+                    while let Ok(Some(line)) = decoder.decode_eof(&mut payload) {
+                        if let Some(event) = build_event(&host_key, received_from.clone(), &line) {
+                            tokio::select! {
+                                result = out.send(event).compat() => {
+                                    out = result?;
+                                }
+                                _ = &mut shutdown => return Ok(()),
+                            }
+                        }
+                    }
+                }
+                _ = &mut shutdown => return Ok(()),
+            }
+        }
+    })
+}

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -20,7 +20,7 @@ use tracing_futures::Instrument;
 /// socket.  Passing in different functions for build_event can allow
 /// for different source-specific logic (such as decoding syslog
 /// messages in the syslog source).
-pub fn build_unix_stream_source<D, E>(
+pub fn build_unix_stream_source<D>(
     listen_path: PathBuf,
     decoder: D,
     host_key: String,
@@ -29,8 +29,8 @@ pub fn build_unix_stream_source<D, E>(
     build_event: impl Fn(&str, Option<Bytes>, &str) -> Option<Event> + Clone + Send + Sync + 'static,
 ) -> Source
 where
-    D: Decoder<Item = String, Error = E> + Clone + Send + 'static,
-    E: From<std::io::Error> + std::fmt::Debug + std::fmt::Display,
+    D: Decoder<Item = String> + Clone + Send + 'static,
+    D::Error: From<std::io::Error> + std::fmt::Debug + std::fmt::Display,
 {
     let out = out.sink_map_err(|error| error!(message = "Error sending line.", %error));
 


### PR DESCRIPTION
Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #4787 

Note that `unix` is still accepted as a socket type for backwards compatibility, so this shouldn't be a breaking change.