### PR TITLE
fix(prometheus_scrape source): Add timestamps to parsed metrics

### DIFF
--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -15,11 +15,13 @@ fn has_values_or_none(tags: BTreeMap<String, String>) -> Option<BTreeMap<String,
     }
 }
 
-fn utc_timestamp(timestamp: Option<i64>) -> Option<DateTime<Utc>> {
-    timestamp.and_then(|timestamp| {
-        Utc.timestamp_opt(timestamp / 1000, (timestamp % 1000) as u32 * 1000000)
-            .latest()
-    })
+fn utc_timestamp(timestamp: Option<i64>) -> DateTime<Utc> {
+    timestamp
+        .and_then(|timestamp| {
+            Utc.timestamp_opt(timestamp / 1000, (timestamp % 1000) as u32 * 1000000)
+                .latest()
+        })
+        .unwrap_or_else(Utc::now)
 }
 
 pub(super) fn parse_text(packet: &str) -> Result<Vec<Event>, ParserError> {
@@ -44,7 +46,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                             value: metric.value,
                         },
                     )
-                    .with_timestamp(utc_timestamp(key.timestamp))
+                    .with_timestamp(Some(utc_timestamp(key.timestamp)))
                     .with_tags(has_values_or_none(key.labels));
 
                     result.push(counter.into());
@@ -59,7 +61,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                             value: metric.value,
                         },
                     )
-                    .with_timestamp(utc_timestamp(key.timestamp))
+                    .with_timestamp(Some(utc_timestamp(key.timestamp)))
                     .with_tags(has_values_or_none(key.labels));
 
                     result.push(gauge.into());
@@ -94,7 +96,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                                 sum: metric.sum,
                             },
                         )
-                        .with_timestamp(utc_timestamp(key.timestamp))
+                        .with_timestamp(Some(utc_timestamp(key.timestamp)))
                         .with_tags(has_values_or_none(key.labels))
                         .into(),
                     );
@@ -119,7 +121,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                                 sum: metric.sum,
                             },
                         )
-                        .with_timestamp(utc_timestamp(key.timestamp))
+                        .with_timestamp(Some(utc_timestamp(key.timestamp)))
                         .with_tags(has_values_or_none(key.labels))
                         .into(),
                     );
@@ -136,11 +138,29 @@ mod test {
     use super::*;
     use crate::event::metric::{Metric, MetricKind, MetricValue};
     use chrono::{TimeZone, Utc};
+    use lazy_static::lazy_static;
     use pretty_assertions::assert_eq;
     use shared::btreemap;
 
+    lazy_static! {
+        static ref TIMESTAMP: DateTime<Utc> = Utc.ymd(2021, 2, 4).and_hms_milli(4, 5, 6, 789);
+    }
+
     fn parse_text(text: &str) -> Result<Vec<Metric>, ParserError> {
         super::parse_text(text).map(|events| events.into_iter().map(Event::into_metric).collect())
+    }
+
+    #[test]
+    fn adds_timestamp_if_missing() {
+        let now = Utc::now();
+        let exp = r##"
+            # HELP counter Some counter
+            # TYPE count counter
+            http_requests_total 1027
+            "##;
+        let result = parse_text(exp).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].data.timestamp.unwrap() >= now);
     }
 
     #[test]
@@ -148,7 +168,7 @@ mod test {
         let exp = r##"
             # HELP uptime A counter
             # TYPE uptime counter
-            uptime 123.0
+            uptime 123.0 1612411506789
             "##;
 
         assert_eq!(
@@ -157,7 +177,8 @@ mod test {
                 "uptime",
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 123.0 },
-            )]),
+            )
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
@@ -192,12 +213,12 @@ mod test {
             # A normal comment.
             #
             # TYPE name counter
-            name {labelname="val2",basename="base\"v\\al\nue"} 0.23
+            name {labelname="val2",basename="base\"v\\al\nue"} 0.23 1612411506789
             # HELP name two-line\n doc  str\\ing
             # HELP  name2  	doc str"ing 2
             #    TYPE    name2 counter
-            name2{labelname="val2"	,basename   =   "basevalue2"		} +Inf
-            name2{ labelname = "val1" , }-Inf
+            name2{labelname="val2"	,basename   =   "basevalue2"		} +Inf 1612411506789
+            name2{ labelname = "val1" , }-Inf 1612411506789
             "##;
 
         assert_eq!(
@@ -215,7 +236,8 @@ mod test {
                     ]
                     .into_iter()
                     .collect()
-                )),
+                ))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "name2",
                     MetricKind::Absolute,
@@ -230,7 +252,8 @@ mod test {
                     ]
                     .into_iter()
                     .collect()
-                )),
+                ))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "name2",
                     MetricKind::Absolute,
@@ -242,7 +265,8 @@ mod test {
                     vec![("labelname".into(), "val1".into()),]
                         .into_iter()
                         .collect()
-                )),
+                ))
+                .with_timestamp(Some(*TIMESTAMP)),
             ]),
         );
     }
