### PR TITLE
fix(vrl): fix byte-swapped integers in ip_aton() and ip_ntoa() functions

### DIFF
--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -466,7 +466,7 @@ bench_function! {
 
     valid {
         args: func_args![value: "1.2.3.4"],
-        want: Ok(value!(67305985)),
+        want: Ok(value!(16909060)),
     }
 }
 
@@ -488,7 +488,7 @@ bench_function! {
     ip_ntoa => vrl_stdlib::IpNtoa;
 
     valid {
-        args: func_args![value: 67305985],
+        args: func_args![value: 16909060],
         want: Ok(value!("1.2.3.4")),
     }
 }

--- a/lib/vrl/stdlib/src/ip_aton.rs
+++ b/lib/vrl/stdlib/src/ip_aton.rs
@@ -22,7 +22,7 @@ impl Function for IpAton {
         &[Example {
             title: "Example",
             source: r#"ip_aton!("1.2.3.4")"#,
-            result: Ok("67305985"),
+            result: Ok("16909060"),
         }]
     }
 
@@ -47,9 +47,7 @@ impl Expression for IpAtonFn {
             .parse()
             .map_err(|err| format!("unable to parse IPv4 address: {}", err))?;
 
-        let i = u32::from(ip); // host-order
-
-        Ok(i.to_be().into())
+        Ok(u32::from(ip).into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
@@ -72,7 +70,7 @@ mod tests {
 
         valid {
             args: func_args![value: "1.2.3.4"],
-            want: Ok(value!(67305985)),
+            want: Ok(value!(16909060)),
             tdef: TypeDef::new().fallible().integer(),
         }
     ];

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -21,7 +21,7 @@ impl Function for IpNtoa {
     fn examples(&self) -> &'static [Example] {
         &[Example {
             title: "Example",
-            source: r#"ip_ntoa!(67305985)"#,
+            source: r#"ip_ntoa!(16909060)"#,
             result: Ok("1.2.3.4"),
         }]
     }
@@ -47,9 +47,7 @@ impl Expression for IpNtoaFn {
             .try_into()
             .map_err(|_| String::from("cannot convert to bytes: integer does not fit in u32"))?;
 
-        let ip = Ipv4Addr::from(u32::from_be(i));
-
-        Ok(ip.to_string().into())
+        Ok(Ipv4Addr::from(i).to_string().into())
     }
 
     fn type_def(&self, _: &state::Compiler) -> TypeDef {
@@ -71,7 +69,7 @@ mod tests {
         }
 
         valid {
-            args: func_args![value: 67305985],
+            args: func_args![value: 16909060],
             want: Ok(value!("1.2.3.4")),
             tdef: TypeDef::new().fallible().bytes(),
         }

--- a/website/cue/reference/remap/functions/ip_aton.cue
+++ b/website/cue/reference/remap/functions/ip_aton.cue
@@ -28,7 +28,7 @@ remap: functions: ip_aton: {
 			source: #"""
 				ip_aton!("1.2.3.4")
 				"""#
-			return: 67305985
+			return: 16909060
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/ip_ntoa.cue
+++ b/website/cue/reference/remap/functions/ip_ntoa.cue
@@ -26,7 +26,7 @@ remap: functions: ip_ntoa: {
 		{
 			title: "Integer to IPv4"
 			source: #"""
-				ip_ntoa!(67305985)
+				ip_ntoa!(16909060)
 				"""#
 			return: "1.2.3.4"
 		},


### PR DESCRIPTION
These functions were wrongly byte-swapping integers for their conversions, thus giving wrong results.

The `u32::from(Ipv4Addr)` and `Ipv4Addr::from(u32)` functions do not require bitness conversions after all.

I tested this using the `timberio/ci_image` Docker image (thanks for providing a ready-made environment!). But please let me know if anything else needs to be done for this PR.

Closes #9182 

cc: @jszwedko 