### PR TITLE
chore: Add buffer instrumentation spec

### DIFF
--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -21,29 +21,31 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
 #### `EventsReceived`
 
 *All buffers* MUST emit an `EventsReceived` event immediately after receiving one or more Vector events.
+
 * Properties
-  * `entity` - buffer
   * `count` - the number of received events
   * `byte_size` - the byte size of received events
 * Metric
-  * MUST increment the `received_events_total` counter by the defined `count` with other properties as tags
-  * MUST increment the `received_event_bytes_total` counter by the defined `byte_size` with other properties as tags
   * MUST increment the `buffer_event_count` gauge by the defined `count`
+  * MUST increment the `buffer_byte_size` gauge by the defined `byte_size`
   * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes)
 
 #### `EventsFlushed`
+
 *All buffers* MUST emit an `EventsFlushed` event immediately after flushing one or more Vector events.
+
 * Properties
   * `count` - the number of flushed events
   * `byte_size` - the byte size of flushed events
 * Metric
-  * MUST increment the `flushed_events_total` counter by the defined `count` with other properties as tags
-  * MUST increment the `flushed_event_bytes_total` counter by the defined `byte_size` with other properties as tags
   * MUST decrement the `buffer_event_count` gauge by the defined `count`
+  * MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
   * MUST update the `buffer_usage_percentage` gauge
 
 #### `EventsDropped`
+
 *All buffers* MUST emit an `EventsDropped` event immediately after dropping one or more Vector events.
+
 * Properties
   * `count` - the number of dropped events
 * Metric

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -26,25 +26,25 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
 * Metric
   * MUST increment the `received_events_total` counter by the defined `count` with other properties as tags
   * MUST increment the `received_event_bytes_total` counter by the defined `byte_size` with other properties as tags
+  * MUST increment the `buffer_event_count` gauge by the defined `count`
   * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes)
 
 #### `EventsFlushed`
 *All buffers* MUST emit an `EventsFlushed` event immediately after flushing one or more Vector events.
 * Properties
-  * `entity` - buffer
   * `count` - the number of flushed events
   * `byte_size` - the byte size of flushed events
 * Metric
-  * MUST increment the `flushed_events_total` counter by the defined `count` with other properties as tags 
-  * MUST increment the `flushed_event_bytes_total` counter by the defined `byte_size` with other properties as tags 
-  * MUST update the `buffer_usage_percentage` gauge 
+  * MUST increment the `flushed_events_total` counter by the defined `count` with other properties as tags
+  * MUST increment the `flushed_event_bytes_total` counter by the defined `byte_size` with other properties as tags
+  * MUST decrement the `buffer_event_count` gauge by the defined `count`
+  * MUST update the `buffer_usage_percentage` gauge
 
 #### `EventsDropped`
 *All buffers* MUST emit an `EventsDropped` event immediately after dropping one or more Vector events.
 * Properties
-  * `entity` - buffer
   * `count` - the number of dropped events
 * Metric
-  * MUST increment the `discarded_events_total` counter by the defined `count` with other properties as tags
+  * MUST increment the `buffer_discarded_events_total` counter by the defined `count`
 
 [Instrumentation Specification]: instrumentation.md

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -1,0 +1,31 @@
+# Buffer Specification
+
+This document specifies Vector's buffer behavior for the development of Vector.
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
+“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+interpreted as described in [RFC 2119].
+
+<!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
+
+1. [Instrumentation](#instrumentation)
+
+<!-- /MarkdownTOC -->
+
+## Instrumentation
+
+### When a Vector event is stored in the buffer
+* Metric
+  * MUST increment the `buffer_event_count` gauge by one
+  * MUST increment the `buffer_byte_size` gauge by size of the event
+  * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes).
+
+### When a Vector event is removed from the buffer
+* Metric
+  * MUST decrement the `buffer_event_count` gauge by one
+  * MUST decrement the `buffer_byte_size` gauge by size of the event
+  * MUST update the `buffer_usage_percentage` gauge 
+
+### When a Vector event is dropped
+* Metric
+  * MUST increment the `buffer_discarded_events_total` counter by one

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -17,7 +17,9 @@ interpreted as described in [RFC 2119].
 Vector buffers MUST be instrumented for optimal observability and monitoring. This is required to drive various interfaces that Vector users depend on to manage Vector installations in mission critical production environments. This section extends the [Instrumentation Specification].
 
 ### Events
+
 #### `EventsReceived`
+
 *All buffers* MUST emit an `EventsReceived` event immediately after receiving one or more Vector events.
 * Properties
   * `entity` - buffer

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -32,16 +32,16 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST increment the `buffer_byte_size` gauge by the defined `byte_size`
   * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes)
 
-#### `EventsFlushed`
+#### `EventsSent`
 
-*All buffers* MUST emit an `EventsFlushed` event immediately after flushing one or more Vector events.
+*All buffers* MUST emit an `EventsSent` event immediately after sending one or more Vector events.
 
 * Properties
