### PR TITLE
fix(metrics): Add missing methods to Subscriber forwarder

### DIFF
--- a/src/trace.rs
+++ b/src/trace.rs
@@ -124,6 +124,16 @@ impl<F: Subscriber + 'static> Subscriber for BroadcastSubscriber<F> {
     fn register_callsite(&self, meta: &'static Metadata<'static>) -> Interest {
         self.formatter.register_callsite(meta)
     }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+        self.formatter.max_level_hint()
+    }
+
+    #[inline]
+    unsafe fn downcast_raw(&self, id: std::any::TypeId) -> Option<*const ()> {
+        self.formatter.downcast_raw(id)
+    }
 }
 
 impl From<&tracing::Event<'_>> for Event {


### PR DESCRIPTION
The internal_logs source introduced in
f38fb43999a5bb0896ac55c8f901d70db3af0ab8 added a Subscriber forwarding
wrapper so it could send events to both a broadcast bus and to the
formatter. This wrapper was missing the `downcast_raw` method, which
apparently broke internal metrics. This patch adds both that method and
the `max_level_hint` which was also missing.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #5511