### PR TITLE
feat(remap): support multiline expressions

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -90,4 +90,4 @@ char         =  { !("\"" | "\\") ~ ANY | "\\" ~ ("\"" | "\\" | "n" | "t") }
 regex_inner = @{ regex_char* }
 regex_char  =  { !("/" | "\\") ~ ANY | "\\" ~ ANY }
 
-WHITESPACE  = _{ " " | "\t" }
+WHITESPACE  = _{ " " | "\t" | ("\\" ~ NEWLINE) }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -233,6 +233,16 @@ mod tests {
                 Err("remap error: unexpected expression: expected Array, got Literal"),
                 Ok(().into()),
             ),
+            (
+                r#"
+                    .foo        \
+                        =       \
+                        null || \
+                        "bar"
+                "#,
+                Ok(()),
+                Ok("bar".into()),
+            ),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {


### PR DESCRIPTION
While looking at #4946, I wanted to see how easy it was to add support for breaking up expressions over multiple lines.

Turns out, quite easy.

As described in the linked issue, we've had people write long checks, for example:


```rust
match(.log, /^\\d{4}-\\d{2}-\\d{2}(T|\\s)?\\d{2}:\\d{2}:\\d{2}/) || match(.log,/^\\[?\\d{2}\\S\\w{3}\\S\\d{4}:\\d{2}:\\d{2}:\\d{2}/) || match(.log,/^\\d{4}\\S\\d{2}\\S\\d{2}\\s\\d{2}:\\d{2}:\\d{2}/)
```

After this PR, it can be written as:

```rust
match(.log, /^\\d{4}-\\d{2}-\\d{2}(T|\\s)?\\d{2}:\\d{2}:\\d{2}/) 			\
	|| match(.log,/^\\[?\\d{2}\\S\\w{3}\\S\\d{4}:\\d{2}:\\d{2}:\\d{2}/) 	\
	|| match(.log,/^\\d{4}\\S\\d{2}\\S\\d{2}\\s\\d{2}:\\d{2}:\\d{2}/)
```

That is to say, anywhere in an expression where _whitespace_ is supported, you can now add `\<newline>` in addition to the already supported space or tab characters.

This _seems_ useful to me, and I can't think of any major downsides (the only one being "we need to document this"). It also matches closely with other languages that support similar syntax.

Happy to _not_ do this, but curious what others think.

closes #4946