### PR TITLE
enhancement(observability): Add `events_in_total` to sources

### DIFF
--- a/docs/reference/components/sources/apache_metrics.cue
+++ b/docs/reference/components/sources/apache_metrics.cue
@@ -199,6 +199,7 @@ components: sources: apache_metrics: {
 	how_it_works: {}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total

--- a/docs/reference/components/sources/aws_ecs_metrics.cue
+++ b/docs/reference/components/sources/aws_ecs_metrics.cue
@@ -244,6 +244,7 @@ components: sources: aws_ecs_metrics: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total

--- a/docs/reference/components/sources/aws_kinesis_firehose.cue
+++ b/docs/reference/components/sources/aws_kinesis_firehose.cue
@@ -204,6 +204,8 @@ components: sources: aws_kinesis_firehose: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
+		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
 		request_read_errors_total: components.sources.internal_metrics.output.metrics.request_read_errors_total
 		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/docs/reference/components/sources/aws_s3.cue
+++ b/docs/reference/components/sources/aws_s3.cue
@@ -274,6 +274,8 @@ components: sources: aws_s3: components._aws & {
 	]
 
 	telemetry: metrics: {
+		events_in_total:                        components.sources.internal_metrics.output.metrics.events_in_total
+		processed_bytes_total:                  components.sources.internal_metrics.output.metrics.processed_bytes_total
 		sqs_message_delete_failed_total:        components.sources.internal_metrics.output.metrics.sqs_message_delete_failed_total
 		sqs_message_delete_succeeded_total:     components.sources.internal_metrics.output.metrics.sqs_message_delete_succeeded_total
 		sqs_message_processing_failed_total:    components.sources.internal_metrics.output.metrics.sqs_message_processing_failed_total

--- a/docs/reference/components/sources/docker_logs.cue
+++ b/docs/reference/components/sources/docker_logs.cue
@@ -390,6 +390,7 @@ components: sources: docker_logs: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:                       components.sources.internal_metrics.output.metrics.events_in_total
 		communication_errors_total:            components.sources.internal_metrics.output.metrics.communication_errors_total
 		container_metadata_fetch_errors_total: components.sources.internal_metrics.output.metrics.container_metadata_fetch_errors_total
 		container_processed_events_total:      components.sources.internal_metrics.output.metrics.container_processed_events_total

--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -542,6 +542,7 @@ components: sources: file: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:               components.sources.internal_metrics.output.metrics.events_in_total
 		checkpoint_write_errors_total: components.sources.internal_metrics.output.metrics.checkpoint_write_errors_total
 		checkpoints_total:             components.sources.internal_metrics.output.metrics.checkpoints_total
 		checksum_errors_total:         components.sources.internal_metrics.output.metrics.checksum_errors_total

--- a/docs/reference/components/sources/heroku_logs.cue
+++ b/docs/reference/components/sources/heroku_logs.cue
@@ -106,6 +106,8 @@ components: sources: heroku_logs: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
+		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
 		request_read_errors_total: components.sources.internal_metrics.output.metrics.request_read_errors_total
 		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/docs/reference/components/sources/http.cue
+++ b/docs/reference/components/sources/http.cue
@@ -254,6 +254,7 @@ components: sources: http: {
 	]
 
 	telemetry: metrics: {
+		events_in_total:         components.sources.internal_metrics.output.metrics.events_in_total
 		http_bad_requests_total: components.sources.internal_metrics.output.metrics.http_bad_requests_total
 		parse_errors_total:      components.sources.internal_metrics.output.metrics.parse_errors_total
 	}

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -285,7 +285,7 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		events_in_total: {
-			description:       """
+			description: """
 				The number of events accepted by this component either from tagged 
 				origin like file and uri, or cumulatively from other origins.
 				"""

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -285,10 +285,38 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		events_in_total: {
-			description:       "The total number of events accepted by this component."
+			description:       """
+				The number of events accepted by this component either from tagged 
+				origin like file and uri, or cumulatively from other origins.
+				"""
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags:              _component_tags & {
+				file: {
+					description: "The file from which the event originates."
+					required:    false
+				}
+				uri: {
+					description: "The sanitized uri from which the event originates."
+					required:    false
+				}
+				container_name: {
+					description: "The name of the container from which the event originates."
+					required:    false
+				}
+				pod_name: {
+					description: "The name of the pod from which the event originates."
+					required:    false
+				}
+				peer_addr: {
+					description: "The ip from which the event originates."
+					required:    false
+				}
+				peer_path: {
+					description: "The pathname from which the event originates."
+					required:    false
+				}
+			}
 		}
 		events_out_total: {
 			description:       "The total number of events emitted by this component."

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -309,7 +309,7 @@ components: sources: internal_metrics: {
 					required:    false
 				}
 				peer_addr: {
-					description: "The ip from which the event originates."
+					description: "The IP from which the event originates."
 					required:    false
 				}
 				peer_path: {

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -286,7 +286,7 @@ components: sources: internal_metrics: {
 		}
 		events_in_total: {
 			description: """
-				The number of events accepted by this component either from tagged 
+				The number of events accepted by this component either from tagged
 				origin like file and uri, or cumulatively from other origins.
 				"""
 			type:              "counter"

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -316,6 +316,7 @@ components: sources: internal_metrics: {
 					description: "The pathname from which the event originates."
 					required:    false
 				}
+				mode: _mode
 			}
 		}
 		events_out_total: {
@@ -472,10 +473,36 @@ components: sources: internal_metrics: {
 			tags:              _internal_metrics_tags
 		}
 		processed_bytes_total: {
-			description:       "The total number of bytes processed by the component."
+			description:       "The number of bytes processed by the component."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags:              _component_tags & {
+				file: {
+					description: "The file from which the bytes originate."
+					required:    false
+				}
+				uri: {
+					description: "The sanitized uri from which the bytes originate."
+					required:    false
+				}
+				container_name: {
+					description: "The name of the container from which the bytes originate."
+					required:    false
+				}
+				pod_name: {
+					description: "The name of the pod from which the bytes originate."
+					required:    false
+				}
+				peer_addr: {
+					description: "The IP from which the bytes originate."
+					required:    false
+				}
+				peer_path: {
+					description: "The pathname from which the bytes originate."
+					required:    false
+				}
+				mode: _mode
+			}
 		}
 		processing_errors_total: {
 			description:       "The total number of processing errors encountered by this component."
@@ -767,6 +794,15 @@ components: sources: internal_metrics: {
 			description: "The name of the job producing Vector metrics."
 			required:    true
 			default:     "vector"
+		}
+		_mode: {
+			description: "The connection mode used by the component."
+			required:    false
+			enum: {
+				udp: "User Datagram Protocol"
+				tcp: "Transmission Control Protocol"
+				unix: "Unix domain socket"
+			}
 		}
 		_path: {
 			description: "The path that produced the error."

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -799,8 +799,8 @@ components: sources: internal_metrics: {
 			description: "The connection mode used by the component."
 			required:    false
 			enum: {
-				udp: "User Datagram Protocol"
-				tcp: "Transmission Control Protocol"
+				udp:  "User Datagram Protocol"
+				tcp:  "Transmission Control Protocol"
 				unix: "Unix domain socket"
 			}
 		}

--- a/docs/reference/components/sources/journald.cue
+++ b/docs/reference/components/sources/journald.cue
@@ -199,6 +199,7 @@ components: sources: journald: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:            components.sources.internal_metrics.output.metrics.events_in_total
 		invalid_record_total:       components.sources.internal_metrics.output.metrics.invalid_record_total
 		invalid_record_bytes_total: components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
 		processed_bytes_total:      components.sources.internal_metrics.output.metrics.processed_bytes_total

--- a/docs/reference/components/sources/kafka.cue
+++ b/docs/reference/components/sources/kafka.cue
@@ -238,6 +238,7 @@ components: sources: kafka: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:                      components.sources.internal_metrics.output.metrics.events_in_total
 		consumer_offset_updates_failed_total: components.sources.internal_metrics.output.metrics.consumer_offset_updates_failed_total
 		events_failed_total:                  components.sources.internal_metrics.output.metrics.events_failed_total
 		processed_bytes_total:                components.sources.internal_metrics.output.metrics.processed_bytes_total

--- a/docs/reference/components/sources/kubernetes_logs.cue
+++ b/docs/reference/components/sources/kubernetes_logs.cue
@@ -556,6 +556,7 @@ components: sources: kubernetes_logs: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:                        components.sources.internal_metrics.output.metrics.events_in_total
 		k8s_format_picker_edge_cases_total:     components.sources.internal_metrics.output.metrics.k8s_format_picker_edge_cases_total
 		k8s_docker_format_parse_failures_total: components.sources.internal_metrics.output.metrics.k8s_docker_format_parse_failures_total
 		k8s_event_annotation_failures_total:    components.sources.internal_metrics.output.metrics.k8s_event_annotation_failures_total

--- a/docs/reference/components/sources/mongodb_metrics.cue
+++ b/docs/reference/components/sources/mongodb_metrics.cue
@@ -760,6 +760,7 @@ components: sources: mongodb_metrics: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
 		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
 		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total

--- a/docs/reference/components/sources/nginx_metrics.cue
+++ b/docs/reference/components/sources/nginx_metrics.cue
@@ -109,13 +109,6 @@ components: sources: nginx_metrics: {
 		}
 	}
 
-	telemetry: metrics: {
-		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
-		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
-	}
-
 	output: metrics: {
 		// Default Nginx tags
 		_nginx_metrics_tags: {
@@ -182,6 +175,7 @@ components: sources: nginx_metrics: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
 		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
 		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total

--- a/docs/reference/components/sources/postgresql_metrics.cue
+++ b/docs/reference/components/sources/postgresql_metrics.cue
@@ -157,6 +157,7 @@ components: sources: postgresql_metrics: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
 		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
 		request_errors_total:         components.sources.internal_metrics.output.metrics.request_errors_total

--- a/docs/reference/components/sources/prometheus_remote_write.cue
+++ b/docs/reference/components/sources/prometheus_remote_write.cue
@@ -94,6 +94,7 @@ components: sources: prometheus_remote_write: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total

--- a/docs/reference/components/sources/prometheus_scrape.cue
+++ b/docs/reference/components/sources/prometheus_scrape.cue
@@ -95,7 +95,6 @@ components: sources: prometheus_scrape: {
 		summary:   output._passthrough_summary
 	}
 
-
 	telemetry: metrics: {
 		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total

--- a/docs/reference/components/sources/prometheus_scrape.cue
+++ b/docs/reference/components/sources/prometheus_scrape.cue
@@ -94,4 +94,16 @@ components: sources: prometheus_scrape: {
 		histogram: output._passthrough_histogram
 		summary:   output._passthrough_summary
 	}
+
+
+	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
+		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
+		processed_bytes_total:        components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:       components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_completed_total:     components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_nanoseconds: components.sources.internal_metrics.output.metrics.request_duration_nanoseconds
+	}
 }

--- a/docs/reference/components/sources/socket.cue
+++ b/docs/reference/components/sources/socket.cue
@@ -159,6 +159,7 @@ components: sources: socket: {
 	]
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		connection_errors_total:      components.sources.internal_metrics.output.metrics.connection_errors_total
 		connection_failed_total:      components.sources.internal_metrics.output.metrics.connection_failed_total
 		connection_established_total: components.sources.internal_metrics.output.metrics.connection_established_total

--- a/docs/reference/components/sources/splunk_hec.cue
+++ b/docs/reference/components/sources/splunk_hec.cue
@@ -99,6 +99,7 @@ components: sources: splunk_hec: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
 		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
 		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/docs/reference/components/sources/statsd.cue
+++ b/docs/reference/components/sources/statsd.cue
@@ -130,6 +130,7 @@ components: sources: statsd: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:            components.sources.internal_metrics.output.metrics.events_in_total
 		connection_errors_total:    components.sources.internal_metrics.output.metrics.connection_errors_total
 		invalid_record_total:       components.sources.internal_metrics.output.metrics.invalid_record_total
 		invalid_record_bytes_total: components.sources.internal_metrics.output.metrics.invalid_record_bytes_total

--- a/docs/reference/components/sources/stdin.cue
+++ b/docs/reference/components/sources/stdin.cue
@@ -107,6 +107,7 @@ components: sources: stdin: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:          components.sources.internal_metrics.output.metrics.events_in_total
 		processed_bytes_total:    components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:   components.sources.internal_metrics.output.metrics.processed_events_total
 		stdin_reads_failed_total: components.sources.internal_metrics.output.metrics.stdin_reads_failed_total

--- a/docs/reference/components/sources/syslog.cue
+++ b/docs/reference/components/sources/syslog.cue
@@ -202,6 +202,7 @@ components: sources: syslog: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		connection_read_errors_total: components.sources.internal_metrics.output.metrics.connection_read_errors_total
 		processed_bytes_total:        components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:       components.sources.internal_metrics.output.metrics.processed_events_total

--- a/docs/reference/components/sources/vector.cue
+++ b/docs/reference/components/sources/vector.cue
@@ -131,6 +131,7 @@ components: sources: vector: {
 	}
 
 	telemetry: metrics: {
+		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		protobuf_decode_errors_total: components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
 	}
 }

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -4,19 +4,23 @@ use metrics::{counter, histogram};
 use std::time::Instant;
 
 #[derive(Debug)]
-pub struct ApacheMetricsEventReceived {
+pub struct ApacheMetricsEventReceived<'a> {
     pub byte_size: usize,
     pub count: usize,
+    pub url: &'a str,
 }
 
-impl InternalEvent for ApacheMetricsEventReceived {
+impl<'a> InternalEvent for ApacheMetricsEventReceived<'a> {
     fn emit_logs(&self) {
         debug!(message = "Scraped events.", count = ?self.count);
     }
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", self.count as u64);
-        counter!("events_in_total", self.count as u64);
+        counter!(
+            "events_in_total", self.count as u64,
+            "url" => self.url.to_owned(),
+        );
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -21,7 +21,10 @@ impl<'a> InternalEvent for ApacheMetricsEventReceived<'a> {
             "events_in_total", self.count as u64,
             "uri" => self.uri.to_owned(),
         );
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!(
+            "processed_bytes_total", self.byte_size as u64,
+            "uri" => self.uri.to_owned(),
+        );
     }
 }
 

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -16,6 +16,7 @@ impl InternalEvent for ApacheMetricsEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", self.count as u64);
+        counter!("events_in_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 pub struct ApacheMetricsEventReceived<'a> {
     pub byte_size: usize,
     pub count: usize,
-    pub url: &'a str,
+    pub uri: &'a str,
 }
 
 impl<'a> InternalEvent for ApacheMetricsEventReceived<'a> {
@@ -19,7 +19,7 @@ impl<'a> InternalEvent for ApacheMetricsEventReceived<'a> {
         counter!("processed_events_total", self.count as u64);
         counter!(
             "events_in_total", self.count as u64,
-            "url" => self.url.to_owned(),
+            "uri" => self.uri.to_owned(),
         );
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/aws_ecs_metrics.rs
+++ b/src/internal_events/aws_ecs_metrics.rs
@@ -16,6 +16,7 @@ impl InternalEvent for AwsEcsMetricsReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", self.count as u64);
+        counter!("events_in_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/aws_kinesis_firehose.rs
+++ b/src/internal_events/aws_kinesis_firehose.rs
@@ -2,6 +2,18 @@ use super::InternalEvent;
 use metrics::counter;
 
 #[derive(Debug)]
+pub(crate) struct AwsKinesisFirehoseEventReceived {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for AwsKinesisFirehoseEventReceived {
+    fn emit_metrics(&self) {
+        counter!("events_in_total", 1);
+        counter!("processed_bytes_total", self.byte_size as u64);
+    }
+}
+
+#[derive(Debug)]
 pub struct AwsKinesisFirehoseRequestReceived<'a> {
     pub request_id: Option<&'a str>,
     pub source_arn: Option<&'a str>,

--- a/src/internal_events/aws_s3.rs
+++ b/src/internal_events/aws_s3.rs
@@ -7,6 +7,18 @@ pub mod source {
     use rusoto_sqs::{DeleteMessageError, ReceiveMessageError};
 
     #[derive(Debug)]
+    pub(crate) struct SqsS3EventReceived {
+        pub byte_size: usize,
+    }
+
+    impl InternalEvent for SqsS3EventReceived {
+        fn emit_metrics(&self) {
+            counter!("events_in_total", 1);
+            counter!("processed_bytes_total", self.byte_size as u64);
+        }
+    }
+
+    #[derive(Debug)]
     pub(crate) struct SqsMessageReceiveFailed<'a> {
         pub error: &'a RusotoError<ReceiveMessageError>,
     }

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -20,6 +20,7 @@ impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -25,7 +25,10 @@ impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
             "events_in_total", 1,
             "container_name" => self.container_name.to_owned()
         );
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!(
+            "processed_bytes_total", self.byte_size as u64,
+            "container_name" => self.container_name.to_owned()
+        );
     }
 }
 

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -7,6 +7,7 @@ use metrics::counter;
 pub struct DockerLogsEventReceived<'a> {
     pub byte_size: usize,
     pub container_id: &'a str,
+    pub container_name: &'a str,
 }
 
 impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
@@ -20,7 +21,10 @@ impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
-        counter!("events_in_total", 1);
+        counter!(
+            "events_in_total", 1,
+            "container_name" => self.container_name.to_owned()
+        );
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -43,6 +43,10 @@ mod source {
                 "file" => self.file.to_owned(),
             );
             counter!(
+                "events_in_total", 1,
+                "file" => self.file.to_owned(),
+            );
+            counter!(
                 "processed_bytes_total", self.byte_size as u64,
                 "file" => self.file.to_owned(),
             );

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -19,6 +19,7 @@ impl InternalEvent for HTTPEventsReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", self.events_count as u64);
+        counter!("events_in_total", self.events_count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -13,6 +13,7 @@ impl InternalEvent for JournaldEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -13,6 +13,7 @@ impl InternalEvent for KafkaEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -19,13 +19,9 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
-        if let Some(name) = self.pod_name {
-            counter!(
-                "events_in_total", 1,
-                "pod_name" => name.to_owned(),
-            );
-        } else {
-            counter!("events_in_total", 1);
+        match self.pod_name {
+            Some(name) => counter!("events_in_total", 1, "pod_name" => name.to_owned()),
+            None => counter!("events_in_total", 1),
         }
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -20,10 +20,18 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
         match self.pod_name {
-            Some(name) => counter!("events_in_total", 1, "pod_name" => name.to_owned()),
-            None => counter!("events_in_total", 1),
+            Some(name) => {
+                counter!("events_in_total", 1, "pod_name" => name.to_owned());
+                counter!(
+                    "processed_bytes_total", self.byte_size as u64,
+                    "pod_name" => name.to_owned()
+                );
+            }
+            None => {
+                counter!("events_in_total", 1);
+                counter!("processed_bytes_total", self.byte_size as u64);
+            }
         }
-        counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
 

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -18,6 +18,7 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -6,6 +6,7 @@ use metrics::counter;
 pub struct KubernetesLogsEventReceived<'a> {
     pub file: &'a str,
     pub byte_size: usize,
+    pub pod_name: Option<&'a str>,
 }
 
 impl InternalEvent for KubernetesLogsEventReceived<'_> {
@@ -18,7 +19,14 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
-        counter!("events_in_total", 1);
+        if let Some(name) = self.pod_name {
+            counter!(
+                "events_in_total", 1,
+                "pod_name" => name.to_owned(),
+            );
+        } else {
+            counter!("events_in_total", 1);
+        }
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/logplex.rs
+++ b/src/internal_events/logplex.rs
@@ -2,18 +2,6 @@ use super::InternalEvent;
 use metrics::counter;
 
 #[derive(Debug)]
-pub(crate) struct HerokuLogplexEventReceived {
-    pub byte_size: usize,
-}
-
-impl InternalEvent for HerokuLogplexEventReceived {
-    fn emit_metrics(&self) {
-        counter!("events_in_total", 1);
-        counter!("processed_bytes_total", self.byte_size as u64);
-    }
-}
-
-#[derive(Debug)]
 pub struct HerokuLogplexRequestReceived<'a> {
     pub msg_count: usize,
     pub frame_id: &'a str,

--- a/src/internal_events/logplex.rs
+++ b/src/internal_events/logplex.rs
@@ -2,6 +2,18 @@ use super::InternalEvent;
 use metrics::counter;
 
 #[derive(Debug)]
+pub(crate) struct HerokuLogplexEventReceived {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for HerokuLogplexEventReceived {
+    fn emit_metrics(&self) {
+        counter!("events_in_total", 1);
+        counter!("processed_bytes_total", self.byte_size as u64);
+    }
+}
+
+#[derive(Debug)]
 pub struct HerokuLogplexRequestReceived<'a> {
     pub msg_count: usize,
     pub frame_id: &'a str,

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -6,14 +6,14 @@ use std::time::Instant;
 #[derive(Debug)]
 pub(crate) struct MongoDBMetricsEventsReceived<'a> {
     pub count: usize,
-    pub endpoint: &'a str,
+    pub uri: &'a str,
 }
 
 impl<'a> InternalEvent for MongoDBMetricsEventsReceived<'a> {
     fn emit_metrics(&self) {
         counter!(
             "events_in_total", self.count as u64,
-            "endpoint" => self.endpoint.to_owned(),
+            "uri" => self.uri.to_owned(),
         );
     }
 }

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -4,6 +4,17 @@ use mongodb::{bson, error::Error as MongoError};
 use std::time::Instant;
 
 #[derive(Debug)]
+pub(crate) struct MongoDBMetricsEventsReceived {
+    pub count: usize,
+}
+
+impl InternalEvent for MongoDBMetricsEventsReceived {
+    fn emit_metrics(&self) {
+        counter!("events_in_total", self.count as u64);
+    }
+}
+
+#[derive(Debug)]
 pub struct MongoDBMetricsCollectCompleted {
     pub start: Instant,
     pub end: Instant,

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -4,13 +4,17 @@ use mongodb::{bson, error::Error as MongoError};
 use std::time::Instant;
 
 #[derive(Debug)]
-pub(crate) struct MongoDBMetricsEventsReceived {
+pub(crate) struct MongoDBMetricsEventsReceived<'a> {
     pub count: usize,
+    pub endpoint: &'a str,
 }
 
-impl InternalEvent for MongoDBMetricsEventsReceived {
+impl<'a> InternalEvent for MongoDBMetricsEventsReceived<'a> {
     fn emit_metrics(&self) {
-        counter!("events_in_total", self.count as u64);
+        counter!(
+            "events_in_total", self.count as u64,
+            "endpoint" => self.endpoint.to_owned(),
+        );
     }
 }
 

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -6,14 +6,14 @@ use std::time::Instant;
 #[derive(Debug)]
 pub(crate) struct NginxMetricsEventsReceived<'a> {
     pub count: usize,
-    pub endpoint: &'a str,
+    pub uri: &'a str,
 }
 
 impl<'a> InternalEvent for NginxMetricsEventsReceived<'a> {
     fn emit_metrics(&self) {
         counter!(
             "events_in_total", self.count as u64,
-            "endpoint" => self.endpoint.to_owned(),
+            "uri" => self.uri.to_owned(),
         );
     }
 }

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -4,6 +4,17 @@ use metrics::{counter, histogram};
 use std::time::Instant;
 
 #[derive(Debug)]
+pub(crate) struct NginxMetricsEventsReceived {
+    pub count: usize,
+}
+
+impl InternalEvent for NginxMetricsEventsReceived {
+    fn emit_metrics(&self) {
+        counter!("events_in_total", self.count as u64);
+    }
+}
+
+#[derive(Debug)]
 pub struct NginxMetricsCollectCompleted {
     pub start: Instant,
     pub end: Instant,

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -4,13 +4,17 @@ use metrics::{counter, histogram};
 use std::time::Instant;
 
 #[derive(Debug)]
-pub(crate) struct NginxMetricsEventsReceived {
+pub(crate) struct NginxMetricsEventsReceived<'a> {
     pub count: usize,
+    pub endpoint: &'a str,
 }
 
-impl InternalEvent for NginxMetricsEventsReceived {
+impl<'a> InternalEvent for NginxMetricsEventsReceived<'a> {
     fn emit_metrics(&self) {
-        counter!("events_in_total", self.count as u64);
+        counter!(
+            "events_in_total", self.count as u64,
+            "endpoint" => self.endpoint.to_owned(),
+        );
     }
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -25,7 +25,10 @@ impl InternalEvent for PrometheusEventReceived {
             "events_in_total", self.count as u64,
             "uri" => format!("{}",self.uri),
         );
-        counter!("processed_bytes_total", self.byte_size as u64);
+        counter!(
+            "processed_bytes_total", self.byte_size as u64,
+            "uri" => format!("{}",self.uri),
+        );
     }
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 pub struct PrometheusEventReceived {
     pub byte_size: usize,
     pub count: usize,
-    pub url: http::Uri,
+    pub uri: http::Uri,
 }
 
 impl InternalEvent for PrometheusEventReceived {
@@ -23,7 +23,7 @@ impl InternalEvent for PrometheusEventReceived {
         counter!("processed_events_total", self.count as u64);
         counter!(
             "events_in_total", self.count as u64,
-            "url" => format!("{}",self.url),
+            "uri" => format!("{}",self.uri),
         );
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -120,17 +120,11 @@ impl InternalEvent for PrometheusRemoteWriteParseError {
 #[derive(Debug)]
 pub struct PrometheusRemoteWriteReceived {
     pub count: usize,
-    pub byte_size: usize,
 }
 
 impl InternalEvent for PrometheusRemoteWriteReceived {
     fn emit_logs(&self) {
         debug!(message = "Received remote_write events.", count = ?self.count);
-    }
-
-    fn emit_metrics(&self) {
-        counter!("events_in_total", self.count as u64);
-        counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 pub struct PrometheusEventReceived {
     pub byte_size: usize,
     pub count: usize,
+    pub url: http::Uri,
 }
 
 impl InternalEvent for PrometheusEventReceived {
@@ -20,7 +21,10 @@ impl InternalEvent for PrometheusEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", self.count as u64);
-        counter!("events_in_total", self.count as u64);
+        counter!(
+            "events_in_total", self.count as u64,
+            "url" => format!("{}",self.url),
+        );
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -20,6 +20,7 @@ impl InternalEvent for PrometheusEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", self.count as u64);
+        counter!("events_in_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
@@ -115,11 +116,17 @@ impl InternalEvent for PrometheusRemoteWriteParseError {
 #[derive(Debug)]
 pub struct PrometheusRemoteWriteReceived {
     pub count: usize,
+    pub byte_size: usize,
 }
 
 impl InternalEvent for PrometheusRemoteWriteReceived {
     fn emit_logs(&self) {
         debug!(message = "Received remote_write events.", count = ?self.count);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("events_in_total", self.count as u64);
+        counter!("processed_bytes_total", self.byte_size as u64);
     }
 }
 

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -31,6 +31,7 @@ impl InternalEvent for SocketEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1, "mode" => self.mode.as_str());
+        counter!("events_in_total", 1, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
 }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -52,6 +52,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!("processed_events_total", 1);
+            counter!("events_in_total", 1);
         }
     }
 

--- a/src/internal_events/statsd_source.rs
+++ b/src/internal_events/statsd_source.rs
@@ -12,7 +12,8 @@ impl InternalEvent for StatsdEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("processed_events_total", 1,);
+        counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64,);
     }
 }

--- a/src/internal_events/stdin.rs
+++ b/src/internal_events/stdin.rs
@@ -13,6 +13,7 @@ impl InternalEvent for StdinEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -13,6 +13,7 @@ impl InternalEvent for SyslogEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -14,6 +14,7 @@ impl InternalEvent for VectorEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
+        counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }
 }

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -214,7 +214,7 @@ fn apache_metrics(
                                 emit!(ApacheMetricsEventReceived {
                                     byte_size,
                                     count: metrics.len(),
-                                    url: &sanitized_url,
+                                    uri: &sanitized_url,
                                 });
                                 Some(stream::iter(metrics).map(Event::Metric).map(Ok))
                             }

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -214,6 +214,7 @@ fn apache_metrics(
                                 emit!(ApacheMetricsEventReceived {
                                     byte_size,
                                     count: metrics.len(),
+                                    url: &sanitized_url,
                                 });
                                 Some(stream::iter(metrics).map(Event::Metric).map(Ok))
                             }

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -1,6 +1,8 @@
 use super::errors::{ParseRecords, RequestError};
 use super::models::{EncodedFirehoseRecord, FirehoseRequest, FirehoseResponse};
-use crate::{config::log_schema, event::Event, Pipeline};
+use crate::{
+    config::log_schema, event::Event, internal_events::AwsKinesisFirehoseEventReceived, Pipeline,
+};
 use bytes::Bytes;
 use chrono::Utc;
 use flate2::read::GzDecoder;
@@ -57,6 +59,10 @@ fn parse_records(
         .iter()
         .map(|record| {
             decode_record(record).map(|record| {
+                emit!(AwsKinesisFirehoseEventReceived {
+                    byte_size: record.len()
+                });
+
                 let mut event = Event::new_empty_log();
                 let log = event.as_mut_log();
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -4,7 +4,7 @@ use crate::{
     internal_events::aws_s3::source::{
         SqsMessageDeleteFailed, SqsMessageDeleteSucceeded, SqsMessageProcessingFailed,
         SqsMessageProcessingSucceeded, SqsMessageReceiveFailed, SqsMessageReceiveSucceeded,
-        SqsS3EventRecordInvalidEventIgnored,
+        SqsS3EventReceived, SqsS3EventRecordInvalidEventIgnored,
     },
     line_agg::{self, LineAgg},
     shutdown::ShutdownSignal,
@@ -352,6 +352,10 @@ impl Ingestor {
                 };
 
                 let stream = lines.filter_map(|line| {
+                    emit!(SqsS3EventReceived {
+                        byte_size: line.len()
+                    });
+
                     let mut event = Event::from(line);
 
                     let log = event.as_mut_log();

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -952,7 +952,8 @@ impl ContainerLogInfo {
 
         emit!(DockerLogsEventReceived {
             byte_size,
-            container_id: self.id.as_str()
+            container_id: self.id.as_str(),
+            container_name: &self.metadata.name_str
         });
 
         Some(event)
@@ -964,6 +965,8 @@ struct ContainerMetadata {
     labels: Vec<(String, Value)>,
     /// name -> String
     name: Value,
+    /// name
+    name_str: String,
     /// image -> String
     image: Value,
     /// created_at
@@ -991,6 +994,7 @@ impl ContainerMetadata {
         Ok(ContainerMetadata {
             labels,
             name: name.as_str().trim_start_matches('/').to_owned().into(),
+            name_str: name,
             image: config.image.unwrap().into(),
             created_at: DateTime::parse_from_rfc3339(created.as_str())?.with_timezone(&Utc),
         })

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -4,7 +4,9 @@ use crate::{
         SourceDescription,
     },
     event::Event,
-    internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
+    internal_events::{
+        HerokuLogplexEventReceived, HerokuLogplexRequestReadError, HerokuLogplexRequestReceived,
+    },
     shutdown::ShutdownSignal,
     sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     tls::TlsConfig,
@@ -200,6 +202,10 @@ fn body_to_events(body: Bytes) -> Vec<Event> {
 }
 
 fn line_to_event(line: String) -> Event {
+    emit!(HerokuLogplexEventReceived {
+        byte_size: line.len()
+    });
+
     let parts = line.splitn(8, ' ').collect::<Vec<&str>>();
 
     let mut event = if parts.len() == 8 {

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -4,9 +4,7 @@ use crate::{
         SourceDescription,
     },
     event::Event,
-    internal_events::{
-        HerokuLogplexEventReceived, HerokuLogplexRequestReadError, HerokuLogplexRequestReceived,
-    },
+    internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
     shutdown::ShutdownSignal,
     sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     tls::TlsConfig,
@@ -202,10 +200,6 @@ fn body_to_events(body: Bytes) -> Vec<Event> {
 }
 
 fn line_to_event(line: String) -> Event {
-    emit!(HerokuLogplexEventReceived {
-        byte_size: line.len()
-    });
-
     let parts = line.splitn(8, ' ').collect::<Vec<&str>>();
 
     let mut event = if parts.len() == 8 {

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -69,7 +69,7 @@ impl PodMetadataAnnotator {
     /// Annotates an event with the information from the [`Pod::metadata`].
     /// The event has to be obtained from kubernetes log file, and have a
     /// [`FILE_KEY`] field set with a file that the line came from.
-    pub fn annotate(&self, event: &mut Event, file: &str) -> Option<()> {
+    pub fn annotate<'a>(&self, event: &mut Event, file: &'a str) -> Option<LogFileInfo<'a>> {
         let log = event.as_mut_log();
         let file_info = parse_log_file_path(file)?;
         let guard = self.pods_state_reader.get(file_info.pod_uid)?;
@@ -103,7 +103,7 @@ impl PodMetadataAnnotator {
                 }
             }
         }
-        Some(())
+        Some(file_info)
     }
 }
 

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -258,7 +258,8 @@ impl MongoDBMetrics {
         metrics.push(self.create_metric("up", gauge!(up_value), tags!(self.tags)));
 
         emit!(MongoDBMetricsEventsReceived {
-            count: metrics.len()
+            count: metrics.len(),
+            endpoint: &self.endpoint,
         });
 
         metrics

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -259,7 +259,7 @@ impl MongoDBMetrics {
 
         emit!(MongoDBMetricsEventsReceived {
             count: metrics.len(),
-            endpoint: &self.endpoint,
+            uri: &self.endpoint,
         });
 
         metrics

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -2,7 +2,8 @@ use crate::{
     config::{self, GlobalOptions, SourceConfig, SourceDescription},
     event::metric::{Metric, MetricKind, MetricValue},
     internal_events::{
-        MongoDBMetricsBsonParseError, MongoDBMetricsCollectCompleted, MongoDBMetricsRequestError,
+        MongoDBMetricsBsonParseError, MongoDBMetricsCollectCompleted, MongoDBMetricsEventsReceived,
+        MongoDBMetricsRequestError,
     },
     shutdown::ShutdownSignal,
     Event, Pipeline,
@@ -20,7 +21,7 @@ use mongodb::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::{collections::BTreeMap, future::ready, time::Instant};
+use std::{collections::BTreeMap, time::Instant};
 use tokio::time;
 
 mod types;
@@ -134,7 +135,11 @@ impl SourceConfig for MongoDBMetricsConfig {
                     end: Instant::now()
                 });
 
-                let mut stream = stream::iter(metrics).flatten().map(Event::Metric).map(Ok);
+                let mut stream = stream::iter(metrics)
+                    .map(stream::iter)
+                    .flatten()
+                    .map(Event::Metric)
+                    .map(Ok);
                 out.send_all(&mut stream).await?;
             }
 
@@ -230,9 +235,9 @@ impl MongoDBMetrics {
             .with_timestamp(Some(Utc::now()))
     }
 
-    async fn collect(&self) -> stream::BoxStream<'static, Metric> {
+    async fn collect(&self) -> Vec<Metric> {
         // `up` metric is `1` if collection is successful, otherwise `0`.
-        let (up_value, metrics) = match self.collect_server_status().await {
+        let (up_value, mut metrics) = match self.collect_server_status().await {
             Ok(metrics) => (1.0, metrics),
             Err(error) => {
                 match error {
@@ -250,13 +255,13 @@ impl MongoDBMetrics {
             }
         };
 
-        stream::once(ready(self.create_metric(
-            "up",
-            gauge!(up_value),
-            tags!(self.tags),
-        )))
-        .chain(stream::iter(metrics))
-        .boxed()
+        metrics.push(self.create_metric("up", gauge!(up_value), tags!(self.tags)));
+
+        emit!(MongoDBMetricsEventsReceived {
+            count: metrics.len()
+        });
+
+        metrics
     }
 
     /// Collect metrics from `serverStatus` command.

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -182,7 +182,8 @@ impl NginxMetrics {
         metrics.push(self.create_metric("up", gauge!(up_value)));
 
         emit!(NginxMetricsEventsReceived {
-            count: metrics.len()
+            count: metrics.len(),
+            endpoint: &self.endpoint
         });
 
         metrics

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -183,7 +183,7 @@ impl NginxMetrics {
 
         emit!(NginxMetricsEventsReceived {
             count: metrics.len(),
-            endpoint: &self.endpoint
+            uri: &self.endpoint
         });
 
         metrics

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -3,7 +3,8 @@ use crate::{
     event::metric::{Metric, MetricKind, MetricValue},
     http::{Auth, HttpClient},
     internal_events::{
-        NginxMetricsCollectCompleted, NginxMetricsRequestError, NginxMetricsStubStatusParseError,
+        NginxMetricsCollectCompleted, NginxMetricsEventsReceived, NginxMetricsRequestError,
+        NginxMetricsStubStatusParseError,
     },
     shutdown::ShutdownSignal,
     tls::{TlsOptions, TlsSettings},
@@ -16,7 +17,7 @@ use http::{Request, StatusCode};
 use hyper::{body::to_bytes as body_to_bytes, Body, Uri};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::{collections::BTreeMap, convert::TryFrom, future::ready, time::Instant};
+use std::{collections::BTreeMap, convert::TryFrom, time::Instant};
 use tokio::time;
 
 pub mod parser;
@@ -114,7 +115,11 @@ impl SourceConfig for NginxMetricsConfig {
                     end: Instant::now()
                 });
 
-                let mut stream = stream::iter(metrics).flatten().map(Event::Metric).map(Ok);
+                let mut stream = stream::iter(metrics)
+                    .map(stream::iter)
+                    .flatten()
+                    .map(Event::Metric)
+                    .map(Ok);
                 out.send_all(&mut stream).await?;
             }
 
@@ -168,15 +173,19 @@ impl NginxMetrics {
         })
     }
 
-    async fn collect(&self) -> stream::BoxStream<'static, Metric> {
-        let (up_value, metrics) = match self.collect_metrics().await {
+    async fn collect(&self) -> Vec<Metric> {
+        let (up_value, mut metrics) = match self.collect_metrics().await {
             Ok(metrics) => (1.0, metrics),
             Err(()) => (0.0, vec![]),
         };
 
-        stream::once(ready(self.create_metric("up", gauge!(up_value))))
-            .chain(stream::iter(metrics))
-            .boxed()
+        metrics.push(self.create_metric("up", gauge!(up_value)));
+
+        emit!(NginxMetricsEventsReceived {
+            count: metrics.len()
+        });
+
+        metrics
     }
 
     async fn collect_metrics(&self) -> Result<Vec<Metric>, ()> {

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -106,9 +106,10 @@ impl HttpSource for RemoteWriteSource {
         {
             body = decode(&Some("snappy".to_string()), body)?;
         }
+        let byte_size = body.len();
         let result = self.decode_body(body)?;
         let count = result.len();
-        emit!(PrometheusRemoteWriteReceived { count });
+        emit!(PrometheusRemoteWriteReceived { count, byte_size });
         Ok(result)
     }
 }

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -106,10 +106,9 @@ impl HttpSource for RemoteWriteSource {
         {
             body = decode(&Some("snappy".to_string()), body)?;
         }
-        let byte_size = body.len();
         let result = self.decode_body(body)?;
         let count = result.len();
-        emit!(PrometheusRemoteWriteReceived { count, byte_size });
+        emit!(PrometheusRemoteWriteReceived { count });
         Ok(result)
     }
 }

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -196,7 +196,7 @@ fn prometheus(
                                     emit!(PrometheusEventReceived {
                                         byte_size,
                                         count: metrics.len(),
-                                        url: url.clone()
+                                        uri: url.clone()
                                     });
                                     Some(stream::iter(metrics).map(Ok))
                                 }

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -196,6 +196,7 @@ fn prometheus(
                                     emit!(PrometheusEventReceived {
                                         byte_size,
                                         count: metrics.len(),
+                                        url: url.clone()
                                     });
                                     Some(stream::iter(metrics).map(Ok))
                                 }


### PR DESCRIPTION
Follow up on #6433

Adds `events_in_total` internal metric to all sources with exception of:
* `generator`
* `host_metrics`
* `internal_logs`
* `internal_metrics`

instead, their `events_in_total` will stay `0` permanently. This follows a loose definition of counting only those events that came from outside the process and kernal, or in other words that came through some I/O like files, channels, connections, etc.


Ref #6367

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
