### PR TITLE
feat(remap): add initial "trl" CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5068,6 +5068,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
+name = "remap-cli"
+version = "0.1.0"
+dependencies = [
+ "bytes 0.5.6",
+ "remap-lang",
+ "serde_json",
+ "structopt",
+ "thiserror",
+]
+
+[[package]]
 name = "remap-lang"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ members = [
   "lib/k8s-e2e-tests",
   "lib/prometheus-parser",
   "lib/vector-api-client",
-  "lib/remap-lang"
+  "lib/remap-lang",
+  "lib/remap-cli",
 ]
 
 [dependencies]

--- a/lib/remap-cli/Cargo.toml
+++ b/lib/remap-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "remap-cli"
+version = "0.1.0"
+authors = ["Vector Contributors <vector@timber.io>"]
+edition = "2018"
+publish = false
+
+[[bin]]
+name = "trl"
+path = "src/main.rs"
+
+[dependencies]
+bytes = "0.5"
+remap = { package = "remap-lang", path = "../remap-lang" }
+serde_json = "1"
+structopt = { version = "0.3", default-features = false }
+thiserror = "1"

--- a/lib/remap-cli/TODO.md
+++ b/lib/remap-cli/TODO.md
@@ -37,9 +37,9 @@ be filed as issues, once development is a bit further along.
 - program state is kept for the duration of CLI execution
 - this means variable state is available between expression evaluations
 
-**example**
+### example
 
-```
+```text
 '{ "foo": "bar" }\n{ "foo": 42 }' | trl
 
 > Welcome to TRL: Timber Remap Language

--- a/lib/remap-cli/TODO.md
+++ b/lib/remap-cli/TODO.md
@@ -61,7 +61,7 @@ $ .foo
 "bar"
 
 $ next
-{ "foo": true }
+{ "foo": 42 }
 
 $ .foo
 42

