### PR TITLE
fix(deps): fix features for lib/shared

### DIFF
--- a/lib/shared/Cargo.toml
+++ b/lib/shared/Cargo.toml
@@ -23,7 +23,7 @@ default = [
 
 aws_cloudwatch_logs_subscription = [
     "chrono/serde",
-    "serde",
+    "serde/derive",
 ]
 
 conversion = [


### PR DESCRIPTION
Introduced in #5764 

`cargo build -p shared` is ok because we have `derive` in root `Cargo.toml`
`cd lib/shared && cargo build` is not ok because we do not have `derive` feature for `serde`

Thanks to @FungusHumungus that reported to me about this in DM.