### PR TITLE
chore(vrl): String interpolation RFC

### DIFF
--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -27,7 +27,14 @@ with `{{..}}`. VRL will evaluate the expressions and will call `to_string` on
 that expression to return the text representation.
 
 ```
-l'The message is {{ .message }} created at {{ .timestamp }}'
+i'The message is {{ .message }} created at {{ .timestamp }}'
+```
+
+If you wish to actually insert a `{{` into a string, these characters will need
+to be escaped with a `\`. A single `{` will not need escaping. For example:
+
+```
+i'Here is a curly brace -> { and here are some more -> \{{'
 ```
 
 Since this is a new string type there are no backward compatibility issues.

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -1,0 +1,135 @@
+# RFC 7117 - 2021-07-27 - VRL string interpolation
+
+VRL needs a better way to format strings. Currently the only way to do this is
+to concatenate strings, which can get unwieldly.
+
+## Scope
+
+This RFC discusses creating a new string type within VRL that can use template
+literals, also known as string interpolation, to format strings.
+
+## Pain
+
+Currently the way to create strings is through either string concatenation or 
+the `join` function. 
+
+Syntactically this is unwieldly. It requires extra key presses and the code 
+created doesn't necessarily give an instant idea of what the resulting string 
+will look like. Thus the true intent behind the code is obfuscated, which can 
+result in bugs.
+
+## User Experience
+
+To format a string there will be a string type denoted with the prefix `l'`.
+
+Within that string, it is possible to embed VRL expressions by surrounding them
+with `{{..}}`. VRL will evaluate the expressions and will call `to_string` on
+that expression to return the text representation.
+
+```
+l'The message is {{ .message }} created at {{ .timestamp }}'
+```
+
+Since this is a new string type there are no backward compatibility issues.
+
+## Implementation
+
+This new string type can be considered as syntactic sugar for string 
+concatenation. 
+
+The VRL parser will take a template literal string such as:
+
+```
+i'The message is {{ .message }} created at {{ .timestamp }}'
+```
+
+and create an AST identical to the AST for the following expression:
+
+```
+s'The message is ' + 
+to_string(.message) + 
+s' created at ' + 
+to_string(.timestamp)
+```
+
+## Rationale
+
+String interpolation or string formats are prevalent in modern programming 
+languages. Users have an expectation that this feature will be available.
+
+String formatting is a common task within VRL. Currently the process involves
+string concatenation. This works, but the code required to do this does not
+create an immediately apparent representation of what the string may look like.
+
+There is little impact of not doing this beyond requiring users to use a less
+elegant form for string creation.
+
+## Prior Art
+
+- Template strings are used within certain fields within Vector. 
+- Many programming languages offer string interpolation.
+  - [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) 
+  - [Ruby](http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html)
+
+## Drawbacks
+
+This does add additional code complexity and an maintenance burden to VRL.
+
+## Alternatives
+
+### Format Strings
+
+One alternative is to create a `sprintf` function. `sprintf` takes one parameter
+that represents the format string. Within the format string if a format tag is 
+found, the function will take the next parameter passed and will format that 
+parameter according to the tag and will embed the resulting text in that 
+position.
+
+For example:
+
+```
+sprintf("The message is %s created at %t", .message, .timestamp)
+```
+
+will return 
+
+```
+The message is the message created at Tue, 27 Jul 2021 10:10:01 +0000
+```
+
+The advantages of this method is that it does not require any changes to the
+VRL compiler, all changes are isolated to a single function. Also it provides
+a way to influence the formatting of the parameters.
+
+Downsides are that the format strings are a hidden DSL themselves and there is 
+a cognitive overhead involved in maintaining the position of the format tags
+within the string and the parameters passed to the function.
+
+### Extended template strings
+
+The advantage of format strings over string interpolation is that format strings
+provide for parameters to indicate how numbers could be formatted. 
+
+For example, `sprintf("%.2f", 3.14159)` will return `3.14`. With simple string
+interpolation `i'{{ 3.14159 }}'` there is no way to control the number of 
+decimals output.
+
+We could extend the format strings to allow for any format parameters to be 
+added after a `|` character in the template string. So 
+`i'{{ 3.14159 | decimals: 2 }}'` would result in the number formatted to 2 
+decimal places - `3.14`.
+
+## Outstanding Questions
+
+- Is there a better prefix than `i` for string interpolation?
+
+## Plan Of Attack
+
+Incremental steps to execute this change. These will be converted to issues after the RFC is approved:
+
+- [ ] Submit a PR with spike-level code _roughly_ demonstrating the change.
+- [ ] Incremental change #1
+- [ ] Incremental change #2
+- [ ] ...
+
+Note: This can be filled out during the review process.

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -53,26 +53,39 @@ f'The time is {ts : %v %R}'
 
 ### Errors
 
-The question arises about what we should do if an error occurs.
-
-I would argue that we do not want an f string to be fallible as this would
-cumbersome to the experience of using VRL. If an error occurs the error text is
-output. For example:
+We do not want an f string to be fallible as this would cumbersome to the experience of using VRL.
+If an error occurs the error text is output. For example:
 
 ```coffee
 f'This is some json { parse_json(.thing) }'
 # This is some json function call error for "parse_json" at (0:18): unable to parse json: expected ident at line 1 column 2
 ```
 
+Errors could still be handled to provide alternative text if needed:
+
+```coffee
+f'This is some json { parse_json(.thing) ?? "oops" }'
+# This is some json oops
+```
+
 Another source of error would be if the format string is specified for a different
 type - for example using date format strings when the type is an integer.
 
-If this occurs, we just ignore the format string and display the unformatted value.
+If format strings are provided, we need to lean on VRLs type system to ensure that the format
+strings are valid for the given type. The user must ensure the types are coerced if
+necessary.
+
+For example this will not compile:
 
 ```coffee
 thing = 2
 f'The date is {thing: %v %R}.'
-# The date is 2.
+```
+
+If needed the user will be expected to coerce the type:
+
+```coffee
+f'The date is {timestamp!(thing): %v %R}.'
 ```
 
 ## Implementation
@@ -159,13 +172,6 @@ F-strings could be fallible and their use could require any errors to be handled
 ```coffee
 f'The date is { .date: %v %R }' ?? "invalid date"
 ```
-
-Or
-
-```coffee
-f'The date is { timestamp!(.date): %v %R }'
-```
-
 
 ## Outstanding Questions
 

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -20,7 +20,7 @@ result in bugs.
 
 ## User Experience
 
-We will be loosely basing our format strings on Pythons [f-strings](https://datagy.io/python-f-strings/).
+We will be loosely basing our format strings on Pythons [f-strings](https://peps.python.org/pep-0498/).
 
 To format a string there will be a string type denoted with the prefix `f'`.
 
@@ -114,7 +114,7 @@ elegant form for string creation.
 
 - Template strings are used within certain fields within Vector.
 - Many programming languages offer string interpolation.
-  - [Python](https://datagy.io/python-f-strings/)
+  - [Python](https://peps.python.org/pep-0498/)
   - [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
   - [Ruby](http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html)
 

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -89,7 +89,7 @@ feeling +
 
 ### Fallibility
 
-Due to the way the format strings are implemented as expanding to to an expression
+Due to the way the format strings are implemented as expanding to an expression
 they are automatically fallible if the variable used is not a string.
 
 ```coffee

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -52,14 +52,14 @@ foobar = upcase("foo bar")
 Also, the variable has to resolve to an exact string type, and nothing else:
 ```
 
-# not allowed
+### not allowed
 
 ```coffee
 number = 1
 "{{ number }}"
 ```
 
-# allowed
+### allowed
 
 ```coffee
 number = to_string(1)

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -25,7 +25,7 @@ We will be loosely basing our format strings on Pythons [f-strings](https://peps
 To format a string there will be a string type denoted with the prefix `f'`.
 
 Within that string, it is possible to embed VRL expressions by surrounding them
-with `{..}`. VRL will evaluate the expressions and will call `to_string` on
+with `{..}`. VRL will evaluate the expressions and will call `as_string` on
 that expression to return the text representation.
 
 ```coffee
@@ -83,7 +83,7 @@ concatenation.
 The VRL parser will take a template literal string such as:
 
 ```
-i'The message is {{ .message }} created at {{ .timestamp: %v %R }}'
+f'The message is { .message } created at { .timestamp: %v %R }'
 ```
 
 and create an AST identical to the AST for the following expression:
@@ -152,20 +152,6 @@ Downsides are that the format strings are a hidden DSL themselves and there is
 a cognitive overhead involved in maintaining the position of the format tags
 within the string and the parameters passed to the function.
 
-### Extended template strings
-
-The advantage of format strings over string interpolation is that format strings
-provide for parameters to indicate how numbers could be formatted.
-
-For example, `sprintf("%.2f", 3.14159)` will return `3.14`. With simple string
-interpolation `i'{{ 3.14159 }}'` there is no way to control the number of
-decimals output.
-
-We could extend the format strings to allow for any format parameters to be
-added after a `|` character in the template string. So
-`i'{{ 3.14159 | decimals: 2 }}'` would result in the number formatted to 2
-decimal places - `3.14`.
-
 ### Fallibility
 
 F-strings could be fallible and their use could require any errors to be handled.
@@ -183,7 +169,6 @@ f'The date is { timestamp!(.date): %v %R }'
 
 ## Outstanding Questions
 
-- Is there a better prefix than `i` for string interpolation?
 
 ## Plan Of Attack
 

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -23,18 +23,24 @@ result in bugs.
 The initial version of string interpolation will be the simplest possible, allowing
 for further expansion in the future should it be deemed useful.
 
-We will allow interpolating only string variables in strings delimited by `f'...'`.
+We will allow interpolating only string variables in strings delimited by `"..."`.
 
 Syntax would be as follows:
 
 ```coffee
-f'foo {bar}'
+"foo {bar}"
 ```
 
 You can "escape" `{` and `}` to avoid interpolation:
 
 ```coffee
-f'foo {{bar}}'
+"foo {{bar}}"
+```
+
+Alternatively raw strings can be used:
+
+```coffee
+s'foo {bar}'
 ```
 
 As mentioned, only variables are supported, any other expression evaluation has
@@ -42,20 +48,20 @@ to be done before interpolating:
 
 ```coffee
 foobar = upcase("foo bar")
-f'{foobar} BAZ'
+"{foobar} BAZ"
 Also, the variable has to resolve to an exact string type, and nothing else:
 ```
 
 # not allowed
 ```coffee
 number = 1
-f'{number}'
+"{number}"
 ```
 
 # allowed
 ```coffee
 number = to_string(1)
-f'{number}'
+"{number}"
 ```
 
 ## Implementation
@@ -66,17 +72,17 @@ concatenation.
 The VRL parser will take a template literal string such as:
 
 ```coffee
-f'The message is { message } and we { feeling } it'
+"The message is { message } and we { feeling } it"
 ```
 
 and create an AST identical to the AST for the following expression:
 
 ```coffee
-s'The message is ' +
+"The message is " +
 message +
-s' and we ' +
+" and we " +
 feeling +
-s' it'
+" it"
 ```
 
 ## Rationale

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -22,6 +22,10 @@ result in bugs.
 
 We will be loosely basing our format strings on Pythons [f-strings](https://peps.python.org/pep-0498/).
 
+`f-strings` allow for a combination of embedded expressions and include the ability
+to specify formatting options for the outputs. Plus, their use in a widespread language
+should mean a lot of users will already be familiar with the functionality.
+
 To format a string there will be a string type denoted with the prefix `f'`.
 
 Within that string, it is possible to embed VRL expressions by surrounding them

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -58,14 +58,9 @@ f'The time is {ts : %v %R}'
 ### Errors
 
 We do not want an f string to be fallible as this would cumbersome to the experience of using VRL.
-If an error occurs the error text is output. For example:
 
-```coffee
-f'This is some json { parse_json(.thing) }'
-# This is some json function call error for "parse_json" at (0:18): unable to parse json: expected ident at line 1 column 2
-```
-
-Errors could still be handled to provide alternative text if needed:
+Each template segment must be infallible in order for the string to compile. Errors must be
+handled to provide alternative text if needed:
 
 ```coffee
 f'This is some json { parse_json(.thing) ?? "oops" }'
@@ -176,6 +171,16 @@ F-strings could be fallible and their use could require any errors to be handled
 ```coffee
 f'The date is { .date: %v %R }' ?? "invalid date"
 ```
+
+### Output error text
+
+Rather than forcing the user to handle errors, if an error occurs the error text is output. For example:
+
+```coffee
+f'This is some json { parse_json(.thing) }'
+# This is some json function call error for "parse_json" at (0:18): unable to parse json: expected ident at line 1 column 2
+```
+
 
 ## Outstanding Questions
 

--- a/rfcs/2021-07-27-7117-vrl-string-interpolation.md
+++ b/rfcs/2021-07-27-7117-vrl-string-interpolation.md
@@ -10,58 +10,97 @@ literals, also known as string interpolation, to format strings.
 
 ## Pain
 
-Currently the way to create strings is through either string concatenation or 
-the `join` function. 
+Currently the way to create strings is through either string concatenation or
+the `join` function.
 
-Syntactically this is unwieldly. It requires extra key presses and the code 
-created doesn't necessarily give an instant idea of what the resulting string 
-will look like. Thus the true intent behind the code is obfuscated, which can 
+Syntactically this is unwieldly. It requires extra key presses and the code
+created doesn't necessarily give an instant idea of what the resulting string
+will look like. Thus the true intent behind the code is obfuscated, which can
 result in bugs.
 
 ## User Experience
 
-To format a string there will be a string type denoted with the prefix `l'`.
+We will be loosely basing our format strings on Pythons [f-strings](https://datagy.io/python-f-strings/).
+
+To format a string there will be a string type denoted with the prefix `f'`.
 
 Within that string, it is possible to embed VRL expressions by surrounding them
-with `{{..}}`. VRL will evaluate the expressions and will call `to_string` on
+with `{..}`. VRL will evaluate the expressions and will call `to_string` on
 that expression to return the text representation.
 
-```
-i'The message is {{ .message }} created at {{ .timestamp }}'
+```coffee
+f'The message is { .message } created at { .timestamp }'
 ```
 
-If you wish to actually insert a `{{` into a string, these characters will need
-to be escaped with a `\`. A single `{` will not need escaping. For example:
+If you wish to actually insert a `{` into a string, a double '{{' will be needed.
 
-```
-i'Here is a curly brace -> { and here are some more -> \{{'
+```coffee
+f'Here is a curly brace -> {{'
 ```
 
 Since this is a new string type there are no backward compatibility issues.
 
+### Format strings
+
+The format can be specified by adding format strings after a `:` in the string.
+
+For example to format date the following would be valid:
+
+```coffee
+ts = t'2020-10-21T16:00:00Z'
+f'The time is {ts : %v %R}'
+```
+
+### Errors
+
+The question arises about what we should do if an error occurs.
+
+I would argue that we do not want an f string to be fallible as this would
+cumbersome to the experience of using VRL. If an error occurs the error text is
+output. For example:
+
+```coffee
+f'This is some json { parse_json(.thing) }'
+# This is some json function call error for "parse_json" at (0:18): unable to parse json: expected ident at line 1 column 2
+```
+
+Another source of error would be if the format string is specified for a different
+type - for example using date format strings when the type is an integer.
+
+If this occurs, we just ignore the format string and display the unformatted value.
+
+```coffee
+thing = 2
+f'The date is {thing: %v %R}.'
+# The date is 2.
+```
+
 ## Implementation
 
-This new string type can be considered as syntactic sugar for string 
-concatenation. 
+This new string type can be considered as syntactic sugar for string
+concatenation.
 
 The VRL parser will take a template literal string such as:
 
 ```
-i'The message is {{ .message }} created at {{ .timestamp }}'
+i'The message is {{ .message }} created at {{ .timestamp: %v %R }}'
 ```
 
 and create an AST identical to the AST for the following expression:
 
 ```
-s'The message is ' + 
-to_string(.message) + 
-s' created at ' + 
-to_string(.timestamp)
+s'The message is ' +
+as_string(.message) +
+s' created at ' +
+as_string(.timestamp, format: "%v %R")
 ```
+
+`as_string` is a new function that will convert any type to a string and potentially
+apply format strings. Objects will be json encoded.
 
 ## Rationale
 
-String interpolation or string formats are prevalent in modern programming 
+String interpolation or string formats are prevalent in modern programming
 languages. Users have an expectation that this feature will be available.
 
 String formatting is a common task within VRL. Currently the process involves
@@ -73,9 +112,10 @@ elegant form for string creation.
 
 ## Prior Art
 
-- Template strings are used within certain fields within Vector. 
+- Template strings are used within certain fields within Vector.
 - Many programming languages offer string interpolation.
-  - [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) 
+  - [Python](https://datagy.io/python-f-strings/)
+  - [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
   - [Ruby](http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html)
 
 ## Drawbacks
@@ -87,9 +127,9 @@ This does add additional code complexity and an maintenance burden to VRL.
 ### Format Strings
 
 One alternative is to create a `sprintf` function. `sprintf` takes one parameter
-that represents the format string. Within the format string if a format tag is 
-found, the function will take the next parameter passed and will format that 
-parameter according to the tag and will embed the resulting text in that 
+that represents the format string. Within the format string if a format tag is
+found, the function will take the next parameter passed and will format that
+parameter according to the tag and will embed the resulting text in that
 position.
 
 For example:
@@ -98,7 +138,7 @@ For example:
 sprintf("The message is %s created at %t", .message, .timestamp)
 ```
 
-will return 
+will return
 
 ```
 The message is the message created at Tue, 27 Jul 2021 10:10:01 +0000
@@ -108,23 +148,38 @@ The advantages of this method is that it does not require any changes to the
 VRL compiler, all changes are isolated to a single function. Also it provides
 a way to influence the formatting of the parameters.
 
-Downsides are that the format strings are a hidden DSL themselves and there is 
+Downsides are that the format strings are a hidden DSL themselves and there is
 a cognitive overhead involved in maintaining the position of the format tags
 within the string and the parameters passed to the function.
 
 ### Extended template strings
 
 The advantage of format strings over string interpolation is that format strings
-provide for parameters to indicate how numbers could be formatted. 
+provide for parameters to indicate how numbers could be formatted.
 
 For example, `sprintf("%.2f", 3.14159)` will return `3.14`. With simple string
-interpolation `i'{{ 3.14159 }}'` there is no way to control the number of 
+interpolation `i'{{ 3.14159 }}'` there is no way to control the number of
 decimals output.
 
-We could extend the format strings to allow for any format parameters to be 
-added after a `|` character in the template string. So 
-`i'{{ 3.14159 | decimals: 2 }}'` would result in the number formatted to 2 
+We could extend the format strings to allow for any format parameters to be
+added after a `|` character in the template string. So
+`i'{{ 3.14159 | decimals: 2 }}'` would result in the number formatted to 2
 decimal places - `3.14`.
+
+### Fallibility
+
+F-strings could be fallible and their use could require any errors to be handled.
+
+```coffee
+f'The date is { .date: %v %R }' ?? "invalid date"
+```
+
+Or
+
+```coffee
+f'The date is { timestamp!(.date): %v %R }'
+```
+
 
 ## Outstanding Questions
 


### PR DESCRIPTION
Ref #7117 

This RFC discusses adding string interpolation to VRL so it is possible to construct strings like:

```
"The message is {{ .message }}"
```

Templates are delimited by `{{..}}`, and can be escaped by `\{{...\}}` if necessary.

[Readable](https://github.com/vectordotdev/vector/blob/7117_template_rfc/rfcs/2021-07-27-7117-vrl-string-interpolation.md)


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
