### PR TITLE
chore: Make tokio non-optional for core/buffers

### DIFF
--- a/lib/vector-core/buffers/Cargo.toml
+++ b/lib/vector-core/buffers/Cargo.toml
@@ -14,7 +14,7 @@ metrics = { version = "0.15.1", default-features = false, features = ["std"] }
 pin-project = { version = "1.0.7", default-features = false }
 serde = { version = "1.0.126", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.10", default-features = false, features = ["std"], optional = true }
-tokio = { version = "1.5.0", default-features = false, features = ["rt-multi-thread"], optional = true }
+tokio = { version = "1.5.0", default-features = false, features = ["rt-multi-thread"] }
 tracing = { version = "0.1.26", default-features = false }
 
 [dev-dependencies]
@@ -22,4 +22,4 @@ pretty_assertions = "0.7.2"
 tokio-test = "0.4.2"
 
 [features]
-disk-buffer = ["db-key", "snafu", "tokio", "leveldb"]
+disk-buffer = ["db-key", "snafu", "leveldb"]


### PR DESCRIPTION
I incorrectly believed that tokio could be an optional dependency for buffers,
used only when we enabled the disk buffer. This is not accurate. core/buffers
requires tokio in tests. @bruceg reported that the following build string was
broken for him:

> cargo check --workspace --no-default-features --tests

This suggests that our CI has a hole in it.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
