### PR TITLE
enhancement(topology): Reuse buffers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use crate::{
     config, generate, heartbeat, list, metrics, signal, topology, trace, unit_test, validate,
 };
 use std::cmp::max;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use futures::{
@@ -148,7 +149,7 @@ impl Application {
                     .expect("Couldn't set schema");
 
                 let diff = config::ConfigDiff::initial(&config);
-                let pieces = topology::build_or_log_errors(&config, &diff)
+                let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
                     .await
                     .ok_or(exitcode::CONFIG)?;
 

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -138,6 +138,7 @@ impl BufferConfig {
     pub fn resources(&self, sink_name: &str) -> Vec<Resource> {
         match self {
             BufferConfig::Memory { .. } => Vec::new(),
+            #[cfg(feature = "leveldb")]
             BufferConfig::Disk { .. } => vec![Resource::DiskBuffer(sink_name.to_string())],
         }
     }

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{
 #[cfg(feature = "leveldb")]
 pub mod disk;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum BufferConfig {
@@ -50,6 +50,7 @@ impl Default for WhenFull {
     }
 }
 
+#[derive(Clone)]
 pub enum BufferInputCloner {
     Memory(mpsc::Sender<Event>, WhenFull),
     #[cfg(feature = "leveldb")]

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -1,4 +1,4 @@
-use crate::Event;
+use crate::{config::Resource, Event};
 use futures01::{sync::mpsc, task::AtomicTask, AsyncSink, Poll, Sink, StartSend, Stream};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -131,6 +131,14 @@ impl BufferConfig {
                 let rx = Box::new(rx);
                 Ok((tx, rx, acker))
             }
+        }
+    }
+
+    /// Resources that the sink is using.
+    pub fn resources(&self, sink_name: &str) -> Vec<Resource> {
+        match self {
+            BufferConfig::Memory { .. } => Vec::new(),
+            BufferConfig::Disk { .. } => vec![Resource::DiskBuffer(sink_name.to_string())],
         }
     }
 }

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -135,6 +135,7 @@ impl BufferConfig {
     }
 
     /// Resources that the sink is using.
+    #[cfg_attr(not(feature = "leveldb"), allow(unused))]
     pub fn resources(&self, sink_name: &str) -> Vec<Resource> {
         match self {
             BufferConfig::Memory { .. } => Vec::new(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -185,6 +185,14 @@ pub struct SinkOuter {
     pub inner: Box<dyn SinkConfig>,
 }
 
+impl SinkOuter {
+    pub fn resources(&self, name: &str) -> Vec<Resource> {
+        let mut resources = self.inner.resources();
+        resources.append(&mut self.buffer.resources(name));
+        resources
+    }
+}
+
 #[async_trait]
 #[typetag::serde(tag = "type")]
 pub trait SinkConfig: core::fmt::Debug + Send + Sync {
@@ -261,6 +269,7 @@ pub enum Resource {
     Port(SocketAddr),
     SystemFdOffset(usize),
     Stdin,
+    DiskBuffer(String),
 }
 
 impl Resource {
@@ -318,6 +327,7 @@ impl Display for Resource {
             Resource::Port(address) => write!(fmt, "{}", address),
             Resource::SystemFdOffset(offset) => write!(fmt, "systemd {}th socket", offset + 1),
             Resource::Stdin => write!(fmt, "stdin"),
+            Resource::DiskBuffer(name) => write!(fmt, "disk buffer {:?}", name),
         }
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -54,7 +54,7 @@ pub fn check_resources(config: &Config) -> Result<(), Vec<String>> {
     let sink_resources = config
         .sinks
         .iter()
-        .map(|(name, config)| (name, config.inner.resources()));
+        .map(|(name, config)| (name, config.resources(name)));
 
     let conflicting_componenets = Resource::conflicts(source_resources.chain(sink_resources));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub mod top;
 pub mod topology;
 pub mod trace;
 pub mod transforms;
+pub mod trigger;
 pub mod types;
 pub mod unit_test;
 pub mod validate;

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -98,7 +98,7 @@ pub enum HealthcheckError {
 impl VectorSink {
     pub async fn run<S>(mut self, input: S) -> Result<(), ()>
     where
-        S: Stream<Item = Event> + Send + 'static,
+        S: Stream<Item = Event> + Send,
     {
         match self {
             Self::Sink(sink) => input.map(Ok).forward(sink).await,

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -520,7 +520,9 @@ pub async fn start_topology(
     require_healthy: bool,
 ) -> (RunningTopology, mpsc::UnboundedReceiver<()>) {
     let diff = ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff).await.unwrap();
+    let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
+        .await
+        .unwrap();
     topology::start_validated(config, diff, pieces, require_healthy)
         .await
         .unwrap()

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1,7 +1,7 @@
 use super::{
     fanout::{self, Fanout},
     task::{Task, TaskOutput},
-    BuildedBuffer, ConfigDiff,
+    BuiltBuffer, ConfigDiff,
 };
 use crate::{
     buffers,
@@ -38,7 +38,7 @@ pub struct Pieces {
 pub async fn build_pieces(
     config: &super::Config,
     diff: &ConfigDiff,
-    mut buffers: HashMap<String, BuildedBuffer>,
+    mut buffers: HashMap<String, BuiltBuffer>,
 ) -> Result<Pieces, Vec<String>> {
     let mut inputs = HashMap::new();
     let mut outputs = HashMap::new();
@@ -188,7 +188,7 @@ pub async fn build_pieces(
                 errors.push(format!("Sink \"{}\": {}", name, error));
                 continue;
             }
-            Ok(builded) => builded,
+            Ok(built) => built,
         };
 
         let (trigger, tripwire) = Tripwire::new();

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -194,6 +194,12 @@ pub async fn build_pieces(
         let (trigger, tripwire) = Tripwire::new();
 
         let sink = async move {
+            // Why is this Arc<Mutex<Option<_>>> needed you ask.
+            // In case when this function build_pieces errors
+            // this future won't be run so this rx won't be taken
+            // which will enable us to reuse rx to rebuild
+            // old configuration by passing this Arc<Mutex<Option<_>>>
+            // yet again.
             let mut rx = rx
                 .lock()
                 .unwrap()

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -21,7 +21,7 @@ use std::{
     future::ready,
     sync::{Arc, Mutex},
 };
-use stream_cancel::{Trigger, Tripwire};
+use stream_cancel::{StreamExt as StreamCancelExt, Trigger, Tripwire};
 use tokio::time::{timeout, Duration};
 
 pub struct Pieces {
@@ -215,7 +215,7 @@ pub async fn build_pieces(
                     })
                     .compat()
                     .take_while(|e| ready(e.is_ok()))
-                    .take_until(tripwire)
+                    .take_until_if(tripwire)
                     .map(|x| x.unwrap()),
             )
             .await

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -35,7 +35,7 @@ use tracing_futures::Instrument;
 // TODO: Result is only for compat, remove when not needed
 type TaskHandle = tokio::task::JoinHandle<Result<TaskOutput, ()>>;
 
-type BuildedBuffer = (
+type BuiltBuffer = (
     buffers::BufferInputCloner,
     Arc<Mutex<Option<Box<dyn Stream01<Item = Event, Error = ()> + Send>>>>,
     buffers::Acker,
@@ -87,7 +87,7 @@ pub async fn start_validated(
 pub async fn build_or_log_errors(
     config: &Config,
     diff: &ConfigDiff,
-    buffers: HashMap<String, BuildedBuffer>,
+    buffers: HashMap<String, BuiltBuffer>,
 ) -> Option<Pieces> {
     match builder::build_pieces(config, diff, buffers).await {
         Err(errors) => {
@@ -314,7 +314,7 @@ impl RunningTopology {
         &mut self,
         diff: &ConfigDiff,
         new_config: &Config,
-    ) -> HashMap<String, BuildedBuffer> {
+    ) -> HashMap<String, BuiltBuffer> {
         // Sources
         let timeout = Duration::from_secs(30); //sec
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -824,13 +824,9 @@ mod reload_tests {
     use crate::config::Config;
     use crate::sinks::console::{ConsoleSinkConfig, Encoding, Target};
     use crate::sinks::prometheus::exporter::PrometheusExporterConfig;
-    use crate::sinks::socket::{Mode, SocketSinkConfig};
-    use crate::sinks::util::{tcp::TcpSinkConfig, Encoding as SinkEncoding};
     use crate::sources::generator::GeneratorConfig;
     use crate::sources::splunk_hec::SplunkConfig;
-    use crate::test_util::{
-        next_addr, start_topology, temp_dir, trace_init, wait_for_tcp, CountReceiver,
-    };
+    use crate::test_util::{next_addr, start_topology, temp_dir, wait_for_tcp};
     use crate::transforms::log_to_metric::{GaugeConfig, LogToMetricConfig, MetricConfig};
     use futures::{compat::Stream01CompatExt, StreamExt};
     use std::net::{SocketAddr, TcpListener};

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1097,7 +1097,7 @@ mod reload_tests {
         let (mut topology, crash) = start_topology(old_config, false).await;
         let mut crash = crash.compat();
 
-        // Wait for sink to come onlineEncoding
+        // Wait for sink to come online
         wait_for_tcp(old_address).await;
 
         // Give topology some time to run

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -455,6 +455,7 @@ impl RunningTopology {
         for name in &diff.sinks.to_remove {
             let previous = self.tasks.remove(name).unwrap();
             if wait_for_sinks.contains(name) {
+                debug!(message = "Waiting for sink to shutdown.", %name);
                 previous.await.unwrap().unwrap();
             } else {
                 drop(previous); // detach and forget
@@ -466,6 +467,7 @@ impl RunningTopology {
         for name in &diff.sinks.to_change {
             if wait_for_sinks.contains(name) {
                 let previous = self.tasks.remove(name).unwrap();
+                debug!(message = "Waiting for sink to shutdown.", %name);
                 let buffer = previous.await.unwrap().unwrap();
 
                 if reuse_buffers.contains(name) {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     shutdown::SourceShutdownCoordinator,
     topology::{
         builder::Pieces,
-        task::{Task, TaskBuffer},
+        task::{Task, TaskOutput},
     },
     trigger::DisabledTrigger,
 };
@@ -33,7 +33,7 @@ use tokio::time::{delay_until, interval, Duration, Instant};
 use tracing_futures::Instrument;
 
 // TODO: Result is only for compat, remove when not needed
-type TaskHandle = tokio::task::JoinHandle<Result<TaskBuffer, ()>>;
+type TaskHandle = tokio::task::JoinHandle<Result<TaskOutput, ()>>;
 
 type BuildedBuffer = (
     buffers::BufferInputCloner,
@@ -473,7 +473,7 @@ impl RunningTopology {
                 if reuse_buffers.contains(name) {
                     let tx = self.inputs.remove(name).unwrap();
                     let (rx, acker) = match buffer {
-                        TaskBuffer::Sink(rx, acker) => (rx, acker),
+                        TaskOutput::Sink(rx, acker) => (rx, acker),
                         _ => unreachable!(),
                     };
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -721,7 +721,6 @@ impl RunningTopology {
         });
     }
 
-    // TODO: remove replace None
     fn detach_inputs(&mut self, name: &str) {
         self.inputs.remove(name);
         self.detach_triggers.remove(name);

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1,0 +1,29 @@
+use stream_cancel::Trigger;
+
+pub struct DisabledTrigger {
+    trigger: Option<Trigger>,
+}
+
+impl DisabledTrigger {
+    pub fn new(t: Trigger) -> Self {
+        Self { trigger: Some(t) }
+    }
+
+    pub fn into_inner(mut self) -> Trigger {
+        self.trigger.take().unwrap()
+    }
+}
+
+impl Drop for DisabledTrigger {
+    fn drop(&mut self) {
+        if let Some(trigger) = self.trigger.take() {
+            trigger.disable();
+        }
+    }
+}
+
+impl From<Trigger> for DisabledTrigger {
+    fn from(t: Trigger) -> Self {
+        Self::new(t)
+    }
+}

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use colored::*;
 use exitcode::ExitCode;
+use std::collections::HashMap;
 use std::{fmt, fs::remove_dir_all, path::PathBuf};
 use structopt::StructOpt;
 
@@ -99,7 +100,7 @@ async fn validate_components(
         .set(config.global.log_schema.clone())
         .expect("Couldn't set schema");
 
-    match topology::builder::build_pieces(config, diff).await {
+    match topology::builder::build_pieces(config, diff, HashMap::new()).await {
         Ok(pieces) => {
             fmt.success("Component configuration");
             Some(pieces)
@@ -130,7 +131,7 @@ async fn validate_healthchecks(
         };
 
         match tokio::spawn(healthcheck).await {
-            Ok(Ok(())) => {
+            Ok(Ok(_)) => {
                 if config
                     .sinks
                     .get(&name)

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -10,6 +10,7 @@ mod tests {
     use chrono::Utc;
     use futures::StreamExt;
     use std::{
+        collections::HashMap,
         net::SocketAddr,
         sync::Once,
         time::{Duration, Instant},
@@ -71,7 +72,7 @@ mod tests {
         c.api.address = Some(next_addr());
 
         let diff = config::ConfigDiff::initial(&c);
-        let pieces = vector::topology::build_or_log_errors(&c, &diff)
+        let pieces = vector::topology::build_or_log_errors(&c, &diff, &mut HashMap::new())
             .await
             .unwrap();
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -72,7 +72,7 @@ mod tests {
         c.api.address = Some(next_addr());
 
         let diff = config::ConfigDiff::initial(&c);
-        let pieces = vector::topology::build_or_log_errors(&c, &diff, &mut HashMap::new())
+        let pieces = vector::topology::build_or_log_errors(&c, &diff, HashMap::new())
             .await
             .unwrap();
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use vector::{
     config::{self, ConfigDiff},
     topology,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -9,7 +9,7 @@ async fn load(config: &str) -> Result<Vec<String>, Vec<String>> {
             let diff = ConfigDiff::initial(&c);
             match (
                 config::warnings(&c),
-                topology::builder::build_pieces(&c, &diff).await,
+                topology::builder::build_pieces(&c, &diff, HashMap::new()).await,
             ) {
                 (warnings, Ok(_pieces)) => Ok(warnings),
                 (_, Err(errors)) => Err(errors),

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -493,7 +493,7 @@ async fn topology_swap_transform_is_atomic() {
 async fn topology_required_healthcheck_fails_start() {
     let config = basic_config_with_sink_failing_healthcheck();
     let diff = vector::config::ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff, &mut HashMap::new())
+    let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
     assert!(topology::start_validated(config, diff, pieces, true)
@@ -505,7 +505,7 @@ async fn topology_required_healthcheck_fails_start() {
 async fn topology_optional_healthcheck_does_not_fail_start() {
     let config = basic_config_with_sink_failing_healthcheck();
     let diff = vector::config::ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff, &mut HashMap::new())
+    let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
     assert!(topology::start_validated(config, diff, pieces, false)

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -6,6 +6,7 @@ use futures01::{
     future, future::Future, sink::Sink, stream::iter_ok, stream::Stream, sync::mpsc::SendError,
 };
 use std::{
+    collections::HashMap,
     iter,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -492,7 +493,9 @@ async fn topology_swap_transform_is_atomic() {
 async fn topology_required_healthcheck_fails_start() {
     let config = basic_config_with_sink_failing_healthcheck();
     let diff = vector::config::ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff).await.unwrap();
+    let pieces = topology::build_or_log_errors(&config, &diff, &mut HashMap::new())
+        .await
+        .unwrap();
     assert!(topology::start_validated(config, diff, pieces, true)
         .await
         .is_none());
@@ -502,7 +505,9 @@ async fn topology_required_healthcheck_fails_start() {
 async fn topology_optional_healthcheck_does_not_fail_start() {
     let config = basic_config_with_sink_failing_healthcheck();
     let diff = vector::config::ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff).await.unwrap();
+    let pieces = topology::build_or_log_errors(&config, &diff, &mut HashMap::new())
+        .await
+        .unwrap();
     assert!(topology::start_validated(config, diff, pieces, false)
         .await
         .is_some());


### PR DESCRIPTION
Closes #5147 

With this PR, the behavior for a changed sink is:
- If buffer configuration wasn't changed, buffer will be reused in the new sink.
- Else if both new and old buffer configurations use disk, we will wait for the old sink to finish. That includes draining the buffer. 
- Else sink is detached with its buffer and left to run in the background.

### Todo

- [x] Open issue for: instead of waiting for old sink to drain disk buffer, we can adjust old disk buffer to new disk buffer configuration.


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
