### PR TITLE
chore: Fix warning in version.sh script

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -10,6 +10,6 @@ set -euo pipefail
 #   An optional "nightly" suffix is added if the build channel
 #   is nightly.
 
-VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
+VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
 CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
 echo "$VERSION"


### PR DESCRIPTION
The new version of gawk warns about the escaped quote in
`scripts/version.sh` (`[\"]`):

```awk: cmd. line:1: warning: regexp escape sequence `\"' is not a known regexp operator```

This patch removes the superfluous escape from the quote.

Signed-off-by: Bruce Guenter <bruce@timber.io>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
