### PR TITLE
chore: Add specifications for configuration and instrumentation

### DIFF
--- a/docs/USER_EXPERIENCE_DESIGN.md
+++ b/docs/USER_EXPERIENCE_DESIGN.md
@@ -21,9 +21,6 @@ shared vision of good user experience -- the purpose of this document.
    1. [Logical boundaries](#logical-boundaries)
       1. [Source & sink boundaries](#source--sink-boundaries)
       1. [Transform boundaries](#transform-boundaries)
-   1. [Naming](#naming)
-      1. [Option naming](#option-naming)
-      1. [Metric naming](#metric-naming)
 1. [Adherence](#adherence)
    1. [Roles](#roles)
       1. [Contributors](#contributors)
@@ -50,8 +47,8 @@ we strive to be the best in this domain.
 
 Examples:
 
-- Avoiding analytics specific use cases.
-- Leaning into tools like Kafka instead of trying to replace them.
+* Avoiding analytics specific use cases.
+* Leaning into tools like Kafka instead of trying to replace them.
 
 ### Be opinionated & reduce decisions
 
@@ -64,9 +61,9 @@ creative exercises for the user.
 
 Examples:
 
-- Vector's pipeline model as a solution to team collaboration as opposed to
+* Vector's pipeline model as a solution to team collaboration as opposed to
   generic config files.
-- Vector's metric data model as a solution for metrics interoperability as
+* Vector's metric data model as a solution for metrics interoperability as
   opposed to specifically structured log lines.
 
 ### Build momentum with consistency
@@ -82,8 +79,8 @@ error handling, since this often results in data loss.
 
 Examples:
 
-- Using the same `codec` option name in both sources and sinks that support it.
-- Defaulting to applying back pressure regardless of the component or topology.
+* Using the same `codec` option name in both sources and sinks that support it.
+* Defaulting to applying back pressure regardless of the component or topology.
 
 ## Guidelines
 
@@ -100,8 +97,8 @@ an opt-in choice by the user.
 
 Examples:
 
-- Choose back pressure over shedding load
-- Retry failed requests in sinks until the service recovers
+* Choose back pressure over shedding load
+* Retry failed requests in sinks until the service recovers
 
 ### Logical boundaries
 
@@ -120,11 +117,11 @@ composability.
 
 Examples:
 
-- A `syslog` source as opposed to a `syslogng` source since it aligns with the
+* A `syslog` source as opposed to a `syslogng` source since it aligns with the
   Syslog protocol.
-- A `datadog_agent` source as opposed to a `datadog_api` source since it aligns
+* A `datadog_agent` source as opposed to a `datadog_api` source since it aligns
   on intent and reduces scope.
-- Again, a `syslog` source _in addition_ to a `socket` source with the `codec`
+* Again, a `syslog` source _in addition_ to a `socket` source with the `codec`
   option set to `syslog` since it is more specific and discoverable.
 
 #### Transform boundaries
@@ -138,58 +135,10 @@ both.
 
 Examples:
 
-- A `remap` transform as opposed to multiple `parse_json`, `parse_syslog`, etc
+* A `remap` transform as opposed to multiple `parse_json`, `parse_syslog`, etc
   transforms.
-- A `filter` transform as opposed to a `filter_regex`, `filter_datadog_search`,
+* A `filter` transform as opposed to a `filter_regex`, `filter_datadog_search`,
   etc transforms.
-
-### Naming
-
-#### Option naming
-
-Configuration option names should adhere to the following rules:
-
-- Alphanumeric, lowercase, snake case format
-- Use nouns, not verbs, as names (e.g., `fingerprint` instead of `fingerprinting`)
-- Suffix options with their unit. (e.g., `_seconds`, `_bytes`, etc.)
-- Be consistent with units within the same scope. (e.g., don't mix seconds and milliseconds)
-- Don't repeat the name space in the option name (e.g., `fingerprint.bytes` instead of `fingerprint.fingerprint_bytes`)
-
-#### Metric naming
-
-For metric naming, Vector broadly follows the
-[Prometheus metric naming standards](https://prometheus.io/docs/practices/naming/).
-Hence, a metric name:
-
-- Must only contain valid characters, which are ASCII letters and digits, as
-  well as underscores. It should match the regular expression: `[a-z_][a-z0-9_]*`.
-- Metrics have a broad template:
-
-  `<namespace>_<name>_<unit>_[total]`
-
-  - The `namespace` is a single word prefix that groups metrics from a specific
-    source, for example host-based metrics like CPU, disk, and memory are
-    prefixed with `host`, Apache metrics are prefixed with `apache`, etc.
-  - The `name` describes what the metric measures.
-  - The `unit` is a [single base unit](https://en.wikipedia.org/wiki/SI_base_unit),
-    for example seconds, bytes, metrics.
-  - The suffix should describe the unit in plural form: seconds, bytes.
-    Accumulating counts, both with units or without, should end in `total`,
-    for example `disk_written_bytes_total` and `http_requests_total`.
-
-- Where required, use tags to differentiate the characteristic of the
-  measurement. For example, whilst `host_cpu_seconds_total` is name of the
-  metric, we also record the `mode` that is being used for each CPU. The `mode`
-  and the specific CPU then become tags on the metric:
-
-```text
-host_cpu_seconds_total{cpu="0",mode="idle"}
-host_cpu_seconds_total{cpu="0",mode="idle"}
-host_cpu_seconds_total{cpu="0",mode="nice"}
-host_cpu_seconds_total{cpu="0",mode="system"}
-host_cpu_seconds_total{cpu="0",mode="user"}
-host_cpu_seconds_total
-```
 
 ## Adherence
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -12,6 +12,9 @@ interpreted as described in [RFC 2119].
 1. [Introduction](#introduction)
 1. [Scope](#scope)
 1. [How to read this document](#how-to-read-this-document)
+1. [Naming](#naming)
+   1. [Source and sink naming](#source-and-sink-naming)
+   1. [Transform naming](#transform-naming)
 1. [Configuration](#configuration)
    1. [Options](#options)
       1. [`endpoint(s)`](#endpoints)
@@ -46,6 +49,22 @@ their telemetry by nature of being a Vector compoent.
 This document is written from the broad perspective of a Vector component.
 Unless otherwise stated, a section applies to all component types (sources,
 transforms, and sinks).
+
+## Naming
+
+To align with the [logical boundaries of components], component naming MUST
+follow the following guidelines.
+
+### Source and sink naming
+
+* MUST only contain ASCII alphanumeric, lowercase, and underscores
+* MUST be a noun named after the protocol or service that the component integrates with
+* MAY be suffixed with the event type, `logs`, `metrics`, or `traces` (e.g., `kubernetes_logs`, `apache_metrics`)
+
+### Transform naming
+
+* MUST only contain ASCII alphanumeric, lowercase, and underscores
+* MUST be a verb describing the broad purpose of the transform (e.g., `route`, `sample`, `delegate`)
 
 ## Configuration
 
@@ -206,6 +225,7 @@ implement since errors are specific to the component.
 [Configuration Specification]: configuration.md
 [high user experience expectations]: https://github.com/timberio/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md
 [Instrumentation Sepcification]: instrumentation.md
+[logical boundaries of components]: ../USER_EXPERIENCE_DESIGN.md#logical-boundaries
 [Pull request #8383]: https://github.com/timberio/vector/pull/8383/
 [RFC 2064]: https://github.com/timberio/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
 [RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -14,7 +14,6 @@ interpreted as described in [RFC 2119].
 1. [How to read this document](#how-to-read-this-document)
 1. [Configuration](#configuration)
    1. [Options](#options)
-      1. [`address`](#address)
       1. [`endpoint(s)`](#endpoints)
 1. [Instrumentation](#instrumentation)
    1. [Batching](#batching)
@@ -50,6 +49,9 @@ transforms, and sinks).
 
 ## Configuration
 
+This section extends the [Configuration Specification] for component specific
+configuration.
+
 ### Options
 
 #### `endpoint(s)`
@@ -63,7 +65,8 @@ representing multiple endpoints.
 
 Vector components MUST be instrumented for optimal observability and monitoring.
 This is required to drive various interfaces that Vector users depend on to
-manage Vector installations in mission critical production environments.
+manage Vector installations in mission critical production environments. This
+section extends the [Instrumentation Sepcification].
 
 ### Batching
 
@@ -200,7 +203,9 @@ implement since errors are specific to the component.
   * MUST log a message at the `error` level with the defined properties
     as key-value pairs. It SHOULD be rate limited to 10 seconds.
 
+[Configuration Specification]: configuration.md
 [high user experience expectations]: https://github.com/timberio/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md
+[Instrumentation Sepcification]: instrumentation.md
 [Pull request #8383]: https://github.com/timberio/vector/pull/8383/
 [RFC 2064]: https://github.com/timberio/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
 [RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/docs/specs/configuration.md
+++ b/docs/specs/configuration.md
@@ -1,0 +1,120 @@
+# Configuration Specification
+
+This document specifies Vector's configuration for the development of Vector.
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119].
+
+<!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
+
+1. [Introduction](#introduction)
+1. [Scope](#scope)
+1. [Terminology](#terminology)
+   1. [Entity](#entity)
+   1. [Option](#option)
+1. [Schema](#schema)
+   1. [Naming](#naming)
+      1. [Entity naming](#entity-naming)
+      1. [Option naming](#option-naming)
+   1. [Types](#types)
+   1. [Polymorphism](#polymorphism)
+      1. [Entity polymorphism](#entity-polymorphism)
+      1. [Option polymorphism](#option-polymorphism)
+
+<!-- /MarkdownTOC -->
+
+## Introduction
+
+Vector's runtime behavior is expressed through user-defined configuration files
+intended to be written directly by users. Therefore, the quality of Vector's
+configuration largely affects Vector's user experience. This document aims to
+make Vector's configuration as high quality as possible in order to achieve a
+[best in class user experience][user_experience].
+
+## Scope
+
+This specification is focused on broad configuration guidelines and not specific
+options. It is intended to guide Vector's configuration without tedious
+management. When necessary, specific configuration will be covered in other
+relevant specifications, such as the [component specifiction].
+
+## Terminology
+
+### Entity
+
+"Entity" refers to a Vector concept used to model Vector's processing graph.
+Sources, transforms, sinks, and enrichment tables are all examples of entities.
+Entities are defined under a root-level type followed by a user-defined ID
+containing the entity's options.
+
+### Option
+
+"Option" refers to a leaf field that takes a primitive value. Options are nested
+under entities and also used to define global Vector behavior.
+
+## Schema
+
+### Naming
+
+#### Entity naming
+
+* MUST only contain ASCII alphanumeric, lowercase, and underscores
+  * The `.` character is reserved for special purposes (e.g., error stream routing)
+* MUST be in snake case format when multiple words are used (e.g., `timeout_seconds`)
+
+#### Option naming
+
+* MUST only contain ASCII alphanumeric, lowercase, and underscores
+* MUST be in snake case format when multiple words are used (e.g., `timeout_seconds`)
+* SHOULD use nouns, not verbs, as names (e.g., `fingerprint` instead of `fingerprinting`)
+* MUST suffix options with their _full_ unit name (e.g., `_seconds`, `_bytes`, etc.)
+* SHOULD consistent with units within the same scope. (e.g., don't mix seconds and milliseconds)
+* MUST NOT repeat the name space in the option name (e.g., `fingerprint.bytes` instead of `fingerprint.fingerprint_bytes`)
+
+### Types
+
+Types MUST consist of [JSON types] only:
+
+* `string`
+* `number`
+* `integer`
+* `object`
+* `array`
+* `boolean`
+* `null`
+
+### Polymorphism
+
+#### Entity polymorphism
+
+By nature entities being namespaced by user-defined IDs, polymorphism MUST be
+supported for entity namespaces.
+
+#### Option polymorphism
+
+Options MUST NOT support polymorphism:
+
+* MUST be strongly typed
+* MUST be [externally tagged] for mutually exclusive sets of options
+  * REQUIRED to implement a top-level `type` key that accept the tag value
+
+For example:
+
+```toml
+buffer.type = "memory"
+buffer.memory.max_events = 10_000
+```
+
+The above configures a Vector memory buffer which can be switched to disk as
+well:
+
+```toml
+buffer.type = "disk"
+buffer.disk.max_bytes = 1_000_000_000
+```
+
+[component specification]: component.md
+[external tagging]: https://docs.rs/serde_tagged/0.2.0/serde_tagged/ser/external/index.html
+[JSON types]: http://json-schema.org/understanding-json-schema/reference/type.html
+[user_experience]: ../USER_EXPERIENCE_DESIGN.md

--- a/docs/specs/configuration.md
+++ b/docs/specs/configuration.md
@@ -74,7 +74,7 @@ under entities and also used to define global Vector behavior.
 
 ### Types
 
-Types MUST consist of [JSON types] only:
+Types MUST consist of [JSON types] only, minus the `null` type:
 
 * `string`
 * `number`
@@ -82,7 +82,6 @@ Types MUST consist of [JSON types] only:
 * `object`
 * `array`
 * `boolean`
-* `null`
 
 ### Polymorphism
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -30,11 +30,11 @@ For metric naming, Vector broadly follows the
 [Prometheus metric naming standards]. Hence, a metric name:
 
 * MUST only contain ASCII alphanumeric, lowercase, and underscores
-* MUST follow the `<namespace>_<name>_<unit>_[total]` template
-  * `namespace` MUST be a _single_ word that groups metrics based on the source (e.g., `host`, `apache`)
+* MUST follow the `<name>_<unit>_[total]` template
   * `name` is one or more words that describes the measurement (e.g., `memory_rss`, `requests`)
   * `unit` MUST be a single [base unit] in plural form, if applicable (e.g., `seconds`, `bytes`)
   * Counters MUST end with `total` (e.g., `disk_written_bytes_total`, `http_requests_total`)
+* MUST NOT contain a namespace since the `internal_metrics` source sets a configurable namespace
 * SHOULD be broad in purpose and use use tags to differentiate characteristics of the measurement (e.g., `host_cpu_seconds_total{cpu="0",mode="idle"}`)
 
 [Prometheus metric naming standards]: https://prometheus.io/docs/practices/naming/

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -1,0 +1,41 @@
+# Instrumentation Specification
+
+This document specifies Vector's instrumentation for the development of Vector.
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119].
+
+<!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
+
+1. [Introduction](#introduction)
+1. [Naming](#naming)
+   1. [Metric naming](#metric-naming)
+
+<!-- /MarkdownTOC -->
+
+## Introduction
+
+Vector's runtime behavior is expressed through user-defined configuration files
+intended to be written directly by users. Therefore, the quality of Vector's
+configuration largely affects Vector's user experience. This document aims to
+make Vector's configuration as high quality as possible in order to achieve a
+[best in class user experience][user_experience].
+
+## Naming
+
+### Metric naming
+
+For metric naming, Vector broadly follows the
+[Prometheus metric naming standards]. Hence, a metric name:
+
+* MUST only contain ASCII alphanumeric, lowercase, and underscores
+* MUST follow the `<namespace>_<name>_<unit>_[total]` template
+  * `namespace` MUST be a _single_ word that groups metrics based on the source (e.g., `host`, `apache`)
+  * `name` is one or more words that describes the measurement (e.g., `memory_rss`, `requests`)
+  * `unit` MUST be a single [base unit] in plural form, if applicable (e.g., `seconds`, `bytes`)
+  * Counters MUST end with `total` (e.g., `disk_written_bytes_total`, `http_requests_total`)
+* SHOULD be broad in purpose and use use tags to differentiate characteristics of the measurement (e.g., `host_cpu_seconds_total{cpu="0",mode="idle"}`)
+
+[Prometheus metric naming standards]: https://prometheus.io/docs/practices/naming/
+[single base unit]: https://en.wikipedia.org/wiki/SI_base_unit


### PR DESCRIPTION
As we prepare efforts to standardize behind Vector's new [User Experience Design document](https://github.com/timberio/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md), I found the need to convert parts of that document to specifications. The User Experience Design document is intended to be theoretical and establish a mental model for UX decision making. Rigid rules, like naming, are better placed in a specification that can be strictly adhered to (e.g., #9110).