### PR TITLE
fix(aws_s3 sink): Set default event limit

### DIFF
--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -30,6 +30,7 @@ const DEFAULT_REQUEST_LIMITS: TowerRequestConfig = {
 // thing, and I really just want batch settings detached from the types that will use them. :/
 const DEFAULT_BATCH_SETTINGS: BatchSettings<()> = {
     BatchSettings::const_default()
+        .events(10_000)
         .bytes(10_000_000)
         .timeout(300)
 };

--- a/src/sinks/aws_s3/tests.rs
+++ b/src/sinks/aws_s3/tests.rs
@@ -286,7 +286,7 @@ mod integration_tests {
             encoding: Encoding::Text.into(),
             compression: Compression::None,
             batch: BatchConfig {
-                max_bytes: Some(batch_size),
+                max_events: Some(batch_size),
                 timeout_secs: Some(5),
                 ..Default::default()
             },

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -19,6 +19,7 @@ components: sinks: aws_s3: components._aws & {
 			batch: {
 				enabled:      true
 				common:       true
+				max_events:   10000
 				max_bytes:    10000000
 				timeout_secs: 300
 			}


### PR DESCRIPTION
Otherwise it uses `usize::max` to try to pre-allocate a Vec. This was introduced by the fix in #9106 which defaulted to no longer setting the `max_events` for `Batcher` (which was previously incorrectly using the user configured `max_bytes` as this parameter).

I think this is a quick fix. I'm imagining the real fix is to not require a maximum number of batch events and, instead of pre-allocating a `Vec` with `usize::max`, just allocate with a smaller number and extend as necessary until we hit the configured `max_bytes`. cc/ @tobz and @blt for thoughts here.

```
---- sinks::aws_s3::tests::integration_tests::s3_insert_message_into_object_lock stdout ----
Sep 10 20:40:44.202 DEBUG vector::tls::settings: Fetching system root certs.
Sep 10 20:40:44.210 DEBUG vector::rusoto: Using default credentials provider for AWS.
Sep 10 20:40:44.210  WARN vector::sinks::util::service: Option `in_flight_limit` has been renamed to `concurrency`. Ignoring `in_flight_limit` and using `concurrency` option.
thread 'main' panicked at 'capacity overflow', library/alloc/src/raw_vec.rs:559:5
stack backtrace:
   0:     0x55b6698f23d0 - std::backtrace_rs::backtrace::libunwind::trace::ha0ad43e8a952bfe7
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/../../backtrace/src/backtrace/libunwind.rs:90:5
   1:     0x55b6698f23d0 - std::backtrace_rs::backtrace::trace_unsynchronized::h6830419c0c4130dc
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x55b6698f23d0 - std::sys_common::backtrace::_print_fmt::h8f3516631ffa1ef5
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:67:5
   3:     0x55b6698f23d0 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::he1640d5f0d93f618
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:46:22
   4:     0x55b66995ed3c - core::fmt::write::h88012e1f01caeebf
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/fmt/mod.rs:1115:17
   5:     0x55b6698e3cb5 - std::io::Write::write_fmt::h7728c39ea5632753
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/io/mod.rs:1665:15
   6:     0x55b6698f612b - std::sys_common::backtrace::_print::ha1f00492f406a015
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:49:5
   7:     0x55b6698f612b - std::sys_common::backtrace::print::hd54561b13feb6af3
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:36:9
   8:     0x55b6698f612b - std::panicking::default_hook::{{closure}}::h84fe124cd0864662
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:208:50
   9:     0x55b6698f5c3c - std::panicking::default_hook::h5a8e74a76ce290a7
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:222:9
  10:     0x55b6698f6934 - std::panicking::rust_panic_with_hook::h67c812a4fe9d4c91
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:622:17
  11:     0x55b6698f63e7 - std::panicking::begin_panic_handler::{{closure}}::h33f9c1b96af300d7
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:517:13
  12:     0x55b6698f28cc - std::sys_common::backtrace::__rust_end_short_backtrace::h51bae64be5921f0e
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:141:18
  13:     0x55b6698f6379 - rust_begin_unwind
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:515:5
  14:     0x55b66529d121 - core::panicking::panic_fmt::h12a3a3c256485fca
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/panicking.rs:92:14
  65:     0x55b66715c7e1 - test::test_main_static::h6c76f95ad277a768
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/test/src/lib.rs:142:5
  66:     0x55b6667afd93 - vector::main::h5bda6d16186062d7
                               at /home/runner/work/vector/vector/src/lib.rs:1:1
  67:     0x55b665a2257b - core::ops::function::FnOnce::call_once::h2a929bf155c38c39
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227:5
  68:     0x55b66547fa5e - std::sys_common::backtrace::__rust_begin_short_backtrace::h79d49ce650bcaa6f
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/sys_common/backtrace.rs:125:18
  69:     0x55b66654fb31 - std::rt::lang_start::{{closure}}::h08005d574db16345
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:63:18
  70:     0x55b6698f6f3a - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::ha9408abe89f69dc4
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:259:13
  71:     0x55b6698f6f3a - std::panicking::try::do_call::h5b0cc9e9102acb65
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401:40
  72:     0x55b6698f6f3a - std::panicking::try::hddc7f8229138b3ba
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365:19
  73:     0x55b6698f6f3a - std::panic::catch_unwind::hfa401ff8bab2986e
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434:14
  74:     0x55b6698f6f3a - std::rt::lang_start_internal::{{closure}}::h8163422320d11405
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:45:48
  75:     0x55b6698f6f3a - std::panicking::try::do_call::hc742cc7bb4f0fb20
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401:40
  76:     0x55b6698f6f3a - std::panicking::try::ha37d8d2dd1acf7d3
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365:19
  77:     0x55b6698f6f3a - std::panic::catch_unwind::h8a5381d5ecf437bc
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434:14
  78:     0x55b6698f6f3a - std::rt::lang_start_internal::h7e2cee8c90d4a4d3
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:45:20
  79:     0x55b66654fb00 - std::rt::lang_start::h4eac9a2b86b6d98b
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/rt.rs:62:5
  80:     0x55b6667afdbc - main
  81:     0x7f59641d00b3 - __libc_start_main
  82:     0x55b66529dbbe - _start
  83:                0x0 - <unknown>
```

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
