### PR TITLE
enhancement(vrl): add `filter_array`

### DIFF
--- a/docs/reference/remap/functions/filter_array.cue
+++ b/docs/reference/remap/functions/filter_array.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: filter_array: {
 	category: "Array"
 	description: """
-		Filters elements from the `value` array. It returns an array containint the elements matching the `pattern`.
+		Filters elements from the `value` array. It returns an array containing the elements matching the `pattern`.
 		"""
 
 	arguments: [

--- a/docs/reference/remap/functions/filter_array.cue
+++ b/docs/reference/remap/functions/filter_array.cue
@@ -1,0 +1,50 @@
+package metadata
+
+remap: functions: filter_array: {
+	category: "Enumerate"
+	description: """
+		Filters elements from the `value` array. It returns an array containint the elements matching the `pattern`.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The array."
+			required:    true
+			type: ["array"]
+		},
+		{
+			name:        "pattern"
+			description: "The regular expression pattern to match against."
+			required:    true
+			type: ["regex"]
+		},
+
+	]
+	internal_failure_reasons: []
+	return: types: ["array"]
+
+	examples: [
+		{
+			title: "Match at least one element"
+			source: #"""
+					filter_array(["foobar", "bazqux"], r'foo')
+				"""#
+			return: ["foobar"]
+		},
+		{
+			title: "Match all elements"
+			source: #"""
+					filter_array(["foo", "foobar", "barfoo"], r'foo')
+				"""#
+			return: ["foo", "foobar", "barfoo"]
+		},
+		{
+			title: "No matches"
+			source: #"""
+					filter_array(["bazqux", "xyz"], r'foo')
+				"""#
+			return: []
+		},
+	]
+}

--- a/docs/reference/remap/functions/filter_array.cue
+++ b/docs/reference/remap/functions/filter_array.cue
@@ -1,7 +1,7 @@
 package metadata
 
 remap: functions: filter_array: {
-	category: "Enumerate"
+	category: "Array"
 	description: """
 		Filters elements from the `value` array. It returns an array containint the elements matching the `pattern`.
 		"""

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -56,6 +56,7 @@ default = [
     "encode_logfmt",
     "ends_with",
     "exists",
+    "filter_array",
     "flatten",
     "float",
     "floor",
@@ -158,6 +159,7 @@ encode_json = ["serde_json"]
 encode_logfmt = []
 ends_with = []
 exists = []
+filter_array = ["regex"]
 flatten = []
 float = []
 floor = []

--- a/lib/vrl/stdlib/src/filter_array.rs
+++ b/lib/vrl/stdlib/src/filter_array.rs
@@ -1,0 +1,141 @@
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct FilterArray;
+
+impl Function for FilterArray {
+    fn identifier(&self) -> &'static str {
+        "filter_array"
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "some item match",
+                source: r#"filter_array(["foobar", "bazqux"], r'foo')"#,
+                result: Ok(r#"["foobar"]"#),
+            },
+            Example {
+                title: "no match",
+                source: r#"filter_array(["bazqux", "xyz"], r'foo')"#,
+                result: Ok(r#"[]"#),
+            },
+        ]
+    }
+
+    fn compile(&self, mut arguments: ArgumentList) -> Compiled {
+        let value = arguments.required("value");
+        let pattern = arguments.required("pattern");
+
+        Ok(Box::new(FilterArrayFn { value, pattern }))
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::ARRAY,
+                required: true,
+            },
+            Parameter {
+                keyword: "pattern",
+                kind: kind::REGEX,
+                required: true,
+            },
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FilterArrayFn {
+    value: Box<dyn Expression>,
+    pattern: Box<dyn Expression>,
+}
+
+impl Expression for FilterArrayFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let mut list = self.value.resolve(ctx)?.try_array()?;
+        let pattern = self.pattern.resolve(ctx)?.try_regex()?;
+
+        let matcher = |i: &Value| match i.try_bytes_utf8_lossy() {
+            Ok(v) => pattern.is_match(&v),
+            _ => false,
+        };
+        list.retain(matcher);
+        Ok(list.into())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new()
+            .infallible()
+            .array_mapped::<(), Kind>(map! {(): Kind::Bytes})
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::trivial_regex)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    test_function![
+        filter_array => FilterArray;
+
+        all {
+            args: func_args![
+                value: value!(["foo", "foobar", "barfoo"]),
+                pattern: Value::Regex(Regex::new("foo").unwrap().into())
+            ],
+            want: Ok(value!(["foo", "foobar", "barfoo"])),
+            tdef: TypeDef::new()
+                .infallible()
+                .array_mapped::<(), Kind>(map! {(): Kind::Bytes}),
+        }
+
+        partial {
+            args: func_args![
+                value: value!(["foo", "foobar", "baz"]),
+                pattern: Value::Regex(Regex::new("foo").unwrap().into()),
+                all: value!(true),
+            ],
+            want: Ok(value!(["foo", "foobar"])),
+            tdef: TypeDef::new()
+                .infallible()
+                .array_mapped::<(), Kind>(map! {(): Kind::Bytes}),
+        }
+
+        none {
+            args: func_args![
+                value: value!(["yyz", "yvr", "yul"]),
+                pattern: Value::Regex(Regex::new("foo").unwrap().into()),
+                all: value!(true),
+            ],
+            want: Ok(value!([])),
+            tdef: TypeDef::new()
+                .infallible()
+                .array_mapped::<(), Kind>(map! {(): Kind::Bytes}),
+        }
+
+        mixed_values {
+            args: func_args![
+                value: value!(["foo", "123abc", 1, true, [1,2,3]]),
+                pattern: Value::Regex(Regex::new("abc").unwrap().into())
+            ],
+            want: Ok(value!(["123abc"])),
+            tdef: TypeDef::new()
+                .infallible()
+                .array_mapped::<(), Kind>(map! {(): Kind::Bytes}),
+        }
+
+        mixed_values_no_match {
+            args: func_args![
+                value: value!(["foo", "123abc", 1, true, [1,2,3]]),
+                pattern: Value::Regex(Regex::new("xyz").unwrap().into()),
+            ],
+            want: Ok(value!([])),
+            tdef: TypeDef::new()
+                .infallible()
+                .array_mapped::<(), Kind>(map! {(): Kind::Bytes}),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -452,6 +452,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(EndsWith),
         #[cfg(feature = "exists")]
         Box::new(Exists),
+        #[cfg(feature = "filter_array")]
+        Box::new(FilterArray),
         #[cfg(feature = "flatten")]
         Box::new(Flatten),
         #[cfg(feature = "float")]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -32,6 +32,8 @@ mod encode_logfmt;
 mod ends_with;
 #[cfg(feature = "exists")]
 mod exists;
+#[cfg(feature = "filter_array")]
+mod filter_array;
 #[cfg(feature = "flatten")]
 mod flatten;
 #[cfg(feature = "float")]
@@ -247,6 +249,8 @@ pub use encode_logfmt::EncodeLogfmt;
 pub use ends_with::EndsWith;
 #[cfg(feature = "exists")]
 pub use exists::Exists;
+#[cfg(feature = "filter_array")]
+pub use filter_array::FilterArray;
 #[cfg(feature = "flatten")]
 pub use flatten::Flatten;
 #[cfg(feature = "float")]


### PR DESCRIPTION
Allow to remove elements from an array based on a regexp.
Non-byte type are removed.

Note: as this PR was mostly anticipating a usecase (datadog tags manipulation) I suggest we don't merge it unless there is a real need for the usecase **and** enumeration/iteration is not available in VRL.  