### PR TITLE
chore: Add note about RBAC required for kubernetes_logs (#8915)

### DIFF
--- a/website/content/en/highlights/2021-08-25-0-16-upgrade-guide.md
+++ b/website/content/en/highlights/2021-08-25-0-16-upgrade-guide.md
@@ -2,7 +2,7 @@
 date: "2021-08-25"
 title: "0.16 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.16.0"
-authors: ["jszwedko", "JeanMertz"]
+authors: ["jszwedko", "JeanMertz", "spencergilbert"]
 pr_numbers: []
 release: "0.16.0"
 hide_on_release_notes: false
@@ -16,6 +16,7 @@ Vector's 0.16.0 release includes three **breaking changes**:
 1. [Datadog Log sink encoding option removed](#encoding)
 1. [Renaming of `memory_use_bytes` internal metric](#memory_use_bytes)
 1. [`datadog_logs` source renamed to `datadog_agent`](#datadog_logs_rename)
+1. [`kubernetes_logs` source's new RBAC](#kubernetes_logs_rbac)
 
 We cover them below to help you upgrade quickly:
 
@@ -105,6 +106,11 @@ compatible and the name change reflects this.
 It is possible that we will re-add a `datadog_logs` source in the future that mimics the Datadog API for use with other
 Datadog clients aside from the agent. Let us know if this would be useful to you!
 
+### `kubernetes_logs` source's new RBAC {#kubernetes_logs_rbac}
+
+The `kubernetes_logs` source will now enrich events with labels from the Namespace they originate from. This enhancement
+requires access to an additional resource in Kubernetes. Our Kubernetes manifests and Helm chart have been updated to
+create a `ClusterRole` granting access to the `namespaces` resource.
 
 ## Upgrade Guide
 
@@ -116,6 +122,24 @@ Rename a `datadog_logs` source components in your configuration to `datadog_agen
 +type = "datadog_agent"
 address = "0.0.0.0:8080"
 store_api_key = true
+```
+
+Updating to 0.16.0 requires that you update to the equivalent chart or Kubernetes manifests. If you don't use either of
+our provided installation methods, you should update your `ClusterRole` as such:
+
+```diff
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
++     - namespaces
+      - pods
+    verbs:
+      - watch
 ```
 
 [datadog_agent]: https://docs.datadoghq.com/agent/


### PR DESCRIPTION
* Add kubernetes_logs note to 0.16.0 upgrade guide

Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

* Fix TOC

Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Cherry picking from master into v0.16

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
