### PR TITLE
chore(kafka sink): Revert "use signal instead timeout (#5007)"

### DIFF
--- a/src/sinks/kafka.rs
+++ b/src/sinks/kafka.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use futures::{
     channel::oneshot::Canceled, future::BoxFuture, ready, stream::FuturesUnordered, FutureExt,
-    Sink, StreamExt, TryFutureExt,
+    Sink, Stream, TryFutureExt,
 };
 use rdkafka::{
     consumer::{BaseConsumer, Consumer},
@@ -29,7 +29,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tokio::{sync::Notify, time::Duration};
+use tokio::time::{delay_for, Duration};
 
 // Maximum number of futures blocked by [send_result](https://docs.rs/rdkafka/0.24.0/rdkafka/producer/future_producer/struct.FutureProducer.html#method.send_result)
 const SEND_RESULT_LIMIT: usize = 5;
@@ -83,7 +83,6 @@ pub struct KafkaSink {
     topic: Template,
     key_field: Option<String>,
     encoding: EncodingConfig<Encoding>,
-    flush_signal: Arc<Notify>,
     delivery_fut: FuturesUnordered<BoxFuture<'static, (usize, Result<DeliveryFuture, KafkaError>)>>,
     in_flight: FuturesUnordered<
         BoxFuture<'static, (usize, Result<Result<(i32, i64), KafkaError>, Canceled>)>,
@@ -232,7 +231,6 @@ impl KafkaSink {
             topic: Template::try_from(config.topic).context(TopicTemplate)?,
             key_field: config.key_field,
             encoding: config.encoding,
-            flush_signal: Arc::new(Notify::new()),
             delivery_fut: FuturesUnordered::new(),
             in_flight: FuturesUnordered::new(),
             acker,
@@ -243,22 +241,23 @@ impl KafkaSink {
     }
 
     fn poll_delivery_fut(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        loop {
-            match ready!(self.delivery_fut.poll_next_unpin(cx)) {
-                Some((seqno, result)) => self.in_flight.push(Box::pin(async move {
-                    let result = match result {
-                        Ok(fut) => {
-                            fut.map_ok(|result| result.map_err(|(error, _owned_message)| error))
-                                .await
-                        }
-                        Err(error) => Ok(Err(error)),
-                    };
+        while !self.delivery_fut.is_empty() {
+            let result = Pin::new(&mut self.delivery_fut).poll_next(cx);
+            let (seqno, result) = ready!(result).expect("`delivery_fut` is endless stream");
+            self.in_flight.push(Box::pin(async move {
+                let result = match result {
+                    Ok(fut) => {
+                        fut.map_ok(|result| result.map_err(|(error, _owned_message)| error))
+                            .await
+                    }
+                    Err(error) => Ok(Err(error)),
+                };
 
-                    (seqno, result)
-                })),
-                None => return Poll::Ready(()),
-            }
+                (seqno, result)
+            }));
         }
+
+        Poll::Ready(())
     }
 }
 
@@ -295,15 +294,14 @@ impl Sink<Event> for KafkaSink {
         self.seq_head += 1;
 
         let producer = Arc::clone(&self.producer);
-        let flush_signal = Arc::clone(&self.flush_signal);
         self.delivery_fut.push(Box::pin(async move {
             let mut record = FutureRecord::to(&topic).key(&key).payload(&body[..]);
             if let Some(timestamp) = timestamp_ms {
                 record = record.timestamp(timestamp);
             }
 
-            debug!(message = "Sending event.", count = 1);
             let result = loop {
+                debug!(message = "Sending event.", count = 1);
                 match producer.send_result(record) {
                     Ok(future) => break Ok(future),
                     // Try again if queue is full.
@@ -314,7 +312,7 @@ impl Sink<Event> for KafkaSink {
                     {
                         debug!(message = "The rdkafka queue full.", %error, %seqno, internal_log_rate_secs = 1);
                         record = future_record;
-                        let _ = flush_signal.notified().await;
+                        delay_for(Duration::from_millis(10)).await;
                     }
                     Err((error, _)) => break Err(error),
                 }
@@ -326,38 +324,35 @@ impl Sink<Event> for KafkaSink {
         Ok(())
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_delivery_fut(cx));
+
         let this = Pin::into_inner(self);
-
-        while !this.delivery_fut.is_empty() || !this.in_flight.is_empty() {
-            while let Poll::Ready(Some(item)) = this.in_flight.poll_next_unpin(cx) {
-                this.flush_signal.notify();
-                match item {
-                    (seqno, Ok(result)) => {
-                        match result {
-                            Ok((partition, offset)) => {
-                                trace!(message = "Produced message.", ?partition, ?offset)
-                            }
-                            Err(error) => error!(message = "Kafka error.", %error),
-                        };
-
-                        this.pending_acks.insert(seqno);
-
-                        let mut num_to_ack = 0;
-                        while this.pending_acks.remove(&this.seq_tail) {
-                            num_to_ack += 1;
-                            this.seq_tail += 1
+        while !this.in_flight.is_empty() {
+            match ready!(Pin::new(&mut this.in_flight).poll_next(cx)) {
+                Some((seqno, Ok(result))) => {
+                    match result {
+                        Ok((partition, offset)) => {
+                            trace!(message = "Produced message.", ?partition, ?offset)
                         }
-                        this.acker.ack(num_to_ack);
-                    }
-                    (_seqno, Err(Canceled)) => {
-                        error!(message = "Request canceled.");
-                        return Poll::Ready(Err(()));
-                    }
-                }
-            }
+                        Err(error) => error!(message = "Kafka error.", %error),
+                    };
 
-            ready!(this.poll_delivery_fut(cx));
+                    this.pending_acks.insert(seqno);
+
+                    let mut num_to_ack = 0;
+                    while this.pending_acks.remove(&this.seq_tail) {
+                        num_to_ack += 1;
+                        this.seq_tail += 1
+                    }
+                    this.acker.ack(num_to_ack);
+                }
+                Some((_, Err(Canceled))) => {
+                    error!(message = "Request canceled.");
+                    return Poll::Ready(Err(()));
+                }
+                None => break,
+            }
         }
 
         Poll::Ready(Ok(()))


### PR DESCRIPTION
This reverts commit 6ac8e131f937d3ffe7ea8d5ac137cf939979701a.

Signed-off-by: Luke Steensen <luke.steensen@gmail.com>

Surprisingly, this commit seems to have cost us about ~50% of our performance from the kafka sink. I'm not entirely sure why yet, but I suspect we are not using the `Notify` API correctly. It's worth noting that this API changed in tokio 1.0, and it seems like the behavior we want is [`notify_waiters`](https://docs.rs/tokio/1.0.1/tokio/sync/struct.Notify.html#method.notify_waiters), which is not present in our current version. It's likely that the current version stores a permit when there are no waiters, which throws off subsequent wakeups/notifications.