### PR TITLE
feat(aws service): add support to use AWS credentials file for AWS authentication

### DIFF
--- a/src/rusoto/auth.rs
+++ b/src/rusoto/auth.rs
@@ -12,6 +12,10 @@ pub enum AwsAuthentication {
         access_key_id: String,
         secret_access_key: String,
     },
+    File {
+        credentials_file: String,
+        profile: String,
+    },
     Role {
         assume_role: String,
     },
@@ -45,6 +49,17 @@ impl AwsAuthentication {
                     secret_access_key,
                 ))
             }
+            Self::File {
+                credentials_file,
+                profile,
+            } => {
+                if old_assume_role.is_some() {
+                    warn!(
+                        "Ignoring option `assume_role`, instead using AWS credentials file options."
+                    );
+                }
+                AwsCredentialsProvider::new_with_credentials_file(credentials_file, profile)
+            }
             Self::Role { assume_role } => {
                 if old_assume_role.is_some() {
                     warn!(
@@ -61,6 +76,9 @@ impl AwsAuthentication {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile;
 
     #[derive(Serialize, Deserialize, Clone, Debug)]
     struct ComponentConfig {
@@ -131,5 +149,32 @@ mod tests {
         .unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::Static { .. }));
+    }
+
+    #[test]
+    fn parsing_credentials_file() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmpfile_path = tmpdir.path().join("credentials");
+        let mut tmpfile = File::create(&tmpfile_path).unwrap();
+
+        writeln!(
+            tmpfile,
+            r#"
+            [default]
+            aws_access_key_id = default-access-key-id
+            aws_secret_access_key = default-secret
+        "#
+        )
+        .unwrap();
+
+        let auth = AwsAuthentication::File {
+            credentials_file: tmpfile_path.to_str().unwrap().to_string(),
+            profile: "default".to_string(),
+        };
+        let result = auth.build(&Region::AfSouth1, None).unwrap();
+        assert!(matches!(result, AwsCredentialsProvider::File { .. }));
+
+        drop(tmpfile);
+        tmpdir.close().unwrap();
     }
 }

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -57,7 +57,7 @@ components: _aws: {
 					profile: {
 						category:    "Auth"
 						common:      false
-						description: "The AWS profile name to find credentials from a file."
+						description: "The AWS profile name. Used to select AWS credentials from a provided credentials file."
 						required:    false
 						type: string: {
 							default: null

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -60,7 +60,7 @@ components: _aws: {
 						description: "The AWS profile name. Used to select AWS credentials from a provided credentials file."
 						required:    false
 						type: string: {
-							default: null
+							default: "default"
 							examples: ["develop"]
 							syntax: "literal"
 						}

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -43,6 +43,28 @@ components: _aws: {
 							syntax: "literal"
 						}
 					}
+					credentials_file: {
+						category:    "Auth"
+						common:      false
+						description: "The path to AWS credentials file. Used for AWS authentication when communicating with AWS services."
+						required:    false
+						type: string: {
+							default: null
+							examples: ["/path/to/aws/credentials"]
+							syntax: "literal"
+						}
+					}
+					profile: {
+						category:    "Auth"
+						common:      false
+						description: "The AWS profile name to find credentials from a file."
+						required:    false
+						type: string: {
+							default: null
+							examples: ["develop"]
+							syntax: "literal"
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Hello,

This pull request intends to introduce the support to use AWS credentials file for AWS authentication instead of specifying `access_key_id` and `secret_access_key` directly.
Usage example in [AWS Kinesis Firehose sink configuration](https://vector.dev/docs/reference/configuration/sinks/aws_kinesis_firehose/):

```toml
[sinks.my_sink_id]
type = "aws_kinesis_firehose"
inputs = [ "my-source-or-transform-id" ]
stream_name = "my-stream"
compression = "none"
region = "us-east-1"
credentials_file = "/path/to/aws/credentials" # <= new
profile = "production"                        # <= new
```
