### PR TITLE
enhancement(aws_cloudwatch_logs sink): add support for custom log retention period

### DIFF
--- a/src/sinks/aws_cloudwatch_logs/mod.rs
+++ b/src/sinks/aws_cloudwatch_logs/mod.rs
@@ -69,6 +69,7 @@ pub struct CloudwatchLogsSinkConfig {
     pub encoding: EncodingConfig<Encoding>,
     pub create_missing_group: Option<bool>,
     pub create_missing_stream: Option<bool>,
+    pub retention_in_days: Option<u64>,
     #[serde(default)]
     pub compression: Compression,
     #[serde(default)]
@@ -99,6 +100,7 @@ fn default_config(e: Encoding) -> CloudwatchLogsSinkConfig {
         encoding: e.into(),
         create_missing_group: Default::default(),
         create_missing_stream: Default::default(),
+        retention_in_days: Default::default(),
         compression: Default::default(),
         batch: Default::default(),
         request: Default::default(),
@@ -113,6 +115,7 @@ pub struct CloudwatchLogsSvc {
     group_name: String,
     create_missing_group: bool,
     create_missing_stream: bool,
+    retention_in_days: u64,
     token: Option<String>,
     token_rx: Option<oneshot::Receiver<Option<String>>>,
 }
@@ -283,6 +286,7 @@ impl CloudwatchLogsSvc {
 
         let create_missing_group = config.create_missing_group.unwrap_or(true);
         let create_missing_stream = config.create_missing_stream.unwrap_or(true);
+        let retention_in_days = config.retention_in_days.unwrap_or(0);
 
         CloudwatchLogsSvc {
             client,
@@ -290,6 +294,7 @@ impl CloudwatchLogsSvc {
             group_name,
             create_missing_group,
             create_missing_stream,
+            retention_in_days,
             token: None,
             token_rx: None,
         }
@@ -386,6 +391,7 @@ impl Service<Vec<InputLogEvent>> for CloudwatchLogsSvc {
                 self.group_name.clone(),
                 self.create_missing_group,
                 self.create_missing_stream,
+                self.retention_in_days,
                 event_batches,
                 self.token.take(),
                 tx,
@@ -882,6 +888,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             create_missing_group: None,
             create_missing_stream: None,
+            retention_in_days: None,
             compression: Default::default(),
             batch: Default::default(),
             request: Default::default(),
@@ -929,6 +936,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             create_missing_group: None,
             create_missing_stream: None,
+            retention_in_days: None,
             compression: Default::default(),
             batch: Default::default(),
             request: Default::default(),
@@ -995,6 +1003,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             create_missing_group: None,
             create_missing_stream: None,
+            retention_in_days: None,
             compression: Default::default(),
             batch: Default::default(),
             request: Default::default(),
@@ -1067,6 +1076,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             create_missing_group: None,
             create_missing_stream: None,
+            retention_in_days: None,
             compression: Default::default(),
             batch: Default::default(),
             request: Default::default(),
@@ -1116,6 +1126,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             create_missing_group: None,
             create_missing_stream: None,
+            retention_in_days: None,
             compression: Default::default(),
             batch: BatchConfig {
                 max_events: Some(2),
@@ -1167,6 +1178,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             create_missing_group: None,
             create_missing_stream: None,
+            retention_in_days: None,
             compression: Default::default(),
             batch: Default::default(),
             request: Default::default(),
@@ -1253,6 +1265,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             create_missing_group: None,
             create_missing_stream: None,
+            retention_in_days: None,
             compression: Default::default(),
             batch: Default::default(),
             request: Default::default(),

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -501,7 +501,7 @@ _values: {
 	unit: #Unit | null
 }
 
-#Unit: "bytes" | "events" | "milliseconds" | "requests" | "seconds" | "lines"
+#Unit: "bytes" | "events" | "requests" | "lines" | "milliseconds" | "seconds" | "days"
 
 administration: _
 components:     _

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -91,9 +91,11 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 			type: bool: default: true
 		}
 		retention_days: {
-			description: "Specifies the number of days log events remain in the log group"
+			common:      false
+			description: "Specifies the number of days log events remain in the log group."
 			required:    false
 			type: uint: {
+				default: null
 				examples: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
 				unit: "days"
 			}

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -90,6 +90,11 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 			required:    false
 			type: bool: default: true
 		}
+		retention_in_days: {
+			description: "Specifies the number of days log events remain in the log group"
+			required:    false
+			type: uint: default: 0
+		}
 		group_name: {
 			description: "The [group name](\(urls.aws_cloudwatch_logs_group_name)) of the target CloudWatch Logs stream."
 			required:    true
@@ -126,6 +131,10 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 				{
 					_action:       "CreateLogStream"
 					required_when: "[`create_missing_stream`](#create_missing_stream) is set to `true`"
+				},
+				{
+					_action:       "PutRetentionPolicy"
+					required_when: "[`retention_in_days`](#retention_in_days) is set"
 				},
 				{
 					_action: "DescribeLogGroups"

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -90,10 +90,13 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 			required:    false
 			type: bool: default: true
 		}
-		retention_in_days: {
+		retention_days: {
 			description: "Specifies the number of days log events remain in the log group"
 			required:    false
-			type: uint: default: 0
+			type: uint: {
+				examples: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+				unit: "days"
+			}
 		}
 		group_name: {
 			description: "The [group name](\(urls.aws_cloudwatch_logs_group_name)) of the target CloudWatch Logs stream."
@@ -134,7 +137,7 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 				},
 				{
 					_action:       "PutRetentionPolicy"
-					required_when: "[`retention_in_days`](#retention_in_days) is set"
+					required_when: "[`retention_days`](#retention_days) is set"
 				},
 				{
 					_action: "DescribeLogGroups"


### PR DESCRIPTION
## Description
This PR adds a new configuration option to set the log retention period (in days) for new cloudwatch log groups created by vector.

~The default value is 0, which sets it to `never expire`.~
