### PR TITLE
chore(generator source): Generate config with JSON default

### DIFF
--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -33,7 +33,6 @@ pub enum GeneratorConfigError {
 #[derivative(Default)]
 #[serde(tag = "format", rename_all = "snake_case")]
 pub enum OutputFormat {
-    #[derivative(Default)]
     Shuffle {
         #[serde(default)]
         sequence: bool,
@@ -45,6 +44,7 @@ pub enum OutputFormat {
     Syslog,
     #[serde(alias = "rfc3164")]
     BsdSyslog,
+    #[derivative(Default)]
     Json,
 }
 


### PR DESCRIPTION
The current generation defaults to shuffle but doesn't provide any
lines so the configuration does not run.

I think JSON is a better default since we should be encouraging
structured logs.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
