### PR TITLE
enhancement(remap): Wdd `whitespace` option to `parse_key_value` function

### DIFF
--- a/docs/reference/remap/functions/parse_key_value.cue
+++ b/docs/reference/remap/functions/parse_key_value.cue
@@ -35,6 +35,17 @@ remap: functions: parse_key_value: {
 			default:     " "
 			type: ["string"]
 		},
+		{
+			name:        "whitespace"
+			description: "Defines the acceptance of unnecessary whitespace surrounding the configured `key_value_delimiter`."
+			required:    false
+			enum: {
+				lenient: "Ignore whitespace."
+				strict:  "Parse whitespace as normal character."
+			}
+			default: "lenient"
+			type: ["string"]
+		},
 	]
 	internal_failure_reasons: [
 		"`value` isn't a properly formatted key/value string",

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -242,17 +242,21 @@ fn parse_key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
 ) -> impl Fn(&'a str) -> IResult<&'a str, (String, Value), E> {
     move |input| {
         map(
-            tuple((
-                preceded(space0, parse_key(key_value_delimiter)),
-                preceded(space0, tag(key_value_delimiter)),
-                |input| {
-                    if whitespace_strict {
-                        parse_value(field_delimiter)(input)
-                    } else {
-                        preceded(space0, parse_value(field_delimiter))(input)
-                    }
-                },
-            )),
+            |input| {
+                if whitespace_strict {
+                    tuple((
+                        preceded(space0, parse_key(key_value_delimiter)),
+                        tag(key_value_delimiter),
+                        parse_value(field_delimiter),
+                    ))(input)
+                } else {
+                    tuple((
+                        preceded(space0, parse_key(key_value_delimiter)),
+                        preceded(space0, tag(key_value_delimiter)),
+                        preceded(space0, parse_value(field_delimiter)),
+                    ))(input)
+                }
+            },
             |(field, _, value): (&str, &str, Value)| (field.to_string(), value),
         )(input)
     }

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -1,4 +1,4 @@
-use crate::parse_key_value::ParseKeyValueFn;
+use crate::parse_key_value::{ParseKeyValueFn, Whitespace};
 use vrl::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
@@ -32,11 +32,13 @@ impl Function for ParseLogFmt {
         // parameters for the delimiters.
         let key_value_delimiter = expr!("=");
         let field_delimiter = expr!(" ");
+        let whitespace = Whitespace::Lenient;
 
         Ok(Box::new(ParseKeyValueFn {
             value,
             key_value_delimiter,
             field_delimiter,
+            whitespace,
         }))
     }
 }


### PR DESCRIPTION
Closes #7184 

Adds `whitespace` option and a fix to parse `user=""` as `{ "user": "" }`.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
