### PR TITLE
chore: Add `Finalizable` and `Partitioner` to vector-core

### DIFF
--- a/lib/vector-core/src/event/finalization.rs
+++ b/lib/vector-core/src/event/finalization.rs
@@ -323,6 +323,16 @@ impl EventStatus {
     }
 }
 
+/// An object that can be finalized.
+pub trait Finalizable {
+    /// Consumes the finalizers of this object.
+    ///
+    /// Typically used for coalescing the finalizers of multiple items, such as
+    /// when batching finalizable objects where all finalizations will be
+    /// processed when the batch itself is processed.
+    fn take_finalizers(&mut self) -> EventFinalizers;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -1,3 +1,4 @@
+use crate::event::finalization::Finalizable;
 use crate::ByteSizeOf;
 use buffers::bytes::{DecodeBytes, EncodeBytes};
 use bytes::{Buf, BufMut, Bytes};
@@ -52,6 +53,15 @@ impl ByteSizeOf for Event {
         match self {
             Event::Log(log_event) => log_event.allocated_bytes(),
             Event::Metric(metric_event) => metric_event.allocated_bytes(),
+        }
+    }
+}
+
+impl Finalizable for Event {
+    fn take_finalizers(&mut self) -> EventFinalizers {
+        match self {
+            Event::Log(log) => log.metadata_mut().take_finalizers(),
+            Event::Metric(metric) => metric.metadata_mut().take_finalizers(),
         }
     }
 }

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -36,6 +36,7 @@ mod test_util;
 pub mod transform;
 pub use buffers;
 mod byte_size_of;
+pub mod partition;
 pub mod serde;
 
 pub use byte_size_of::ByteSizeOf;

--- a/lib/vector-core/src/partition.rs
+++ b/lib/vector-core/src/partition.rs
@@ -1,0 +1,17 @@
+use std::hash::Hash;
+
+/// Calculate partitions for an item
+///
+/// This trait allows us to express in the type system that for some `Item` we
+/// are able to calculate a `Key` that identifies that item.
+pub trait Partitioner {
+    type Item;
+    type Key: Clone + Eq + Hash;
+
+    /// Partition the `Item` by calculating its `Key`
+    ///
+    /// The resulting key should ideally be unique for an `Item` or arrived at
+    /// in such a way that if two distinct `Item` instances partition to the
+    /// same key they are mergable if put into the same collection by this key.
+    fn partition(&self, item: &Self::Item) -> Option<Self::Key>;
+}


### PR DESCRIPTION
This commit extracts the two traits mentioned in the subject from #8884. These
traits allow us to treat with `Event` instances in a type-system generic way and
will have bearing in work on #8825 as well.

This work was originally done by @tobz in #8884.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
