### PR TITLE
fix(influxdb_logs sink): Add missing `drop` in test

### DIFF
--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -709,6 +709,8 @@ mod integration_tests {
         event2.insert("host", "aws.cloud.eur");
         event2.insert("source_type", "file");
 
+        drop(batch);
+
         let events = vec![Event::Log(event1), Event::Log(event2)];
 
         sink.run(stream::iter(events)).await.unwrap();


### PR DESCRIPTION
This fixes the broken integration test on `master`.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>