### PR TITLE
fix(elasticsearch sink): Fix trailing '/' at the end of URL

### DIFF
--- a/src/sinks/elasticsearch.rs
+++ b/src/sinks/elasticsearch.rs
@@ -355,7 +355,7 @@ impl ElasticSearchCommon {
         };
         let uri = config.endpoint.parse::<UriSerde>()?;
         let authorization = authorization.choose_one(&uri.auth)?;
-        let base_url = uri.uri.to_string();
+        let base_url = uri.uri.to_string().trim_end_matches('/').to_owned();
 
         let region = match &config.aws {
             Some(region) => Region::try_from(region)?,


### PR DESCRIPTION
Introduced in #5379

Signed-off-by: Duy Do <juchiast@gmail.com>