### PR TITLE
fix(buffers): Work around a LevelDB mechanism mismatch

### DIFF
--- a/src/buffers/disk/leveldb_buffer.rs
+++ b/src/buffers/disk/leveldb_buffer.rs
@@ -14,7 +14,7 @@ use std::{
     collections::VecDeque,
     convert::TryInto,
     mem::size_of,
-    path::PathBuf,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -343,7 +343,7 @@ pub struct Buffer;
 /// This function does not solve the problem -- LevelDB will still map 1000
 /// files if it wants -- but we at least avoid forcing this to happen at the
 /// start of vector.
-fn db_initial_size(path: &PathBuf) -> Result<usize, Error> {
+fn db_initial_size(path: &Path) -> Result<usize, Error> {
     let mut options = Options::new();
     options.create_if_missing = true;
     let db: Database<Key> = Database::open(&path, options).with_context(|| DataDirOpenError {


### PR DESCRIPTION
This commit moves the computation of the byte size of a disk buffer into a
separate function with a separate, temporary LevelDB handle. When we iterate
LevelDB it maps up to 1000 LDB files into vector's address space, which is fine
for a database but imposes a large memory burden on vector users. See
https://github.com/google/leveldb/issues/866 for details. Unfortunately LevelDB
is not configurable in this regard without forking their code base and so we are
temporarily working around the issue, kind of.

The pattern will be this. At startup vector will scan each of its LDB files for
each disk buffer (see #7380) and map up to 1000 LDB files into vector's address
space, consuming however much memory to do this. Once `db_initial_size` returns
the LevelDB handle will drop and each file will be unmapped, reducing vector's
overall memory use. This will NOT resolve OOM issues for our memory constrained
users but it WILL reduce vector's post-startup memory burden, at least until
LevelDB maps in more LDB files which will happen gradually.

REF #7246

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
