### PR TITLE
feat(remap): enforce error-handling at compile-time in programs

### DIFF
--- a/lib/remap-lang/src/expression.rs
+++ b/lib/remap-lang/src/expression.rs
@@ -41,12 +41,6 @@ pub enum Error {
     #[error("assignment error")]
     Assignment(#[from] assignment::Error),
 
-    #[error(r#"error for variable "{0}""#)]
-    Variable(String, #[source] variable::Error),
-
-    #[error("path error")]
-    Path(#[from] path::Error),
-
     #[error("not operation error")]
     Not(#[from] not::Error),
 

--- a/lib/remap-lang/src/expression/path.rs
+++ b/lib/remap-lang/src/expression/path.rs
@@ -1,15 +1,5 @@
-use super::Error as E;
 use crate::{path, state, Expression, Object, Result, TypeDef, Value};
 use std::fmt;
-
-#[derive(thiserror::Error, Clone, Debug, PartialEq)]
-pub enum Error {
-    #[error("missing path: {0}")]
-    Missing(String),
-
-    #[error("unable to resolve path: {0}")]
-    Resolve(String),
-}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Path {
@@ -62,10 +52,7 @@ impl Path {
 
 impl Expression for Path {
     fn execute(&self, _: &mut state::Program, object: &mut dyn Object) -> Result<Value> {
-        let value = object
-            .get(&self.path)
-            .map_err(|e| E::from(Error::Resolve(e)))?
-            .unwrap_or(Value::Null);
+        let value = object.get(&self.path).ok().flatten().unwrap_or(Value::Null);
 
         Ok(value)
     }
@@ -74,10 +61,11 @@ impl Expression for Path {
     /// specific values to paths during its execution, which increases our exact
     /// understanding of the value kind the path contains.
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
-        state.path_query_type(self).cloned().unwrap_or(TypeDef {
-            fallible: true,
-            ..Default::default()
-        })
+        state
+            .path_query_type(self)
+            .cloned()
+            .unwrap_or_default()
+            .into_fallible(false) // path queries return `null` if they fail
     }
 }
 
@@ -106,7 +94,6 @@ mod tests {
                 Path::from("foo")
             },
             def: TypeDef {
-                fallible: true,
                 kind: Kind::Bytes,
                 ..Default::default()
             },
@@ -121,18 +108,12 @@ mod tests {
 
                 Path::from("bar")
             },
-            def: TypeDef {
-                fallible: true,
-                ..Default::default()
-            },
+            def: TypeDef::default(),
         }
 
         empty_state {
             expr: |_| Path::from("foo"),
-            def: TypeDef {
-                fallible: true,
-                ..Default::default()
-            },
+            def: TypeDef::default(),
         }
     ];
 }

--- a/lib/remap-lang/src/lib.rs
+++ b/lib/remap-lang/src/lib.rs
@@ -285,10 +285,10 @@ mod tests {
             ("5 * 5 ?? true * 5", Ok(()), Ok(value!(25))),
             ("false * 5 ?? true * 5 ?? 5 * 5", Ok(()), Ok(value!(25))),
             ("false * 5 ?? 5 * 5 ?? true * 5", Ok(()), Ok(value!(25))),
-            ("false * 5 ?? true * 5", Ok(()), Err("remap error: value error: unable to multiply value type boolean by integer")),
+            ("false * 5 ?? true * 5", Err("remap error: parser error: the following expression must be made infallible for the program to be valid: false * 5 ?? true * 5"), Ok(().into())),
             ("5 + (true * 5 ?? 0)", Ok(()), Ok(value!(5))),
             ("fallible_func!()", Ok(()), Err("remap error: function call error: failed!")),
-            ("fallible_func()", Ok(()), Err("remap error: function call error: failed!")),
+            ("fallible_func()", Err("remap error: parser error: the following expression must be made infallible for the program to be valid: fallible_func()"), Ok(().into())),
             (
                 "map_printer!({})",
                 Err(r#"remap error: error for function "map_printer": cannot mark infallible function as "abort on error", remove the "!" signature"#),

--- a/lib/remap-lang/src/program.rs
+++ b/lib/remap-lang/src/program.rs
@@ -177,12 +177,12 @@ mod tests {
                     },
                     allow_any: false,
                 }),
-                Err("expected to resolve to boolean value, but instead resolves to any value"),
+                Err("expected to resolve to an error, or boolean value, but instead resolves to any value"),
             ),
             // The final expression is infallible, but the first one isn't, so
             // this isn't allowed.
             (
-                ".foo\ntrue",
+                "true * 5\ntrue",
                 Some(TypeConstraint {
                     type_def: TypeDef {
                         fallible: false,
@@ -190,10 +190,10 @@ mod tests {
                     },
                     allow_any: false,
                 }),
-                Err("expected to be infallible, but is not"),
+                Err("the following expression must be made infallible for the program to be valid: true * 5"),
             ),
             (
-                ".foo",
+                "true * 5",
                 Some(TypeConstraint {
                     type_def: TypeDef {
                         fallible: false,
@@ -201,7 +201,7 @@ mod tests {
                     },
                     allow_any: false,
                 }),
-                Err("expected to resolve to any value, but instead resolves to an error, or any value"),
+                Err("the following expression must be made infallible for the program to be valid: true * 5"),
             ),
             (
                 ".foo",
@@ -213,7 +213,7 @@ mod tests {
                     },
                     allow_any: false,
                 }),
-                Err("expected to resolve to string value, but instead resolves to an error, or any value"),
+                Err("expected to resolve to string value, but instead resolves to any value"),
             ),
             (
                 "false || 2",


### PR DESCRIPTION
This "flips the switch" in VRL to require all errors in a program to be explicitly handled (through [one of the available error-handling techniques](https://gist.github.com/JeanMertz/f36e0aae6191231d1a37d81ba560047e)) before you can run the program.

For simplicity’s sake, every root expression is checked to be infallible. In reality, you could see a use-case for lazily evaluating assignments for example, since their fallibility might not matter, but that's an improvement we can make in the future.

Specifically, when we add a "dead-code detector" into the parser, we're going to have to track more state across root expressions, at which point I suspect we'll have the plumbing in place to for example allow this:

```rust
foo = 5 / .foo 	// currently fails program, but shouldn't
.bar = foo ?? 0 // caught the `foo` variable error, so program should be infallible
```

Regardless, even in its simplistic first version, this should prevent a lot of unexpected runtime problems 🎉 🌮

The error message is fairly simplistic for now, but I avoided spending too much time on that right now, as we first need to upgrade the error reporting infrastructure, which is being tracked in https://github.com/timberio/vector/issues/4803.

Also, this uncovered an issue were the type definition of variable and path queries still had it set to being fallible, while in reality we changed this a while ago to always return `null` if a path or variable doesn't exist yet.

This still leaves the potential for variable name typo's in your program resulting in unexpected outcomes, so I hope in the future we can come up with a nice solution for this as well, but for the time being we considered the fallibility of variable/path queries to be too much of a nuisance.

closes #5479.