### PR TITLE
chore: Remove the `sink::Response` trait from the s3 sinks

### DIFF
--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -6,10 +6,12 @@ use crate::sinks::Healthcheck;
 use futures::FutureExt;
 use http::StatusCode;
 use rusoto_core::RusotoError;
-use rusoto_s3::{HeadBucketRequest, PutObjectError, PutObjectOutput, S3Client, S3};
+use rusoto_s3::{HeadBucketRequest, PutObjectError, S3Client, S3};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::{collections::BTreeMap, convert::TryInto};
+
+use super::service::S3Response;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct S3Options {
@@ -68,7 +70,7 @@ pub struct S3RetryLogic;
 
 impl RetryLogic for S3RetryLogic {
     type Error = RusotoError<PutObjectError>;
-    type Response = PutObjectOutput;
+    type Response = S3Response;
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         rusoto::is_retriable_error(error)


### PR DESCRIPTION
This commit removes the need for `sink::Response` from the s3 sinks, in a like
manner to the work done in #9172.

Resolves #9140

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
