### PR TITLE
enhancement(remap): track inner container type definitions

### DIFF
--- a/lib/remap-functions/src/ceil.rs
+++ b/lib/remap-functions/src/ceil.rs
@@ -109,7 +109,7 @@ mod tests {
                 value: Variable::new("foo".to_owned(), None).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
         }
 
         fallible_precision {
@@ -117,7 +117,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned(), None).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/del.rs
+++ b/lib/remap-functions/src/del.rs
@@ -50,6 +50,7 @@ impl Expression for DelFn {
         TypeDef {
             fallible: true,
             kind: value::Kind::Null,
+            ..Default::default()
         }
     }
 }
@@ -65,6 +66,7 @@ mod tests {
         def: TypeDef {
             fallible: true,
             kind: value::Kind::Null,
+            ..Default::default()
         },
     }];
 }

--- a/lib/remap-functions/src/downcase.rs
+++ b/lib/remap-functions/src/downcase.rs
@@ -86,7 +86,7 @@ mod tests {
 
         non_string {
             expr: |_| DowncaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
         }
     ];
 }

--- a/lib/remap-functions/src/ends_with.rs
+++ b/lib/remap-functions/src/ends_with.rs
@@ -134,7 +134,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         substring_non_string {
@@ -143,7 +143,7 @@ mod tests {
                 substring: Literal::from(true).boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         case_sensitive_non_boolean {
@@ -152,7 +152,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: Some(Literal::from(1).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/exists.rs
+++ b/lib/remap-functions/src/exists.rs
@@ -45,6 +45,7 @@ impl Expression for ExistsFn {
         TypeDef {
             fallible: false,
             kind: value::Kind::Boolean,
+            ..Default::default()
         }
     }
 }

--- a/lib/remap-functions/src/floor.rs
+++ b/lib/remap-functions/src/floor.rs
@@ -109,7 +109,7 @@ mod tests {
                 value: Variable::new("foo".to_owned(), None).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
         }
 
         fallible_precision {
@@ -117,7 +117,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned(), None).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/format_number.rs
+++ b/lib/remap-functions/src/format_number.rs
@@ -200,7 +200,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_float {
@@ -210,7 +210,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         // TODO(jean): we should update the function to ignore `None` values,
@@ -222,7 +222,7 @@ mod tests {
                 decimal_separator: None,
                 grouping_separator: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/format_timestamp.rs
+++ b/lib/remap-functions/src/format_timestamp.rs
@@ -96,7 +96,7 @@ mod tests {
                 value: Literal::from(chrono::Utc::now()).boxed(),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         optional_value {
@@ -104,7 +104,7 @@ mod tests {
                 value: Box::new(Noop),
                 format: Literal::from("%s").boxed(),
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/match.rs
+++ b/lib/remap-functions/src/match.rs
@@ -82,7 +82,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 pattern: Regex::new("").unwrap(),
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         value_optional {
@@ -90,7 +90,7 @@ mod tests {
                 value: Box::new(Noop),
                 pattern: Regex::new("").unwrap(),
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/md5.rs
+++ b/lib/remap-functions/src/md5.rs
@@ -65,12 +65,12 @@ mod tests {
 
         value_non_string {
             expr: |_| Md5Fn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_optional {
             expr: |_| Md5Fn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/only_fields.rs
+++ b/lib/remap-functions/src/only_fields.rs
@@ -55,6 +55,7 @@ impl Expression for OnlyFieldsFn {
         TypeDef {
             fallible: true,
             kind: value::Kind::Null,
+            ..Default::default()
         }
     }
 }
@@ -70,6 +71,7 @@ mod tests {
         def: TypeDef {
             fallible: true,
             kind: value::Kind::Null,
+            ..Default::default()
         },
     }];
 }

--- a/lib/remap-functions/src/parse_duration.rs
+++ b/lib/remap-functions/src/parse_duration.rs
@@ -137,7 +137,7 @@ mod tests {
                 value: Literal::from("foo").boxed(),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, kind: value::Kind::Float },
+            def: TypeDef { fallible: true, kind: value::Kind::Float, ..Default::default() },
         }
 
         optional_expression {
@@ -145,7 +145,7 @@ mod tests {
                 value: Box::new(Noop),
                 output: Literal::from("foo").boxed(),
             },
-            def: TypeDef { fallible: true, kind: value::Kind::Float },
+            def: TypeDef { fallible: true, kind: value::Kind::Float, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/parse_json.rs
+++ b/lib/remap-functions/src/parse_json.rs
@@ -134,6 +134,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                ..Default::default()
             },
         }
 
@@ -145,6 +146,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                ..Default::default()
             },
         }
 
@@ -156,6 +158,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                ..Default::default()
             },
         }
 
@@ -167,6 +170,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Boolean | Kind::Integer | Kind::Float | Kind::Array | Kind::Map | Kind::Null,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/parse_syslog.rs
+++ b/lib/remap-functions/src/parse_syslog.rs
@@ -131,12 +131,12 @@ mod tests {
 
         value_non_string {
             expr: |_| ParseSyslogFn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Map },
+            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
         }
 
         value_optional {
             expr: |_| ParseSyslogFn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, kind: value::Kind::Map },
+            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/parse_timestamp.rs
+++ b/lib/remap-functions/src/parse_timestamp.rs
@@ -140,6 +140,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Timestamp,
+                ..Default::default()
             },
         }
 
@@ -152,6 +153,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Timestamp,
+                ..Default::default()
             },
         }
 

--- a/lib/remap-functions/src/parse_url.rs
+++ b/lib/remap-functions/src/parse_url.rs
@@ -92,12 +92,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| ParseUrlFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Map },
+            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
         }
 
         value_optional {
             expr: |_| ParseUrlFn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, kind: value::Kind::Map },
