### PR TITLE
feat(new sink): Initial `datadog_events` sink

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -180,6 +180,7 @@ scopes:
   - blackhole sink # Anything `blackhole` sink related
   - clickhouse sink # Anything `clickhouse` sink related
   - console sink # Anything `console` sink related
+  - datadog_events sink # Anything `datadog_events` sink related
   - datadog_logs sink # Anything `datadog_logs` sink related
   - datadog_metrics sink # Anything `datadog_metrics` sink related
   - elasticsearch sink # Anything `elasticsearch` sink related

--- a/docs/reference/components/sinks/datadog_events.cue
+++ b/docs/reference/components/sinks/datadog_events.cue
@@ -1,0 +1,61 @@
+package metadata
+
+components: sinks: datadog_events: {
+	title: "Datadog Events"
+
+	classes: sinks._datadog.classes
+
+	features: {
+		buffer: enabled:      true
+		healthcheck: enabled: true
+		send: {
+			batch: enabled:       false
+			compression: enabled: false
+			encoding: enabled:    false
+			request: enabled:     true
+			tls: {
+				enabled:                true
+				can_enable:             true
+				can_verify_certificate: true
+				can_verify_hostname:    true
+				enabled_default:        true
+			}
+			to: {
+				service: services.datadog_events
+
+				interface: {
+					socket: {
+						api: {
+							title: "Datadog events API"
+							url:   urls.datadog_events_endpoints
+						}
+						direction: "outgoing"
+						protocols: ["http"]
+						ssl: "required"
+					}
+				}
+			}
+		}
+	}
+
+	support: sinks._datadog.support
+
+	configuration: {
+		default_api_key: {
+			description: "Default Datadog [API key](https://docs.datadoghq.com/api/?lang=bash#authentication), if an event has a key set in its metadata it will prevail over the one set here."
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
+				syntax: "literal"
+			}
+		}
+		endpoint: sinks._datadog.configuration.endpoint
+		site:     sinks._datadog.configuration.site
+	}
+
+	input: {
+		logs:    true
+		metrics: null
+	}
+}

