### PR TITLE
docs(vector sink): Document that `request` options can be set

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -377,6 +377,7 @@ components: {
 				retry_max_duration_secs:    uint64 | *3600
 				timeout_secs:               uint64 | *60
 				headers:                    bool
+				relevant_when?:             string
 			}
 		}
 

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -244,6 +244,9 @@ components: sinks: [Name=string]: {
 					common:      false
 					description: "Configures the sink request behavior."
 					required:    false
+					if features.send.request.relevant_when != _|_ {
+						relevant_when: features.send.request.relevant_when
+					}
 					type: object: {
 						examples: []
 						options: {

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -17,7 +17,6 @@ components: sinks: vector: {
 		service_providers: []
 		stateful: false
 	}
-
 	features: {
 		buffer: enabled:      true
 		healthcheck: enabled: true
@@ -26,7 +25,12 @@ components: sinks: vector: {
 			encoding: enabled:          false
 			send_buffer_bytes: enabled: true
 			keepalive: enabled:         true
-			request: enabled:           false
+			request: {
+				enabled:       true
+				headers:       false
+				relevant_when: "version = \"v2\""
+			}
+
 			tls: {
 				enabled:                true
 				can_enable:             true


### PR DESCRIPTION
If version is v2

Prompted by [user in
discord](https://discord.com/channels/742820443487993987/746070591097798688/880220172722507897)

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
