### PR TITLE
enhancement(vrl): allow statements in `if` predicates over multiple lines.

### DIFF
--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -445,9 +445,13 @@ ElseIf: IfStatement =
     IfStatement { predicate, consequent, alternative: None }
 };
 
+StatementSeparator: () = {
+    NonterminalNewline, ";"
+};
+
 Predicate: Predicate = {
     Box<ArithmeticExpr> => Predicate::One(<>),
-    "(" <v:(<AssignmentExpr> ";")+> <e:(<AssignmentExpr>)?> ")" => {
+    "(" StatementSeparator? <v:(<AssignmentExpr> StatementSeparator)+> <e:(<AssignmentExpr>)?> ")" => {
         let expressions = match e {
             None => v,
             Some(e) => {

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -451,7 +451,7 @@ StatementSeparator: () = {
 
 Predicate: Predicate = {
     Box<ArithmeticExpr> => Predicate::One(<>),
-    "(" StatementSeparator? <v:(<AssignmentExpr> StatementSeparator)+> <e:(<AssignmentExpr>)?> ")" => {
+    "(" NonterminalNewline* <v:(<AssignmentExpr> StatementSeparator+)+> <e:(<AssignmentExpr>)?> ")" => {
         let expressions = match e {
             None => v,
             Some(e) => {

--- a/lib/vrl/tests/tests/expressions/if_statement/multiline_predicates.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/multiline_predicates.vrl
@@ -1,0 +1,21 @@
+# result: [true, true, true]
+
+x = 2
+
+v1 = if (x = x + 1; x == 3) {
+  true
+}
+
+v2 = if (x = x + 1
+         x == 4) {
+  true
+}
+
+v3 = if (
+  x = x + 1
+  x == 5
+) {
+  true
+}
+
+[v1, v2, v3]

--- a/lib/vrl/tests/tests/expressions/if_statement/multiline_predicates.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/multiline_predicates.vrl
@@ -1,4 +1,4 @@
-# result: [true, true, true]
+# result: [true, true, true, true]
 
 x = 2
 
@@ -18,4 +18,16 @@ v3 = if (
   true
 }
 
-[v1, v2, v3]
+v4 = if (
+  # Lets test spaces
+  x = x + 1
+
+  # Does it work?
+
+  x = x + 1; x == 7;
+
+  ) {
+  true
+}
+
+[v1, v2, v3, v4]

--- a/lib/vrl/tests/tests/expressions/if_statement/multiline_predicates.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/multiline_predicates.vrl
@@ -1,4 +1,4 @@
-# result: [true, true, true, true]
+# result: [true, true, true, true, true]
 
 x = 2
 
@@ -30,4 +30,13 @@ v4 = if (
   true
 }
 
-[v1, v2, v3, v4]
+v5 = if (x = x + 1; x == 9) {
+       null
+     } else if (
+       x = x + 1
+       x == 9
+     ) {
+       true
+     }
+
+[v1, v2, v3, v4, v5]

--- a/website/cue/reference/remap/expressions/if.cue
+++ b/website/cue/reference/remap/expressions/if.cue
@@ -20,6 +20,8 @@ remap: expressions: if: {
 				description: """
 					The `predicate` _must_ be an expression that resolves to a Boolean. If a Boolean isn't returned, a
 					compile-time error is raised.
+					The predicate can contain multiple expressions. Multiple expression predicates must be wrapped in
+					parentheses. The expressions need to be seperated by either a semicolon (`;`) or a new line.
 					"""
 			}
 		}
@@ -72,5 +74,22 @@ remap: expressions: if: {
 				"""#
 			return: "Hello, World!"
 		},
+		{
+			title: "Multiline expression"
+			source: #"""
+				x = 3
+				if (x = x + 1; x == 5) {
+					# not evaluated
+					null
+				} else if (
+					x = x + 1
+					x == 5
+				) {
+					"Hello, World!"
+				}
+				"""#
+			return: "Hello, World!"
+		},
+
 	]
 }


### PR DESCRIPTION
This PR makes it possible to specify the statements in `if` predicates to work over multiple lines, so the following becomes possible:

```
if (
  x = thing
  y= thung
  x == y 
) {
...
}
```

I've noticed some users have fairly lengthy predicates and this change makes things more ergonomic for them.

