### PR TITLE
chore: Silence a couple of clippy warnings

### DIFF
--- a/lib/lookup/src/lookup_buf/mod.rs
+++ b/lib/lookup/src/lookup_buf/mod.rs
@@ -235,6 +235,10 @@ impl Look<'static> for LookupBuf {
         self.is_empty()
     }
 
+    #[allow(clippy::should_implement_trait)]
+    // This is also defined as `FromStr` on `LookupBuf` but we need `from_str` to be defined on the
+    // `Lookup` trait itself since we cannot define `FromStr` for `LookupView` due to the lifetime
+    // constraint
     pub fn from_str(value: &'static str) -> Result<LookupBuf, LookupError> {
         Lookup::from_str(value).map(|l| l.into_buf())
     }

--- a/lib/lookup/src/lookup_view/mod.rs
+++ b/lib/lookup/src/lookup_view/mod.rs
@@ -159,6 +159,8 @@ impl<'a> Look<'a> for Lookup<'a> {
     }
 
     /// Parse the lookup from a str.
+    #[allow(clippy::should_implement_trait)]
+    // Cannot be defined as `FromStr` due to lifetime constraint on return type
     pub fn from_str(input: &'a str) -> Result<Self, LookupError> {
         crate::parser::parse_lookup(input).map_err(|err| LookupError::Invalid { message: err })
     }


### PR DESCRIPTION
These snuck in in https://github.com/timberio/vector/pull/8832 because I merged it thinking that the only error was the helm whitespace error already fixed on master.

The alternative would be to eschew `FromStr` and implement `TryFrom<&'a str>` instead as mentioned on https://stackoverflow.com/questions/28931515/how-do-i-implement-fromstr-with-a-concrete-lifetime

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
