### PR TITLE
enhancement(sinks): Add `logfmt` encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8487,6 +8487,7 @@ dependencies = [
  "vrl-cli",
  "vrl-compiler",
  "vrl-parser",
+ "vrl-shared",
  "vrl-stdlib",
  "walkdir",
  "warp",
@@ -8682,6 +8683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vrl-shared"
+version = "0.1.0"
+dependencies = [
+ "nom 6.1.2",
+ "shared",
+ "vrl-compiler",
+]
+
+[[package]]
 name = "vrl-stdlib"
 version = "0.1.0"
 dependencies = [
@@ -8718,6 +8728,7 @@ dependencies = [
  "url",
  "uuid",
  "vrl",
+ "vrl-shared",
  "woothee",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ tui = { version = "0.16.0", optional = true, default-features = false, features 
 
 # VRL Lang
 vrl = { path = "lib/vrl/core" }
+vrl-shared = { path = "lib/vrl/shared" }
 vrl-stdlib = { path = "lib/vrl/stdlib" }
 vrl-parser = { path = "lib/vrl/parser", optional = true }
 vrl-compiler = { path = "lib/vrl/compiler", optional = true }

--- a/lib/vrl/README.md
+++ b/lib/vrl/README.md
@@ -14,6 +14,7 @@ Library | Purpose
 [`vrl-diagnostic`](diagnostic) | Compiler and runtime error messages as well as runtime error logging
 [`vrl-parser`](parser) | The VRL parser uses an abstract syntax tree (AST) to convert VRL programs inside of Vector configurations into systems of expressions
 [`vrl-proptests`](proptests) | A collection of property-based tests for VRL parser
+[`vrl-shared`](shared) | The code shared between vrl-stdlib and main crate that depends on vrl in some way.
 [`vrl-stdlib`](stdlib) | The current standard library of VRL functions
 [`vrl-tests`](tests) |
 

--- a/lib/vrl/shared/Cargo.toml
+++ b/lib/vrl/shared/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vrl-shared"
+version = "0.1.0"
+authors = ["Vector Contributors <vector@timber.io>"]
+edition = "2018"
+publish = false
+license = "MPL-2.0"
+
+[dependencies]
+vrl-compiler = { path = "../compiler" }
+nom = { version = "6"}
+shared = { path = "../../shared", default-features = false, features = ["btreemap"]}
+

--- a/lib/vrl/shared/LICENSE
+++ b/lib/vrl/shared/LICENSE
@@ -1,0 +1,363 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/lib/vrl/shared/src/encode_key_value.rs
+++ b/lib/vrl/shared/src/encode_key_value.rs
@@ -1,0 +1,327 @@
+use std::collections::BTreeMap;
+use std::fmt::Write;
+use vrl_compiler::Value;
+use Value::{Array, Boolean, Object};
+
+pub fn encode<'a>(
+    input: impl IntoIterator<Item = (String, Value)> + 'a,
+    fields: &[String],
+    key_value_delimiter: &'a str,
+    field_delimiter: &'a str,
+    flatten_boolean: bool,
+) -> String {
+    let mut output = String::new();
+
+    let mut input: BTreeMap<_, _> = flatten(input, String::from(""), '.', 0).collect();
+
+    for field in fields.iter() {
+        match (input.remove(field), flatten_boolean) {
+            (Some(Boolean(false)), true) => (),
+            (Some(Boolean(true)), true) => {
+                encode_string(&mut output, field);
+                output.write_str(field_delimiter).unwrap();
+            }
+            (Some(val), _) => {
+                encode_field(&mut output, field, &val, key_value_delimiter);
+                output.write_str(field_delimiter).unwrap();
+            }
+            (None, _) => (),
+        };
+    }
+
+    for (key, value) in input.iter() {
+        match (value, flatten_boolean) {
+            (Boolean(false), true) => (),
+            (Boolean(true), true) => {
+                encode_string(&mut output, key);
+                output.write_str(field_delimiter).unwrap();
+            }
+            (_, _) => {
+                encode_field(&mut output, key, value, key_value_delimiter);
+                output.write_str(field_delimiter).unwrap();
+            }
+        };
+    }
+
+    if output.ends_with(field_delimiter) {
+        output.truncate(output.len() - field_delimiter.len())
+    }
+
+    output
+}
+
+fn flatten<'a>(
+    input: impl IntoIterator<Item = (String, Value)> + 'a,
+    parent_key: String,
+    separator: char,
+    depth: usize,
+) -> Box<dyn Iterator<Item = (String, Value)> + 'a> {
+    let iter = input.into_iter().map(move |(key, value)| {
+        let new_key = if depth > 0 {
+            format!("{}{}{}", parent_key, separator, key)
+        } else {
+            key
+        };
+
+        match value {
+            Object(map) => flatten(map, new_key, separator, depth + 1),
+            Array(array) => {
+                let array_map: BTreeMap<_, _> = array
+                    .into_iter()
+                    .enumerate()
+                    .map(|(key, value)| (key.to_string(), value))
+                    .collect();
+                flatten(array_map, new_key, separator, depth + 1)
+            }
+            _ => Box::new(std::iter::once((new_key, value)))
+                as Box<dyn Iterator<Item = (String, Value)>>,
+        }
+    });
+
+    Box::new(iter.flatten())
+}
+
+fn encode_field<'a>(output: &mut String, key: &str, value: &Value, key_value_delimiter: &'a str) {
+    encode_string(output, key);
+    output.write_str(key_value_delimiter).unwrap();
+    encode_value(output, value)
+}
+
+fn encode_value(output: &mut String, value: &Value) {
+    match value {
+        Value::Bytes(b) => {
+            let val = String::from_utf8_lossy(b);
+            encode_string(output, &val)
+        }
+        _ => encode_string(output, &value.to_string()),
+    }
+}
+
+fn encode_string(output: &mut String, str: &str) {
+    let needs_quoting = str.chars().any(char::is_whitespace);
+
+    if needs_quoting {
+        output.write_char('"').unwrap();
+    }
+
+    for c in str.chars() {
+        match c {
+            '\\' => output.write_str(r#"\\"#).unwrap(),
+            '"' => output.write_str(r#"\""#).unwrap(),
+            '\n' => output.write_str(r#"\\n"#).unwrap(),
+            _ => output.write_char(c).unwrap(),
+        }
+    }
+
+    if needs_quoting {
+        output.write_char('"').unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::btreemap;
+    use vrl_compiler::value;
+
+    #[test]
+    fn single_element() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "lvl" => "info"
+                },
+                &[],
+                "=",
+                " ",
+                true
+            ),
+            "lvl=info"
+        )
+    }
+
+    #[test]
+    fn multiple_elements() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "lvl" => "info",
+                    "log_id" => 12345
+                },
+                &[],
+                "=",
+                " ",
+                true
+            ),
+            "log_id=12345 lvl=info"
+        )
+    }
+
+    #[test]
+    fn string_with_spaces() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "lvl" => "info",
+                    "msg" => "This is a log message"
+                },
+                &[],
+                "=",
+                " ",
+                true
+            ),
+            r#"lvl=info msg="This is a log message""#
+        )
+    }
+
+    #[test]
+    fn flatten_boolean() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "beta" => true,
+                    "prod" => false,
+                    "lvl" => "info",
+                    "msg" => "This is a log message",
+                },
+                &[],
+                "=",
+                " ",
+                true
+            ),
+            r#"beta lvl=info msg="This is a log message""#
+        )
+    }
+
+    #[test]
+    fn dont_flatten_boolean() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "beta" => true,
+                    "prod" => false,
+                    "lvl" => "info",
+                    "msg" => "This is a log message",
+                },
+                &[],
+                "=",
+                " ",
+                false
+            ),
+            r#"beta=true lvl=info msg="This is a log message" prod=false"#
+        )
+    }
+
+    #[test]
+    fn other_delimiters() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "tag_a" => "val_a",
+                    "tag_b" => "val_b",
+                    "tag_c" => true,
+                },
+                &[],
+                ":",
+                ",",
+                true
+            ),
+            r#"tag_a:val_a,tag_b:val_b,tag_c"#
+        )
+    }
+
+    #[test]
+    fn string_with_characters_to_escape() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "lvl" => "info",
+                    "msg" => r#"payload: {"code": 200}\n"#,
+                    "another_field" => "some\nfield\\and things",
+                    "space key" => "foo"
+                },
+                &[],
+                "=",
+                " ",
+                true
+            ),
+            r#"another_field="some\\nfield\\and things" lvl=info msg="payload: {\"code\": 200}\\n" "space key"=foo"#
+        )
+    }
+
+    #[test]
+    fn nested_fields() {
+        assert_eq!(
+                &encode(
+                    btreemap! {
+                        "log" => btreemap! {
+                            "file" => btreemap! {
+                                "path" => "encode_key_value.rs"
+                            },
+                        },
+                        "agent" => btreemap! {
+                            "name" => "vector",
+                            "id" => 1234
+                        },
+                        "network" => btreemap! {
+                            "ip" => value!([127, 0, 0, 1]),
+                            "proto" => "tcp"
+                        },
+                        "event" => "log"
+                    },
+                    &[],
+                    "=",
+                    " ",
+                    true
+                )
+                ,
+                "agent.id=1234 agent.name=vector event=log log.file.path=encode_key_value.rs network.ip.0=127 network.ip.1=0 network.ip.2=0 network.ip.3=1 network.proto=tcp"
+            )
+    }
+
+    #[test]
+    fn fields_ordering() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "lvl" => "info",
+                    "msg" => "This is a log message",
+                    "log_id" => 12345,
+                },
+                &["lvl".to_string(), "msg".to_string()],
+                "=",
+                " ",
+                true
+            ),
+            r#"lvl=info msg="This is a log message" log_id=12345"#
+        )
+    }
+
+    #[test]
+    fn nested_fields_ordering() {
+        assert_eq!(
+            &encode(
+                btreemap! {
+                    "log" => btreemap! {
+                        "file" => btreemap! {
+                            "path" => "encode_key_value.rs"
+                        },
+                    },
+                    "agent" => btreemap! {
+                        "name" => "vector",
+                    },
+                    "event" => "log"
+                },
+                &[
+                    "event".to_owned(),
+                    "log.file.path".to_owned(),
+                    "agent.name".to_owned()
+                ],
+                "=",
+                " ",
+                true
+            ),
+            "event=log log.file.path=encode_key_value.rs agent.name=vector"
+        )
+    }
+}