--- a/docs/reference/components/sinks/datadog_events.cue
+++ b/docs/reference/components/sinks/datadog_events.cue
@@ -9,7 +9,11 @@ components: sinks: datadog_events: {
 		buffer: enabled:      true
 		healthcheck: enabled: true
 		send: {
-			batch: enabled:       false
+			batch: {
+				enabled:      false
+				common:       false
+				timeout_secs: 0
+			}
 			compression: enabled: false
 			encoding: enabled:    false
 			request: {

--- a/docs/reference/components/sinks/datadog_events.cue
+++ b/docs/reference/components/sinks/datadog_events.cue
@@ -12,7 +12,17 @@ components: sinks: datadog_events: {
 			batch: enabled:       false
 			compression: enabled: false
 			encoding: enabled:    false
-			request: enabled:     true
+			request: {
+				enabled:                    true
+				adaptive_concurrency:       true
+				concurrency:                5
+				rate_limit_duration_secs:   1
+				rate_limit_num:             5
+				retry_initial_backoff_secs: 1
+				retry_max_duration_secs:    10
+				timeout_secs:               30
+				headers:                    false
+			}
 			tls: {
 				enabled:                true
 				can_enable:             true

--- a/docs/reference/services/datadog_events.cue
+++ b/docs/reference/services/datadog_events.cue
@@ -1,0 +1,10 @@
+package metadata
+
+services: datadog_events: {
+	name:     "Datadog events"
+	thing:    "a \(name) index"
+	url:      urls.datadog_events
+	versions: null
+
+	description: services._datadog.description
+}

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -109,6 +109,8 @@ urls: {
 	datadog_docs:                                             "https://docs.datadoghq.com"
 	datadog_logs:                                             "\(datadog_docs)/logs/"
 	datadog_logs_endpoints:                                   "\(datadog_docs)/logs/log_collection/?tab=http#datadog-logs-endpoints"
+	datadog_events:                                           "\(datadog_docs)/events/"
+	datadog_events_endpoints:                                 "\(datadog_docs)/api/latest/events/#post-an-event
 	datadog_metrics:                                          "\(datadog_docs)/metrics/"
 	datadog_metrics_endpoints:                                "\(datadog_docs)/api/v1/metrics/"
 	date:                                                     "https://man7.org/linux/man-pages/man1/date.1.html"

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -107,10 +107,10 @@ urls: {
 	datadog_agent:                                            "https://github.com/DataDog/datadog-agent"
 	datadog_distribution:                                     "\(datadog_docs)/developers/metrics/types/?tab=distribution#definition"
 	datadog_docs:                                             "https://docs.datadoghq.com"
-	datadog_logs:                                             "\(datadog_docs)/logs/"
-	datadog_logs_endpoints:                                   "\(datadog_docs)/logs/log_collection/?tab=http#datadog-logs-endpoints"
 	datadog_events:                                           "\(datadog_docs)/events/"
 	datadog_events_endpoints:                                 "\(datadog_docs)/api/latest/events/#post-an-event
+	datadog_logs:                                             "\(datadog_docs)/logs/"
+	datadog_logs_endpoints:                                   "\(datadog_docs)/logs/log_collection/?tab=http#datadog-logs-endpoints"
 	datadog_metrics:                                          "\(datadog_docs)/metrics/"
 	datadog_metrics_endpoints:                                "\(datadog_docs)/api/v1/metrics/"
 	date:                                                     "https://man7.org/linux/man-pages/man1/date.1.html"

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -108,7 +108,7 @@ urls: {
 	datadog_distribution:                                     "\(datadog_docs)/developers/metrics/types/?tab=distribution#definition"
 	datadog_docs:                                             "https://docs.datadoghq.com"
 	datadog_events:                                           "\(datadog_docs)/events/"
-	datadog_events_endpoints:                                 "\(datadog_docs)/api/latest/events/#post-an-event
+	datadog_events_endpoints:                                 "\(datadog_docs)/api/latest/events/#post-an-event"
 	datadog_logs:                                             "\(datadog_docs)/logs/"
 	datadog_logs_endpoints:                                   "\(datadog_docs)/logs/log_collection/?tab=http#datadog-logs-endpoints"
 	datadog_metrics:                                          "\(datadog_docs)/metrics/"

--- a/lib/vector-core/src/event/util/log/path_iter.rs
+++ b/lib/vector-core/src/event/util/log/path_iter.rs
@@ -17,12 +17,6 @@ pub enum PathComponent {
     Invalid,
 }
 
-impl<'a> From<&'a str> for PathComponent {
-    fn from(key: &'a str) -> Self {
-        Self::Key(key.to_string())
-    }
-}
-
 /// Iterator over components of paths specified in form `a.b[0].c[2]`.
 pub struct PathIter<'a> {
     path: &'a str,

--- a/lib/vector-core/src/event/util/log/path_iter.rs
+++ b/lib/vector-core/src/event/util/log/path_iter.rs
@@ -17,6 +17,12 @@ pub enum PathComponent {
     Invalid,
 }
 
+impl<'a> From<&'a str> for PathComponent {
+    fn from(key: &'a str) -> Self {
+        Self::Key(key.to_string())
+    }
+}
+
 /// Iterator over components of paths specified in form `a.b[0].c[2]`.
 pub struct PathIter<'a> {
     path: &'a str,

--- a/src/internal_events/datadog_events.rs
+++ b/src/internal_events/datadog_events.rs
@@ -13,11 +13,11 @@ impl InternalEvent for DatadogEventsProcessed {
 }
 
 #[derive(Debug)]
-pub struct DatadogEventsFieldInvalid<'a> {
-    pub field: &'a str,
+pub struct DatadogEventsFieldInvalid {
+    pub field: &'static str,
 }
 
-impl<'a> InternalEvent for DatadogEventsFieldInvalid<'a> {
+impl InternalEvent for DatadogEventsFieldInvalid {
     fn emit_logs(&self) {
         debug!(
             message = "Required field is missing.",
@@ -30,6 +30,6 @@ impl<'a> InternalEvent for DatadogEventsFieldInvalid<'a> {
         counter!(
             "processing_errors_total", 1,
             "error_type" => "field_missing",
-            "field" => self.field.to_owned());
+            "field" => self.field);
     }
 }

--- a/src/internal_events/datadog_events.rs
+++ b/src/internal_events/datadog_events.rs
@@ -19,7 +19,7 @@ pub struct DatadogEventsFieldInvalid {
 
 impl InternalEvent for DatadogEventsFieldInvalid {
     fn emit_logs(&self) {
-        debug!(
+        error!(
             message = "Required field is missing.",
             field = %self.field,
             internal_log_rate_secs = 10

--- a/src/internal_events/datadog_events.rs
+++ b/src/internal_events/datadog_events.rs
@@ -1,0 +1,35 @@
+use super::InternalEvent;
+use metrics::counter;
+
+#[derive(Debug)]
+pub struct DatadogEventsProcessed {
+    pub byte_size: usize,
+}
+
+impl InternalEvent for DatadogEventsProcessed {
+    fn emit_metrics(&self) {
+        counter!("processed_bytes_total", self.byte_size as u64);
+    }
+}
+
+#[derive(Debug)]
+pub struct DatadogEventsFieldInvalid<'a> {
+    pub field: &'a str,
+}
+
+impl<'a> InternalEvent for DatadogEventsFieldInvalid<'a> {
+    fn emit_logs(&self) {
+        debug!(
+            message = "Required field is missing.",
+            field = %self.field,
+            internal_log_rate_secs = 10
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "processing_errors_total", 1,
+            "error_type" => "field_missing",
+            "field" => self.field.to_owned());
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -30,6 +30,8 @@ mod concat;
 #[cfg(feature = "sinks-console")]
 mod console;
 #[cfg(feature = "sinks-datadog")]
+mod datadog_events;
+#[cfg(feature = "sinks-datadog")]
 mod datadog_logs;
 #[cfg(feature = "transforms-dedupe")]
 mod dedupe;
@@ -150,6 +152,8 @@ pub(crate) use self::coercer::*;
 pub use self::concat::*;
 #[cfg(feature = "sinks-console")]
 pub use self::console::*;
+#[cfg(feature = "sinks-datadog")]
+pub use self::datadog_events::*;
 #[cfg(feature = "sinks-datadog")]
 pub use self::datadog_logs::*;
 #[cfg(feature = "transforms-dedupe")]

--- a/src/sinks/datadog/events.rs
+++ b/src/sinks/datadog/events.rs
@@ -121,6 +121,7 @@ impl DatadogEventsConfig {
 #[typetag::serde(name = "datadog_events")]
 impl SinkConfig for DatadogEventsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        // Datadog Event API doesn't support batching.
         let batch_settings = BatchSettings::default()
             .bytes(bytesize::kib(100u64))
             .events(1)

--- a/src/sinks/datadog/events.rs
+++ b/src/sinks/datadog/events.rs
@@ -1,7 +1,7 @@
 use super::healthcheck;
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
-    event::Event,
+    event::{Event, PathComponent},
     http::HttpClient,
     internal_events::{DatadogEventsFieldInvalid, DatadogEventsProcessed},
     sinks::{
@@ -158,19 +158,24 @@ impl DatadogEventsService {
         let encoding = EncodingConfigWithDefault {
             // DataDog Event API allows only some fields, and refuses
             // to accept event if it contains any other field.
-            only_fields: Some(vec![
-                vec!["aggregation_key".into()],
-                vec!["alert_type".into()],
-                vec!["date_happened".into()],
-                vec!["device_name".into()],
-                vec!["host".into()],
-                vec!["priority".into()],
-                vec!["related_event_id".into()],
-                vec!["source_type_name".into()],
-                vec!["tags".into()],
-                vec!["text".into()],
-                vec!["title".into()],
-            ]),
+            only_fields: Some(
+                [
+                    "aggregation_key",
+                    "alert_type",
+                    "date_happened",
+                    "device_name",
+                    "host",
+                    "priority",
+                    "related_event_id",
+                    "source_type_name",
+                    "tags",
+                    "text",
+                    "title",
+                ]
+                .iter()
+                .map(|field| vec![PathComponent::Key(field.to_string())])
+                .collect(),
+            ),
             // DataDog Event API requires unix timestamp.
             timestamp_format: Some(TimestampFormat::Unix),
             ..EncodingConfigWithDefault::default()

--- a/src/sinks/datadog/events.rs
+++ b/src/sinks/datadog/events.rs
@@ -1,4 +1,4 @@
-use super::healthcheck;
+use super::{healthcheck, ApiKey};
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::{Event, PathComponent},
@@ -37,8 +37,6 @@ pub struct DatadogEventsConfig {
     #[serde(default)]
     request: TowerRequestConfig<Concurrency>,
 }
-
-type ApiKey = Arc<str>;
 
 fn default_site() -> String {
     "datadoghq.com".to_owned()
@@ -111,7 +109,7 @@ impl DatadogEventsConfig {
             client,
             cx.acker(),
         )
-        .sink_map_err(|error| error!(message = "Fatal datadog_metrics sink error.", %error));
+        .sink_map_err(|error| error!(message = "Fatal datadog_events sink error.", %error));
 
         Ok((VectorSink::Sink(Box::new(sink)), healthcheck))
     }

--- a/src/sinks/datadog/events.rs
+++ b/src/sinks/datadog/events.rs
@@ -1,0 +1,475 @@
+use super::healthcheck;
+use crate::{
+    config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
+    event::{Event, Value},
+    http::HttpClient,
+    internal_events::{DatadogEventsFieldInvalid, DatadogEventsProcessed},
+    sinks::{
+        util::{
+            batch::{Batch, BatchError},
+            encode_event,
+            encoding::{EncodingConfig, EncodingConfiguration, TimestampFormat},
+            http::{HttpSink, PartitionHttpSink},
+            BatchConfig, BatchSettings, BoxedRawValue, Compression, EncodedEvent, Encoding,
+            JsonArrayBuffer, PartitionBuffer, PartitionInnerBuffer, TowerRequestConfig, VecBuffer,
+        },
+        Healthcheck, VectorSink,
+    },
+    tls::{MaybeTlsSettings, TlsConfig},
+};
+use bytes::Bytes;
+use flate2::write::GzEncoder;
+use futures::{FutureExt, SinkExt};
+use http::{Request, StatusCode};
+use hyper::body::Body;
+use indoc::indoc;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{io::Write, sync::Arc, time::Duration};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DatadogEventsConfig {
+    endpoint: Option<String>,
+
+    #[serde(default = "default_site")]
+    site: String,
+    default_api_key: String,
+    encoding: EncodingConfig<()>,
+
+    tls: Option<TlsConfig>,
+
+    #[serde(default)]
+    compression: Option<Compression>,
+
+    #[serde(default)]
+    batch: BatchConfig,
+
+    #[serde(default)]
+    request: TowerRequestConfig,
+}
+
+type ApiKey = Arc<str>;
+
+fn default_site() -> String {
+    "datadoghq.com".to_owned()
+}
+
+inventory::submit! {
+    SinkDescription::new::<DatadogEventsConfig>("datadog_events")
+}
+
+impl GenerateConfig for DatadogEventsConfig {
+    fn generate_config() -> toml::Value {
+        toml::from_str(indoc! {r#"
+            default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
+        "#})
+        .unwrap()
+    }
+}
+
+impl DatadogEventsConfig {
+    fn get_uri(&self) -> String {
+        format!("{}/api/v1/events", self.get_api_endpoint())
+    }
+
+    // The API endpoint is used for healtcheck/API key validation, it is derived from the `site` or `region` option
+    // the same way the offical Datadog Agent does but the `endpoint` option still override both the main and the
+    // API endpoint.
+    fn get_api_endpoint(&self) -> String {
+        self.endpoint
+            .clone()
+            .unwrap_or_else(|| format!("https://api.{}", &self.site))
+    }
+
+    fn batch_settings<T: Batch>(&self) -> Result<BatchSettings<T>, BatchError> {
+        BatchSettings::default()
+            .bytes(bytesize::kib(100u64))
+            .events(20)
+            .timeout(1)
+            .parse_config(self.batch)
+    }
+
+    /// Builds the required BatchedHttpSink.
+    /// Since the DataDog sink can create one of two different sinks, this
+    /// extracts most of the shared functionality required to create either sink.
+    fn build_sink<T, B, O>(
+        &self,
+        cx: SinkContext,
+        service: T,
+        batch: B,
+        timeout: Duration,
+    ) -> crate::Result<(VectorSink, Healthcheck)>
+    where
+        O: 'static,
+        B: Batch<Output = Vec<O>> + std::marker::Send + 'static,
+        B::Output: std::marker::Send + Clone,
+        B::Input: std::marker::Send,
+        T: HttpSink<
+                Input = PartitionInnerBuffer<B::Input, ApiKey>,
+                Output = PartitionInnerBuffer<B::Output, ApiKey>,
+            > + Clone,
+    {
+        let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
+
+        let tls_settings = MaybeTlsSettings::from_config(
+            &Some(self.tls.clone().unwrap_or_else(TlsConfig::enabled)),
+            false,
+        )?;
+
+        let client = HttpClient::new(tls_settings)?;
+        let healthcheck = healthcheck(
+            self.get_api_endpoint().clone(),
+            self.default_api_key.clone(),
+            client.clone(),
+        )
+        .boxed();
+        let sink = PartitionHttpSink::new(
+            service,
+            PartitionBuffer::new(batch),
+            request_settings,
+            timeout,
+            client,
+            cx.acker(),
+        )
+        .sink_map_err(|error| error!(message = "Fatal datadog_metrics sink error.", %error));
+
+        Ok((VectorSink::Sink(Box::new(sink)), healthcheck))
+    }
+
+    /// Build the request, GZipping the contents if the config specifies.
+    fn build_request(
+        &self,
+        uri: &str,
+        api_key: &str,
+        content_type: &str,
+        body: Vec<u8>,
+    ) -> crate::Result<http::Request<Vec<u8>>> {
+        let request = Request::post(uri)
+            .header("Content-Type", content_type)
+            .header("DD-API-KEY", api_key);
+
+        let compression = self.compression.unwrap_or(Compression::Gzip(None));
+
+        let (request, body) = match compression {
+            Compression::None => (request, body),
+            Compression::Gzip(level) => {
+                // Default the compression level to 6, which is similar to datadog agent.
+                // https://docs.datadoghq.com/agent/logs/log_transport/?tab=https#log-compression
+                let level = level.unwrap_or(6);
+                let mut encoder =
+                    GzEncoder::new(Vec::new(), flate2::Compression::new(level as u32));
+
+                encoder.write_all(&body)?;
+                (
+                    request.header("Content-Encoding", "gzip"),
+                    encoder.finish()?,
+                )
+            }
+        };
+
+        request
+            .header("Content-Length", body.len())
+            .body(body)
+            .map_err(Into::into)
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "datadog_events")]
+impl SinkConfig for DatadogEventsConfig {
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let mut config = self.clone();
+
+        // We modify encoding to fit DataDog requirements
+        config.encoding.timestamp_format = config
+            .encoding
+            .timestamp_format
+            .or(Some(TimestampFormat::Unix));
+
+        let batch_settings = self.batch_settings()?;
+        self.build_sink(
+            cx,
+            DatadogEventsService {
+                config: self.clone(),
+                uri: self.get_uri(),
+                default_api_key: Arc::from(self.default_api_key.clone()),
+            },
+            JsonArrayBuffer::new(batch_settings.size),
+            batch_settings.timeout,
+        )
+    }
+
+    fn input_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "datadog_events"
+    }
+}
+
+#[derive(Clone)]
+struct DatadogEventsService {
+    config: DatadogEventsConfig,
+    // Used to store the complete URI and avoid calling `get_uri` for each request
+    uri: String,
+    default_api_key: ApiKey,
+}
+
+#[async_trait::async_trait]
+impl HttpSink for DatadogEventsService {
+    type Input = PartitionInnerBuffer<serde_json::Value, ApiKey>;
+    type Output = PartitionInnerBuffer<Vec<BoxedRawValue>, ApiKey>;
+
+    fn encode_event(&self, mut event: Event) -> Option<EncodedEvent<Self::Input>> {
+        let log = event.as_mut_log();
+
+        if !log.contains("title") {
+            emit!(DatadogEventsFieldInvalid { field: "title" });
+        }
+
+        if let Some(message) = log.remove(log_schema().message_key()) {
+            log.insert("text", message);
+        } else if !log.contains("text") {
+            emit!(DatadogEventsFieldInvalid {
+                field: log_schema().message_key()
+            });
+        }
+
+        if let Some(host) = log.remove(log_schema().host_key()) {
+            log.insert("host", host);
+        }
+
+        self.config.encoding.apply_rules(&mut event);
+
+        if let Some(timestamp) = event.as_mut_log().remove(log_schema().timestamp_key()) {
+            event.as_mut_log().insert("date_happened", timestamp);
+        }
+
+        let (fields, metadata) = event.into_log().into_parts();
+        let json_event = json!(fields);
+        let api_key = metadata
+            .datadog_api_key()
+            .as_ref()
+            .unwrap_or(&self.default_api_key);
+
+        Some(EncodedEvent {
+            item: PartitionInnerBuffer::new(json_event, Arc::clone(api_key)),
+            metadata: Some(metadata),
+        })
+    }
+
+    async fn build_request(&self, events: Self::Output) -> crate::Result<Request<Vec<u8>>> {
+        let (events, api_key) = events.into_parts();
+
+        let body = serde_json::to_vec(&events)?;
+        // check the number of events to ignore health-check requests
+        if !events.is_empty() {
+            emit!(DatadogEventsProcessed {
+                byte_size: body.len(),
+            });
+        }
+        self.config
+            .build_request(self.uri.as_str(), &api_key[..], "application/json", body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::SinkConfig,
+        sinks::util::test::{build_test_server_status, load_sink},
+        test_util::{next_addr, random_lines_with_stream},
+    };
+    use futures::{
+        channel::mpsc::{Receiver, TryRecvError},
+        stream, StreamExt,
+    };
+    use hyper::StatusCode;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use vector_core::event::{BatchNotifier, BatchStatus};
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<DatadogEventsConfig>();
+    }
+
+    fn event_with_api_key(msg: &str, key: &str) -> Event {
+        let mut e = Event::from(msg);
+        e.as_mut_log()
+            .metadata_mut()
+            .set_datadog_api_key(Some(Arc::from(key)));
+        e
+    }
+    #[tokio::test]
+    async fn smoke() {
+        let (expected, rx) = start_test(StatusCode::OK, BatchStatus::Delivered).await;
+
+        let output = rx.take(expected.len()).collect::<Vec<_>>().await;
+
+        for (i, val) in output.iter().enumerate() {
+            assert_eq!(
+                val.0.headers.get("Content-Type").unwrap(),
+                "application/json"
+            );
+
+            let mut json = serde_json::Deserializer::from_slice(&val.1[..])
+                .into_iter::<serde_json::Value>()
+                .map(|v| v.expect("decoding json"));
+
+            let json = json.next().unwrap();
+
+            // The json we send to Datadog is an array of events.
+            // As we have set batch.max_events to 1, each entry will be
+            // an array containing a single record.
+            let message = json
+                .get(0)
+                .unwrap()
+                .get("message")
+                .unwrap()
+                .as_str()
+                .unwrap();
+            assert_eq!(message, expected[i]);
+        }
+    }
+
+    #[tokio::test]
+    async fn handles_failure() {
+        let (_expected, mut rx) = start_test(StatusCode::FORBIDDEN, BatchStatus::Failed).await;
+
+        assert!(matches!(rx.try_next(), Err(TryRecvError { .. })));
+    }
+
+    async fn start_test(
+        http_status: StatusCode,
+        batch_status: BatchStatus,
+    ) -> (Vec<String>, Receiver<(http::request::Parts, Bytes)>) {
+        let config = indoc! {r#"
+            default_api_key = "atoken"
+            compression = "none"
+            batch.max_events = 1
+        "#};
+        let (mut config, cx) = load_sink::<DatadogEventsConfig>(&config).unwrap();
+
+        let addr = next_addr();
+        // Swap out the endpoint so we can force send it
+        // to our local server
+        let endpoint = format!("http://{}", addr);
+        config.endpoint = Some(endpoint.clone());
+
+        let (sink, _) = config.build(cx).await.unwrap();
+
+        let (rx, _trigger, server) = build_test_server_status(addr, http_status);
+        tokio::spawn(server);
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (expected, events) = random_lines_with_stream(100, 10, Some(batch));
+
+        let _ = sink.run(events).await.unwrap();
+
+        assert_eq!(receiver.try_recv(), Ok(batch_status));
+
+        (expected, rx)
+    }
+
+    #[tokio::test]
+    async fn api_key_in_metadata() {
+        let (mut config, cx) = load_sink::<DatadogEventsConfig>(indoc! {r#"
+            default_api_key = "atoken"
+            compression = "none"
+            batch.max_events = 1
+        "#})
+        .unwrap();
+
+        let addr = next_addr();
+        // Swap out the endpoint so we can force send it
+        // to our local server
+        let endpoint = format!("http://{}", addr);
+        config.endpoint = Some(endpoint.clone());
+
+        let (sink, _) = config.build(cx).await.unwrap();
+
+        let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::OK);
+        tokio::spawn(server);
+
+        let (expected, events) = random_lines_with_stream(100, 10, None);
+
+        let mut events = events.map(|mut e| {
+            e.as_mut_log()
+                .metadata_mut()
+                .set_datadog_api_key(Some(Arc::from("from_metadata")));
+            Ok(e)
+        });
+
+        let _ = sink.into_sink().send_all(&mut events).await.unwrap();
+        let output = rx.take(expected.len()).collect::<Vec<_>>().await;
+
+        for (i, val) in output.iter().enumerate() {
+            assert_eq!(val.0.headers.get("DD-API-KEY").unwrap(), "from_metadata");
+
+            assert_eq!(
+                val.0.headers.get("Content-Type").unwrap(),
+                "application/json"
+            );
+
+            let mut json = serde_json::Deserializer::from_slice(&val.1[..])
+                .into_iter::<serde_json::Value>()
+                .map(|v| v.expect("decoding json"));
+
+            let json = json.next().unwrap();
+
+            // The json we send to Datadog is an array of events.
+            // As we have set batch.max_events to 1, each entry will be
+            // an array containing a single record.
+            let message = json
+                .get(0)
+                .unwrap()
+                .get("message")
+                .unwrap()
+                .as_str()
+                .unwrap();
+            assert_eq!(message, expected[i]);
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_api_keys() {
+        let (mut config, cx) = load_sink::<DatadogEventsConfig>(indoc! {r#"
+            default_api_key = "atoken"
+            compression = "none"
+            batch.max_events = 1
+        "#})
+        .unwrap();
+
+        let addr = next_addr();
+        // Swap out the endpoint so we can force send it
+        // to our local server
+        let endpoint = format!("http://{}", addr);
+        config.endpoint = Some(endpoint.clone());
+
+        let (sink, _) = config.build(cx).await.unwrap();
+
+        let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::OK);
+        tokio::spawn(server);
+
+        let events = vec![
+            event_with_api_key("mow", "pkc"),
+            event_with_api_key("pnh", "vvo"),
+            Event::from("no API key in metadata"),
+        ];
+
+        let _ = sink.run(stream::iter(events)).await.unwrap();
+
+        let mut keys = rx
+            .take(3)
+            .map(|r| r.0.headers.get("DD-API-KEY").unwrap().clone())
+            .collect::<Vec<_>>()
+            .await;
+
+        keys.sort();
+        assert_eq!(keys, vec!["atoken", "pkc", "vvo"])
+    }
+}

--- a/src/sinks/datadog/events.rs
+++ b/src/sinks/datadog/events.rs
@@ -85,7 +85,7 @@ impl DatadogEventsConfig {
                 Output = PartitionInnerBuffer<B::Output, ApiKey>,
             > + Clone,
     {
-        let mut request_opts = self.request.clone();
+        let mut request_opts = self.request;
         // Since we are sending only one event per request we should try to send as much
         // requests in parallel as possible.
         request_opts.concurrency = request_opts.concurrency.if_none(Concurrency::Adaptive);
@@ -98,7 +98,7 @@ impl DatadogEventsConfig {
 
         let client = HttpClient::new(tls_settings)?;
         let healthcheck = healthcheck(
-            self.get_api_endpoint().clone(),
+            self.get_api_endpoint(),
             self.default_api_key.clone(),
             client.clone(),
         )
@@ -155,26 +155,26 @@ struct DatadogEventsService {
 
 impl DatadogEventsService {
     fn new(config: &DatadogEventsConfig) -> Self {
-        let mut encoding = EncodingConfigWithDefault::default();
-
-        // DataDog Event API allows only some fields, and refuses
-        // to accept event if it contains any other field.
-        encoding.only_fields = Some(vec![
-            vec!["aggregation_key".into()],
-            vec!["alert_type".into()],
-            vec!["date_happened".into()],
-            vec!["device_name".into()],
-            vec!["host".into()],
-            vec!["priority".into()],
-            vec!["related_event_id".into()],
-            vec!["source_type_name".into()],
-            vec!["tags".into()],
-            vec!["text".into()],
-            vec!["title".into()],
-        ]);
-
-        // DataDog Event API requires unix timestamp.
-        encoding.timestamp_format = Some(TimestampFormat::Unix);
+        let encoding = EncodingConfigWithDefault {
+            // DataDog Event API allows only some fields, and refuses
+            // to accept event if it contains any other field.
+            only_fields: Some(vec![
+                vec!["aggregation_key".into()],
+                vec!["alert_type".into()],
+                vec!["date_happened".into()],
+                vec!["device_name".into()],
+                vec!["host".into()],
+                vec!["priority".into()],
+                vec!["related_event_id".into()],
+                vec!["source_type_name".into()],
+                vec!["tags".into()],
+                vec!["text".into()],
+                vec!["title".into()],
+            ]),
+            // DataDog Event API requires unix timestamp.
+            timestamp_format: Some(TimestampFormat::Unix),
+            ..EncodingConfigWithDefault::default()
+        };
 
         Self {
             default_api_key: Arc::from(config.default_api_key.clone()),

--- a/src/sinks/datadog/logs.rs
+++ b/src/sinks/datadog/logs.rs
@@ -1,3 +1,4 @@
+use super::ApiKey;
 use crate::{
     config::{log_schema, DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription},
     event::Event,
@@ -48,8 +49,6 @@ pub struct DatadogLogsConfig {
     #[serde(default)]
     request: TowerRequestConfig,
 }
-
-type ApiKey = Arc<str>;
 
 #[derive(Clone)]
 struct DatadogLogsJsonService {

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -184,7 +184,7 @@ impl SinkConfig for DatadogConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = HttpClient::new(None)?;
         let healthcheck = healthcheck(
-            self.get_api_endpoint().clone(),
+            self.get_api_endpoint(),
             self.api_key.clone(),
             client.clone(),
         )

--- a/src/sinks/datadog/metrics.rs
+++ b/src/sinks/datadog/metrics.rs
@@ -13,12 +13,12 @@ use crate::{
             EncodedEvent, PartitionBatchSink, PartitionBuffer, PartitionInnerBuffer,
             TowerRequestConfig,
         },
-        Healthcheck, HealthcheckError, UriParseError, VectorSink,
+        Healthcheck, UriParseError, VectorSink,
     },
 };
 use chrono::{DateTime, Utc};
 use futures::{stream, FutureExt, SinkExt};
-use http::{uri::InvalidUri, Request, StatusCode, Uri};
+use http::{uri::InvalidUri, Request, Uri};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -10,6 +10,8 @@ pub mod events;
 pub mod logs;
 pub mod metrics;
 
+type ApiKey = Arc<str>;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Region {

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -1,10 +1,10 @@
 use crate::{
     http::HttpClient,
-    sinks::{Healthcheck, HealthcheckError, UriParseError, VectorSink},
+    sinks::{HealthcheckError, UriParseError},
 };
-use http::{uri::InvalidUri, Request, StatusCode, Uri};
+use http::{Request, StatusCode, Uri};
 use serde::{Deserialize, Serialize};
-use snafu::{ResultExt, Snafu};
+use snafu::ResultExt;
 
 pub mod events;
 pub mod logs;

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -5,6 +5,7 @@ use crate::{
 use http::{Request, StatusCode, Uri};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
+use std::sync::Arc;
 
 pub mod events;
 pub mod logs;


### PR DESCRIPTION
Closes #7218 

Event API doesn't support compression nor batching so those things aren't implemented.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