--- a/lib/remap-cli/TODO.md
+++ b/lib/remap-cli/TODO.md
@@ -1,0 +1,88 @@
+# TODO
+
+This document contains a list of features we want to add to the CLI. These will
+be filed as issues, once development is a bit further along.
+
+## JSON Input
+
+- support jsonl (e.g. multiple JSON lines) for `--input`
+
+## Output Formatting
+
+- provide `--output-format=simple,json,...` to define the format of the result
+- `simple` returns the (current) easy to read format: `{foo: "bar", baz: [0, true]}`
+- `json` returns valid JSON output
+- might add more if useful
+- should default to `json` for maximum compatibility
+
+## Profiling
+
+- add `--profile` flag
+- profile performance of TRL scripts
+- execution time (total and per expression)
+- memory allocations (<https://docs.rs/dhat/0.1.1/dhat/>)
+
+## Documentation
+
+- add `--docs` flag
+- should open the TRL documentation in the browser
+- add `--examples` flag
+- should print a list of common input > program > result examples
+
+## Read–eval–print loop (REPL)
+
+- if no program is provided, the CLI should start in REPL mode
+- each line provided (terminated with a newline) resolves to an expression
+- expression is evaluated and result printed to stdout
+- program state is kept for the duration of CLI execution
+- this means variable state is available between expression evaluations
+
+**example**
+
+```
+'{ "foo": "bar" }\n{ "foo": 42 }' | trl
+
+> Welcome to TRL: Timber Remap Language
+>
+> The CLI is running in REPL (Read-eval-print loop) mode.
+>
+> Type `help` to learn more.
+> Type `next` to load the next object (if any).
+> Type `exit` to terminate the program.
+>
+> Any other value is resolved to a TRL expression.
+>
+> Try it out now by typing `.` and hitting [enter] to see the result.
+
+$ .
+{ "foo": "bar" }
+
+$ .foo
+"bar"
+
+$ next
+{ "foo": true }
+
+$ .foo
+42
+
+$ exit
+```
+
+## Add Function Support
+
+- currently all TRL functions are implemented in Vector itself
+- this means they aren't available in this CLI
+- we should move those into a `trl-contrib` library
+- this CLI (and Vector) will depend on that library
+- this ensures feature parity between Vector and this CLI
+
+## Support WASM Binary
+
+- this one is only partially related to the CLI
+- the goal is to compile TRL to wasm
+- using that, provide a simple demo website that has two input fields
+- one field takes a JSON payload
+- the second a TRL program
+- running the program shows the execution result on the page
+- TRL runs locally in the browser, no web-server required

--- a/lib/remap-cli/TODO.md
+++ b/lib/remap-cli/TODO.md
@@ -47,8 +47,9 @@ be filed as issues, once development is a bit further along.
 > The CLI is running in REPL (Read-eval-print loop) mode.
 >
 > Type `help` to learn more.
-> Type `next` to load the next object (if any).
-> Type `exit` to terminate the program.
+>      `next` to load the next object (if any).
+>      `prev` to load the previous object (if any).
+>      `exit` to terminate the program.
 >
 > Any other value is resolved to a TRL expression.
 >
@@ -63,8 +64,14 @@ $ .foo
 $ next
 { "foo": 42 }
 
-$ .foo
-42
+$ .foo = 3.14159
+3.14159
+
+$ next
+null
+
+$ prev
+{ "foo": 3.14159 }
 
 $ exit
 ```

--- a/lib/remap-cli/src/main.rs
+++ b/lib/remap-cli/src/main.rs
@@ -1,0 +1,120 @@
+use remap::{state, Object, Program, Runtime, Value};
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{self, Read};
+use std::iter::IntoIterator;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "TRL", about = "Timber Remap Language CLI")]
+struct TRL {
+    /// Program to execute
+    ///
+    /// For example, ".foo = true" will set the object's `foo` field to `true`.
+    #[structopt(name = "PROGRAM")]
+    program: Option<String>,
+
+    /// File containing the object to manipulate, leave empty to use stdin
+    #[structopt(short, long = "input", parse(from_os_str))]
+    input_file: Option<PathBuf>,
+
+    /// File containing the program to execute, can be used instead of
+    /// "PROGRAM"
+    #[structopt(short, long = "program", conflicts_with("program"), parse(from_os_str))]
+    program_file: Option<PathBuf>,
+
+    /// Print the (modified) object, instead of the result of the final
+    /// expression.
+    ///
+    /// The same result can be achieved by using `.` as the final expression.
+    #[structopt(short = "o", long)]
+    print_object: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum Error {
+    #[error("io error")]
+    Io(#[from] io::Error),
+
+    #[error("remap error: {0}")]
+    Remap(#[from] remap::RemapError),
+
+    #[error("json error")]
+    Json(#[from] serde_json::Error),
+}
+
+fn main() {
+    match run(TRL::from_args()) {
+        Ok(out) => println!("{}", out),
+        Err(err) => eprintln!("{}", err),
+    }
+}
+
+fn run(opt: TRL) -> Result<String, Error> {
+    let mut object = read_into_object(opt.input_file.as_ref())?;
+    let program = read_program(opt.program.as_deref(), opt.program_file.as_ref())?;
+
+    execute(&mut object, &program).map(|v| {
+        if opt.print_object {
+            object.to_string()
+        } else {
+            v.to_string()
+        }
+    })
+}
+
+fn execute(object: &mut impl Object, program: &str) -> Result<Value, Error> {
+    let state = state::Program::default();
+    let mut runtime = Runtime::new(state);
+    let program = Program::new(program, &[], None)?;
+
+    runtime.execute(object, &program).map_err(Into::into)
+}
+
+fn read_program(source: Option<&str>, file: Option<&PathBuf>) -> Result<String, Error> {
+    match source {
+        Some(source) => Ok(source.to_owned()),
+        None => match file {
+            Some(path) => read(File::open(path)?),
+            None => Ok("".to_owned()),
+        },
+    }
+}
+
+fn read_into_object(input: Option<&PathBuf>) -> Result<Value, Error> {
+    let input = match input {
+        Some(path) => read(File::open(path)?),
+        None => read(io::stdin()),
+    }?;
+
+    match input.as_str() {
+        "" => Ok(Value::Map(BTreeMap::default())),
+        _ => Ok(serde_to_remap(serde_json::from_str(&input)?)),
+    }
+}
+
+fn serde_to_remap(value: serde_json::Value) -> Value {
+    use serde_json::Value;
+
+    match value {
+        Value::Null => remap::Value::Null,
+        Value::Object(v) => v
+            .into_iter()
+            .map(|(k, v)| (k, serde_to_remap(v)))
+            .collect::<BTreeMap<_, _>>()
+            .into(),
+        Value::Bool(v) => v.into(),
+        Value::Number(v) if v.is_f64() => v.as_f64().unwrap().into(),
+        Value::Number(v) => v.as_i64().unwrap_or(i64::MAX).into(),
+        Value::String(v) => v.into(),
+        Value::Array(v) => v.into_iter().map(serde_to_remap).collect::<Vec<_>>().into(),
+    }
+}
+
+fn read<R: Read>(mut reader: R) -> Result<String, Error> {
+    let mut buffer = String::new();
+    reader.read_to_string(&mut buffer)?;
+
+    Ok(buffer)
+}


### PR DESCRIPTION
This adds a simple `trl` (Timber Remap Language) CLI to help debug programs:

```
echo '{ "foo": "bar" }` | trl .foo
bar
```

_(note: it should print `"bar"`, but that's an improvement that will be made to TRL itself, in a separate PR)_

To run this from the main Vector project, use:

```
echo '{ "foo": "bar" }' | cargo run --no-default-features --package remap-cli .foo
bar
```

There is still much to do here (I added a `TODO.md` since I didn't want to necessarily create issues in such an early state), but it's a start.

Here's the current `-h` output:

```
TRL 0.1.0
Timber Remap Language CLI

USAGE:
    trl [FLAGS] [OPTIONS] [PROGRAM]

FLAGS:
    -h, --help            Prints help information
    -o, --print-object    Print the (modified) object, instead of the result of the final expression
    -V, --version         Prints version information

OPTIONS:
    -i, --input <input-file>        File containing the object to manipulate, leave empty to use stdin
    -p, --program <program-file>    File containing the program to execute, can be used instead of "PROGRAM"

ARGS:
    <PROGRAM>    Program to execute
```