### PR TITLE
docs: add tag/source/service details in datadog_logs sink

### DIFF
--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -4,9 +4,9 @@ components: sinks: datadog_logs: {
 	title: "Datadog Logs"
 
 	description: """
-		Sends data to Datadog. The Datadog platform can leverage specifics fields (namely `ddtags`, `ddsource` and `service`) to further categorize
-		and filter logs. For further details on the purpose of those fields please check the [official Datadog documentation](\urls.datadog_tags).
-		The source (`ddsource` field) and service (`service` field) are expected to be plain text value. The list of tags (The `ddtags` field) should
+		Sends data to the [Datadog logs service](\(urls.datadog_logs)). The Datadog platform can leverage specifics fields (namely `ddtags`, `ddsource` and `service`) to further categorize
+		and filter logs. For further details on the purpose of those fields please check the [official Datadog documentation](\(urls.datadog_tags)).
+		The source (`ddsource` field) and service (`service` field) are expected to be plain text values. The list of tags (The `ddtags` field) should
 		be a single string of coma separated tags, e.g. `tag1:val1,tag2:val2,tag3:val3`.
 		"""
 

--- a/docs/reference/components/sinks/datadog_logs.cue
+++ b/docs/reference/components/sinks/datadog_logs.cue
@@ -3,6 +3,13 @@ package metadata
 components: sinks: datadog_logs: {
 	title: "Datadog Logs"
 
+	description: """
+		Sends data to Datadog. The Datadog platform can leverage specifics fields (namely `ddtags`, `ddsource` and `service`) to further categorize
+		and filter logs. For further details on the purpose of those fields please check the [official Datadog documentation](\urls.datadog_tags).
+		The source (`ddsource` field) and service (`service` field) are expected to be plain text value. The list of tags (The `ddtags` field) should
+		be a single string of coma separated tags, e.g. `tag1:val1,tag2:val2,tag3:val3`.
+		"""
+
 	classes: sinks._datadog.classes
 
 	features: {

--- a/docs/reference/urls.cue
+++ b/docs/reference/urls.cue
@@ -112,6 +112,7 @@ urls: {
 	datadog_logs_endpoints:                                   "\(datadog_docs)/logs/log_collection/?tab=http#datadog-logs-endpoints"
 	datadog_metrics:                                          "\(datadog_docs)/metrics/"
 	datadog_metrics_endpoints:                                "\(datadog_docs)/api/v1/metrics/"
+	datadog_tags:                                             "\(datadog_docs)/getting_started/tagging/"
 	date:                                                     "https://man7.org/linux/man-pages/man1/date.1.html"
 	debian:                                                   "https://www.debian.org/"
 	debian_system_groups:                                     "https://wiki.debian.org/SystemGroups"


### PR DESCRIPTION
Small change to expose tag/service/source field, it mainly targets user that would use the datadog_logs sinks to emit log that does not originate from the datadog_logs source.
