### PR TITLE
fix(tests): Wait for shutdown in `file_start_position_server_restart`

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -977,7 +977,7 @@ mod tests {
 
         // First time server runs it picks up existing lines.
         {
-            let received = run_file_source(&config, false, acking, async {
+            let received = run_file_source(&config, true, acking, async {
                 sleep_500_millis().await;
                 writeln!(&mut file, "first line").unwrap();
                 sleep_500_millis().await;
@@ -989,7 +989,7 @@ mod tests {
         }
         // Restart server, read file from checkpoint.
         {
-            let received = run_file_source(&config, false, acking, async {
+            let received = run_file_source(&config, true, acking, async {
                 sleep_500_millis().await;
                 writeln!(&mut file, "second line").unwrap();
                 sleep_500_millis().await;


### PR DESCRIPTION
AFAICT the race is between the checkpoint file being written by the
first server and then read by the second (restarted) server. With this
pause I have been unable to trigger the race.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

Closes #7988 (again)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
