### PR TITLE
fix(prometheus sink): change logs level on request

### DIFF
--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -167,7 +167,12 @@ pub struct PrometheusServerRequestComplete {
 
 impl InternalEvent for PrometheusServerRequestComplete {
     fn emit_logs(&self) {
-        error!(message = "Request to prometheus server complete.", status_code = %self.status_code);
+        let message = "Request to prometheus server complete.";
+        if self.status_code.is_success() {
+            debug!(message, status_code = %self.status_code);
+        } else {
+            error!(message, status_code = %self.status_code);
+        }
     }
 
     fn emit_metrics(&self) {


### PR DESCRIPTION
Closes #5334 

I think would be useful to log on error level on incorrect requests.