### PR TITLE
fix(observability)!: Correct all `*_nanoseconds` metrics to `_seconds`

### DIFF
--- a/docs/reference/components/sources/apache_metrics.cue
+++ b/docs/reference/components/sources/apache_metrics.cue
@@ -199,13 +199,13 @@ components: sources: apache_metrics: {
 	how_it_works: {}
 
 	telemetry: metrics: {
-		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
-		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
-		processed_bytes_total:        components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:       components.sources.internal_metrics.output.metrics.processed_events_total
-		requests_completed_total:     components.sources.internal_metrics.output.metrics.requests_completed_total
-		request_duration_nanoseconds: components.sources.internal_metrics.output.metrics.request_duration_nanoseconds
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/docs/reference/components/sources/aws_ecs_metrics.cue
+++ b/docs/reference/components/sources/aws_ecs_metrics.cue
@@ -244,13 +244,13 @@ components: sources: aws_ecs_metrics: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
-		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
-		processed_bytes_total:        components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:       components.sources.internal_metrics.output.metrics.processed_events_total
-		requests_completed_total:     components.sources.internal_metrics.output.metrics.requests_completed_total
-		request_duration_nanoseconds: components.sources.internal_metrics.output.metrics.request_duration_nanoseconds
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/docs/reference/components/sources/exec.cue
+++ b/docs/reference/components/sources/exec.cue
@@ -217,11 +217,11 @@ components: sources: exec: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:               components.sources.internal_metrics.output.metrics.events_in_total
-		processed_bytes_total:         components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:        components.sources.internal_metrics.output.metrics.processed_events_total
-		processing_errors_total:       components.sources.internal_metrics.output.metrics.processing_errors_total
-		command_executed_total:        components.sources.internal_metrics.output.metrics.command_executed_total
-		command_execution_duration_ns: components.sources.internal_metrics.output.metrics.command_execution_duration_ns
+		events_in_total:                    components.sources.internal_metrics.output.metrics.events_in_total
+		processed_bytes_total:              components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:             components.sources.internal_metrics.output.metrics.processed_events_total
+		processing_errors_total:            components.sources.internal_metrics.output.metrics.processing_errors_total
+		command_executed_total:             components.sources.internal_metrics.output.metrics.command_executed_total
+		command_execution_duration_seconds: components.sources.internal_metrics.output.metrics.command_execution_duration_seconds
 	}
 }

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -609,7 +609,7 @@ components: sources: internal_metrics: {
 			tags:              _internal_metrics_tags
 		}
 		request_duration_seconds: {
-			description:       "The total request duration in nanoseconds."
+			description:       "The total request duration in seconds."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -216,8 +216,8 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		command_execution_duration_ns: {
-			description:       "The command execution duration in nanoseconds."
+		command_execution_duration_seconds: {
+			description:       "The command execution duration in seconds."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags:              _component_tags

--- a/docs/reference/components/sources/internal_metrics.cue
+++ b/docs/reference/components/sources/internal_metrics.cue
@@ -204,7 +204,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
-		collect_duration_nanoseconds: {
+		collect_duration_seconds: {
 			description:       "The duration spent collecting of metrics for this component."
 			type:              "histogram"
 			default_namespace: "vector"
@@ -608,7 +608,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
-		request_duration_nanoseconds: {
+		request_duration_seconds: {
 			description:       "The total request duration in nanoseconds."
 			type:              "histogram"
 			default_namespace: "vector"

--- a/docs/reference/components/sources/mongodb_metrics.cue
+++ b/docs/reference/components/sources/mongodb_metrics.cue
@@ -106,10 +106,10 @@ components: sources: mongodb_metrics: {
 	}
 
 	telemetry: metrics: {
-		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
-		request_errors_total:         components.sources.internal_metrics.output.metrics.request_errors_total
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
+		collect_completed_total:  components.sources.internal_metrics.output.metrics.collect_completed_total
+		collect_duration_seconds: components.sources.internal_metrics.output.metrics.collect_duration_seconds
+		request_errors_total:     components.sources.internal_metrics.output.metrics.request_errors_total
+		parse_errors_total:       components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 
 	output: metrics: {
@@ -760,10 +760,10 @@ components: sources: mongodb_metrics: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
-		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
-		request_errors_total:         components.sources.internal_metrics.output.metrics.request_errors_total
+		events_in_total:          components.sources.internal_metrics.output.metrics.events_in_total
+		collect_completed_total:  components.sources.internal_metrics.output.metrics.collect_completed_total
+		collect_duration_seconds: components.sources.internal_metrics.output.metrics.collect_duration_seconds
+		parse_errors_total:       components.sources.internal_metrics.output.metrics.parse_errors_total
+		request_errors_total:     components.sources.internal_metrics.output.metrics.request_errors_total
 	}
 }

--- a/docs/reference/components/sources/nginx_metrics.cue
+++ b/docs/reference/components/sources/nginx_metrics.cue
@@ -175,10 +175,10 @@ components: sources: nginx_metrics: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
-		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
-		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
+		collect_completed_total:   components.sources.internal_metrics.output.metrics.collect_completed_total
+		collect_duration_seconds:  components.sources.internal_metrics.output.metrics.collect_duration_seconds
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 }

--- a/docs/reference/components/sources/postgresql_metrics.cue
+++ b/docs/reference/components/sources/postgresql_metrics.cue
@@ -157,10 +157,10 @@ components: sources: postgresql_metrics: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
-		collect_completed_total:      components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_nanoseconds: components.sources.internal_metrics.output.metrics.collect_duration_nanoseconds
-		request_errors_total:         components.sources.internal_metrics.output.metrics.request_errors_total
+		events_in_total:          components.sources.internal_metrics.output.metrics.events_in_total
+		collect_completed_total:  components.sources.internal_metrics.output.metrics.collect_completed_total
+		collect_duration_seconds: components.sources.internal_metrics.output.metrics.collect_duration_seconds
+		request_errors_total:     components.sources.internal_metrics.output.metrics.request_errors_total
 	}
 
 	output: metrics: {

--- a/docs/reference/components/sources/prometheus_remote_write.cue
+++ b/docs/reference/components/sources/prometheus_remote_write.cue
@@ -94,14 +94,14 @@ components: sources: prometheus_remote_write: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
-		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
-		processed_bytes_total:        components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:       components.sources.internal_metrics.output.metrics.processed_events_total
-		requests_completed_total:     components.sources.internal_metrics.output.metrics.requests_completed_total
-		requests_received_total:      components.sources.internal_metrics.output.metrics.requests_received_total
-		request_duration_nanoseconds: components.sources.internal_metrics.output.metrics.request_duration_nanoseconds
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/docs/reference/components/sources/prometheus_scrape.cue
+++ b/docs/reference/components/sources/prometheus_scrape.cue
@@ -96,13 +96,13 @@ components: sources: prometheus_scrape: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
-		http_error_response_total:    components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:    components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:           components.sources.internal_metrics.output.metrics.parse_errors_total
-		processed_bytes_total:        components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:       components.sources.internal_metrics.output.metrics.processed_events_total
-		requests_completed_total:     components.sources.internal_metrics.output.metrics.requests_completed_total
-		request_duration_nanoseconds: components.sources.internal_metrics.output.metrics.request_duration_nanoseconds
+		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -41,7 +41,7 @@ impl InternalEvent for ApacheMetricsRequestCompleted {
 
     fn emit_metrics(&self) {
         counter!("requests_completed_total", 1);
-        histogram!("request_duration_nanoseconds", self.end - self.start);
+        histogram!("request_duration_seconds", self.end - self.start);
     }
 }
 

--- a/src/internal_events/aws_ecs_metrics.rs
+++ b/src/internal_events/aws_ecs_metrics.rs
@@ -34,7 +34,7 @@ impl InternalEvent for AwsEcsMetricsRequestCompleted {
 
     fn emit_metrics(&self) {
         counter!("requests_completed_total", 1);
-        histogram!("request_duration_nanoseconds", self.end - self.start);
+        histogram!("request_duration_seconds", self.end - self.start);
     }
 }
 

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -114,7 +114,7 @@ impl InternalEvent for ExecCommandExecuted<'_> {
         );
 
         histogram!(
-            "command_execution_duration_ns", self.exec_duration,
+            "command_execution_duration_seconds", self.exec_duration,
             "command" => self.command.to_owned(),
             "exit_status" => self.exit_status_string(),
         );

--- a/src/internal_events/http_client.rs
+++ b/src/internal_events/http_client.rs
@@ -84,8 +84,8 @@ impl<'a> InternalEvent for GotHttpError<'a> {
 
     fn emit_metrics(&self) {
         counter!("http_client_errors_total", 1, "error_kind" => self.error.to_string());
-        histogram!("http_client_rtt_ns", self.roundtrip);
-        histogram!("http_client_error_rtt_ns", self.roundtrip, "error_kind" => self.error.to_string());
+        histogram!("http_client_rtt_seconds", self.roundtrip);
+        histogram!("http_client_error_rtt_seconds", self.roundtrip, "error_kind" => self.error.to_string());
     }
 }
 

--- a/src/internal_events/http_client.rs
+++ b/src/internal_events/http_client.rs
@@ -63,8 +63,8 @@ impl<'a, T: HttpBody> InternalEvent for GotHttpResponse<'a, T> {
 
     fn emit_metrics(&self) {
         counter!("http_client_responses_total", 1, "status" => self.response.status().to_string());
-        histogram!("http_client_rtt_nanoseconds", self.roundtrip);
-        histogram!("http_client_response_rtt_nanoseconds", self.roundtrip, "status" => self.response.status().to_string());
+        histogram!("http_client_rtt_seconds", self.roundtrip);
+        histogram!("http_client_response_rtt_seconds", self.roundtrip, "status" => self.response.status().to_string());
     }
 }
 

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -31,7 +31,7 @@ impl InternalEvent for MongoDbMetricsCollectCompleted {
 
     fn emit_metrics(&self) {
         counter!("collect_completed_total", 1);
-        histogram!("collect_duration_nanoseconds", self.end - self.start);
+        histogram!("collect_duration_seconds", self.end - self.start);
     }
 }
 

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -31,7 +31,7 @@ impl InternalEvent for NginxMetricsCollectCompleted {
 
     fn emit_metrics(&self) {
         counter!("collect_completed_total", 1);
-        histogram!("collect_duration_nanoseconds", self.end - self.start);
+        histogram!("collect_duration_seconds", self.end - self.start);
     }
 }
 

--- a/src/internal_events/postgresql_metrics.rs
+++ b/src/internal_events/postgresql_metrics.rs
@@ -15,7 +15,7 @@ impl InternalEvent for PostgresqlMetricsCollectCompleted {
 
     fn emit_metrics(&self) {
         counter!("collect_completed_total", 1);
-        histogram!("collect_duration_nanoseconds", self.end - self.start);
+        histogram!("collect_duration_seconds", self.end - self.start);
     }
 }
 

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -45,7 +45,7 @@ impl InternalEvent for PrometheusRequestCompleted {
 
     fn emit_metrics(&self) {
         counter!("requests_completed_total", 1);
-        histogram!("request_duration_nanoseconds", self.end - self.start);
+        histogram!("request_duration_seconds", self.end - self.start);
     }
 }
 


### PR DESCRIPTION
All the referenced metrics labelled as "nanoseconds" are passed a
`Duration` as the value, which the `metrics` crate automatically
converts into (fractional) seconds internally. As such, all these names
are incorrect and need correction.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

Closes #7372 