### PR TITLE
enhancement(graphql api): FileSourceMetrics Relay connections

### DIFF
--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -664,6 +664,149 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Information to aid in pagination.",
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of edges.",
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FileSourceMetricFileEdge",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Total result set count",
+              "isDeprecated": false,
+              "name": "totalCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FileSourceMetricFileConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": "An edge in a connection.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The item at the end of the edge",
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FileSourceMetricFile",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A cursor for use in pagination",
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FileSourceMetricFileEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
               "description": "File metrics",
               "isDeprecated": false,
               "name": "files",
@@ -671,17 +814,9 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "FileSourceMetricFile",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "OBJECT",
+                  "name": "FileSourceMetricFileConnection",
+                  "ofType": null
                 }
               }
             },

--- a/lib/vector-api-client/tests/queries/file_source_metrics.graphql
+++ b/lib/vector-api-client/tests/queries/file_source_metrics.graphql
@@ -1,5 +1,5 @@
 query FileSourceMetricsQuery($after: String, $before: String, $first: Int, $last: Int) {
-    sources(after: $after, before: $before, first: $first, last: $last) {
+    sources {
         __typename
         edges {
             node {
@@ -7,10 +7,14 @@ query FileSourceMetricsQuery($after: String, $before: String, $first: Int, $last
                     __typename
                     ...on FileSourceMetrics {
                         __typename
-                        files {
-                            name
-                            processedEventsTotal {
-                                processedEventsTotal
+                        files(after: $after, before: $before, first: $first, last: $last) {
+                            edges {
+                                node {
+                                    name
+                                    processedEventsTotal {
+                                        processedEventsTotal
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -873,8 +873,9 @@ mod tests {
                 file_source_metrics_query::FileSourceMetricsQuerySourcesEdgesNodeMetricsOn::FileSourceMetrics(
                     file_source_metrics_query::FileSourceMetricsQuerySourcesEdgesNodeMetricsOnFileSourceMetrics { files, .. },
                 ) => {
-                    assert_eq!(files[0].name, path);
-                    assert_eq!(files[0].processed_events_total.as_ref().unwrap().processed_events_total as usize, lines.len());
+                    let node = &files.edges.iter().flatten().next().unwrap().as_ref().unwrap().node;
+                    assert_eq!(node.name, path);
+                    assert_eq!(node.processed_events_total.as_ref().unwrap().processed_events_total as usize, lines.len());
                 }
                 _ => panic!("not a file source"),
             }


### PR DESCRIPTION
Adds Relay-style connections to `FileSourceMetrics.files`:

```gql
{
  sources {
    totalCount
    edges {
      node {
        name
        metrics {
          __typename
          processedBytesTotal {
            processedBytesTotal
          }
          processedEventsTotal {
            processedEventsTotal
          }
          ... on FileSourceMetrics {
            files {
              edges {
                cursor
                node {
                  name
                  processedBytesTotal {
                    processedBytesTotal
                  }
                  processedEventsTotal {
                    processedEventsTotal
                  }
                }
              }
              pageInfo {
                startCursor
                endCursor
                hasPreviousPage
                hasNextPage
              }
              totalCount
            }
          }
        }
      }
    }
  }
}
```

Returning (example):

```json
{
  "data": {
    "sources": {
      "edges": [
        {
          "node": {
            "metrics": {
              "__typename": "GenericSourceMetrics",
              "processedBytesTotal": null,
              "processedEventsTotal": {
                "processedEventsTotal": 21253
              }
            },
            "name": "gen1"
          }
        },
        {
          "node": {
            "metrics": {
              "__typename": "FileSourceMetrics",
              "files": {
                "edges": [
                  {
                    "cursor": "Q3Vyc29yOjA",
                    "node": {
                      "name": "/var/log/wifi.log",
                      "processedBytesTotal": {
                        "processedBytesTotal": 13608
                      },
                      "processedEventsTotal": {
                        "processedEventsTotal": 96
                      }
                    }
                  }
                ],
                "pageInfo": {
                  "endCursor": "Q3Vyc29yOjA",
                  "hasNextPage": false,
                  "hasPreviousPage": false,
                  "startCursor": "Q3Vyc29yOjA"
                },
                "totalCount": 1
              },
              "processedBytesTotal": {
                "processedBytesTotal": 13608
              },
              "processedEventsTotal": {
                "processedEventsTotal": 96
              }
            },
            "name": "wifi"
          }
        }
      ],
      "totalCount": 2
    }
  }
}
```

Closes #5827.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
