### PR TITLE
enhancement(observability): Add `events_in_total` & `events_out_total` metrics

### DIFF
--- a/docs/reference/components/sinks.cue
+++ b/docs/reference/components/sinks.cue
@@ -565,4 +565,9 @@ components: sinks: [Name=string]: {
 			}
 		}
 	}
+
+	telemetry: metrics: {
+		events_in_total:  components.sources.internal_metrics.output.metrics.events_in_total
+		events_out_total: components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/docs/reference/components/sources.cue
+++ b/docs/reference/components/sources.cue
@@ -228,4 +228,8 @@ components: sources: [Name=string]: {
 			}
 		}
 	}
+
+	telemetry: metrics: {
+		events_out_total: components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -284,6 +284,18 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		events_in_total: {
+			description:       "The total number of events accepted by this component."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		events_out_total: {
+			description:       "The total number of events emitted by this component."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
 		processed_events_total: {
 			description:       "The total number of events processed by this component."
 			type:              "counter"

--- a/docs/reference/components/transforms.cue
+++ b/docs/reference/components/transforms.cue
@@ -9,4 +9,9 @@ components: transforms: [Name=string]: {
 		"""
 
 	kind: "transform"
+
+	telemetry: metrics: {
+		events_in_total:  components.sources.internal_metrics.output.metrics.events_in_total
+		events_out_total: components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/src/buffers/mod.rs
+++ b/src/buffers/mod.rs
@@ -1,4 +1,4 @@
-use crate::{config::Resource, Event};
+use crate::{config::Resource, internal_events::EventOut, Event};
 #[cfg(feature = "leveldb")]
 use futures::compat::{Sink01CompatExt, Stream01CompatExt};
 use futures::{channel::mpsc, Sink, SinkExt, Stream};
@@ -181,6 +181,7 @@ impl Acker {
                     notifier.notify();
                 }
             }
+            emit!(EventOut { count: num });
         }
     }
 

--- a/src/internal_events/topology.rs
+++ b/src/internal_events/topology.rs
@@ -9,3 +9,21 @@ impl InternalEvent for EventProcessed {
         counter!("processed_events_total", 1);
     }
 }
+
+#[derive(Debug)]
+pub struct EventIn;
+
+impl InternalEvent for EventIn {
+    fn emit_metrics(&self) {
+        counter!("events_in_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct EventOut;
+
+impl InternalEvent for EventOut {
+    fn emit_metrics(&self) {
+        counter!("events_out_total", 1);
+    }
+}

--- a/src/internal_events/topology.rs
+++ b/src/internal_events/topology.rs
@@ -20,10 +20,14 @@ impl InternalEvent for EventIn {
 }
 
 #[derive(Debug)]
-pub struct EventOut;
+pub struct EventOut {
+    pub count: usize,
+}
 
 impl InternalEvent for EventOut {
     fn emit_metrics(&self) {
-        counter!("events_out_total", 1);
+        if self.count > 0 {
+            counter!("events_out_total", self.count as u64);
+        }
     }
 }

--- a/src/internal_events/topology.rs
+++ b/src/internal_events/topology.rs
@@ -20,6 +20,15 @@ impl InternalEvent for EventIn {
 }
 
 #[derive(Debug)]
+pub struct EventZeroIn;
+
+impl InternalEvent for EventZeroIn {
+    fn emit_metrics(&self) {
+        counter!("events_in_total", 0);
+    }
+}
+
+#[derive(Debug)]
 pub struct EventOut {
     pub count: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[macro_use]
 pub mod config;
-pub mod buffers;
 pub mod cli;
 pub mod conditions;
 pub mod dns;
@@ -41,6 +40,7 @@ pub mod internal_events;
 pub mod api;
 pub mod app;
 pub mod async_read;
+pub mod buffers;
 pub mod encoding_transcode;
 pub mod heartbeat;
 pub mod http;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,4 +1,4 @@
-use crate::{transforms::FunctionTransform, Event};
+use crate::{internal_events::EventOut, transforms::FunctionTransform, Event};
 use futures::{task::Poll, Sink};
 use std::{collections::VecDeque, fmt, pin::Pin, task::Context};
 use tokio::sync::mpsc;
@@ -76,6 +76,7 @@ impl Sink<Event> for Pipeline {
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Event) -> Result<(), Self::Error> {
+        emit!(EventOut { count: 1 });
         // Note how this gets **swapped** with `new_working_set` in the loop.
         // At the end of the loop, it will only contain finalized events.
         let mut working_set = vec![item];

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -213,6 +213,7 @@ pub async fn build_pieces(
             sink.run(
                 rx.by_ref()
                     .filter(|event| ready(filter_event_type(event, input_type)))
+                    .inspect(|_| emit!(EventIn))
                     .take_until_if(tripwire),
             )
             .await

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -7,7 +7,7 @@ use crate::{
     buffers,
     config::{DataType, SinkContext},
     event::Event,
-    internal_events::{EventIn, EventOut, EventProcessed},
+    internal_events::{EventIn, EventOut, EventProcessed, EventZeroIn},
     shutdown::SourceShutdownCoordinator,
     stream::VecStreamExt,
     transforms::Transform,
@@ -81,12 +81,16 @@ pub async fn build_pieces(
         // forcibly shut down. We accomplish this by select()-ing on the server Task with the
         // force_shutdown_tripwire. That means that if the force_shutdown_tripwire resolves while
         // the server Task is still running the Task will simply be dropped on the floor.
-        let server = future::try_select(server, force_shutdown_tripwire.unit_error().boxed())
-            .map_ok(|_| {
-                debug!("Finished.");
-                TaskOutput::Source
-            })
-            .map_err(|_| ());
+        let server = async {
+            emit!(EventZeroIn);
+            match future::try_select(server, force_shutdown_tripwire.unit_error().boxed()).await {
+                Ok(_) => {
+                    debug!("Finished.");
+                    Ok(TaskOutput::Source)
+                }
+                Err(_) => Err(()),
+            }
+        };
         let server = Task::new(name, typetag, server);
 
         outputs.insert(name.clone(), control);

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -125,13 +125,11 @@ pub async fn build_pieces(
                 .flat_map(move |v| {
                     let mut buf = Vec::with_capacity(1);
                     t.transform(&mut buf, v);
+                    emit!(EventOut { count: buf.len() });
                     emit!(EventProcessed);
                     stream::iter(buf.into_iter()).map(Ok)
                 })
-                .forward(output.with(|event| async {
-                    emit!(EventOut);
-                    Ok(event)
-                }))
+                .forward(output)
                 .boxed(),
             Transform::Task(t) => {
                 let filtered = input_rx
@@ -141,7 +139,7 @@ pub async fn build_pieces(
                 t.transform(Box::pin(filtered))
                     .map(Ok)
                     .forward(output.with(|event| async {
-                        emit!(EventOut);
+                        emit!(EventOut { count: 1 });
                         Ok(event)
                     }))
                     .boxed()


### PR DESCRIPTION
Ref. #6367 

---

Source `events_in_total` (component)
* Emitted for each event that came from outside the source.
* May contain labels marking the origin like: file path, IP, etc.
	* ~~If it's emitted with the label, then it shouldn't be emitted without it.~~
* This is basically equivalent to `events_processed_total` although there are some differences, notably `generator` source won't emit it.
* Topology does emit this once for all sources without incrementing the counter so to cover the cases like `generator` source.  
- [x] Add to sources in a follow up PR. #6758

Source `events_out_total` (topology)
* Emitted for each event coming out of the source.

---

Transform `events_in_total` (topology)
* Emitted for each event passed to the transform.

Transform `events_out_total` (topology)
* Emitted for each event coming out of the transform.

---

Sink `events_in_total` (topology)
* Emitted for each event passed to the sink.
* This differs from the original idea of emitting it on entry to buffer, which would be really useful but
   * requires switching spans which is costly to call for each event
   * there are edge cases when reusing buffers on reload whose fixes would also have performance cost
   - [x] In theory this all is avoidable/doable but I think it deserve it's own issue since it could end up quite complex and/or not worthy of doing, plus it can easily build on top of this PR. (EDIT: Let's roll with current implementation until we decide to instrument the buffers, then we can decide to either change this metric, or add a new gauge metric) 

Sink `events_out_total` (topology)
* Emitted for each event acked by the sink.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->
