### PR TITLE
chore(observability): Add script to check components

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -171,7 +171,7 @@ downstream target regardless if the transmission was successful or not.
   * MUST increment the `sent_bytes_total` counter by the defined value with the
     defined properties as metric tags.
 * Logs
-  * MUST log a `Bytes received.` message at the `trace` level with the
+  * MUST log a `Bytes sent.` message at the `trace` level with the
     defined properties as key-value pairs. It MUST NOT be rate limited.
 
 #### Error

--- a/scripts/check-components
+++ b/scripts/check-components
@@ -1,0 +1,258 @@
+#!/usr/bin/ruby
+# coding: utf-8
+
+require 'find'
+
+COMMON_EVENTS = ['EventsReceived', 'EventsSent']
+SOURCE_EVENTS = ['BytesReceived'] + COMMON_EVENTS
+SINK_EVENTS = COMMON_EVENTS + ['BytesSent']
+# Transforms implicitly handle the common events in the topology, and
+# have no other emit requirements.
+TRANSFORM_EVENTS = []
+
+$error_count = 0
+
+def hash_array_add(hash, key, item)
+  arr = hash.fetch(key, Array::new)
+  arr.append(item)
+  hash[key] = arr
+end
+
+# Reduce a path to a component name, used to group all the emits for a
+# component that may be split over multiple files.
+def path_component(path)
+  parts = path.split('/')
+  parts.shift # Drop the leading 'src'
+  group = parts.shift
+  component = parts.shift
+
+  # Skip the top-level module files and utilities
+  if component == 'mod.rs' or component == 'util'
+    return nil
+  end
+
+  if component == 'gcp'
+    component = "gcp_#{parts.shift}"
+  end
+
+  if component.end_with? '.rs'
+    component = component[..-4]
+  end
+  return "#{group}/#{component}"
+end
+
+# A class to hold error reports and common functionality
+class Event
+  def initialize(name)
+    @path = nil
+    @name = name
+    @reports = []
+    @members = []
+    @counters = []
+    @logs = []
+  end
+
+  def path(path)
+    @path = path
+  end
+
+  def members(list)
+    @members = list
+  end
+
+  def add_counter(name, tags)
+    @counters.append(name)
+  end
+
+  def add_log(type, message, parameters)
+    @logs.append([type, message, parameters])
+  end
+
+  def validate
+    # Check BytesReceived events (for sources)
+    if @name.end_with? 'BytesReceived'
+      members_must_include(['byte_size'])
+      counters_must_include(['received_bytes_total'])
+    end
+
+    # Check EventsReceived events (common)
+    if @name.end_with? 'EventsReceived'
+      members_must_include(['count', 'byte_size'])
+      counters_must_include(['received_events_total', 'received_event_bytes_total'])
+    end
+
+    # Check EventsSent events (common)
+    if @name.end_with? 'EventsSent'
+      members_must_include(['count', 'bytes_sent'])
+      counters_must_include(['sent_events_total', 'sent_event_bytes_total'])
+    end
+
+    # Check BytesSent events (for sinks)
+    if @name.end_with? 'BytesSent'
+      members_must_include(['byte_size'])
+    end
+
+    has_errors = @logs.one? { |type, _, _| type == 'error' }
+
+    # Make sure Error events output an error
+    if has_errors or @name.end_with? 'Error'
+      append('Error events MUST be named "___Error".') unless @name.end_with? 'Error'
+      counters_must_include(['errors_total'])
+    end
+
+    # Make sure error events contain the right parameters
+    @logs.each { |type, message, parameters|
+      if type == 'error'
+        ['error', 'stage'].each { |parameter|
+          unless parameters.include? parameter
+            @reports.append("Error log MUST include parameter \"#{parameter}\".")
+          end
+        }
+      end
+    }
+
+    unless @reports.empty?
+      puts "#{@path}: Errors in event #{@name}:"
+      @reports.each { |report|
+        puts "    #{report}"
+        $error_count += 1
+      }
+    end
+  end
+
+  private
+
+  def append(report)
+    @reports.append(report)
+  end
+
+  def generic_must_contain(array, names, prefix, suffix)
+    names.each { |name|
+      unless array.include? name
+        @reports.append("#{prefix} MUST #{suffix} \"#{name}\".")
+      end
+    }
+  end
+
+  def counters_must_include(names)
+    generic_must_contain(@counters, names, 'This event', 'increment counter')
+    # TODO: Scan each counter for parameters
+  end
+
+  def members_must_include(names)
+    generic_must_contain(@members, names, 'This event', 'have a member named')
+  end
+end
+
+class Component
+  def initialize(name)
+    @name = name
+    @emits = []
+  end
+
+  def emits(array)
+    @emits += array
+  end
+
+  def validate
+    @missing = []
+    require_events(SOURCE_EVENTS) if @name.start_with? 'sources/'
+    require_events(TRANSFORM_EVENTS) if @name.start_with? 'transforms/'
+    require_events(SINK_EVENTS) if @name.start_with? 'sinks/'
+
+    if @missing.length > 0
+      puts "#{@name}: Missing required event:"
+      @missing.each { |event|
+        puts "    #{event}"
+        $error_count += 1
+      }
+    end
+  end
+
+  private
+
+  def require_events(names)
+    names.each { |name|
+      if @emits.none? { |event| event.end_with? name }
+        @missing.append(name)
+      end
+    }
+  end
+end
+
+$all_events = Hash::new { |hash, key| hash[key] = Event::new(key) }
+$all_components = Hash::new { |hash, key| hash[key] = Component::new(key) }
+
+# Scan sources and build internal structures
+Find.find('src') { |path|
+  if path.end_with? '.rs'
+    text = File.read(path)
+
+    # Check log message texts for correct formatting. See below for the
+    # full regex
+    text.scan(/(trace|debug|info|warn|error)!\(\s*(message\s*=\s*)?"([^({)][^("]+)"/) {
+      |type, has_message_prefix, message|
+      reports = []
+      reports.append('Message must start with a capital.') unless message.match(/^[[:upper:]]/)
+      reports.append('Message must end with a period.') unless message.match(/\.$/)
+      unless reports.empty?
+        puts "#{path}: Errors in message \"#{message}\":"
+        reports.each { |report| puts "  #{report}" }
+        $error_count += 1
+      end
+    }
+
+    if path.start_with? 'src/internal_events/'
+      # Scan internal event structs for member names
+      text.scan(/[\n ]struct (\S+?)(?:<.+?>)? {\n(.+?)\n}\n/m) { |struct_name, members|
+        $all_events[struct_name].path(path)
+        member_names = members.scan(/ ([A-Za-z0-9_]+): /).map { |member,| member }
+        $all_events[struct_name].members(member_names)
+      }
+
+      # Scan internal event implementation blocks for logs and metrics
+      text.scan(/^impl InternalEvent for ([A-Za-z0-9_]+)(?:<.+?>)? {\n(.+?)\n}$/m) { |event_name, block|
+        # Scan for counter names
+        # TODO: parse out tags
+        block.scan(/ counter!\("([^"]+)"/) { |name,|
+          $all_events[event_name].add_counter(name, [])
+        }
+
+        # Scan for log outputs and their parameters
+        block.scan(/
+                    (trace|debug|info|warn|error)! # The log type
+                    \(\s*(?:message\s*=\s*)? # Skip any leading "message =" bit
+                    "([^({)][^("]+)" # The log message text
+                    ([^;]*?) # Match the parameter list
+                    \)(?:;|\n\s*}) # Normally would end with simply ");", but some are missing the semicolon
+                   /mx) { |type, message, parameters|
+          parameters = parameters.scan(/([a-z0-9_]+) *= .|[?%]([a-z0-9_.]+)/) \
+                         .map { |assignment, simple| assignment or simple }
+
+          $all_events[event_name].add_log(type, message, parameters)
+        }
+      }
+
+    # Scan all the source, transform, and sink components for all
+    # internal events they emit, to be handled below.
+    elsif path.start_with? 'src/sinks/' or path.start_with? 'src/sources/' or path.start_with? 'src/transforms/'
+      component_name = path_component(path)
+
+      if component_name
+        emits = text.scan(/emit!\(([A-Za-z0-9]+)/).map { |name,| name }
+        $all_components[component_name].emits(emits)
+      end
+    end
+  end
+}
+
+$all_events.each_value { |event|
+  event.validate
+}
+
+$all_components.each_value { |component|
+  component.validate
+}
+
+puts "#{$error_count} error(s)"
+exit 1 if $error_count > 0