--- a/lib/vrl/shared/src/encode_logfmt.rs
+++ b/lib/vrl/shared/src/encode_logfmt.rs
@@ -1,0 +1,6 @@
+use crate::encode_key_value;
+use vrl_compiler::Value;
+
+pub fn encode<'a>(input: impl IntoIterator<Item = (String, Value)> + 'a) -> String {
+    encode_key_value::encode(input, &[], "=", " ", true)
+}

--- a/lib/vrl/shared/src/lib.rs
+++ b/lib/vrl/shared/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod encode_key_value;
+pub mod encode_logfmt;

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 
 [dependencies]
 vrl = { path = "../core" }
+vrl-shared = { path = "../shared" }
 lookup = { path = "../../lookup" }
 datadog-search-syntax = { path = "../../datadog/search-syntax", optional = true }
 

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -1,8 +1,6 @@
-use std::collections::BTreeMap;
-use std::fmt::Write;
 use std::result::Result;
 use vrl::prelude::*;
-use Value::{Array, Boolean, Object};
+use vrl_shared::encode_key_value::encode;
 
 #[derive(Clone, Copy, Debug)]
 pub struct EncodeKeyValue;
@@ -144,121 +142,6 @@ impl Expression for EncodeKeyValueFn {
             .bytes()
             .with_fallibility(self.fields.is_some())
     }
