### PR TITLE
fix(influxdb_metrics sink): Fix transmission of counter metrics

### DIFF
--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -7,6 +7,7 @@ use super::{
     Batch, BatchSink, Partition, PartitionBatchSink,
 };
 use crate::buffers::Acker;
+use futures::TryFutureExt;
 use serde::{
     de::{self, Unexpected, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -23,7 +24,7 @@ use tower::{
 
 pub type Svc<S, L> = RateLimit<Retry<FixedRetryPolicy<L>, AdaptiveConcurrencyLimit<Timeout<S>, L>>>;
 pub type TowerBatchedSink<S, B, L, Request> = BatchSink<Svc<S, L>, B, Request>;
-pub type TowerPartitionSink<S, B, L, K, Request> = PartitionBatchSink<Svc<S, L>, B, K, Request>;
+pub type TowerPartitionSink<S, B, L, K, Request> = PartitionBatchSink<B, Svc<S, L>, K, Request>;
 
 pub trait ServiceBuilderExt<L> {
     fn map<R1, R2, F>(self, f: F) -> ServiceBuilder<Stack<MapLayer<R1, R2>, L>>
@@ -265,6 +266,10 @@ impl TowerRequestSettings {
         batch_timeout: Duration,
         acker: Acker,
     ) -> TowerBatchedSink<S, B, L, Request>
+    // Would like to return `impl Sink + SinkExt<T>` here, but that
+    // doesn't work with later calls to `batched_with_min` etc (via
+    // `trait SinkExt` above), as it is missing a bound on the
+    // associated types that cannot be expressed in stable Rust.
     where
         L: RetryLogic<Response = S::Response>,
         S: Service<Request> + Clone + Send + 'static,
@@ -362,45 +367,36 @@ where
 
 pub struct Map<S, R1, R2> {
     f: Arc<dyn Fn(R1) -> R2 + Send + Sync + 'static>,
-    pub(crate) inner: S,
+    inner: S,
 }
 
 impl<S, R1, R2> Service<R1> for Map<S, R1, R2>
 where
     S: Service<R2>,
+    crate::Error: From<S::Error>,
 {
     type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
+    type Error = crate::Error;
+    type Future = futures::future::MapErr<S::Future, fn(S::Error) -> crate::Error>;
 
     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
+        self.inner
+            .poll_ready(cx)
+            .map(|result| result.map_err(|e| e.into()))
     }
 
     fn call(&mut self, req: R1) -> Self::Future {
         let req = (self.f)(req);
-        self.inner.call(req)
+        self.inner.call(req).map_err(Into::into)
     }
 }
 
-impl<S, R1, R2> Clone for Map<S, R1, R2>
-where
-    S: Clone,
-{
+impl<S: Clone, R1, R2> Clone for Map<S, R1, R2> {
     fn clone(&self) -> Self {
         Self {
             f: Arc::clone(&self.f),
             inner: self.inner.clone(),
         }
-    }
-}
-
-impl<S, R1, R2> fmt::Debug for Map<S, R1, R2>
-where
-    S: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Map").field("inner", &self.inner).finish()
     }
 }
 


### PR DESCRIPTION
This reverts commit 95f767d02f92cb6e320b8dc51371dd02959f9499.

After reverting this commit, the internal_metrics (and possibly other
metrics sources) ends up sending its metrics through the metrics batch
buffer twice before the batch is flushed to the sink. This allows the
counter handling in the metrics batch buffer to generate the required
incremental record in the batch, which then persists after the batch is
reset. Without it, the metrics are sent once, no record is added to the
batch, and it is never added later.

Closes #5698 