--- a/scripts/check-components
+++ b/scripts/check-components
@@ -10,8 +10,6 @@ SINK_EVENTS = COMMON_EVENTS + ['BytesSent']
 # have no other emit requirements.
 TRANSFORM_EVENTS = []
 
-$error_count = 0
-
 def hash_array_add(hash, key, item)
   arr = hash.fetch(key, Array::new)
   arr.append(item)
@@ -38,11 +36,15 @@ def path_component(path)
   if component.end_with? '.rs'
     component = component[..-4]
   end
-  return "#{group}/#{component}"
+  "#{group}/#{component}"
 end
 
 # A class to hold error reports and common functionality
 class Event
+  attr_accessor :path
+  attr_reader :name, :reports
+  attr_writer :members
+
   def initialize(name)
     @path = nil
     @name = name
@@ -50,14 +52,6 @@ class Event
     @members = []
     @counters = []
     @logs = []
-  end
-
-  def path(path)
-    @path = path
-  end
-
-  def members(list)
-    @members = list
   end
 
   def add_counter(name, tags)
@@ -68,7 +62,9 @@ class Event
     @logs.append([type, message, parameters])
   end
 
-  def validate
+  def valid?
+    @reports.clear
+
     # Check BytesReceived events (for sources)
     if @name.end_with? 'BytesReceived'
       members_must_include(['byte_size'])
