### PR TITLE
enhancement(remap): Support identifiers with leading numeric characters as fields in path

### DIFF
--- a/docs/reference/remap/expressions/path.cue
+++ b/docs/reference/remap/expressions/path.cue
@@ -87,8 +87,8 @@ remap: expressions: path: {
 						title: "Valid path characters"
 						description: """
 							Path segments only allow for underscores and ASCII alpha-numeric characters
-							(`[a-zA-Z0-9_]`). Segments must be delimited with periods (`.`). If a segment contains
-							characters outside of this list it must be quoted.
+							(`[a-zA-Z0-9_]`) where integers like `0` are not supported. Quoting
+							can be used to escape these constraints.
 							"""
 					}
 				}

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -528,7 +528,7 @@ impl<'input> Iterator for Lexer<'input> {
 
                     ch if is_ident_start(ch) => Some(Ok(self.identifier_or_function_call(start))),
                     ch if is_digit(ch) || (ch == '-' && self.test_peek(is_digit)) => {
-                        Some(self.numeric_literal(start))
+                        Some(self.numeric_literal_or_identifier(start))
                     }
                     ch if is_operator(ch) => Some(Ok(self.operator(start))),
                     ch if ch.is_whitespace() => continue,
@@ -905,7 +905,7 @@ impl<'input> Lexer<'input> {
         self.quoted_literal(start, Token::TimestampLiteral)
     }
 
-    fn numeric_literal(&mut self, start: usize) -> SpannedResult<'input, usize> {
+    fn numeric_literal_or_identifier(&mut self, start: usize) -> SpannedResult<'input, usize> {
         let (end, int) = self.take_while(start, |ch| is_digit(ch) || ch == '_');
 
         let negative = self.input.get(start..start + 1) == Some("-");

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -527,13 +527,7 @@ impl<'input> Iterator for Lexer<'input> {
                     't' if self.test_peek(|ch| ch == '\'') => Some(self.timestamp_literal(start)),
 
                     ch if is_ident_start(ch)
-                        || (is_digit(ch)
-                            && (0..start)
-                                .into_iter()
-                                .rev()
-                                .filter_map(|i| self.input.get(i..start))
-                                .next()
-                                == Some(".")) =>
+                        || (is_digit(ch) && self.before(start) == Some('.')) =>
                     {
                         Some(Ok(self.identifier_or_function_call(start)))
                     }
@@ -1068,6 +1062,15 @@ impl<'input> Lexer<'input> {
 
     fn next_index(&mut self) -> usize {
         self.peek().as_ref().map_or(self.input.len(), |l| l.0)
+    }
+
+    fn before(&self, from: usize) -> Option<char> {
+        (0..from)
+            .into_iter()
+            .rev()
+            .filter_map(|i| self.input.get(i..from))
+            .next()
+            .and_then(|s| s.chars().next())
     }
 
     fn escape_code(&mut self, start: usize) -> Result<char, Error> {

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -526,7 +526,17 @@ impl<'input> Iterator for Lexer<'input> {
                     's' if self.test_peek(|ch| ch == '\'') => Some(self.raw_string_literal(start)),
                     't' if self.test_peek(|ch| ch == '\'') => Some(self.timestamp_literal(start)),
 
-                    ch if is_ident_start(ch) || (is_digit(ch) && (0..start).into_iter().rev().filter_map(|i|self.input.get(i..start)).next()==Some(".")) => Some(Ok(self.identifier_or_function_call(start))),
+                    ch if is_ident_start(ch)
+                        || (is_digit(ch)
+                            && (0..start)
+                                .into_iter()
+                                .rev()
+                                .filter_map(|i| self.input.get(i..start))
+                                .next()
+                                == Some(".")) =>
+                    {
+                        Some(Ok(self.identifier_or_function_call(start)))
+                    }
                     ch if is_digit(ch) || (ch == '-' && self.test_peek(is_digit)) => {
                         Some(self.numeric_literal(start))
                     }

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -388,9 +388,9 @@ PathSegment: PathSegment = {
 pub ExtendedField: Field = {
     Field,
     <i:Integer> <s:AnyIdent?> => {
-        let field = match s{
-            Some(s) => format!("{}{}",i,s),
-            None => format!("{}",i),
+        let field = match s {
+            Some(s) => format!("{}{}", i, s),
+            None => i.to_string(),
         };
         Field::Quoted(field)
     },

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -387,13 +387,7 @@ PathSegment: PathSegment = {
 
 pub ExtendedField: Field = {
     Field,
-    <i:Integer> <s:AnyIdent?> => {
-        let field = match s {
-            Some(s) => format!("{}{}", i, s),
-            None => i.to_string(),
-        };
-        Field::Quoted(field)
-    },
+    <Integer> => Field::Quoted(<>.to_string()),
 };
 
 pub Field: Field = {

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -378,16 +378,11 @@ Path: Path = PathSegment+ => Path(<>);
 PathSegment: PathSegment = {
     "."? <Field> => PathSegment::Field(<>),
     "[" <Integer> "]" => PathSegment::Index(<>),
-    "."? "(" <v:(<ExtendedField> "|")+> <e:ExtendedField> ")" => {
+    "."? "(" <v:(<Field> "|")+> <e:Field> ")" => {
         let mut v = v;
         v.push(e);
         PathSegment::Coalesce(v)
     },
-};
-
-pub ExtendedField: Field = {
-    Field,
-    <Integer> => Field::Quoted(<>.to_string()),
 };
 
 pub Field: Field = {

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -378,10 +378,21 @@ Path: Path = PathSegment+ => Path(<>);
 PathSegment: PathSegment = {
     "."? <Field> => PathSegment::Field(<>),
     "[" <Integer> "]" => PathSegment::Index(<>),
-    "."? "(" <v:(<Field> "|")+> <e:Field> ")" => {
+    "."? "(" <v:(<ExtendedField> "|")+> <e:ExtendedField> ")" => {
         let mut v = v;
         v.push(e);
         PathSegment::Coalesce(v)
+    },
+};
+
+pub ExtendedField: Field = {
+    Field,
+    <i:Integer> <s:AnyIdent?> => {
+        let field = match s{
+            Some(s) => format!("{}{}",i,s),
+            None => format!("{}",i),
+        };
+        Field::Quoted(field)
     },
 };
 

--- a/lib/vrl/tests/tests/expressions/query/coalesce.vrl
+++ b/lib/vrl/tests/tests/expressions/query/coalesce.vrl
@@ -1,0 +1,4 @@
+# result: 2
+
+foo = { "0bar": 2 }
+foo.(a | 0bar)

--- a/lib/vrl/tests/tests/expressions/query/mixed.vrl
+++ b/lib/vrl/tests/tests/expressions/query/mixed.vrl
@@ -5,8 +5,8 @@
     {
         "foo": [
             {
-                "bar": parse_json!("{ \"baz\": true }").baz,
+                "bar": parse_json!("{ \"baz\": {\"0\": true} }").baz,
             }
         ]
     }
-][1].foo[0].bar
+][1].foo[0].bar.0

--- a/lib/vrl/tests/tests/expressions/query/mixed.vrl
+++ b/lib/vrl/tests/tests/expressions/query/mixed.vrl
@@ -5,8 +5,8 @@
     {
         "foo": [
             {
-                "bar": parse_json!("{ \"baz\": {\"0\": true} }").baz,
+                "bar": parse_json!("{ \"baz\": {\"0tar\": true} }").baz,
             }
         ]
     }
-][1].foo[0].bar.0
+][1].foo[0].bar.0tar


### PR DESCRIPTION
Closes vectordotdev/vector#6780

@JeanMertz there was a simpler solution than the ones we talked about. This lexer is quite powerful.

### Todo

- [x] Support only `0foo` in this PR.
- [x] Update documentation.
- [x] Open issue for `.0` (#7190)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
