### PR TITLE
fix(metrics): Rework the metrics batch buffer

### DIFF
--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -257,11 +257,15 @@ impl Metric {
         self
     }
 
-    /// Create a new Metric from this with all the data but marked as absolute.
-    pub fn to_absolute(&self) -> Self {
+    pub fn into_parts(self) -> (MetricSeries, MetricData) {
+        (self.series, self.data)
+    }
+
+    /// Rewrite this into a Metric with the data marked as absolute.
+    pub fn into_absolute(self) -> Self {
         Self {
-            series: self.series.clone(),
-            data: self.data.to_absolute(),
+            series: self.series,
+            data: self.data.into_absolute(),
         }
     }
 
@@ -350,12 +354,12 @@ impl Metric {
 }
 
 impl MetricData {
-    /// Create new MetricData from this with all the data but marked as absolute.
-    pub fn to_absolute(&self) -> Self {
+    /// Rewrite this data to mark it as absolute.
+    pub fn into_absolute(self) -> Self {
         Self {
             timestamp: self.timestamp,
             kind: MetricKind::Absolute,
-            value: self.value.clone(),
+            value: self.value,
         }
     }
 

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -269,6 +269,14 @@ impl Metric {
         }
     }
 
+    /// Rewrite this into a Metric with the data marked as incremental.
+    pub fn into_incremental(self) -> Self {
+        Self {
+            series: self.series,
+            data: self.data.into_incremental(),
+        }
+    }
+
     /// Convert the metrics_runtime::Measurement value plus the name and
     /// labels from a Key into our internal Metric format.
     pub fn from_metric_kv(key: &metrics::Key, handle: &metrics_util::Handle) -> Self {
@@ -367,6 +375,15 @@ impl MetricData {
         Self {
             timestamp: self.timestamp,
             kind: MetricKind::Absolute,
+            value: self.value,
+        }
+    }
+
+    /// Rewrite this data to mark it as incremental.
+    pub fn into_incremental(self) -> Self {
+        Self {
+            timestamp: self.timestamp,
+            kind: MetricKind::Incremental,
             value: self.value,
         }
     }

--- a/src/event/metric.rs
+++ b/src/event/metric.rs
@@ -257,10 +257,6 @@ impl Metric {
         self
     }
 
-    pub fn into_parts(self) -> (MetricSeries, MetricData) {
-        (self.series, self.data)
-    }
-
     /// Rewrite this into a Metric with the data marked as absolute.
     pub fn into_absolute(self) -> Self {
         Self {

--- a/src/internal_events/sematext_metrics.rs
+++ b/src/internal_events/sematext_metrics.rs
@@ -1,19 +1,18 @@
 use super::InternalEvent;
-use crate::event::metric::{MetricKind, MetricValue};
+use crate::event::metric::Metric;
 use metrics::counter;
 
 #[derive(Debug)]
-pub struct SematextMetricsInvalidMetricReceived {
-    pub value: MetricValue,
-    pub kind: MetricKind,
+pub struct SematextMetricsInvalidMetricReceived<'a> {
+    pub metric: &'a Metric,
 }
 
-impl InternalEvent for SematextMetricsInvalidMetricReceived {
+impl<'a> InternalEvent for SematextMetricsInvalidMetricReceived<'a> {
     fn emit_logs(&self) {
         warn!(
             message = "Invalid metric received; dropping event.",
-            value = ?self.value,
-            kind = ?self.kind,
+            value = ?self.metric.data.value,
+            kind = ?self.metric.data.kind,
             internal_log_rate_secs = 30,
         )
     }

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -1,13 +1,15 @@
 use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
     event::{
-        metric::{Metric, MetricKind, MetricValue},
+        metric::{Metric, MetricValue},
         Event,
     },
     rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
-        retries::RetryLogic, BatchConfig, BatchSettings, Compression, MetricBuffer,
-        PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer, TowerRequestConfig,
+        buffer::metrics::{AwsCloudwatchMetricsState, MetricsBuffer},
+        retries::RetryLogic,
+        BatchConfig, BatchSettings, Compression, PartitionBatchSink, PartitionBuffer,
+        PartitionInnerBuffer, TowerRequestConfig,
     },
 };
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -141,7 +143,8 @@ impl CloudWatchMetricsSvc {
 
         let svc = request.service(CloudWatchMetricsRetryLogic, cloudwatch_metrics);
 
-        let buffer = PartitionBuffer::new(MetricBuffer::new(batch.size));
+        let buffer =
+            PartitionBuffer::new(MetricsBuffer::<AwsCloudwatchMetricsState>::new(batch.size));
 
         let sink = PartitionBatchSink::new(svc, buffer, batch.timeout, cx.acker())
             .sink_map_err(|error| error!(message = "Fatal CloudwatchMetrics sink error.", %error))
@@ -166,45 +169,41 @@ impl CloudWatchMetricsSvc {
                 let metric_name = event.name().to_string();
                 let timestamp = event.data.timestamp.map(timestamp_to_string);
                 let dimensions = event.series.tags.clone().map(tags_to_dimensions);
-                match event.data.kind {
-                    MetricKind::Incremental => match event.data.value {
-                        MetricValue::Counter { value } => Some(MetricDatum {
-                            metric_name,
-                            value: Some(value),
-                            timestamp,
-                            dimensions,
-                            ..Default::default()
-                        }),
-                        MetricValue::Distribution {
-                            samples,
-                            statistic: _,
-                        } => Some(MetricDatum {
-                            metric_name,
-                            values: Some(samples.iter().map(|s| s.value).collect()),
-                            counts: Some(samples.iter().map(|s| f64::from(s.rate)).collect()),
-                            timestamp,
-                            dimensions,
-                            ..Default::default()
-                        }),
-                        MetricValue::Set { values } => Some(MetricDatum {
-                            metric_name,
-                            value: Some(values.len() as f64),
-                            timestamp,
-                            dimensions,
-                            ..Default::default()
-                        }),
-                        _ => None,
-                    },
-                    MetricKind::Absolute => match event.data.value {
-                        MetricValue::Gauge { value } => Some(MetricDatum {
-                            metric_name,
-                            value: Some(value),
-                            timestamp,
-                            dimensions,
-                            ..Default::default()
-                        }),
-                        _ => None,
-                    },
+                // AwsCloudwatchMetricsState converts these to the right MetricKind
+                match event.data.value {
+                    MetricValue::Counter { value } => Some(MetricDatum {
+                        metric_name,
+                        value: Some(value),
+                        timestamp,
+                        dimensions,
+                        ..Default::default()
+                    }),
+                    MetricValue::Distribution {
+                        samples,
+                        statistic: _,
+                    } => Some(MetricDatum {
+                        metric_name,
+                        values: Some(samples.iter().map(|s| s.value).collect()),
+                        counts: Some(samples.iter().map(|s| f64::from(s.rate)).collect()),
+                        timestamp,
+                        dimensions,
+                        ..Default::default()
+                    }),
+                    MetricValue::Set { values } => Some(MetricDatum {
+                        metric_name,
+                        value: Some(values.len() as f64),
+                        timestamp,
+                        dimensions,
+                        ..Default::default()
+                    }),
+                    MetricValue::Gauge { value } => Some(MetricDatum {
+                        metric_name,
+                        value: Some(value),
+                        timestamp,
+                        dimensions,
+                        ..Default::default()
+                    }),
+                    _ => None,
                 }
             })
             .collect()
@@ -418,7 +417,7 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
-    use crate::{event::metric::StatisticKind, test_util::random_string, Event};
+    use crate::{event::metric::StatisticKind, event::MetricKind, test_util::random_string, Event};
     use chrono::offset::TimeZone;
     use rand::seq::SliceRandom;
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     rusoto::{self, AWSAuthentication, RegionOrEndpoint},
     sinks::util::{
-        buffer::metrics::{AwsCloudwatchMetricNormalize, MetricsBuffer},
+        buffer::metrics::{MetricNormalize, MetricSet, MetricsBuffer},
         retries::RetryLogic,
         BatchConfig, BatchSettings, Compression, PartitionBatchSink, PartitionBuffer,
         PartitionInnerBuffer, TowerRequestConfig,
@@ -208,6 +208,17 @@ impl CloudWatchMetricsSvc {
                 }
             })
             .collect()
+    }
+}
+
+struct AwsCloudwatchMetricNormalize;
+
+impl MetricNormalize for AwsCloudwatchMetricNormalize {
+    fn apply_state(state: &mut MetricSet, metric: Metric) -> Option<Metric> {
+        match &metric.data.value {
+            MetricValue::Gauge { .. } => state.make_absolute(metric),
+            _ => state.make_incremental(metric),
+        }
     }
 }
 

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -296,6 +296,7 @@ mod tests {
         test_util::{next_addr, random_lines_with_stream},
     };
     use futures::StreamExt;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn generate_config() {

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -612,14 +612,6 @@ mod tests {
             .with_namespace(Some("ns".into()))
             .with_tags(Some(tags()))
             .with_timestamp(Some(ts())),
-            Metric::new(
-                "unsupported".into(),
-                MetricKind::Absolute,
-                MetricValue::Counter { value: 1.0 },
-            )
-            .with_namespace(Some("ns".into()))
-            .with_tags(Some(tags()))
-            .with_timestamp(Some(ts())),
         ];
         let input = encode_events(events, None, interval);
         let json = serde_json::to_string(&input).unwrap();
@@ -632,20 +624,12 @@ mod tests {
 
     #[test]
     fn encode_gauge() {
-        let events = vec![
-            Metric::new(
-                "unsupported".into(),
-                MetricKind::Incremental,
-                MetricValue::Gauge { value: 0.1 },
-            )
-            .with_timestamp(Some(ts())),
-            Metric::new(
-                "volume".into(),
-                MetricKind::Absolute,
-                MetricValue::Gauge { value: -1.1 },
-            )
-            .with_timestamp(Some(ts())),
-        ];
+        let events = vec![Metric::new(
+            "volume".into(),
+            MetricKind::Absolute,
+            MetricValue::Gauge { value: -1.1 },
+        )
+        .with_timestamp(Some(ts()))];
         let input = encode_events(events, None, 60);
         let json = serde_json::to_string(&input).unwrap();
 

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
-    event::metric::{Metric, MetricKind, MetricValue, Sample, StatisticKind},
+    event::metric::{Metric, MetricValue, Sample, StatisticKind},
     http::HttpClient,
     sinks::{
         influxdb::{
@@ -221,9 +221,8 @@ impl MetricNormalize for InfluxMetricNormalize {
             (_, MetricValue::Counter { .. }) => state.make_incremental(metric),
             // Convert incremental gauges into absolute ones
             (_, MetricValue::Gauge { .. }) => state.make_absolute(metric),
-            // All others are left as-is but aggregated
-            (MetricKind::Incremental, _) => state.aggregate_incremental(metric),
-            (MetricKind::Absolute, _) => Some(metric),
+            // All others are left as-is
+            _ => Some(metric),
         }
     }
 }

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{DataType, SinkConfig, SinkContext, SinkDescription},
-    event::metric::{Metric, MetricValue, Sample, StatisticKind},
+    event::metric::{Metric, MetricKind, MetricValue, Sample, StatisticKind},
     http::HttpClient,
     sinks::{
         influxdb::{
@@ -8,10 +8,11 @@ use crate::{
             InfluxDB1Settings, InfluxDB2Settings, ProtocolVersion,
         },
         util::{
+            buffer::metrics::{MetricNormalize, MetricSet, MetricsBuffer},
             encode_namespace,
             http::{HttpBatchService, HttpRetryLogic},
             statistic::{validate_quantiles, DistributionStatistic},
-            BatchConfig, BatchSettings, MetricBuffer, TowerRequestConfig,
+            BatchConfig, BatchSettings, TowerRequestConfig,
         },
         Healthcheck, VectorSink,
     },
@@ -139,7 +140,7 @@ impl InfluxDBSvc {
             .batch_sink(
                 HttpRetryLogic,
                 influxdb_http_service,
-                MetricBuffer::new(batch.size),
+                MetricsBuffer::<InfluxMetricNormalize>::new(batch.size),
                 batch.timeout,
                 cx.acker(),
             )
@@ -207,6 +208,23 @@ fn merge_tags(
                 .collect(),
         ),
         (None, None) => None,
+    }
+}
+
+pub struct InfluxMetricNormalize;
+
+impl MetricNormalize for InfluxMetricNormalize {
+    fn apply_state(state: &mut MetricSet, metric: Metric) -> Option<Metric> {
+        match (metric.data.kind, &metric.data.value) {
+            // Counters are disaggregated. We take the previous value from the state
+            // and emit the difference between previous and current as a Counter
+            (_, MetricValue::Counter { .. }) => state.make_incremental(metric),
+            // Convert incremental gauges into absolute ones
+            (_, MetricValue::Gauge { .. }) => state.make_absolute(metric),
+            // All others are left as-is but aggregated
+            (MetricKind::Incremental, _) => state.aggregate_incremental(metric),
+            (MetricKind::Absolute, _) => Some(metric),
+        }
     }
 }
 

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -303,7 +303,7 @@ impl StreamSink for PrometheusExporter {
                     .drain(..)
                     .map(|(MetricEntry(mut metric), is_incremental_set)| {
                         if is_incremental_set {
-                            metric.data.reset();
+                            metric.data.value = metric.data.value.zero();
                         }
                         (MetricEntry(metric), is_incremental_set)
                     })

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -312,12 +312,13 @@ impl StreamSink for PrometheusExporter {
 
             match item.data.kind {
                 MetricKind::Incremental => {
-                    let mut new = MetricEntry(item.to_absolute());
-                    if let Some((MetricEntry(mut existing), _)) = metrics.map.remove_entry(&new) {
-                        existing.data.add(&item.data);
-                        new = MetricEntry(existing);
+                    let mut entry = MetricEntry(item.into_absolute());
+                    if let Some((MetricEntry(mut existing), _)) = metrics.map.remove_entry(&entry) {
+                        existing.data.update(&entry.data);
+                        entry = MetricEntry(existing);
                     }
-                    metrics.map.insert(new, item.data.value.is_set());
+                    let is_set = entry.data.value.is_set();
+                    metrics.map.insert(entry, is_set);
                 }
                 MetricKind::Absolute => {
                     let new = MetricEntry(item);
@@ -476,12 +477,12 @@ mod tests {
         let map = &sink.metrics.read().unwrap().map;
 
         assert_eq!(
-            map.get_full(&MetricEntry(m1)).unwrap().1 .0.data.value,
+            map.get_full(&MetricEntry(m1)).unwrap().1.data.value,
             MetricValue::Counter { value: 40. }
         );
 
         assert_eq!(
-            map.get_full(&MetricEntry(m2)).unwrap().1 .0.data.value,
+            map.get_full(&MetricEntry(m2)).unwrap().1.data.value,
             MetricValue::Counter { value: 33. }
         );
     }

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -7,7 +7,7 @@ use crate::{
     sinks::{
         self,
         util::{
-            buffer::metrics::{AbsoluteMetricsState, MetricsBuffer},
+            buffer::metrics::{AbsoluteMetricNormalize, MetricsBuffer},
             http::HttpRetryLogic,
             BatchConfig, BatchSettings, PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer,
             TowerRequestConfig,
@@ -97,7 +97,7 @@ impl SinkConfig for RemoteWriteConfig {
             let service = request.service(HttpRetryLogic, service);
             let service = ServiceBuilder::new().service(service);
             let buffer =
-                PartitionBuffer::new(MetricsBuffer::<AbsoluteMetricsState>::new(batch.size));
+                PartitionBuffer::new(MetricsBuffer::<AbsoluteMetricNormalize>::new(batch.size));
             PartitionBatchSink::new(service, buffer, batch.timeout, cx.acker())
                 .with_flat_map(move |event: Event| {
                     let tenant_id = tenant_id.as_ref().and_then(|template| {

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -7,8 +7,10 @@ use crate::{
     sinks::{
         self,
         util::{
-            http::HttpRetryLogic, BatchConfig, BatchSettings, MetricBuffer, PartitionBatchSink,
-            PartitionBuffer, PartitionInnerBuffer, TowerRequestConfig,
+            buffer::metrics::{AbsoluteMetricsState, MetricsBuffer},
+            http::HttpRetryLogic,
+            BatchConfig, BatchSettings, PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer,
+            TowerRequestConfig,
         },
     },
     template::Template,
@@ -94,7 +96,8 @@ impl SinkConfig for RemoteWriteConfig {
         let sink = {
             let service = request.service(HttpRetryLogic, service);
             let service = ServiceBuilder::new().service(service);
-            let buffer = PartitionBuffer::new(MetricBuffer::new(batch.size));
+            let buffer =
+                PartitionBuffer::new(MetricsBuffer::<AbsoluteMetricsState>::new(batch.size));
             PartitionBatchSink::new(service, buffer, batch.timeout, cx.acker())
                 .with_flat_map(move |event: Event| {
                     let tenant_id = tenant_id.as_ref().and_then(|template| {

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -6,7 +6,7 @@ use crate::{
     internal_events::SematextMetricsEncodeEventFailed,
     sinks::influxdb::{encode_timestamp, encode_uri, influx_line_protocol, Field, ProtocolVersion},
     sinks::util::{
-        buffer::metrics::{MetricsBuffer, SematextMetricsState},
+        buffer::metrics::{MetricsBuffer, SematextMetricNormalize},
         http::{HttpBatchService, HttpRetryLogic},
         BatchConfig, BatchSettings, TowerRequestConfig,
     },
@@ -147,7 +147,7 @@ impl SematextMetricsService {
             .batch_sink(
                 HttpRetryLogic,
                 sematext_service,
-                MetricsBuffer::<SematextMetricsState>::new(batch.size),
+                MetricsBuffer::<SematextMetricNormalize>::new(batch.size),
                 batch.timeout,
                 cx.acker(),
             )
@@ -208,7 +208,7 @@ fn encode_events(token: &str, default_namespace: &str, events: Vec<Metric>) -> S
         let (metric_type, fields) = match event.data.value {
             MetricValue::Counter { value } => ("counter", to_fields(label, value)),
             MetricValue::Gauge { value } => ("gauge", to_fields(label, value)),
-            _ => unreachable!(), // handled by SematextMetricsState
+            _ => unreachable!(), // handled by SematextMetricNormalize
         };
 
         if let Err(error) = influx_line_protocol(

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -90,7 +90,6 @@ impl Deref for MetricEntry {
     }
 }
 
-#[derive(Clone, PartialEq)]
 pub struct MetricBuffer {
     state: HashSet<MetricEntry>,
     metrics: HashSet<MetricEntry>,

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -102,10 +102,10 @@ impl DerefMut for MetricEntry {
 ///
 /// Batching mostly means that we will aggregate away timestamp
 /// information, and apply metric-specific compression to improve the
-/// performance of the pipeline.  In particular, only the latest in a
+/// performance of the pipeline. In particular, only the latest in a
 /// series of metrics are output, and incremental metrics are summed
-/// into the output buffer.  Any conversion of metrics is handled by the
-/// normalization type `N: MetricNormalize`.  Further, distribution
+/// into the output buffer. Any conversion of metrics is handled by the
+/// normalization type `N: MetricNormalize`. Further, distribution
 /// metrics have their their samples compressed with
 /// `compress_distribution` below.
 pub struct MetricsBuffer<N> {
@@ -198,7 +198,7 @@ impl<N: MetricNormalize> Batch for MetricsBuffer<N> {
 }
 
 /// The metrics state trait abstracts how data point normalization is
-/// done.  Normalisation is required to make sure Sources and Sinks are
+/// done. Normalisation is required to make sure Sources and Sinks are
 /// exchanging compatible data structures. For instance, delta gauges
 /// produced by Statsd source cannot be directly sent to Datadog API. In
 /// this case the buffer will keep the state of a gauge value, and

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -276,12 +276,14 @@ impl MetricsState for IncrementalMetricsState {
 }
 
 /// A metric state handler specialized for the types of metrics that
-/// Datadog expects. In particular, it can handle absolute gauges but
-/// everything else should be incremental.
+/// AWS Cloudwatch and Datadog expect. In particular, they can want
+/// absolute gauges but everything else should be incremental.
 #[derive(Default)]
 pub struct DatadogMetricsState {
     state: MetricSet,
 }
+
+pub type AwsCloudwatchMetricsState = DatadogMetricsState;
 
 impl MetricsState for DatadogMetricsState {
     fn apply_state(&mut self, metric: Metric) -> Option<Metric> {

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -25,7 +25,7 @@ use std::borrow::Cow;
 
 pub use batch::{Batch, BatchConfig, BatchSettings, BatchSize, PushResult};
 pub use buffer::json::{BoxedRawValue, JsonArrayBuffer};
-pub use buffer::metrics::{MetricBuffer, MetricEntry};
+pub use buffer::metrics::MetricEntry;
 pub use buffer::partition::Partition;
 pub use buffer::vec::{EncodedLength, VecBuffer};
 pub use buffer::{Buffer, Compression, PartitionBuffer, PartitionInnerBuffer};


### PR DESCRIPTION
The core of this change however is to split the metric normalization logic out of the metrics batch buffer and attach it to the sinks, since there are differing requirements for most of the sinks.

This is a pretty large change to the metrics batch buffer system. A large chunk of the lines changed are relatively simple moves or re-indentation.

I am unsure if the normalization logic for Influxdb metrics sink is actually correct, but it should be the same effective behavior as what it used to do, so it shouldn't introduce any problems.

Closes #5589 

Signed-off-by: Bruce Guenter <bruce@timber.io>