### PR TITLE
feat(new sink): Initial `syslog` sink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -567,7 +567,7 @@ sinks-sematext = ["sinks-elasticsearch", "sinks-influxdb"]
 sinks-socket = ["sinks-utils-udp"]
 sinks-splunk_hec = ["bytesize"]
 sinks-statsd = ["sinks-utils-udp", "tokio-util/net"]
-sinks-syslog = ["sinks-utils-udp"]
+sinks-syslog = ["sinks-utils-udp", "syslog_loose"]
 sinks-utils-udp = []
 sinks-vector = ["sinks-utils-udp"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,6 +520,7 @@ sinks-logs = [
   "sinks-sematext",
   "sinks-socket",
   "sinks-splunk_hec",
+  "sinks-syslog",
   "sinks-vector"
 ]
 sinks-metrics = [
@@ -566,6 +567,7 @@ sinks-sematext = ["sinks-elasticsearch", "sinks-influxdb"]
 sinks-socket = ["sinks-utils-udp"]
 sinks-splunk_hec = ["bytesize"]
 sinks-statsd = ["sinks-utils-udp", "tokio-util/net"]
+sinks-syslog = ["sinks-utils-udp"]
 sinks-utils-udp = []
 sinks-vector = ["sinks-utils-udp"]
 

--- a/docs/reference/components/sinks/syslog.cue
+++ b/docs/reference/components/sinks/syslog.cue
@@ -67,12 +67,19 @@ components: sinks: syslog: {
 
 	configuration:  sinks.socket.configuration & {
 	    "type": "type": string: enum: syslog: "The type of this component."
-		rfc3164: {
-			common: true
-			description: "If this is set to `true` the message will be formatted according to the RFC3164 else the RFC5424 will be used."
-			required: false
+		format: {
+			common:      true
+			description: "The Syslog format used to send message, RFC3164 and RFC5424 are supported."
+			required:    false
 			warnings: []
-            type: bool: default: false
+			type: string: {
+				default: "rfc5424"
+				enum: {
+					rfc3164: "Format message according to [RFC3164](https://tools.ietf.org/html/rfc3164."
+					rfc5424: "Format message according to [RFC5424](https://tools.ietf.org/html/rfc5424."
+				}
+			syntax: "literal"
+			}
 		}
 		include_extra_fields: {
 			common: false

--- a/docs/reference/components/sinks/syslog.cue
+++ b/docs/reference/components/sinks/syslog.cue
@@ -75,8 +75,8 @@ components: sinks: syslog: {
 			type: string: {
 				default: "rfc5424"
 				enum: {
-					rfc3164: "Format message according to [RFC3164](https://tools.ietf.org/html/rfc3164."
-					rfc5424: "Format message according to [RFC5424](https://tools.ietf.org/html/rfc5424."
+					rfc3164: "Format message according to [RFC3164](https://tools.ietf.org/html/rfc3164)."
+					rfc5424: "Format message according to [RFC5424](https://tools.ietf.org/html/rfc5424)."
 				}
 				syntax: "literal"
 			}
@@ -169,16 +169,38 @@ components: sinks: syslog: {
 			common: false
 			description: """
 				The default facility when there is no facility in the message or when it cannot be matched to a known
-				facility. Supported value are: `LOG_KERN`, `LOG_USER`, `LOG_MAIL`, `LOG_DAEMON`, `LOG_AUTH`, `LOG_SYSLOG`,
-				`LOG_LPR`, `LOG_NEWS`, `LOG_UUCP`, `LOG_CRON`, `LOG_AUTHPRIV`, `LOG_FTP`, `LOG_NTP`, `LOG_AUDIT`, `LOG_ALERT`,
-				`LOG_CLOCKD`, `LOG_LOCAL0`, `LOG_LOCAL1`, `LOG_LOCAL2`, `LOG_LOCAL3`, `LOG_LOCAL4`, `LOG_LOCAL5`, `LOG_LOCAL6`
-				and `LOG_LOCAL7` *(TODO reword as enum and probably harmonise with the value accepted in log even)*
+				facility. Possible values and their descriptions comes from the [RFC5424](https://tools.ietf.org/html/rfc5424.
 				"""
 			required: false
 			warnings: []
 			type: string: {
-				default: "LOG_SYSLOG"
-				examples: ["LOG_UUCP"]
+				default: "syslog"
+				enum: {
+					kern:     "kernel messages (numerical code 0)"
+					user:     "user-level messages (numerical code 1)"
+					mail:     "mail system (numerical code 2)"
+					daemon:   "system daemons (numerical code 3)"
+					auth:     "security/authorization messages (numerical code 4)"
+					syslog:   "messages generated internally by syslogd (numerical code 5)"
+					lpr:      "line printer subsystem (numerical code 6)"
+					news:     "network news subsystem (numerical code 7)"
+					uucp:     "UUCP subsystem (numerical code 8)"
+					cron:     "clock daemon (numerical code 9)"
+					authpriv: "security/authorization messages (numerical code 10)"
+					ftp:      "FTP daemon (numerical code 11)"
+					ntp:      "NTP subsystem messages (numerical code 12)"
+					audit:    "log audit (numerical code 13)"
+					alert:    "log alert (numerical code 14)"
+					clockd:   "clock daemon (numerical code 15)"
+					local0:   "local use 0 (numerical code 16)"
+					local1:   "local use 0 (numerical code 17)"
+					local2:   "local use 0 (numerical code 18)"
+					local3:   "local use 0 (numerical code 19)"
+					local4:   "local use 0 (numerical code 20)"
+					local5:   "local use 0 (numerical code 21)"
+					local6:   "local use 0 (numerical code 22)"
+					local7:   "local use 0 (numerical code 23)"
+				}
 				syntax: "literal"
 			}
 		}
@@ -186,14 +208,22 @@ components: sinks: syslog: {
 			common: false
 			description: """
 				The default severity when there is no severity in the message or when it cannot be matched to a known
-				severity. Supported value are: `SEV_EMERG`, `SEV_ALERT`, `SEV_CRIT`, `SEV_ERR`, `SEV_WARNING`, `SEV_NOTICE`,
-				`SEV_INFO` and `SEV_DEBUG` *(TODO: reword as enum and probably harmonise with the value accepted in log even)*
+				severity. Possible values and their descriptions comes from the [RFC5424](https://tools.ietf.org/html/rfc5424).
 				"""
 			required: false
 			warnings: []
 			type: string: {
-				default: "SEV_DEBUG"
-				examples: ["SEV_ALERT"]
+				default: "debug"
+				enum: {
+					emerg:   "Emergency: system is unusable (numerical code 0)"
+					alert:   "Alert: action must be taken immediately (numerical code 1)"
+					crit:    "Critical: critical conditions (numerical code 2)"
+					err:     "Error: error conditions (numerical code 3)"
+					warning: "Warning: warning conditions (numerical code 4)"
+					notice:  "Notice: normal but significant condition (numerical code 5)"
+					info:    "Informational: informational messages (numerical code 6)"
+					debug:   "Debug: debug-level messages (numerical code 7)"
+				}
 				syntax: "literal"
 			}
 		}

--- a/docs/reference/components/sinks/syslog.cue
+++ b/docs/reference/components/sinks/syslog.cue
@@ -181,7 +181,7 @@ components: sinks: syslog: {
 			required: false
 			warnings: []
 			type: string: {
-				default: "syslog"
+				default: "user"
 				enum: {
 					kern:     "kernel messages (numerical code 0)"
 					user:     "user-level messages (numerical code 1)"
@@ -220,7 +220,7 @@ components: sinks: syslog: {
 			required: false
 			warnings: []
 			type: string: {
-				default: "debug"
+				default: "info"
 				enum: {
 					emerg:   "Emergency: system is unusable (numerical code 0)"
 					alert:   "Alert: action must be taken immediately (numerical code 1)"

--- a/docs/reference/components/sinks/syslog.cue
+++ b/docs/reference/components/sinks/syslog.cue
@@ -67,12 +67,12 @@ components: sinks: syslog: {
 
 	configuration:  sinks.socket.configuration & {
 	    "type": "type": string: enum: syslog: "The type of this component."
-		rfc5424: {
+		rfc3164: {
 			common: true
-			description: "If this is set to `true` message will be formatted according to the RFC5424 else the RFC3164 will be used."
+			description: "If this is set to `true` the message will be formatted according to the RFC3164 else the RFC5424 will be used."
 			required: false
 			warnings: []
-            type: bool: default: true
+            type: bool: default: false
 		}
 		include_extra_fields: {
 			common: false

--- a/docs/reference/components/sinks/syslog.cue
+++ b/docs/reference/components/sinks/syslog.cue
@@ -1,0 +1,200 @@
+package metadata
+
+components: sinks: syslog: {
+	title: "Syslog"
+
+	classes: {
+		commonly_used: true
+		delivery:      "best_effort"
+		development:   "beta"
+		egress_method: "stream"
+		service_providers: []
+		stateful: false
+	}
+
+	features: {
+		buffer: enabled:      true
+		healthcheck: enabled: true
+		send: {
+			compression: enabled: false
+			encoding: enabled: false
+			send_buffer_bytes: {
+				enabled:       true
+				relevant_when: "mode = `tcp` or mode = `udp`"
+			}
+			keepalive: enabled: true
+			request: enabled:   false
+			tls: {
+				enabled:                true
+				can_enable:             true
+				can_verify_certificate: true
+				can_verify_hostname:    true
+				enabled_default:        false
+			}
+			to: {
+				service: services.syslog
+
+				interface: {
+					socket: {
+						api: {
+							title: "Syslog"
+							url:   urls.syslog
+						}
+						direction: "outgoing"
+						protocols: ["tcp", "udp", "unix"]
+						ssl: "required"
+					}
+				}
+			}
+		}
+	}
+
+	support: {
+		targets: {
+			"aarch64-unknown-linux-gnu":      true
+			"aarch64-unknown-linux-musl":     true
+			"armv7-unknown-linux-gnueabihf":  true
+			"armv7-unknown-linux-musleabihf": true
+			"x86_64-apple-darwin":            true
+			"x86_64-pc-windows-msv":          true
+			"x86_64-unknown-linux-gnu":       true
+			"x86_64-unknown-linux-musl":      true
+		}
+		requirements: []
+		warnings: []
+		notices: []
+	}
+
+	configuration:  sinks.socket.configuration & {
+	    "type": "type": string: enum: syslog: "The type of this component."
+		rfc5424: {
+			common: true
+			description: "If this is set to `true` message will be formatted according to the RFC5424 else the RFC3164 will be used."
+			required: false
+			warnings: []
+            type: bool: default: true
+		}
+		include_extra_fields: {
+			common: false
+			description: "If this is set to `true` all fields that have not been mapped to a Syslog field will be included as structured data in the resulting message."
+			required: false
+			warnings: []
+            type: bool: default: false
+		}
+		appname_key: {
+            common:      false
+            description: "The key for the field that will be used as the `APP-NAME`."
+            required:    false
+            warnings: []
+            type: string: {
+                default: "appname"
+                examples: ["application_name"]
+                syntax: "literal"
+            }
+        }
+		facility_key: {
+            common:      false
+            description: """
+				The key for the field that will be used as the Syslog facility. The following value will be recognized as
+				valid facility: integer from 0 (included) to 23 (included) and the matching string representation: `kern`, `user`,
+				`mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`, `ntp`, `audit`, `alert`, `clockd`,
+				`local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6` and `local7`. Please check the
+				[RFC5424](https://tools.ietf.org/html/rfc5424) for additional information.
+				"""
+            required:    false
+            warnings: []
+            type: string: {
+                default: "facility"
+                examples: ["facility"]
+                syntax: "literal"
+            }
+        }
+		host_key: {
+            common:      false
+            description: "The key for the field that will be used to as the host in Syslog messages. This overrides the [global `host_key` option][docs.reference.configuration.global-options#host_key]."
+            required:    false
+            warnings: []
+            type: string: {
+                default: "hostname"
+                examples: ["host"]
+                syntax: "literal"
+            }
+        }
+		msgid_key: {
+            common:      false
+            description: "The key for the field that will be used as the Syslog `MSGID`."
+            required:    false
+            warnings: []
+            type: string: {
+                default: "msgid"
+                examples: ["msg_is"]
+                syntax: "literal"
+            }
+        }
+		procid_key: {
+            common:      false
+            description: "The key for the field that will be used as the Syslog `PROCID`."
+            required:    false
+            warnings: []
+            type: string: {
+                default: "procid"
+                examples: ["proc_id"]
+                syntax: "literal"
+            }
+        }
+		severity_key: {
+            common:      false
+            description: """
+				The key for the field that will be used as the Syslog severity. The following value will be recognized as
+				valid severity: integer from 0 (included) to 7 (included) and the matching string representation: `emerg`,
+				`alert`, `crit`, `err`, `warning`, `notice`, `info` and `debug`. Please check the
+				[RFC5424](https://tools.ietf.org/html/rfc5424) for additional information.
+				"""
+            required:    false
+            warnings: []
+            type: string: {
+                default: "severity"
+                examples: ["sev"]
+                syntax: "literal"
+            }
+        }
+		default_facility: {
+            common:      false
+            description: """
+				The default facility when there is no facility in the message or when it cannot be matched to a known
+				facility. Supported value are: `LOG_KERN`, `LOG_USER`, `LOG_MAIL`, `LOG_DAEMON`, `LOG_AUTH`, `LOG_SYSLOG`,
+				`LOG_LPR`, `LOG_NEWS`, `LOG_UUCP`, `LOG_CRON`, `LOG_AUTHPRIV`, `LOG_FTP`, `LOG_NTP`, `LOG_AUDIT`, `LOG_ALERT`,
+				`LOG_CLOCKD`, `LOG_LOCAL0`, `LOG_LOCAL1`, `LOG_LOCAL2`, `LOG_LOCAL3`, `LOG_LOCAL4`, `LOG_LOCAL5`, `LOG_LOCAL6`
+				and `LOG_LOCAL7` *(TODO reword as enum and probably harmonise with the value accepted in log even)*
+				"""
+            required:    false
+            warnings: []
+            type: string: {
+                default: "LOG_SYSLOG"
+                examples: ["LOG_UUCP"]
+                syntax: "literal"
+            }
+        }
+		default_severity: {
+            common:      false
+            description: """
+				The default severity when there is no severity in the message or when it cannot be matched to a known
+				severity. Supported value are: `SEV_EMERG`, `SEV_ALERT`, `SEV_CRIT`, `SEV_ERR`, `SEV_WARNING`, `SEV_NOTICE`,
+				`SEV_INFO` and `SEV_DEBUG` *(TODO: reword as enum and probably harmonise with the value accepted in log even)*
+				"""
+            required:    false
+            warnings: []
+            type: string: {
+                default: "SEV_DEBUG"
+                examples: ["SEV_ALERT"]
+                syntax: "literal"
+            }
+        }
+	}
+
+	input: {
+		logs:    true
+		metrics: null
+	}
+
+}

--- a/docs/reference/components/sinks/syslog.cue
+++ b/docs/reference/components/sinks/syslog.cue
@@ -17,7 +17,7 @@ components: sinks: syslog: {
 		healthcheck: enabled: true
 		send: {
 			compression: enabled: false
-			encoding: enabled: false
+			encoding: enabled:    false
 			send_buffer_bytes: {
 				enabled:       true
 				relevant_when: "mode = `tcp` or mode = `udp`"
@@ -65,8 +65,8 @@ components: sinks: syslog: {
 		notices: []
 	}
 
-	configuration:  sinks.socket.configuration & {
-	    "type": "type": string: enum: syslog: "The type of this component."
+	configuration: sinks.socket.configuration & {
+		"type": "type": string: enum: syslog: "The type of this component."
 		format: {
 			common:      true
 			description: "The Syslog format used to send message, RFC3164 and RFC5424 are supported."
@@ -78,125 +78,125 @@ components: sinks: syslog: {
 					rfc3164: "Format message according to [RFC3164](https://tools.ietf.org/html/rfc3164."
 					rfc5424: "Format message according to [RFC5424](https://tools.ietf.org/html/rfc5424."
 				}
-			syntax: "literal"
+				syntax: "literal"
 			}
 		}
 		include_extra_fields: {
-			common: false
+			common:      false
 			description: "If this is set to `true` all fields that have not been mapped to a Syslog field will be included as structured data in the resulting message."
-			required: false
+			required:    false
 			warnings: []
-            type: bool: default: false
+			type: bool: default: false
 		}
 		appname_key: {
-            common:      false
-            description: "The key for the field that will be used as the `APP-NAME`."
-            required:    false
-            warnings: []
-            type: string: {
-                default: "appname"
-                examples: ["application_name"]
-                syntax: "literal"
-            }
-        }
+			common:      false
+			description: "The key for the field that will be used as the `APP-NAME`."
+			required:    false
+			warnings: []
+			type: string: {
+				default: "appname"
+				examples: ["application_name"]
+				syntax: "literal"
+			}
+		}
 		facility_key: {
-            common:      false
-            description: """
+			common: false
+			description: """
 				The key for the field that will be used as the Syslog facility. The following value will be recognized as
 				valid facility: integer from 0 (included) to 23 (included) and the matching string representation: `kern`, `user`,
 				`mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`, `ntp`, `audit`, `alert`, `clockd`,
 				`local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6` and `local7`. Please check the
 				[RFC5424](https://tools.ietf.org/html/rfc5424) for additional information.
 				"""
-            required:    false
-            warnings: []
-            type: string: {
-                default: "facility"
-                examples: ["facility"]
-                syntax: "literal"
-            }
-        }
+			required: false
+			warnings: []
+			type: string: {
+				default: "facility"
+				examples: ["facility"]
+				syntax: "literal"
+			}
+		}
 		host_key: {
-            common:      false
-            description: "The key for the field that will be used to as the host in Syslog messages. This overrides the [global `host_key` option][docs.reference.configuration.global-options#host_key]."
-            required:    false
-            warnings: []
-            type: string: {
-                default: "hostname"
-                examples: ["host"]
-                syntax: "literal"
-            }
-        }
+			common:      false
+			description: "The key for the field that will be used to as the host in Syslog messages. This overrides the [global `host_key` option][docs.reference.configuration.global-options#host_key]."
+			required:    false
+			warnings: []
+			type: string: {
+				default: "hostname"
+				examples: ["host"]
+				syntax: "literal"
+			}
+		}
 		msgid_key: {
-            common:      false
-            description: "The key for the field that will be used as the Syslog `MSGID`."
-            required:    false
-            warnings: []
-            type: string: {
-                default: "msgid"
-                examples: ["msg_is"]
-                syntax: "literal"
-            }
-        }
+			common:      false
+			description: "The key for the field that will be used as the Syslog `MSGID`."
+			required:    false
+			warnings: []
+			type: string: {
+				default: "msgid"
+				examples: ["msg_is"]
+				syntax: "literal"
+			}
+		}
 		procid_key: {
-            common:      false
-            description: "The key for the field that will be used as the Syslog `PROCID`."
-            required:    false
-            warnings: []
-            type: string: {
-                default: "procid"
-                examples: ["proc_id"]
-                syntax: "literal"
-            }
-        }
+			common:      false
+			description: "The key for the field that will be used as the Syslog `PROCID`."
+			required:    false
+			warnings: []
+			type: string: {
+				default: "procid"
+				examples: ["proc_id"]
+				syntax: "literal"
+			}
+		}
 		severity_key: {
-            common:      false
-            description: """
+			common: false
+			description: """
 				The key for the field that will be used as the Syslog severity. The following value will be recognized as
 				valid severity: integer from 0 (included) to 7 (included) and the matching string representation: `emerg`,
 				`alert`, `crit`, `err`, `warning`, `notice`, `info` and `debug`. Please check the
 				[RFC5424](https://tools.ietf.org/html/rfc5424) for additional information.
 				"""
-            required:    false
-            warnings: []
-            type: string: {
-                default: "severity"
-                examples: ["sev"]
-                syntax: "literal"
-            }
-        }
+			required: false
+			warnings: []
+			type: string: {
+				default: "severity"
+				examples: ["sev"]
+				syntax: "literal"
+			}
+		}
 		default_facility: {
-            common:      false
-            description: """
+			common: false
+			description: """
 				The default facility when there is no facility in the message or when it cannot be matched to a known
 				facility. Supported value are: `LOG_KERN`, `LOG_USER`, `LOG_MAIL`, `LOG_DAEMON`, `LOG_AUTH`, `LOG_SYSLOG`,
 				`LOG_LPR`, `LOG_NEWS`, `LOG_UUCP`, `LOG_CRON`, `LOG_AUTHPRIV`, `LOG_FTP`, `LOG_NTP`, `LOG_AUDIT`, `LOG_ALERT`,
 				`LOG_CLOCKD`, `LOG_LOCAL0`, `LOG_LOCAL1`, `LOG_LOCAL2`, `LOG_LOCAL3`, `LOG_LOCAL4`, `LOG_LOCAL5`, `LOG_LOCAL6`
 				and `LOG_LOCAL7` *(TODO reword as enum and probably harmonise with the value accepted in log even)*
 				"""
-            required:    false
-            warnings: []
-            type: string: {
-                default: "LOG_SYSLOG"
-                examples: ["LOG_UUCP"]
-                syntax: "literal"
-            }
-        }
+			required: false
+			warnings: []
+			type: string: {
+				default: "LOG_SYSLOG"
+				examples: ["LOG_UUCP"]
+				syntax: "literal"
+			}
+		}
 		default_severity: {
-            common:      false
-            description: """
+			common: false
+			description: """
 				The default severity when there is no severity in the message or when it cannot be matched to a known
 				severity. Supported value are: `SEV_EMERG`, `SEV_ALERT`, `SEV_CRIT`, `SEV_ERR`, `SEV_WARNING`, `SEV_NOTICE`,
 				`SEV_INFO` and `SEV_DEBUG` *(TODO: reword as enum and probably harmonise with the value accepted in log even)*
 				"""
-            required:    false
-            warnings: []
-            type: string: {
-                default: "SEV_DEBUG"
-                examples: ["SEV_ALERT"]
-                syntax: "literal"
-            }
-        }
+			required: false
+			warnings: []
+			type: string: {
+				default: "SEV_DEBUG"
+				examples: ["SEV_ALERT"]
+				syntax: "literal"
+			}
+		}
 	}
 
 	input: {

--- a/docs/reference/components/sinks/syslog.cue
+++ b/docs/reference/components/sinks/syslog.cue
@@ -3,6 +3,13 @@ package metadata
 components: sinks: syslog: {
 	title: "Syslog"
 
+	description: """
+		Sends data to a Syslog collector. Both [RFC3164](https://tools.ietf.org/html/rfc3164)
+		and [RFC5424](https://tools.ietf.org/html/rfc5424) are supported. If TCP or a stream Unix
+		domain socket is used then the message will be encoded according to the
+		[RFC6587](https://tools.ietf.org/html/rfc6587).
+		"""
+
 	classes: {
 		commonly_used: true
 		delivery:      "best_effort"

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -65,6 +65,8 @@ pub mod socket;
 pub mod splunk_hec;
 #[cfg(feature = "sinks-statsd")]
 pub mod statsd;
+#[cfg(feature = "sinks-syslog")]
+pub mod syslog;
 #[cfg(feature = "sinks-vector")]
 pub mod vector;
 

--- a/src/sinks/syslog.rs
+++ b/src/sinks/syslog.rs
@@ -429,8 +429,7 @@ mod tests {
 
         let bytes = build_message(event, false).unwrap();
 
-        let msg =
-            Bytes::from("<4> 2021-04-12T21:00:01+00:00 foo bar[vector]: A message\n");
+        let msg = Bytes::from("<4> 2021-04-12T21:00:01+00:00 foo bar[vector]: A message\n");
 
         assert_eq!(bytes, msg);
     }

--- a/src/sinks/syslog.rs
+++ b/src/sinks/syslog.rs
@@ -1,0 +1,86 @@
+#[cfg(unix)]
+use crate::sinks::util::unix::UnixSinkConfig;
+use crate::{
+    config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    Event,
+    sinks::util::{
+        tcp::TcpSinkConfig, udp::UdpSinkConfig,
+    },
+};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+// TODO: add back when serde-rs/serde#1358 is addressed
+// #[serde(deny_unknown_fields)]
+pub struct SyslogSinkConfig {
+    #[serde(flatten)]
+    pub mode: Mode,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum Mode {
+    Tcp(TcpSinkConfig),
+    Udp(UdpSinkConfig),
+    #[cfg(unix)]
+    Unix(UnixSinkConfig),
+}
+
+inventory::submit! {
+    SinkDescription::new::<SyslogSinkConfig>("syslog")
+}
+
+impl GenerateConfig for SyslogSinkConfig {
+    fn generate_config() -> toml::Value {
+        toml::from_str(
+            r#"address = "2001:db8::1:514"
+            mode = "tcp"
+            "#,
+        )
+        .unwrap()
+    }
+}
+
+impl SyslogSinkConfig {
+    pub fn new(mode: Mode) -> Self {
+        SyslogSinkConfig { mode }
+    }
+
+    pub fn make_basic_tcp_config(address: String) -> Self {
+        Self::new(
+            Mode::Tcp(TcpSinkConfig::from_address(address)),
+        )
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "syslog")]
+impl SinkConfig for SyslogSinkConfig {
+    async fn build(
+        &self,
+        cx: SinkContext,
+    ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
+        let syslog_encode = move |event| build_syslog_message(event);
+        match &self.mode {
+            Mode::Tcp(config) => config.build(cx, syslog_encode),
+            Mode::Udp(config) => config.build(cx, syslog_encode),
+            #[cfg(unix)]
+            Mode::Unix(config) => config.build(cx, syslog_encode),
+        }
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "syslog"
+    }
+}
+
+fn build_syslog_message(event: Event) -> Option<Bytes> {
+    let log = event.into_log();
+    // TODO: syslog conversion
+    None
+}

--- a/src/sinks/syslog.rs
+++ b/src/sinks/syslog.rs
@@ -38,54 +38,54 @@ pub struct SyslogSinkConfig {
     format: Format,
     #[serde(default = "crate::serde::default_false")]
     include_extra_fields: bool,
-    #[serde(default = "appname_key")]
+    #[serde(default = "default_appname_key")]
     appname_key: String,
-    #[serde(default = "facility_key")]
+    #[serde(default = "default_facility_key")]
     facility_key: String,
-    #[serde(default = "host_key")]
+    #[serde(default = "default_host_key")]
     host_key: String,
-    #[serde(default = "msgid_key")]
+    #[serde(default = "default_msgid_key")]
     msgid_key: String,
-    #[serde(default = "procid_key")]
+    #[serde(default = "default_procid_key")]
     procid_key: String,
-    #[serde(default = "severity_key")]
+    #[serde(default = "default_severity_key")]
     severity_key: String,
-    #[serde(with = "SyslogFacilityDef", default = "facility")]
+    #[serde(with = "SyslogFacilityDef", default = "default_facility")]
     default_facility: SyslogFacility,
-    #[serde(with = "SyslogSeverityDef", default = "severity")]
+    #[serde(with = "SyslogSeverityDef", default = "default_severity")]
     default_severity: SyslogSeverity,
 }
 
-fn appname_key() -> String {
+fn default_appname_key() -> String {
     "appname".to_string()
 }
 
-fn facility_key() -> String {
+fn default_facility_key() -> String {
     "facility".to_string()
 }
 
-fn host_key() -> String {
+fn default_host_key() -> String {
     crate::config::log_schema().host_key().to_string()
 }
 
-fn msgid_key() -> String {
+fn default_msgid_key() -> String {
     "msgid".to_string()
 }
 
-fn procid_key() -> String {
+fn default_procid_key() -> String {
     "procid".to_string()
 }
 
-fn severity_key() -> String {
+fn default_severity_key() -> String {
     "severity".to_string()
 }
 
-fn facility() -> SyslogFacility {
-    SyslogFacility::LOG_SYSLOG
+fn default_facility() -> SyslogFacility {
+    SyslogFacility::LOG_USER
 }
 
-fn severity() -> SyslogSeverity {
-    SyslogSeverity::SEV_DEBUG
+fn default_severity() -> SyslogSeverity {
+    SyslogSeverity::SEV_INFO
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/sinks/syslog.rs
+++ b/src/sinks/syslog.rs
@@ -218,7 +218,7 @@ fn build_syslog_message(
 
 fn build_structured_data(log: LogEvent) -> Vec<StructuredElement<String>> {
     let mut d = vec![];
-    for (k, v) in log.into_iter() {
+    for (k, v) in log.as_map().iter() {
         let mut e = StructuredElement {
             id: k.clone(),
             params: vec![],

--- a/src/sinks/syslog.rs
+++ b/src/sinks/syslog.rs
@@ -2,7 +2,7 @@
 use crate::sinks::util::unix::UnixSinkConfig;
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
-    event::{Event,LogEvent,Value},
+    event::{Event, LogEvent, Value},
     sinks::util::{tcp::TcpSinkConfig, udp::UdpSinkConfig},
 };
 use bytes::Bytes;
@@ -13,15 +13,15 @@ use syslog_loose::{Message, ProcId, Protocol, StructuredElement, SyslogFacility,
 #[derive(Derivative, Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Format {
-    RFC3164,
-    RFC5424,
+    Rfc3164,
+    Rfc5424,
 }
 
 impl From<Format> for Protocol {
     fn from(f: Format) -> Protocol {
         match f {
-            Format::RFC3164 => Protocol::RFC3164,
-            Format::RFC5424 => Protocol::RFC5424(1),
+            Format::Rfc3164 => Protocol::RFC3164,
+            Format::Rfc5424 => Protocol::RFC5424(1),
         }
     }
 }
@@ -55,7 +55,7 @@ pub struct SyslogSinkConfig {
 }
 
 fn format() -> Format {
-    Format::RFC5424
+    Format::Rfc5424
 }
 
 fn appname_key() -> String {
@@ -121,16 +121,16 @@ impl SinkConfig for SyslogSinkConfig {
         &self,
         cx: SinkContext,
     ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
-        let format = self.format.clone();
-        let include_extra_fields = self.include_extra_fields.clone();
+        let format = self.format;
+        let include_extra_fields = self.include_extra_fields;
         let appname_key = self.appname_key.to_owned();
         let facility_key = self.facility_key.to_owned();
         let host_key = self.host_key.to_owned();
         let msgid_key = self.procid_key.to_owned();
         let procid_key = self.msgid_key.to_owned();
         let severity_key = self.severity_key.to_owned();
-        let default_facility = self.default_facility.clone();
-        let default_severity = self.default_severity.clone();
+        let default_facility = self.default_facility;
+        let default_severity = self.default_severity;
 
         let syslog_encode = move |event, include_len| {
             build_syslog_message(
@@ -150,10 +150,10 @@ impl SinkConfig for SyslogSinkConfig {
         };
 
         match &self.mode {
-            Mode::Tcp(config) => config.build(cx, move |e| syslog_encode(e, true)),
-            Mode::Udp(config) => config.build(cx, move |e| syslog_encode(e, false)),
+            Mode::Tcp(config) => config.build(cx, move |e| Some(syslog_encode(e, true))),
+            Mode::Udp(config) => config.build(cx, move |e| Some(syslog_encode(e, false))),
             #[cfg(unix)]
-            Mode::Unix(config) => config.build(cx, move |e| syslog_encode(e, true)),
+            Mode::Unix(config) => config.build(cx, move |e| Some(syslog_encode(e, true))),
         }
     }
 
@@ -179,7 +179,7 @@ fn build_syslog_message(
     severity_key: &str,
     default_facility: SyslogFacility,
     default_severity: SyslogSeverity,
-) -> Option<Bytes> {
+) -> Bytes {
     let mut log = event.into_log();
 
     let ts = log.remove(log_schema().timestamp_key()).and_then(|v| {
@@ -194,19 +194,19 @@ fn build_syslog_message(
             Value::Bytes(_) => ProcId::Name(procid.to_string_lossy()),
             _ => ProcId::Name("vector".to_string()),
         })
-        .or(Some(ProcId::Name("vector".to_string())));
+        .or_else(|| Some(ProcId::Name("vector".to_string())));
 
     let msg = Message {
+        procid,
         protocol: format.into(),
         timestamp: ts,
-        procid: procid,
         facility: log
             .remove(facility_key)
-            .and_then(get_facility)
+            .and_then(|v| v.into())
             .or(Some(default_facility)),
         severity: log
             .remove(severity_key)
-            .and_then(get_severity)
+            .and_then(|v| v.into())
             .or(Some(default_severity)),
         appname: log.remove(appname_key).map(|v| v.to_string_lossy()),
         msgid: log.remove(msgid_key).map(|v| v.to_string_lossy()),
@@ -214,7 +214,7 @@ fn build_syslog_message(
         msg: log
             .remove(log_schema().message_key())
             .map(|v| v.to_string_lossy())
-            .unwrap_or("-".to_owned()),
+            .unwrap_or_else(|| "-".to_owned()),
         structured_data: if include_extra_fields {
             build_structured_data(log)
         } else {
@@ -224,9 +224,9 @@ fn build_syslog_message(
 
     if include_len {
         let msg = format!("{}", msg);
-        Some(Bytes::from(format!("{} {}\n", msg.len(), msg)))
+        Bytes::from(format!("{} {}\n", msg.len(), msg))
     } else {
-        Some(Bytes::from(format!("{}\n", msg)))
+        Bytes::from(format!("{}\n", msg))
     }
 }
 
@@ -249,137 +249,173 @@ fn build_structured_data(log: LogEvent) -> Vec<StructuredElement<String>> {
     d
 }
 
-fn get_facility(value: Value) -> Option<SyslogFacility> {
-    match value {
-        Value::Integer(i) => match i {
-            0 => Some(SyslogFacility::LOG_KERN),
-            1 => Some(SyslogFacility::LOG_USER),
-            2 => Some(SyslogFacility::LOG_MAIL),
-            3 => Some(SyslogFacility::LOG_DAEMON),
-            4 => Some(SyslogFacility::LOG_AUTH),
-            5 => Some(SyslogFacility::LOG_SYSLOG),
-            6 => Some(SyslogFacility::LOG_LPR),
-            7 => Some(SyslogFacility::LOG_NEWS),
-            8 => Some(SyslogFacility::LOG_UUCP),
-            9 => Some(SyslogFacility::LOG_CRON),
-            10 => Some(SyslogFacility::LOG_AUTHPRIV),
-            11 => Some(SyslogFacility::LOG_FTP),
-            12 => Some(SyslogFacility::LOG_NTP),
-            13 => Some(SyslogFacility::LOG_AUDIT),
-            14 => Some(SyslogFacility::LOG_ALERT),
-            15 => Some(SyslogFacility::LOG_CLOCKD),
-            16 => Some(SyslogFacility::LOG_LOCAL0),
-            17 => Some(SyslogFacility::LOG_LOCAL1),
-            18 => Some(SyslogFacility::LOG_LOCAL2),
-            19 => Some(SyslogFacility::LOG_LOCAL3),
-            20 => Some(SyslogFacility::LOG_LOCAL4),
-            21 => Some(SyslogFacility::LOG_LOCAL5),
-            22 => Some(SyslogFacility::LOG_LOCAL6),
-            23 => Some(SyslogFacility::LOG_LOCAL7),
+impl From<Value> for Option<SyslogFacility> {
+    fn from(v: Value) -> Option<SyslogFacility> {
+        match v {
+            Value::Integer(i) => match i {
+                0 => Some(SyslogFacility::LOG_KERN),
+                1 => Some(SyslogFacility::LOG_USER),
+                2 => Some(SyslogFacility::LOG_MAIL),
+                3 => Some(SyslogFacility::LOG_DAEMON),
+                4 => Some(SyslogFacility::LOG_AUTH),
+                5 => Some(SyslogFacility::LOG_SYSLOG),
+                6 => Some(SyslogFacility::LOG_LPR),
+                7 => Some(SyslogFacility::LOG_NEWS),
+                8 => Some(SyslogFacility::LOG_UUCP),
+                9 => Some(SyslogFacility::LOG_CRON),
+                10 => Some(SyslogFacility::LOG_AUTHPRIV),
+                11 => Some(SyslogFacility::LOG_FTP),
+                12 => Some(SyslogFacility::LOG_NTP),
+                13 => Some(SyslogFacility::LOG_AUDIT),
+                14 => Some(SyslogFacility::LOG_ALERT),
+                15 => Some(SyslogFacility::LOG_CLOCKD),
+                16 => Some(SyslogFacility::LOG_LOCAL0),
+                17 => Some(SyslogFacility::LOG_LOCAL1),
+                18 => Some(SyslogFacility::LOG_LOCAL2),
+                19 => Some(SyslogFacility::LOG_LOCAL3),
+                20 => Some(SyslogFacility::LOG_LOCAL4),
+                21 => Some(SyslogFacility::LOG_LOCAL5),
+                22 => Some(SyslogFacility::LOG_LOCAL6),
+                23 => Some(SyslogFacility::LOG_LOCAL7),
+                _ => None,
+            },
+            Value::Bytes(_) => match v.to_string_lossy().to_lowercase().as_str() {
+                "kern" => Some(SyslogFacility::LOG_KERN),
+                "user" => Some(SyslogFacility::LOG_USER),
+                "mail" => Some(SyslogFacility::LOG_MAIL),
+                "daemon" => Some(SyslogFacility::LOG_DAEMON),
+                "auth" => Some(SyslogFacility::LOG_AUTH),
+                "syslog" => Some(SyslogFacility::LOG_SYSLOG),
+                "lpr" => Some(SyslogFacility::LOG_LPR),
+                "news" => Some(SyslogFacility::LOG_NEWS),
+                "uucp" => Some(SyslogFacility::LOG_UUCP),
+                "cron" => Some(SyslogFacility::LOG_CRON),
+                "authpriv" => Some(SyslogFacility::LOG_AUTHPRIV),
+                "ftp" => Some(SyslogFacility::LOG_FTP),
+                "ntp" => Some(SyslogFacility::LOG_NTP),
+                "audit" => Some(SyslogFacility::LOG_AUDIT),
+                "alert" => Some(SyslogFacility::LOG_ALERT),
+                "clockd" => Some(SyslogFacility::LOG_CLOCKD),
+                "local0" => Some(SyslogFacility::LOG_LOCAL0),
+                "local1" => Some(SyslogFacility::LOG_LOCAL1),
+                "local2" => Some(SyslogFacility::LOG_LOCAL2),
+                "local3" => Some(SyslogFacility::LOG_LOCAL3),
+                "local4" => Some(SyslogFacility::LOG_LOCAL4),
+                "local5" => Some(SyslogFacility::LOG_LOCAL5),
+                "local6" => Some(SyslogFacility::LOG_LOCAL6),
+                "local7" => Some(SyslogFacility::LOG_LOCAL7),
+                _ => None,
+            },
             _ => None,
-        },
-        Value::Bytes(_) => match value.to_string_lossy().to_lowercase().as_str() {
-            "kern" => Some(SyslogFacility::LOG_KERN),
-            "user" => Some(SyslogFacility::LOG_USER),
-            "mail" => Some(SyslogFacility::LOG_MAIL),
-            "daemon" => Some(SyslogFacility::LOG_DAEMON),
-            "auth" => Some(SyslogFacility::LOG_AUTH),
-            "syslog" => Some(SyslogFacility::LOG_SYSLOG),
-            "lpr" => Some(SyslogFacility::LOG_LPR),
-            "news" => Some(SyslogFacility::LOG_NEWS),
-            "uucp" => Some(SyslogFacility::LOG_UUCP),
-            "cron" => Some(SyslogFacility::LOG_CRON),
-            "authpriv" => Some(SyslogFacility::LOG_AUTHPRIV),
-            "ftp" => Some(SyslogFacility::LOG_FTP),
-            "ntp" => Some(SyslogFacility::LOG_NTP),
-            "audit" => Some(SyslogFacility::LOG_AUDIT),
-            "alert" => Some(SyslogFacility::LOG_ALERT),
-            "clockd" => Some(SyslogFacility::LOG_CLOCKD),
-            "local0" => Some(SyslogFacility::LOG_LOCAL0),
-            "local1" => Some(SyslogFacility::LOG_LOCAL1),
-            "local2" => Some(SyslogFacility::LOG_LOCAL2),
-            "local3" => Some(SyslogFacility::LOG_LOCAL3),
-            "local4" => Some(SyslogFacility::LOG_LOCAL4),
-            "local5" => Some(SyslogFacility::LOG_LOCAL5),
-            "local6" => Some(SyslogFacility::LOG_LOCAL6),
-            "local7" => Some(SyslogFacility::LOG_LOCAL7),
-            _ => None,
-        },
-        _ => None,
+        }
     }
 }
 
-fn get_severity(value: Value) -> Option<SyslogSeverity> {
-    match value {
-        Value::Integer(i) => match i {
-            0 => Some(SyslogSeverity::SEV_EMERG),
-            1 => Some(SyslogSeverity::SEV_ALERT),
-            2 => Some(SyslogSeverity::SEV_CRIT),
-            3 => Some(SyslogSeverity::SEV_ERR),
-            4 => Some(SyslogSeverity::SEV_WARNING),
-            5 => Some(SyslogSeverity::SEV_NOTICE),
-            6 => Some(SyslogSeverity::SEV_INFO),
-            7 => Some(SyslogSeverity::SEV_DEBUG),
+impl From<Value> for Option<SyslogSeverity> {
+    fn from(v: Value) -> Option<SyslogSeverity> {
+        match v {
+            Value::Integer(i) => match i {
+                0 => Some(SyslogSeverity::SEV_EMERG),
+                1 => Some(SyslogSeverity::SEV_ALERT),
+                2 => Some(SyslogSeverity::SEV_CRIT),
+                3 => Some(SyslogSeverity::SEV_ERR),
+                4 => Some(SyslogSeverity::SEV_WARNING),
+                5 => Some(SyslogSeverity::SEV_NOTICE),
+                6 => Some(SyslogSeverity::SEV_INFO),
+                7 => Some(SyslogSeverity::SEV_DEBUG),
+                _ => None,
+            },
+            Value::Bytes(_) => match v.to_string_lossy().to_lowercase().as_str() {
+                "emerg" => Some(SyslogSeverity::SEV_EMERG),
+                "alert" => Some(SyslogSeverity::SEV_ALERT),
+                "crit" => Some(SyslogSeverity::SEV_CRIT),
+                "err" => Some(SyslogSeverity::SEV_ERR),
+                "warning" => Some(SyslogSeverity::SEV_WARNING),
+                "notice" => Some(SyslogSeverity::SEV_NOTICE),
+                "info" => Some(SyslogSeverity::SEV_INFO),
+                "debug" => Some(SyslogSeverity::SEV_DEBUG),
+                _ => None,
+            },
             _ => None,
-        },
-        Value::Bytes(_) => match value.to_string_lossy().to_lowercase().as_str() {
-            "emerg" => Some(SyslogSeverity::SEV_EMERG),
-            "alert" => Some(SyslogSeverity::SEV_ALERT),
-            "crit" => Some(SyslogSeverity::SEV_CRIT),
-            "err" => Some(SyslogSeverity::SEV_ERR),
-            "warning" => Some(SyslogSeverity::SEV_WARNING),
-            "notice" => Some(SyslogSeverity::SEV_NOTICE),
-            "info" => Some(SyslogSeverity::SEV_INFO),
-            "debug" => Some(SyslogSeverity::SEV_DEBUG),
-            _ => None,
-        },
-        _ => None,
+        }
     }
 }
 
 // Syslog Severities from RFC 5424.
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "SyslogSeverity")]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum SyslogSeverityDef {
+    #[serde(rename = "emerg")]
     SEV_EMERG = 0,
+    #[serde(rename = "alert")]
     SEV_ALERT = 1,
+    #[serde(rename = "crit")]
     SEV_CRIT = 2,
+    #[serde(rename = "err")]
     SEV_ERR = 3,
+    #[serde(rename = "warning")]
     SEV_WARNING = 4,
+    #[serde(rename = "notice")]
     SEV_NOTICE = 5,
+    #[serde(rename = "info")]
     SEV_INFO = 6,
+    #[serde(rename = "debug")]
     SEV_DEBUG = 7,
 }
 
 // Names are from Linux.
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "SyslogFacility")]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum SyslogFacilityDef {
+    #[serde(rename = "kern")]
     LOG_KERN = 0,
+    #[serde(rename = "user")]
     LOG_USER = 1,
+    #[serde(rename = "mail")]
     LOG_MAIL = 2,
+    #[serde(rename = "daemon")]
     LOG_DAEMON = 3,
+    #[serde(rename = "auth")]
     LOG_AUTH = 4,
+    #[serde(rename = "syslog")]
     LOG_SYSLOG = 5,
+    #[serde(rename = "lpr")]
     LOG_LPR = 6,
+    #[serde(rename = "news")]
     LOG_NEWS = 7,
+    #[serde(rename = "uucp")]
     LOG_UUCP = 8,
+    #[serde(rename = "cron")]
     LOG_CRON = 9,
+    #[serde(rename = "authpriv")]
     LOG_AUTHPRIV = 10,
+    #[serde(rename = "ftp")]
     LOG_FTP = 11,
+    #[serde(rename = "ntp")]
     LOG_NTP = 12,
+    #[serde(rename = "audit")]
     LOG_AUDIT = 13,
+    #[serde(rename = "alert")]
     LOG_ALERT = 14,
+    #[serde(rename = "clockd")]
     LOG_CLOCKD = 15,
+    #[serde(rename = "local0")]
     LOG_LOCAL0 = 16,
+    #[serde(rename = "local1")]
     LOG_LOCAL1 = 17,
+    #[serde(rename = "local2")]
     LOG_LOCAL2 = 18,
+    #[serde(rename = "local3")]
     LOG_LOCAL3 = 19,
+    #[serde(rename = "local4")]
     LOG_LOCAL4 = 20,
+    #[serde(rename = "local5")]
     LOG_LOCAL5 = 21,
+    #[serde(rename = "local6")]
     LOG_LOCAL6 = 22,
+    #[serde(rename = "local7")]
     LOG_LOCAL7 = 23,
 }
 
@@ -388,13 +424,14 @@ mod tests {
     use super::*;
     use crate::event::Event;
     use chrono::Utc;
+    use serde_json::json;
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<SyslogSinkConfig>();
     }
 
-    fn build_message(event: Event, format: Format) -> Option<Bytes> {
+    fn build_message(event: Event, format: Format) -> Bytes {
         build_syslog_message(
             event,
             false,
@@ -415,13 +452,13 @@ mod tests {
     fn basic_syslog5424_message() {
         let mut event = Event::from("A message");
 
-        let timestamp = Utc.ymd(2021, 04, 12).and_hms(21, 0, 1);
+        let timestamp = Utc.ymd(2021, 4, 12).and_hms(21, 0, 1);
 
         event.as_mut_log().insert("timestamp", timestamp);
         event.as_mut_log().insert("hostname", "foohost");
         event.as_mut_log().insert("appname", "myapp");
 
-        let bytes = build_message(event, Format::RFC5424).unwrap();
+        let bytes = build_message(event, Format::Rfc5424);
 
         let msg =
             Bytes::from("<14>1 2021-04-12T21:00:01+00:00 foohost myapp vector - - A message\n");
@@ -433,7 +470,7 @@ mod tests {
     fn basic_syslog3164_message() {
         let mut event = Event::from("A message");
 
-        let timestamp = Utc.ymd(2021, 04, 12).and_hms(21, 0, 1);
+        let timestamp = Utc.ymd(2021, 4, 12).and_hms(21, 0, 1);
 
         event.as_mut_log().insert("timestamp", timestamp);
         event.as_mut_log().insert("hostname", "foo");
@@ -441,10 +478,119 @@ mod tests {
         event.as_mut_log().insert("severity", "warning");
         event.as_mut_log().insert("facility", "kern");
 
-        let bytes = build_message(event, Format::RFC3164).unwrap();
+        let bytes = build_message(event, Format::Rfc3164);
 
         let msg = Bytes::from("<4> 2021-04-12T21:00:01+00:00 foo bar[vector]: A message\n");
 
         assert_eq!(bytes, msg);
+    }
+
+    #[test]
+    fn syslog_structured_data() {
+        let mut event = Event::from("A message");
+
+        let timestamp = Utc.ymd(2021, 4, 12).and_hms(21, 0, 1);
+
+        event.as_mut_log().insert("timestamp", timestamp);
+        event.as_mut_log().insert("hostname", "foo");
+        event.as_mut_log().insert("appname", "bar");
+        event.as_mut_log().insert("severity", "warning");
+        event.as_mut_log().insert("facility", "kern");
+        event.as_mut_log().insert(
+            "foo",
+            json!({"mow": "moscow", "pnh": "pnomh-penh", "lpb": "la paz"}),
+        );
+
+        let bytes = build_message(event, Format::Rfc5424);
+
+        let msg = Bytes::from("<4>1 2021-04-12T21:00:01+00:00 foo bar vector - [foo lpb=\"la paz\" mow=\"moscow\" pnh=\"pnomh-penh\"] A message\n");
+
+        assert_eq!(bytes, msg);
+    }
+
+    #[test]
+    fn syslog_string_procid() {
+        let mut event = Event::from("rib full");
+
+        let timestamp = Utc.ymd(2021, 4, 12).and_hms(21, 0, 1);
+
+        event.as_mut_log().insert("timestamp", timestamp);
+        event.as_mut_log().insert("hostname", "foo");
+        event.as_mut_log().insert("appname", "quagga");
+        event.as_mut_log().insert("severity", "crit");
+        event.as_mut_log().insert("facility", "kern");
+        event.as_mut_log().insert("procid", "bgpd");
+
+        let bytes = build_message(event, Format::Rfc5424);
+
+        let msg = Bytes::from("<2>1 2021-04-12T21:00:01+00:00 foo quagga bgpd - - rib full\n");
+
+        assert_eq!(bytes, msg);
+    }
+
+    #[test]
+    fn syslog_numeric_procid() {
+        let mut event = Event::from("bdr unreachable");
+
+        let timestamp = Utc.ymd(2021, 4, 12).and_hms(21, 0, 1);
+
+        event.as_mut_log().insert("timestamp", timestamp);
+        event.as_mut_log().insert("hostname", "foo");
+        event.as_mut_log().insert("appname", "ospfd");
+        event.as_mut_log().insert("severity", "emerg");
+        event.as_mut_log().insert("facility", "kern");
+        event.as_mut_log().insert("procid", 217);
+
+        let bytes = build_message(event, Format::Rfc5424);
+
+        let msg = Bytes::from("<0>1 2021-04-12T21:00:01+00:00 foo ospfd 217 - - bdr unreachable\n");
+
+        assert_eq!(bytes, msg);
+    }
+
+    #[test]
+    fn syslog_default_facility() {
+        let timestamp = Utc.ymd(2021, 4, 12).and_hms(21, 0, 1);
+
+        let mut event = Event::from("A message");
+        event.as_mut_log().insert("timestamp", timestamp);
+        let b1 = build_message(event, Format::Rfc5424);
+
+        let mut event = Event::from("A message");
+        event.as_mut_log().insert("timestamp", timestamp);
+        event.as_mut_log().insert("facility", "invalid");
+        let b2 = build_message(event, Format::Rfc5424);
+
+        assert_eq!(b1, b2);
+
+        let mut event = Event::from("A message");
+        event.as_mut_log().insert("timestamp", timestamp);
+        event.as_mut_log().insert("facility", "user");
+        let b3 = build_message(event, Format::Rfc5424);
+
+        assert_eq!(b2, b3);
+    }
+
+    #[test]
+    fn syslog_default_severity() {
+        let timestamp = Utc.ymd(2021, 4, 12).and_hms(21, 0, 1);
+
+        let mut event = Event::from("A message");
+        event.as_mut_log().insert("timestamp", timestamp);
+        let b1 = build_message(event, Format::Rfc5424);
+
+        let mut event = Event::from("A message");
+        event.as_mut_log().insert("timestamp", timestamp);
+        event.as_mut_log().insert("severity", "invalid");
+        let b2 = build_message(event, Format::Rfc5424);
+
+        assert_eq!(b1, b2);
+
+        let mut event = Event::from("A message");
+        event.as_mut_log().insert("timestamp", timestamp);
+        event.as_mut_log().insert("severity", "info");
+        let b3 = build_message(event, Format::Rfc5424);
+
+        assert_eq!(b2, b3);
     }
 }

--- a/src/sinks/syslog.rs
+++ b/src/sinks/syslog.rs
@@ -1,21 +1,23 @@
 #[cfg(unix)]
 use crate::sinks::util::unix::UnixSinkConfig;
 use crate::{
-    config::{DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::LogEvent,
+    event::Value,
+    sinks::util::{tcp::TcpSinkConfig, udp::UdpSinkConfig},
     Event,
-    sinks::util::{
-        tcp::TcpSinkConfig, udp::UdpSinkConfig,
-    },
 };
 use bytes::Bytes;
+use chrono::{FixedOffset, TimeZone};
 use serde::{Deserialize, Serialize};
+use syslog_loose::{Message, ProcId, Protocol, StructuredElement, SyslogFacility, SyslogSeverity};
 
 #[derive(Deserialize, Serialize, Debug)]
 // TODO: add back when serde-rs/serde#1358 is addressed
 // #[serde(deny_unknown_fields)]
 pub struct SyslogSinkConfig {
     #[serde(flatten)]
-    pub mode: Mode,
+    mode: Mode,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -48,9 +50,7 @@ impl SyslogSinkConfig {
     }
 
     pub fn make_basic_tcp_config(address: String) -> Self {
-        Self::new(
-            Mode::Tcp(TcpSinkConfig::from_address(address)),
-        )
+        Self::new(Mode::Tcp(TcpSinkConfig::from_address(address)))
     }
 }
 
@@ -62,6 +62,7 @@ impl SinkConfig for SyslogSinkConfig {
         cx: SinkContext,
     ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let syslog_encode = move |event| build_syslog_message(event);
+
         match &self.mode {
             Mode::Tcp(config) => config.build(cx, syslog_encode),
             Mode::Udp(config) => config.build(cx, syslog_encode),
@@ -79,8 +80,148 @@ impl SinkConfig for SyslogSinkConfig {
     }
 }
 
+/*
+
+{
+  "appname": "root",
+  "facility": "user",
+  "host": "74794bfb6795",
+  "hostname": "74794bfb6795",
+  "message": "i am foobar",
+  "meta": {
+    "sequenceId": "1"
+  },
+  "procid": 8449,
+  "service": "vector",
+  "severity": "notice",
+  "source_ip": "10.121.132.66",
+  "source_type": "syslog",
+  "timestamp": "2019-02-13T19:48:34Z",
+  "version": 1
+}*/
+
 fn build_syslog_message(event: Event) -> Option<Bytes> {
-    let log = event.into_log();
-    // TODO: syslog conversion
-    None
+    let mut log = event.into_log();
+    let ts = log.remove(log_schema().timestamp_key()).and_then(|v| {
+        v.as_timestamp()
+            .map(|v| FixedOffset::west(0).timestamp_nanos(v.timestamp_nanos()))
+    });
+
+    let procid = log.remove("procid").map(|procid| match procid {
+        Value::Integer(pid) => ProcId::PID(pid as i32),
+        Value::Bytes(_) => ProcId::Name(procid.to_string_lossy()),
+        _ => ProcId::Name("vector".to_string()),
+    });
+
+    let msg = Message {
+        protocol: Protocol::RFC5424(1),
+        facility: log.remove("facility").and_then(get_facility),
+        severity: log.remove("severity").and_then(get_severity),
+        timestamp: ts,
+        // Note: the syslog source uses host and hostname key
+        hostname: log
+            .remove(log_schema().host_key())
+            .map(|v| v.to_string_lossy()),
+        appname: log.remove("appname").map(|v| v.to_string_lossy()),
+        procid: procid,
+        msgid: log.remove("appname").map(|v| v.to_string_lossy()),
+        msg: log
+            .remove(log_schema().message_key())
+            .map(|v| v.to_string_lossy())
+            .unwrap_or("-".to_owned()),
+        structured_data: build_structured_data(log),
+    };
+    Some(Bytes::from(format!("{}", msg)))
+}
+
+fn build_structured_data(log: LogEvent) -> Vec<StructuredElement<String>> {
+    vec![]
+}
+
+fn get_facility(value: Value) -> Option<SyslogFacility> {
+    match value {
+        Value::Integer(i) => match i {
+            0 => Some(SyslogFacility::LOG_KERN),
+            1 => Some(SyslogFacility::LOG_USER),
+            2 => Some(SyslogFacility::LOG_MAIL),
+            3 => Some(SyslogFacility::LOG_DAEMON),
+            4 => Some(SyslogFacility::LOG_AUTH),
+            5 => Some(SyslogFacility::LOG_SYSLOG),
+            6 => Some(SyslogFacility::LOG_LPR),
+            7 => Some(SyslogFacility::LOG_NEWS),
+            8 => Some(SyslogFacility::LOG_UUCP),
+            9 => Some(SyslogFacility::LOG_CRON),
+            10 => Some(SyslogFacility::LOG_AUTHPRIV),
+            11 => Some(SyslogFacility::LOG_FTP),
+            12 => Some(SyslogFacility::LOG_NTP),
+            13 => Some(SyslogFacility::LOG_AUDIT),
+            14 => Some(SyslogFacility::LOG_ALERT),
+            15 => Some(SyslogFacility::LOG_CLOCKD),
+            16 => Some(SyslogFacility::LOG_LOCAL0),
+            17 => Some(SyslogFacility::LOG_LOCAL1),
+            18 => Some(SyslogFacility::LOG_LOCAL2),
+            19 => Some(SyslogFacility::LOG_LOCAL3),
+            20 => Some(SyslogFacility::LOG_LOCAL4),
+            21 => Some(SyslogFacility::LOG_LOCAL5),
+            22 => Some(SyslogFacility::LOG_LOCAL6),
+            23 => Some(SyslogFacility::LOG_LOCAL7),
+            _ => None,
+        },
+        Value::Bytes(_) => match value.to_string_lossy().to_lowercase().as_str() {
+            "kern" => Some(SyslogFacility::LOG_KERN),
+            "user" => Some(SyslogFacility::LOG_USER),
+            "mail" => Some(SyslogFacility::LOG_MAIL),
+            "daemon" => Some(SyslogFacility::LOG_DAEMON),
+            "auth" => Some(SyslogFacility::LOG_AUTH),
+            "syslog" => Some(SyslogFacility::LOG_SYSLOG),
+            "lpr" => Some(SyslogFacility::LOG_LPR),
+            "news" => Some(SyslogFacility::LOG_NEWS),
+            "uucp" => Some(SyslogFacility::LOG_UUCP),
+            "cron" => Some(SyslogFacility::LOG_CRON),
+            "authpriv" => Some(SyslogFacility::LOG_AUTHPRIV),
+            "ftp" => Some(SyslogFacility::LOG_FTP),
+            "ntp" => Some(SyslogFacility::LOG_NTP),
+            "audit" => Some(SyslogFacility::LOG_AUDIT),
+            "alert" => Some(SyslogFacility::LOG_ALERT),
+            "clockd" => Some(SyslogFacility::LOG_CLOCKD),
+            "local0" => Some(SyslogFacility::LOG_LOCAL0),
+            "local1" => Some(SyslogFacility::LOG_LOCAL1),
+            "local2" => Some(SyslogFacility::LOG_LOCAL2),
+            "local3" => Some(SyslogFacility::LOG_LOCAL3),
+            "local4" => Some(SyslogFacility::LOG_LOCAL4),
+            "local5" => Some(SyslogFacility::LOG_LOCAL5),
+            "local6" => Some(SyslogFacility::LOG_LOCAL6),
+            "local7" => Some(SyslogFacility::LOG_LOCAL7),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn get_severity(value: Value) -> Option<SyslogSeverity> {
+    match value {
+        Value::Integer(i) => match i {
+            0 => Some(SyslogSeverity::SEV_EMERG),
+            1 => Some(SyslogSeverity::SEV_ALERT),
+            2 => Some(SyslogSeverity::SEV_CRIT),
+            3 => Some(SyslogSeverity::SEV_ERR),
+            4 => Some(SyslogSeverity::SEV_WARNING),
+            5 => Some(SyslogSeverity::SEV_NOTICE),
+            6 => Some(SyslogSeverity::SEV_INFO),
+            7 => Some(SyslogSeverity::SEV_DEBUG),
+            _ => None,
+        },
+        Value::Bytes(_) => match value.to_string_lossy().to_lowercase().as_str() {
+            "emerg" => Some(SyslogSeverity::SEV_EMERG),
+            "alert" => Some(SyslogSeverity::SEV_ALERT),
+            "crit" => Some(SyslogSeverity::SEV_CRIT),
+            "err" => Some(SyslogSeverity::SEV_ERR),
+            "warning" => Some(SyslogSeverity::SEV_WARNING),
+            "notice" => Some(SyslogSeverity::SEV_NOTICE),
+            "info" => Some(SyslogSeverity::SEV_INFO),
+            "debug" => Some(SyslogSeverity::SEV_DEBUG),
+            _ => None,
+        },
+        _ => None,
+    }
 }

--- a/src/sinks/syslog.rs
+++ b/src/sinks/syslog.rs
@@ -10,10 +10,12 @@ use chrono::{FixedOffset, TimeZone};
 use serde::{Deserialize, Serialize};
 use syslog_loose::{Message, ProcId, Protocol, StructuredElement, SyslogFacility, SyslogSeverity};
 
-#[derive(Derivative, Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
+#[derivative(Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Format {
     Rfc3164,
+    #[derivative(Default)]
     Rfc5424,
 }
 
@@ -32,7 +34,7 @@ impl From<Format> for Protocol {
 pub struct SyslogSinkConfig {
     #[serde(flatten)]
     mode: Mode,
-    #[serde(default = "format")]
+    #[serde(default)]
     format: Format,
     #[serde(default = "crate::serde::default_false")]
     include_extra_fields: bool,
@@ -52,10 +54,6 @@ pub struct SyslogSinkConfig {
     default_facility: SyslogFacility,
     #[serde(with = "SyslogSeverityDef", default = "severity")]
     default_severity: SyslogSeverity,
-}
-
-fn format() -> Format {
-    Format::Rfc5424
 }
 
 fn appname_key() -> String {

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -12,7 +12,7 @@ pub mod tcp;
 #[cfg(test)]
 pub mod test;
 pub mod udp;
-#[cfg(all(any(feature = "sinks-socket", feature = "sinks-statsd"), unix))]
+#[cfg(all(any(feature = "sinks-socket", feature = "sinks-statsd", feature = "sinks-syslog"), unix))]
 pub mod unix;
 pub mod uri;
 

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -12,7 +12,14 @@ pub mod tcp;
 #[cfg(test)]
 pub mod test;
 pub mod udp;
-#[cfg(all(any(feature = "sinks-socket", feature = "sinks-statsd", feature = "sinks-syslog"), unix))]
+#[cfg(all(
+    any(
+        feature = "sinks-socket",
+        feature = "sinks-statsd",
+        feature = "sinks-syslog"
+    ),
+    unix
+))]
 pub mod unix;
 pub mod uri;
 


### PR DESCRIPTION
closes #6863

Default field name are aligned to the ones populated by the `syslog` source.

Basic support for structured data (attempt to f<sup>-1</sup> the syslog source), there is room for improvement here for sure.

Subsequent tasks : end-to-end syslog sink to syslog source tests, better structured data support (likely to need slight adjustment in the syslog source for consistency), leverage schemas support when available. 



