### PR TITLE
chore(topology): Upgrade fanout to futures 0.3 and tokio channels

### DIFF
--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -192,16 +192,20 @@ impl Sink<Event> for Fanout {
 #[cfg(test)]
 mod tests {
     use super::{ControlMessage, Fanout};
-    use crate::{test_util::collect_ready01, Event};
-    use futures::compat::Future01CompatExt;
-    use futures01::{stream, sync::mpsc, Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
+    use crate::{test_util::collect_ready, Event};
+    use futures::{stream, Sink, SinkExt, StreamExt};
+    use std::{
+        pin::Pin,
+        task::{Context, Poll},
+    };
+    use tokio::sync::mpsc;
     use tokio::time::{delay_for, Duration};
 
     #[tokio::test]
     async fn fanout_writes_to_all() {
-        let (tx_a, rx_a) = mpsc::unbounded();
+        let (tx_a, rx_a) = unbounded_channel();
         let tx_a = Box::new(tx_a.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::unbounded();
+        let (tx_b, rx_b) = unbounded_channel();
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
 
         let mut fanout = Fanout::new().0;
@@ -210,20 +214,20 @@ mod tests {
         fanout.add("b".to_string(), tx_b);
 
         let recs = make_events(2);
-        let fanout = fanout.send_all(stream::iter_ok(recs.clone())).compat();
-        let _ = fanout.await.unwrap();
+        let send = stream::iter(recs.clone()).map(Ok).forward(fanout);
+        let _ = send.await.unwrap();
 
-        assert_eq!(collect_ready01(rx_a).await.unwrap(), recs);
-        assert_eq!(collect_ready01(rx_b).await.unwrap(), recs);
+        assert_eq!(collect_ready(rx_a).await, recs);
+        assert_eq!(collect_ready(rx_b).await, recs);
     }
 
     #[tokio::test]
     async fn fanout_notready() {
-        let (tx_a, rx_a) = mpsc::channel(1);
+        let (tx_a, rx_a) = channel(2);
         let tx_a = Box::new(tx_a.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::channel(0);
+        let (tx_b, rx_b) = channel(1);
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
-        let (tx_c, rx_c) = mpsc::channel(1);
+        let (tx_c, rx_c) = channel(2);
         let tx_c = Box::new(tx_c.sink_map_err(|_| unreachable!()));
 
         let mut fanout = Fanout::new().0;
@@ -233,26 +237,26 @@ mod tests {
         fanout.add("c".to_string(), tx_c);
 
         let recs = make_events(3);
-        let send = fanout.send_all(stream::iter_ok(recs.clone()));
-        tokio::spawn(send.map(|_| ()).compat());
+        let send = stream::iter(recs.clone()).map(Ok).forward(fanout);
+        tokio::spawn(send);
 
         delay_for(Duration::from_millis(50)).await;
-        // The send_all task will be blocked on sending rec2 to b right now.
+        // The send_all task will be blocked on sending rec1 because of b right now.
 
-        let collect_a = tokio::spawn(rx_a.collect().compat());
-        let collect_b = tokio::spawn(rx_b.collect().compat());
-        let collect_c = tokio::spawn(rx_c.collect().compat());
+        let collect_a = tokio::spawn(rx_a.collect::<Vec<_>>());
+        let collect_b = tokio::spawn(rx_b.collect::<Vec<_>>());
+        let collect_c = tokio::spawn(rx_c.collect::<Vec<_>>());
 
-        assert_eq!(collect_a.await.unwrap().unwrap(), recs);
-        assert_eq!(collect_b.await.unwrap().unwrap(), recs);
-        assert_eq!(collect_c.await.unwrap().unwrap(), recs);
+        assert_eq!(collect_a.await.unwrap(), recs);
+        assert_eq!(collect_b.await.unwrap(), recs);
+        assert_eq!(collect_c.await.unwrap(), recs);
     }
 
     #[tokio::test]
     async fn fanout_grow() {
-        let (tx_a, rx_a) = mpsc::unbounded();
+        let (tx_a, rx_a) = unbounded_channel();
         let tx_a = Box::new(tx_a.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::unbounded();
+        let (tx_b, rx_b) = unbounded_channel();
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
 
         let mut fanout = Fanout::new().0;
@@ -262,25 +266,25 @@ mod tests {
 
         let recs = make_events(3);
 
-        let fanout = fanout.send(recs[0].clone()).compat().await.unwrap();
-        let mut fanout = fanout.send(recs[1].clone()).compat().await.unwrap();
+        fanout.send(recs[0].clone()).await.unwrap();
+        fanout.send(recs[1].clone()).await.unwrap();
 
-        let (tx_c, rx_c) = mpsc::unbounded();
+        let (tx_c, rx_c) = unbounded_channel();
         let tx_c = Box::new(tx_c.sink_map_err(|_| unreachable!()));
         fanout.add("c".to_string(), tx_c);
 
-        let _fanout = fanout.send(recs[2].clone()).compat().await.unwrap();
+        fanout.send(recs[2].clone()).await.unwrap();
 
-        assert_eq!(collect_ready01(rx_a).await.unwrap(), recs);
-        assert_eq!(collect_ready01(rx_b).await.unwrap(), recs);
-        assert_eq!(collect_ready01(rx_c).await.unwrap(), &recs[2..]);
+        assert_eq!(collect_ready(rx_a).await, recs);
+        assert_eq!(collect_ready(rx_b).await, recs);
+        assert_eq!(collect_ready(rx_c).await, &recs[2..]);
     }
 
     #[tokio::test]
     async fn fanout_shrink() {
-        let (tx_a, rx_a) = mpsc::unbounded();
+        let (tx_a, rx_a) = unbounded_channel();
         let tx_a = Box::new(tx_a.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::unbounded();
+        let (tx_b, rx_b) = unbounded_channel();
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
 
         let (mut fanout, fanout_control) = Fanout::new();
@@ -290,27 +294,26 @@ mod tests {
 
         let recs = make_events(3);
 
-        let fanout = fanout.send(recs[0].clone()).compat().await.unwrap();
-        let fanout = fanout.send(recs[1].clone()).compat().await.unwrap();
+        fanout.send(recs[0].clone()).await.unwrap();
+        fanout.send(recs[1].clone()).await.unwrap();
 
         fanout_control
-            .unbounded_send(ControlMessage::Remove("b".to_string()))
+            .send(ControlMessage::Remove("b".to_string()))
             .unwrap();
 
-        use futures::compat::Future01CompatExt;
-        let _fanout = fanout.send(recs[2].clone()).compat().await.unwrap();
+        fanout.send(recs[2].clone()).await.unwrap();
 
-        assert_eq!(collect_ready01(rx_a).await.unwrap(), recs);
-        assert_eq!(collect_ready01(rx_b).await.unwrap(), &recs[..2]);
+        assert_eq!(collect_ready(rx_a).await, recs);
+        assert_eq!(collect_ready(rx_b).await, &recs[..2]);
     }
 
     #[tokio::test]
     async fn fanout_shrink_after_notready() {
-        let (tx_a, rx_a) = mpsc::channel(1);
+        let (tx_a, rx_a) = channel(2);
         let tx_a = Box::new(tx_a.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::channel(0);
+        let (tx_b, rx_b) = channel(1);
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
-        let (tx_c, rx_c) = mpsc::channel(1);
+        let (tx_c, rx_c) = channel(2);
         let tx_c = Box::new(tx_c.sink_map_err(|_| unreachable!()));
 
         let (mut fanout, fanout_control) = Fanout::new();
@@ -320,31 +323,31 @@ mod tests {
         fanout.add("c".to_string(), tx_c);
 
         let recs = make_events(3);
-        let send = fanout.send_all(stream::iter_ok(recs.clone()));
-        tokio::spawn(send.map(|_| ()).compat());
+        let send = stream::iter(recs.clone()).map(Ok).forward(fanout);
+        tokio::spawn(send);
 
         delay_for(Duration::from_millis(50)).await;
-        // The send_all task will be blocked on sending rec2 to b right now.
+        // The send_all task will be blocked on sending rec1 because of b right now.
         fanout_control
-            .unbounded_send(ControlMessage::Remove("c".to_string()))
+            .send(ControlMessage::Remove("c".to_string()))
             .unwrap();
 
-        let collect_a = tokio::spawn(rx_a.collect().compat());
-        let collect_b = tokio::spawn(rx_b.collect().compat());
-        let collect_c = tokio::spawn(rx_c.collect().compat());
+        let collect_a = tokio::spawn(rx_a.collect::<Vec<_>>());
+        let collect_b = tokio::spawn(rx_b.collect::<Vec<_>>());
+        let collect_c = tokio::spawn(rx_c.collect::<Vec<_>>());
 
-        assert_eq!(collect_a.await.unwrap().unwrap(), recs);
-        assert_eq!(collect_b.await.unwrap().unwrap(), recs);
-        assert_eq!(collect_c.await.unwrap().unwrap(), &recs[..1]);
+        assert_eq!(collect_a.await.unwrap(), recs);
+        assert_eq!(collect_b.await.unwrap(), recs);
+        assert_eq!(collect_c.await.unwrap(), &recs[..1]);
     }
 
     #[tokio::test]
     async fn fanout_shrink_at_notready() {
-        let (tx_a, rx_a) = mpsc::channel(1);
+        let (tx_a, rx_a) = channel(2);
         let tx_a = Box::new(tx_a.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::channel(0);
+        let (tx_b, rx_b) = channel(1);
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
-        let (tx_c, rx_c) = mpsc::channel(1);
+        let (tx_c, rx_c) = channel(2);
         let tx_c = Box::new(tx_c.sink_map_err(|_| unreachable!()));
 
         let (mut fanout, fanout_control) = Fanout::new();
@@ -354,31 +357,31 @@ mod tests {
         fanout.add("c".to_string(), tx_c);
 
         let recs = make_events(3);
-        let send = fanout.send_all(stream::iter_ok(recs.clone()));
-        tokio::spawn(send.map(|_| ()).compat());
+        let send = stream::iter(recs.clone()).map(Ok).forward(fanout);
+        tokio::spawn(send);
 
         delay_for(Duration::from_millis(50)).await;
-        // The send_all task will be blocked on sending rec2 to b right now.
+        // The send_all task will be blocked on sending rec1 because of b right now.
         fanout_control
-            .unbounded_send(ControlMessage::Remove("b".to_string()))
+            .send(ControlMessage::Remove("b".to_string()))
             .unwrap();
 
-        let collect_a = tokio::spawn(rx_a.collect().compat());
-        let collect_b = tokio::spawn(rx_b.collect().compat());
-        let collect_c = tokio::spawn(rx_c.collect().compat());
+        let collect_a = tokio::spawn(rx_a.collect::<Vec<_>>());
+        let collect_b = tokio::spawn(rx_b.collect::<Vec<_>>());
+        let collect_c = tokio::spawn(rx_c.collect::<Vec<_>>());
 
-        assert_eq!(collect_a.await.unwrap().unwrap(), recs);
-        assert_eq!(collect_b.await.unwrap().unwrap(), &recs[..1]);
-        assert_eq!(collect_c.await.unwrap().unwrap(), recs);
+        assert_eq!(collect_a.await.unwrap(), recs);
+        assert_eq!(collect_b.await.unwrap(), &recs[..1]);
+        assert_eq!(collect_c.await.unwrap(), recs);
     }
 
     #[tokio::test]
     async fn fanout_shrink_before_notready() {
-        let (tx_a, rx_a) = mpsc::channel(1);
+        let (tx_a, rx_a) = channel(2);
         let tx_a = Box::new(tx_a.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::channel(0);
+        let (tx_b, rx_b) = channel(1);
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
-        let (tx_c, rx_c) = mpsc::channel(1);
+        let (tx_c, rx_c) = channel(2);
         let tx_c = Box::new(tx_c.sink_map_err(|_| unreachable!()));
 
         let (mut fanout, fanout_control) = Fanout::new();
@@ -388,40 +391,40 @@ mod tests {
         fanout.add("c".to_string(), tx_c);
 
         let recs = make_events(3);
-        let send = fanout.send_all(stream::iter_ok(recs.clone()));
-        tokio::spawn(send.map(|_| ()).compat());
+        let send = stream::iter(recs.clone()).map(Ok).forward(fanout);
+        tokio::spawn(send);
 
         delay_for(Duration::from_millis(50)).await;
-        // The send_all task will be blocked on sending rec2 to b right now.
+        // The send_all task will be blocked on sending rec1 because of b right now.
 
         fanout_control
-            .unbounded_send(ControlMessage::Remove("a".to_string()))
+            .send(ControlMessage::Remove("a".to_string()))
             .unwrap();
 
-        let collect_a = tokio::spawn(rx_a.collect().compat());
-        let collect_b = tokio::spawn(rx_b.collect().compat());
-        let collect_c = tokio::spawn(rx_c.collect().compat());
+        let collect_a = tokio::spawn(rx_a.collect::<Vec<_>>());
+        let collect_b = tokio::spawn(rx_b.collect::<Vec<_>>());
+        let collect_c = tokio::spawn(rx_c.collect::<Vec<_>>());
 
-        assert_eq!(collect_a.await.unwrap().unwrap(), &recs[..2]);
-        assert_eq!(collect_b.await.unwrap().unwrap(), recs);
-        assert_eq!(collect_c.await.unwrap().unwrap(), recs);
+        assert_eq!(collect_a.await.unwrap(), &recs[..1]);
+        assert_eq!(collect_b.await.unwrap(), recs);
+        assert_eq!(collect_c.await.unwrap(), recs);
     }
 
     #[tokio::test]
     async fn fanout_no_sinks() {
-        let fanout = Fanout::new().0;
+        let mut fanout = Fanout::new().0;
 
         let recs = make_events(2);
 
-        let fanout = fanout.send(recs[0].clone()).compat().await.unwrap();
-        let _fanout = fanout.send(recs[1].clone()).compat().await.unwrap();
+        fanout.send(recs[0].clone()).await.unwrap();
+        fanout.send(recs[1].clone()).await.unwrap();
     }
 
     #[tokio::test]
     async fn fanout_replace() {
-        let (tx_a1, rx_a1) = mpsc::unbounded();
+        let (tx_a1, rx_a1) = unbounded_channel();
         let tx_a1 = Box::new(tx_a1.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::unbounded();
+        let (tx_b, rx_b) = unbounded_channel();
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
 
         let mut fanout = Fanout::new().0;
@@ -431,25 +434,25 @@ mod tests {
 
         let recs = make_events(3);
 
-        let fanout = fanout.send(recs[0].clone()).compat().await.unwrap();
-        let mut fanout = fanout.send(recs[1].clone()).compat().await.unwrap();
+        fanout.send(recs[0].clone()).await.unwrap();
+        fanout.send(recs[1].clone()).await.unwrap();
 
-        let (tx_a2, rx_a2) = mpsc::unbounded();
+        let (tx_a2, rx_a2) = unbounded_channel();
         let tx_a2 = Box::new(tx_a2.sink_map_err(|_| unreachable!()));
         fanout.replace("a".to_string(), Some(tx_a2));
 
-        let _fanout = fanout.send(recs[2].clone()).compat().await.unwrap();
+        fanout.send(recs[2].clone()).await.unwrap();
 
-        assert_eq!(collect_ready01(rx_a1).await.unwrap(), &recs[..2]);
-        assert_eq!(collect_ready01(rx_b).await.unwrap(), recs);
-        assert_eq!(collect_ready01(rx_a2).await.unwrap(), &recs[2..]);
+        assert_eq!(collect_ready(rx_a1).await, &recs[..2]);
+        assert_eq!(collect_ready(rx_b).await, recs);
+        assert_eq!(collect_ready(rx_a2).await, &recs[2..]);
     }
 
     #[tokio::test]
     async fn fanout_wait() {
-        let (tx_a1, rx_a1) = mpsc::unbounded();
+        let (tx_a1, rx_a1) = unbounded_channel();
         let tx_a1 = Box::new(tx_a1.sink_map_err(|_| unreachable!()));
-        let (tx_b, rx_b) = mpsc::unbounded();
+        let (tx_b, rx_b) = unbounded_channel();
         let tx_b = Box::new(tx_b.sink_map_err(|_| unreachable!()));
 
         let (mut fanout, cc) = Fanout::new();
@@ -459,26 +462,24 @@ mod tests {
 
         let recs = make_events(3);
 
-        let fanout = fanout.send(recs[0].clone()).compat().await.unwrap();
-        let mut fanout = fanout.send(recs[1].clone()).compat().await.unwrap();
+        fanout.send(recs[0].clone()).await.unwrap();
+        fanout.send(recs[1].clone()).await.unwrap();
 
-        let (tx_a2, rx_a2) = mpsc::unbounded();
+        let (tx_a2, rx_a2) = unbounded_channel();
         let tx_a2 = Box::new(tx_a2.sink_map_err(|_| unreachable!()));
         fanout.replace("a".to_string(), None);
 
         tokio::spawn(async move {
             delay_for(Duration::from_millis(100)).await;
             cc.send(ControlMessage::Replace("a".to_string(), Some(tx_a2)))
-                .compat()
-                .await
                 .unwrap();
         });
 
-        let _fanout = fanout.send(recs[2].clone()).compat().await.unwrap();
+        fanout.send(recs[2].clone()).await.unwrap();
 
-        assert_eq!(collect_ready01(rx_a1).await.unwrap(), &recs[..2]);
-        assert_eq!(collect_ready01(rx_b).await.unwrap(), recs);
-        assert_eq!(collect_ready01(rx_a2).await.unwrap(), &recs[2..]);
+        assert_eq!(collect_ready(rx_a1).await, &recs[..2]);
+        assert_eq!(collect_ready(rx_b).await, recs);
+        assert_eq!(collect_ready(rx_a2).await, &recs[2..]);
     }
 
     #[tokio::test]
@@ -534,7 +535,7 @@ mod tests {
                     fanout.add(name, tx);
                 }
                 None => {
-                    let (tx, rx) = mpsc::channel(1);
+                    let (tx, rx) = channel(1);
                     let tx = Box::new(tx.sink_map_err(|_| unreachable!()));
                     fanout.add(name, tx);
                     rx_channels.push(rx);
@@ -543,18 +544,18 @@ mod tests {
         }
 
         let recs = make_events(3);
-        let send = fanout.send_all(stream::iter_ok(recs.clone()));
-        tokio::spawn(send.map(|_| ()).compat());
+        let send = stream::iter(recs.clone()).map(Ok).forward(fanout);
+        tokio::spawn(send);
 
         delay_for(Duration::from_millis(50)).await;
 
         // Start collecting from all at once
         let collectors = rx_channels
             .into_iter()
-            .map(|rx| tokio::spawn(rx.collect().compat()))
+            .map(|rx| tokio::spawn(rx.collect::<Vec<_>>()))
             .collect::<Vec<_>>();
         for collect in collectors {
-            assert_eq!(collect.await.unwrap().unwrap(), recs);
+            assert_eq!(collect.await.unwrap(), recs);
         }
     }
 
@@ -568,25 +569,35 @@ mod tests {
         when: ErrorWhen,
     }
 
-    impl Sink for AlwaysErrors {
-        type SinkItem = Event;
-        type SinkError = crate::Error;
+    impl Sink<Event> for AlwaysErrors {
+        type Error = crate::Error;
 
-        fn start_send(
-            &mut self,
-            _item: Self::SinkItem,
-        ) -> StartSend<Self::SinkItem, Self::SinkError> {
+        fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(match self.when {
+                ErrorWhen::Poll => Err("Something failed".into()),
+                _ => Ok(()),
+            })
+        }
+
+        fn start_send(self: Pin<&mut Self>, _: Event) -> Result<(), Self::Error> {
             match self.when {
-                ErrorWhen::Send => Err("Something failed".into()),
-                _ => Ok(AsyncSink::Ready),
+                ErrorWhen::Poll => Err("Something failed".into()),
+                _ => Ok(()),
             }
         }
 
-        fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-            match self.when {
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(match self.when {
                 ErrorWhen::Poll => Err("Something failed".into()),
-                _ => Ok(Async::Ready(())),
-            }
+                _ => Ok(()),
+            })
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(match self.when {
+                ErrorWhen::Poll => Err("Something failed".into()),
+                _ => Ok(()),
+            })
         }
     }
 
@@ -594,5 +605,58 @@ mod tests {
         (0..count)
             .map(|i| Event::from(format!("line {}", i)))
             .collect()
+    }
+
+    fn unbounded_channel<T>() -> (UnboundedSink<T>, mpsc::UnboundedReceiver<T>) {
+        let (sender, recv) = mpsc::unbounded_channel();
+        (UnboundedSink { sender }, recv)
+    }
+
+    fn channel<T>(capacity: usize) -> (BoundedSink<T>, mpsc::Receiver<T>) {
+        let (sender, recv) = mpsc::channel(capacity);
+        (BoundedSink { sender }, recv)
+    }
+
+    struct UnboundedSink<T> {
+        sender: mpsc::UnboundedSender<T>,
+    }
+
+    impl<T> Sink<T> for UnboundedSink<T> {
+        type Error = mpsc::error::SendError<T>;
+        fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+            self.sender.send(item)
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    struct BoundedSink<T> {
+        sender: mpsc::Sender<T>,
+    }
+
+    impl<T> Sink<T> for BoundedSink<T> {
+        type Error = ();
+        fn poll_ready(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.sender.poll_ready(cx).map_err(|_| ())
+        }
+        fn start_send(mut self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+            self.sender.try_send(item).map_err(|_| ())
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
     }
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -623,7 +623,7 @@ impl RunningTopology {
             for input in inputs {
                 if let Some(output) = self.outputs.get(input) {
                     // This can only fail if we are disconnected, which is a valid situation.
-                    let _ = output.unbounded_send(fanout::ControlMessage::Remove(name.to_string()));
+                    let _ = output.send(fanout::ControlMessage::Remove(name.to_string()));
                 }
             }
         }
@@ -637,7 +637,7 @@ impl RunningTopology {
                 // Sink may have been removed with the new config so it may not be present.
                 if let Some(input) = self.inputs.get(sink_name) {
                     output
-                        .unbounded_send(fanout::ControlMessage::Add(sink_name.clone(), input.get()))
+                        .send(fanout::ControlMessage::Add(sink_name.clone(), input.get()))
                         .expect("Components shouldn't be spawned before connecting them together.");
                 }
             }
@@ -647,7 +647,7 @@ impl RunningTopology {
                 // Transform may have been removed with the new config so it may not be present.
                 if let Some(input) = self.inputs.get(transform_name) {
                     output
-                        .unbounded_send(fanout::ControlMessage::Add(
+                        .send(fanout::ControlMessage::Add(
                             transform_name.clone(),
                             input.get(),
                         ))
@@ -664,8 +664,8 @@ impl RunningTopology {
 
         for input in inputs {
             // This can only fail if we are disconnected, which is a valid situation.
-            let _ = self.outputs[&input]
-                .unbounded_send(fanout::ControlMessage::Add(name.to_string(), tx.get()));
+            let _ =
+                self.outputs[&input].send(fanout::ControlMessage::Add(name.to_string(), tx.get()));
         }
 
         self.inputs.insert(name.to_string(), tx);
@@ -695,19 +695,19 @@ impl RunningTopology {
         for input in inputs_to_remove {
             if let Some(output) = self.outputs.get(input) {
                 // This can only fail if we are disconnected, which is a valid situation.
-                let _ = output.unbounded_send(fanout::ControlMessage::Remove(name.to_string()));
+                let _ = output.send(fanout::ControlMessage::Remove(name.to_string()));
             }
         }
 
         for input in inputs_to_add {
             // This can only fail if we are disconnected, which is a valid situation.
-            let _ = self.outputs[input]
-                .unbounded_send(fanout::ControlMessage::Add(name.to_string(), tx.get()));
+            let _ =
+                self.outputs[input].send(fanout::ControlMessage::Add(name.to_string(), tx.get()));
         }
 
         for &input in inputs_to_replace {
             // This can only fail if we are disconnected, which is a valid situation.
-            let _ = self.outputs[input].unbounded_send(fanout::ControlMessage::Replace(
+            let _ = self.outputs[input].send(fanout::ControlMessage::Replace(
                 name.to_string(),
                 Some(tx.get()),
             ));
@@ -730,8 +730,8 @@ impl RunningTopology {
 
         for input in old_inputs {
             // This can only fail if we are disconnected, which is a valid situation.
-            let _ = self.outputs[input]
-                .unbounded_send(fanout::ControlMessage::Replace(name.to_string(), None));
+            let _ =
+                self.outputs[input].send(fanout::ControlMessage::Replace(name.to_string(), None));
         }
     }
 

--- a/tests/buffering.rs
+++ b/tests/buffering.rs
@@ -124,7 +124,14 @@ fn test_buffering() {
         topology.stop().compat().await.unwrap();
 
         let output_events = output_events.await;
-        assert_eq!(expected_events_count, output_events.len());
+        assert_eq!(
+            expected_events_count,
+            output_events.len(),
+            "Expected: {:?}{:?}, got: {:?}",
+            input_events,
+            input_events2,
+            output_events
+        );
         assert_eq!(input_events, &output_events[..num_events]);
         assert_eq!(input_events2, &output_events[num_events..]);
     });


### PR DESCRIPTION
Closes #5774 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