@@ -296,7 +320,7 @@ mod test {
         let exp = r##"
             # HELP latency A gauge
             # TYPE latency gauge
-            latency 123.0
+            latency 123.0 1612411506789
             "##;
 
         assert_eq!(
@@ -305,14 +329,15 @@ mod test {
                 "latency",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 123.0 },
-            )]),
+            )
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
     #[test]
     fn test_gauge_minimalistic() {
         let exp = r##"
-            metric_without_timestamp_and_labels 12.47
+            metric_without_timestamp_and_labels 12.47 1612411506789
             "##;
 
         assert_eq!(
@@ -321,14 +346,15 @@ mod test {
                 "metric_without_timestamp_and_labels",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 12.47 },
-            )]),
+            )
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
     #[test]
     fn test_gauge_empty_labels() {
         let exp = r##"
-            no_labels{} 3
+            no_labels{} 3 1612411506789
             "##;
 
         assert_eq!(
@@ -337,14 +363,15 @@ mod test {
                 "no_labels",
                 MetricKind::Absolute,
                 MetricValue::Gauge { value: 3.0 },
-            )]),
+            )
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
     #[test]
     fn test_gauge_minimalistic_escaped() {
         let exp = r##"
-            msdos_file_access_time_seconds{path="C:\\DIR\\FILE.TXT",error="Cannot find file:\n\"FILE.TXT\""} 1.458255915e9
+            msdos_file_access_time_seconds{path="C:\\DIR\\FILE.TXT",error="Cannot find file:\n\"FILE.TXT\""} 1.458255915e9 1612411506789
             "##;
 
         assert_eq!(
@@ -363,7 +390,8 @@ mod test {
                 ]
                 .into_iter()
                 .collect()
-            )),]),
+            ))
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
@@ -372,7 +400,7 @@ mod test {
         let exp = r##"
             # HELP name counter
             # TYPE name counter
-            name{tag="}"} 0
+            name{tag="}"} 0 1612411506789
             "##;
         assert_eq!(
             parse_text(exp),
@@ -381,7 +409,8 @@ mod test {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
-            .with_tags(Some(btreemap! { "tag" => "}" }))]),
+            .with_tags(Some(btreemap! { "tag" => "}" }))
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
@@ -390,7 +419,7 @@ mod test {
         let exp = r##"
             # HELP name counter
             # TYPE name counter
-            name{tag="a,b"} 0
+            name{tag="a,b"} 0 1612411506789
             "##;
         assert_eq!(
             parse_text(exp),
@@ -399,7 +428,8 @@ mod test {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
-            .with_tags(Some(btreemap! { "tag" => "a,b" }))]),
+            .with_tags(Some(btreemap! { "tag" => "a,b" }))
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
@@ -408,7 +438,7 @@ mod test {
         let exp = r##"
             # HELP name counter
             # TYPE name counter
-            name{tag="\\n"} 0
+            name{tag="\\n"} 0 1612411506789
             "##;
         assert_eq!(
             parse_text(exp),
@@ -417,7 +447,8 @@ mod test {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
-            .with_tags(Some(btreemap! { "tag" => "\\n" }))]),
+            .with_tags(Some(btreemap! { "tag" => "\\n" }))
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
@@ -426,7 +457,7 @@ mod test {
         let exp = r##"
             # HELP name counter
             # TYPE name counter
-            name{tag=" * "} 0
+            name{tag=" * "} 0 1612411506789
             "##;
         assert_eq!(
             parse_text(exp),
@@ -435,14 +466,15 @@ mod test {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 0.0 },
             )
-            .with_tags(Some(btreemap! { "tag" => " * " }))]),
+            .with_tags(Some(btreemap! { "tag" => " * " }))
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
     #[test]
     fn test_parse_tag_value_containing_equals() {
         let exp = r##"
-            telemetry_scrape_size_bytes_count{registry="default",content_type="text/plain; version=0.0.4"} 1890
+            telemetry_scrape_size_bytes_count{registry="default",content_type="text/plain; version=0.0.4"} 1890 1612411506789
             "##;
 
         assert_eq!(
@@ -459,14 +491,15 @@ mod test {
                 ]
                 .into_iter()
                 .collect()
-            ))]),
+            ))
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
     #[test]
     fn test_parse_tag_error_no_value() {
         let exp = r##"
-            telemetry_scrape_size_bytes_count{registry="default",content_type} 1890
+            telemetry_scrape_size_bytes_count{registry="default",content_type} 1890 1612411506789
             "##;
 
         assert!(parse_text(exp).is_err());
@@ -475,7 +508,7 @@ mod test {
     #[test]
     fn test_parse_tag_error_equals_empty_value() {
         let exp = r##"
-            telemetry_scrape_size_bytes_count{registry="default",content_type=} 1890
+            telemetry_scrape_size_bytes_count{registry="default",content_type=} 1890 1612411506789
             "##;
 
         assert!(parse_text(exp).is_err());
@@ -544,11 +577,11 @@ mod test {
     fn test_mixed() {
         let exp = r##"
             # TYPE uptime counter
-            uptime 123.0
+            uptime 123.0 1612411506789
             # TYPE temperature gauge
-            temperature -1.5
+            temperature -1.5 1612411506789
             # TYPE launch_count counter
-            launch_count 10.0
+            launch_count 10.0 1612411506789
             "##;
 
         assert_eq!(
@@ -558,17 +591,20 @@ mod test {
                     "uptime",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 123.0 },
-                ),
+                )
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "temperature",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: -1.5 },
-                ),
+                )
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "launch_count",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 10.0 },
                 )
