### PR TITLE
feat(config): handle BufferConfig parsing without a type tag

### DIFF
--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -1,11 +1,136 @@
 use crate::config::{ComponentKey, Resource};
 use crate::event::Event;
 use futures::Stream;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{Deserializer, Error, Visitor},
+    Deserialize, Serialize,
+};
 use std::path::PathBuf;
 pub use vector_core::buffers::*;
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum BufferConfigKind {
+    Memory,
+    #[cfg(feature = "disk-buffer")]
+    Disk,
+}
+
+#[cfg(feature = "disk-buffer")]
+const ALL_FIELDS: [&str; 4] = ["type", "max_events", "max_size", "when_full"];
+#[cfg(not(feature = "disk-buffer"))]
+const ALL_FIELDS: [&str; 3] = ["type", "max_events", "when_full"];
+
+struct BufferConfigVisitor;
+
+impl<'de> Visitor<'de> for BufferConfigVisitor {
+    type Value = BufferConfig;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("enum BufferConfig")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut kind: Option<BufferConfigKind> = None;
+        let mut max_events: Option<usize> = None;
+        #[cfg(feature = "disk-buffer")]
+        let mut max_size: Option<usize> = None;
+        let mut when_full: Option<WhenFull> = None;
+        while let Some(key) = map.next_key()? {
+            match key {
+                "type" => {
+                    if kind.is_some() {
+                        return Err(Error::duplicate_field("type"));
+                    }
+                    kind = Some(map.next_value()?);
+                }
+                "max_events" => {
+                    if max_events.is_some() {
+                        return Err(Error::duplicate_field("max_events"));
+                    }
+                    max_events = Some(map.next_value()?);
+                }
+                #[cfg(feature = "disk-buffer")]
+                "max_size" => {
+                    if max_size.is_some() {
+                        return Err(Error::duplicate_field("max_size"));
+                    }
+                    max_size = Some(map.next_value()?);
+                }
+                "when_full" => {
+                    if when_full.is_some() {
+                        return Err(Error::duplicate_field("when_full"));
+                    }
+                    when_full = Some(map.next_value()?);
+                }
+                other => {
+                    return Err(Error::unknown_field(other, &ALL_FIELDS));
+                }
+            }
+        }
+        let when_full = when_full.unwrap_or_default();
+        match kind {
+            Some(BufferConfigKind::Memory) => {
+                #[cfg(feature = "disk-buffer")]
+                if max_size.is_some() {
+                    return Err(Error::unknown_field(
+                        "max_size",
+                        &["type", "max_events", "when_full"],
+                    ));
+                }
+                Ok(BufferConfig::Memory {
+                    max_events: max_events.unwrap_or_else(BufferConfig::memory_max_events),
+                    when_full,
+                })
+            }
+            #[cfg(feature = "disk-buffer")]
+            Some(BufferConfigKind::Disk) => {
+                if max_events.is_some() {
+                    return Err(Error::unknown_field(
+                        "max_events",
+                        &["type", "max_size", "when_full"],
+                    ));
+                }
+                Ok(BufferConfig::Disk {
+                    max_size: max_size.ok_or_else(|| Error::missing_field("max_size"))?,
+                    when_full,
+                })
+            }
+            None => {
+                #[cfg(feature = "disk-buffer")]
+                if let Some(max_size) = max_size {
+                    if max_events.is_some() {
+                        return Err(Error::custom(
+                            "\"max_events\" and \"max_size\" cannot be both defined",
+                        ));
+                    }
+                    return Ok(BufferConfig::Disk {
+                        max_size,
+                        when_full,
+                    });
+                }
+                Ok(BufferConfig::Memory {
+                    max_events: max_events.unwrap_or_else(BufferConfig::memory_max_events),
+                    when_full,
+                })
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BufferConfig {
+    fn deserialize<D>(deserializer: D) -> Result<BufferConfig, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(BufferConfigVisitor)
+    }
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum BufferConfig {
@@ -86,13 +211,13 @@ impl BufferConfig {
 mod test {
     use crate::buffers::{BufferConfig, WhenFull};
 
+    fn check(source: &str, config: BufferConfig) {
+        let conf: BufferConfig = toml::from_str(source).unwrap();
+        assert_eq!(toml::to_string(&conf), toml::to_string(&config));
+    }
+
     #[test]
     fn config_default_values() {
-        fn check(source: &str, config: BufferConfig) {
-            let conf: BufferConfig = toml::from_str(source).unwrap();
-            assert_eq!(toml::to_string(&conf), toml::to_string(&config));
-        }
-
         check(
             r#"
           type = "memory"
@@ -135,6 +260,32 @@ mod test {
                 max_size: 1024,
                 when_full: WhenFull::Block,
             },
+        );
+    }
+
+    #[test]
+    fn parse_without_tag() {
+        check(
+            r#"
+          max_events = 100
+          "#,
+            BufferConfig::Memory {
+                max_events: 100,
+                when_full: WhenFull::Block,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_invalid_keys() {
+        let source = r#"
+    max_events = 100
+    max_size = 42
+    "#;
+        let error = toml::from_str::<BufferConfig>(source).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "\"max_events\" and \"max_size\" cannot be both defined at line 1 column 1"
         );
     }
 }

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -39,8 +39,8 @@ impl<'de> Visitor<'de> for BufferConfigVisitor {
         #[cfg(feature = "disk-buffer")]
         let mut max_size: Option<usize> = None;
         let mut when_full: Option<WhenFull> = None;
-        while let Some(key) = map.next_key()? {
-            match key {
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
                 "type" => {
                     if kind.is_some() {
                         return Err(Error::duplicate_field("type"));


### PR DESCRIPTION
Fixes #7326 

Actually the following cannot be parsed
```toml
max_events = 42
```
because it requires the field `type` to be defined.
This is due to `#[serde(tag = "type")]`.
Implementing a custom deserializer fixes the issue.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>