### PR TITLE
fix(prometheus_scrape source): allow `:` in metric names

### DIFF
--- a/lib/prometheus-parser/src/line.rs
+++ b/lib/prometheus-parser/src/line.rs
@@ -362,8 +362,8 @@ impl Line {
 fn parse_name(input: &str) -> IResult<String> {
     let input = trim_space(input);
     let (input, (a, b)) = pair(
-        take_while1(|c: char| c.is_alphabetic() || c == '_'),
-        take_while(|c: char| c.is_alphanumeric() || c == '_'),
+        take_while1(|c: char| c.is_alphabetic() || c == '_' || c == ':'),
+        take_while(|c: char| c.is_alphanumeric() || c == '_' || c == ':'),
     )(input)
     .map_err(|_: NomError| ErrorKind::ParseNameError {
         input: input.to_owned(),
@@ -455,6 +455,11 @@ mod test {
 
         let input = wrap("99");
         assert!(parse_name(&input).is_err());
+
+        let input = wrap("consul_serf_events_consul:new_leader");
+        let (left, r) = parse_name(&input).unwrap();
+        assert_eq!(left, tail);
+        assert_eq!(r, "consul_serf_events_consul:new_leader");
     }
 
     #[test]

--- a/lib/prometheus-parser/src/line.rs
+++ b/lib/prometheus-parser/src/line.rs
@@ -362,7 +362,7 @@ impl Line {
 fn parse_name(input: &str) -> IResult<String> {
     let input = trim_space(input);
     let (input, (a, b)) = pair(
-        take_while1(|c: char| c.is_alphabetic() || c == '_' || c == ':'),
+        take_while1(|c: char| c.is_alphabetic() || c == '_'),
         take_while(|c: char| c.is_alphanumeric() || c == '_' || c == ':'),
     )(input)
     .map_err(|_: NomError| ErrorKind::ParseNameError {


### PR DESCRIPTION
Closes #8946 

As per the docs [here](https://prometheus.io/docs/instrumenting/writing_exporters/#naming), we should allow `:` in metric names.

I am a little unclear about what the docs mean:

> Exposed metrics should not contain colons, these are reserved for user defined recording rules to use when aggregating.

Does this imply that we should accept the `:` but remove the text after the `:` when we expose the metric in the prometheus sink?


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

