### PR TITLE
fix(tests): Handle early return from influxdb create database

### DIFF
--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -309,19 +309,16 @@ pub(in crate::sinks) fn encode_uri(
 #[allow(dead_code)]
 pub mod test_util {
     use super::*;
-    use chrono::offset::TimeZone;
+    use chrono::{offset::TimeZone, Utc};
     use std::fs::File;
     use std::io::Read;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     pub(crate) const ORG: &str = "my-org";
     pub(crate) const BUCKET: &str = "my-bucket";
     pub(crate) const TOKEN: &str = "my-token";
 
-    static DATABASE_NUM: AtomicUsize = AtomicUsize::new(0);
-
     pub(crate) fn next_database() -> String {
-        format!("testdb{}", DATABASE_NUM.fetch_add(1, Ordering::Relaxed))
+        format!("testdb{}", Utc::now().timestamp_nanos())
     }
 
     pub(crate) fn ts() -> DateTime<Utc> {

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -389,7 +389,6 @@ pub mod test_util {
 
     pub(crate) async fn onboarding_v1(endpoint: &str) -> String {
         let database = next_database();
-        query_v1(endpoint, &format!("drop database {}", database)).await;
         let status = query_v1(endpoint, &format!("create database {}", database))
             .await
             .status();

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -413,7 +413,7 @@ pub mod test_util {
             {
                 http::StatusCode::NO_CONTENT => break,
                 http::StatusCode::NOT_FOUND => delay_for(Duration::from_millis(500)).await,
-                status @ _ => panic!("Unexpected status: {}", status),
+                status => panic!("Unexpected status: {}", status),
             }
         }
         database

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -392,10 +392,7 @@ pub mod test_util {
         let status = query_v1(endpoint, &format!("create database {}", database))
             .await
             .status();
-        assert!(
-            status == http::StatusCode::OK,
-            format!("UnexpectedStatus: {}", status)
-        );
+        assert_eq!(status, http::StatusCode::OK, "UnexpectedStatus: {}", status);
         database
     }
 
@@ -403,10 +400,7 @@ pub mod test_util {
         let status = query_v1(endpoint, &format!("drop database {}", database))
             .await
             .status();
-        assert!(
-            status == http::StatusCode::OK,
-            format!("UnexpectedStatus: {}", status)
-        );
+        assert_eq!(status, http::StatusCode::OK, "UnexpectedStatus: {}", status);
     }
 
     pub(crate) async fn onboarding_v2() {

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -218,6 +218,8 @@ mod integration_tests {
     }
 
     async fn insert_metrics(url: &str) {
+        crate::test_util::trace_init();
+
         let database = onboarding_v1(url).await;
 
         let cx = SinkContext::new_test();


### PR DESCRIPTION
Sometimes, the influxdb v1 server will return early from creating the
    database, providing an OK response code before the database is actually
    created. Subsequent sink calls will then encounter a NOT_FOUND response
    when trying to write to the database, resulting in a spurious failure.
    This tests for database existence after creating it by doing an empty
    write, and looping until that returns NO_CONTENT.

Closes #5612 

Signed-off-by: Bruce Guenter <bruce@timber.io>
