### PR TITLE
fix(metrics): Fix metrics::tests::test_cardinality_metric

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -320,9 +320,22 @@ mod tests {
         counter!("cardinality_test_metric_3", 1);
         assert!(capture_value() >= intial_value + 3.0);
 
-        counter!("cardinality_test_metric_1", 1);
-        counter!("cardinality_test_metric_2", 1);
-        counter!("cardinality_test_metric_3", 1);
-        assert!(capture_value() >= intial_value + 3.0);
+        // Other tests could possibly increase the cardinality, so just
+        // try adding the same test metrics a few times and fail only if
+        // it keeps increasing.
+        for count in 1..=10 {
+            let start_value = capture_value();
+            counter!("cardinality_test_metric_1", 1);
+            counter!("cardinality_test_metric_2", 1);
+            counter!("cardinality_test_metric_3", 1);
+            let end_value = capture_value();
+            assert!(end_value >= start_value);
+            if start_value == end_value {
+                break;
+            }
+            if count == 10 {
+                panic!("Cardinality count still increasing after 10 loops!");
+            }
+        }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -248,7 +248,7 @@ pub fn capture_metrics(controller: &Controller) -> impl Iterator<Item = Event> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_util::trace_init;
+    use crate::{event::Event, test_util::trace_init};
     use metrics::counter;
     use tracing::{span, Level};
 
@@ -299,7 +299,7 @@ mod tests {
 
         let capture_value = || {
             let metric = super::capture_metrics(super::get_controller().unwrap())
-                .map(|e| e.into_metric())
+                .map(Event::into_metric)
                 .find(|metric| metric.name() == super::CARDINALITY_KEY_NAME)
                 .unwrap();
             match metric.data.value {
@@ -311,18 +311,18 @@ mod tests {
         let intial_value = capture_value();
 
         counter!("cardinality_test_metric_1", 1);
-        assert_eq!(capture_value(), intial_value + 1.0);
+        assert!(capture_value() >= intial_value + 1.0);
 
         counter!("cardinality_test_metric_1", 1);
-        assert_eq!(capture_value(), intial_value + 1.0);
+        assert!(capture_value() >= intial_value + 1.0);
 
         counter!("cardinality_test_metric_2", 1);
         counter!("cardinality_test_metric_3", 1);
-        assert_eq!(capture_value(), intial_value + 3.0);
+        assert!(capture_value() >= intial_value + 3.0);
 
         counter!("cardinality_test_metric_1", 1);
         counter!("cardinality_test_metric_2", 1);
         counter!("cardinality_test_metric_3", 1);
-        assert_eq!(capture_value(), intial_value + 3.0);
+        assert!(capture_value() >= intial_value + 3.0);
     }
 }


### PR DESCRIPTION
The test `test_cardinality_metric` has a race condition. Multiple tests
may be running simultaneously, but the internal metrics controller is
global. If a test introduces a new metric between capturing
`initial_value` and later checks on its value, the assertions of
equality will fail the test.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #5398 