### PR TITLE
chore(releasing): Remove debug build verification for release build

### DIFF
--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -127,9 +127,6 @@ elif [[ "$CHANNEL" == "latest" ]]; then
   verify_artifact \
     "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
     "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
-  verify_artifact \
-    "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu-debug.tar.gz" \
-    "$td/vector-$VERSION-x86_64-unknown-linux-gnu-debug.tar.gz"
 fi
 
 #


### PR DESCRIPTION
This isn't built for normal releases, just nightlies.

(the failure: https://github.com/timberio/vector/runs/3426078963?check_suite_focus=true)

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
