### PR TITLE
fix(cli): Fix `top` quitting when the host has gone away

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,7 @@ checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "futures-core",
  "libc",
  "mio 0.7.13",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ async-graphql-warp = { version = "=2.6.4", default-features = false, optional = 
 itertools = { version = "0.10.1", default-features = false, optional = true }
 
 # API client
-crossterm = { version = "0.21.0", default-features = false, optional = true }
+crossterm = { version = "0.21.0", default-features = false, features = ["event-stream"], optional = true }
 num-format = { version = "0.4.0", default-features = false, features = ["with-num-bigint"], optional = true }
 number_prefix = { version = "0.4.0", default-features = false, features = ["std"], optional = true }
 tui = { version = "0.16.0", optional = true, default-features = false, features = ["crossterm"] }

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -64,7 +64,10 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
 
     // Initialize the dashboard
     match init_dashboard(url.as_str(), opts, sender).await {
-        // Exit the process to clean up any lingering subscriptions.
+        // Even though we could return an `exitcode::OK` here, the upstream block_on won't
+        // return due to lingering subscriptions, which manifests as a hung cursor in the
+        // terminal. To work around this for now, exit immediately.
+        // TODO: https://github.com/vectordotdev/vector/issues/9206
         Ok(_) => std::process::exit(0),
         _ => {
             eprintln!("Your terminal doesn't support building a dashboard. Exiting.");

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -64,7 +64,8 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
 
     // Initialize the dashboard
     match init_dashboard(url.as_str(), opts, sender).await {
-        Ok(_) => exitcode::OK,
+        // Exit the process to clean up any lingering subscriptions.
+        Ok(_) => std::process::exit(0),
         _ => {
             eprintln!("Your terminal doesn't support building a dashboard. Exiting.");
             exitcode::IOERR

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -1,5 +1,6 @@
 use super::{events::capture_key_press, state};
 use crossterm::{
+    cursor::Show,
     event::{DisableMouseCapture, EnableMouseCapture, KeyCode},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -317,6 +318,7 @@ pub async fn init_dashboard<'a>(
     // Clean-up terminal
     terminal.backend_mut().execute(DisableMouseCapture)?;
     terminal.backend_mut().execute(LeaveAlternateScreen)?;
+    terminal.backend_mut().execute(Show)?;
 
     disable_raw_mode()?;
 

--- a/src/top/events.rs
+++ b/src/top/events.rs
@@ -1,7 +1,6 @@
-use crossterm::event::{poll, read, Event, KeyCode};
+use crossterm::event::{Event, EventStream, KeyCode};
+use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
-
-static INPUT_INVARIANT: &str = "Couldn't capture keyboard input. Please report.";
 
 /// Capture keyboard input, and send it upstream via a channel. This is used for interaction
 /// with the dashboard, and exiting from `vector top`.
@@ -9,14 +8,18 @@ pub fn capture_key_press() -> (mpsc::UnboundedReceiver<KeyCode>, oneshot::Sender
     let (tx, rx) = mpsc::unbounded_channel();
     let (kill_tx, mut kill_rx) = oneshot::channel();
 
+    let mut events = EventStream::new();
+
     tokio::spawn(async move {
         loop {
-            if poll(std::time::Duration::from_millis(250)).unwrap_or(false) {
-                if let Event::Key(k) = read().expect(INPUT_INVARIANT) {
-                    let _ = tx.clone().send(k.code);
-                };
-            } else if kill_rx.try_recv().is_ok() {
-                return;
+            tokio::select! {
+                biased;
+                _ = &mut kill_rx => return,
+                Some(Ok(event)) = events.next() => {
+                     if let Event::Key(k) = event {
+                        let _ = tx.clone().send(k.code);
+                    };
+                }
             }
         }
     });


### PR DESCRIPTION
Fixes #8449.

Note: This PR handles exiting gracefully (preventing the terminal stalling, and returning the cursor back to the active session). 

It doesn't tackle the CPU spike which still occurs when the host process is terminated. Tracking in #8770.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
