### PR TITLE
fix(file source): Add needed shutdown to file rotation test

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1067,7 +1067,7 @@ mod tests {
         let path_for_old_file = dir.path().join("file.old");
         // Run server first time, collect some lines.
         {
-            let received = run_file_source(&config, false, acking, async {
+            let received = run_file_source(&config, true, acking, async {
                 let mut file = File::create(&path).unwrap();
                 sleep_500_millis().await;
                 writeln!(&mut file, "first line").unwrap();


### PR DESCRIPTION
This took an annoying amount of time to pin down but ended up being simply a matter of the first test in the series requiring waiting for shutdown in order to prevent a race on the last checkpoint to be written. Unfortunately, based on instrumenting the sources with `println`s, there may still be a near race, but I have not been able to trigger it in several dozen runs on my Mac.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

Closes #7988 