### PR TITLE
enhancement(remap): Add VRL `match_array` function

### DIFF
--- a/docs/reference/remap/functions/match_array.cue
+++ b/docs/reference/remap/functions/match_array.cue
@@ -41,21 +41,21 @@ remap: functions: match_array: {
 		{
 			title: "Match all elements"
 			source: #"""
-					match(["foo", "foobar", "barfoo"], r'foo', all: true)
+					match_array(["foo", "foobar", "barfoo"], r'foo', all: true)
 				"""#
 			return: true
 		},
 		{
 			title: "No matches"
 			source: #"""
-					match(["bazqux", "xyz"], r'foo')
+					match_array(["bazqux", "xyz"], r'foo')
 				"""#
 			return: false
 		},
 		{
 			title: "Not all elements match"
 			source: #"""
-					match(["foo", "foobar", "baz"], r'foo', all: true)
+					match_array(["foo", "foobar", "baz"], r'foo', all: true)
 				"""#
 			return: false
 		},

--- a/docs/reference/remap/functions/match_array.cue
+++ b/docs/reference/remap/functions/match_array.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: match_array: {
 	category: "Enumerate"
 	description: """
-		Determines whether the `value` array matches the `pattern`.
+		Determines whether at least one element in the `value` array matches the `pattern`.
 		"""
 
 	arguments: [
@@ -20,12 +20,12 @@ remap: functions: match_array: {
 			type: ["regex"]
 		},
 		{
-			name: "all",
-			description: "Whether to match on all elements of `value`",
-			required: false,
-			default: false,
-			type: ["boolean"],
-		}
+			name:        "all"
+			description: "Whether to match on all elements of `value`"
+			required:    false
+			default:     false
+			type: ["boolean"]
+		},
 	]
 	internal_failure_reasons: []
 	return: types: ["boolean"]
@@ -34,29 +34,29 @@ remap: functions: match_array: {
 		{
 			title: "Match at least one element"
 			source: #"""
-				match_array(["foobar", "bazqux"], r'foo')
-			"""#
+					match_array(["foobar", "bazqux"], r'foo')
+				"""#
 			return: true
 		},
 		{
 			title: "Match all elements"
 			source: #"""
-				match(["foo", "foobar", "barfoo"], r'foo', all:true)
-			"""#
+					match(["foo", "foobar", "barfoo"], r'foo', all:true)
+				"""#
 			return: true
 		},
 		{
 			title: "No matches"
 			source: #"""
-				match(["bazqux", "xyz"], r'foo')
-			"""#
+					match(["bazqux", "xyz"], r'foo')
+				"""#
 			return: false
 		},
 		{
 			title: "Not all elements match"
 			source: #"""
-				match(["foo", "foobar", "baz"], r'foo', all:true)
-			"""#
+					match(["foo", "foobar", "baz"], r'foo', all:true)
+				"""#
 			return: false
 		},
 	]

