### PR TITLE
feat(remap): support "abort on error" bang-function-calls

### DIFF
--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -25,7 +25,7 @@ group    =  { "(" ~ expression ~ ")" }
 
 // Function Calls --------------------------------------------------------------
 
-call           = ${ ident ~ "(" ~ arguments? ~ ")"  }
+call           = ${ ident ~ bang? ~ "(" ~ arguments? ~ ")"  }
 arguments      = !{ argument ~ ("," ~ argument)* }
 argument       =  { (ident ~ "=")? ~ expression }
 
@@ -84,6 +84,7 @@ regex_flags =  { ("i" | "x" | "m")* }
 // Other ----------------------------------------------------------------------
 
 ident  = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
+bang   =  { "!" }
 target = _{ variable | path }
 block  =  { "{" ~ NEWLINE* ~ expressions ~ NEWLINE* ~ "}" }
 

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -83,6 +83,7 @@ impl fmt::Display for Rule {
             arguments,
             array,
             assignment,
+            bang: "",
             block,
             boolean,
             boolean_expr,


### PR DESCRIPTION
This PR moves us closer to resolving #5479.

This adds support for "bang-function-calls" which signals to the compiler that any error raised by the function should result in an early termination of the program at runtime.

```rust
.foo = to_int(true) // infallible
.foo = parse_json(...) // fallible, can error implicitly at runtime, will be disallowed in the future
.foo = parse_json!(...) // fallible, can error explicitly at runtime, abort program execution
```

I opted to make it a compile-time error when you provide a bang-function-call for an infallible function, as this would incorrectly convey to readers of the source that a function might fail, while in reality it cannot:

```rust
.foo = to_int!(true)
// remap error:
// error for function "to_int":
// cannot mark infallible function as "abort on error", remove the "!" signature
```

Note that this PR doesn't actually do anything with the "abort on error" information yet because that is actually the way it works currently already. What this does, is adding the plumbing for when we "flip the switch" and expect all errors to be handled at compile-time, such that there are no implicit runtime errors any more.

closes #5863.