+            def: TypeDef { fallible: true, kind: value::Kind::Map, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/replace.rs
+++ b/lib/remap-functions/src/replace.rs
@@ -176,6 +176,7 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -202,6 +203,7 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -215,6 +217,7 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -241,6 +244,7 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Bytes,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/round.rs
+++ b/lib/remap-functions/src/round.rs
@@ -109,7 +109,7 @@ mod tests {
                 value: Variable::new("foo".to_owned(), None).boxed(),
                 precision: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float },
+            def: TypeDef { fallible: true, kind: Kind::Integer | Kind::Float, ..Default::default() },
         }
 
         fallible_precision {
@@ -117,7 +117,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 precision: Some(Variable::new("foo".to_owned(), None).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Integer },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/sha1.rs
+++ b/lib/remap-functions/src/sha1.rs
@@ -65,12 +65,12 @@ mod tests {
 
         value_non_string {
             expr: |_| Sha1Fn { value: Literal::from(1).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_optional {
             expr: |_| Sha1Fn { value: Box::new(Noop) },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/sha2.rs
+++ b/lib/remap-functions/src/sha2.rs
@@ -106,7 +106,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_optional {
@@ -114,7 +114,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/sha3.rs
+++ b/lib/remap-functions/src/sha3.rs
@@ -97,7 +97,7 @@ mod tests {
                 value: Literal::from(1).boxed(),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_optional {
@@ -105,7 +105,7 @@ mod tests {
                 value: Box::new(Noop),
                 variant: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/slice.rs
+++ b/lib/remap-functions/src/slice.rs
@@ -132,16 +132,20 @@ mod tests {
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef { fallible: true, kind: Kind::Bytes, ..Default::default() },
         }
 
         value_array {
             expr: |_| SliceFn {
-                value: Array::from(vec!["foo"]).boxed(),
+                value: array!["foo"].boxed(),
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Array },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Array,
+                inner_type_def: Some(TypeDef { kind: Kind::Bytes, ..Default::default() }.boxed()),
+            },
         }
 
         value_unknown {
@@ -150,7 +154,7 @@ mod tests {
                 start: Literal::from(0).boxed(),
                 end: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes | Kind::Array },
+            def: TypeDef { fallible: true, kind: Kind::Bytes | Kind::Array, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/split.rs
+++ b/lib/remap-functions/src/split.rs
@@ -135,6 +135,7 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Array,
+                ..Default::default()
             },
         }
 
@@ -159,6 +160,7 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Array,
+                ..Default::default()
             },
         }
 
@@ -183,6 +185,7 @@ mod test {
             def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Array,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/starts_with.rs
+++ b/lib/remap-functions/src/starts_with.rs
@@ -132,7 +132,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         substring_non_string {
@@ -141,7 +141,7 @@ mod tests {
                 substring: Literal::from(true).boxed(),
                 case_sensitive: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         case_sensitive_non_boolean {
@@ -150,7 +150,7 @@ mod tests {
                 substring: Literal::from("foo").boxed(),
                 case_sensitive: Some(Literal::from(1).boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/strip_ansi_escape_codes.rs
+++ b/lib/remap-functions/src/strip_ansi_escape_codes.rs
@@ -66,12 +66,12 @@ mod tests {
     remap::test_type_def![
         value_string {
             expr: |_| StripAnsiEscapeCodesFn { value: Literal::from("foo").boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
         }
 
         fallible_expression {
             expr: |_| StripAnsiEscapeCodesFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/strip_whitespace.rs
+++ b/lib/remap-functions/src/strip_whitespace.rs
@@ -64,7 +64,7 @@ mod tests {
 
         fallible_expression {
             expr: |_| StripWhitespaceFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, kind: value::Kind::Bytes },
+            def: TypeDef { fallible: true, kind: value::Kind::Bytes, ..Default::default() },
         }
     ];
 

--- a/lib/remap-functions/src/to_bool.rs
+++ b/lib/remap-functions/src/to_bool.rs
@@ -115,22 +115,22 @@ mod tests {
 
         string_fallible {
             expr: |_| ToBoolFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         map_fallible {
             expr: |_| ToBoolFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         array_fallible {
-            expr: |_| ToBoolFn { value: Array::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            expr: |_| ToBoolFn { value: array![].boxed(), default: None },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         timestamp_fallible {
             expr: |_| ToBoolFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Boolean },
+            def: TypeDef { fallible: true, kind: Kind::Boolean, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -138,39 +138,43 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
        fallible_value_with_fallible_default {
             expr: |_| ToBoolFn {
-                value: Array::from(vec![0]).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                value: array![].boxed(),
+                default: Some(array![].boxed()),
             },
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
        fallible_value_with_infallible_default {
             expr: |_| ToBoolFn {
-                value: Array::from(vec![0]).boxed(),
+                value: array![].boxed(),
                 default: Some(Literal::from(true).boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
         infallible_value_with_fallible_default {
             expr: |_| ToBoolFn {
                 value: Literal::from(true).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                default: Some(array![].boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -182,6 +186,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/to_float.rs
+++ b/lib/remap-functions/src/to_float.rs
@@ -115,22 +115,22 @@ mod tests {
 
         string_fallible {
             expr: |_| ToFloatFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         map_fallible {
             expr: |_| ToFloatFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         array_fallible {
-            expr: |_| ToFloatFn { value: Array::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float },
+            expr: |_| ToFloatFn { value: array![].boxed(), default: None },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         timestamp_infallible {
             expr: |_| ToFloatFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Float },
+            def: TypeDef { fallible: true, kind: Kind::Float, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -138,39 +138,43 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Float,
+                ..Default::default()
             },
         }
 
        fallible_value_with_fallible_default {
             expr: |_| ToFloatFn {
-                value: Array::from(vec![0]).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                value: array![].boxed(),
+                default: Some(array![].boxed()),
             },
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Float,
+                ..Default::default()
             },
         }
 
        fallible_value_with_infallible_default {
             expr: |_| ToFloatFn {
-                value: Array::from(vec![0]).boxed(),
+                value: array![].boxed(),
                 default: Some(Literal::from(1).boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Float,
+                ..Default::default()
             },
         }
 
         infallible_value_with_fallible_default {
             expr: |_| ToFloatFn {
                 value: Literal::from(1).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                default: Some(array![].boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Float,
+                ..Default::default()
             },
         }
 
@@ -182,6 +186,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Float,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/to_int.rs
+++ b/lib/remap-functions/src/to_int.rs
@@ -115,22 +115,22 @@ mod tests {
 
         string_fallible {
             expr: |_| ToIntFn { value: Literal::from("foo").boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         map_fallible {
             expr: |_| ToIntFn { value: Literal::from(BTreeMap::new()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         array_fallible {
-            expr: |_| ToIntFn { value: Array::from(vec![0]).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer },
+            expr: |_| ToIntFn { value: array![].boxed(), default: None },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         timestamp_infallible {
             expr: |_| ToIntFn { value: Literal::from(chrono::Utc::now()).boxed(), default: None },
-            def: TypeDef { fallible: true, kind: Kind::Integer },
+            def: TypeDef { fallible: true, kind: Kind::Integer, ..Default::default() },
         }
 
         fallible_value_without_default {
@@ -138,39 +138,43 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Integer,
+                ..Default::default()
             },
         }
 
        fallible_value_with_fallible_default {
             expr: |_| ToIntFn {
-                value: Array::from(vec![0]).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                value: array![].boxed(),
+                default: Some(array![].boxed()),
             },
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Integer,
+                ..Default::default()
             },
         }
 
        fallible_value_with_infallible_default {
             expr: |_| ToIntFn {
-                value: Array::from(vec![0]).boxed(),
+                value: array![].boxed(),
                 default: Some(Literal::from(1).boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Integer,
+                ..Default::default()
             },
         }
 
         infallible_value_with_fallible_default {
             expr: |_| ToIntFn {
                 value: Literal::from(1).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                default: Some(array![].boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Integer,
+                ..Default::default()
             },
         }
 
@@ -182,6 +186,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Integer,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/to_string.rs
+++ b/lib/remap-functions/src/to_string.rs
@@ -116,7 +116,7 @@ mod tests {
         }
 
         array_infallible {
-            expr: |_| ToStringFn { value: Array::from(vec![0]).boxed(), default: None},
+            expr: |_| ToStringFn { value: array![].boxed(), default: None},
             def: TypeDef { kind: Kind::Bytes, ..Default::default() },
         }
 
@@ -130,6 +130,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -141,6 +142,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -152,6 +154,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -163,6 +166,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -174,6 +178,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/to_timestamp.rs
+++ b/lib/remap-functions/src/to_timestamp.rs
@@ -126,27 +126,47 @@ mod tests {
 
         null_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(()).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Timestamp,
+                ..Default::default()
+            },
         }
 
         string_fallible {
             expr: |_| ToTimestampFn { value: Literal::from("foo").boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Timestamp,
+                ..Default::default()
+            },
         }
 
         map_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(BTreeMap::new()).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Timestamp,
+                ..Default::default()
+            },
         }
 
         array_fallible {
-            expr: |_| ToTimestampFn { value: Array::from(vec![0]).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp },
+            expr: |_| ToTimestampFn { value: array![].boxed(), default: None},
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Timestamp,
+                ..Default::default()
+            },
         }
 
         boolean_fallible {
             expr: |_| ToTimestampFn { value: Literal::from(true).boxed(), default: None},
-            def: TypeDef { fallible: true, kind: Kind::Timestamp },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Timestamp,
+                ..Default::default()
+            },
         }
 
         fallible_value_without_default {
@@ -154,39 +174,43 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Timestamp,
+                ..Default::default()
             },
         }
 
        fallible_value_with_fallible_default {
             expr: |_| ToTimestampFn {
-                value: Array::from(vec![0]).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                value: lit!(null).boxed(),
+                default: Some(lit!(null).boxed()),
             },
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Timestamp,
+                ..Default::default()
             },
         }
 
        fallible_value_with_infallible_default {
             expr: |_| ToTimestampFn {
-                value: Array::from(vec![0]).boxed(),
+                value: lit!(null).boxed(),
                 default: Some(Literal::from(1).boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Timestamp,
+                ..Default::default()
             },
         }
 
         infallible_value_with_fallible_default {
             expr: |_| ToTimestampFn {
                 value: Literal::from(1).boxed(),
-                default: Some(Array::from(vec![0]).boxed()),
+                default: Some(lit!(null).boxed()),
             },
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Timestamp,
+                ..Default::default()
             },
         }
 
@@ -198,6 +222,7 @@ mod tests {
             def: TypeDef {
                 fallible: false,
                 kind: Kind::Timestamp,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-functions/src/tokenize.rs
+++ b/lib/remap-functions/src/tokenize.rs
@@ -75,7 +75,11 @@ mod tests {
 
         value_non_string {
             expr: |_| TokenizeFn { value: Literal::from(10).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Array },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Array,
+                ..Default::default()
+            },
         }
     ];
 

--- a/lib/remap-functions/src/truncate.rs
+++ b/lib/remap-functions/src/truncate.rs
@@ -144,7 +144,11 @@ mod tests {
                 limit: Literal::from(1).boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Bytes,
+                ..Default::default()
+            },
         }
 
         limit_float {
@@ -162,7 +166,11 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: None,
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Bytes,
+                ..Default::default()
+            },
         }
 
         ellipsis_boolean {
@@ -180,7 +188,11 @@ mod tests {
                 limit: Literal::from("bar").boxed(),
                 ellipsis: Some(Literal::from("baz").boxed()),
             },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Bytes,
+                ..Default::default()
+            },
         }
     ];
 

--- a/lib/remap-functions/src/upcase.rs
+++ b/lib/remap-functions/src/upcase.rs
@@ -67,7 +67,11 @@ mod tests {
 
         non_string {
             expr: |_| UpcaseFn { value: Literal::from(true).boxed() },
-            def: TypeDef { fallible: true, kind: Kind::Bytes },
+            def: TypeDef {
+                fallible: true,
+                kind: Kind::Bytes,
+                ..Default::default()
+            },
         }
     ];
 

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -46,7 +46,7 @@ impl Expression for Arithmetic {
 
         let lhs_def = self.lhs.type_def(state);
         let rhs_def = self.rhs.type_def(state);
-        let type_def = lhs_def | rhs_def;
+        let type_def = lhs_def.clone() | rhs_def.clone();
 
         match self.op {
             Or if lhs_def.kind.is_null() => rhs_def,
@@ -90,8 +90,8 @@ mod tests {
                 Operator::Or,
             ),
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
 
@@ -102,8 +102,8 @@ mod tests {
                 Operator::Or,
             ),
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -116,6 +116,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Integer | Kind::Float,
+                ..Default::default()
             },
         }
 
@@ -128,6 +129,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Integer | Kind::Float,
+                ..Default::default()
             },
         }
 
@@ -140,6 +142,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Integer | Kind::Float,
+                ..Default::default()
             },
         }
 
@@ -152,6 +155,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Integer | Kind::Float,
+                ..Default::default()
             },
         }
 
@@ -164,6 +168,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Integer | Kind::Float,
+                ..Default::default()
             },
         }
 
@@ -186,8 +191,8 @@ mod tests {
                 Operator::And,
             ),
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -198,8 +203,8 @@ mod tests {
                 Operator::Equal,
             ),
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -210,8 +215,8 @@ mod tests {
                 Operator::NotEqual,
             ),
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -224,6 +229,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -236,6 +242,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -248,6 +255,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -260,6 +268,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-lang/src/expression/arithmetic.rs
+++ b/lib/remap-lang/src/expression/arithmetic.rs
@@ -180,7 +180,8 @@ mod tests {
             ),
             def: TypeDef {
                 fallible: true,
-                kind: Kind::Integer
+                kind: Kind::Integer,
+                ..Default::default()
             },
         }
 

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -108,7 +108,6 @@ mod tests {
                     kind: Kind::Integer,
                     ..Default::default()
                 }.boxed()),
-                ..Default::default()
             },
         }
     ];

--- a/lib/remap-lang/src/expression/block.rs
+++ b/lib/remap-lang/src/expression/block.rs
@@ -55,8 +55,8 @@ mod tests {
         no_expression {
             expr: |_| Block::new(vec![]),
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Null,
+                ..Default::default()
             },
         }
 
@@ -86,6 +86,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes | Kind::Integer | Kind::Float,
+                ..Default::default()
             },
         }
 
@@ -102,6 +103,12 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Array,
+                inner_type_def: Some(TypeDef {
+                    fallible: false,
+                    kind: Kind::Integer,
+                    ..Default::default()
+                }.boxed()),
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -145,8 +145,8 @@ mod tests {
             }
         },
         def: TypeDef {
-            fallible: false,
             kind: Kind::Null,
+            ..Default::default()
         },
     }];
 }

--- a/lib/remap-lang/src/expression/if_statement.rs
+++ b/lib/remap-lang/src/expression/if_statement.rs
@@ -66,8 +66,8 @@ mod tests {
                 IfStatement::new(conditional, true_expression, false_expression)
             },
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Boolean,
+                ..Default::default()
             },
         }
 
@@ -80,8 +80,8 @@ mod tests {
                 IfStatement::new(conditional, true_expression, false_expression)
             },
             def: TypeDef {
-                fallible: false,
                 kind: Kind::Boolean | Kind::Null,
+                ..Default::default()
             },
         }
     ];

--- a/lib/remap-lang/src/expression/noop.rs
+++ b/lib/remap-lang/src/expression/noop.rs
@@ -10,8 +10,8 @@ impl Expression for Noop {
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
         TypeDef {
-            fallible: false,
             kind: value::Kind::Null,
+            ..Default::default()
         }
     }
 }
@@ -24,8 +24,8 @@ mod tests {
     test_type_def![noop {
         expr: |_| Noop,
         def: TypeDef {
-            fallible: false,
             kind: value::Kind::Null,
+            ..Default::default()
         },
     }];
 }

--- a/lib/remap-lang/src/expression/not.rs
+++ b/lib/remap-lang/src/expression/not.rs
@@ -24,11 +24,11 @@ impl Expression for Not {
         Ok((!boolean).into())
     }
 
-    fn type_def(&self, _: &state::Compiler) -> TypeDef {
-        TypeDef {
-            fallible: true,
-            kind: value::Kind::Boolean,
-        }
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.expression
+            .type_def(state)
+            .fallible_unless(value::Kind::Boolean)
+            .with_constraint(value::Kind::Boolean)
     }
 }
 
@@ -72,6 +72,7 @@ mod tests {
         def: TypeDef {
             fallible: true,
             kind: Kind::Boolean,
+            ..Default::default()
         },
     }];
 }

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -99,7 +99,8 @@ mod tests {
             expr: |state: &mut state::Compiler| {
                 state.path_query_types_mut().insert(Path::from("foo").into(), TypeDef {
                     fallible: true,
-                    kind: Kind::Bytes
+                    kind: Kind::Bytes,
+                    ..Default::default()
                 });
 
                 Path::from("foo")
@@ -107,6 +108,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
 

--- a/lib/remap-lang/src/expression/variable.rs
+++ b/lib/remap-lang/src/expression/variable.rs
@@ -85,7 +85,8 @@ mod tests {
             expr: |state: &mut state::Compiler| {
                 state.variable_types_mut().insert("foo".to_owned(), TypeDef {
                     fallible: true,
-                    kind: Kind::Bytes
+                    kind: Kind::Bytes,
+                    ..Default::default()
                 });
 
                 Variable::new("foo".to_owned(), None)
@@ -93,6 +94,7 @@ mod tests {
             def: TypeDef {
                 fallible: true,
                 kind: Kind::Bytes,
+                ..Default::default()
             },
         }
 

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -146,9 +146,9 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(expression) = expressions.last() {
-            let type_def = expression.type_def(&self.compiler_state);
+            let kind = expression.type_def(&self.compiler_state).scalar_kind();
 
-            if !type_def.kind.is_all() && type_def.kind.contains_regex() {
+            if !kind.is_all() && kind.contains_regex() {
                 return Err(Error::RegexResult.into());
             }
         }
@@ -796,6 +796,32 @@ mod tests {
                 // We cannot assign to a regular expression.
                 r#"/ab/ = .foo"#,
                 vec![" 1:6\n", "= expected EOI, assignment, if_statement, not, operator_boolean_expr, operator_equality, operator_comparison, operator_addition, operator_multiplication, or block"],
+            ),
+            (
+                r#"/ab/"#,
+                vec!["remap error: parser error: cannot return regex from program"],
+            ),
+            (
+                r#"$foo = /ab/"#,
+                vec!["remap error: parser error: cannot return regex from program"],
+            ),
+            (
+                r#"[/ab/]"#,
+                vec!["remap error: parser error: cannot return regex from program"],
+            ),
+            (
+                r#"
+                    $foo = /ab/
+                    [$foo]
+                "#,
+                vec!["remap error: parser error: cannot return regex from program"],
+            ),
+            (
+                r#"
+                    $foo = [/ab/]
+                    $foo
+                "#,
+                vec!["remap error: parser error: cannot return regex from program"],
             ),
         ];
 

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -146,9 +146,9 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(expression) = expressions.last() {
-            let kind = expression.type_def(&self.compiler_state).scalar_kind();
+            let type_def = expression.type_def(&self.compiler_state);
 
-            if !kind.is_all() && kind.contains_regex() {
+            if !type_def.kind.is_all() && type_def.scalar_kind().contains_regex() {
                 return Err(Error::RegexResult.into());
             }
         }
@@ -666,8 +666,6 @@ mod tests {
 
             let mut parser = Parser::new(&[]);
             let pairs = parser.program_from_str(source).map_err(RemapError::from);
-
-            dbg!(&pairs);
 
             match pairs {
                 Ok(got) => {

--- a/lib/remap-lang/src/prelude.rs
+++ b/lib/remap-lang/src/prelude.rs
@@ -14,4 +14,4 @@ pub use crate::function::{ArgumentList, Parameter};
 pub use crate::generate_param_list;
 
 // test helpers
-pub use crate::{array, bench_function, func_args, test_function, test_type_def};
+pub use crate::{array, bench_function, func_args, lit, test_function, test_type_def};

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -103,6 +103,7 @@ impl Program {
             let program_def = type_defs.pop().unwrap_or(TypeDef {
                 fallible: true,
                 kind: value::Kind::Null,
+                ..Default::default()
             });
 
             if !constraint.type_def.contains(&program_def)
@@ -145,6 +146,7 @@ mod tests {
                     type_def: TypeDef {
                         fallible: true,
                         kind: Kind::Boolean,
+                        ..Default::default()
                     },
                     allow_any: true,
                 }),
@@ -157,6 +159,7 @@ mod tests {
                     type_def: TypeDef {
                         fallible: false,
                         kind: Kind::Boolean,
+                        ..Default::default()
                     },
                     allow_any: true,
                 }),
@@ -169,6 +172,7 @@ mod tests {
                     type_def: TypeDef {
                         fallible: true,
                         kind: Kind::Boolean,
+                        ..Default::default()
                     },
                     allow_any: false,
                 }),
@@ -204,6 +208,7 @@ mod tests {
                     type_def: TypeDef {
                         fallible: false,
                         kind: Kind::Bytes,
+                        ..Default::default()
                     },
                     allow_any: false,
                 }),
@@ -215,6 +220,7 @@ mod tests {
                     type_def: TypeDef {
                         fallible: false,
                         kind: Kind::Bytes | Kind::Float,
+                        ..Default::default()
                     },
                     allow_any: false,
                 }),

--- a/lib/remap-lang/src/test_util.rs
+++ b/lib/remap-lang/src/test_util.rs
@@ -91,6 +91,14 @@ macro_rules! array {
     })
 }
 
+/// Create a `Literal` expression type.
+#[macro_export]
+macro_rules! lit {
+    ($v:tt) => {
+        $crate::expression::Literal::from($crate::value!($v))
+    };
+}
+
 #[macro_export]
 macro_rules! value {
     ([]) => ({

--- a/lib/remap-lang/src/type_def.rs
+++ b/lib/remap-lang/src/type_def.rs
@@ -123,11 +123,11 @@ impl TypeDef {
     /// If a type definition includes an `inner_type_def`, this method will
     /// recursively resolve those until the final scalar kinds are known.
     pub fn scalar_kind(&self) -> value::Kind {
-        let mut kind = self.kind;
+        let mut kind = self.kind.scalar();
         let mut type_def = self.inner_type_def.clone();
 
         while let Some(td) = type_def {
-            kind |= td.kind;
+            kind |= td.kind.scalar();
             type_def = td.inner_type_def;
         }
 
@@ -215,7 +215,7 @@ mod tests {
         use value::Kind;
 
         let type_def = TypeDef {
-            kind: Kind::Boolean,
+            kind: Kind::Array,
             inner_type_def: Some(
                 TypeDef {
                     kind: Kind::Boolean | Kind::Float,

--- a/lib/remap-lang/src/type_def.rs
+++ b/lib/remap-lang/src/type_def.rs
@@ -127,7 +127,7 @@ impl TypeDef {
         let mut type_def = self.inner_type_def.clone();
 
         while let Some(td) = type_def {
-            kind = kind | td.kind;
+            kind |= td.kind;
             type_def = td.inner_type_def;
         }
 

--- a/lib/remap-lang/src/value/kind.rs
+++ b/lib/remap-lang/src/value/kind.rs
@@ -24,6 +24,11 @@ impl Kind {
     pub fn is_some(self) -> bool {
         !self.is_exact() && !self.is_all() && !self.is_empty()
     }
+
+    /// Return the existing kinds, without non-scalar kinds (maps and arrays).
+    pub fn scalar(self) -> Self {
+        self & !(Kind::Array | Kind::Map)
+    }
 }
 
 macro_rules! impl_kind {

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -26,6 +26,7 @@ impl ConditionConfig for RemapConfig {
             type_def: TypeDef {
                 fallible: true,
                 kind: value::Kind::Boolean,
+                ..Default::default()
             },
         };
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -55,6 +55,7 @@ impl Remap {
             type_def: TypeDef {
                 fallible: true,
                 kind: value::Kind::all(),
+                ..Default::default()
             },
         };
 


### PR DESCRIPTION
This change allows our type check system to track the type definitions of values contained within collections.

For example:

```rust
let vec = vec![Value::Null, Value::Boolean(true)];
let expression = Array::from(vec);
let state = state::Compiler::default();

let def = expression.type_def(&state)

def.kind 			// Kind::Array
def.scalar_kind() 	// Kind::Null | Kind::Boolean
```

This also works for nested arrays.