### PR TITLE
fix(nats sink): call ack on any result

### DIFF
--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -177,12 +177,13 @@ impl StreamSink for NatsSink {
                     emit!(NatsEventSendSuccess {
                         byte_size: message_len,
                     });
-                    self.acker.ack(1);
                 }
                 Err(error) => {
                     emit!(NatsEventSendFail { error });
                 }
             }
+
+            self.acker.ack(1);
         }
 
         Ok(())


### PR DESCRIPTION
We should call `.ack(1)` on any result.