+                .with_timestamp(Some(*TIMESTAMP))
             ]),
         );
     }
@@ -587,7 +623,7 @@ mod test {
     fn test_no_name() {
         let exp = r##"
             # TYPE uptime counter
-            123.0
+            123.0 1612411506789
             "##;
 
         assert!(parse_text(exp).is_err());
@@ -597,11 +633,11 @@ mod test {
     fn test_mixed_and_loosely_typed() {
         let exp = r##"
             # TYPE uptime counter
-            uptime 123.0
-            last_downtime 4.0
+            uptime 123.0 1612411506789
+            last_downtime 4.0 1612411506789
             # TYPE temperature gauge
-            temperature -1.5
-            temperature_7_days_average 0.1
+            temperature -1.5 1612411506789
+            temperature_7_days_average 0.1 1612411506789
             "##;
 
         assert_eq!(
@@ -611,22 +647,26 @@ mod test {
                     "uptime",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 123.0 },
-                ),
+                )
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "last_downtime",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 4.0 },
-                ),
+                )
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "temperature",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: -1.5 },
-                ),
+                )
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "temperature_7_days_average",
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: 0.1 },
                 )
+                .with_timestamp(Some(*TIMESTAMP))
             ]),
         );
     }
@@ -636,14 +676,14 @@ mod test {
         let exp = r##"
             # HELP http_request_duration_seconds A histogram of the request duration.
             # TYPE http_request_duration_seconds histogram
-            http_request_duration_seconds_bucket{le="0.05"} 24054
-            http_request_duration_seconds_bucket{le="0.1"} 33444
-            http_request_duration_seconds_bucket{le="0.2"} 100392
-            http_request_duration_seconds_bucket{le="0.5"} 129389
-            http_request_duration_seconds_bucket{le="1"} 133988
-            http_request_duration_seconds_bucket{le="+Inf"} 144320
-            http_request_duration_seconds_sum 53423
-            http_request_duration_seconds_count 144320
+            http_request_duration_seconds_bucket{le="0.05"} 24054 1612411506789
+            http_request_duration_seconds_bucket{le="0.1"} 33444 1612411506789
+            http_request_duration_seconds_bucket{le="0.2"} 100392 1612411506789
+            http_request_duration_seconds_bucket{le="0.5"} 129389 1612411506789
+            http_request_duration_seconds_bucket{le="1"} 133988 1612411506789
+            http_request_duration_seconds_bucket{le="+Inf"} 144320 1612411506789
+            http_request_duration_seconds_sum 53423 1612411506789
+            http_request_duration_seconds_count 144320 1612411506789
             "##;
 
         assert_eq!(
@@ -658,7 +698,8 @@ mod test {
                     count: 144320,
                     sum: 53423.0,
                 },
-            )]),
+            )
+            .with_timestamp(Some(*TIMESTAMP))]),
         );
     }
 
