### PR TITLE
chore: Clarify messages about internal logs being rate limited

### DIFF
--- a/lib/codec/src/lib.rs
+++ b/lib/codec/src/lib.rs
@@ -96,7 +96,7 @@ impl Decoder for BytesDelimitedCodec {
                         message = "Discarding frame larger than max_length.",
                         buf_len = buf.len(),
                         max_length = self.max_length,
-                        rate_limit_secs = 30
+                        internal_log_rate_secs = 30
                     );
                     return Ok(None);
                 }

--- a/lib/file-source/src/file_watcher.rs
+++ b/lib/file-source/src/file_watcher.rs
@@ -257,7 +257,7 @@ fn read_until_with_max_size<R: BufRead + ?Sized>(
         if !discarding && buf.len() > max_size {
             warn!(
                 message = "Found line that exceeds max_line_bytes; discarding.",
-                rate_limit_secs = 30
+                internal_log_rate_secs = 30
             );
             discarding = true;
         }

--- a/lib/tracing-limit/benches/limit.rs
+++ b/lib/tracing-limit/benches/limit.rs
@@ -52,7 +52,7 @@ fn bench(c: &mut Criterion) {
                             bar = "bar",
                             baz = 3,
                             quuux = ?0.99,
-                            rate_limit_secs = 5
+                            internal_log_rate_secs = 5
                         )
                     }
                 })

