### PR TITLE
enhancement(file source): Add support for acknowledgements

### DIFF
--- a/docs/reference/components/sources/file.cue
+++ b/docs/reference/components/sources/file.cue
@@ -57,6 +57,7 @@ components: sources: file: {
 	}
 
 	configuration: {
+		acknowledgements: configuration._acknowledgements
 		exclude: {
 			common:      false
 			description: "Array of file patterns to exclude. [Globbing](#globbing) is supported.*Takes precedence over the [`include` option](#include).*"

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -75,10 +75,10 @@ where
         self,
         mut chans: C,
         shutdown: S,
-    ) -> Result<Shutdown, <C as Sink<Vec<(Bytes, String)>>>::Error>
+    ) -> Result<Shutdown, <C as Sink<Vec<Line>>>::Error>
     where
-        C: Sink<Vec<(Bytes, String)>> + Unpin,
-        <C as Sink<Vec<(Bytes, String)>>>::Error: std::error::Error,
+        C: Sink<Vec<Line>> + Unpin,
+        <C as Sink<Vec<Line>>>::Error: std::error::Error,
         S: Future + Unpin + Send + 'static,
         <S as Future>::Output: Clone + Send + Sync,
     {
@@ -284,10 +284,10 @@ where
 
                     bytes_read += sz;
 
-                    lines.push((
-                        line,
-                        watcher.path.to_str().expect("not a valid path").to_owned(),
-                    ));
+                    lines.push(Line {
+                        text: line,
+                        filename: watcher.path.to_str().expect("not a valid path").to_owned(),
+                    });
 
                     if bytes_read > self.max_read_bytes {
                         maxed_out_reading_single_file = true;
@@ -504,4 +504,10 @@ impl Default for TimingStats {
             bytes: Default::default(),
         }
     }
+}
+
+#[derive(Debug)]
+pub struct Line {
+    pub text: Bytes,
+    pub filename: String,
 }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -287,6 +287,8 @@ where
                     lines.push(Line {
                         text: line,
                         filename: watcher.path.to_str().expect("not a valid path").to_owned(),
+                        file_id,
+                        offset: watcher.get_file_position(),
                     });
 
                     if bytes_read > self.max_read_bytes {
@@ -510,4 +512,6 @@ impl Default for TimingStats {
 pub struct Line {
     pub text: Bytes,
     pub filename: String,
+    pub file_id: FileFingerprint,
+    pub offset: u64,
 }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -300,7 +300,6 @@ where
 
                 if bytes_read > 0 {
                     global_bytes_read = global_bytes_read.saturating_add(bytes_read);
-                    checkpoints.update(file_id, watcher.get_file_position());
                 } else {
                     // Should the file be removed
                     if let Some(grace_period) = self.remove_after {

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -12,7 +12,7 @@ mod internal_events;
 mod metadata_ext;
 pub mod paths_provider;
 
-pub use self::file_server::{FileServer, Shutdown as FileServerShutdown};
+pub use self::file_server::{FileServer, Line, Shutdown as FileServerShutdown};
 pub use self::fingerprinter::{FingerprintStrategy, Fingerprinter};
 pub use self::internal_events::FileSourceInternalEvents;
 

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -12,9 +12,9 @@ mod internal_events;
 mod metadata_ext;
 pub mod paths_provider;
 
-pub use self::checkpointer::Checkpointer;
+pub use self::checkpointer::{Checkpointer, CheckpointsView};
 pub use self::file_server::{FileServer, Line, Shutdown as FileServerShutdown};
-pub use self::fingerprinter::{FingerprintStrategy, Fingerprinter};
+pub use self::fingerprinter::{FileFingerprint, FingerprintStrategy, Fingerprinter};
 pub use self::internal_events::FileSourceInternalEvents;
 
 pub type FilePosition = u64;

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -12,6 +12,7 @@ mod internal_events;
 mod metadata_ext;
 pub mod paths_provider;
 
+pub use self::checkpointer::Checkpointer;
 pub use self::file_server::{FileServer, Line, Shutdown as FileServerShutdown};
 pub use self::fingerprinter::{FingerprintStrategy, Fingerprinter};
 pub use self::internal_events::FileSourceInternalEvents;

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -490,7 +490,7 @@ mod tests {
                 ignored_header_bytes: 0,
             },
             data_dir: Some(dir.path().to_path_buf()),
-            glob_minimum_cooldown_ms: 0, // millis
+            glob_minimum_cooldown_ms: 100, // millis
             ..Default::default()
         }
     }
@@ -1536,7 +1536,6 @@ mod tests {
         let config = file::FileConfig {
             include: vec![dir.path().join("*")],
             remove_after_secs: Some(remove_after_secs),
-            glob_minimum_cooldown_ms: 100,
             ..test_default_file_config(&dir)
         };
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -288,6 +288,7 @@ pub fn file_source(
     let multiline_config = config.multiline.clone();
     let message_start_indicator = config.message_start_indicator.clone();
     let multi_line_timeout = config.multi_line_timeout;
+    let checkpoints = checkpointer.view();
 
     Box::pin(async move {
         info!(message = "Starting file server.", include = ?include, exclude = ?exclude);
@@ -332,6 +333,7 @@ pub fn file_source(
         let span2 = span.clone();
         let mut messages = messages
             .map(move |line| {
+                checkpoints.update(line.file_id, line.offset);
                 let _enter = span2.enter();
                 create_event(line.text, line.filename, &host_key, &hostname, &file_key)
             })

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -2,7 +2,7 @@ use super::util::{EncodingConfig, MultilineConfig};
 use crate::{
     config::{log_schema, DataType, SourceConfig, SourceContext, SourceDescription},
     encoding_transcode::{Decoder, Encoder},
-    event::Event,
+    event::{Event, LogEvent},
     internal_events::{FileEventReceived, FileOpen, FileSourceInternalEventsEmitter},
     line_agg::{self, LineAgg},
     shutdown::ShutdownSignal,
@@ -397,22 +397,20 @@ fn create_event(
         byte_size: line.len(),
     });
 
-    let mut event = Event::from(line);
+    let mut event = LogEvent::from(line);
 
     // Add source type
-    event
-        .as_mut_log()
-        .insert(log_schema().source_type_key(), Bytes::from("file"));
+    event.insert(log_schema().source_type_key(), Bytes::from("file"));
 
     if let Some(file_key) = &file_key {
-        event.as_mut_log().insert(file_key.clone(), file);
+        event.insert(file_key.clone(), file);
     }
 
     if let Some(hostname) = &hostname {
-        event.as_mut_log().insert(host_key, hostname.clone());
+        event.insert(host_key, hostname.clone());
     }
 
-    event
+    event.into()
 }
 
 #[cfg(test)]

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -5,7 +5,7 @@
 
 #![deny(missing_docs)]
 
-use crate::event::Event;
+use crate::event::{Event, LogEvent};
 use crate::internal_events::{
     FileSourceInternalEventsEmitter, KubernetesLogsEventAnnotationFailed,
     KubernetesLogsEventReceived,
@@ -401,25 +401,23 @@ impl Source {
 }
 
 fn create_event(line: Bytes, file: &str, ingestion_timestamp_field: Option<&str>) -> Event {
-    let mut event = Event::from(line);
+    let mut event = LogEvent::from(line);
 
     // Add source type.
-    event.as_mut_log().insert(
+    event.insert(
         crate::config::log_schema().source_type_key(),
         COMPONENT_NAME.to_owned(),
     );
 
     // Add file.
-    event.as_mut_log().insert(FILE_KEY, file.to_owned());
+    event.insert(FILE_KEY, file.to_owned());
 
     // Add ingestion timestamp if requested.
     if let Some(ingestion_timestamp_field) = ingestion_timestamp_field {
-        event
-            .as_mut_log()
-            .insert(ingestion_timestamp_field, chrono::Utc::now());
+        event.insert(ingestion_timestamp_field, chrono::Utc::now());
     }
 
-    event
+    event.into()
 }
 
 /// This function returns the default value for `self_node_name` variable

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -322,13 +322,17 @@ impl Source {
 
         let events = file_source_rx.map(futures::stream::iter);
         let events = events.flatten();
-        let events = events.map(move |Line { text, filename }| {
-            let byte_size = text.len();
-            let mut event = create_event(text, &filename, ingestion_timestamp_field.as_deref());
-            let file_info = annotator.annotate(&mut event, &filename);
+        let events = events.map(move |line| {
+            let byte_size = line.text.len();
+            let mut event = create_event(
+                line.text,
+                &line.filename,
+                ingestion_timestamp_field.as_deref(),
+            );
+            let file_info = annotator.annotate(&mut event, &line.filename);
 
             emit!(KubernetesLogsEventReceived {
-                file: &filename,
+                file: &line.filename,
                 byte_size,
                 pod_name: file_info.as_ref().map(|info| info.pod_name),
             });

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -322,6 +322,7 @@ impl Source {
         let mut parser = parser::build(timezone);
         let partial_events_merger = Box::new(partial_events_merger::build(auto_partial_merge));
 
+        let checkpoints = checkpointer.view();
         let events = file_source_rx.map(futures::stream::iter);
         let events = events.flatten();
         let events = events.map(move |line| {
@@ -342,6 +343,7 @@ impl Source {
                 emit!(KubernetesLogsEventAnnotationFailed { event: &event });
             }
 
+            checkpoints.update(line.file_id, line.offset);
             event
         });
         let events = events.flat_map(move |event| {

--- a/src/sources/kubernetes_logs/util.rs
+++ b/src/sources/kubernetes_logs/util.rs
@@ -1,6 +1,5 @@
-use bytes::Bytes;
 use file_source::{
-    paths_provider::PathsProvider, FileServer, FileServerShutdown, FileSourceInternalEvents,
+    paths_provider::PathsProvider, FileServer, FileServerShutdown, FileSourceInternalEvents, Line,
 };
 use futures::future::{select, Either};
 use futures::{pin_mut, Sink};
@@ -19,8 +18,8 @@ pub async fn run_file_server<PP, E, C, S>(
 where
     PP: PathsProvider + Send + 'static,
     E: FileSourceInternalEvents,
-    C: Sink<Vec<(Bytes, String)>> + Unpin + Send + 'static,
-    <C as Sink<Vec<(Bytes, String)>>>::Error: Error + Send,
+    C: Sink<Vec<Line>> + Unpin + Send + 'static,
+    <C as Sink<Vec<Line>>>::Error: Error + Send,
     S: Future + Unpin + Send + 'static,
     <S as Future>::Output: Clone + Send + Sync,
 {

--- a/src/sources/util/committer.rs
+++ b/src/sources/util/committer.rs
@@ -1,0 +1,147 @@
+use crate::event::BatchStatusReceiver;
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Poll;
+use stream_cancel::{Trigger, Tripwire};
+use tokio::sync::mpsc;
+
+pub(crate) struct Committer<T> {
+    sender: Option<mpsc::UnboundedSender<(BatchStatusReceiver, T)>>,
+    shutdown_done: Tripwire,
+}
+
+impl<T: Send + 'static> Committer<T> {
+    pub(crate) fn new(apply_done: impl Fn(T) + Send + 'static) -> Self {
+        let (shutdown_trigger, shutdown_done) = Tripwire::new();
+        let (sender, receiver) = mpsc::unbounded_channel();
+        tokio::spawn(run_committer(
+            shutdown_trigger,
+            receiver,
+            apply_done, //move |entry: CommitterEntry| checkpoints.update(entry.file_id, entry.offset),
+        ));
+        Self {
+            sender: Some(sender),
+            shutdown_done,
+        }
+    }
+
+    pub(crate) fn shutdown_done(&self) -> Tripwire {
+        self.shutdown_done.clone()
+    }
+
+    pub(crate) fn start_shutdown(&mut self) {
+        self.sender.take();
+    }
+
+    pub(crate) fn add(&self, entry: T, receiver: BatchStatusReceiver) {
+        if let Some(sender) = &self.sender {
+            if let Err(error) = sender.send((receiver, entry)) {
+                error!(message = "Committer task ended prematurely.", %error);
+            }
+        }
+    }
+}
+
+async fn run_committer<T>(
+    shutdown: Trigger,
+    mut receiver: mpsc::UnboundedReceiver<(BatchStatusReceiver, T)>,
+    apply_done: impl Fn(T),
+) {
+    let mut receivers = FuturesUnordered::default();
+    let mut store = CommitterStore::new();
+
+    loop {
+        if receivers.is_empty() {
+            match receiver.recv().await {
+                Some((receiver, entry)) => {
+                    let index = store.add_entry(entry);
+                    receivers.push(CommitterFuture { receiver, index });
+                }
+                None => break,
+            }
+        } else {
+            tokio::select! {
+                received = receiver.recv() => match received {
+                    Some((receiver, entry)) => {
+                        let index = store.add_entry(entry);
+                        receivers.push(CommitterFuture { receiver, index });
+                    }
+                    None => break,
+                },
+                result = receivers.next() => match result {
+                    Some((_status, index)) => {
+                        store.mark_done(index);
+                        store.extract_done(&apply_done);
+                    }
+                    None => break,
+                },
+            }
+        }
+    }
+    while let Some((_status, index)) = receivers.next().await {
+        store.mark_done(index);
+        store.extract_done(&apply_done);
+    }
+    drop(shutdown);
+}
+
+struct CommitterFuture {
+    receiver: BatchStatusReceiver,
+    index: u64,
+}
+
+impl Future for CommitterFuture {
+    type Output = (<BatchStatusReceiver as Future>::Output, u64);
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        self.receiver
+            .poll_unpin(ctx)
+            .map(|status| (status, self.index))
+    }
+}
+
+struct CommitterStore<T> {
+    first: u64,
+    entries: VecDeque<(bool, T)>,
+}
+
+impl<T> CommitterStore<T> {
+    fn new() -> Self {
+        Self {
+            first: 0,
+            entries: VecDeque::new(),
+        }
+    }
+
+    /// Add the needed data from the given message into the store and
+    /// return the index.
+    #[must_use]
+    fn add_entry(&mut self, entry: T) -> u64 {
+        let index = self.first + self.entries.len() as u64;
+        self.entries.push_back((false, entry));
+        index
+    }
+
+    fn mark_done(&mut self, index: u64) {
+        // Under normal usage, both of these conditions should be true,
+        // but they are guarded to avoid panics.
+        if index >= self.first {
+            let offset = (index - self.first) as usize;
+            if let Some(entry) = self.entries.get_mut(offset) {
+                entry.0 = true;
+            }
+        }
+    }
+
+    fn extract_done(&mut self, apply: impl Fn(T)) {
+        while let Some(entry) = self.entries.front() {
+            if !entry.0 {
+                break;
+            }
+            let entry = self.entries.pop_front().unwrap().1;
+            self.first += 1;
+            apply(entry);
+        }
+    }
+}

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -1,7 +1,6 @@
 use crate::event::BatchStatusReceiver;
 use crate::shutdown::ShutdownSignal;
-use futures::{future::Shared, stream::FuturesUnordered, FutureExt, StreamExt};
-use std::collections::VecDeque;
+use futures::{future::Shared, stream::FuturesOrdered, FutureExt, StreamExt};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;
@@ -45,24 +44,22 @@ async fn run_finalizer<T>(
     mut new_entries: mpsc::UnboundedReceiver<(BatchStatusReceiver, T)>,
     apply_done: impl Fn(T),
 ) {
-    let mut status_receivers = FuturesUnordered::default();
-    let mut store = FinalizerStore::new();
+    let mut status_receivers = FuturesOrdered::default();
 
     loop {
         tokio::select! {
             _ = shutdown.clone() => break,
             new_entry = new_entries.recv() => match new_entry {
                 Some((receiver, entry)) => {
-                    let index = store.add_entry(entry);
-                    status_receivers.push(FinalizerFuture { receiver, index });
+                    status_receivers.push(FinalizerFuture {
+                        receiver,
+                        entry: Some(entry),
+                    });
                 }
                 None => break,
             },
             finished = status_receivers.next(), if !status_receivers.is_empty() => match finished {
-                Some((_status, index)) => {
-                    store.mark_done(index);
-                    store.extract_done(&apply_done);
-                }
+                Some((_status, entry)) => apply_done(entry),
                 // The is_empty guard above prevents this from being reachable.
                 None => unreachable!(),
             },
@@ -71,68 +68,24 @@ async fn run_finalizer<T>(
     // We've either seen a shutdown signal or the new entry sender was
     // closed. Wait for the last statuses to come in before indicating
     // we are done.
-    while let Some((_status, index)) = status_receivers.next().await {
-        store.mark_done(index);
-        store.extract_done(&apply_done);
+    while let Some((_status, entry)) = status_receivers.next().await {
+        apply_done(entry);
     }
     drop(shutdown);
 }
 
-struct FinalizerFuture {
+#[pin_project::pin_project]
+struct FinalizerFuture<T> {
     receiver: BatchStatusReceiver,
-    index: u64,
+    entry: Option<T>,
 }
 
-impl Future for FinalizerFuture {
-    type Output = (<BatchStatusReceiver as Future>::Output, u64);
+impl<T> Future for FinalizerFuture<T> {
+    type Output = (<BatchStatusReceiver as Future>::Output, T);
     fn poll(mut self: Pin<&mut Self>, ctx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        self.receiver
-            .poll_unpin(ctx)
-            .map(|status| (status, self.index))
-    }
-}
-
-struct FinalizerStore<T> {
-    first: u64,
-    entries: VecDeque<(bool, T)>,
-}
-
-impl<T> FinalizerStore<T> {
-    fn new() -> Self {
-        Self {
-            first: 0,
-            entries: VecDeque::new(),
-        }
-    }
-
-    /// Add the needed data from the given message into the store and
-    /// return the index.
-    #[must_use]
-    fn add_entry(&mut self, entry: T) -> u64 {
-        let index = self.first + self.entries.len() as u64;
-        self.entries.push_back((false, entry));
-        index
-    }
-
-    fn mark_done(&mut self, index: u64) {
-        // Under normal usage, both of these conditions should be true,
-        // but they are guarded to avoid panics.
-        if index >= self.first {
-            let offset = (index - self.first) as usize;
-            if let Some(entry) = self.entries.get_mut(offset) {
-                entry.0 = true;
-            }
-        }
-    }
-
-    fn extract_done(&mut self, apply: impl Fn(T)) {
-        while let Some(entry) = self.entries.front() {
-            if !entry.0 {
-                break;
-            }
-            let entry = self.entries.pop_front().unwrap().1;
-            self.first += 1;
-            apply(entry);
-        }
+        let status = futures::ready!(self.receiver.poll_unpin(ctx));
+        // The use of this above in a `FuturesOrdered` will only take
+        // this once before dropping the future.
+        Poll::Ready((status, self.entry.take().unwrap_or_else(|| unreachable!())))
     }
 }

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -15,9 +15,6 @@ pub(crate) struct OrderedFinalizer<T> {
     sender: Option<mpsc::UnboundedSender<(BatchStatusReceiver, T)>>,
 }
 
-// TODO: Rewrite `apply_done` below into a trait once there are more
-// than one user of this framework. This works for now.
-
 impl<T: Send + 'static> OrderedFinalizer<T> {
     pub(crate) fn new(
         shutdown: Shared<ShutdownSignal>,

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 mod body_decoding;
+#[cfg(feature = "sources-file")]
+pub(crate) mod committer;
 mod encoding_config;
 #[cfg(all(unix, feature = "sources-dnstap"))]
 pub mod framestream;

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -1,8 +1,8 @@
 #[cfg(any(feature = "sources-http", feature = "sources-datadog"))]
 mod body_decoding;
-#[cfg(feature = "sources-file")]
-pub(crate) mod committer;
 mod encoding_config;
+#[cfg(feature = "sources-file")]
+pub(crate) mod finalizer;
 #[cfg(all(unix, feature = "sources-dnstap"))]
 pub mod framestream;
 #[cfg(feature = "sources-utils-http")]


### PR DESCRIPTION
Closes #7459 

It looks like a fair chunk of the asynchronous acknowledgement framework can be reused between this and the Kafka source work #7787, but that's not reviewed yet. Once this is merged, supporting this in the Kubernetes source should be pretty short work. This also does no batching of events, so the performance is likely to plummet once acknowledgements are turned on. The file server already reads lines in batches, and we now expose a nice structure that could make this possibly without major reworks to the sources, but that was beyond the scope of this PR.