### PR TITLE
chore: Set Datadog Logs sink timeout to 60 seconds

### DIFF
--- a/website/cue/reference/components/sinks/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/datadog_logs.cue
@@ -12,7 +12,7 @@ components: sinks: datadog_logs: {
 			batch: {
 				enabled:      true
 				common:       false
-				timeout_secs: 1
+				timeout_secs: 60
 			}
 			compression: {
 				enabled: true


### PR DESCRIPTION
Reflected in the code but not in our documentation the new sink implementation
times out batches on 60 second intervals.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
