### PR TITLE
enhancement(data model): Enhance vector protocol for new metric data

### DIFF
--- a/proto/event.proto
+++ b/proto/event.proto
@@ -54,9 +54,12 @@ message Metric {
     Counter counter = 5;
     Gauge gauge = 6;
     Set set = 7;
-    Distribution distribution = 8;
-    AggregatedHistogram aggregated_histogram = 9;
-    AggregatedSummary aggregated_summary = 10;
+    Distribution1 distribution1 = 8;
+    AggregatedHistogram1 aggregated_histogram1 = 9;
+    AggregatedSummary1 aggregated_summary1 = 10;
+    Distribution2 distribution2 = 12;
+    AggregatedHistogram2 aggregated_histogram2 = 13;
+    AggregatedSummary2 aggregated_summary2 = 14;
   }
   string namespace = 11;
 }
@@ -73,26 +76,59 @@ message Set {
   repeated string values = 1;
 }
 
-message Distribution {
+enum StatisticKind {
+  Histogram = 0;
+  Summary = 1;
+}
+
+message Distribution1 {
   repeated double values = 1;
   repeated uint32 sample_rates = 2;
-  enum StatisticKind {
-    Histogram = 0;
-    Summary = 1;
-  }
   StatisticKind statistic = 3;
 }
 
-message AggregatedHistogram {
+message Distribution2 {
+  repeated DistributionSample samples = 1;
+  StatisticKind statistic = 2;
+}
+
+message DistributionSample {
+  double value = 1;
+  uint32 rate = 2;
+}
+
+message AggregatedHistogram1 {
   repeated double buckets = 1;
   repeated uint32 counts = 2;
   uint32 count = 3;
   double sum = 4;
 }
 
-message AggregatedSummary {
+message AggregatedHistogram2 {
+  repeated HistogramBucket buckets = 1;
+  uint32 count = 2;
+  double sum = 3;
+}
+
+message HistogramBucket {
+  double upper_limit = 1;
+  uint32 count = 2;
+}
+
+message AggregatedSummary1 {
   repeated double quantiles = 1;
   repeated double values = 2;
   uint32 count = 3;
   double sum = 4;
+}
+
+message AggregatedSummary2 {
+  repeated SummaryQuantile quantiles = 1;
+  uint32 count = 2;
+  double sum = 3;
+}
+
+message SummaryQuantile {
+  double upper_limit = 1;
+  double value = 2;
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -216,22 +216,31 @@ impl From<proto::EventWrapper> for Event {
                     MetricProto::Set(set) => MetricValue::Set {
                         values: set.values.into_iter().collect(),
                     },
-                    MetricProto::Distribution(dist) => MetricValue::Distribution {
-                        statistic: match dist.statistic() {
-                            proto::distribution::StatisticKind::Histogram => {
-                                StatisticKind::Histogram
-                            }
-                            proto::distribution::StatisticKind::Summary => StatisticKind::Summary,
-                        },
+                    MetricProto::Distribution1(dist) => MetricValue::Distribution {
+                        statistic: dist.statistic().into(),
                         samples: metric::zip_samples(dist.values, dist.sample_rates),
                     },
-                    MetricProto::AggregatedHistogram(hist) => MetricValue::AggregatedHistogram {
+                    MetricProto::Distribution2(dist) => MetricValue::Distribution {
+                        statistic: dist.statistic().into(),
+                        samples: dist.samples.into_iter().map(Into::into).collect(),
+                    },
+                    MetricProto::AggregatedHistogram1(hist) => MetricValue::AggregatedHistogram {
                         buckets: metric::zip_buckets(hist.buckets, hist.counts),
                         count: hist.count,
                         sum: hist.sum,
                     },
-                    MetricProto::AggregatedSummary(summary) => MetricValue::AggregatedSummary {
+                    MetricProto::AggregatedHistogram2(hist) => MetricValue::AggregatedHistogram {
+                        buckets: hist.buckets.into_iter().map(Into::into).collect(),
+                        count: hist.count,
+                        sum: hist.sum,
+                    },
+                    MetricProto::AggregatedSummary1(summary) => MetricValue::AggregatedSummary {
                         quantiles: metric::zip_quantiles(summary.quantiles, summary.values),
+                        count: summary.count,
+                        sum: summary.sum,
+                    },
+                    MetricProto::AggregatedSummary2(summary) => MetricValue::AggregatedSummary {
+                        quantiles: summary.quantiles.into_iter().map(Into::into).collect(),
                         count: summary.count,
                         sum: summary.sum,
                     },
@@ -320,16 +329,11 @@ impl From<Event> for proto::EventWrapper {
                         values: values.into_iter().collect(),
                     }),
                     MetricValue::Distribution { samples, statistic } => {
-                        MetricProto::Distribution(proto::Distribution {
-                            values: samples.iter().map(|s| s.value).collect(),
-                            sample_rates: samples.iter().map(|s| s.rate).collect(),
+                        MetricProto::Distribution2(proto::Distribution2 {
+                            samples: samples.into_iter().map(Into::into).collect(),
                             statistic: match statistic {
-                                StatisticKind::Histogram => {
-                                    proto::distribution::StatisticKind::Histogram
-                                }
-                                StatisticKind::Summary => {
-                                    proto::distribution::StatisticKind::Summary
-                                }
+                                StatisticKind::Histogram => proto::StatisticKind::Histogram,
+                                StatisticKind::Summary => proto::StatisticKind::Summary,
                             }
                             .into(),
                         })
@@ -338,9 +342,8 @@ impl From<Event> for proto::EventWrapper {
                         buckets,
                         count,
                         sum,
-                    } => MetricProto::AggregatedHistogram(proto::AggregatedHistogram {
-                        buckets: buckets.iter().map(|b| b.upper_limit).collect(),
-                        counts: buckets.iter().map(|b| b.count).collect(),
+                    } => MetricProto::AggregatedHistogram2(proto::AggregatedHistogram2 {
+                        buckets: buckets.into_iter().map(Into::into).collect(),
                         count,
                         sum,
                     }),
@@ -348,9 +351,8 @@ impl From<Event> for proto::EventWrapper {
                         quantiles,
                         count,
                         sum,
-                    } => MetricProto::AggregatedSummary(proto::AggregatedSummary {
-                        quantiles: quantiles.iter().map(|q| q.upper_limit).collect(),
-                        values: quantiles.iter().map(|q| q.value).collect(),
+                    } => MetricProto::AggregatedSummary2(proto::AggregatedSummary2 {
+                        quantiles: quantiles.into_iter().map(Into::into).collect(),
                         count,
                         sum,
                     }),
@@ -367,6 +369,69 @@ impl From<Event> for proto::EventWrapper {
 
                 proto::EventWrapper { event: Some(event) }
             }
+        }
+    }
+}
+
+impl From<proto::StatisticKind> for StatisticKind {
+    fn from(kind: proto::StatisticKind) -> Self {
+        match kind {
+            proto::StatisticKind::Histogram => StatisticKind::Histogram,
+            proto::StatisticKind::Summary => StatisticKind::Summary,
+        }
+    }
+}
+
+impl From<metric::Sample> for proto::DistributionSample {
+    fn from(sample: metric::Sample) -> Self {
+        Self {
+            value: sample.value,
+            rate: sample.rate,
+        }
+    }
+}
+
+impl From<proto::DistributionSample> for metric::Sample {
+    fn from(sample: proto::DistributionSample) -> Self {
+        Self {
+            value: sample.value,
+            rate: sample.rate,
+        }
+    }
+}
+
+impl From<metric::Bucket> for proto::HistogramBucket {
+    fn from(bucket: metric::Bucket) -> Self {
+        Self {
+            upper_limit: bucket.upper_limit,
+            count: bucket.count,
+        }
+    }
+}
+
+impl From<proto::HistogramBucket> for metric::Bucket {
+    fn from(bucket: proto::HistogramBucket) -> Self {
+        Self {
+            upper_limit: bucket.upper_limit,
+            count: bucket.count,
+        }
+    }
+}
+
+impl From<metric::Quantile> for proto::SummaryQuantile {
+    fn from(quantile: metric::Quantile) -> Self {
+        Self {
+            upper_limit: quantile.upper_limit,
+            value: quantile.value,
+        }
+    }
+}
+
+impl From<proto::SummaryQuantile> for metric::Quantile {
+    fn from(quantile: proto::SummaryQuantile) -> Self {
+        Self {
+            upper_limit: quantile.upper_limit,
+            value: quantile.value,
         }
     }
 }


### PR DESCRIPTION
The shape of the metric distribution, histogram, and quantile data has
changed internally, requiring them to be reshaped going into and out of
the existing vector protocol. This change adds new fields to the metric
record that match the new structures, reducing the encoding and decoding
overhead.

Signed-off-by: Bruce Guenter <bruce@timber.io>

Closes #6159 