### PR TITLE
enhancement(templating): Add support for metrics in templates

### DIFF
--- a/docs/manual/setup/configuration.md
+++ b/docs/manual/setup/configuration.md
@@ -141,7 +141,8 @@ from the event's data. Two syntaxes are supported for fields that support field
 interpolation:
 
 1. [Strptime specifiers][urls.strptime_specifiers]. Ex: `date=%Y/%m/%d`
-2. [Event fields][docs.data-model]. Ex: `{{ field_name }}`
+2. [Log fields][docs.data-model.log]. Ex: `{{ field_name }}`
+3. [Metric name, namespace, or tags][docs.data-model.metric]. Ex: `{{ name }} {{ namespace }} {{ tags.tag_name }}`
 
 For example:
 


### PR DESCRIPTION
Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #5985 

This diverges from the issue by prefixing tags (`{{tags.tag_name}}`) in order to allow use of the `name` and `namespace` in templates.

Are there other places I need to add documentation for this?