### PR TITLE
chore: Remove `sink::Response` from Vector V2

### DIFF
--- a/src/sinks/vector/v2.rs
+++ b/src/sinks/vector/v2.rs
@@ -3,8 +3,8 @@ use crate::{
     event::{proto::EventWrapper, Event},
     proto::vector as proto,
     sinks::util::{
-        retries::RetryLogic, sink, BatchConfig, BatchSettings, BatchSink, EncodedEvent,
-        EncodedLength, ServiceBuilderExt, TowerRequestConfig, VecBuffer,
+        retries::RetryLogic, BatchConfig, BatchSettings, BatchSink, EncodedEvent, EncodedLength,
+        ServiceBuilderExt, TowerRequestConfig, VecBuffer,
     },
     sinks::{Healthcheck, VectorSink},
     tls::{tls_connector_builder, MaybeTlsSettings, TlsConfig},
@@ -21,7 +21,6 @@ use tonic::{body::BoxBody, IntoRequest};
 use tower::ServiceBuilder;
 
 type Client = proto::Client<HyperSvc>;
-type Response = Result<tonic::Response<proto::PushEventsResponse>, tonic::Status>;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -244,12 +243,6 @@ fn encode_event(mut event: Event) -> EncodedEvent<EventWrapper> {
 impl EncodedLength for EventWrapper {
     fn encoded_length(&self) -> usize {
         self.encoded_len()
-    }
-}
-
-impl sink::Response for Response {
-    fn is_successful(&self) -> bool {
-        self.is_ok()
     }
 }
 


### PR DESCRIPTION
In a like manner to #9203 and #9172 it turns out this trait, while implemented
in the v2 Vector sink, is not actually in use.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
