### PR TITLE
chore(observability): Humanized bytes

### DIFF
--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -142,7 +142,7 @@ impl<'a> Widgets<'a> {
                     v => format!(
                         "{} ({}/s)",
                         if self.opts.human_metrics {
-                            v.human_format()
+                            v.human_format_bytes()
                         } else {
                             v.thousands_format()
                         },


### PR DESCRIPTION
Fixes the display of abbreviated bytes metrics when using the `-h` flag in `vector top`.

Previously, byte stats were suffixed with `K`, `G`, `T`, etc, used with non-bytes metrics via `human_format`.

Bytes metrics now use the `human_format_bytes` extension in all places.

Result:

**With no `-h` flag:**

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/719722/102464022-be064300-4043-11eb-8fff-7d746f70258f.png">

**With `-h`:**

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/719722/102464046-c8284180-4043-11eb-99ff-07bd9fc7bae3.png">

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
