### PR TITLE
fix(prometheus_scrape source): Don't crash on out-of-order histograms 

### DIFF
--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -79,7 +79,7 @@ pub struct SummaryMetric {
     pub count: u32,
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, PartialOrd)]
 pub struct HistogramBucket {
     pub bucket: f64,
     pub count: u32,

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-pub use prometheus_parser::*;
+use prometheus_parser::{proto, GroupKind, MetricGroup, ParserError};
 
 fn has_values_or_none(tags: BTreeMap<String, String>) -> Option<BTreeMap<String, String>> {
     if tags.is_empty() {
@@ -74,7 +74,7 @@ fn reparse_groups(groups: Vec<MetricGroup>) -> Vec<Event> {
                     let mut buckets = metric.buckets;
                     buckets.sort_unstable_by(|a, b| a.partial_cmp(&b).unwrap_or(Ordering::Equal));
                     for i in (1..buckets.len()).rev() {
-                        buckets[i].count -= buckets[i - 1].count;
+                        buckets[i].count = buckets[i].count.saturating_sub(buckets[i - 1].count);
                     }
                     let drop_last = buckets
                         .last()
@@ -726,6 +726,33 @@ mod test {
                     buckets: vector_core::buckets![1.0 => 133988],
                     count: 144320,
                     sum: 53423.0,
+                },
+            )
+            .with_timestamp(Some(*TIMESTAMP))]),
+        );
+    }
+
+    #[test]
+    fn test_histogram_backward_values() {
+        let exp = r##"
+            # HELP duration A histogram of the request duration.
+            # TYPE duration histogram
+            duration_bucket{le="1"} 2000 1612411506789
+            duration_bucket{le="10"} 1000 1612411506789
+            duration_bucket{le="+Inf"} 2000 1612411506789
+            duration_sum 2000 1612411506789
+            duration_count 2000 1612411506789
+            "##;
+
+        assert_event_data_eq!(
+            parse_text(exp),
+            Ok(vec![Metric::new(
+                "duration",
+                MetricKind::Absolute,
+                MetricValue::AggregatedHistogram {
+                    buckets: vector_core::buckets![1.0 => 2000, 10.0 => 0],
+                    count: 2000,
+                    sum: 2000.0,
                 },
             )
             .with_timestamp(Some(*TIMESTAMP))]),


### PR DESCRIPTION
Closes #8012 