### PR TITLE
feat(remap): add for-loop statement

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -2,7 +2,7 @@
 
 program     = _{ SOI ~ NEWLINE* ~ expressions ~ NEWLINE* ~ EOI }
 expressions = _{ (expression ~ (EOE+ ~ expression)*)+ ~ EOE? }
-expression  = _{ assignment | if_statement | boolean_expr | block }
+expression  = _{ assignment | if_statement | for_loop | boolean_expr | block }
 
 // Program Rules ---------------------------------------------------------------
 
@@ -15,6 +15,8 @@ rule_string_inner = _{ SOI ~ string_inner ~ EOI }
 assignment   = { target ~ "=" ~ expression }
 if_statement = { "if" ~ if_condition ~ block ~ ("else if" ~ if_condition ~ block)* ~ ("else" ~ block)? }
 if_condition = { boolean_expr | ("(" ~ expressions ~ ")") }
+
+for_loop = { "for" ~ variable ~ ("," ~ variable)? ~ "in" ~ expression ~ block}
 
 // Primary ---------------------------------------------------------------------
 

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -125,6 +125,7 @@ impl fmt::Display for Rule {
             regex_flags,
             regex_inner,
             rule_ident,
+            for_loop: "for-loop",
             rule_path,
             rule_string_inner,
             string,

--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -7,6 +7,7 @@ mod arithmetic;
 mod array;
 mod assignment;
 mod block;
+mod for_loop;
 pub(crate) mod function;
 mod if_statement;
 mod literal;
@@ -21,6 +22,7 @@ pub use arithmetic::Arithmetic;
 pub use array::Array;
 pub use assignment::{Assignment, Target};
 pub use block::Block;
+pub use for_loop::ForLoop;
 pub use function::Function;
 pub use if_statement::IfStatement;
 pub use literal::Literal;
@@ -52,6 +54,9 @@ pub enum Error {
 
     #[error("if-statement error")]
     IfStatement(#[from] if_statement::Error),
+
+    #[error("for-loop error")]
+    ForLoop(#[from] for_loop::Error),
 }
 
 pub trait Expression: Send + Sync + fmt::Debug + dyn_clone::DynClone {
@@ -166,6 +171,7 @@ expression_dispatch![
     Not,
     Path,
     Variable,
+    ForLoop,
 ];
 
 impl<T: Into<Value>> From<T> for Expr {

--- a/lib/remap-lang/src/expression/for_loop.rs
+++ b/lib/remap-lang/src/expression/for_loop.rs
@@ -1,0 +1,129 @@
+use super::Error as E;
+use crate::{expression::Variable, state, value, Expr, Expression, Object, Result, TypeDef, Value};
+
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
+pub enum Error {
+    #[error("collection error")]
+    Collection(#[from] value::Error),
+
+    #[error("iterating over a map requires two variables, one for the key and one for the value")]
+    MissingMapVariable,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForLoop {
+    collection: Box<Expr>,
+
+    // map key or array value
+    var1: Variable,
+
+    // map value or array index
+    var2: Option<Variable>,
+
+    // block
+    expression: Box<Expr>,
+}
+
+impl ForLoop {
+    pub fn new(
+        collection: Expr,
+        var1: Variable,
+        var2: Option<Variable>,
+        expression: Expr,
+        state: &state::Compiler,
+    ) -> Result<Self> {
+        let type_def = collection.type_def(state);
+
+        // We expect this to resolve to exactly an array or a map, so that we
+        // know what to assign to the first (and optional second) variable.
+        if !type_def.kind.is_array() && !type_def.kind.is_map() {
+            return Err(E::from(Error::Collection(value::Error::Expected(
+                value::Kind::Array | value::Kind::Map,
+                type_def.kind,
+            )))
+            .into());
+        }
+
+        // When dealing with a map, the second variable identifier is required.
+        if type_def.kind.is_map() && var2.is_none() {
+            return Err(E::from(Error::MissingMapVariable).into());
+        }
+
+        let collection = Box::new(collection);
+        let expression = Box::new(expression);
+
+        Ok(Self {
+            collection,
+            var1,
+            var2,
+            expression,
+        })
+    }
+}
+
+impl Expression for ForLoop {
+    fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
+        let collection = self.collection.execute(state, object)?;
+
+        match collection {
+            Value::Array(array) => {
+                array
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        // If we have a second variable, the first becomes the
+                        // index, otherwise it's the value.
+                        let var_value = match &self.var2 {
+                            Some(var2) => var2,
+                            None => &self.var1,
+                        };
+
+                        state
+                            .variables_mut()
+                            .insert(var_value.ident().to_owned(), value);
+
+                        if self.var2.is_some() {
+                            state
+                                .variables_mut()
+                                .insert(self.var1.ident().to_owned(), (index as i64).into());
+                        }
+
+                        self.expression.execute(state, object)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                // purge variables after loop ends
+                state.variables_mut().remove(&self.var1.ident().to_owned());
+                if let Some(var2) = &self.var2 {
+                    state.variables_mut().remove(&var2.ident().to_owned());
+                }
+            }
+
+            Value::Map(map) => {
+                map.into_iter()
+                    .map(|(key, value)| {
+                        state
+                            .variables_mut()
+                            .insert(self.var1.ident().to_owned(), key.into());
+
+                        if let Some(var2) = &self.var2 {
+                            state.variables_mut().insert(var2.ident().to_owned(), value);
+                        }
+
+                        self.expression.execute(state, object)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+            }
+
+            _ => unreachable!("value is map or array"),
+        }
+
+        Ok(().into())
+    }
+
+    fn type_def(&self, state: &state::Compiler) -> TypeDef {
+        self.expression
+            .type_def(state)
+            .with_constraint(value::Kind::Null)
+    }
+}

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -281,6 +281,51 @@ mod tests {
                     "g": r#"{"1": Integer(1), "true": Boolean(true)}"#,
                 })),
             ),
+            (
+                r#"
+                    $result = ""
+                    for $value in ["foo", "bar"] {
+                        $result = $result + $value
+                    }
+                    $result
+                "#,
+                Ok(()),
+                Ok(value!("foobar")),
+            ),
+            (
+                r#"
+                    $count = 0
+                    $result = ""
+                    for $index, $value in ["foo", "bar"] {
+                        $count = $count + $index + 1
+                        $result = $result + $value
+                    }
+                    $result + " " + $count
+                "#,
+                Ok(()),
+                Ok(value!("foobar 3")),
+            ),
+            (
+                r#"
+                    $keys = ""
+                    $values = ""
+                    for $key, $value in { "foo": "bar", "baz": true } {
+                        $keys = $keys + $key
+                        $values = $values + $value
+                    }
+
+                    $keys + " " + $values
+                "#,
+                Ok(()),
+                Ok(value!("bazfoo truebar")),
+            ),
+            (
+                r#"
+                    for $value in { "foo": "bar" } { true }
+                "#,
+                Err("remap error: for-loop error: iterating over a map requires two variables, one for the key and one for the value"),
+                Ok(().into()),
+            ),
         ];
 
         for (script, compile_expected, runtime_expected) in cases {


### PR DESCRIPTION
This is:

1. A _proof of concept_, since we aren't even sure we want to have this in the language, but I had it lying around, so wanted to push this up given the discussion happening in #5852.
2. A _work in progress_, as some tests are still missing (and the type-def impl isn't accurate yet).

Here're some examples of what works right now:

**array without index**

```rust
for value in ["foo", "bar"] {
	value // "foo", "bar"
}
```

**array with index**

```rust
for index, value in ["foo", "bar"] {
	index // 0, 1
	value // "foo", "bar"
}
```

**map**

```rust
for key, value in { "foo": "bar" } {
	key // "foo"
	value // "bar"
}
```

Some other relevant points:

* You **have** to provide an _exact_ array or map type for the loop to compile (e.g. use `to_map` or `to_array` if needed).
* You **have** to provide a variable, _not a path_ to assign the collection values to.
* For now, the loop always returns `null`, but in the spirit of this being an expression-based language, I'd like it to return the final value of the iteration.
* There are no control-flow statements such as `continue` and `break` _yet_. It's questionable if we want those or not (similarly to how it's questionable if we want to have for-loops at all).