### PR TITLE
fix(internal_metrics source): Bucket for 64 was broken

### DIFF
--- a/lib/vector-core/src/metrics/handle.rs
+++ b/lib/vector-core/src/metrics/handle.rs
@@ -110,7 +110,7 @@ impl Histogram {
             (8.0, AtomicU32::new(0)),
             (16.0, AtomicU32::new(0)),
             (32.0, AtomicU32::new(0)),
-            (32.0, AtomicU32::new(0)),
+            (64.0, AtomicU32::new(0)),
             (128.0, AtomicU32::new(0)),
             (256.0, AtomicU32::new(0)),
             (512.0, AtomicU32::new(0)),


### PR DESCRIPTION
The hard-coded power-of-2 buckets list used for internal metrics had two
buckets for 32.0 and none for 64.0. This fixes the number on the higher
bucket.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>