### PR TITLE
feat(remap): error-return-value error handling pattern

### DIFF
--- a/lib/remap-cli/src/cmd.rs
+++ b/lib/remap-cli/src/cmd.rs
@@ -82,7 +82,7 @@ fn repl(object: Vec<Value>) -> Result<(), Error> {
 fn execute(object: &mut impl Object, program: &str) -> Result<Value, Error> {
     let state = state::Program::default();
     let mut runtime = Runtime::new(state);
-    let program = Program::new(program, &remap_functions::all(), None)?;
+    let program = Program::new(program, &remap_functions::all(), None, true)?;
 
     runtime.execute(object, &program).map_err(Into::into)
 }

--- a/lib/remap-cli/src/repl.rs
+++ b/lib/remap-cli/src/repl.rs
@@ -111,7 +111,7 @@ fn resolve(object: Option<&mut impl Object>, runtime: &mut Runtime, program: &st
         Some(object) => object,
     };
 
-    let program = match Program::new(program, &remap_functions::all(), None) {
+    let program = match Program::new(program, &remap_functions::all(), None, true) {
         Ok(program) => program,
         Err(err) => return err.to_string(),
     };

--- a/lib/remap-lang/grammar.pest
+++ b/lib/remap-lang/grammar.pest
@@ -10,9 +10,15 @@ rule_path         = _{ SOI ~ path ~ EOI }
 rule_ident        = _{ SOI ~ ident ~ EOI }
 rule_string_inner = _{ SOI ~ string_inner ~ EOI }
 
-// Statements ------------------------------------------------------------------
+// Assignment -------------------------------------------------------------------
 
-assignment   = { target ~ "=" ~ expression }
+assignment        =  { target ~ "=" ~ expression }
+target            = _{ target_infallible | target_regular }
+target_regular    = _{ variable | path }
+target_infallible =  { target_regular ~ "," ~ target_regular }
+
+// If Statement -----------------------------------------------------------------
+
 if_statement = { "if" ~ if_condition ~ block ~ ("else if" ~ if_condition ~ block)* ~ ("else" ~ block)? }
 if_condition = { boolean_expr | ("(" ~ expressions ~ ")") }
 
@@ -23,11 +29,11 @@ value    =  { string | float | integer | boolean | null | array | map | regex }
 variable = ${ "$" ~ ident ~ path_index* ~ ("." ~ path_segments)?  }
 group    =  { "(" ~ expression ~ ")" }
 
-// Function Calls --------------------------------------------------------------
+// Function Call ---------------------------------------------------------------
 
-call           = ${ ident ~ bang? ~ "(" ~ arguments? ~ ")"  }
-arguments      = !{ argument ~ ("," ~ argument)* }
-argument       =  { (ident ~ "=")? ~ expression }
+call      = ${ ident ~ bang? ~ "(" ~ arguments? ~ ")"  }
+arguments = !{ argument ~ ("," ~ argument)* }
+argument  =  { (ident ~ "=")? ~ expression }
 
 // Operations ------------------------------------------------------------------
 
@@ -83,10 +89,9 @@ regex_flags =  { ("i" | "x" | "m")* }
 
 // Other ----------------------------------------------------------------------
 
-ident  = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
-bang   =  { "!" }
-target = _{ variable | path }
-block  =  { "{" ~ NEWLINE* ~ expressions ~ NEWLINE* ~ "}" }
+ident = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
+bang  =  { "!" }
+block =  { "{" ~ NEWLINE* ~ expressions ~ NEWLINE* ~ "}" }
 
 string_inner = @{ char* }
 char         =  { !("\"" | "\\") ~ ANY | "\\" ~ ("\"" | "\\" | "n" | "t") }

--- a/lib/remap-lang/src/error.rs
+++ b/lib/remap-lang/src/error.rs
@@ -131,6 +131,8 @@ impl fmt::Display for Rule {
             string,
             string_inner,
             target,
+            target_infallible,
+            target_regular,
             value,
             variable,
             WHITESPACE,

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -1,7 +1,9 @@
 use super::Error as E;
 use crate::{
     expression::{Path, Variable},
-    state, Expr, Expression, Object, Result, TypeDef, Value,
+    state,
+    value::Kind,
+    Expr, Expression, Object, Result, TypeDef, Value,
 };
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq)]
@@ -14,6 +16,7 @@ pub enum Error {
 pub enum Target {
     Path(Path),
     Variable(Variable),
+    Infallible { ok: Box<Target>, err: Box<Target> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -26,14 +29,47 @@ impl Assignment {
     pub fn new(target: Target, value: Box<Expr>, state: &mut state::Compiler) -> Self {
         let type_def = value.type_def(state);
 
-        match &target {
-            Target::Variable(variable) => state
+        let var_type_def = |state: &mut state::Compiler, var: &Variable, type_def| {
+            state
                 .variable_types_mut()
-                .insert(variable.ident().to_owned(), type_def),
-            Target::Path(path) => state
-                .path_query_types_mut()
-                .insert(path.as_ref().clone(), type_def),
+                .insert(var.ident().to_owned(), type_def);
         };
+
+        let path_type_def = |state: &mut state::Compiler, path: &Path, type_def| {
+            state
+                .path_query_types_mut()
+                .insert(path.as_ref().clone(), type_def);
+        };
+
+        match &target {
+            Target::Variable(var) => var_type_def(state, var, type_def),
+            Target::Path(path) => path_type_def(state, path, type_def),
+            Target::Infallible { ok, err } => {
+                // "ok" variable takes on the type definition of the value, but
+                // is set to being infallible, as the error will be captured by
+                // the "err" variable.
+                let type_def = type_def.into_fallible(false);
+
+                match ok.as_ref() {
+                    Target::Variable(var) => var_type_def(state, var, type_def),
+                    Target::Path(path) => path_type_def(state, path, type_def),
+                    _ => unreachable!("nested infallible targets not supported"),
+                }
+
+                // "err" variable is either `null` or a string containing the
+                // error message.
+                let err_type_def = TypeDef {
+                    kind: Kind::Bytes | Kind::Null,
+                    ..Default::default()
+                };
+
+                match err.as_ref() {
+                    Target::Variable(var) => var_type_def(state, var, err_type_def),
+                    Target::Path(path) => path_type_def(state, path, err_type_def),
+                    _ => unreachable!("nested infallible targets not supported"),
+                }
+            }
+        }
 
         Self { target, value }
     }
@@ -41,32 +77,106 @@ impl Assignment {
 
 impl Expression for Assignment {
     fn execute(&self, state: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = self.value.execute(state, object)?;
+        let value = self.value.execute(state, object);
 
         match &self.target {
             Target::Variable(variable) => {
                 state
                     .variables_mut()
-                    .insert(variable.ident().to_owned(), value.clone());
-            }
-            Target::Path(path) => object
-                .insert(path.as_ref(), value.clone())
-                .map_err(|e| E::Assignment(Error::PathInsertion(e)))?,
-        }
+                    .insert(variable.ident().to_owned(), value.clone()?);
 
-        Ok(value)
+                value
+            }
+            Target::Path(path) => {
+                object
+                    .insert(path.as_ref(), value.clone()?)
+                    .map_err(|e| E::Assignment(Error::PathInsertion(e)))?;
+
+                value
+            }
+
+            Target::Infallible { ok, err } => {
+                let (ok_value, err_value) = match value {
+                    Ok(value) => (value, Value::Null),
+                    Err(err) => (Value::Null, Value::from(err)),
+                };
+
+                match ok.as_ref() {
+                    Target::Variable(variable) => {
+                        state
+                            .variables_mut()
+                            .insert(variable.ident().to_owned(), ok_value.clone());
+                    }
+                    Target::Path(path) => object
+                        .insert(path.as_ref(), ok_value.clone())
+                        .map_err(|e| E::Assignment(Error::PathInsertion(e)))?,
+
+                    _ => unreachable!("nested infallible targets not supported"),
+                }
+
+                match err.as_ref() {
+                    Target::Variable(variable) => {
+                        state
+                            .variables_mut()
+                            .insert(variable.ident().to_owned(), err_value.clone());
+                    }
+                    Target::Path(path) => object
+                        .insert(path.as_ref(), err_value.clone())
+                        .map_err(|e| E::Assignment(Error::PathInsertion(e)))?,
+
+                    _ => unreachable!("nested infallible targets not supported"),
+                };
+
+                if err_value.is_null() {
+                    Ok(ok_value)
+                } else {
+                    Ok(err_value)
+                }
+            }
+        }
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        match &self.target {
-            Target::Variable(variable) => state
-                .variable_type(variable.ident().to_owned())
+        let var_type_def = |var: &Variable| {
+            state
+                .variable_type(var.ident().to_owned())
                 .cloned()
-                .expect("variable must be assigned via Assignment::new"),
-            Target::Path(path) => state
+                .expect("variable must be assigned via Assignment::new")
+        };
+
+        let path_type_def = |path: &Path| {
+            state
                 .path_query_type(path)
                 .cloned()
-                .expect("path must be assigned via Assignment::new"),
+                .expect("path must be assigned via Assignment::new")
+        };
+
+        match &self.target {
+            Target::Variable(var) => var_type_def(var),
+            Target::Path(path) => path_type_def(path),
+            Target::Infallible { ok, err } => {
+                let ok_type_def = match ok.as_ref() {
+                    Target::Variable(var) => var_type_def(var),
+                    Target::Path(path) => path_type_def(path),
+                    _ => unreachable!("nested infallible targets not supported"),
+                };
+
+                // Technically the parser rejects this invariant, because an
+                // expression that is known to be infallible cannot be assigned
+                // to an infallible target, since the error will always be
+                // `null`.
+                if !ok_type_def.is_fallible() {
+                    return ok_type_def;
+                }
+
+                let err_type_def = match err.as_ref() {
+                    Target::Variable(var) => var_type_def(var),
+                    Target::Path(path) => path_type_def(path),
+                    _ => unreachable!("nested infallible targets not supported"),
+                };
+
+                ok_type_def.merge(err_type_def).into_fallible(false)
+            }
         }
     }
 }
@@ -74,7 +184,7 @@ impl Expression for Assignment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{expression::Literal, test_type_def, value::Kind};
+    use crate::{expression::Literal, lit, test_type_def, Operator};
 
     test_type_def![
         variable {
@@ -99,6 +209,23 @@ mod tests {
             },
             def: TypeDef {
                 kind: Kind::Bytes,
+                ..Default::default()
+            },
+        }
+
+        infallible_ok {
+            expr: |state: &mut state::Compiler| {
+                let ok = Box::new(Target::Variable(Variable::new("ok".to_owned(), None)));
+                let err = Box::new(Target::Variable(Variable::new("err".to_owned(), None)));
+
+                let target = Target::Infallible { ok, err };
+                let value = Box::new(lit!(true).into());
+
+                Assignment::new(target, value, state)
+            },
+            def: TypeDef {
+                fallible: false,
+                kind: Kind::Boolean,
                 ..Default::default()
             },
         }

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -32,7 +32,9 @@ impl Target {
             Target::Infallible { ok, .. } => match ok.as_ref() {
                 Target::Path(_) => "infallible path",
                 Target::Variable(_) => "infallible variable",
-                _ => unimplemented!(),
+                Target::Infallible { .. } => {
+                    unimplemented!("nested infallible targets not supported")
+                }
             },
         }
     }
@@ -73,7 +75,9 @@ impl Assignment {
                         match ok.as_ref() {
                             Target::Variable(v) => v.ident().to_owned(),
                             Target::Path(v) => v.to_string(),
-                            Target::Infallible { .. } => unimplemented!(),
+                            Target::Infallible { .. } => {
+                                unimplemented!("nested infallible targets not supported")
+                            }
                         },
                     ))
                     .into());

--- a/lib/remap-lang/src/expression/assignment.rs
+++ b/lib/remap-lang/src/expression/assignment.rs
@@ -83,9 +83,9 @@ impl Assignment {
                     .into());
                 }
 
-                // "ok" variable takes on the type definition of the value, but
-                // is set to being infallible, as the error will be captured by
-                // the "err" variable.
+                // "ok" target takes on the type definition of the value, but is
+                // set to being infallible, as the error will be captured by the
+                // "err" target.
                 let type_def = type_def.into_fallible(false);
 
                 match ok.as_ref() {
@@ -94,7 +94,7 @@ impl Assignment {
                     _ => unimplemented!("nested infallible targets not supported"),
                 }
 
-                // "err" variable is either `null` or a string containing the
+                // "err" target is assigned `null` or a string containing the
                 // error message.
                 let err_type_def = TypeDef {
                     kind: Kind::Bytes | Kind::Null,

--- a/lib/remap-lang/src/expression/function.rs
+++ b/lib/remap-lang/src/expression/function.rs
@@ -152,7 +152,13 @@ impl Expression for Function {
     }
 
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        self.function.type_def(state)
+        let mut type_def = self.function.type_def(state);
+
+        if self.abort_on_error {
+            type_def.fallible = false;
+        }
+
+        type_def
     }
 }
 

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -294,9 +294,22 @@ mod tests {
                 Err(r#"remap error: error for function "map_printer": cannot mark infallible function as "abort on error", remove the "!" signature"#),
                 Ok(().into()),
             ),
-            ("$foo, $err = fallible_func!()", Ok(()), Ok(value!("function call error: failed!"))),
+            (
+                "$foo, $err = fallible_func!()",
+                Err(r#"remap error: assignment error: the variable "foo" does not need to handle the error-case, because its result is infallible"#),
+                Ok(().into()),
+            ),
             ("$foo, $err = fallible_func()", Ok(()), Ok(value!("function call error: failed!"))),
-            ("$foo, $err = map_printer({})", Ok(()), Ok(value!({}))),
+            (
+                "$foo, $err = map_printer({})",
+                Err(r#"remap error: assignment error: the variable "foo" does not need to handle the error-case, because its result is infallible"#),
+                Ok(().into()),
+            ),
+            (
+                ".foo.bar, $err = map_printer({})",
+                Err(r#"remap error: assignment error: the path ".foo.bar" does not need to handle the error-case, because its result is infallible"#),
+                Ok(().into()),
+            ),
             (
                 "
                     $foo, $err = fallible_func()
@@ -307,11 +320,19 @@ mod tests {
             ),
             (
                 "
-                    $foo, $err = map_printer({})
+                    $foo, $err = fallible_func(true)
                     [$foo, $err]
                 ",
                 Ok(()),
-                Ok(value!([{}, null])),
+                Ok(value!([true, null])),
+            ),
+            (
+                "
+                    .foo.bar, $err = fallible_func(true)
+                    [.foo, $err]
+                ",
+                Ok(()),
+                Ok(value!([{ bar: true, qux: [1, 2, {quux: true}]}, null])),
             ),
         ];
 
@@ -544,20 +565,30 @@ mod tests {
                 "fallible_func"
             }
 
-            fn compile(&self, _: ArgumentList) -> Result<Box<dyn Expression>> {
-                Ok(Box::new(FallibleFuncFn))
+            fn compile(&self, mut arguments: ArgumentList) -> Result<Box<dyn Expression>> {
+                Ok(Box::new(FallibleFuncFn(
+                    arguments.optional("value").map(Expr::boxed),
+                )))
             }
 
             fn parameters(&self) -> &'static [Parameter] {
-                &[]
+                &[Parameter {
+                    keyword: "value",
+                    accepts: |_| true,
+                    required: false,
+                }]
             }
         }
 
         #[derive(Debug, Clone)]
-        struct FallibleFuncFn;
+        struct FallibleFuncFn(Option<Box<dyn Expression>>);
         impl Expression for FallibleFuncFn {
             fn execute(&self, _: &mut state::Program, _: &mut dyn Object) -> Result<Value> {
-                Err("failed!".into())
+                if self.0.is_some() {
+                    Ok(true.into())
+                } else {
+                    Err("failed!".into())
+                }
             }
 
             fn type_def(&self, _: &state::Compiler) -> TypeDef {

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -594,7 +594,7 @@ mod tests {
             fn type_def(&self, _: &state::Compiler) -> TypeDef {
                 TypeDef {
                     fallible: true,
-                    kind: value::Kind::Null,
+                    kind: value::Kind::Boolean,
                     ..Default::default()
                 }
             }

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -237,7 +237,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Ok(Assignment::new(target, Box::new(expression), &mut self.compiler_state).into())
+        Assignment::new(target, Box::new(expression), &mut self.compiler_state).map(Into::into)
     }
 
     /// Return the target type to which a value is being assigned.

--- a/lib/remap-lang/src/parser.rs
+++ b/lib/remap-lang/src/parser.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 #[grammar = "../grammar.pest"]
 pub(super) struct Parser<'a> {
     pub function_definitions: &'a [Box<dyn Fn>],
+    pub allow_regex_return: bool,
     pub compiler_state: state::Compiler,
 }
 
@@ -98,9 +99,10 @@ macro_rules! operation_fns {
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(function_definitions: &'a [Box<dyn Fn>]) -> Self {
+    pub fn new(function_definitions: &'a [Box<dyn Fn>], allow_regex_return: bool) -> Self {
         Self {
             function_definitions,
+            allow_regex_return,
             ..Default::default()
         }
     }
@@ -171,7 +173,10 @@ impl<'a> Parser<'a> {
         if let Some(expression) = expressions.last() {
             let type_def = expression.type_def(&self.compiler_state);
 
-            if !type_def.kind.is_all() && type_def.scalar_kind().contains_regex() {
+            if !self.allow_regex_return
+                && !type_def.kind.is_all()
+                && type_def.scalar_kind().contains_regex()
+            {
                 return Err(Error::RegexResult.into());
             }
         }
@@ -206,13 +211,13 @@ impl<'a> Parser<'a> {
         // JSON.
         if matches!(target, Target::Path(_)) {
             match &expression {
-                Expr::Literal(literal) if literal.is_regex() => {
+                Expr::Literal(literal) if !self.allow_regex_return && literal.is_regex() => {
                     return Err(Error::RegexAssignment.into())
                 }
                 Expr::Literal(literal) => {
                     if let Some(array) = literal.as_array() {
                         array.iter().try_for_each(|value| {
-                            if value.is_regex() {
+                            if !self.allow_regex_return && value.is_regex() {
                                 Err(E::from(Error::RegexAssignment))
                             } else {
                                 Ok(())
@@ -222,7 +227,7 @@ impl<'a> Parser<'a> {
                 }
                 Expr::Array(array)
                     if array.expressions().iter().any(|expr| match expr {
-                        Expr::Literal(literal) => literal.is_regex(),
+                        Expr::Literal(literal) if !self.allow_regex_return => literal.is_regex(),
                         _ => false,
                     }) =>
                 {
@@ -253,8 +258,23 @@ impl<'a> Parser<'a> {
                 Ok(Target::Variable(variable))
             }),
             R::path => Ok(Target::Path(Path::new(self.path_from_pair(pair)?))),
+            R::target_infallible => self.target_infallible_from_pairs(pair.into_inner()),
             _ => Err(e(R::target)),
         }
+    }
+
+    fn target_infallible_from_pairs(&mut self, mut pairs: Pairs<R>) -> Result<Target> {
+        let ok = pairs
+            .next()
+            .ok_or(e(R::target_infallible))
+            .and_then(|pair| Ok(Box::new(self.target_from_pair(pair)?)))?;
+
+        let err = pairs
+            .next()
+            .ok_or(e(R::target_infallible))
+            .and_then(|pair| Ok(Box::new(self.target_from_pair(pair)?)))?;
+
+        Ok(Target::Infallible { ok, err })
     }
 
     /// Parse block expressions.
@@ -722,7 +742,7 @@ mod tests {
             let compile_check: Vec<&str> = compile_check;
             i += 1;
 
-            let mut parser = Parser::new(&[]);
+            let mut parser = Parser::new(&[], true);
             let pairs = parser.program_from_str(source).map_err(RemapError::from);
 
             match pairs {
@@ -832,9 +852,9 @@ mod tests {
                     "= expected assignment, if-statement, query, operator, path index, or block",
                 ],
             ),
-            ("only_fields(.foo,)", vec![" 1:18\n", "= expected argument"]),
+            ("only_fields(.foo,)", vec![" 1:18\n", "= expected variable, argument, or path"]),
             ("only_fields(,)", vec![" 1:13\n", "= expected argument"]),
-            ("only_fields(.foo,)", vec![" 1:18\n", "= expected argument"]),
+            ("only_fields(.foo,)", vec![" 1:18\n", "= expected variable, argument, or path"]),
             ("only_fields(,)", vec![" 1:13\n", "= expected argument"]),
             (
                 // Due to the explicit list of allowed escape chars our grammar
@@ -905,7 +925,7 @@ mod tests {
         ];
 
         for (source, exp_expressions) in cases {
-            let mut parser = Parser::new(&[]);
+            let mut parser = Parser::new(&[], false);
             let err = parser
                 .program_from_str(source)
                 .err()

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -89,8 +89,9 @@ impl Program {
         source: &str,
         function_definitions: &[Box<dyn Function>],
         constraint: Option<TypeConstraint>,
+        allow_regex_return: bool, // TODO: move this into a builder pattern
     ) -> Result<Self, RemapError> {
-        let mut parser = Parser::new(function_definitions);
+        let mut parser = Parser::new(function_definitions, allow_regex_return);
         let expressions = parser.program_from_str(source)?;
 
         // optional type constraint checking
@@ -229,7 +230,7 @@ mod tests {
         ];
 
         for (source, constraint, expect) in cases {
-            let program = Program::new(source, &[], constraint)
+            let program = Program::new(source, &[], constraint, false)
                 .map(|_| ())
                 .map_err(|e| {
                     e.source()

--- a/lib/remap-lang/src/value.rs
+++ b/lib/remap-lang/src/value.rs
@@ -275,6 +275,12 @@ impl From<String> for Value {
     }
 }
 
+impl From<crate::Error> for Value {
+    fn from(v: crate::Error) -> Self {
+        Value::Bytes(v.to_string().into())
+    }
+}
+
 impl From<bool> for Value {
     fn from(v: bool) -> Self {
         Value::Boolean(v)

--- a/src/conditions/remap.rs
+++ b/src/conditions/remap.rs
@@ -40,8 +40,8 @@ impl ConditionConfig for RemapConfig {
             .filter(|f| f.identifier() != "only_fields")
             .collect::<Vec<_>>();
 
-        let program =
-            Program::new(&self.source, &functions, Some(constraint)).map_err(|e| e.to_string())?;
+        let program = Program::new(&self.source, &functions, Some(constraint), false)
+            .map_err(|e| e.to_string())?;
 
         Ok(Box::new(Remap { program }))
     }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -59,7 +59,12 @@ impl Remap {
             },
         };
 
-        let program = Program::new(&config.source, &remap_functions::all(), Some(accepts))?;
+        let program = Program::new(
+            &config.source,
+            &remap_functions::all(),
+            Some(accepts),
+            false,
+        )?;
 
         Ok(Remap {
             program,


### PR DESCRIPTION
Another step towards solving our error-handling story as described in https://github.com/timberio/vector/issues/5479 and [this gist](https://gist.github.com/JeanMertz/f36e0aae6191231d1a37d81ba560047e).

You can now make the rhs expression in an assignment infallible by capturing the error message:

```rust
// fallible, will be rejected at compile-time in the future
json = parse_json(...)

// infallible
json, err = parse_json(...)

// infallible, rejected at compile-time since the `err` case will always be null
five, err = 5
```

`err` is null if the rhs expression succeeded, otherwise it contains the error message as a string.

This joins the existing error-handling strategies introduced in https://github.com/timberio/vector/pull/5876 and https://github.com/timberio/vector/pull/5830.

note: this does not yet implement the "ignore-target" (e.g. `json, _ = parse_json(...)`), I'll create a follow-up issue to add that, as it's not strictly needed for this to be useful.

closes #5865.