--- a/docs/reference/remap/functions/match_array.cue
+++ b/docs/reference/remap/functions/match_array.cue
@@ -21,7 +21,7 @@ remap: functions: match_array: {
 		},
 		{
 			name:        "all"
-			description: "Whether to match on all elements of `value`"
+			description: "Whether to match on all elements of `value`."
 			required:    false
 			default:     false
 			type: ["boolean"]
@@ -41,7 +41,7 @@ remap: functions: match_array: {
 		{
 			title: "Match all elements"
 			source: #"""
-					match(["foo", "foobar", "barfoo"], r'foo', all:true)
+					match(["foo", "foobar", "barfoo"], r'foo', all: true)
 				"""#
 			return: true
 		},
@@ -55,7 +55,7 @@ remap: functions: match_array: {
 		{
 			title: "Not all elements match"
 			source: #"""
-					match(["foo", "foobar", "baz"], r'foo', all:true)
+					match(["foo", "foobar", "baz"], r'foo', all: true)
 				"""#
 			return: false
 		},

--- a/docs/reference/remap/functions/match_array.cue
+++ b/docs/reference/remap/functions/match_array.cue
@@ -1,0 +1,63 @@
+package metadata
+
+remap: functions: match_array: {
+	category: "Enumerate"
+	description: """
+		Determines whether the `value` array matches the `pattern`.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The array."
+			required:    true
+			type: ["array"]
+		},
+		{
+			name:        "pattern"
+			description: "The regular expression pattern to match against."
+			required:    true
+			type: ["regex"]
+		},
+		{
+			name: "all",
+			description: "Whether to match on all elements of `value`",
+			required: false,
+			default: false,
+			type: ["boolean"],
+		}
+	]
+	internal_failure_reasons: []
+	return: types: ["boolean"]
+
+	examples: [
+		{
+			title: "Match at least one element"
+			source: #"""
+				match_array(["foobar", "bazqux"], r'foo')
+			"""#
+			return: true
+		},
+		{
+			title: "Match all elements"
+			source: #"""
+				match(["foo", "foobar", "barfoo"], r'foo', all:true)
+			"""#
+			return: true
+		},
+		{
+			title: "No matches"
+			source: #"""
+				match(["bazqux", "xyz"], r'foo')
+			"""#
+			return: false
+		},
+		{
+			title: "Not all elements match"
+			source: #"""
+				match(["foo", "foobar", "baz"], r'foo', all:true)
+			"""#
+			return: false
+		},
+	]
+}

--- a/docs/reference/remap/functions/match_array.cue
+++ b/docs/reference/remap/functions/match_array.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: match_array: {
 	category: "Enumerate"
 	description: """
-		Determines whether at least one element in the `value` array matches the `pattern`.
+		Determines whether the elements in the `value` array matches the `pattern` - by default it checks at least one element matches, but can be set to determine if all the elements match.
 		"""
 
 	arguments: [

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -83,6 +83,7 @@ default = [
     "log",
     "match",
     "match_any",
+    "match_array",
     "md5",
     "merge",
     "now",
@@ -182,6 +183,7 @@ length = []
 log = ["tracing"]
 match = ["regex"]
 match_any = ["regex"]
+match_array = ["regex"]
 md5 = ["md-5", "hex"]
 merge = []
 now = ["chrono"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -49,6 +49,7 @@ criterion_group!(
               log,
               r#match,
               match_any,
+              match_array,
               md5,
               merge,
               // TODO: value is dynamic so we cannot assert equality
@@ -596,6 +597,52 @@ bench_function! {
     simple {
         args: func_args![value: "foo 2 bar", patterns: vec![Regex::new(r"foo \d bar").unwrap()]],
         want: Ok(true),
+    }
+}
+
+bench_function! {
+    match_array => vrl_stdlib::MatchArray;
+
+    single_match {
+        args: func_args![
+            value: value!(["foo 1 bar"]),
+            pattern: Regex::new(r"foo \d bar").unwrap(),
+        ],
+        want: Ok(true),
+    }
+
+    no_match {
+        args: func_args![
+            value: value!(["foo x bar"]),
+            pattern: Regex::new(r"foo \d bar").unwrap(),
+        ],
+        want: Ok(false),
+    }
+
+    some_match {
+        args: func_args![
+            value: value!(["foo 2 bar", "foo 3 bar", "foo 4 bar", "foo 5 bar"]),
+            patterns: Regex::new(r"foo \d bar").unwrap(),
+        ],
+        want: Ok(true),
+    }
+
+    all_match {
+        args: func_args![
+            value: value!(["foo 2 bar", "foo 3 bar", "foo 4 bar", "foo 5 bar"]),
+            patterns: Regex::new(r"foo \d bar").unwrap(),
+            all: value!(true)
+        ],
+        want: Ok(true),
+    }
+
+    not_all_match {
+        args: func_args![
+            value: value!(["foo 2 bar", "foo 3 bar", "foo 4 bar", "foo x bar"]),
+            patterns: Regex::new(r"foo \d bar").unwrap(),
+            all: value!(true)
+        ],
+        want: Ok(false),
     }
 }
 

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -622,7 +622,7 @@ bench_function! {
     some_match {
         args: func_args![
             value: value!(["foo 2 bar", "foo 3 bar", "foo 4 bar", "foo 5 bar"]),
-            patterns: Regex::new(r"foo \d bar").unwrap(),
+            pattern: Regex::new(r"foo \d bar").unwrap(),
         ],
         want: Ok(true),
     }
@@ -630,7 +630,7 @@ bench_function! {
     all_match {
         args: func_args![
             value: value!(["foo 2 bar", "foo 3 bar", "foo 4 bar", "foo 5 bar"]),
-            patterns: Regex::new(r"foo \d bar").unwrap(),
+            pattern: Regex::new(r"foo \d bar").unwrap(),
             all: value!(true)
         ],
         want: Ok(true),
@@ -639,7 +639,7 @@ bench_function! {
     not_all_match {
         args: func_args![
             value: value!(["foo 2 bar", "foo 3 bar", "foo 4 bar", "foo x bar"]),
-            patterns: Regex::new(r"foo \d bar").unwrap(),
+            pattern: Regex::new(r"foo \d bar").unwrap(),
             all: value!(true)
         ],
         want: Ok(false),

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -92,6 +92,8 @@ mod log_util;
 mod r#match;
 #[cfg(feature = "match_any")]
 mod match_any;
+#[cfg(feature = "match_array")]
+mod match_array;
 #[cfg(feature = "md5")]
 mod md5;
 #[cfg(feature = "merge")]
@@ -293,6 +295,8 @@ pub use length::Length;
 pub use log::Log;
 #[cfg(feature = "match_any")]
 pub use match_any::MatchAny;
+#[cfg(feature = "match_array")]
+pub use match_array::MatchArray;
 #[cfg(feature = "merge")]
 pub use merge::Merge;
 #[cfg(feature = "now")]
@@ -488,8 +492,10 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Log),
         #[cfg(feature = "match")]
         Box::new(Match),
-        #[cfg(feature = "match")]
+        #[cfg(feature = "match_any")]
         Box::new(MatchAny),
+        #[cfg(feature = "match_array")]
+        Box::new(MatchArray),
         #[cfg(feature = "md5")]
         Box::new(Md5),
         #[cfg(feature = "merge")]
@@ -550,8 +556,10 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Push),
         #[cfg(feature = "match")]
         Box::new(Match),
-        #[cfg(feature = "match")]
+        #[cfg(feature = "match_any")]
         Box::new(MatchAny),
+        #[cfg(feature = "match_array")]
+        Box::new(MatchArray),
         #[cfg(feature = "redact")]
         Box::new(Redact),
         #[cfg(feature = "replace")]

--- a/lib/vrl/stdlib/src/match_array.rs
+++ b/lib/vrl/stdlib/src/match_array.rs
@@ -17,7 +17,7 @@ impl Function for MatchArray {
             },
             Example {
                 title: "mismatch",
-                source: r#"match(["bazqux", "xyz"], r'foo')"#,
+                source: r#"match_array(["bazqux", "xyz"], r'foo')"#,
                 result: Ok("false"),
             },
         ]

--- a/lib/vrl/stdlib/src/match_array.rs
+++ b/lib/vrl/stdlib/src/match_array.rs
@@ -1,0 +1,161 @@
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct MatchArray;
+
+impl Function for MatchArray {
+    fn identifier(&self) -> &'static str {
+        "match_array"
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "match",
+                source: r#"match_array(["foobar", "bazqux"], r'foo')"#,
+                result: Ok("true"),
+            },
+            Example {
+                title: "mismatch",
+                source: r#"match(["bazqux", "xyz"], r'foo')"#,
+                result: Ok("false"),
+            },
+        ]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+        let pattern = arguments.required("pattern");
+        let all = arguments.optional("all");
+
+        Ok(Box::new(MatchArrayFn {
+            value,
+            pattern,
+            all,
+        }))
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::ARRAY,
+                required: true,
+            },
+            Parameter {
+                keyword: "pattern",
+                kind: kind::REGEX,
+                required: true,
+            },
+            Parameter {
+                keyword: "all",
+                kind: kind::BOOLEAN,
+                required: false,
+            },
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MatchArrayFn {
+    value: Box<dyn Expression>,
+    pattern: Box<dyn Expression>,
+    all: Option<Box<dyn Expression>>,
+}
+
+impl Expression for MatchArrayFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let list = self.value.resolve(ctx)?.try_array()?;
+        let pattern = self.pattern.resolve(ctx)?.try_regex()?;
+
+        let all = match &self.all {
+            Some(expr) => expr.resolve(ctx)?.try_boolean()?,
+            None => false,
+        };
+
+        let matcher = |i: &Value| match i.try_bytes_utf8_lossy() {
+            Ok(v) => pattern.is_match(&v),
+            _ => false,
+        };
+
+        let included = if all {
+            list.iter().all(matcher)
+        } else {
+            list.iter().any(matcher)
+        };
+
+        Ok(included.into())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new().infallible().boolean()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::trivial_regex)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    test_function![
+        match_array => MatchArray;
+
+        default {
+            args: func_args![
+                value: value!(["foo", "foobar", "barfoo"]),
+                pattern: Value::Regex(Regex::new("foo").unwrap().into())
+            ],
+            want: Ok(value!(true)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+
+        all {
+            args: func_args![
+                value: value!(["foo", "foobar", "barfoo"]),
+                pattern: Value::Regex(Regex::new("foo").unwrap().into()),
+                all: value!(true),
+            ],
+            want: Ok(value!(true)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+
+        not_all {
+            args: func_args![
+                value: value!(["foo", "foobar", "baz"]),
+                pattern: Value::Regex(Regex::new("foo").unwrap().into()),
+                all: value!(true),
+            ],
+            want: Ok(value!(false)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+
+        mixed_values {
+            args: func_args![
+                value: value!(["foo", "123abc", 1, true, [1,2,3]]),
+                pattern: Value::Regex(Regex::new("abc").unwrap().into())
+            ],
+            want: Ok(value!(true)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+
+        mixed_values_no_match {
+            args: func_args![
+                value: value!(["foo", "123abc", 1, true, [1,2,3]]),
+                pattern: Value::Regex(Regex::new("xyz").unwrap().into()),
+            ],
+            want: Ok(value!(false)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+
+        mixed_values_no_match_all {
+            args: func_args![
+                value: value!(["foo", "123abc", 1, true, [1,2,3]]),
+                pattern: Value::Regex(Regex::new("abc`").unwrap().into()),
+                all: value!(true),
+            ],
+            want: Ok(value!(false)),
+            tdef: TypeDef::new().infallible().boolean(),
+        }
+    ];
+}


### PR DESCRIPTION
Adds a `match_array` function, for matching a regex `pattern` against at least one element of an array `value`.

An optional `all:true` can be provided to require matching against all.

Motivated by a requirement surfaced in https://github.com/timberio/vector/pull/7633#discussion_r644143907 to parse wildcard patterns on elements inside of a _tags_ array.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, enhancement, feat, fix
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * chore(external docs): Clarified `batch_size` option
-->