@@ -101,96 +97,88 @@ class Event
     end
 
     # Make sure error events contain the right parameters
-    @logs.each { |type, message, parameters|
+    @logs.each do |type, message, parameters|
       if type == 'error'
-        ['error', 'stage'].each { |parameter|
+        ['error', 'stage'].each do |parameter|
           unless parameters.include? parameter
             @reports.append("Error log MUST include parameter \"#{parameter}\".")
           end
-        }
+        end
       end
-    }
-
-    unless @reports.empty?
-      puts "#{@path}: Errors in event #{@name}:"
-      @reports.each { |report|
-        puts "    #{report}"
-        $error_count += 1
-      }
     end
+
+    @reports.empty?
   end
 
   private
 
-  def append(report)
-    @reports.append(report)
-  end
+    def append(report)
+      @reports.append(report)
+    end
 
-  def generic_must_contain(array, names, prefix, suffix)
-    names.each { |name|
-      unless array.include? name
-        @reports.append("#{prefix} MUST #{suffix} \"#{name}\".")
+    def generic_must_contain(array, names, prefix, suffix)
+      names.each do |name|
+        unless array.include? name
+          @reports.append("#{prefix} MUST #{suffix} \"#{name}\".")
+        end
       end
-    }
-  end
+    end
 
-  def counters_must_include(names)
-    generic_must_contain(@counters, names, 'This event', 'increment counter')
-    # TODO: Scan each counter for parameters
-  end
+    def counters_must_include(names)
+      generic_must_contain(@counters, names, 'This event', 'increment counter')
+      # TODO: Scan each counter for parameters
+    end
 
-  def members_must_include(names)
-    generic_must_contain(@members, names, 'This event', 'have a member named')
-  end
+    def members_must_include(names)
+      generic_must_contain(@members, names, 'This event', 'have a member named')
+    end
 end
 
 class Component
+  attr_reader :missing, :name
+
   def initialize(name)
     @name = name
     @emits = []
+    @missing = []
   end
 
   def emits(array)
     @emits += array
   end
 
-  def validate
-    @missing = []
+  def valid?
+    @missing.clear
     require_events(SOURCE_EVENTS) if @name.start_with? 'sources/'
     require_events(TRANSFORM_EVENTS) if @name.start_with? 'transforms/'
     require_events(SINK_EVENTS) if @name.start_with? 'sinks/'
-
-    if @missing.length > 0
-      puts "#{@name}: Missing required event:"
-      @missing.each { |event|
-        puts "    #{event}"
-        $error_count += 1
-      }
-    end
+    @missing.empty?
   end
 
   private
 
-  def require_events(names)
-    names.each { |name|
-      if @emits.none? { |event| event.end_with? name }
-        @missing.append(name)
+    def require_events(names)
+      names.each do |name|
+        if @emits.none? { |event| event.end_with? name }
+          @missing.append(name)
+        end
       end
-    }
-  end
+    end
 end
 
 $all_events = Hash::new { |hash, key| hash[key] = Event::new(key) }
 $all_components = Hash::new { |hash, key| hash[key] = Component::new(key) }
 
+error_count = 0
+
 # Scan sources and build internal structures