-  * `count` - the number of flushed events
-  * `byte_size` - the byte size of flushed events
+  * `count` - the number of sent events
+  * `byte_size` - the byte size of sent events
 * Metric
-  * MUST increment the `buffer_flushed_events_total` counter by the defined `count`
-  * MUST increment the `buffer_flushed_bytes_total` counter by the defined `byte_size`
+  * MUST increment the `buffer_sent_events_total` counter by the defined `count`
+  * MUST increment the `buffer_sent_bytes_total` counter by the defined `byte_size`
   * MUST decrement the `buffer_events` gauge by the defined `count`
   * MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
   * MUST update the `buffer_usage_percentage` gauge

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -16,20 +16,35 @@ interpreted as described in [RFC 2119].
 
 Vector buffers MUST be instrumented for optimal observability and monitoring. This is required to drive various interfaces that Vector users depend on to manage Vector installations in mission critical production environments. This section extends the [Instrumentation Specification].
 
-### When a Vector event is stored in the buffer
+### Events
+#### `EventsReceived`
+*All buffers* MUST emit an `EventsReceived` event immediately after receiving one or more Vector events.
+* Properties
+  * `entity` - buffer
+  * `count` - the number of received events
+  * `byte_size` - the byte size of received events
 * Metric
-  * MUST increment the `buffer_event_count` gauge by one
-  * MUST increment the `buffer_byte_size` gauge by size of the event
-  * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes).
+  * MUST increment the `received_events_total` counter by the defined `count` with other properties as tags
+  * MUST increment the `received_event_bytes_total` counter by the defined `byte_size` with other properties as tags
+  * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes)
 
-### When a Vector event is removed from the buffer
+#### `EventsFlushed`
+*All buffers* MUST emit an `EventsFlushed` event immediately after flushing one or more Vector events.
+* Properties
+  * `entity` - buffer
+  * `count` - the number of flushed events
+  * `byte_size` - the byte size of flushed events
 * Metric
-  * MUST decrement the `buffer_event_count` gauge by one
-  * MUST decrement the `buffer_byte_size` gauge by size of the event
+  * MUST increment the `flushed_events_total` counter by the defined `count` with other properties as tags 
+  * MUST increment the `flushed_event_bytes_total` counter by the defined `byte_size` with other properties as tags 
   * MUST update the `buffer_usage_percentage` gauge 
 
-### When a Vector event is dropped
+#### `EventsDropped`
+*All buffers* MUST emit an `EventsDropped` event immediately after dropping one or more Vector events.
+* Properties
+  * `entity` - buffer
+  * `count` - the number of dropped events
 * Metric
-  * MUST increment the `buffer_discarded_events_total` counter by one
+  * MUST increment the `discarded_events_total` counter by the defined `count` with other properties as tags
 
 [Instrumentation Specification]: instrumentation.md

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -14,6 +14,8 @@ interpreted as described in [RFC 2119].
 
 ## Instrumentation
 
+Vector buffers MUST be instrumented for optimal observability and monitoring. This is required to drive various interfaces that Vector users depend on to manage Vector installations in mission critical production environments. This section extends the [Instrumentation Specification].
+
 ### When a Vector event is stored in the buffer
 * Metric
   * MUST increment the `buffer_event_count` gauge by one
@@ -29,3 +31,5 @@ interpreted as described in [RFC 2119].
 ### When a Vector event is dropped
 * Metric
   * MUST increment the `buffer_discarded_events_total` counter by one
+
+[Instrumentation Specification]: instrumentation.md

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -26,7 +26,9 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * `count` - the number of received events
   * `byte_size` - the byte size of received events
 * Metric
-  * MUST increment the `buffer_event_count` gauge by the defined `count`
+  * MUST increment the `buffer_received_events_total` counter by the defined `count`
+  * MUST increment the `buffer_received_bytes_total` counter by the defined `byte_size`
+  * MUST increment the `buffer_events` gauge by the defined `count`
   * MUST increment the `buffer_byte_size` gauge by the defined `byte_size`
   * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes)
 
@@ -38,7 +40,9 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * `count` - the number of flushed events
   * `byte_size` - the byte size of flushed events
 * Metric
-  * MUST decrement the `buffer_event_count` gauge by the defined `count`
+  * MUST increment the `buffer_flushed_events_total` counter by the defined `count`
+  * MUST increment the `buffer_flushed_bytes_total` counter by the defined `byte_size`
+  * MUST decrement the `buffer_events` gauge by the defined `count`
   * MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
   * MUST update the `buffer_usage_percentage` gauge
 


### PR DESCRIPTION
As mentioned in #7185, #5654, #4936, we'd like to provide more insight on buffer usage through instrumentation. Desired information includes (from #4936):

-  Buffer size in event quantity
-  Buffer size in bytes
-  Latency of the buffer (how long events are in the buffer)
-  Buffer total/possible size (to determine % used)
-  Events dropped quantity

This buffer specification details exact metrics that can be used. 

Signed-off-by: 001wwang <will.wang@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
