### PR TITLE
fix(docker_logs source): Fix HTTP and HTTPS URL

### DIFF
--- a/docs/reference/components/sources/docker_logs.cue
+++ b/docs/reference/components/sources/docker_logs.cue
@@ -101,12 +101,19 @@ components: sources: docker_logs: {
 				The Docker host to connect to. Use an HTTPS URL to enable TLS encryption.
 				If absent, Vector will try to use `DOCKER_HOST` enviroment variable.
 				If `DOCKER_HOST` is also absent, Vector will use default Docker local socket
-				(`/var/run/docker.sock` on Unix flatforms, `\\\\.\\pipe\\docker_engine` on Windows).
+				(`/var/run/docker.sock` on Unix flatforms, `//./pipe/docker_engine` on Windows).
 				"""
 			required: false
 			type: string: {
 				default: null
-				examples: ["http://localhost:2375", "https://localhost:2376", "/var/run/docker.sock", "\\\\.\\pipe\\docker_engine"]
+				examples: [
+					"http://localhost:2375",
+					"https://localhost:2376",
+					"unix:///var/run/docker.sock",
+					"npipe:////./pipe/docker_engine",
+					"/var/run/docker.sock",
+					"//./pipe/docker_engine",
+				]
 			}
 		}
 		tls: {

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -1052,7 +1052,7 @@ fn get_authority(url: &str) -> Result<String, Error> {
     url.parse::<Uri>()
         .ok()
         .and_then(|uri| uri.authority().map(<_>::to_string))
-        .ok_or_else(|| Error::NoHost)
+        .ok_or(Error::NoHost)
 }
 
 fn docker(host: Option<String>, tls: Option<DockerTlsConfig>) -> crate::Result<Docker> {


### PR DESCRIPTION
close #4526

Documentation of Bollard suggested that passing in an URL with http:// should work, but in fact it doesn't, Bollard only trims tcp://.

