### PR TITLE
fix: reorder service layers to prevent unbounded retries

### DIFF
--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -28,6 +28,7 @@ use rand::{thread_rng, Rng};
 use rand_distr::Exp1;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
+use std::pin::Pin;
 use std::{
     collections::{HashMap, VecDeque},
     fmt,
@@ -163,11 +164,7 @@ impl SinkConfig for TestConfig {
 
         // Dig deep to get at the internal controller statistics
         let stats = Arc::clone(
-            &sink
-                .get_ref()
-                .get_ref()
-                .get_ref()
-                .get_ref()
+            &Pin::new(&sink.get_ref().get_ref().get_ref().get_ref())
                 .get_ref()
                 .controller
                 .stats,

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -22,7 +22,7 @@ use tower::{
 mod concurrency;
 mod map;
 
-pub type Svc<S, L> = RateLimit<Retry<FixedRetryPolicy<L>, AdaptiveConcurrencyLimit<Timeout<S>, L>>>;
+pub type Svc<S, L> = RateLimit<AdaptiveConcurrencyLimit<Retry<FixedRetryPolicy<L>, Timeout<S>>, L>>;
 pub type TowerBatchedSink<S, B, RL, SL> = BatchSink<Svc<S, RL>, B, SL>;
 pub type TowerPartitionSink<S, B, RL, K, SL> = PartitionBatchSink<Svc<S, RL>, B, K, SL>;
 
@@ -245,12 +245,12 @@ impl TowerRequestSettings {
         let policy = self.retry_policy(retry_logic.clone());
         ServiceBuilder::new()
             .rate_limit(self.rate_limit_num, self.rate_limit_duration)
-            .retry(policy)
             .layer(AdaptiveConcurrencyLimitLayer::new(
                 self.concurrency,
                 self.adaptive_concurrency,
                 retry_logic,
             ))
+            .retry(policy)
             .timeout(self.timeout)
             .service(service)
     }

--- a/tests/data/adaptive-concurrency/defers-at-high-concurrency.toml
+++ b/tests/data/adaptive-concurrency/defers-at-high-concurrency.toml
@@ -10,30 +10,31 @@ concurrency_limit_params.action = "defer"
 # this may actually occasionally go over the error limit above, but it
 # will be rare.
 [stats.in_flight]
-max = [5, 7]
-mode = [4, 6]
-mean = [3.5, 5.0]
+max = [5, 18]
+mode = [0, 6]
+mean = [2.2, 5.0]
 
 [stats.rate]
-max = [52, 52]
-mean = [43, 44]
+max = [52, 62]
+mean = [20, 44]
 
 [controller.in_flight]
-max = [5, 7]
-mode = [4, 6]
-mean = [3.5, 5.0]
+max = [5, 39]
+mode = [4, 27]
+mean = [3.5, 26]
 
 [controller.concurrency_limit]
-max = [6, 7]
-mode = [2, 6]
-mean = [4.0, 6.0]
+max = [6, 39]
+mode = [2, 27]
+mean = [4.0, 26.5]
 
 [controller.observed_rtt]
 min = [0.100, 0.102]
-max = [0.100, 0.102]
-mean = [0.100, 0.102]
+max = [0.100, 12.7]
+mean = [0.100, 5.7]
 
 [controller.averaged_rtt]
 min = [0.100, 0.102]
-max = [0.100, 0.102]
-mean = [0.100, 0.102]
+max = [0.100, 7.0]
+mean = [0.100, 3.2]
+

--- a/tests/data/adaptive-concurrency/defers-at-high-rate.toml
+++ b/tests/data/adaptive-concurrency/defers-at-high-rate.toml
@@ -9,27 +9,27 @@ rate.action = "defer"
 # drop down repeatedly.
 
 [stats.in_flight]
-max = [16, 16]
-mean = [8.0, 9.0]
+max = [16, 24]
+mean = [6.0, 9.0]
 
 [stats.rate]
-max = [90, 120]
-mean = [74, 78]
+max = [90, 123]
+mean = [31, 75]
 
 [controller.in_flight]
-max = [16, 16]
-mean = [8.0, 10.0]
+max = [16, 24]
+mean = [8.0, 19.0]
 
 [controller.concurrency_limit]
-max = [16, 16]
-mean = [8.0, 10.0]
+max = [16, 24]
+mean = [8.0, 18.5]
 
 [controller.observed_rtt]
 min = [0.100, 0.102]
-max = [0.100, 0.102]
-mean = [0.100, 0.102]
+max = [0.100, 1.203]
+mean = [0.100, 0.85]
 
 [controller.averaged_rtt]
 min = [0.100, 0.102]
-max = [0.100, 0.102]
-mean = [0.100, 0.102]
+max = [0.100, 1.203]
+mean = [0.100, 0.30]

--- a/tests/data/adaptive-concurrency/drops-at-high-concurrency.toml
+++ b/tests/data/adaptive-concurrency/drops-at-high-concurrency.toml
@@ -10,29 +10,29 @@ mean = [3.0, 4.0]
 mode = [3, 5]
 
 [stats.rate]
-max = [55, 56]
-mean = [31, 32]
+max = [55, 90]
+mean = [31, 54]
 
 # Since our internal framework doesn't track the dropped requests, the
 # values won't be representative of the actual number of requests in
 # flight.
 
 [controller.in_flight]
-max = [13, 15]
-mean = [7.0, 8.0]
-mode = [3, 11]
+max = [13, 85]
+mean = [7.0, 40]
+mode = [1, 11]
 
 [controller.concurrency_limit]
-max = [10, 15]
-mean = [7.0, 8.0]
-mode = [8, 12]
+max = [10, 86]
+mean = [7.0, 52]
+mode = [4, 77]
 
 [controller.observed_rtt]
 min = [0.100, 0.102]
-max = [0.100, 0.102]
-mean = [0.100, 0.102]
+max = [0.100, 11.2]
+mean = [0.100, 2.4]
 
 [controller.averaged_rtt]
 min = [0.100, 0.102]
-max = [0.100, 0.102]
-mean = [0.100, 0.102]
+max = [0.100, 7.0]
+mean = [0.100, 2.0]


### PR DESCRIPTION
This change is intended to handle the issues noted in  https://github.com/timberio/vector/issues/8647 and https://github.com/timberio/vector/issues/8211, where concurrency limits were not being respected for http-based sinks when bad network conditions arose.

In changing this code, I noticed that the test `sinks::util::adaptive_concurrency::tests::all_tests` fails, due to the test sink achieving values well outside the maximums specified in the test file. I'm not sure if this is a case where the maximums were simply wrong before, or the layer swap has introduced improper behavior. I didn't want to commit to changing all of the concurrency test files until I had a better idea of which direction to take, so I would appreciate input there.
