### PR TITLE
fix(metrics): Trivial fixes for metrics batch buffer

### DIFF
--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -26,7 +26,7 @@ pub struct Metric {
     pub value: MetricValue,
 }
 
-#[derive(Debug, Hash, Clone, PartialEq, Deserialize, Serialize, is_enum_variant)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Deserialize, Serialize, is_enum_variant)]
 #[serde(rename_all = "snake_case")]
 /// A metric may be an incremental value, updating the previous value of
 /// the metric, or absolute, which sets the reference for future

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -134,8 +134,8 @@ impl Batch for MetricBuffer {
         } else {
             let item = item.into_metric();
 
-            match &item.value {
-                MetricValue::Counter { value } if item.kind.is_absolute() => {
+            match (item.kind, &item.value) {
+                (MetricKind::Absolute, MetricValue::Counter { value }) => {
                     let new = MetricEntry(item.clone());
                     if let Some(MetricEntry(Metric {
                         value: MetricValue::Counter { value: value0, .. },
@@ -167,7 +167,7 @@ impl Batch for MetricBuffer {
                         self.state.insert(new);
                     }
                 }
-                MetricValue::Gauge { .. } if item.kind.is_incremental() => {
+                (MetricKind::Incremental, MetricValue::Gauge { .. }) => {
                     let new = MetricEntry(item.to_absolute());
                     if let Some(MetricEntry(mut existing)) = self.metrics.take(&new) {
                         existing.add(&item);
@@ -193,7 +193,7 @@ impl Batch for MetricBuffer {
                         self.metrics.insert(MetricEntry(initial));
                     }
                 }
-                _metric if item.kind.is_absolute() => {
+                (MetricKind::Absolute, _) => {
                     let new = MetricEntry(item);
                     self.metrics.replace(new);
                 }

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -20,6 +20,7 @@ impl Hash for MetricEntry {
         let metric = &self.0;
         std::mem::discriminant(&metric.value).hash(state);
         metric.name.hash(state);
+        metric.namespace.hash(state);
         metric.kind.hash(state);
 
         if let Some(tags) = &metric.tags {

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -203,13 +203,12 @@ impl Batch for MetricBuffer {
                     }
                 }
                 (MetricKind::Absolute, _) => {
-                    let new = MetricEntry(item);
-                    self.metrics.replace(new);
+                    self.metrics.replace(MetricEntry(item));
                 }
                 _ => {
-                    let new = MetricEntry(item.clone());
+                    let new = MetricEntry(item);
                     if let Some(MetricEntry(mut existing)) = self.metrics.take(&new) {
-                        existing.add(&item);
+                        existing.add(&new);
                         self.metrics.insert(MetricEntry(existing));
                     } else {
                         self.metrics.insert(new);

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -50,6 +50,9 @@ impl Hash for MetricEntry {
 
 impl PartialEq for MetricEntry {
     fn eq(&self, other: &Self) -> bool {
+        // This differs from a straightforward implementation of `eq` by
+        // comparing only the "shape" bits (name, tags, and type) while
+        // allowing the contained values to be different.
         self.name == other.name
             && self.namespace == other.namespace
             && self.kind == other.kind

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -352,10 +352,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 2);
-        assert_eq!(buffer[0].len(), 6);
-        assert_eq!(buffer[1].len(), 2);
-
         assert_eq!(
             buffer[0],
             [
@@ -375,6 +371,8 @@ mod test {
                 sample_counter(3, "production", Incremental, 3.0),
             ]
         );
+
+        assert_eq!(buffer.len(), 2);
     }
 
     #[test]
@@ -390,9 +388,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-        assert_eq!(buffer[0].len(), 4);
-
         assert_eq!(
             buffer[0],
             [
@@ -402,6 +397,8 @@ mod test {
                 sample_counter(3, "production", Incremental, 6.0),
             ]
         );
+
+        assert_eq!(buffer.len(), 1);
     }
 
     #[test]
@@ -417,9 +414,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-        assert_eq!(buffer[0].len(), 4);
-
         assert_eq!(
             buffer[0],
             [
@@ -429,6 +423,8 @@ mod test {
                 sample_gauge(4, Absolute, 8.0),
             ]
         );
+
+        assert_eq!(buffer.len(), 1);
     }
 
     #[test]
@@ -448,9 +444,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-        assert_eq!(buffer[0].len(), 5);
-
         assert_eq!(
             buffer[0],
             [
@@ -461,6 +454,8 @@ mod test {
                 sample_gauge(5, Absolute, 50.0),
             ]
         );
+
+        assert_eq!(buffer.len(), 1);
     }
 
     #[test]
@@ -476,9 +471,9 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-
         assert_eq!(buffer[0], [sample_set(0, &[0, 1, 2, 3])]);
+
+        assert_eq!(buffer.len(), 1);
     }
 
     #[test]
@@ -494,8 +489,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-
         assert_eq!(
             buffer[0],
             [
@@ -505,6 +498,8 @@ mod test {
                 sample_distribution_histogram(5, 10),
             ]
         );
+
+        assert_eq!(buffer.len(), 1);
     }
 
     #[test]
@@ -533,8 +528,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-
         assert_eq!(
             buffer[0],
             [
@@ -543,6 +536,8 @@ mod test {
                 sample_aggregated_histogram(4, Absolute, 1.0, 4, 10.0),
             ]
         );
+
+        assert_eq!(buffer.len(), 1);
     }
 
     #[test]
@@ -558,8 +553,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-
         assert_eq!(
             buffer[0],
             [
@@ -567,6 +560,8 @@ mod test {
                 sample_aggregated_histogram(2, Incremental, 2.0, 6, 30.0),
             ]
         );
+
+        assert_eq!(buffer.len(), 1);
     }
 
     #[test]
@@ -580,8 +575,6 @@ mod test {
 
         let buffer = rebuffer(events);
 
-        assert_eq!(buffer.len(), 1);
-
         assert_eq!(
             buffer[0],
             [
@@ -590,6 +583,8 @@ mod test {
                 sample_aggregated_summary(4),
             ]
         );
+
+        assert_eq!(buffer.len(), 1);
     }
 
     fn sample_counter(num: usize, tagstr: &str, kind: MetricKind, value: f64) -> Metric {


### PR DESCRIPTION
These are some relatively trivial fixes and clean-ups found while investigating #5589 and #5698. They should not affect behavior and don't directly fix those issues.

Signed-off-by: Bruce Guenter <bruce@timber.io>