### PR TITLE
enhancement(remap): bare variable names

### DIFF
--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -197,7 +197,7 @@ fn benchmark_remap(c: &mut Criterion) {
             Remap::new(RemapConfig {
                 source: r#".number = to_int(.number)
                 .bool = to_bool(.bool)
-                .timestamp = parse_timestamp(.timestamp, format = "%d/%m/%Y:%H:%M:%S %z")
+                .timestamp = parse_timestamp(.timestamp, format: "%d/%m/%Y:%H:%M:%S %z")
                 "#
                 .to_owned(),
                 drop_on_err: true,

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -1,7 +1,7 @@
 // Root ------------------------------------------------------------------------
 
 program     = _{ SOI ~ NEWLINE* ~ expressions ~ NEWLINE* ~ EOI }
-expressions = _{ (expression ~ (EOE+ ~ expression)*)+ ~ EOE? }
+expressions = _{ expression ~ (EOE+ ~ expression)* ~ EOE? }
 expression  = _{ assignment | if_statement | boolean_expr | block }
 
 // Program Rules ---------------------------------------------------------------

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -64,7 +64,7 @@ path_segments    = ${
     | path_index+
 }
 path_segment     = ${ path_field | path_coalesce }
-path_field       = ${ ident | string }
+path_field       = ${ field | string }
 path_coalesce    = !{ "(" ~ path_field ~ ("|" ~ path_field)+ ~ ")" }
 path_index       =  { "[" ~ path_index_inner ~ "]" }
 path_index_inner =  { ("0" | ASCII_NONZERO_DIGIT) ~ ASCII_DIGIT* }
@@ -90,6 +90,7 @@ regex_flags =  { ("i" | "x" | "m")* }
 // Other ----------------------------------------------------------------------
 
 ident = @{ !reserved_keyword ~ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
+field = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 bang  =  { "!" }
 block =  { "{" ~ NEWLINE* ~ expressions ~ NEWLINE* ~ "}" }
 

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -89,7 +89,7 @@ regex_flags =  { ("i" | "x" | "m")* }
 
 // Other ----------------------------------------------------------------------
 
-ident = @{ !reserved_keyword ~ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
+ident = @{ !(reserved_keyword ~ !ASCII_ALPHANUMERIC) ~ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 field = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 bang  =  { "!" }
 block =  { "{" ~ NEWLINE* ~ expressions ~ NEWLINE* ~ "}" }

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -124,7 +124,6 @@ reserved_keyword = @{
     | "let"
     | "until"
     | "then"
-    | "match"
     | "impl"
     | "in"
     | "self"

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -101,6 +101,13 @@ regex_char  =  { !("/" | "\\") ~ ANY | "\\" ~ ANY }
 
 kv_pair = { string ~ ":" ~ expression }
 
+// NOTE: Not all of these keywords are actually in use, but we reserve them
+// anyway to avoid introducing breaking changes if/when we add features that
+// require these keywords.
+//
+// We'll gradually remove the non-used keywords from this list as we move
+// towards the final version of the language and decide not to implement
+// certain features.
 reserved_keyword = @{
     "if"
     | "else"

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -33,7 +33,7 @@ group    =  { "(" ~ expression ~ ")" }
 
 call      = ${ ident ~ bang? ~ "(" ~ arguments? ~ ")"  }
 arguments = !{ argument ~ ("," ~ argument)* }
-argument  =  { (ident ~ "=")? ~ expression }
+argument  =  { (ident ~ ":")? ~ expression }
 
 // Operations ------------------------------------------------------------------
 

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -111,6 +111,18 @@ reserved_keyword = @{
     | "break"
     | "continue"
     | "return"
+    | "as"
+    | "type"
+    | "let"
+    | "until"
+    | "then"
+    | "match"
+    | "impl"
+    | "in"
+    | "self"
+    | "this"
+    | "use"
+    | "std"
     | null
     | boolean
 }

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -26,7 +26,7 @@ if_condition = { boolean_expr | ("(" ~ expressions ~ ")") }
 
 primary  =  { value | variable | path | group }
 value    =  { string | float | integer | boolean | null | array | map | regex }
-variable = ${ "$" ~ ident ~ path_index* ~ ("." ~ path_segments)?  }
+variable = ${ ident ~ path_index* ~ ("." ~ path_segments)?  }
 group    =  { "(" ~ expression ~ ")" }
 
 // Function Call ---------------------------------------------------------------
@@ -89,7 +89,7 @@ regex_flags =  { ("i" | "x" | "m")* }
 
 // Other ----------------------------------------------------------------------
 
-ident = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
+ident = @{ !reserved_keyword ~ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 bang  =  { "!" }
 block =  { "{" ~ NEWLINE* ~ expressions ~ NEWLINE* ~ "}" }
 
@@ -100,6 +100,20 @@ regex_inner = @{ regex_char* }
 regex_char  =  { !("/" | "\\") ~ ANY | "\\" ~ ANY }
 
 kv_pair = { string ~ ":" ~ expression }
+
+reserved_keyword = @{
+    "if"
+    | "else"
+    | "for"
+    | "while"
+    | "loop"
+    | "abort"
+    | "break"
+    | "continue"
+    | "return"
+    | null
+    | boolean
+}
 
 WHITESPACE  = _{ " " | "\t" | ("\\" ~ NEWLINE) }
 

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -125,6 +125,7 @@ impl fmt::Display for Rule {
             regex_char,
             regex_flags,
             regex_inner,
+            reserved_keyword,
             rule_ident,
             rule_path,
             rule_string_inner,

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -95,6 +95,7 @@ impl fmt::Display for Rule {
             equality,
             expression,
             expressions,
+            field,
             float,
             group,
             ident: "",

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -40,7 +40,7 @@ mod tests {
         #[rustfmt::skip]
         let cases = vec![
             (r#".foo = null || "bar""#, Ok(()), Ok("bar".into())),
-            (r#"$foo = null || "bar""#, Ok(()), Ok("bar".into())),
+            (r#"foo = null || "bar""#, Ok(()), Ok("bar".into())),
             (r#".qux == .quux"#, Ok(()), Ok(true.into())),
             (
                 r#"if "foo" { "bar" }"#,
@@ -56,11 +56,11 @@ mod tests {
             //     r#".a.b.(c | d) == .e."f.g"[2].(h | i)"#,
             //     Ok(Value::Boolean(false)),
             // ),
-            ("$bar = true\n.foo = $bar", Ok(()), Ok(Value::Boolean(true))),
+            ("bar = true\n.foo = bar", Ok(()), Ok(Value::Boolean(true))),
             (
                 r#"{
-                    $foo = "foo"
-                    .foo = $foo + "bar"
+                    foo = "foo"
+                    .foo = foo + "bar"
                     .foo
                 }"#,
                 Ok(()),
@@ -105,13 +105,13 @@ mod tests {
                 Ok(()), Ok(4.into()),
             ),
             (
-                r#"if ($foo = true; $foo) { $foo } else { false }"#,
+                r#"if (foo = true; foo) { foo } else { false }"#,
                 Ok(()), Ok(true.into())
             ),
             (
-                r#"if ($foo = "sproink"
-                       $foo == "sproink") {
-                      $foo
+                r#"if (foo = "sproink"
+                       foo == "sproink") {
+                      foo
                    } else {
                      false
                    }"#,
@@ -168,18 +168,18 @@ mod tests {
             (
                 r#"
                     .foo.bar = "baz"
-                    $foo = .foo
+                    foo = .foo
                     .foo.bar
                 "#,
                 Ok(()),
                 Ok("baz".into()),
             ),
-            ("$foo = .foo\n$foo.bar", Ok(()), Ok("baz".into())),
-            ("$foo = .foo.qux\n$foo[1]", Ok(()), Ok(2.into())),
-            ("$foo = .foo.qux\n$foo[2].quux", Ok(()), Ok(true.into())),
+            ("foo = .foo\nfoo.bar", Ok(()), Ok("baz".into())),
+            ("foo = .foo.qux\nfoo[1]", Ok(()), Ok(2.into())),
+            ("foo = .foo.qux\nfoo[2].quux", Ok(()), Ok(true.into())),
             (
-                "$foo[0] = true",
-                Err(r#"remap error: parser error: path in variable assignment unsupported, use "$foo" without ".[0]""#),
+                "foo[0] = true",
+                Err(r#"remap error: parser error: path in variable assignment unsupported, use "foo" without ".[0]""#),
                 Ok(().into()),
             ),
             (r#"["foo", "bar", "baz"]"#, Ok(()), Ok(value!(["foo", "bar", "baz"]))),
@@ -247,7 +247,7 @@ mod tests {
                 Ok("bar".into()),
             ),
             (
-                r#"$foo = 1;$nork = $foo + 3;$nork"#,
+                r#"foo = 1;nork = foo + 3;nork"#,
                 Ok(()),
                 Ok(4.into()),
             ),
@@ -258,8 +258,8 @@ mod tests {
                 r#"
                     .result = {
                         .foo = true
-                        $bar = 5
-                        { "foo": .foo, "bar": $bar, "baz": "qux" }
+                        bar = 5
+                        { "foo": .foo, "bar": bar, "baz": "qux" }
                     }
 
                     { "result": .result }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -334,6 +334,7 @@ mod tests {
                 Ok(()),
                 Ok(value!([{ bar: true, qux: [1, 2, {quux: true}]}, null])),
             ),
+            (".if.loop.bar", Ok(()), Ok(value!(null))),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -295,41 +295,41 @@ mod tests {
                 Ok(().into()),
             ),
             (
-                "$foo, $err = fallible_func!()",
+                "foo, err = fallible_func!()",
                 Err(r#"remap error: assignment error: the variable "foo" does not need to handle the error-case, because its result is infallible"#),
                 Ok(().into()),
             ),
-            ("$foo, $err = fallible_func()", Ok(()), Ok(value!("function call error: failed!"))),
+            ("foo, err = fallible_func()", Ok(()), Ok(value!("function call error: failed!"))),
             (
-                "$foo, $err = map_printer({})",
+                "foo, err = map_printer({})",
                 Err(r#"remap error: assignment error: the variable "foo" does not need to handle the error-case, because its result is infallible"#),
                 Ok(().into()),
             ),
             (
-                ".foo.bar, $err = map_printer({})",
+                ".foo.bar, err = map_printer({})",
                 Err(r#"remap error: assignment error: the path ".foo.bar" does not need to handle the error-case, because its result is infallible"#),
                 Ok(().into()),
             ),
             (
                 "
-                    $foo, $err = fallible_func()
-                    [$foo, $err]
+                    foo, err = fallible_func()
+                    [foo, err]
                 ",
                 Ok(()),
                 Ok(value!([null, "function call error: failed!"])),
             ),
             (
                 "
-                    $foo, $err = fallible_func(true)
-                    [$foo, $err]
+                    foo, err = fallible_func(true)
+                    [foo, err]
                 ",
                 Ok(()),
                 Ok(value!([true, null])),
             ),
             (
                 "
-                    .foo.bar, $err = fallible_func(true)
-                    [.foo, $err]
+                    .foo.bar, err = fallible_func(true)
+                    [.foo, err]
                 ",
                 Ok(()),
                 Ok(value!([{ bar: true, qux: [1, 2, {quux: true}]}, null])),

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -336,6 +336,9 @@ mod tests {
             ),
             (".if.loop.bar", Ok(()), Ok(value!(null))),
             ("asyousee = true", Ok(()), Ok(value!(true))),
+            ("regex_printer(value: /foo/)", Ok(()), Ok(value!("regex: foo"))),
+            ("regex_printer(value:/foo/)", Ok(()), Ok(value!("regex: foo"))),
+            ("regex_printer(value  :   /foo/)", Ok(()), Ok(value!("regex: foo"))),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -335,6 +335,7 @@ mod tests {
                 Ok(value!([{ bar: true, qux: [1, 2, {quux: true}]}, null])),
             ),
             (".if.loop.bar", Ok(()), Ok(value!(null))),
+            ("asyousee = true", Ok(()), Ok(value!(true))),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -835,7 +835,7 @@ mod tests {
                 // This message isn't great, ideally I'd like "expected closing bracket"
                 vec![
                     " 1:48\n",
-                    "= expected assignment, if-statement, query, operator, path index, or block",
+                    "= expected operator or path index",
                 ],
             ),
             ("only_fields(.foo,)", vec![" 1:18\n", "= expected variable, argument, or path"]),
@@ -877,7 +877,7 @@ mod tests {
                 r#"/ab/ = .foo"#,
                 vec![
                     " 1:6\n",
-                    "= expected assignment, if-statement, query, operator, or block",
+                    "= expected operator",
                 ],
             ),
             (
@@ -906,6 +906,8 @@ mod tests {
                 "#,
                 vec!["remap error: parser error: cannot return regex from program"],
             ),
+            ("foo bar", vec![" 1:5\n", "= expected operator"]),
+            ("[true] [false]", vec![" 1:8\n", "= expected operator"]),
         ];
 
         for (source, exp_expressions) in cases {

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[error("cannot return regex from program")]
     RegexResult,
 
-    #[error(r#"path in variable assignment unsupported, use "${0}" without "{1}""#)]
+    #[error(r#"path in variable assignment unsupported, use "{0}" without "{1}""#)]
     VariableAssignmentPath(String, String),
 
     #[error("regex error")]
@@ -721,11 +721,11 @@ mod tests {
                 Ok(vec![Path::new(path::Path::new_unchecked(vec![])).into()]),
             ),
             ("..", vec![" 1:2\n", "= expected path segment"], Ok(vec![])),
-            (
-                ". bar",
-                vec![" 1:6\n", "= unknown parsing error"],
-                Ok(vec![]),
-            ),
+            // (
+            //     ". bar",
+            //     vec![" 1:6\n", "= unknown parsing error"],
+            //     Ok(vec![]),
+            // ),
             (
                 r#". "bar""#,
                 vec![" 1:2\n", "= expected path segment"], // TODO: improve error message
@@ -782,13 +782,13 @@ mod tests {
     #[test]
     fn check_parser_errors() {
         let cases = vec![
-            (
-                ".foo bar",
-                vec![
-                    " 1:9\n",
-                    "= unknown parsing error",
-                ],
-            ),
+            // (
+            //     ".foo bar",
+            //     vec![
+            //         " 1:9\n",
+            //         "= unknown parsing error",
+            //     ],
+            // ),
             (
                 ".=",
                 vec![
@@ -803,27 +803,13 @@ mod tests {
                     "= expected value, variable, path, group or function call, value, variable, path, group, !",
                 ],
             ),
-            (
-                ".foo = to_string",
-                vec![
-                    " 1:17\n",
-                    "= unknown parsing error",
-                ],
-            ),
-            (
-                r#"foo = "bar""#,
-                vec![
-                    " 1:4\n",
-                    "= unknown parsing error",
-                ],
-            ),
-            (
-                r#".foo.bar = "baz" and this"#,
-                vec![
-                    " 1:21\n",
-                    "= unknown parsing error",
-                ],
-            ),
+            // (
+            //     r#".foo.bar = "baz" and this"#,
+            //     vec![
+            //         " 1:21\n",
+            //         "= unknown parsing error",
+            //     ],
+            // ),
             (r#".foo.bar = "baz" +"#, vec![" 1:19", "= expected query"]),
             (
                 ".foo.bar = .foo.(bar |)",
@@ -853,9 +839,7 @@ mod tests {
                 ],
             ),
             ("only_fields(.foo,)", vec![" 1:18\n", "= expected variable, argument, or path"]),
-            ("only_fields(,)", vec![" 1:13\n", "= expected argument"]),
-            ("only_fields(.foo,)", vec![" 1:18\n", "= expected variable, argument, or path"]),
-            ("only_fields(,)", vec![" 1:13\n", "= expected argument"]),
+            // ("only_fields(,)", vec![" 1:13\n", "= expected variable, argument, or path"]),
             (
                 // Due to the explicit list of allowed escape chars our grammar
                 // doesn't actually recognize this as a string literal.
@@ -870,14 +854,14 @@ mod tests {
                 r#".foo."invalid \k escape".sequence = "foo""#,
                 vec![" 1:6\n", "= expected path segment"],
             ),
-            (
-                // Regexes can't be parsed as part of a path
-                r#".foo = split(.foo, ./[aa]/)"#,
-                vec![
-                    " 1:25\n",
-                    "= unknown parsing error",
-                ],
-            ),
+            // (
+            //     // Regexes can't be parsed as part of a path
+            //     r#".foo = split(.foo, ./[aa]/)"#,
+            //     vec![
+            //         " 1:25\n",
+            //         "= unknown parsing error",
+            //     ],
+            // ),
             (
                 // we cannot assign a regular expression to a field.
                 r#".foo = /ab/i"#,
@@ -901,7 +885,7 @@ mod tests {
                 vec!["remap error: parser error: cannot return regex from program"],
             ),
             (
-                r#"$foo = /ab/"#,
+                r#"foo = /ab/"#,
                 vec!["remap error: parser error: cannot return regex from program"],
             ),
             (
@@ -910,15 +894,15 @@ mod tests {
             ),
             (
                 r#"
-                    $foo = /ab/
-                    [$foo]
+                    foo = /ab/
+                    [foo]
                 "#,
                 vec!["remap error: parser error: cannot return regex from program"],
             ),
             (
                 r#"
-                    $foo = [/ab/]
-                    $foo
+                    foo = [/ab/]
+                    foo
                 "#,
                 vec!["remap error: parser error: cannot return regex from program"],
             ),

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -904,6 +904,29 @@ mod tests {
             ),
             ("foo bar", vec![" 1:5\n", "= expected operator"]),
             ("[true] [false]", vec![" 1:8\n", "= expected operator"]),
+
+            // reserved keywords
+            ("if = true", vec![" 1:4\n", "= expected query"]),
+            ("else = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("for = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("while = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("loop = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("abort = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("break = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("continue = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("return = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("as = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("type = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("let = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("until = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("then = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("match = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("impl = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("in = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("self = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("this = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("use = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
+            ("std = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
         ];
 
         for (source, exp_expressions) in cases {

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -920,7 +920,6 @@ mod tests {
             ("let = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
             ("until = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
             ("then = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
-            ("match = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
             ("impl = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
             ("in = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),
             ("self = true", vec![" 1:1\n", "= expected assignment, if-statement, query, or block"]),

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -571,7 +571,7 @@ impl<'a> Parser<'a> {
 
         match field.as_rule() {
             R::string => Ok(path::Field::Quoted(self.string_from_pair(field)?)),
-            R::ident => Ok(path::Field::Regular(field.as_str().to_owned())),
+            R::field => Ok(path::Field::Regular(field.as_str().to_owned())),
             _ => Err(e(R::path_field)),
         }
     }

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -721,11 +721,7 @@ mod tests {
                 Ok(vec![Path::new(path::Path::new_unchecked(vec![])).into()]),
             ),
             ("..", vec![" 1:2\n", "= expected path segment"], Ok(vec![])),
-            // (
-            //     ". bar",
-            //     vec![" 1:6\n", "= unknown parsing error"],
-            //     Ok(vec![]),
-            // ),
+            (". bar", vec![" 1:3\n", "= expected operator"], Ok(vec![])),
             (
                 r#". "bar""#,
                 vec![" 1:2\n", "= expected path segment"], // TODO: improve error message
@@ -782,13 +778,13 @@ mod tests {
     #[test]
     fn check_parser_errors() {
         let cases = vec![
-            // (
-            //     ".foo bar",
-            //     vec![
-            //         " 1:9\n",
-            //         "= unknown parsing error",
-            //     ],
-            // ),
+            (
+                ".foo bar",
+                vec![
+                    " 1:6\n",
+                    "= expected operator",
+                ],
+            ),
             (
                 ".=",
                 vec![
@@ -803,13 +799,13 @@ mod tests {
                     "= expected value, variable, path, group or function call, value, variable, path, group, !",
                 ],
             ),
-            // (
-            //     r#".foo.bar = "baz" and this"#,
-            //     vec![
-            //         " 1:21\n",
-            //         "= unknown parsing error",
-            //     ],
-            // ),
+            (
+                r#".foo.bar = "baz" and this"#,
+                vec![
+                    " 1:18\n",
+                    "= expected operator",
+                ],
+            ),
             (r#".foo.bar = "baz" +"#, vec![" 1:19", "= expected query"]),
             (
                 ".foo.bar = .foo.(bar |)",
@@ -839,7 +835,7 @@ mod tests {
                 ],
             ),
             ("only_fields(.foo,)", vec![" 1:18\n", "= expected variable, argument, or path"]),
-            // ("only_fields(,)", vec![" 1:13\n", "= expected variable, argument, or path"]),
+            ("only_fields(,)", vec![" 1:13\n", "= expected variable, argument, or path"]),
             (
                 // Due to the explicit list of allowed escape chars our grammar
                 // doesn't actually recognize this as a string literal.
@@ -854,14 +850,14 @@ mod tests {
                 r#".foo."invalid \k escape".sequence = "foo""#,
                 vec![" 1:6\n", "= expected path segment"],
             ),
-            // (
-            //     // Regexes can't be parsed as part of a path
-            //     r#".foo = split(.foo, ./[aa]/)"#,
-            //     vec![
-            //         " 1:25\n",
-            //         "= unknown parsing error",
-            //     ],
-            // ),
+            (
+                // Regexes can't be parsed as part of a path
+                r#".foo = split(.foo, ./[aa]/)"#,
+                vec![
+                    " 1:27\n",
+                    "= expected query",
+                ],
+            ),
             (
                 // we cannot assign a regular expression to a field.
                 r#".foo = /ab/i"#,

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -834,8 +834,8 @@ mod tests {
                     "= expected operator or path index",
                 ],
             ),
-            ("only_fields(.foo,)", vec![" 1:18\n", "= expected variable, argument, or path"]),
-            ("only_fields(,)", vec![" 1:13\n", "= expected variable, argument, or path"]),
+            ("only_fields(.foo,)", vec![" 1:18\n", "= expected argument or path"]),
+            ("only_fields(,)", vec![" 1:13\n", "= expected argument"]),
             (
                 // Due to the explicit list of allowed escape chars our grammar
                 // doesn't actually recognize this as a string literal.

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -206,11 +206,11 @@
   type = "remap"
   source = """
     .a = to_string(.in)
-    .b = to_string(value = .in)
+    .b = to_string(value: .in)
     .c = to_string(.nope)
-    .d = to_string(value = .nope)
+    .d = to_string(value: .nope)
     .e = to_string(.other)
-    .f = to_string(value = .other)
+    .f = to_string(value: .other)
   """
 [[tests]]
   name = "remap_function_arguments"
@@ -455,7 +455,7 @@
   inputs = []
   type = "remap"
   source = """
-    .a = format_timestamp(to_timestamp(.foo), format = "%+")
+    .a = format_timestamp(to_timestamp(.foo), format: "%+")
   """
 [[tests]]
   name = "remap_function_format_timestamp"
@@ -473,13 +473,13 @@
   inputs = []
   type = "remap"
   source = """
-    .a = contains(.foo, substring = .bar)
-    .b = contains(.bar, substring = "bar")
-    .c = contains(.bar, substring = "BAR", case_sensitive = true)
-    .d = contains(.bar, substring = "BAR", case_sensitive = false)
-    .e = contains(.foobar, substring = "oba")
-    .f = contains(.foobar, substring = "OBA", case_sensitive = true)
-    .g = contains(.foobar, substring = "OBA", case_sensitive = false)
+    .a = contains(.foo, substring: .bar)
+    .b = contains(.bar, substring: "bar")
+    .c = contains(.bar, substring: "BAR", case_sensitive = true)
+    .d = contains(.bar, substring: "BAR", case_sensitive = false)
+    .e = contains(.foobar, substring: "oba")
+    .f = contains(.foobar, substring: "OBA", case_sensitive = true)
+    .g = contains(.foobar, substring: "OBA", case_sensitive = false)
   """
 [[tests]]
   name = "remap_function_contains"
@@ -505,11 +505,11 @@
   inputs = []
   type = "remap"
   source = """
-    .a = starts_with(.foobar, substring = .foo)
-    .b = starts_with(.foobar, substring = "foo")
-    .c = starts_with(.foobar, substring = "bar")
-    .d = starts_with(.foobar, substring = "FOO", case_sensitive = true)
-    .e = starts_with(.foobar, substring = "FOO", case_sensitive = false)
+    .a = starts_with(.foobar, substring: .foo)
+    .b = starts_with(.foobar, substring: "foo")
+    .c = starts_with(.foobar, substring: "bar")
+    .d = starts_with(.foobar, substring: "FOO", case_sensitive: true)
+    .e = starts_with(.foobar, substring: "FOO", case_sensitive: false)
   """
 [[tests]]
   name = "remap_function_starts_with"
@@ -532,11 +532,11 @@
   inputs = []
   type = "remap"
   source = """
-    .a = ends_with(.foobar, substring = .bar)
-    .b = ends_with(.foobar, substring = "bar")
-    .c = ends_with(.foobar, substring = "foo")
-    .d = ends_with(.foobar, substring = "BAR", case_sensitive = true)
-    .e = ends_with(.foobar, substring = "BAR", case_sensitive = false)
+    .a = ends_with(.foobar, substring: .bar)
+    .b = ends_with(.foobar, substring: "bar")
+    .c = ends_with(.foobar, substring: "foo")
+    .d = ends_with(.foobar, substring: "BAR", case_sensitive: true)
+    .e = ends_with(.foobar, substring: "BAR", case_sensitive: false)
   """
 [[tests]]
   name = "remap_function_ends_with"
@@ -561,8 +561,8 @@
   source = """
     .a = slice(.foo + .bar, 1)
     .b = slice(.foo + .bar, 0, 1)
-    .c = slice(.foo + .bar, start = -2)
-    .d = slice(.foo + .bar, start = 1, end = -1)
+    .c = slice(.foo + .bar, start: -2)
+    .d = slice(.foo + .bar, start: 1, end: -1)
   """
 [[tests]]
   name = "remap_function_slice"
@@ -662,7 +662,7 @@
   type = "remap"
   source = """
     .a = parse_duration(.a, "ms")
-    .b = parse_duration("100ms", output = .b)
+    .b = parse_duration("100ms", output: .b)
   """
 [[tests]]
   name = "remap_function_parse_duration"
@@ -682,7 +682,7 @@
   inputs = []
   type = "remap"
   source = """
-    .a = format_number(.a, scale = 2, decimal_separator = ",", grouping_separator = ".")
+    .a = format_number(.a, scale: 2, decimal_separator: ",", grouping_separator: ".")
   """
 [[tests]]
   name = "remap_function_format_number"
@@ -727,8 +727,8 @@
   type = "remap"
   source = """
     .a = ceil(.num)
-    .b = ceil(.num, precision = 1)
-    .c = ceil(.num, precision = 2)
+    .b = ceil(.num, precision: 1)
+    .c = ceil(.num, precision: 2)
   """
 [[tests]]
   name = "remap_function_ceil"
@@ -749,8 +749,8 @@
   type = "remap"
   source = """
     .a = floor(.num)
-    .b = floor(.num, precision = 1)
-    .c = floor(.num, precision = 2)
+    .b = floor(.num, precision: 1)
+    .c = floor(.num, precision: 2)
   """
 [[tests]]
   name = "remap_function_floor"
@@ -771,8 +771,8 @@
   type = "remap"
   source = """
     .a = round(.num)
-    .b = round(.num, precision = 1)
-    .c = round(.num, precision = 2)
+    .b = round(.num, precision: 1)
+    .c = round(.num, precision: 2)
   """
 [[tests]]
   name = "remap_function_round"
@@ -873,8 +873,8 @@
   inputs = []
   type = "remap"
   source = """
-    .foo = truncate("foobar", limit = 3)
-    .bar = truncate("foobar", limit = 4, ellipsis = true)
+    .foo = truncate("foobar", limit: 3)
+    .bar = truncate("foobar", limit: 4, ellipsis: true)
   """
 [[tests]]
   name = "remap_function_truncate"
@@ -910,7 +910,7 @@
   type = "remap"
   source = """
     .grokked = parse_grok(.message, "%{TIMESTAMP_ISO8601:timestamp} (%{EMAILADDRESS:email}|%{LOGLEVEL:level}) %{GREEDYDATA:message}")
-    .grokked2 = parse_grok(.message, "%{TIMESTAMP_ISO8601:timestamp} (%{EMAILADDRESS:email}|%{LOGLEVEL:level}) %{GREEDYDATA:message}", remove_empty = true)
+    .grokked2 = parse_grok(.message, "%{TIMESTAMP_ISO8601:timestamp} (%{EMAILADDRESS:email}|%{LOGLEVEL:level}) %{GREEDYDATA:message}", remove_empty: true)
     """
 [[tests]]
   name = "remap_function_parse_grok"
@@ -958,9 +958,9 @@
   inputs = []
   type = "remap"
   source = """
-    .a = ip_cidr_contains(cidr = "192.168.0.0/16", value = "192.168.10.2")
-    .b = ip_cidr_contains(cidr = "192.168.0.0/16", value = "192.169.10.2")
-    .c = ip_cidr_contains(cidr = "2404:6800:4003:c02::/64", value = "2404:6800:4003:c02::aaaa")
+    .a = ip_cidr_contains(cidr: "192.168.0.0/16", value: "192.168.10.2")
+    .b = ip_cidr_contains(cidr: "192.168.0.0/16", value: "192.169.10.2")
+    .c = ip_cidr_contains(cidr: "2404:6800:4003:c02::/64", value: "2404:6800:4003:c02::aaaa")
     .d = ip_cidr_contains("2404:6800:4003:c02::/64", "2404:6800:4004:c02::aaaa")
   """
 [[tests]]
@@ -1086,7 +1086,7 @@
   type = "remap"
   drop_on_err = true
   source = """
-    assert(.foo, message = "assert failed")
+    assert(.foo, message: "assert failed")
     .check = "checked"
   """
 [[tests]]
@@ -1106,7 +1106,7 @@
   type = "remap"
   drop_on_err = true
   source = """
-    assert(.foo, message = "assert failed")
+    assert(.foo, message: "assert failed")
   """
 [[tests]]
   name = "remap_function_assert_fail"
@@ -1121,7 +1121,7 @@
   inputs=[]
   type = "remap"
   source = """
-    log(.foo, level="info")
+    log(.foo, level:"info")
   """
 [[tests]]
   name = "remap_function_log"
@@ -1141,7 +1141,7 @@
   source = """
     .foo = parse_json(.foo)
     .bar = parse_json(.bar)
-    merge(.bar, .foo, deep = true)
+    merge(.bar, .foo, deep: true)
   """
 [[tests]]
   name = "remap_function_merge"
@@ -1196,11 +1196,11 @@
   inputs = []
   type = "remap"
   source = """
-    .a = redact(.input, filters = ["pattern"], patterns = ["hello"])
-    .b = redact(.input, filters = ["pattern"], patterns = ["hello", "wor"])
-    .c = redact(.input, filters = ["pattern"], patterns = [/world|universe/])
-    .d = redact(.input, filters = ["pattern"], patterns = [])
-    .e = redact(.input, filters = ["pattern"], patterns = ["hello", /[uieao]/])
+    .a = redact(.input, filters: ["pattern"], patterns: ["hello"])
+    .b = redact(.input, filters: ["pattern"], patterns: ["hello", "wor"])
+    .c = redact(.input, filters: ["pattern"], patterns: [/world|universe/])
+    .d = redact(.input, filters: ["pattern"], patterns: [])
+    .e = redact(.input, filters: ["pattern"], patterns: ["hello", /[uieao]/])
   """
 [[tests]]
   name = "remap_function_redact"
@@ -1222,8 +1222,8 @@
   inputs = []
   type = "remap"
   source = """
-    .a = replace("foo", pattern = "o", with = "bar", 1)
-    .b = replace("foo", pattern = /o/, with = "bar")
+    .a = replace("foo", pattern: "o", with: "bar", 1)
+    .b = replace("foo", pattern: /o/, with: "bar")
   """
 [[tests]]
   name = "remap_function_replace"
@@ -1242,8 +1242,8 @@
   inputs = []
   type = "remap"
   source = """
-    .pass = ok(.a = .a * 3)
-    .fail = ok(.b = true * false)
+    .pass = ok(.a: .a * 3)
+    .fail = ok(.b: true * false)
   """
 [[tests]]
   name = "remap_function_ok"
@@ -1312,7 +1312,7 @@
   type = "remap"
   source = """
     .a = parse_aws_vpc_flow_log(.a)
-    .b = parse_aws_vpc_flow_log(.b, format = "instance_id interface_id srcaddr dstaddr pkt_srcaddr pkt_dstaddr")
+    .b = parse_aws_vpc_flow_log(.b, format: "instance_id interface_id srcaddr dstaddr pkt_srcaddr pkt_dstaddr")
   """
 [[tests]]
   name = "remap_function_parse_aws_vpc_flow_log"
@@ -1476,7 +1476,7 @@
   inputs = []
   type = "remap"
   source = '''
-    . = parse_key_value(.message, key_value_delimiter = "=", field_delimiter = " ")
+    . = parse_key_value(.message, key_value_delimiter: "=", field_delimiter: " ")
   '''
 [[tests]]
   name = "remap_function_parse_key_value"

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -1242,8 +1242,8 @@
   inputs = []
   type = "remap"
   source = """
-    .pass = ok(.a: .a * 3)
-    .fail = ok(.b: true * false)
+    .pass = ok(.a = .a * 3)
+    .fail = ok(.b = true * false)
   """
 [[tests]]
   name = "remap_function_ok"


### PR DESCRIPTION
This PR changes variables names from `$foo` to `foo`, that is, you provide an ident without the leading `$` sign.

The downside of this change is that we have to reserve some keywords in advance so that we can use them later without breaking people's programs. I added a few (some which we'll likely never use), but feel free to suggest others that would be good to reserve for now. I'd rather be conservative to start, and then gradually reduce this list as time goes on.

closes #5842