### PR TITLE
fix(host_metrics source): Detect cgroup memory controller before scanning

### DIFF
--- a/src/api/schema/metrics/host.rs
+++ b/src/api/schema/metrics/host.rs
@@ -1,6 +1,5 @@
 use crate::event::{Metric, MetricValue};
-use crate::sources;
-use crate::sources::host_metrics::HostMetricsConfig;
+use crate::sources::host_metrics;
 use async_graphql::Object;
 
 pub struct MemoryMetrics(Vec<Metric>);
@@ -257,12 +256,13 @@ impl DiskMetrics {
     }
 }
 
-pub struct HostMetrics(HostMetricsConfig);
+pub struct HostMetrics(host_metrics::HostMetrics);
 
 impl HostMetrics {
-    /// Primes the host metrics pump by passing through a new `HostMetricsConfig`
+    /// Primes the host metrics pump by passing through a new `HostMetrics`
     pub fn new() -> Self {
-        Self(sources::host_metrics::HostMetricsConfig::default())
+        let config = host_metrics::HostMetricsConfig::default();
+        Self(host_metrics::HostMetrics::new(config))
     }
 }
 

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -17,7 +17,7 @@ const MICROSECONDS: f64 = 1.0 / 1_000_000.0;
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
 #[serde(default)]
