### PR TITLE
enhancement(external docs): Move Netlify configuration into website directory

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,9 +1,5 @@
 [build]
-base = "website"
 publish = "public"
-
-# Reinstate this when we figure out how to target this better
-#ignore = "./scripts/build-ignore.sh"
 
 [build.environment]
 HUGO_VERSION = "0.84.0"

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+base = "website"
 publish = "public"
 
 [build.environment]


### PR DESCRIPTION
This PR stems from something I learned from the [Netlify docs](https://docs.netlify.com/configure-builds/common-configurations/monorepos). Apparently you don't have to put the Netlify config in the root directory. Instead,  you can put it in a subdirectory, which case Netlify only builds upon changes in that subdirectory (I tried to emulate this same behavior using the `ignore` directive but didn't manage to get it working properly). This should cut down on build minute usage and general noise.