### PR TITLE
fix(ci): Use use_v2_api: false for k8s datadog agent tests

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -61,6 +61,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
             logs_config.use_http: true
             logs_config.logs_no_ssl: true
             logs_config.logs_dd_url: {}:8080
+            logs_config.use_v2_api: false
             listeners:
               - name: kubelet
             config_providers:


### PR DESCRIPTION
Ref: https://github.com/vectordotdev/vector/issues/9144

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
