### PR TITLE
fix(tests): Export default container tool setting

### DIFF
--- a/scripts/setup_integration_env.sh
+++ b/scripts/setup_integration_env.sh
@@ -20,7 +20,7 @@ ACTION=$2
 # Check container tool and default to podman
 if [ -z "${CONTAINER_TOOL}" ]; then
 	echo "Container tool is unset, defaulting to podman"
-	CONTAINER_TOOL="podman"
+	export CONTAINER_TOOL="podman"
 else
 	echo "Container tool is ${CONTAINER_TOOL}..."
 fi

--- a/scripts/setup_integration_env.sh
+++ b/scripts/setup_integration_env.sh
@@ -7,8 +7,6 @@ set -o pipefail
 #
 #  Sets up Vector integration test environments
 
-set -x
-
 if [ $# -ne 2 ]
 then
     echo "Usage: $0 {integration_test_suite} {stop|start}" 1>&2; exit 1;


### PR DESCRIPTION
When setting up the default container tool, the new environment variable
needs to be exported so the sub-script can use it.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>