### PR TITLE
docs(vector sink): Fix relevant_when documentation for request options

### DIFF
--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -28,7 +28,7 @@ components: sinks: vector: {
 			request: {
 				enabled:       true
 				headers:       false
-				relevant_when: "version = \"v2\""
+				relevant_when: "version = \"2\""
 			}
 
 			tls: {


### PR DESCRIPTION
Should just be `2` not `v2`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
