### PR TITLE
fix(aws_s3 sink): ship final batches when shutting down

### DIFF
--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -11,7 +11,6 @@ use futures::{
     stream::{BoxStream, FuturesUnordered, StreamExt},
     FutureExt, TryFutureExt,
 };
-use tokio::sync::Barrier;
 use std::sync::Arc;
 use std::{
     collections::HashMap,
@@ -20,6 +19,7 @@ use std::{
     num::NonZeroUsize,
     time::Duration,
 };
+use tokio::sync::Barrier;
 use tokio::{
     pin, select,
     sync::{

--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -11,6 +11,8 @@ use futures::{
     stream::{BoxStream, FuturesUnordered, StreamExt},
     FutureExt, TryFutureExt,
 };
+use tokio::sync::Barrier;
+use std::sync::Arc;
 use std::{
     collections::HashMap,
     fmt::Debug,
@@ -93,6 +95,7 @@ where
         // exclusively with I/O, while we deal with everything else here:
         // batching, ordering, and so on.
         let (io_tx, io_rx) = channel(64);
+        let io_barrier = Arc::new(Barrier::new(2));
         let service = self
             .service
             .take()
@@ -106,7 +109,7 @@ where
             .take()
             .expect("same sink should not be run twice");
 
-        let io = run_io(io_rx, service, acker).in_current_span();
+        let io = run_io(io_rx, Arc::clone(&io_barrier), service, acker).in_current_span();
         let _ = tokio::spawn(io);
 
         let batcher = Batcher::new(
@@ -142,11 +145,19 @@ where
             }
         }
 
+        // Wait for the I/O task to complete.
+        //
+        // TODO: the need for this synchronization means we should probably look into something more
+        // ergonomic like `buffered`/`buffer_unordered` + `tokio::spawn`, otherwise every sink will
+        // be reimplementing this logic for the common case.
+        drop(io_tx);
+        io_barrier.wait().await;
+
         Ok(())
     }
 }
 
-async fn run_io<S>(mut rx: Receiver<S3Request>, mut service: S, acker: Acker)
+async fn run_io<S>(mut rx: Receiver<S3Request>, barrier: Arc<Barrier>, mut service: S, acker: Acker)
 where
     S: Service<S3Request>,
     S::Future: Send + 'static,
@@ -221,6 +232,8 @@ where
             else => break
         }
     }
+
+    barrier.wait().await;
 }
 
 pub trait S3RequestBuilder {


### PR DESCRIPTION
This PR fixes the behavior of the S3 sink by ensuring that the main task does not shut down until the I/O task shuts down, and that the I/O task only shuts down when it has processed all requests.

Prior to this, exiting the process (via something like Ctrl-C) would lead to in-flight batches never being fully sent, because while the batcher would recognize that it needed to emit them, the I/O task never had a chance to send them.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>