### PR TITLE
chore: Address vector_core build break

### DIFF
--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -24,6 +24,7 @@
 #[cfg(feature = "api")]
 pub mod api;
 pub mod config;
+#[cfg(feature = "vrl")]
 pub mod enrichment;
 pub mod event;
 pub mod mapping;

--- a/lib/vector-core/src/transform/config.rs
+++ b/lib/vector-core/src/transform/config.rs
@@ -1,4 +1,5 @@
 use crate::config::GlobalOptions;
+#[cfg(feature = "vrl")]
 use crate::enrichment;
 use async_trait::async_trait;
 use indexmap::IndexMap;
@@ -16,10 +17,17 @@ pub enum ExpandType {
     Serial,
 }
 
+#[cfg(feature = "vrl")]
 #[derive(Debug, Default)]
 pub struct TransformContext {
     pub globals: GlobalOptions,
     pub enrichment_tables: enrichment::TableRegistry,
+}
+
+#[cfg(not(feature = "vrl"))]
+#[derive(Debug, Default)]
+pub struct TransformContext {
+    pub globals: GlobalOptions,
 }
 
 impl TransformContext {


### PR DESCRIPTION
This commit addresses a build break in vector_core. The problem was introduced
along with the enrichment table work, primarily baking in the assumption that
VRL is always lit in core. By default it is not but you'll only notice this if
you're working on core directly.

This commit makes no adjustment to our CI process to run vector_core's tests
independently of the vector super-crate. This commit also makes no adjustment of
where enrichment code lives, though if it's primarily VRL support we might
consider if core is the proper location for it.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
