### PR TITLE
fix(http source): adjust deflate compression handling

### DIFF
--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -166,7 +166,7 @@ mod tests {
         Pipeline,
     };
     use flate2::{
-        write::{ZlibEncoder, GzEncoder},
+        write::{GzEncoder, ZlibEncoder},
         Compression,
     };
     use futures::Stream;

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -166,7 +166,7 @@ mod tests {
         Pipeline,
     };
     use flate2::{
-        write::{DeflateEncoder, GzEncoder},
+        write::{ZlibEncoder, GzEncoder},
         Compression,
     };
     use futures::Stream;
@@ -664,7 +664,7 @@ mod tests {
         encoder.write_all(body.as_bytes()).unwrap();
         let body = encoder.finish().unwrap();
 
-        let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(body.as_slice()).unwrap();
         let body = encoder.finish().unwrap();
 

--- a/src/sources/util/http.rs
+++ b/src/sources/util/http.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::{Buf, Bytes};
-use flate2::read::{DeflateDecoder, MultiGzDecoder};
+use flate2::read::{MultiGzDecoder, ZlibDecoder};
 use futures::{FutureExt, SinkExt, StreamExt, TryFutureExt};
 use headers::{Authorization, HeaderMapExt};
 use serde::{Deserialize, Serialize};
@@ -141,7 +141,7 @@ pub fn decode(header: &Option<String>, mut body: Bytes) -> Result<Bytes, ErrorMe
                 }
                 "deflate" => {
                     let mut decoded = Vec::new();
-                    DeflateDecoder::new(body.reader())
+                    ZlibDecoder::new(body.reader())
                         .read_to_end(&mut decoded)
                         .map_err(|error| handle_decode_error(encoding, error))?;
                     decoded.into()


### PR DESCRIPTION
According to https://httpwg.org/specs/rfc7230.html#deflate.coding HTTP request with `Content-encoding: deflate` 
shall send data using "zlib" data format containing a "deflate" compressed data stream, hence the shift from a `DeflateDecoder` to a `ZlibDecoder`.

Signed-off-by: prognant <pierre.rognant@datadoghq.com>