-pub(super) struct CgroupsConfig {
+pub(super) struct CGroupsConfig {
     #[derivative(Default(value = "100"))]
     levels: usize,
     pub(super) base: Option<PathBuf>,
@@ -25,7 +25,7 @@ pub(super) struct CgroupsConfig {
 }
 
 #[derive(Debug, Snafu)]
-enum CgroupsError {
+enum CGroupsError {
     #[snafu(display("Could not open cgroup data file {:?}.", filename))]
     Opening {
         filename: PathBuf,
@@ -43,7 +43,7 @@ enum CgroupsError {
     },
 }
 
-type CgroupsResult<T> = Result<T, CgroupsError>;
+type CGroupsResult<T> = Result<T, CGroupsError>;
 
 impl HostMetrics {
     pub async fn cgroups_metrics(&self) -> Vec<Metric> {
@@ -203,12 +203,12 @@ impl CGroup {
         let has_cpu = controllers.iter().any(|name| name == "cpu");
         let has_memory = controllers.iter().any(|name| name == "memory");
         if !has_cpu {
-            warn!(message = "Cgroups CPU controller is not active, there will be no CPU metrics.");
+            warn!(message = "CGroups CPU controller is not active, there will be no CPU metrics.");
         }
         if !has_memory {
             warn!(
                 message =
-                    "Cgroups memory controller is not active, there will be no memory metrics."
+                    "CGroups memory controller is not active, there will be no memory metrics."
             );
         }
 
@@ -236,7 +236,7 @@ impl CGroup {
         self.name == Path::new("/")
     }
 
-    async fn load_cpu(&self, buffer: &mut String) -> CgroupsResult<CpuStat> {
+    async fn load_cpu(&self, buffer: &mut String) -> CGroupsResult<CpuStat> {
         self.open_read_parse("cpu.stat", buffer).await
     }
 
@@ -248,7 +248,7 @@ impl CGroup {
         &self,
         filename: impl AsRef<Path>,
         buffer: &mut String,
-    ) -> CgroupsResult<PathBuf> {
+    ) -> CGroupsResult<PathBuf> {
         buffer.clear();
         let filename = self.make_path(filename);
         File::open(&filename)
@@ -268,16 +268,16 @@ impl CGroup {
         &self,
         filename: impl AsRef<Path>,
         buffer: &mut String,
-    ) -> CgroupsResult<T> {
+    ) -> CGroupsResult<T> {
         let filename = self.open_read(filename, buffer).await?;
         buffer.trim().parse().with_context(|| Parsing { filename })
     }
 
-    async fn load_memory_current(&self, buffer: &mut String) -> CgroupsResult<u64> {
+    async fn load_memory_current(&self, buffer: &mut String) -> CGroupsResult<u64> {
         self.open_read_parse("memory.current", buffer).await
     }
 
-    async fn load_memory_stat(&self, buffer: &mut String) -> CgroupsResult<MemoryStat> {
+    async fn load_memory_stat(&self, buffer: &mut String) -> CGroupsResult<MemoryStat> {
         self.open_read_parse("memory.stat", buffer).await
     }
 
@@ -299,7 +299,7 @@ impl CGroup {
     }
 }
 
-fn load_controllers(filename: &Path) -> CgroupsResult<Vec<String>> {
+fn load_controllers(filename: &Path) -> CGroupsResult<Vec<String>> {
     let mut buffer = String::new();
     std::fs::File::open(&filename)
         .with_context(|| Opening {

--- a/src/sources/host_metrics/cpu.rs
+++ b/src/sources/host_metrics/cpu.rs
@@ -1,4 +1,4 @@
-use super::{filter_result, HostMetricsConfig};
+use super::{filter_result, HostMetrics};
 use crate::event::metric::Metric;
 use chrono::Utc;
 use futures::{stream, StreamExt};
@@ -7,7 +7,7 @@ use heim::cpu::os::linux::CpuTimeExt;
 use heim::units::time::second;
 use shared::btreemap;
 
-impl HostMetricsConfig {
+impl HostMetrics {
     pub async fn cpu_metrics(&self) -> Vec<Metric> {
         match heim::cpu::times().await {
             Ok(times) => {
@@ -63,11 +63,13 @@ impl HostMetricsConfig {
 #[cfg(test)]
 mod tests {
     use super::super::tests::{all_counters, count_name, count_tag};
-    use super::super::HostMetricsConfig;
+    use super::super::{HostMetrics, HostMetricsConfig};
 
     #[tokio::test]
     async fn generates_cpu_metrics() {
-        let metrics = HostMetricsConfig::default().cpu_metrics().await;
+        let metrics = HostMetrics::new(HostMetricsConfig::default())
+            .cpu_metrics()
+            .await;
         assert!(!metrics.is_empty());
         assert!(all_counters(&metrics));
 

--- a/src/sources/host_metrics/filesystem.rs
+++ b/src/sources/host_metrics/filesystem.rs
@@ -1,4 +1,4 @@
-use super::{filter_result, FilterList, HostMetricsConfig};
+use super::{filter_result, FilterList, HostMetrics};
 use crate::event::metric::Metric;
 use chrono::Utc;
 use futures::{stream, StreamExt};
@@ -18,7 +18,7 @@ pub(super) struct FilesystemConfig {
     mountpoints: FilterList,
 }
 
-impl HostMetricsConfig {
+impl HostMetrics {
     pub async fn filesystem_metrics(&self) -> Vec<Metric> {
         match heim::disk::partitions().await {
             Ok(partitions) => {
@@ -28,7 +28,8 @@ impl HostMetricsConfig {
                     })
                     // Filter on configured mountpoints
                     .map(|partition| {
-                        self.filesystem
+                        self.config
+                            .filesystem
                             .mountpoints
                             .contains_path(Some(partition.mount_point()))
                             .then(|| partition)
@@ -36,7 +37,8 @@ impl HostMetricsConfig {
                     .filter_map(|partition| async { partition })
                     // Filter on configured devices
                     .map(|partition| {
-                        self.filesystem
+                        self.config
+                            .filesystem
                             .devices
                             .contains_path(partition.device().map(|d| d.as_ref()))
                             .then(|| partition)
@@ -44,7 +46,8 @@ impl HostMetricsConfig {
                     .filter_map(|partition| async { partition })
                     // Filter on configured filesystems
                     .map(|partition| {
-                        self.filesystem
+                        self.config
+                            .filesystem
                             .filesystems
                             .contains_str(Some(partition.file_system().as_str()))
                             .then(|| partition)
@@ -121,13 +124,15 @@ impl HostMetricsConfig {
 #[cfg(test)]
 mod tests {
     use super::super::tests::{all_gauges, assert_filtered_metrics, count_name, count_tag};
-    use super::super::HostMetricsConfig;
+    use super::super::{HostMetrics, HostMetricsConfig};
     use super::FilesystemConfig;
 
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn generates_filesystem_metrics() {
-        let metrics = HostMetricsConfig::default().filesystem_metrics().await;
+        let metrics = HostMetrics::new(HostMetricsConfig::default())
+            .filesystem_metrics()
+            .await;
         assert!(!metrics.is_empty());
         assert!(metrics.len() % 4 == 0);
         assert!(all_gauges(&metrics));
@@ -155,7 +160,9 @@ mod tests {
     #[cfg(target_os = "windows")]
     #[tokio::test]
     async fn generates_filesystem_metrics() {
-        let metrics = HostMetricsConfig::default().filesystem_metrics().await;
+        let metrics = HostMetrics::new(HostMetricsConfig::default())
+            .filesystem_metrics()
+            .await;
         assert!(!metrics.is_empty());
         assert!(metrics.len() % 3 == 0);
         assert!(all_gauges(&metrics));
@@ -182,13 +189,13 @@ mod tests {
     #[tokio::test]
     async fn filesystem_metrics_filters_on_device() {
         assert_filtered_metrics("device", |devices| async {
-            HostMetricsConfig {
+            HostMetrics::new(HostMetricsConfig {
                 filesystem: FilesystemConfig {
                     devices,
                     ..Default::default()
                 },
                 ..Default::default()
-            }
+            })
             .filesystem_metrics()
             .await
         })
@@ -198,13 +205,13 @@ mod tests {
     #[tokio::test]
     async fn filesystem_metrics_filters_on_filesystem() {
         assert_filtered_metrics("filesystem", |filesystems| async {
-            HostMetricsConfig {
+            HostMetrics::new(HostMetricsConfig {
                 filesystem: FilesystemConfig {
                     filesystems,
                     ..Default::default()
                 },
                 ..Default::default()
-            }
+            })
             .filesystem_metrics()
             .await
         })
@@ -214,13 +221,13 @@ mod tests {
     #[tokio::test]
     async fn filesystem_metrics_filters_on_mountpoint() {
         assert_filtered_metrics("mountpoint", |mountpoints| async {
-            HostMetricsConfig {
+            HostMetrics::new(HostMetricsConfig {
                 filesystem: FilesystemConfig {
                     mountpoints,
                     ..Default::default()
                 },
                 ..Default::default()
-            }
+            })
             .filesystem_metrics()
             .await
         })

--- a/src/sources/host_metrics/memory.rs
+++ b/src/sources/host_metrics/memory.rs
@@ -1,4 +1,4 @@
-use super::HostMetricsConfig;
+use super::HostMetrics;
 use crate::event::metric::Metric;
 use chrono::Utc;
 #[cfg(target_os = "linux")]
@@ -10,7 +10,7 @@ use heim::memory::os::SwapExt;
 use heim::units::information::byte;
 use shared::btreemap;
 
-impl HostMetricsConfig {
+impl HostMetrics {
     pub async fn memory_metrics(&self) -> Vec<Metric> {
         match heim::memory::memory().await {
             Ok(memory) => {

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -143,14 +143,17 @@ impl HostMetricsConfig {
 
 pub struct HostMetrics {
     config: HostMetricsConfig,
+    #[cfg(target_os = "linux")]
     root_cgroup: Option<cgroups::CGroup>,
 }
 
 impl HostMetrics {
     pub fn new(config: HostMetricsConfig) -> Self {
+        #[cfg(target_os = "linux")]
         let root_cgroup = cgroups::CGroup::root(config.cgroups.base.as_deref());
         Self {
             config,
+            #[cfg(target_os = "linux")]
             root_cgroup,
         }
     }

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -38,7 +38,7 @@ mod network;
 #[serde(rename_all = "lowercase")]
 enum Collector {
     #[cfg(target_os = "linux")]
-    Cgroups,
+    CGroups,
     Cpu,
     Disk,
     Filesystem,
@@ -75,7 +75,7 @@ pub struct HostMetricsConfig {
 
     #[cfg(target_os = "linux")]
     #[serde(default)]
-    cgroups: cgroups::CgroupsConfig,
+    cgroups: cgroups::CGroupsConfig,
     #[serde(default)]
     disk: disk::DiskConfig,
     #[serde(default)]
@@ -159,7 +159,7 @@ impl HostMetrics {
         let hostname = crate::get_hostname();
         let mut metrics = Vec::new();
         #[cfg(target_os = "linux")]
-        if self.config.has_collector(Collector::Cgroups) {
+        if self.config.has_collector(Collector::CGroups) {
             metrics.extend(add_collector("cgroups", self.cgroups_metrics().await));
         }
         if self.config.has_collector(Collector::Cpu) {
@@ -518,7 +518,7 @@ pub(self) mod tests {
 
         for collector in &[
             #[cfg(target_os = "linux")]
-            Collector::Cgroups,
+            Collector::CGroups,
             Collector::Cpu,
             Collector::Disk,
             Collector::Filesystem,

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -143,11 +143,16 @@ impl HostMetricsConfig {
 
 pub struct HostMetrics {
     config: HostMetricsConfig,
+    root_cgroup: Option<cgroups::CGroup>,
 }
 
 impl HostMetrics {
-    pub const fn new(config: HostMetricsConfig) -> Self {
-        Self { config }
+    pub fn new(config: HostMetricsConfig) -> Self {
+        let root_cgroup = cgroups::CGroup::root(config.cgroups.base.as_deref());
+        Self {
+            config,
+            root_cgroup,
+        }
     }
 
     async fn capture_metrics(&self) -> impl Iterator<Item = Event> {


### PR DESCRIPTION
This is a bigger patch than strictly needed, as it moves the root cgroup detection into an initialization function instead of running once per cycle, which in turn breaks up the host metrics config type.

Closes #9158 