### PR TITLE
enhancement(vrl, cli): improve vrl repl behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4614,6 +4614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "oauth2"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5859,6 +5865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall 0.2.6",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7007,6 +7022,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stdio-override"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c22512d2e95aa9a717da4c955c0085078a1f28b988e0736fc7066fdcc030c8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7333,6 +7357,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall 0.2.6",
+ "redox_termios",
 ]
 
 [[package]]
@@ -8569,7 +8605,9 @@ dependencies = [
  "rustyline",
  "serde_json",
  "shared",
+ "stdio-override",
  "structopt 0.3.22",
+ "termion",
  "thiserror",
  "vrl",
  "vrl-stdlib",

--- a/lib/shared/src/datetime.rs
+++ b/lib/shared/src/datetime.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Local, ParseError, TimeZone as _, Utc};
 use chrono_tz::Tz;
 use derivative::Derivative;
-use std::fmt::Debug;
+use std::{fmt::Debug, str::FromStr};
 
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 #[derivative(Default)]
@@ -9,6 +9,17 @@ pub enum TimeZone {
     #[derivative(Default)]
     Local,
     Named(Tz),
+}
+
+impl FromStr for TimeZone {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "" | "local" => Ok(Self::Local),
+            _ => s.parse::<Tz>().map(Self::Named),
+        }
+    }
 }
 
 /// This is a wrapper trait to allow `TimeZone` types to be passed generically.

--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -11,19 +11,21 @@ name = "vrl"
 path = "src/main.rs"
 
 [dependencies]
-shared = { path = "../../shared", default-features = false }
-vrl = { path = "../core" }
-bytes = "1.0.0"
+bytes = "1"
 exitcode = "1"
+indoc = "1"
+lazy_static = { version = "1", optional = true }
 prettytable-rs = { version = "0.8", default-features = false, optional = true }
 regex = { version = "1", default-features = false, optional = true }
 rustyline = { version = "8", default-features = false, optional = true }
 serde_json = "1"
+shared = { path = "../../shared", default-features = false }
+stdio-override = { version = "0.1", default-features = false, optional = true }
 structopt = { version = "0.3", default-features = false }
+termion = { version = "1", default-features = false, optional = true }
 thiserror = "1"
+vrl = { path = "../core" }
 webbrowser = { version = "0.5", default-features = false, optional = true }
-lazy_static = { version = "1", optional = true }
-indoc = "1.0.3"
 
 [dependencies.stdlib]
 package = "vrl-stdlib"
@@ -31,4 +33,12 @@ path = "../stdlib"
 
 [features]
 default = ["repl"]
-repl = ["lazy_static", "prettytable-rs", "regex", "rustyline", "webbrowser"]
+repl = [
+  "lazy_static",
+  "prettytable-rs",
+  "regex",
+  "rustyline",
+  "stdio-override",
+  "termion",
+  "webbrowser",
+]

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,7 +140,7 @@ impl Application {
                         SubCommand::Tap(t) => tap::cmd(&t).await,
                         SubCommand::Validate(v) => validate::validate(&v, color).await,
                         #[cfg(feature = "vrl-cli")]
-                        SubCommand::Vrl(s) => vrl_cli::cmd::cmd(&s),
+                        SubCommand::Vrl(s) => vrl_cli::cmd(&s),
                     };
 
                     return Err(code);


### PR DESCRIPTION
This PR resolves a long-standing issue I've had with the VRL CLI.

Previously when providing this command:

```
echo '{"foo":"bar"}' | vrl
```

It would open the REPL, but immediately exit because stdin was connected to a piped stream, which precludes the REPL from accepting additional user input on stdin.

After this PR, this works as expected. The CLI first reads the provided input from stdin and generates an event from it, before reconnecting stdin to the underlying TTY FD (if possible), allowing additional user input, making the REPL work as expected.

All other behaviour is kept as is (because I find them to work as expected):


- `echo '{"foo":"bar"}' | vrl .foo` prints `"bar"` without opening the REPL (i.e. "jq" mode)
- `vrl` opens the REPL with a default (empty) event
- `vrl .foo` returns `null` because it's running in "jq" mode, with a default (empty) event, which doesn't contain the `foo` field
- You can still use the available `--input` option to point to an input file instead of stdin
- Similarly, you can point `--program` to a file instead of using the first positional argument as the program (and run in jq mode)