### PR TITLE
fix(clickhouse sink): Use correct batch status

### DIFF
--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -544,7 +544,7 @@ timestamp_format = "unix""#,
         .unwrap()
         .unwrap();
 
-        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Failed));
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Errored));
     }
 
     fn make_event() -> (Event, BatchStatusReceiver) {


### PR DESCRIPTION
Bug introduced in #7411

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>