### PR TITLE
fix(external docs): Add link checking to preview builds for vector.dev

### DIFF
--- a/website/content/en/docs/reference/configuration/transforms/wasm.md
+++ b/website/content/en/docs/reference/configuration/transforms/wasm.md
@@ -1,0 +1,15 @@
+---
+title: WebAssembly (Wasm) transform
+description: Modify events using an embedded [WebAssembly](https://webassembly.org) (Wasm) virtual machine
+short: Wasm
+kind: transform
+layout: component
+tags: ["wasm", "webassembly", "runtime", "component", "transform"]
+---
+
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}


### PR DESCRIPTION
This was an oversight on my part. The issue is that this introduces the possibility that the site builds fine for previews and then fails in production builds. This should eliminate any future headaches around discrepancies in build results between the two environments.

FYI this PR includes the link fix pushed to the `v0.16` branch (via cherry pick).