### PR TITLE
docs(datadog_agent source): Document setting use_v2_api to false

### DIFF
--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -10,9 +10,13 @@ components: sources: datadog_agent: {
 		be expanded in the future to cover metrics and traces.
 
 		To send logs from a Datadog Agent to this source, the [Datadog Agent](\(urls.datadog_agent_doc)) configuration
-		must be updated to use `logs_config.dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"`, `logs_config.use_http` should be set
-		to `true` as this source only supports HTTP/HTTPS and `logs_config.logs_no_ssl` must be set to `true` or `false`
-		in accordance to the source SSL configuration.
+		must be updated to use:
+
+		```
+		logs_config.dd_url = "<VECTOR_HOST>:<SOURCE_PORT>"
+		logs_config.use_v2_api = false # source does not yet support new v2 API
+		logs_config.use_http = true # this source only supports HTTP/HTTPS
+		logs_config.logs_no_ssl = true|false # should match source SSL configuration.
 		"""
 
 	classes: {


### PR DESCRIPTION
As Vector does not yet support the V2 logs API
(https://github.com/vectordotdev/vector/issues/9144)



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->