### PR TITLE
fix(unit tests): check_fields deprecation notice is incorrect

### DIFF
--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -524,7 +524,7 @@ impl CheckFieldsConfig {
 #[typetag::serde(name = "check_fields")]
 impl ConditionConfig for CheckFieldsConfig {
     fn build(&self) -> crate::Result<Box<dyn Condition>> {
-        warn!(message = "The `check_fields` condition is deprecated, use `remap` instead.",);
+        warn!(message = "The `check_fields` condition is deprecated, use `vrl` instead.",);
         build_predicates(&self.predicates)
             .map(|preds| -> Box<dyn Condition> { Box::new(CheckFields { predicates: preds }) })
             .map_err(|errs| {


### PR DESCRIPTION
The `check_fields` deprecation notice suggests to use `remap` instead,
but this has been renamed to `vrl`.

Noticed while replying to #8105 

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>