### PR TITLE
fix(metrics): Deny adding aggregated summaries

### DIFF
--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -669,31 +669,6 @@ impl MetricValue {
                 true
             }
 
-            (
-                Self::AggregatedSummary {
-                    ref mut quantiles,
-                    ref mut count,
-                    ref mut sum,
-                },
-                Self::AggregatedSummary {
-                    quantiles: quantiles2,
-                    count: count2,
-                    sum: sum2,
-                },
-            ) if quantiles.len() == quantiles2.len()
-                && quantiles
-                    .iter()
-                    .zip(quantiles2.iter())
-                    .all(|(b1, b2)| b1.upper_limit == b2.upper_limit) =>
-            {
-                for (b1, b2) in quantiles.iter_mut().zip(quantiles2) {
-                    b1.value += b2.value;
-                }
-                *count += count2;
-                *sum += sum2;
-                true
-            }
-
             _ => false,
         }
     }
@@ -752,30 +727,6 @@ impl MetricValue {
             {
                 for (b1, b2) in buckets.iter_mut().zip(buckets2) {
                     b1.count -= b2.count;
-                }
-                *count -= count2;
-                *sum -= sum2;
-                true
-            }
-            (
-                Self::AggregatedSummary {
-                    ref mut quantiles,
-                    ref mut count,
-                    ref mut sum,
-                },
-                Self::AggregatedSummary {
-                    quantiles: quantiles2,
-                    count: count2,
-                    sum: sum2,
-                },
-            ) if quantiles.len() == quantiles2.len()
-                && quantiles
-                    .iter()
-                    .zip(quantiles2.iter())
-                    .all(|(b1, b2)| b1.upper_limit == b2.upper_limit) =>
-            {
-                for (b1, b2) in quantiles.iter_mut().zip(quantiles2) {
-                    b1.value -= b2.value;
                 }
                 *count -= count2;
                 *sum -= sum2;

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -791,7 +791,7 @@ mod test {
 
     #[test]
     fn inc_buffer_aggregated_summaries() {
-        let buffer = dbg!(rebuffer_aggregated_summaries::<IncrementalMetricNormalize>());
+        let buffer = rebuffer_aggregated_summaries::<IncrementalMetricNormalize>();
 
         // Since aggregated summaries cannot be added, they don't work
         // as incremental metrics and this results in an empty buffer.

--- a/src/sinks/util/buffer/metrics.rs
+++ b/src/sinks/util/buffer/metrics.rs
@@ -761,8 +761,8 @@ mod test {
 
     fn rebuffer_aggregated_summaries<State: MetricNormalize>() -> Buffer {
         let mut events = Vec::new();
-        for factor in 0..10 {
-            for num in 2..5 {
+        for factor in 0..2 {
+            for num in 2..4 {
                 events.push(sample_aggregated_summary(
                     num,
                     Absolute,
@@ -781,9 +781,8 @@ mod test {
         assert_eq!(
             buffer[0],
             [
-                sample_aggregated_summary(2, Absolute, 11.0),
-                sample_aggregated_summary(3, Absolute, 12.0),
-                sample_aggregated_summary(4, Absolute, 13.0),
+                sample_aggregated_summary(2, Absolute, 3.0),
+                sample_aggregated_summary(3, Absolute, 4.0),
             ]
         );
 
@@ -792,18 +791,11 @@ mod test {
 
     #[test]
     fn inc_buffer_aggregated_summaries() {
-        let buffer = rebuffer_aggregated_summaries::<IncrementalMetricNormalize>();
+        let buffer = dbg!(rebuffer_aggregated_summaries::<IncrementalMetricNormalize>());
 
-        assert_eq!(
-            buffer[0],
-            [
-                sample_aggregated_summary(2, Incremental, 9.0),
-                sample_aggregated_summary(3, Incremental, 9.0),
-                sample_aggregated_summary(4, Incremental, 9.0),
-            ]
-        );
-
-        assert_eq!(buffer.len(), 1);
+        // Since aggregated summaries cannot be added, they don't work
+        // as incremental metrics and this results in an empty buffer.
+        assert_eq!(buffer.len(), 0);
     }
 
     fn sample_counter(num: usize, tagstr: &str, kind: MetricKind, value: f64) -> Metric {


### PR DESCRIPTION
An aggregated summary is composed of a set of quantiles, which aggregate
values across *variable* buckets, where the division points of the
buckets are dependent on the total number of observations going into
each bucket. As the data changes, the actual division points change, and
so adding two summaries together is statistically meaningless.

Note that I punted on how to make the metrics buffer emit incremental aggregated summaries. Since adding them doesn't make sense, there isn't much use in even allowing them to be emitted, and I *think* most of the metrics buffer users coerce these to be absolutes anyways. I am open to better ideas, as this is deeply dissatisfying to me, but I can't conceive of a simple solution that doesn't totally special-case this type of metric.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

Closes #7723 