### PR TITLE
fix(config): temporarily revert only load valid config files

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -187,9 +187,9 @@ fn load_builder_from_paths(
                     for res in readdir {
                         match res {
                             Ok(direntry) => {
-                                // skip any unknown file formats
-                                if let Ok(format) = Format::from_path(direntry.path()) {
-                                    if let Some(file) = open_config(&direntry.path()) {
+                                if let Some(file) = open_config(&direntry.path()) {
+                                    // skip any unknown file formats
+                                    if let Ok(format) = Format::from_path(direntry.path()) {
                                         inputs.push((file, Some(format)));
                                     }
                                 }


### PR DESCRIPTION
Reverts vectordotdev/vector#9125

Just getting master back to green. I'll open reverting the revert as another PR so we can fix the tests before merging.