### PR TITLE
chore: Update link on 0.16.0 release page to fix build

### DIFF
--- a/website/cue/reference/releases/0.16.0.cue
+++ b/website/cue/reference/releases/0.16.0.cue
@@ -9,7 +9,7 @@ releases: "0.16.0": {
 
 	The Vector team is pleased to announce version 0.16.0!
 
-	Be sure to check out the [upgrade guide](/highlights/2021-07-21-0-16-upgrade-guide) for breaking changes in this release.
+	Be sure to check out the [upgrade guide](/highlights/2021-08-25-0-16-upgrade-guide) for breaking changes in this release.
 
 	This release includes:
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

@jszwedko updated the filename for the 0.16 upgrade guide, which in turn would mean a new path on the website for it. Once this change was merged we began to fail the netlify build process which checks the built site for broken links. The link I've changed here _is_ broken in the current code, but not on the current site (which hasn't been updated since we renamed the upgrade guide)
