### PR TITLE
chore(tests): Refactor internal_logs tests to not be flakey

### DIFF
--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -72,31 +72,39 @@ mod tests {
         crate::test_util::test_generate_config::<InternalLogsConfig>();
     }
 
-    const ERROR_TEXT: &str = "This is not an error.";
-
     #[tokio::test]
     async fn receives_logs() {
         let start = chrono::Utc::now();
         trace::init(false, false, "debug");
+        error!(message = "before source started");
 
         let rx = start_source().await;
-        error!(message = ERROR_TEXT);
-        let logs = collect_output(rx).await;
 
-        check_events(logs, start);
-    }
+        error!(message = "after source started");
 
-    #[tokio::test]
-    async fn receives_early_logs() {
-        let start = chrono::Utc::now();
-        trace::init(false, false, "debug");
-        trace::reset_early_buffer();
-        error!(message = ERROR_TEXT);
+        sleep(Duration::from_millis(1)).await;
+        let events = collect_ready(rx).await;
 
-        let rx = start_source().await;
-        let logs = collect_output(rx).await;
+        let end = chrono::Utc::now();
 
-        check_events(logs, start);
+        assert_eq!(events.len(), 2);
+
+        assert_eq!(
+            events[0].as_log()["message"],
+            "before source started".into()
+        );
+        assert_eq!(events[1].as_log()["message"], "after source started".into());
+
+        for event in events {
+            let log = event.as_log();
+            let timestamp = *log["timestamp"]
+                .as_timestamp()
+                .expect("timestamp isn't a timestamp");
+            assert!(timestamp >= start);
+            assert!(timestamp <= end);
+            assert_eq!(log["metadata.kind"], "event".into());
+            assert_eq!(log["metadata.level"], "ERROR".into());
+        }
     }
 
     async fn start_source() -> mpsc::Receiver<Event> {
@@ -110,26 +118,5 @@ mod tests {
         sleep(Duration::from_millis(1)).await;
         trace::stop_buffering();
         rx
-    }
-
-    async fn collect_output(rx: mpsc::Receiver<Event>) -> Vec<Event> {
-        sleep(Duration::from_millis(1)).await;
-        collect_ready(rx).await
-    }
-
-    fn check_events(events: Vec<Event>, start: chrono::DateTime<chrono::Utc>) {
-        let end = chrono::Utc::now();
-
-        assert_eq!(events.len(), 1);
-
-        let log = events[0].as_log();
-        assert_eq!(log["message"], ERROR_TEXT.into());
-        let timestamp = *log["timestamp"]
-            .as_timestamp()
-            .expect("timestamp isn't a timestamp");
-        assert!(timestamp >= start);
-        assert!(timestamp <= end);
-        assert_eq!(log["metadata.kind"], "event".into());
-        assert_eq!(log["metadata.level"], "ERROR".into());
     }
 }

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -76,6 +76,7 @@ mod tests {
     async fn receives_logs() {
         let start = chrono::Utc::now();
         trace::init(false, false, "debug");
+        trace::reset_early_buffer();
         error!(message = "Before source started.");
 
         let rx = start_source().await;

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -76,11 +76,11 @@ mod tests {
     async fn receives_logs() {
         let start = chrono::Utc::now();
         trace::init(false, false, "debug");
-        error!(message = "before source started");
+        error!(message = "Before source started.");
 
         let rx = start_source().await;
 
-        error!(message = "after source started");
+        error!(message = "After source started.");
 
         sleep(Duration::from_millis(1)).await;
         let events = collect_ready(rx).await;
@@ -91,9 +91,12 @@ mod tests {
 
         assert_eq!(
             events[0].as_log()["message"],
-            "before source started".into()
+            "Before source started.".into()
         );
-        assert_eq!(events[1].as_log()["message"], "after source started".into());
+        assert_eq!(
+            events[1].as_log()["message"],
+            "After source started.".into()
+        );
 
         for event in events {
             let log = event.as_log();


### PR DESCRIPTION
A discord user reported that the `internal_logs` tests always failed for
them. After taking a look, it seems like these would be very flakey
since they run in parallel but modify global state. I just refactored
them into one test that verifies both conditions the other tests were
verifying.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
