### PR TITLE
docs(vector source,vector sink): update the example to the correct version options

### DIFF
--- a/website/content/en/highlights/2021-08-24-vector-source-sink.md
+++ b/website/content/en/highlights/2021-08-24-vector-source-sink.md
@@ -35,11 +35,11 @@ follows:
 ```diff
 [sinks.vector]
   type = "vector"
-+ version = "v2"
++ version = "2"
 
 [sources.vector]
   type = "vector"
-+ version = "v2"
++ version = "2"
 ```
 
 There are a couple of things to be aware of:
@@ -62,12 +62,12 @@ First, deploy the configuration that defines the source:
   [sources.vector]
     address = "0.0.0.0:9000"
     type = "vector"
-+   version = "v1"
++   version = "1"
 
 + [sources.vector]
 +   address = "0.0.0.0:5000"
 +   type = "vector"
-+   version = "v2"
++   version = "2"
 ```
 
 Then, deploy the sink configuration, switching it over to the new version:
@@ -77,7 +77,7 @@ Then, deploy the sink configuration, switching it over to the new version:
 -   address = "127.0.1.2:9000"
 +   address = "127.0.1.2:5000"
     type = "vector"
-+   version = "v2"
++   version = "2"
 ```
 
 Once the sink is deployed, you can do another deploy of the source, removing the
@@ -87,12 +87,12 @@ old version:
 - [sources.vector]
 -   address = "0.0.0.0:9000"
 -   type = "vector"
--   version = "v1"
+-   version = "1"
 -
   [sources.vector]
     address = "0.0.0.0:5000"
     type = "vector"
-    version = "v2"
+    version = "2"
 ```
 
 That's it! You are now using the new transport protocol for Vector-to-Vector


### PR DESCRIPTION
Hi,

the example in https://vector.dev/highlights/2021-08-24-vector-source-sink/ which describes how to use the new vector v2 version does not work.

The PR should align this to the correct options as described in the [docs](https://vector.dev/docs/reference/configuration/sinks/vector/#version).
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
