### PR TITLE
fix(elasticsearch sink): Fix data stream timestamp handling

### DIFF
--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -1396,7 +1396,7 @@ mod integration_tests {
             .await
             .expect("Data stream creation error");
 
-        run_insert_tests_with_config(&cfg, true, BatchStatus::Delivered).await;
+        run_insert_tests_with_config(&cfg, false, BatchStatus::Delivered).await;
     }
 
     async fn run_insert_tests(
@@ -1442,6 +1442,10 @@ mod integration_tests {
 
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
         let (input, events) = random_events_with_stream(100, 100, Some(batch));
+        let events = events.map(|mut event| {
+            event.as_mut_log().insert("@timestamp", chrono::Utc::now());
+            event
+        });
         if break_events {
             // Break all but the first event to simulate some kind of partial failure
             let mut doit = false;

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -1118,6 +1118,7 @@ mod integration_tests {
         test_util::{random_events_with_stream, random_string, trace_init},
         tls::{self, TlsOptions},
     };
+    use chrono::Utc;
     use futures::{stream, StreamExt};
     use http::{Request, StatusCode};
     use hyper::Body;
@@ -1429,7 +1430,14 @@ mod integration_tests {
         batch_status: BatchStatus,
     ) {
         let common = ElasticSearchCommon::parse_config(&config).expect("Config error");
-        let index = config.index.clone().unwrap();
+        let index = match config.mode {
+            // Data stream mode uses an index name generated from the event.
+            ElasticSearchMode::DataStream => format!(
+                "{}",
+                Utc::now().format(".ds-logs-generic-default-%Y.%m.%d-000001")
+            ),
+            ElasticSearchMode::Normal => config.index.clone().unwrap(),
+        };
         let base_url = common.base_url.clone();
 
         let cx = SinkContext::new_test();

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -904,7 +904,7 @@ mod tests {
         event.as_mut_log().insert("data_stream", data_stream_body());
         let encoded = es.encode_event(event).unwrap().item;
         let expected = r#"{"create":{"_index":"synthetics-testing-default","_type":"_doc"}}
-{"data_stream":{"dataset":"testing","namespace":"default","type":"synthetics"},"message":"hello there","timestamp":"2020-12-01T01:02:03Z"}
+{"@timestamp":"2020-12-01T01:02:03Z","data_stream":{"dataset":"testing","namespace":"default","type":"synthetics"},"message":"hello there"}
 "#;
         assert_eq!(std::str::from_utf8(&encoded).unwrap(), expected);
     }
@@ -965,7 +965,6 @@ mod tests {
             encoded_lines.get(0).unwrap(),
             r#"{"create":{"_index":"vector","_type":"_doc"}}"#
         );
-        println!("line: {}", encoded_lines.get(1).unwrap());
         assert!(encoded_lines
             .get(1)
             .unwrap()
@@ -1031,7 +1030,7 @@ mod tests {
         );
         let encoded = es.encode_event(event).unwrap().item;
         let expected = r#"{"create":{"_index":"synthetics-testing-something","_type":"_doc"}}
-{"data_stream":{"dataset":"testing","type":"synthetics"},"message":"hello there","timestamp":"2020-12-01T01:02:03Z"}
+{"@timestamp":"2020-12-01T01:02:03Z","data_stream":{"dataset":"testing","type":"synthetics"},"message":"hello there"}
 "#;
         assert_eq!(std::str::from_utf8(&encoded).unwrap(), expected);
     }


### PR DESCRIPTION
Closes #8267 

The comparison here still isn't working right due to the additional timestamp and `data_stream` fields, and I don't think we should have to add a timestamp in the test to make this work. https://github.com/timberio/vector/blob/03a76433806a87899fa2f5e3325c071069f1f432/src/sinks/elasticsearch/mod.rs#L1513