### PR TITLE
fix(elasticsearch sink): set content encoding header when compression is on

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -713,7 +713,7 @@ mod integration_tests {
             },
             false,
         )
-            .await;
+        .await;
     }
 
     #[tokio::test]
@@ -729,7 +729,7 @@ mod integration_tests {
             },
             false,
         )
-            .await;
+        .await;
     }
 
     #[tokio::test]

--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -212,6 +212,10 @@ impl HttpSink for ElasticSearchCommon {
 
             request.add_header("Content-Type", "application/x-ndjson");
 
+            if let Some(ce) = self.compression.content_encoding() {
+                request.add_header("Content-Encoding", ce);
+            }
+
             if let Some(headers) = &self.config.headers {
                 for (header, value) in headers {
                     request.add_header(header, value);
@@ -709,7 +713,23 @@ mod integration_tests {
             },
             false,
         )
-        .await;
+            .await;
+    }
+
+    #[tokio::test]
+    async fn insert_events_on_aws_with_compression() {
+        trace_init();
+
+        run_insert_tests(
+            ElasticSearchConfig {
+                auth: Some(ElasticSearchAuth::Aws { assume_role: None }),
+                endpoint: "http://localhost:4571".into(),
+                compression: Compression::gzip_default(),
+                ..config()
+            },
+            false,
+        )
+            .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Following error is returned when using compression on AWS ES:

400 Bad Request: {\"error\":{\"root_cause\":[{\"type\":\"json_parse_exception\",\"reason\":\"Illegal character ((CTRL-CHAR, code 31)): only regular white space (\\\\r, \\\\n, \\\\t) is allowed between tokens\\n at [Source: (org.elasticsearch.common.bytes.AbstractBytesReference$MarkSupportingStreamInputWrapper); line: 1, column: 2]\"}]

I suspect the content-encoding header is missing, so the payload is gzip compressed, but ES doesn't expect it to be.