@@ -667,45 +708,45 @@ mod test {
         let exp = r##"
             # HELP gitlab_runner_job_duration_seconds Histogram of job durations
             # TYPE gitlab_runner_job_duration_seconds histogram
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="30"} 327
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="60"} 474
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="300"} 535
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="600"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="1800"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="3600"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="7200"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="10800"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="18000"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="36000"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="z",le="+Inf"} 536
-            gitlab_runner_job_duration_seconds_sum{runner="z"} 19690.129384881966
-            gitlab_runner_job_duration_seconds_count{runner="z"} 536
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="30"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="60"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="300"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="600"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="1800"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="3600"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="7200"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="10800"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="18000"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="36000"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="x",le="+Inf"} 1
-            gitlab_runner_job_duration_seconds_sum{runner="x"} 28.975436316
-            gitlab_runner_job_duration_seconds_count{runner="x"} 1
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="30"} 285
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="60"} 1165
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="300"} 3071
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="600"} 3151
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="1800"} 3252
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="3600"} 3255
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="7200"} 3255
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="10800"} 3255
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="18000"} 3255
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="36000"} 3255
-            gitlab_runner_job_duration_seconds_bucket{runner="y",le="+Inf"} 3255
-            gitlab_runner_job_duration_seconds_sum{runner="y"} 381111.7498891335
-            gitlab_runner_job_duration_seconds_count{runner="y"} 3255
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="30"} 327 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="60"} 474 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="300"} 535 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="600"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="1800"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="3600"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="7200"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="10800"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="18000"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="36000"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="z",le="+Inf"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_sum{runner="z"} 19690.129384881966 1612411506789
+            gitlab_runner_job_duration_seconds_count{runner="z"} 536 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="30"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="60"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="300"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="600"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="1800"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="3600"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="7200"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="10800"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="18000"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="36000"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="x",le="+Inf"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_sum{runner="x"} 28.975436316 1612411506789
+            gitlab_runner_job_duration_seconds_count{runner="x"} 1 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="30"} 285 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="60"} 1165 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="300"} 3071 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="600"} 3151 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="1800"} 3252 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="3600"} 3255 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="7200"} 3255 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="10800"} 3255 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="18000"} 3255 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="36000"} 3255 1612411506789
+            gitlab_runner_job_duration_seconds_bucket{runner="y",le="+Inf"} 3255 1612411506789
+            gitlab_runner_job_duration_seconds_sum{runner="y"} 381111.7498891335 1612411506789
+            gitlab_runner_job_duration_seconds_count{runner="y"} 3255 1612411506789
         "##;
 
         assert_eq!(
@@ -728,7 +769,9 @@ mod test {
                         count: 536,
                         sum: 19690.129384881966,
                     },
-                ).with_tags(Some(vec![("runner".into(), "z".into())].into_iter().collect())),
+                )
+                    .with_tags(Some(vec![("runner".into(), "z".into())].into_iter().collect()))
+                    .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "gitlab_runner_job_duration_seconds", MetricKind::Absolute, MetricValue::AggregatedHistogram {
                         buckets: crate::buckets![
@@ -746,7 +789,9 @@ mod test {
                         count: 1,
                         sum: 28.975436316,
                     },
-                ).with_tags(Some(vec![("runner".into(), "x".into())].into_iter().collect())),
+                )
+                    .with_tags(Some(vec![("runner".into(), "x".into())].into_iter().collect()))
+                    .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "gitlab_runner_job_duration_seconds", MetricKind::Absolute, MetricValue::AggregatedHistogram {
                         buckets: crate::buckets![
@@ -756,7 +801,9 @@ mod test {
                         count: 3255,
                         sum: 381111.7498891335,
                     },
-                ).with_tags(Some(vec![("runner".into(), "y".into())].into_iter().collect()))
+                )
+                    .with_tags(Some(vec![("runner".into(), "y".into())].into_iter().collect()))
+                    .with_timestamp(Some(*TIMESTAMP))
             ]),
         );
     }
@@ -766,22 +813,22 @@ mod test {
         let exp = r##"
             # HELP rpc_duration_seconds A summary of the RPC duration in seconds.
             # TYPE rpc_duration_seconds summary
-            rpc_duration_seconds{service="a",quantile="0.01"} 3102
-            rpc_duration_seconds{service="a",quantile="0.05"} 3272
-            rpc_duration_seconds{service="a",quantile="0.5"} 4773
-            rpc_duration_seconds{service="a",quantile="0.9"} 9001
-            rpc_duration_seconds{service="a",quantile="0.99"} 76656
-            rpc_duration_seconds_sum{service="a"} 1.7560473e+07
-            rpc_duration_seconds_count{service="a"} 2693
+            rpc_duration_seconds{service="a",quantile="0.01"} 3102 1612411506789
+            rpc_duration_seconds{service="a",quantile="0.05"} 3272 1612411506789
+            rpc_duration_seconds{service="a",quantile="0.5"} 4773 1612411506789
+            rpc_duration_seconds{service="a",quantile="0.9"} 9001 1612411506789
+            rpc_duration_seconds{service="a",quantile="0.99"} 76656 1612411506789
+            rpc_duration_seconds_sum{service="a"} 1.7560473e+07 1612411506789
+            rpc_duration_seconds_count{service="a"} 2693 1612411506789
             # HELP go_gc_duration_seconds A summary of the GC invocation durations.
             # TYPE go_gc_duration_seconds summary
-            go_gc_duration_seconds{quantile="0"} 0.009460965
-            go_gc_duration_seconds{quantile="0.25"} 0.009793382
-            go_gc_duration_seconds{quantile="0.5"} 0.009870205
-            go_gc_duration_seconds{quantile="0.75"} 0.01001838
-            go_gc_duration_seconds{quantile="1"} 0.018827136
-            go_gc_duration_seconds_sum 4668.551713715
-            go_gc_duration_seconds_count 602767
+            go_gc_duration_seconds{quantile="0"} 0.009460965 1612411506789
+            go_gc_duration_seconds{quantile="0.25"} 0.009793382 1612411506789
+            go_gc_duration_seconds{quantile="0.5"} 0.009870205 1612411506789
+            go_gc_duration_seconds{quantile="0.75"} 0.01001838 1612411506789
+            go_gc_duration_seconds{quantile="1"} 0.018827136 1612411506789
+            go_gc_duration_seconds_sum 4668.551713715 1612411506789
+            go_gc_duration_seconds_count 602767 1612411506789
             "##;
 
         assert_eq!(
@@ -804,7 +851,8 @@ mod test {
                 )
                 .with_tags(Some(
                     vec![("service".into(), "a".into())].into_iter().collect()
-                )),
+                ))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "go_gc_duration_seconds",
                     MetricKind::Absolute,
