### PR TITLE
chore: Removes `sink::Response` from the Datadog Logs sink

### DIFF
--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -63,11 +63,11 @@ pub enum LogApiResponse {
     PermissionIssue,
 }
 
-impl Into<EventStatus> for LogApiResponse {
-    fn into(self) -> EventStatus {
+impl AsRef<EventStatus> for LogApiResponse {
+    fn as_ref(&self) -> &EventStatus {
         match self {
-            LogApiResponse::Ok => EventStatus::Delivered,
-            LogApiResponse::PermissionIssue => EventStatus::Errored,
+            LogApiResponse::Ok => &EventStatus::Delivered,
+            LogApiResponse::PermissionIssue => &EventStatus::Errored,
         }
     }
 }

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -365,7 +365,7 @@ where
                     .map(move |result| {
                         let status = match result {
                             Err(error) => {
-                                error!("Sink IO failed with error: {}", error);
+                                error!("Sink IO failed with error: {}.", error);
                                 EventStatus::Failed
                             },
                             Ok(response) => { *response.as_ref() }

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -251,7 +251,7 @@ impl<S> StreamSink for LogSink<S>
 where
     S: Service<LogApiRequest> + Send + 'static,
     S::Future: Send + 'static,
-    S::Response: Into<EventStatus> + Send + 'static,
+    S::Response: AsRef<EventStatus> + Send + 'static,
     S::Error: Debug + Into<crate::Error> + Send,
 {
     async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
@@ -322,7 +322,7 @@ async fn run_io<S>(mut rx: Receiver<LogApiRequest>, mut service: S, acker: Acker
 where
     S: Service<LogApiRequest>,
     S::Future: Send + 'static,
-    S::Response: Into<EventStatus> + Send + 'static,
+    S::Response: AsRef<EventStatus> + Send + 'static,
     S::Error: Debug + Into<crate::Error> + Send,
 {
     let in_flight = FuturesUnordered::new();
@@ -368,7 +368,7 @@ where
                                 error!("Sink IO failed with error: {}", error);
                                 EventStatus::Failed
                             },
-                            Ok(response) => { response.into() }
+                            Ok(response) => { *response.as_ref() }
                         };
                         finalizers.update_status(status);
                         // If the rx end is dropped we still completed

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -3,7 +3,6 @@ use crate::config::SinkContext;
 use crate::sinks::datadog::logs::config::Encoding;
 use crate::sinks::util::buffer::GZIP_FAST;
 use crate::sinks::util::encoding::{EncodingConfigWithDefault, EncodingConfiguration};
-use crate::sinks::util::sink::{Response, ServiceLogic, StdServiceLogic};
 use crate::sinks::util::Compression;
 use async_trait::async_trait;
 use flate2::write::GzEncoder;
@@ -29,7 +28,7 @@ use tracing_futures::Instrument;
 use twox_hash::XxHash64;
 use vector_core::buffers::Acker;
 use vector_core::config::{log_schema, LogSchema};
-use vector_core::event::{Event, EventFinalizers, Finalizable, Value};
+use vector_core::event::{Event, EventFinalizers, EventStatus, Finalizable, Value};
 use vector_core::partition::Partitioner;
 use vector_core::sink::StreamSink;
 use vector_core::stream::batcher::Batcher;
@@ -252,7 +251,7 @@ impl<S> StreamSink for LogSink<S>
 where
     S: Service<LogApiRequest> + Send + 'static,
     S::Future: Send + 'static,
-    S::Response: Response + Send + 'static,
+    S::Response: Into<EventStatus> + Send + 'static,
     S::Error: Debug + Into<crate::Error> + Send,
 {
     async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
@@ -323,7 +322,7 @@ async fn run_io<S>(mut rx: Receiver<LogApiRequest>, mut service: S, acker: Acker
 where
     S: Service<LogApiRequest>,
     S::Future: Send + 'static,
-    S::Response: Response + Send + 'static,
+    S::Response: Into<EventStatus> + Send + 'static,
     S::Error: Debug + Into<crate::Error> + Send,
 {
     let in_flight = FuturesUnordered::new();
@@ -351,10 +350,6 @@ where
                     message = "Submitting service request.",
                     in_flight_requests = in_flight.len()
                 );
-                // TODO: This likely need be parameterized, which builds a
-                // stronger case for following through with the comment
-                // mentioned below.
-                let logic = StdServiceLogic::default();
                 // TODO: I'm not entirely happy with how we're smuggling
                 // batch_size/finalizers this far through, from the finished
                 // batch all the way through to the concrete request type...we
@@ -368,8 +363,14 @@ where
                 let fut = svc.call(req)
                     .err_into()
                     .map(move |result| {
-                        logic.update_finalizers(result, finalizers);
-
+                        let status = match result {
+                            Err(error) => {
+                                error!("Sink IO failed with error: {}", error);
+                                EventStatus::Failed
+                            },
+                            Ok(response) => { response.into() }
+                        };
+                        finalizers.update_status(status);
                         // If the rx end is dropped we still completed
                         // the request so this is a weird case that we can
                         // ignore for now.

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -287,7 +287,7 @@ pub struct TowerRequestLayer<L, Request> {
 impl<S, RL, Request> Layer<S> for TowerRequestLayer<RL, Request>
 where
     S: Service<Request> + Send + Clone + 'static,
-    S::Response: Response + Send + 'static,
+    S::Response: Send + 'static,
     S::Error: Into<crate::Error> + Send + Sync + 'static,
     S::Future: Send + 'static,
     RL: RetryLogic<Response = S::Response> + Send + 'static,


### PR DESCRIPTION
This commit removes the referenced trait from the sink and from the
`TowerRequestLayer` implementation. Other callers can choose to leave this
constraint in place but it is not required. This change has also allowed me to
clean up the odd Ok/Err split noted in #8825.

I intend to do a similar bit of work to the s3 sinks.

REF #9140

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
