### PR TITLE
enhancement(remap): support newlines in if-statement

### DIFF
--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -413,9 +413,12 @@ FunctionArgument: FunctionArgument = {
 // -----------------------------------------------------------------------------
 
 IfStatement: IfStatement =
-    "if" <predicate: Sp<Predicate>> <consequent: Sp<Block>>
+    "if"
+    <predicate: Sp<Predicate>>
+    NonterminalNewline*
+    <consequent: Sp<Block>>
     <alternatives: (Sp<ElseIf>)*>
-    <alternative: ("else" <Sp<Block>>)?> => {
+    <alternative: ("else" NonterminalNewline* <Sp<Block>>)?> => {
         let mut alternative = alternative;
 
         for Node { span, mut node } in alternatives {
@@ -428,7 +431,11 @@ IfStatement: IfStatement =
         IfStatement { predicate, consequent, alternative }
 };
 
-ElseIf: IfStatement = "else" "if" <predicate: Sp<Predicate>> <consequent: Sp<Block>> => {
+ElseIf: IfStatement =
+    "else" NonterminalNewline* "if"
+    <predicate: Sp<Predicate>>
+    NonterminalNewline*
+    <consequent: Sp<Block>> => {
     IfStatement { predicate, consequent, alternative: None }
 };
 

--- a/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
@@ -1,0 +1,34 @@
+# result: [true, true, false, false, true, true]
+
+v1 = if true
+{
+    true
+}
+
+v2 = if true
+{ true }
+
+v3 = if false
+{ true } else
+{ false }
+
+v4 = if false
+{ true } else
+if false
+{ true } else
+{ false }
+
+v5 = if false {
+    true
+} else
+if false {
+    false
+} else {
+    true
+}
+
+v6 =
+    if true {
+        true }
+
+[v1, v2, v3, v4, v5, v6]


### PR DESCRIPTION
This allows more newlines in places they weren't allowed before.

E.g. this now is allowed:

```rust
// if
if true 
{ true }

// if-else
if true { true } else
{ false }

// if-elseif
if true
{ true } else
if false
{ false }
```

It doesn't allow for adding the `else` on a new line though, as that requires some more work on the parser that I considered out of scope for this PR.

At some point we might add a linter/formatter to converge on a set of standards on how to write VRL programs, but that would be an optional addition. This allows people to use whatever style they prefer.

ref #6848