@@ -819,7 +867,8 @@ mod test {
                         count: 602767,
                         sum: 4668.551713715,
                     },
-                ),
+                )
+                .with_timestamp(Some(*TIMESTAMP)),
             ]),
         );
     }
@@ -830,20 +879,20 @@ mod test {
         let exp = r##"
             # HELP nginx_server_bytes request/response bytes
             # TYPE nginx_server_bytes counter
-            nginx_server_bytes{direction="in",host="*"} 263719
-            nginx_server_bytes{direction="in",host="_"} 255061
-            nginx_server_bytes{direction="in",host="nginx-vts-status"} 8658
-            nginx_server_bytes{direction="out",host="*"} 944199
-            nginx_server_bytes{direction="out",host="_"} 360775
-            nginx_server_bytes{direction="out",host="nginx-vts-status"} 583424
+            nginx_server_bytes{direction="in",host="*"} 263719 1612411506789
+            nginx_server_bytes{direction="in",host="_"} 255061 1612411506789
+            nginx_server_bytes{direction="in",host="nginx-vts-status"} 8658 1612411506789
+            nginx_server_bytes{direction="out",host="*"} 944199 1612411506789
+            nginx_server_bytes{direction="out",host="_"} 360775 1612411506789
+            nginx_server_bytes{direction="out",host="nginx-vts-status"} 583424 1612411506789
             # HELP nginx_server_cache cache counter
             # TYPE nginx_server_cache counter
-            nginx_server_cache{host="*",status="bypass"} 0
-            nginx_server_cache{host="*",status="expired"} 0
-            nginx_server_cache{host="*",status="hit"} 0
-            nginx_server_cache{host="*",status="miss"} 0
-            nginx_server_cache{host="*",status="revalidated"} 0
-            nginx_server_cache{host="*",status="scarce"} 0
+            nginx_server_cache{host="*",status="bypass"} 0 1612411506789
+            nginx_server_cache{host="*",status="expired"} 0 1612411506789
+            nginx_server_cache{host="*",status="hit"} 0 1612411506789
+            nginx_server_cache{host="*",status="miss"} 0 1612411506789
+            nginx_server_cache{host="*",status="revalidated"} 0 1612411506789
+            nginx_server_cache{host="*",status="scarce"} 0 1612411506789
             "##;
 
         assert_eq!(
@@ -854,13 +903,15 @@ mod test {
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 263719.0 },
                 )
-                .with_tags(Some(btreemap! { "direction" => "in", "host" => "*" })),
+                .with_tags(Some(btreemap! { "direction" => "in", "host" => "*" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 255061.0 },
                 )
-                .with_tags(Some(btreemap! { "direction" => "in", "host" => "_" })),
+                .with_tags(Some(btreemap! { "direction" => "in", "host" => "_" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_bytes",
                     MetricKind::Absolute,
@@ -868,19 +919,22 @@ mod test {
                 )
                 .with_tags(Some(
                     btreemap! { "direction" => "in", "host" => "nginx-vts-status" }
-                )),
+                ))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 944199.0 },
                 )
-                .with_tags(Some(btreemap! { "direction" => "out", "host" => "*" })),
+                .with_tags(Some(btreemap! { "direction" => "out", "host" => "*" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_bytes",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 360775.0 },
                 )
-                .with_tags(Some(btreemap! { "direction" => "out", "host" => "_" })),
+                .with_tags(Some(btreemap! { "direction" => "out", "host" => "_" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_bytes",
                     MetricKind::Absolute,
@@ -888,43 +942,50 @@ mod test {
                 )
                 .with_tags(Some(
                     btreemap! { "direction" => "out", "host" => "nginx-vts-status" }
-                )),
+                ))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
-                .with_tags(Some(btreemap! { "host" => "*", "status" => "bypass" })),
+                .with_tags(Some(btreemap! { "host" => "*", "status" => "bypass" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
-                .with_tags(Some(btreemap! { "host" => "*", "status" => "expired" })),
+                .with_tags(Some(btreemap! { "host" => "*", "status" => "expired" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
-                .with_tags(Some(btreemap! { "host" => "*", "status" => "hit" })),
+                .with_tags(Some(btreemap! { "host" => "*", "status" => "hit" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
-                .with_tags(Some(btreemap! { "host" => "*", "status" => "miss" })),
+                .with_tags(Some(btreemap! { "host" => "*", "status" => "miss" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
-                .with_tags(Some(btreemap! { "host" => "*", "status" => "revalidated" })),
+                .with_tags(Some(btreemap! { "host" => "*", "status" => "revalidated" }))
+                .with_timestamp(Some(*TIMESTAMP)),
                 Metric::new(
                     "nginx_server_cache",
                     MetricKind::Absolute,
                     MetricValue::Counter { value: 0.0 },
                 )
                 .with_tags(Some(btreemap! { "host" => "*", "status" => "scarce" }))
+                .with_timestamp(Some(*TIMESTAMP))
             ])
         );
     }

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -880,25 +880,32 @@ mod test {
         let exp = r##"
             # HELP nginx_server_bytes request/response bytes
             # TYPE nginx_server_bytes counter
-            nginx_server_bytes{direction="in",host="*"} 263719 1612411506789
-            nginx_server_bytes{direction="in",host="_"} 255061 1612411506789
-            nginx_server_bytes{direction="in",host="nginx-vts-status"} 8658 1612411506789
-            nginx_server_bytes{direction="out",host="*"} 944199 1612411506789
-            nginx_server_bytes{direction="out",host="_"} 360775 1612411506789
-            nginx_server_bytes{direction="out",host="nginx-vts-status"} 583424 1612411506789
+            nginx_server_bytes{direction="in",host="*"} 263719
+            nginx_server_bytes{direction="in",host="_"} 255061
+            nginx_server_bytes{direction="in",host="nginx-vts-status"} 8658
+            nginx_server_bytes{direction="out",host="*"} 944199
+            nginx_server_bytes{direction="out",host="_"} 360775
+            nginx_server_bytes{direction="out",host="nginx-vts-status"} 583424
             # HELP nginx_server_cache cache counter
             # TYPE nginx_server_cache counter
-            nginx_server_cache{host="*",status="bypass"} 0 1612411506789
-            nginx_server_cache{host="*",status="expired"} 0 1612411506789
-            nginx_server_cache{host="*",status="hit"} 0 1612411506789
-            nginx_server_cache{host="*",status="miss"} 0 1612411506789
-            nginx_server_cache{host="*",status="revalidated"} 0 1612411506789
-            nginx_server_cache{host="*",status="scarce"} 0 1612411506789
+            nginx_server_cache{host="*",status="bypass"} 0
+            nginx_server_cache{host="*",status="expired"} 0
+            nginx_server_cache{host="*",status="hit"} 0
+            nginx_server_cache{host="*",status="miss"} 0
+            nginx_server_cache{host="*",status="revalidated"} 0
+            nginx_server_cache{host="*",status="scarce"} 0
             "##;
 
+        let now = Utc::now();
+        let mut result = parse_text(exp).expect("Parsing failed");
+        for metric in &mut result {
+            assert!(metric.data.timestamp.expect("Missing timestamp") >= now);
+            metric.data.timestamp = Some(*TIMESTAMP);
+        }
+
         assert_eq!(
-            parse_text(exp),
-            Ok(vec![
+            result,
+            vec![
                 Metric::new(
                     "nginx_server_bytes",
                     MetricKind::Absolute,
@@ -987,7 +994,7 @@ mod test {
                 )
                 .with_tags(Some(btreemap! { "host" => "*", "status" => "scarce" }))
                 .with_timestamp(Some(*TIMESTAMP))
-            ])
+            ]
         );
     }
 }

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -15,13 +15,13 @@ fn has_values_or_none(tags: BTreeMap<String, String>) -> Option<BTreeMap<String,
     }
 }
 
-fn utc_timestamp(timestamp: Option<i64>) -> DateTime<Utc> {
+fn utc_timestamp(timestamp: Option<i64>, now: &mut Option<DateTime<Utc>>) -> DateTime<Utc> {
     timestamp
         .and_then(|timestamp| {
             Utc.timestamp_opt(timestamp / 1000, (timestamp % 1000) as u32 * 1000000)
                 .latest()
         })
-        .unwrap_or_else(Utc::now)
+        .unwrap_or_else(|| *now.get_or_insert_with(Utc::now))
 }
 
 pub(super) fn parse_text(packet: &str) -> Result<Vec<Event>, ParserError> {
@@ -34,6 +34,7 @@ pub(super) fn parse_request(request: proto::WriteRequest) -> Result<Vec<Event>, 
 
 fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
     let mut result = Vec::new();
+    let mut now = None;
 
     for group in groups {
         match group.metrics {
@@ -46,7 +47,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                             value: metric.value,
                         },
                     )
-                    .with_timestamp(Some(utc_timestamp(key.timestamp)))
+                    .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
                     .with_tags(has_values_or_none(key.labels));
 
                     result.push(counter.into());
@@ -61,7 +62,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                             value: metric.value,
                         },
                     )
-                    .with_timestamp(Some(utc_timestamp(key.timestamp)))
+                    .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
                     .with_tags(has_values_or_none(key.labels));
 
                     result.push(gauge.into());
@@ -96,7 +97,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                                 sum: metric.sum,
                             },
                         )
-                        .with_timestamp(Some(utc_timestamp(key.timestamp)))
+                        .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
                         .with_tags(has_values_or_none(key.labels))
                         .into(),
                     );
@@ -121,7 +122,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                                 sum: metric.sum,
                             },
                         )
-                        .with_timestamp(Some(utc_timestamp(key.timestamp)))
+                        .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
                         .with_tags(has_values_or_none(key.labels))
                         .into(),
                     );

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -15,13 +15,13 @@ fn has_values_or_none(tags: BTreeMap<String, String>) -> Option<BTreeMap<String,
     }
 }
 
-fn utc_timestamp(timestamp: Option<i64>, now: &mut Option<DateTime<Utc>>) -> DateTime<Utc> {
+fn utc_timestamp(timestamp: Option<i64>, now: DateTime<Utc>) -> DateTime<Utc> {
     timestamp
         .and_then(|timestamp| {
             Utc.timestamp_opt(timestamp / 1000, (timestamp % 1000) as u32 * 1000000)
                 .latest()
         })
-        .unwrap_or_else(|| *now.get_or_insert_with(Utc::now))
+        .unwrap_or(now)
 }
 
 pub(super) fn parse_text(packet: &str) -> Result<Vec<Event>, ParserError> {
@@ -34,7 +34,7 @@ pub(super) fn parse_request(request: proto::WriteRequest) -> Result<Vec<Event>, 
 
 fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
     let mut result = Vec::new();
-    let mut now = None;
+    let now = Utc::now();
 
     for group in groups {
         match group.metrics {
@@ -47,7 +47,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                             value: metric.value,
                         },
                     )
-                    .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
+                    .with_timestamp(Some(utc_timestamp(key.timestamp, now)))
                     .with_tags(has_values_or_none(key.labels));
 
                     result.push(counter.into());
@@ -62,7 +62,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                             value: metric.value,
                         },
                     )
-                    .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
+                    .with_timestamp(Some(utc_timestamp(key.timestamp, now)))
                     .with_tags(has_values_or_none(key.labels));
 
                     result.push(gauge.into());
@@ -97,7 +97,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                                 sum: metric.sum,
                             },
                         )