--- a/lib/tracing-limit/examples/basic.rs
+++ b/lib/tracing-limit/examples/basic.rs
@@ -17,7 +17,11 @@ fn main() {
     tracing::dispatcher::with_default(&dispatch, || {
         // This should print every 2 events
         for i in 0..40 {
-            info!(message = "Hello, world!", count = &i, rate_limit_secs = 5);
+            info!(
+                message = "Hello, world!",
+                count = &i,
+                internal_log_rate_secs = 5
+            );
             trace!("This field is not rate limited!");
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -15,7 +15,7 @@ use tracing_core::{
 };
 use tracing_subscriber::layer::{Context, Layer};
 
-const RATE_LIMIT_FIELD: &str = "rate_limit_secs";
+const RATE_LIMIT_FIELD: &str = "internal_log_rate_secs";
 const MESSAGE_FIELD: &str = "message";
 const DEFAULT_LIMIT: u64 = 5;
 

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -34,7 +34,13 @@ struct State {
 }
 
 impl Limit {
-    fn create_event<S: Subscriber>(&self, id: &Identifier, ctx: &Context<S>, message: String) {
+    fn create_event<S: Subscriber>(
+        &self,
+        id: &Identifier,
+        ctx: &Context<S>,
+        message: String,
+        rate_limit: u64,
+    ) {
         let store = self.callsite_store.read().unwrap();
         let metadata = store.get(id).unwrap();
 
@@ -43,13 +49,7 @@ impl Limit {
         let message = display(message);
 
         if let Some(message_field) = fields.field("message") {
-            let values = [
-                (&message_field, Some(&message as &dyn Value)),
-                (
-                    &fields.field(RATE_LIMIT_FIELD).unwrap(),
-                    Some(&5 as &dyn Value),
-                ),
-            ];
+            let values = [(&message_field, Some(&message as &dyn Value))];
 
             let valueset = fields.value_set(&values);
             let event = Event::new(metadata, &valueset);
@@ -58,7 +58,7 @@ impl Limit {
         } else {
             let values = [(
                 &fields.field(RATE_LIMIT_FIELD).unwrap(),
-                Some(&5 as &dyn Value),
+                Some(&rate_limit as &dyn Value),
             )];
 
             let valueset = fields.value_set(&values);
@@ -115,16 +115,18 @@ where
                     let start = state.start.unwrap_or_else(Instant::now);
 
                     if start.elapsed().as_secs() < state.limit {
-                        if state.count.load(Ordering::Acquire) == 1 {
-                            let message = format!("{:?} is being rate limited.", state.message);
-
-                            self.create_event(&id, &ctx, message);
-                        }
-
                         let prev = state.count.fetch_add(1, Ordering::Relaxed);
+                        match prev {
+                            0 => return true,
+                            1 => {
+                                let message = format!(
+                                    "Internal log [{}] is being rate limited.",
+                                    state.message
+                                );
 
-                        if prev == 0 {
-                            return true;
+                                self.create_event(&id, &ctx, message, state.limit);
+                            }
+                            _ => (),
                         }
                     } else {
                         drop(events);
@@ -132,12 +134,16 @@ where
                         let mut events = self.events.write().expect("lock poisoned!");
 
                         if let Some(state) = events.remove(&id) {
-                            let message = format!(
-                                "{:?} {:?} events were rate limited.",
-                                state.count, state.message
-                            );
+                            let count = state.count.load(Ordering::Relaxed);
+                            if count > 1 {
+                                let message = format!(
+                                    "Internal log [{}] has been rate limited {} times.",
+                                    state.message,
+                                    count - 1
+                                );
 
-                            self.create_event(&id, &ctx, message);
+                                self.create_event(&id, &ctx, message, state.limit);
+                            }
                         }
                     }
 

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -193,7 +193,7 @@ impl<S: Sink> Sink for DropWhenFull<S> {
             Ok(AsyncSink::NotReady(_)) => {
                 debug!(
                     message = "Shedding load; dropping event.",
-                    rate_limit_secs = 10
+                    internal_log_rate_secs = 10
                 );
                 Ok(AsyncSink::Ready)
             }

--- a/src/internal_events/add_fields.rs
+++ b/src/internal_events/add_fields.rs
@@ -8,7 +8,7 @@ pub struct AddFieldsTemplateRenderingError<'a> {
 
 impl<'a> InternalEvent for AddFieldsTemplateRenderingError<'a> {
     fn emit_logs(&self) {
-        error!(message = "Failed to render templated value; discarding value.", field = %self.field, rate_limit_secs = 30);
+        error!(message = "Failed to render templated value; discarding value.", field = %self.field, internal_log_rate_secs = 30);
     }
 
     fn emit_metrics(&self) {
@@ -24,7 +24,7 @@ pub struct AddFieldsTemplateInvalid<'a> {
 
 impl<'a> InternalEvent for AddFieldsTemplateInvalid<'a> {
     fn emit_logs(&self) {
-        error!(message = "Invalid template; using as string.", field = %self.field, error = ?self.error, rate_limit_secs = 30);
+        error!(message = "Invalid template; using as string.", field = %self.field, error = ?self.error, internal_log_rate_secs = 30);
     }
 
     fn emit_metrics(&self) {
@@ -39,7 +39,7 @@ pub struct AddFieldsFieldOverwritten<'a> {
 
 impl<'a> InternalEvent for AddFieldsFieldOverwritten<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Field overwritten.", field = %self.field, rate_limit_secs = 30);
+        debug!(message = "Field overwritten.", field = %self.field, internal_log_rate_secs = 30);
     }
 }
 
@@ -50,6 +50,6 @@ pub struct AddFieldsFieldNotOverwritten<'a> {
 
 impl<'a> InternalEvent for AddFieldsFieldNotOverwritten<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Field not overwritten.", field = %self.field, rate_limit_secs = 30);
+        debug!(message = "Field not overwritten.", field = %self.field, internal_log_rate_secs = 30);
     }
 }

--- a/src/internal_events/add_tags.rs
+++ b/src/internal_events/add_tags.rs
@@ -7,7 +7,7 @@ pub struct AddTagsTagOverwritten<'a> {
 
 impl<'a> InternalEvent for AddTagsTagOverwritten<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Tag overwritten.", tag = %self.tag, rate_limit_secs = 30);
+        debug!(message = "Tag overwritten.", tag = %self.tag, internal_log_rate_secs = 30);
     }
 }
 
@@ -18,6 +18,6 @@ pub struct AddTagsTagNotOverwritten<'a> {
 
 impl<'a> InternalEvent for AddTagsTagNotOverwritten<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Tag not overwritten.", tag = %self.tag, rate_limit_secs = 30);
+        debug!(message = "Tag not overwritten.", tag = %self.tag, internal_log_rate_secs = 30);
     }
 }

--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -11,7 +11,7 @@ impl InternalEvent for ANSIStripperFieldMissing<'_> {
         debug!(
             message = "Field does not exist.",
             field = %self.field,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -30,7 +30,7 @@ impl InternalEvent for ANSIStripperFieldInvalid<'_> {
         debug!(
             message = "Field value must be a string.",
             field = %self.field,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -51,7 +51,7 @@ impl InternalEvent for ANSIStripperFailed<'_> {
             message = "Could not strip ANSI escape sequences.",
             field = %self.field,
             error = ?self.error,
-            rate_limit_secs = 10,
+            internal_log_rate_secs = 10,
         );
     }
 

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -49,7 +49,7 @@ impl InternalEvent for ApacheMetricsParseError<'_> {
         debug!(
             message = %format!("Parse error:\n\n{}\n\n", self.error),
             url = %self.url,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
@@ -11,7 +11,7 @@ impl InternalEvent for AwsCloudwatchLogsSubscriptionParserFailedParse {
         warn!(
             message = "Event failed to parse as a CloudWatch Logs subscirption JSON message.",
             error = ?self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 

--- a/src/internal_events/aws_ecs_metrics.rs
+++ b/src/internal_events/aws_ecs_metrics.rs
@@ -50,7 +50,7 @@ impl<'a> InternalEvent for AwsEcsMetricsParseError<'_> {
         debug!(
             message = %format!("Failed to parse response:\\n\\n{}\\n\\n", self.body.escape_debug()),
             url = %self.url,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/aws_kinesis_firehose.rs
+++ b/src/internal_events/aws_kinesis_firehose.rs
@@ -13,7 +13,7 @@ impl<'a> InternalEvent for AwsKinesisFirehoseRequestReceived<'a> {
             message = "Handling AWS Kinesis Firehose request.",
             request_id = %self.request_id.unwrap_or_default(),
             source_arn = %self.source_arn.unwrap_or_default(),
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -33,7 +33,7 @@ impl<'a> InternalEvent for AwsKinesisFirehoseRequestError<'a> {
         error!(
             message = "Error occurred while handling request.",
             error = ?self.error,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -28,7 +28,7 @@ impl<'a> InternalEvent for AwsSqsMessageGroupIdMissingKeys<'a> {
         warn!(
             message = "Keys do not exist on the event; dropping event.",
             missing_keys = ?self.keys,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         )
     }
 

--- a/src/internal_events/coercer.rs
+++ b/src/internal_events/coercer.rs
@@ -13,7 +13,7 @@ impl<'a> InternalEvent for CoercerConversionFailed<'a> {
             message = "Could not convert types.",
             field = %self.field,
             error = %self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 

--- a/src/internal_events/concat.rs
+++ b/src/internal_events/concat.rs
@@ -19,7 +19,7 @@ impl<'a> InternalEvent for ConcatSubstringError<'a> {
             self.start,
             self.end,
             self.length,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 
@@ -38,7 +38,7 @@ impl<'a> InternalEvent for ConcatSubstringSourceMissing<'a> {
         debug!(
             message = "Substring source missing.",
             self.source,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 }

--- a/src/internal_events/console.rs
+++ b/src/internal_events/console.rs
@@ -23,7 +23,7 @@ impl<'a> InternalEvent for ConsoleFieldNotFound<'a> {
         warn!(
             message = "Field not found; dropping event.",
             missing_field = ?self.missing_field,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         )
     }
 

--- a/src/internal_events/dedupe.rs
+++ b/src/internal_events/dedupe.rs
@@ -10,7 +10,7 @@ impl InternalEvent for DedupeEventDiscarded {
     fn emit_logs(&self) {
         warn!(
             message = "Encountered duplicate event; discarding.",
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
         trace!(message = "Encountered duplicate event; discarding.", event = ?self.event);
     }

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -92,7 +92,7 @@ impl<'a> InternalEvent for DockerLogsCommunicationError<'a> {
             message = "Error in communication with Docker daemon.",
             error = ?self.error,
             container_id = ?self.container_id,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -113,7 +113,7 @@ impl<'a> InternalEvent for DockerLogsContainerMetadataFetchFailed<'a> {
             message = "Failed to fetch container metadata.",
             error = ?self.error,
             container_id = ?self.container_id,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -134,7 +134,7 @@ impl<'a> InternalEvent for DockerLogsTimestampParseFailed<'a> {
             message = "Failed to parse timestamp as RFC3339 timestamp.",
             error = ?self.error,
             container_id = ?self.container_id,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -157,7 +157,7 @@ impl<'a> InternalEvent for DockerLogsLoggingDriverUnsupported<'a> {
                 to get logs from the Docker daemon."#,
             error = ?self.error,
             container_id = ?self.container_id,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -28,7 +28,7 @@ impl<'a> InternalEvent for ElasticSearchMissingKeys<'a> {
         warn!(
             message = "Keys do not exist on the event; dropping event.",
             missing_keys = ?self.keys,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         )
     }
 

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -105,7 +105,7 @@ mod source {
                 message = "Failed in deleting file.",
                 path = ?self.path,
                 error = ?self.error,
-                rate_limit_secs = 1
+                internal_log_rate_secs = 1
             );
         }
 

--- a/src/internal_events/geoip.rs
+++ b/src/internal_events/geoip.rs
@@ -11,7 +11,7 @@ impl<'a> InternalEvent for GeoipIpAddressParseError<'a> {
         error!(
             message = "IP Address not parsed correctly.",
             address = %self.address,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 
@@ -30,7 +30,7 @@ impl<'a> InternalEvent for GeoipFieldDoesNotExist<'a> {
         error!(
             message = "Field does not exist.",
             field = %self.field,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 

--- a/src/internal_events/grok_parser.rs
+++ b/src/internal_events/grok_parser.rs
@@ -11,7 +11,7 @@ impl InternalEvent for GrokParserFailedMatch<'_> {
         warn!(
             message = "Grok pattern failed to match.",
             field = &super::truncate_string_at(self.value, 60)[..],
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 
@@ -51,7 +51,7 @@ impl<'a> InternalEvent for GrokParserConversionFailed<'a> {
             message = "Could not convert types.",
             name = %self.name,
             error = ?self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -88,7 +88,7 @@ impl<'a> InternalEvent for HTTPDecompressError<'a> {
             message = "Failed decompressing payload.",
             encoding= %self.encoding,
             error = %self.error,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -35,7 +35,7 @@ impl<'a> InternalEvent for HTTPBadRequest<'a> {
             message = "Received bad request.",
             code = ?self.error_code,
             error_message = ?self.error_message,
-            rate_limit_secs = 10,
+            internal_log_rate_secs = 10,
         );
     }
 
@@ -51,7 +51,7 @@ impl InternalEvent for HTTPEventMissingMessage {
     fn emit_logs(&self) {
         warn!(
             message = "Event missing the message key; dropping event.",
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         );
     }
 

--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -18,7 +18,7 @@ impl<'a> InternalEvent for JsonParserFailedParse<'a> {
                 field = %self.field,
                 value = %self.value,
                 error = ?self.error,
-                rate_limit_secs = 30
+                internal_log_rate_secs = 30
             )
         } else {
             warn!(
@@ -26,7 +26,7 @@ impl<'a> InternalEvent for JsonParserFailedParse<'a> {
                 field = %self.field,
                 value = %self.value,
                 error = ?self.error,
-                rate_limit_secs = 30
+                internal_log_rate_secs = 30
             )
         }
     }
@@ -48,7 +48,7 @@ impl<'a> InternalEvent for JsonParserTargetExists<'a> {
         warn!(
             message = "Target field already exists.",
             target_field = %self.target_field,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -8,7 +8,7 @@ pub struct KafkaEventReceived {
 
 impl InternalEvent for KafkaEventReceived {
     fn emit_logs(&self) {
-        trace!(message = "Received one event.", rate_limit_secs = 10);
+        trace!(message = "Received one event.", internal_log_rate_secs = 10);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/key_value_parser.rs
+++ b/src/internal_events/key_value_parser.rs
@@ -13,7 +13,7 @@ impl InternalEvent for KeyValueParseFailed {
             message = "Event failed to parse as key/value.",
             key = %self.key,
             error = %self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 
@@ -34,7 +34,7 @@ impl<'a> InternalEvent for KeyValueTargetExists<'a> {
         warn!(
             message = "Target field already exists.",
             target_field = %self.target_field,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 
@@ -55,7 +55,7 @@ impl InternalEvent for KeyValueFieldDoesNotExist {
         warn!(
             message = "Field specified does not exist.",
             field = %self.field,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 

--- a/src/internal_events/kubernetes/instrumenting_watcher.rs
+++ b/src/internal_events/kubernetes/instrumenting_watcher.rs
@@ -18,7 +18,7 @@ pub struct WatchRequestInvocationFailed<E> {
 
 impl<E: Debug> InternalEvent for WatchRequestInvocationFailed<E> {
     fn emit_logs(&self) {
-        error!(message = "Watch invocation failed.", error = ?self.error, rate_limit_secs = 5);
+        error!(message = "Watch invocation failed.", error = ?self.error, internal_log_rate_secs = 5);
     }
 
     fn emit_metrics(&self) {
@@ -42,7 +42,7 @@ pub struct WatchStreamErrored<E> {
 
 impl<E: Debug> InternalEvent for WatchStreamErrored<E> {
     fn emit_logs(&self) {
-        error!(message = "Watch stream errored.", error = ?self.error, rate_limit_secs = 5);
+        error!(message = "Watch stream errored.", error = ?self.error, internal_log_rate_secs = 5);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -33,7 +33,7 @@ impl<'a> InternalEvent for LogToMetricParseFloatError<'a> {
             message = "Failed to parse field as float.",
             field = %self.field,
             error = ?self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 
@@ -54,7 +54,7 @@ impl InternalEvent for LogToMetricTemplateRenderError {
         warn!(
             message = "Failed to render template.",
             %error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 
@@ -71,7 +71,7 @@ pub(crate) struct LogToMetricTemplateParseError {
 
 impl InternalEvent for LogToMetricTemplateParseError {
     fn emit_logs(&self) {
-        warn!(message = "Failed to parse template.", error = ?self.error, rate_limit_secs = 30);
+        warn!(message = "Failed to parse template.", error = ?self.error, internal_log_rate_secs = 30);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/logfmt_parser.rs
+++ b/src/internal_events/logfmt_parser.rs
@@ -30,7 +30,7 @@ impl<'a> InternalEvent for LogfmtParserConversionFailed<'a> {
             message = "Could not convert types.",
             name = %self.name,
             error = ?self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 

--- a/src/internal_events/logplex.rs
+++ b/src/internal_events/logplex.rs
@@ -15,7 +15,7 @@ impl<'a> InternalEvent for HerokuLogplexRequestReceived<'a> {
             msg_count = %self.msg_count,
             frame_id = %self.frame_id,
             drain_token = %self.drain_token,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -34,7 +34,7 @@ impl InternalEvent for HerokuLogplexRequestReadError {
         error!(
             message = "Error reading request body.",
             error = ?self.error,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -19,7 +19,7 @@ pub struct LuaScriptError {
 
 impl InternalEvent for LuaScriptError {
     fn emit_logs(&self) {
-        error!(message = "Error in lua script; discarding event.", error = ?self.error, rate_limit_secs = 30);
+        error!(message = "Error in lua script; discarding event.", error = ?self.error, internal_log_rate_secs = 30);
     }
 
     fn emit_metrics(&self) {
@@ -34,7 +34,7 @@ pub struct LuaBuildError {
 
 impl InternalEvent for LuaBuildError {
     fn emit_logs(&self) {
-        error!(message = "Error in lua script; discarding event.", error = ?self.error, rate_limit_secs = 30);
+        error!(message = "Error in lua script; discarding event.", error = ?self.error, internal_log_rate_secs = 30);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -12,7 +12,7 @@ impl<'a> InternalEvent for MetricToLogFailedSerialize {
         warn!(
             message = "Metric failed to serialize as JSON.",
             error = ?self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -43,7 +43,7 @@ impl<'a> InternalEvent for NatsEventMissingKeys<'a> {
         warn!(
             message = "Keys do not exist on the event; dropping event.",
             missing_keys = ?self.keys,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         )
     }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -56,7 +56,7 @@ impl<'a> InternalEvent for PrometheusParseError<'a> {
         debug!(
             message = %format!("Failed to parse response:\n\n{}\n\n", self.body),
             url = %self.url,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -130,7 +130,7 @@ impl InternalEvent for PrometheusNoNameError {
     fn emit_logs(&self) {
         error!(
             message = "Decoded timeseries is missing the __name__ field.",
-            rate_limit_secs = 5
+            internal_log_rate_secs = 5
         );
     }
 

--- a/src/internal_events/pulsar.rs
+++ b/src/internal_events/pulsar.rs
@@ -11,7 +11,7 @@ impl<'a> InternalEvent for PulsarEncodeEventFailed<'a> {
         error!(
             message = "Event encode failed; dropping event.",
             error = %self.error,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         );
     }
 

--- a/src/internal_events/regex_parser.rs
+++ b/src/internal_events/regex_parser.rs
@@ -11,7 +11,7 @@ impl InternalEvent for RegexParserFailedMatch<'_> {
         warn!(
             message = "Regex pattern failed to match.",
             field = &super::truncate_string_at(&String::from_utf8_lossy(&self.value), 60)[..],
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 
@@ -45,7 +45,7 @@ impl<'a> InternalEvent for RegexParserTargetExists<'a> {
         warn!(
             message = "Target field already exists.",
             target_field = %self.target_field,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 
@@ -66,7 +66,7 @@ impl<'a> InternalEvent for RegexParserConversionFailed<'a> {
             message = "Could not convert types.",
             name = %self.name,
             error = ?self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         );
     }
 

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -20,7 +20,7 @@ impl InternalEvent for RemapMappingError {
         warn!(
             message,
             error = ?self.error,
-            rate_limit_secs = 30
+            internal_log_rate_secs = 30
         )
     }
 
@@ -37,7 +37,7 @@ impl InternalEvent for RemapConditionExecutionError {
     fn emit_logs(&self) {
         warn!(
             message = "Remap condition execution failed.",
-            rate_limit_secs = 120
+            internal_log_rate_secs = 120
         )
     }
 

--- a/src/internal_events/remove_fields.rs
+++ b/src/internal_events/remove_fields.rs
@@ -7,6 +7,6 @@ pub struct RemoveFieldsFieldMissing<'a> {
 
 impl<'a> InternalEvent for RemoveFieldsFieldMissing<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Field did not exist.", field = %self.field, rate_limit_secs = 30);
+        debug!(message = "Field did not exist.", field = %self.field, internal_log_rate_secs = 30);
     }
 }

--- a/src/internal_events/rename_fields.rs
+++ b/src/internal_events/rename_fields.rs
@@ -7,7 +7,7 @@ pub struct RenameFieldsFieldOverwritten<'a> {
 
 impl<'a> InternalEvent for RenameFieldsFieldOverwritten<'a> {
     fn emit_logs(&self) {
-        debug!(message = "Field overwritten.", field = %self.field, rate_limit_secs = 30);
+        debug!(message = "Field overwritten.", field = %self.field, internal_log_rate_secs = 30);
     }
 }
 
@@ -18,6 +18,6 @@ pub struct RenameFieldsFieldDoesNotExist<'a> {
 
 impl<'a> InternalEvent for RenameFieldsFieldDoesNotExist<'a> {
     fn emit_logs(&self) {
-        warn!(message = "Field did not exist.", field = %self.field, rate_limit_secs = 30);
+        warn!(message = "Field did not exist.", field = %self.field, internal_log_rate_secs = 30);
     }
 }

--- a/src/internal_events/sematext_metrics.rs
+++ b/src/internal_events/sematext_metrics.rs
@@ -14,7 +14,7 @@ impl InternalEvent for SematextMetricsInvalidMetricReceived {
             message = "Invalid metric received; dropping event.",
             value = ?self.value,
             kind = ?self.kind,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         )
     }
 
@@ -36,7 +36,7 @@ impl InternalEvent for SematextMetricsEncodeEventFailed {
         warn!(
              message = "Failed to encode event; dropping event.",
              error = %self.error,
-             rate_limit_secs = 30
+             internal_log_rate_secs = 30
         );
     }
 

--- a/src/internal_events/split.rs
+++ b/src/internal_events/split.rs
@@ -11,7 +11,7 @@ impl<'a> InternalEvent for SplitFieldMissing<'a> {
         warn!(
             message = "Field does not exist.",
             field = %self.field,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -32,7 +32,7 @@ impl<'a> InternalEvent for SplitConvertFailed<'a> {
             message = "Could not convert types.",
             field = %self.field,
             error = ?self.error,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -27,7 +27,7 @@ impl InternalEvent for SplunkEventEncodeError {
         error!(
             message = "Error encoding Splunk HEC event to JSON.",
             error = ?self.error,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         );
     }
 
@@ -48,7 +48,7 @@ impl<'a> InternalEvent for SplunkMissingKeys<'a> {
             message = "Failed to render template for {}, leaving empty.",
             self.field,
             missing_keys = ?self.keys,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         )
     }
 
@@ -86,7 +86,7 @@ mod source {
             debug!(
                 message = "Received one request.",
                 path = %self.path,
-                rate_limit_secs = 10
+                internal_log_rate_secs = 10
             );
         }
 
@@ -105,7 +105,7 @@ mod source {
             error!(
                 message = "Invalid request body.",
                 error = ?self.error,
-                rate_limit_secs = 10
+                internal_log_rate_secs = 10
             );
         }
 
@@ -122,7 +122,7 @@ mod source {
             error!(
                 message = "Error processing request.",
                 error = ?self.error,
-                rate_limit_secs = 10
+                internal_log_rate_secs = 10
             );
         }
 

--- a/src/internal_events/statsd_sink.rs
+++ b/src/internal_events/statsd_sink.rs
@@ -14,7 +14,7 @@ impl<'a> InternalEvent for StatsdInvalidMetricReceived<'a> {
             message = "Invalid metric received; dropping event.",
             value = ?self.value,
             kind = ?self.kind,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         )
     }
 

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -24,7 +24,7 @@ pub struct SyslogUdpReadError {
 
 impl InternalEvent for SyslogUdpReadError {
     fn emit_logs(&self) {
-        error!(message = "Error reading datagram.", error = ?self.error, rate_limit_secs = 10);
+        error!(message = "Error reading datagram.", error = ?self.error, internal_log_rate_secs = 10);
     }
 
     fn emit_metrics(&self) {
@@ -39,7 +39,7 @@ pub struct SyslogUdpUtf8Error {
 
 impl InternalEvent for SyslogUdpUtf8Error {
     fn emit_logs(&self) {
-        error!(message = "Error converting bytes to UTF8 string in UDP mode.", error = ?self.error, rate_limit_secs = 10);
+        error!(message = "Error converting bytes to UTF8 string in UDP mode.", error = ?self.error, internal_log_rate_secs = 10);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -12,7 +12,7 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingEvent<'a> {
             message = "Event containing tag with new value after hitting configured 'value_limit'; discarding event.",
             tag_key = self.tag_key,
             tag_value = self.tag_value,
-            rate_limit_secs = 10,
+            internal_log_rate_secs = 10,
         );
     }
 
@@ -32,7 +32,7 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingTag<'a> {
             message = "Rejecting tag after hitting configured 'value_limit'.",
             tag_key = self.tag_key,
             tag_value = self.tag_value,
-            rate_limit_secs = 10,
+            internal_log_rate_secs = 10,
         );
     }
 

--- a/src/internal_events/tcp.rs
+++ b/src/internal_events/tcp.rs
@@ -58,7 +58,7 @@ pub struct TcpSocketConnectionError {
 
 impl InternalEvent for TcpSocketConnectionError {
     fn emit_logs(&self) {
-        warn!(message = "Connection error.", error = %self.error, rate_limit_secs = 10);
+        warn!(message = "Connection error.", error = %self.error, internal_log_rate_secs = 10);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/tokenizer.rs
+++ b/src/internal_events/tokenizer.rs
@@ -11,7 +11,7 @@ impl<'a> InternalEvent for TokenizerFieldMissing<'a> {
         warn!(
             message = "Field does not exist.",
             field = %self.field,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 
@@ -32,7 +32,7 @@ impl<'a> InternalEvent for TokenizerConvertFailed<'a> {
             message = "Could not convert types.",
             field = %self.field,
             error = ?self.error,
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
     }
 

--- a/src/internal_events/udp.rs
+++ b/src/internal_events/udp.rs
@@ -60,7 +60,7 @@ impl InternalEvent for UdpSendIncomplete {
             data_size = self.data_size,
             sent = self.sent,
             dropped = self.data_size - self.sent,
-            rate_limit_secs = 30,
+            internal_log_rate_secs = 30,
         );
     }
 

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -25,7 +25,7 @@ pub struct VectorProtoDecodeError {
 
 impl InternalEvent for VectorProtoDecodeError {
     fn emit_logs(&self) {
-        error!(message = "Failed to decode protobuf message.", error = ?self.error, rate_limit_secs = 10);
+        error!(message = "Failed to decode protobuf message.", error = ?self.error, internal_log_rate_secs = 10);
     }
 
     fn emit_metrics(&self) {

--- a/src/internal_events/wasm/event_processing.rs
+++ b/src/internal_events/wasm/event_processing.rs
@@ -59,7 +59,7 @@ impl InternalEvent for EventProcessingProgress {
                 role = self.role.as_const_str(),
                 error = ?self.error.as_ref().unwrap_or(&String::from("")),
                 elapsed_micros = self.elapsed.as_micros() as u64,
-                rate_limit_secs = 30,
+                internal_log_rate_secs = 30,
                 "Event processing error.",
             ),
         }

--- a/src/internal_events/wasm/hostcall.rs
+++ b/src/internal_events/wasm/hostcall.rs
@@ -64,7 +64,7 @@ impl InternalEvent for WasmHostcallProgress {
                 role = self.role.as_const_str(),
                 error = ?self.error.as_ref().unwrap_or(&String::from("")),
                 elapsed_micros = self.elapsed.as_micros() as u64,
-                rate_limit_secs = 30,
+                internal_log_rate_secs = 30,
                 "Hostcall errored.",
             ),
         }

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -442,7 +442,7 @@ fn partition_encode(
             warn!(
                 message = "Keys in group template do not exist on the event; dropping event.",
                 ?missing_keys,
-                rate_limit_secs = 30
+                internal_log_rate_secs = 30
             );
             return None;
         }
@@ -454,7 +454,7 @@ fn partition_encode(
             warn!(
                 message = "Keys in stream template do not exist on the event; dropping event.",
                 ?missing_keys,
-                rate_limit_secs = 30
+                internal_log_rate_secs = 30
             );
             return None;
         }
@@ -464,7 +464,7 @@ fn partition_encode(
 
     encoding.apply_rules(&mut event);
     let event = encode_log(event.into_log(), encoding)
-        .map_err(|error| error!(message = "Could not encode event.", %error, rate_limit_secs = 5))
+        .map_err(|error| error!(message = "Could not encode event.", %error, internal_log_rate_secs = 5))
         .ok()?;
 
     Some(PartitionInnerBuffer::new(event, key))

--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -464,7 +464,9 @@ fn partition_encode(
 
     encoding.apply_rules(&mut event);
     let event = encode_log(event.into_log(), encoding)
-        .map_err(|error| error!(message = "Could not encode event.", %error, internal_log_rate_secs = 5))
+        .map_err(
+            |error| error!(message = "Could not encode event.", %error, internal_log_rate_secs = 5),
+        )
         .ok()?;
 
     Some(PartitionInnerBuffer::new(event, key))

--- a/src/sinks/aws_kinesis_streams.rs
+++ b/src/sinks/aws_kinesis_streams.rs
@@ -274,7 +274,7 @@ fn encode_event(
             warn!(
                 message = "Partition key does not exist; dropping event.",
                 %partition_key_field,
-                rate_limit_secs = 30,
+                internal_log_rate_secs = 30,
             );
             return None;
         }

--- a/src/sinks/aws_s3.rs
+++ b/src/sinks/aws_s3.rs
@@ -397,7 +397,7 @@ fn encode_event(
             warn!(
                 message = "Keys do not exist on the event; dropping event.",
                 ?missing_keys,
-                rate_limit_secs = 30,
+                internal_log_rate_secs = 30,
             );
         })
         .ok()?;

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -407,7 +407,7 @@ fn encode_event(
             warn!(
                 message = "Keys do not exist on the event; dropping event.",
                 ?missing_keys,
-                rate_limit_secs = 30,
+                internal_log_rate_secs = 30,
             );
         })
         .ok()?;

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -229,7 +229,7 @@ fn remap_severity(severity: Value) -> Value {
                         warn!(
                             message = "Unknown severity value string, using DEFAULT.",
                             value = %s,
-                            rate_limit_secs = 10
+                            internal_log_rate_secs = 10
                         );
                         0
                     }
@@ -240,7 +240,7 @@ fn remap_severity(severity: Value) -> Value {
             warn!(
                 message = "Unknown severity value type, using DEFAULT.",
                 ?value,
-                rate_limit_secs = 10
+                internal_log_rate_secs = 10
             );
             0
         }

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -195,7 +195,7 @@ impl HttpSink for InfluxDBLogsSink {
             timestamp,
             &mut output,
         ) {
-            warn!(message = "Failed to encode event; dropping event.", %error, rate_limit_secs = 30);
+            warn!(message = "Failed to encode event; dropping event.", %error, internal_log_rate_secs = 30);
             return None;
         };
 

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -237,7 +237,7 @@ fn encode_events(
             ts,
             &mut output,
         ) {
-            warn!(message = "Failed to encode event; dropping event.", %error, rate_limit_secs = 30);
+            warn!(message = "Failed to encode event; dropping event.", %error, internal_log_rate_secs = 30);
         };
     }
 

--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -275,7 +275,7 @@ impl Sink<Event> for KafkaSink {
                     Err((error, future_record))
                         if error == KafkaError::MessageProduction(RDKafkaError::QueueFull) =>
                     {
-                        debug!(message = "The rdkafka queue full.", %error, %seqno, rate_limit_secs = 1);
+                        debug!(message = "The rdkafka queue full.", %error, %seqno, internal_log_rate_secs = 1);
                         record = future_record;
                         let _ = flush_signal.notified().await;
                     }

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -128,7 +128,7 @@ impl HttpSink for LogdnaConfig {
                 error!(
                     message = "Error rendering template.",
                     ?missing,
-                    rate_limit_secs = 30
+                    internal_log_rate_secs = 30
                 );
             })
             .ok()?;

--- a/src/sinks/loki.rs
+++ b/src/sinks/loki.rs
@@ -143,7 +143,7 @@ impl HttpSink for LokiConfig {
                     error!(
                         message = "Error rendering `tenant_id` template.",
                         ?missing,
-                        rate_limit_secs = 30
+                        internal_log_rate_secs = 30
                     );
                 })
                 .ok()

--- a/src/sinks/util/adaptive_concurrency/controller.rs
+++ b/src/sinks/util/adaptive_concurrency/controller.rs
@@ -252,7 +252,7 @@ where
                     warn!(
                         message = "Unhandled error response.",
                         ?error,
-                        rate_limit_secs = 5
+                        internal_log_rate_secs = 5
                     );
                     false
                 }

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -153,7 +153,7 @@ impl<B> BatchSettings<B> {
 }
 
 pub(super) fn err_event_too_large<T>(length: usize) -> PushResult<T> {
-    error!(message = "Event larger than batch size, dropping.", length = %length, rate_limit_secs = 1);
+    error!(message = "Event larger than batch size, dropping.", length = %length, internal_log_rate_secs = 1);
     PushResult::Ok(false)
 }
 

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -217,7 +217,7 @@ fn line_to_event(line: String) -> Event {
         warn!(
             message = "Line didn't match expected logplex format, so raw message is forwarded.",
             fields = parts.len(),
-            rate_limit_secs = 10
+            internal_log_rate_secs = 10
         );
         Event::from(line)
     };

--- a/src/sources/host_metrics.rs
+++ b/src/sources/host_metrics.rs
@@ -247,7 +247,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load CPU times.", %error, rate_limit_secs = 60);
+                error!(message = "Failed to load CPU times.", %error, internal_log_rate_secs = 60);
                 vec![]
             }
         }
@@ -328,7 +328,7 @@ impl HostMetricsConfig {
                 ]
             }
             Err(error) => {
-                error!(message = "Failed to load memory info.", %error, rate_limit_secs = 60);
+                error!(message = "Failed to load memory info.", %error, internal_log_rate_secs = 60);
                 vec![]
             }
         }
@@ -374,7 +374,7 @@ impl HostMetricsConfig {
                 ]
             }
             Err(error) => {
-                error!(message = "Failed to load swap info.", %error, rate_limit_secs = 60);
+                error!(message = "Failed to load swap info.", %error, internal_log_rate_secs = 60);
                 vec![]
             }
         }
@@ -397,7 +397,7 @@ impl HostMetricsConfig {
                 ]
             }
             Err(error) => {
-                error!(message = "Failed to load load average info.", %error, rate_limit_secs = 60);
+                error!(message = "Failed to load load average info.", %error, internal_log_rate_secs = 60);
                 vec![]
             }
         };
@@ -482,7 +482,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load network I/O counters.", %error, rate_limit_secs = 60);
+                error!(message = "Failed to load network I/O counters.", %error, internal_log_rate_secs = 60);
                 vec![]
             }
         }
@@ -532,7 +532,7 @@ impl HostMetricsConfig {
                                     message = "Failed to load partition usage data.",
                                     mount_point = ?partition.mount_point(),
                                     %error,
-                                    rate_limit_secs = 60,
+                                    internal_log_rate_secs = 60,
                                 )
                             })
                             .map(|usage| (partition, usage))
@@ -577,7 +577,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load partitions info", %error, rate_limit_secs = 60);
+                error!(message = "Failed to load partitions info", %error, internal_log_rate_secs = 60);
                 vec![]
             }
         }
@@ -637,7 +637,7 @@ impl HostMetricsConfig {
                     .await
             }
             Err(error) => {
-                error!(message = "Failed to load disk I/O info.", %error, rate_limit_secs = 60);
+                error!(message = "Failed to load disk I/O info.", %error, internal_log_rate_secs = 60);
                 vec![]
             }
         }
@@ -680,7 +680,7 @@ impl HostMetricsConfig {
 
 async fn filter_result<T>(result: Result<T, Error>, message: &'static str) -> Option<T> {
     result
-        .map_err(|error| error!(message, %error, rate_limit_secs = 60))
+        .map_err(|error| error!(message, %error, internal_log_rate_secs = 60))
         .ok()
 }
 

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -216,7 +216,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                           body: Bytes,
                           query_parameters: HashMap<String, String>| {
                         let _guard=span.enter();
-                        info!(message = "Handling HTTP request.", headers = ?headers, rate_limit_secs = 30);
+                        info!(message = "Handling HTTP request.", headers = ?headers, internal_log_rate_secs = 30);
 
                         let mut out = out.clone();
 

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -208,7 +208,7 @@ impl rlua::UserData for LuaEvent {
                             message =
                                 "Could not set field to Lua value of invalid type, dropping field.",
                             field = key.as_str(),
-                            rate_limit_secs = 30
+                            internal_log_rate_secs = 30
                         );
                         this.inner.as_mut_log().remove(key);
                     }


### PR DESCRIPTION
Closes #5223

Before:
```
Field not found; dropping event. missing_field="message" rate_limit_secs=30
"Field not found; dropping event." is being rate limited. rate_limit_secs=5
3004 "Field not found; dropping event." events were rate limited. rate_limit_secs=5
```

After:
```
Field not found; dropping event. missing_field="message" internal_log_rate_secs=30
Internal log [Field not found; dropping event.] is being rate limited.
Internal log [Field not found; dropping event.] has been rate limited 3003 times.
```

### Notes
* A notable side effect is that we have to start using field `internal_log_rate_secs` instead of old `rate_limit_secs`. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
