### PR TITLE
chore: Adjust Datadog Logs sink timeout to 5 seconds

### DIFF
--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -44,7 +44,7 @@ const MAX_PAYLOAD_BYTES: usize = 5_000_000;
 // of escaped double-quotes -- but we believe this should be very rare in
 // practice.
 const BATCH_GOAL_BYTES: usize = 4_250_000;
-const BATCH_DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+const BATCH_DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Default)]
 struct EventPartitioner {}

--- a/website/cue/reference/components/sinks/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/datadog_logs.cue
@@ -12,7 +12,7 @@ components: sinks: datadog_logs: {
 			batch: {
 				enabled:      true
 				common:       false
-				timeout_secs: 60
+				timeout_secs: 5
 			}
 			compression: {
 				enabled: true


### PR DESCRIPTION
Inspired by the conversation on #9185 this PR adjusts the timeout down from 60
seconds to 5.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