-                        .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
+                        .with_timestamp(Some(utc_timestamp(key.timestamp, now)))
                         .with_tags(has_values_or_none(key.labels))
                         .into(),
                     );
@@ -122,7 +122,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                                 sum: metric.sum,
                             },
                         )
-                        .with_timestamp(Some(utc_timestamp(key.timestamp, &mut now)))
+                        .with_timestamp(Some(utc_timestamp(key.timestamp, now)))
                         .with_tags(has_values_or_none(key.labels))
                         .into(),
                     );

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -279,30 +279,30 @@ mod test {
                     r##"
                     # HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
                     # TYPE promhttp_metric_handler_requests_total counter
-                    promhttp_metric_handler_requests_total{code="200"} 100
-                    promhttp_metric_handler_requests_total{code="404"} 7
-                    prometheus_remote_storage_samples_in_total 57011636
+                    promhttp_metric_handler_requests_total{code="200"} 100 1612411516789
+                    promhttp_metric_handler_requests_total{code="404"} 7 1612411516789
+                    prometheus_remote_storage_samples_in_total 57011636 1612411516789
                     # A histogram, which has a pretty complex representation in the text format:
                     # HELP http_request_duration_seconds A histogram of the request duration.
                     # TYPE http_request_duration_seconds histogram
-                    http_request_duration_seconds_bucket{le="0.05"} 24054
-                    http_request_duration_seconds_bucket{le="0.1"} 33444
-                    http_request_duration_seconds_bucket{le="0.2"} 100392
-                    http_request_duration_seconds_bucket{le="0.5"} 129389
-                    http_request_duration_seconds_bucket{le="1"} 133988
-                    http_request_duration_seconds_bucket{le="+Inf"} 144320
-                    http_request_duration_seconds_sum 53423
-                    http_request_duration_seconds_count 144320
+                    http_request_duration_seconds_bucket{le="0.05"} 24054 1612411516789
+                    http_request_duration_seconds_bucket{le="0.1"} 33444 1612411516789
+                    http_request_duration_seconds_bucket{le="0.2"} 100392 1612411516789
+                    http_request_duration_seconds_bucket{le="0.5"} 129389 1612411516789
+                    http_request_duration_seconds_bucket{le="1"} 133988 1612411516789
+                    http_request_duration_seconds_bucket{le="+Inf"} 144320 1612411516789
+                    http_request_duration_seconds_sum 53423 1612411516789
+                    http_request_duration_seconds_count 144320 1612411516789
                     # Finally a summary, which has a complex representation, too:
                     # HELP rpc_duration_seconds A summary of the RPC duration in seconds.
                     # TYPE rpc_duration_seconds summary
-                    rpc_duration_seconds{code="200",quantile="0.01"} 3102
-                    rpc_duration_seconds{code="200",quantile="0.05"} 3272
-                    rpc_duration_seconds{code="200",quantile="0.5"} 4773
-                    rpc_duration_seconds{code="200",quantile="0.9"} 9001
-                    rpc_duration_seconds{code="200",quantile="0.99"} 76656
-                    rpc_duration_seconds_sum{code="200"} 1.7560473e+07
-                    rpc_duration_seconds_count{code="200"} 2693
+                    rpc_duration_seconds{code="200",quantile="0.01"} 3102 1612411516789
+                    rpc_duration_seconds{code="200",quantile="0.05"} 3272 1612411516789
+                    rpc_duration_seconds{code="200",quantile="0.5"} 4773 1612411516789
+                    rpc_duration_seconds{code="200",quantile="0.9"} 9001 1612411516789
+                    rpc_duration_seconds{code="200",quantile="0.99"} 76656 1612411516789
+                    rpc_duration_seconds_sum{code="200"} 1.7560473e+07 1612411516789
+                    rpc_duration_seconds_count{code="200"} 2693 1612411516789
                     "##,
                 )))
             }))
