### PR TITLE
chore(ci): don't expand Discord link with preview

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -524,4 +524,4 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       uses: Ilshidur/action-discord@0.3.0
       with:
-        args: "Nightly failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+        args: "Nightly failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"


### PR DESCRIPTION
The preview cards are useless, so let's disable them.