### PR TITLE
fix(host_metrics source): Silence the symlink loop error message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ jemallocator = { version = "0.3.0", optional = true }
 k8s-openapi = { version = "0.11.0", features = ["v1_16"], optional = true }
 lazy_static = "1.3.0"
 leveldb = { version = "0.8", optional = true, default-features = false }
+libc = "0.2.80"
 listenfd = { version = "0.3.3", optional = true }
 logfmt = { version = "0.0.2", optional = true }
 lru = { version = "0.6.3", optional = true }
@@ -269,7 +270,6 @@ assert_cmd = "1.0.2"
 base64 = "0.13"
 criterion = { version = "0.3", features = ["html_reports"] }
 httpmock = "0.5.7"
-libc = "0.2.80"
 libz-sys = "1.1.2"
 matches = "0.1.8"
 pretty_assertions = "0.7.1"


### PR DESCRIPTION
A common system configuration issue causes a symlink loop error when
calling `statvfs` to load the partition usage data. This is a nuisance
condition only seen on pseudo-filesystems, so just silence the error
message for it.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

Closes #6842 

Note that there is likely no way of actually testing this in a normal environment, hence the lack of any additional tests for this.