### PR TITLE
fix(remap): allow newlines in REPL

### DIFF
--- a/lib/vrl/cli/src/repl.rs
+++ b/lib/vrl/cli/src/repl.rs
@@ -9,7 +9,7 @@ use rustyline::hint::{Hinter, HistoryHinter};
 use rustyline::validate::{self, MatchingBracketValidator, ValidationResult, Validator};
 use rustyline::{Context, Editor, Helper};
 use std::borrow::Cow::{self, Borrowed, Owned};
-use vrl::{diagnostic::Formatter, state, value, Abort, Runtime, RuntimeResult, Target, Value};
+use vrl::{diagnostic::Formatter, state, value, Runtime, RuntimeResult, Target, Terminate, Value};
 
 // Create a list of all possible error values for potential docs lookup
 lazy_static! {
@@ -132,7 +132,7 @@ fn resolve(
     let program = match vrl::compile_with_state(program, &stdlib::all(), state) {
         Ok(program) => program,
         Err(diagnostics) => {
-            return Err(Abort(
+            return Err(Terminate::Error(
                 Formatter::new(program, diagnostics).colored().to_string(),
             ))
         }


### PR DESCRIPTION
By default, the REPL is configured to resolve an expression when it encounters a newline. We had custom logic to prevent that from happening if the last character was a backslash (`\`), which is something we also supported in VRL itself.

A while ago we removed support for that in the language, but never updated to REPL to go along with that change.

This PR does two things:

- It removes support for `\` in the REPL (it no longer did what it was intended to do, as it would now result in a VRL compilation error, since it doesn't know how to handle `\` in arbitrary places).
- It delegates checking if an expression is "completed" to the VRL compiler, allowing you to write multi-line expressions in the REPL similar to how you'd write them in a Vector config.

This last part is a bit hacky, in that we have to match the compiler error message against strings, since we don't have typed errors in the VRL compiler yet. This is the first use-case where we actually want to distinguish between error messages from the compiler, so I didn't want to update the compiler to support this just yet. Given that the REPL isn't such a high priority right now, I deemed the simple approach sufficient.

closes #6848