-Find.find('src') { |path|
+Find.find('src') do |path|
   if path.end_with? '.rs'
     text = File.read(path)
 
     # Check log message texts for correct formatting. See below for the
     # full regex
-    text.scan(/(trace|debug|info|warn|error)!\(\s*(message\s*=\s*)?"([^({)][^("]+)"/) {
+    text.scan(/(trace|debug|info|warn|error)!\(\s*(message\s*=\s*)?"([^({)][^("]+)"/) do
       |type, has_message_prefix, message|
       reports = []
       reports.append('Message must start with a capital.') unless message.match(/^[[:upper:]]/)
@@ -198,25 +186,25 @@ Find.find('src') { |path|
       unless reports.empty?
         puts "#{path}: Errors in message \"#{message}\":"
         reports.each { |report| puts "  #{report}" }
-        $error_count += 1
+        error_count += 1
       end
-    }
+    end
 
     if path.start_with? 'src/internal_events/'
       # Scan internal event structs for member names
-      text.scan(/[\n ]struct (\S+?)(?:<.+?>)? {\n(.+?)\n}\n/m) { |struct_name, members|
-        $all_events[struct_name].path(path)
+      text.scan(/[\n ]struct (\S+?)(?:<.+?>)? {\n(.+?)\n}\n/m) do |struct_name, members|
+        $all_events[struct_name].path = path
         member_names = members.scan(/ ([A-Za-z0-9_]+): /).map { |member,| member }
-        $all_events[struct_name].members(member_names)
-      }
+        $all_events[struct_name].members = member_names
+      end
 
       # Scan internal event implementation blocks for logs and metrics
-      text.scan(/^impl InternalEvent for ([A-Za-z0-9_]+)(?:<.+?>)? {\n(.+?)\n}$/m) { |event_name, block|
+      text.scan(/^impl InternalEvent for ([A-Za-z0-9_]+)(?:<.+?>)? {\n(.+?)\n}$/m) do |event_name, block|
         # Scan for counter names
         # TODO: parse out tags
-        block.scan(/ counter!\("([^"]+)"/) { |name,|
+        block.scan(/ counter!\("([^"]+)"/) do |name,|
           $all_events[event_name].add_counter(name, [])
-        }
+        end
 
         # Scan for log outputs and their parameters
         block.scan(/
@@ -225,13 +213,13 @@ Find.find('src') { |path|
                     "([^({)][^("]+)" # The log message text
                     ([^;]*?) # Match the parameter list
                     \)(?:;|\n\s*}) # Normally would end with simply ");", but some are missing the semicolon
-                   /mx) { |type, message, parameters|
+                   /mx) do |type, message, parameters|
           parameters = parameters.scan(/([a-z0-9_]+) *= .|[?%]([a-z0-9_.]+)/) \
                          .map { |assignment, simple| assignment or simple }
 
           $all_events[event_name].add_log(type, message, parameters)
-        }
-      }
+        end
+      end
 
     # Scan all the source, transform, and sink components for all
     # internal events they emit, to be handled below.
@@ -244,15 +232,23 @@ Find.find('src') { |path|
       end
     end
   end
-}
+end
 
-$all_events.each_value { |event|
-  event.validate
-}
+$all_events.each_value do |event|
+  unless event.valid?
+    puts "#{event.path}: Errors in event #{event.name}:"
+    event.reports.each { |report| puts "    #{report}" }
+    error_count += 1
+  end
+end
 
-$all_components.each_value { |component|
-  component.validate
-}
+$all_components.each_value do |component|
+  unless component.valid?
+    puts "#{component.name}: Missing required event(s):"
+    component.missing.each { |event| puts "    #{event}" }
+    error_count += 1
+  end
+end
 
-puts "#{$error_count} error(s)"
-exit 1 if $error_count > 0
+puts "#{error_count} error(s)"
+exit 1 if error_count > 0

--- a/scripts/check-components
+++ b/scripts/check-components
@@ -4,10 +4,12 @@
 require 'find'
 
 COMMON_EVENTS = ['EventsReceived', 'EventsSent']
-SOURCE_EVENTS = ['BytesReceived'] + COMMON_EVENTS
-SINK_EVENTS = COMMON_EVENTS + ['BytesSent']
-# Transforms implicitly handle the common events in the topology, and
-# have no other emit requirements.
+# Sources implicitly emit EventsSent in the common pipeline code
+SOURCE_EVENTS = ['BytesReceived'] + COMMON_EVENTS - ['EventsSent']
+# Sinks implicitly emit EventsReceived in the common pipeline code
+SINK_EVENTS = COMMON_EVENTS + ['BytesSent'] - ['EventsReceived']
+# Transforms implicitly emit the common events in the topology, and have
+# no other emit requirements.
 TRANSFORM_EVENTS = []
 
 def hash_array_add(hash, key, item)


### PR DESCRIPTION
Surfacing this for initial looks. The regex patterns are pretty hairy, but seem to work well (assuming sources passed through `rustfmt` of course). This also reveals too many errors to be useful (345 at current count), and it's not quite complete yet, so vector is definitely not ready to have this in CI.

Closes #8969 