@@ -355,30 +355,30 @@ mod test {
         assert_eq!(lines, vec![
             "# HELP vector_http_request_duration_seconds http_request_duration_seconds",
             "# TYPE vector_http_request_duration_seconds histogram",
-            "vector_http_request_duration_seconds_bucket{le=\"0.05\"} 24054",
-            "vector_http_request_duration_seconds_bucket{le=\"0.1\"} 33444",
-            "vector_http_request_duration_seconds_bucket{le=\"0.2\"} 100392",
-            "vector_http_request_duration_seconds_bucket{le=\"0.5\"} 129389",
-            "vector_http_request_duration_seconds_bucket{le=\"1\"} 133988",
-            "vector_http_request_duration_seconds_bucket{le=\"+Inf\"} 144320",
-            "vector_http_request_duration_seconds_sum 53423",
-            "vector_http_request_duration_seconds_count 144320",
+            "vector_http_request_duration_seconds_bucket{le=\"0.05\"} 24054 1612411516789",
+            "vector_http_request_duration_seconds_bucket{le=\"0.1\"} 33444 1612411516789",
+            "vector_http_request_duration_seconds_bucket{le=\"0.2\"} 100392 1612411516789",
+            "vector_http_request_duration_seconds_bucket{le=\"0.5\"} 129389 1612411516789",
+            "vector_http_request_duration_seconds_bucket{le=\"1\"} 133988 1612411516789",
+            "vector_http_request_duration_seconds_bucket{le=\"+Inf\"} 144320 1612411516789",
+            "vector_http_request_duration_seconds_sum 53423 1612411516789",
+            "vector_http_request_duration_seconds_count 144320 1612411516789",
             "# HELP vector_prometheus_remote_storage_samples_in_total prometheus_remote_storage_samples_in_total",
             "# TYPE vector_prometheus_remote_storage_samples_in_total gauge",
-            "vector_prometheus_remote_storage_samples_in_total 57011636",
+            "vector_prometheus_remote_storage_samples_in_total 57011636 1612411516789",
             "# HELP vector_promhttp_metric_handler_requests_total promhttp_metric_handler_requests_total",
             "# TYPE vector_promhttp_metric_handler_requests_total counter",
-            "vector_promhttp_metric_handler_requests_total{code=\"200\"} 100",
-            "vector_promhttp_metric_handler_requests_total{code=\"404\"} 7",
+            "vector_promhttp_metric_handler_requests_total{code=\"200\"} 100 1612411516789",
+            "vector_promhttp_metric_handler_requests_total{code=\"404\"} 7 1612411516789",
             "# HELP vector_rpc_duration_seconds rpc_duration_seconds",
             "# TYPE vector_rpc_duration_seconds summary",
-            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.01\"} 3102",
-            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.05\"} 3272",
-            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.5\"} 4773",
-            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.9\"} 9001",
-            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.99\"} 76656",
-            "vector_rpc_duration_seconds_sum{code=\"200\"} 17560473",
-            "vector_rpc_duration_seconds_count{code=\"200\"} 2693",
+            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.01\"} 3102 1612411516789",
+            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.05\"} 3272 1612411516789",
+            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.5\"} 4773 1612411516789",
+            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.9\"} 9001 1612411516789",
+            "vector_rpc_duration_seconds{code=\"200\",quantile=\"0.99\"} 76656 1612411516789",
+            "vector_rpc_duration_seconds_sum{code=\"200\"} 17560473 1612411516789",
+            "vector_rpc_duration_seconds_count{code=\"200\"} 2693 1612411516789",
             ],
         );
 


### PR DESCRIPTION
The Prometheus scrape agent adds a default timestamp of the current time
to all metrics it scrapes without a timestamp. This change gives Vector
the same behavior.

Ref #6814 

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>