-}
-
-fn encode_string(output: &mut String, str: &str) {
-    let needs_quoting = str.chars().any(char::is_whitespace);
-
-    if needs_quoting {
-        output.write_char('"').unwrap();
-    }
-
-    for c in str.chars() {
-        match c {
-            '\\' => output.write_str(r#"\\"#).unwrap(),
-            '"' => output.write_str(r#"\""#).unwrap(),
-            '\n' => output.write_str(r#"\\n"#).unwrap(),
-            _ => output.write_char(c).unwrap(),
-        }
-    }
-
-    if needs_quoting {
-        output.write_char('"').unwrap();
-    }
-}
-
-fn encode_value(output: &mut String, value: &Value) {
-    match value {
-        Value::Bytes(b) => {
-            let val = String::from_utf8_lossy(b);
-            encode_string(output, &val)
-        }
-        _ => encode_string(output, &value.to_string()),
-    }
-}
-
-fn flatten<'a>(
-    input: impl IntoIterator<Item = (String, Value)> + 'a,
-    parent_key: String,
-    separator: char,
-    depth: usize,
-) -> Box<dyn Iterator<Item = (String, Value)> + 'a> {
-    let iter = input.into_iter().map(move |(key, value)| {
-        let new_key = if depth > 0 {
-            format!("{}{}{}", parent_key, separator, key)
-        } else {
-            key
-        };
-
-        match value {
-            Object(map) => flatten(map, new_key, separator, depth + 1),
-            Array(array) => {
-                let array_map: BTreeMap<_, _> = array
-                    .into_iter()
-                    .enumerate()
-                    .map(|(key, value)| (key.to_string(), value))
-                    .collect();
-                flatten(array_map, new_key, separator, depth + 1)
-            }
-            _ => Box::new(std::iter::once((new_key, value)))
-                as Box<dyn Iterator<Item = (std::string::String, vrl::Value)>>,
-        }
-    });
-
-    Box::new(iter.flatten())
-}
-
-fn encode_field<'a>(output: &mut String, key: &str, value: &Value, key_value_delimiter: &'a str) {
-    encode_string(output, key);
-    output.write_str(key_value_delimiter).unwrap();
-    encode_value(output, value)
-}
-
-pub fn encode<'a>(
-    input: BTreeMap<String, Value>,
-    fields: &[String],
-    key_value_delimiter: &'a str,
-    field_delimiter: &'a str,
-    flatten_boolean: bool,
-) -> String {
-    let mut output = String::new();
-
-    let mut input: BTreeMap<_, _> = flatten(input, String::from(""), '.', 0).collect();
-
-    for field in fields.iter() {
-        match (input.remove(field), flatten_boolean) {
-            (Some(Boolean(false)), true) => (),
-            (Some(Boolean(true)), true) => {
-                encode_string(&mut output, field);
-                output.write_str(field_delimiter).unwrap();
-            }
-            (Some(val), _) => {
-                encode_field(&mut output, field, &val, key_value_delimiter);
-                output.write_str(field_delimiter).unwrap();
-            }
-            (None, _) => (),
-        };
-    }
-
-    for (key, value) in input.iter() {
-        match (value, flatten_boolean) {
-            (Boolean(false), true) => (),
-            (Boolean(true), true) => {
-                encode_string(&mut output, key);
-                output.write_str(field_delimiter).unwrap();
-            }
-            (_, _) => {
-                encode_field(&mut output, key, value, key_value_delimiter);
-                output.write_str(field_delimiter).unwrap();
-            }
-        };
-    }
-
-    if output.ends_with(field_delimiter) {
-        output.truncate(output.len() - field_delimiter.len())
-    }
-
-    output
 }
 
 #[cfg(test)]

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -51,7 +51,7 @@ _values: {
 // * `deprecated` - The component will be removed in a future version.
 #DevelopmentStatus: "beta" | "stable" | "deprecated"
 
-#EncodingCodec: "json" | "ndjson" | "text"
+#EncodingCodec: "json" | "logfmt" | "ndjson" | "text"
 
 #Endpoint: {
 	description: string

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -29,7 +29,7 @@ components: sinks: loki: {
 				codec: {
 					enabled: true
 					default: "json"
-					enum: ["json", "text"]
+					enum: ["json", "logfmt", "text"]
 				}
 			}
 			proxy: enabled: true


### PR DESCRIPTION
Closes #8060

Existence of two representations for `Value`, one VRL other Vector, complicates things. For now it seems simplest to transform Vector `Value` to VRL `Value` since even with this conversion it will be faster than going through remap. 

An alternative would be to abstract over both values via trait or enum. But the resulting abstraction would be quite specific and probably won't be useful anywhere else at the moment. `Serialize` could be used instead but some 300 lines extra would be needed to bridge the gap which seems kinda much for this. 

This is a draft at the moment so to gather comments on the direction. What remains is to extend this to other sinks.

cc. @bruceg @jszwedko 


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
