### PR TITLE
chore: Add component_ prefix to metric naming

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -110,7 +110,7 @@ There is leeway in the implementation of these events:
 * Components MAY emit events for batches of Vector events for performance
   reasons, but the resulting telemetry state MUST be equivalent to emitting
   individual events. For example, emitting the `EventsReceived` event for 10
-  events MUST increment the `received_events_total` counter by 10.
+  events MUST increment the `component_received_events_total` counter by 10.
 
 #### BytesReceived
 
@@ -130,7 +130,7 @@ from the upstream source and before the creation of a Vector event.
   * `http_path` - If relevant, the HTTP path, excluding query strings.
   * `socket` - If relevant, the socket number that bytes were received from.
 * Metrics
-  * MUST increment the `received_bytes_total` counter by the defined value with
+  * MUST increment the `component_received_bytes_total` counter by the defined value with
     the defined properties as metric tags.
 * Logs
   * MUST log a `Bytes received.` message at the `trace` level with the
@@ -145,9 +145,9 @@ or receiving one or more Vector events.
   * `count` - The count of Vector events.
   * `byte_size` - The cumulative in-memory byte size of all events received.
 * Metrics
-  * MUST increment the `received_events_total` counter by the defined `quantity`
+  * MUST increment the `component_received_events_total` counter by the defined `quantity`
     property with the other properties as metric tags.
-  * MUST increment the `received_event_bytes_total` counter by the defined
+  * MUST increment the `component_received_event_bytes_total` counter by the defined
     `byte_size` property with the other properties as metric tags.
 * Logs
   * MUST log a `Events received.` message at the `trace` level with the
@@ -163,9 +163,9 @@ as encoding.
   * `count` - The count of Vector events.
   * `byte_size` - The cumulative in-memory byte size of all events sent.
 * Metrics
-  * MUST increment the `sent_events_total` counter by the defined value with the
+  * MUST increment the `component_sent_events_total` counter by the defined value with the
     defined properties as metric tags.
-  * MUST increment the `sent_event_bytes_total` counter by the event's byte size
+  * MUST increment the `component_sent_event_bytes_total` counter by the event's byte size
     in JSON representation.
 * Logs
   * MUST log a `Events sent.` message at the `trace` level with the
@@ -190,7 +190,7 @@ downstream target regardless if the transmission was successful or not.
     HTTP, this MUST be the host and path only, excluding the query string.
   * `file` - If relevant, the absolute path of the file.
 * Metrics
-  * MUST increment the `sent_bytes_total` counter by the defined value with the
+  * MUST increment the `component_sent_bytes_total` counter by the defined value with the
     defined properties as metric tags.
 * Logs
   * MUST log a `Bytes received.` message at the `trace` level with the
@@ -214,9 +214,9 @@ implement since errors are specific to the component.
     only happen at one stage, but MUST be included in the emitted logs
     and metrics as if it were present.
 * Metrics
-  * MUST increment the `errors_total` counter by 1 with the defined properties
+  * MUST increment the `component_errors_total` counter by 1 with the defined properties
     as metric tags.
-  * MUST increment the `discarded_events_total` counter by the number of Vector
+  * MUST increment the `component_discarded_events_total` counter by the number of Vector
     events discarded if the error resulted in discarding (dropping) events.
 * Logs
   * MUST log a message at the `error` level with the defined properties

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -17,7 +17,7 @@ impl<'a> InternalEvent for ApacheMetricsEventReceived<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "received_events_total", self.count as u64,
+            "component_received_events_total", self.count as u64,
             "uri" => self.uri.to_owned(),
         );
         counter!(

--- a/src/internal_events/aws_ecs_metrics.rs
+++ b/src/internal_events/aws_ecs_metrics.rs
@@ -15,7 +15,7 @@ impl InternalEvent for AwsEcsMetricsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", self.count as u64);
+        counter!("component_received_events_total", self.count as u64);
         counter!("events_in_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/aws_kinesis_firehose.rs
+++ b/src/internal_events/aws_kinesis_firehose.rs
@@ -9,7 +9,7 @@ pub struct AwsKinesisFirehoseEventReceived {
 
 impl InternalEvent for AwsKinesisFirehoseEventReceived {
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/aws_s3.rs
+++ b/src/internal_events/aws_s3.rs
@@ -16,7 +16,7 @@ pub mod source {
 
     impl InternalEvent for SqsS3EventReceived {
         fn emit_metrics(&self) {
-            counter!("received_events_total", 1);
+            counter!("component_received_events_total", 1);
             counter!("events_in_total", 1);
             counter!("processed_bytes_total", self.byte_size as u64);
         }

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -15,7 +15,10 @@ impl InternalEvent for EventsReceived {
     fn emit_metrics(&self) {
         counter!("component_received_events_total", self.count as u64);
         counter!("events_in_total", self.count as u64);
-        counter!("component_received_event_bytes_total", self.byte_size as u64);
+        counter!(
+            "component_received_event_bytes_total",
+            self.byte_size as u64
+        );
     }
 }
 

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -13,9 +13,9 @@ impl InternalEvent for EventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", self.count as u64);
+        counter!("component_received_events_total", self.count as u64);
         counter!("events_in_total", self.count as u64);
-        counter!("received_event_bytes_total", self.byte_size as u64);
+        counter!("component_received_event_bytes_total", self.byte_size as u64);
     }
 }
 
@@ -33,8 +33,8 @@ impl InternalEvent for EventsSent {
     fn emit_metrics(&self) {
         if self.count > 0 {
             counter!("events_out_total", self.count as u64);
-            counter!("sent_events_total", self.count as u64);
-            counter!("sent_event_bytes_total", self.byte_size as u64);
+            counter!("component_sent_events_total", self.count as u64);
+            counter!("component_sent_event_bytes_total", self.byte_size as u64);
         }
     }
 }

--- a/src/internal_events/dnstap.rs
+++ b/src/internal_events/dnstap.rs
@@ -13,7 +13,7 @@ impl InternalEvent for DnstapEventReceived {
 
     fn emit_metrics(&self) {
         counter!("processed_events_total", 1);
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -21,7 +21,7 @@ impl<'a> InternalEvent for DockerLogsEventReceived<'a> {
 
     fn emit_metrics(&self) {
         counter!(
-            "received_events_total", 1,
+            "component_received_events_total", 1,
             "container_name" => self.container_name.to_owned()
         );
         counter!(

--- a/src/internal_events/eventstoredb_metrics.rs
+++ b/src/internal_events/eventstoredb_metrics.rs
@@ -42,7 +42,7 @@ impl InternalEvent for EventStoreDbMetricsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", self.events as u64);
+        counter!("component_received_events_total", self.events as u64);
         counter!("events_in_total", self.events as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -18,7 +18,7 @@ impl InternalEvent for ExecEventReceived<'_> {
 
     fn emit_metrics(&self) {
         counter!(
-            "received_events_total", 1,
+            "component_received_events_total", 1,
             "command" => self.command.to_owned(),
         );
         counter!(

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -39,7 +39,7 @@ mod source {
 
         fn emit_metrics(&self) {
             counter!(
-                "received_events_total", 1,
+                "component_received_events_total", 1,
                 "file" => self.file.to_owned(),
             );
             counter!(

--- a/src/internal_events/fluent.rs
+++ b/src/internal_events/fluent.rs
@@ -13,7 +13,7 @@ impl InternalEvent for FluentMessageReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -18,7 +18,7 @@ impl InternalEvent for HttpEventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", self.events_count as u64);
+        counter!("component_received_events_total", self.events_count as u64);
         counter!("events_in_total", self.events_count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -12,7 +12,7 @@ impl InternalEvent for JournaldEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -13,7 +13,7 @@ impl InternalEvent for KafkaEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -20,7 +20,7 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
     fn emit_metrics(&self) {
         match self.pod_name {
             Some(name) => {
-                counter!("received_events_total", 1, "pod_name" => name.to_owned());
+                counter!("component_received_events_total", 1, "pod_name" => name.to_owned());
                 counter!("events_in_total", 1, "pod_name" => name.to_owned());
                 counter!(
                     "processed_bytes_total", self.byte_size as u64,
@@ -28,7 +28,7 @@ impl InternalEvent for KubernetesLogsEventReceived<'_> {
                 );
             }
             None => {
-                counter!("received_events_total", 1);
+                counter!("component_received_events_total", 1);
                 counter!("events_in_total", 1);
                 counter!("processed_bytes_total", self.byte_size as u64);
             }

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -12,7 +12,7 @@ pub struct MongoDbMetricsEventsReceived<'a> {
 impl<'a> InternalEvent for MongoDbMetricsEventsReceived<'a> {
     fn emit_metrics(&self) {
         counter!(
-            "received_events_total", self.count as u64,
+            "component_received_events_total", self.count as u64,
             "uri" => self.uri.to_owned(),
         );
         counter!(

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -13,7 +13,7 @@ impl InternalEvent for NatsEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -12,7 +12,7 @@ pub struct NginxMetricsEventsReceived<'a> {
 impl<'a> InternalEvent for NginxMetricsEventsReceived<'a> {
     fn emit_metrics(&self) {
         counter!(
-            "received_events_total", self.count as u64,
+            "component_received_events_total", self.count as u64,
             "uri" => self.uri.to_owned(),
         );
         counter!(

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -21,7 +21,7 @@ impl InternalEvent for PrometheusEventReceived {
 
     fn emit_metrics(&self) {
         counter!(
-            "received_events_total", self.count as u64,
+            "component_received_events_total", self.count as u64,
             "uri" => format!("{}",self.uri),
         );
         counter!(

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -37,7 +37,7 @@ impl InternalEvent for SocketEventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1, "mode" => self.mode.as_str());
+        counter!("component_received_events_total", 1, "mode" => self.mode.as_str());
         counter!("events_in_total", 1, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -72,7 +72,7 @@ mod source {
         }
 
         fn emit_metrics(&self) {
-            counter!("received_events_total", 1);
+            counter!("component_received_events_total", 1);
             counter!("events_in_total", 1);
         }
     }

--- a/src/internal_events/statsd_source.rs
+++ b/src/internal_events/statsd_source.rs
@@ -13,7 +13,7 @@ impl InternalEvent for StatsdEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64,);
     }

--- a/src/internal_events/stdin.rs
+++ b/src/internal_events/stdin.rs
@@ -13,7 +13,7 @@ impl InternalEvent for StdinEventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", self.count as u64);
+        counter!("component_received_events_total", self.count as u64);
         counter!("events_in_total", self.count as u64);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/syslog.rs
+++ b/src/internal_events/syslog.rs
@@ -12,7 +12,7 @@ impl InternalEvent for SyslogEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/src/internal_events/vector.rs
+++ b/src/internal_events/vector.rs
@@ -13,7 +13,7 @@ impl InternalEvent for VectorEventReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("received_events_total", 1);
+        counter!("component_received_events_total", 1);
         counter!("events_in_total", 1);
         counter!("processed_bytes_total", self.byte_size as u64);
     }

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -629,8 +629,8 @@ components: sinks: [Name=string]: {
 	telemetry: metrics: {
 		events_in_total:            components.sources.internal_metrics.output.metrics.events_in_total
 		events_out_total:           components.sources.internal_metrics.output.metrics.events_out_total
-		received_events_total:      components.sources.internal_metrics.output.metrics.received_events_total
-		received_event_bytes_total: components.sources.internal_metrics.output.metrics.received_event_bytes_total
+		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
+		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		utilization:                components.sources.internal_metrics.output.metrics.utilization
 	}
 }

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -241,7 +241,7 @@ components: sources: [Name=string]: {
 
 	telemetry: metrics: {
 		events_out_total:       components.sources.internal_metrics.output.metrics.events_out_total
-		sent_events_total:      components.sources.internal_metrics.output.metrics.sent_events_total
-		sent_event_bytes_total: components.sources.internal_metrics.output.metrics.sent_event_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/apache_metrics.cue
+++ b/website/cue/reference/components/sources/apache_metrics.cue
@@ -206,7 +206,7 @@ components: sources: apache_metrics: {
 		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
 		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:     components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:     components.sources.internal_metrics.output.metrics.component_received_events_total
 		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
 		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}

--- a/website/cue/reference/components/sources/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/aws_ecs_metrics.cue
@@ -250,7 +250,7 @@ components: sources: aws_ecs_metrics: {
 		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
 		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:     components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:     components.sources.internal_metrics.output.metrics.component_received_events_total
 		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
 		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -238,7 +238,7 @@ components: sources: aws_kinesis_firehose: {
 	telemetry: metrics: {
 		events_in_total:                       components.sources.internal_metrics.output.metrics.events_in_total
 		processed_bytes_total:                 components.sources.internal_metrics.output.metrics.processed_bytes_total
-		received_events_total:                 components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:                 components.sources.internal_metrics.output.metrics.component_received_events_total
 		request_read_errors_total:             components.sources.internal_metrics.output.metrics.request_read_errors_total
 		requests_received_total:               components.sources.internal_metrics.output.metrics.requests_received_total
 		request_automatic_decode_errors_total: components.sources.internal_metrics.output.metrics.request_automatic_decode_errors_total

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -279,7 +279,7 @@ components: sources: aws_s3: components._aws & {
 	telemetry: metrics: {
 		events_in_total:                        components.sources.internal_metrics.output.metrics.events_in_total
 		processed_bytes_total:                  components.sources.internal_metrics.output.metrics.processed_bytes_total
-		received_events_total:                  components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:                  components.sources.internal_metrics.output.metrics.component_received_events_total
 		sqs_message_delete_failed_total:        components.sources.internal_metrics.output.metrics.sqs_message_delete_failed_total
 		sqs_message_delete_succeeded_total:     components.sources.internal_metrics.output.metrics.sqs_message_delete_succeeded_total
 		sqs_message_processing_failed_total:    components.sources.internal_metrics.output.metrics.sqs_message_processing_failed_total

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -1270,6 +1270,6 @@ components: sources: dnstap: {
 		processed_bytes_total:  components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total: components.sources.internal_metrics.output.metrics.processed_events_total
 		parse_errors_total:     components.sources.internal_metrics.output.metrics.parse_errors_total
-		received_events_total:  components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:  components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -402,6 +402,6 @@ components: sources: docker_logs: {
 		logging_driver_errors_total:           components.sources.internal_metrics.output.metrics.logging_driver_errors_total
 		processed_bytes_total:                 components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:                components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:                 components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:                 components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/eventstoredb_metrics.cue
+++ b/website/cue/reference/components/sources/eventstoredb_metrics.cue
@@ -162,6 +162,6 @@ components: sources: eventstoredb_metrics: {
 		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
 		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
-		received_events_total:     components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:     components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/exec.cue
+++ b/website/cue/reference/components/sources/exec.cue
@@ -219,6 +219,6 @@ components: sources: exec: {
 		processed_bytes_total:              components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:             components.sources.internal_metrics.output.metrics.processed_events_total
 		processing_errors_total:            components.sources.internal_metrics.output.metrics.processing_errors_total
-		received_events_total:              components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:              components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -617,6 +617,6 @@ components: sources: file: {
 		files_unwatched_total:         components.sources.internal_metrics.output.metrics.files_unwatched_total
 		fingerprint_read_errors_total: components.sources.internal_metrics.output.metrics.fingerprint_read_errors_total
 		glob_errors_total:             components.sources.internal_metrics.output.metrics.glob_errors_total
-		received_events_total:         components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:         components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/fluent.cue
+++ b/website/cue/reference/components/sources/fluent.cue
@@ -211,6 +211,6 @@ components: sources: fluent: {
 		decode_errors_total:    components.sources.internal_metrics.output.metrics.decode_errors_total
 		processed_bytes_total:  components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total: components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:  components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:  components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -109,7 +109,7 @@ components: sources: heroku_logs: {
 	telemetry: metrics: {
 		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
 		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
-		received_events_total:     components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:     components.sources.internal_metrics.output.metrics.component_received_events_total
 		request_read_errors_total: components.sources.internal_metrics.output.metrics.request_read_errors_total
 		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/website/cue/reference/components/sources/http.cue
+++ b/website/cue/reference/components/sources/http.cue
@@ -244,7 +244,7 @@ components: sources: http: {
 		events_in_total:         components.sources.internal_metrics.output.metrics.events_in_total
 		http_bad_requests_total: components.sources.internal_metrics.output.metrics.http_bad_requests_total
 		parse_errors_total:      components.sources.internal_metrics.output.metrics.parse_errors_total
-		received_events_total:   components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:   components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -456,17 +456,17 @@ components: sources: internal_metrics: {
 				The number of events accepted by this component either from tagged
 				origins like file and uri, or cumulatively from other origins.
 				This metric is deprecated and will be removed in a future version.
-				Use [`received_events_total`](\(urls.vector_sources)/internal_metrics/#received_events_total) instead.
+				Use [`component_received_events_total`](\(urls.vector_sources)/internal_metrics/#component_received_events_total) instead.
 				"""
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              received_events_total.tags
+			tags:              component_received_events_total.tags
 		}
 		events_out_total: {
 			description: """
 				The total number of events emitted by this component.
 				This metric is deprecated and will be removed in a future version.
-				Use [`sent_events_total`](\(urls.vector_sources)/internal_metrics/#sent_events_total) instead.
+				Use [`component_sent_events_total`](\(urls.vector_sources)/internal_metrics/#component_sent_events_total) instead.
 				"""
 			type:              "counter"
 			default_namespace: "vector"
@@ -476,14 +476,14 @@ components: sources: internal_metrics: {
 			description:       """
 				The total number of events processed by this component.
 				This metric is deprecated in place of using
-				[`received_events_total`](\(urls.vector_sources)/internal_metrics/#received_events_total) and
-				[`sent_events_total`](\(urls.vector_sources)/internal_metrics/#sent_events_total) metrics.
+				[`component_received_events_total`](\(urls.vector_sources)/internal_metrics/#component_received_events_total) and
+				[`component_sent_events_total`](\(urls.vector_sources)/internal_metrics/#component_sent_events_total) metrics.
 				"""
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		received_events_total: {
+		component_received_events_total: {
 			description: """
 				The number of events accepted by this component either from tagged
 				origins like file and uri, or cumulatively from other origins.
@@ -518,22 +518,22 @@ components: sources: internal_metrics: {
 				mode: _mode
 			}
 		}
-		received_event_bytes_total: {
+		component_received_event_bytes_total: {
 			description: """
 				The number of event bytes accepted by this component either from
 				tagged origins like file and uri, or cumulatively from other origins.
 				"""
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              received_events_total.tags
+			tags:              component_received_events_total.tags
 		}
-		sent_events_total: {
+		component_sent_events_total: {
 			description:       "The total number of events emitted by this component."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		sent_event_bytes_total: {
+		component_sent_event_bytes_total: {
 			description:       "The total number of event bytes emitted by this component."
 			type:              "counter"
 			default_namespace: "vector"

--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -269,6 +269,6 @@ components: sources: journald: {
 		invalid_record_bytes_total: components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
 		processed_bytes_total:      components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:     components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:      components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/kafka.cue
+++ b/website/cue/reference/components/sources/kafka.cue
@@ -269,7 +269,7 @@ components: sources: kafka: {
 		kafka_consumed_messages_bytes_total:  components.sources.internal_metrics.output.metrics.kafka_consumed_messages_bytes_total
 		processed_bytes_total:                components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:               components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:                components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:                components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 
 	how_it_works: components._kafka.how_it_works

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -663,6 +663,6 @@ components: sources: kubernetes_logs: {
 		k8s_watcher_http_error_total:           components.sources.internal_metrics.output.metrics.k8s_watcher_http_error_total
 		processed_bytes_total:                  components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:                 components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:                  components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:                  components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/logstash.cue
+++ b/website/cue/reference/components/sources/logstash.cue
@@ -321,6 +321,6 @@ components: sources: logstash: {
 		open_connections:                 components.sources.internal_metrics.output.metrics.open_connections
 		processed_bytes_total:            components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:           components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:            components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:            components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/mongodb_metrics.cue
+++ b/website/cue/reference/components/sources/mongodb_metrics.cue
@@ -765,6 +765,6 @@ components: sources: mongodb_metrics: {
 		collect_duration_seconds: components.sources.internal_metrics.output.metrics.collect_duration_seconds
 		parse_errors_total:       components.sources.internal_metrics.output.metrics.parse_errors_total
 		request_errors_total:     components.sources.internal_metrics.output.metrics.request_errors_total
-		received_events_total:    components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:    components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/nats.cue
+++ b/website/cue/reference/components/sources/nats.cue
@@ -57,7 +57,7 @@ components: sources: nats: {
 		events_in_total:        components.sources.internal_metrics.output.metrics.events_in_total
 		processed_bytes_total:  components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total: components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:  components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:  components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 
 	how_it_works: components._nats.how_it_works

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -181,6 +181,6 @@ components: sources: nginx_metrics: {
 		collect_duration_seconds:  components.sources.internal_metrics.output.metrics.collect_duration_seconds
 		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
-		received_events_total:     components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:     components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -163,7 +163,7 @@ components: sources: postgresql_metrics: {
 		events_in_total:          components.sources.internal_metrics.output.metrics.events_in_total
 		collect_completed_total:  components.sources.internal_metrics.output.metrics.collect_completed_total
 		collect_duration_seconds: components.sources.internal_metrics.output.metrics.collect_duration_seconds
-		received_events_total:    components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:    components.sources.internal_metrics.output.metrics.component_received_events_total
 		request_errors_total:     components.sources.internal_metrics.output.metrics.request_errors_total
 	}
 

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -99,7 +99,7 @@ components: sources: prometheus_remote_write: {
 		parse_errors_total:       components.sources.internal_metrics.output.metrics.parse_errors_total
 		processed_bytes_total:    components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:   components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:    components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:    components.sources.internal_metrics.output.metrics.component_received_events_total
 		requests_completed_total: components.sources.internal_metrics.output.metrics.requests_completed_total
 		requests_received_total:  components.sources.internal_metrics.output.metrics.requests_received_total
 		request_duration_seconds: components.sources.internal_metrics.output.metrics.request_duration_seconds

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -103,7 +103,7 @@ components: sources: prometheus_scrape: {
 		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
 		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:     components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:     components.sources.internal_metrics.output.metrics.component_received_events_total
 		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
 		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -168,6 +168,6 @@ components: sources: socket: {
 		connection_send_errors_total:     components.sources.internal_metrics.output.metrics.connection_send_errors_total
 		connection_send_ack_errors_total: components.sources.internal_metrics.output.metrics.connection_send_ack_errors_total
 		connection_shutdown_total:        components.sources.internal_metrics.output.metrics.connection_shutdown_total
-		received_events_total:            components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:            components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -114,7 +114,7 @@ components: sources: splunk_hec: {
 	telemetry: metrics: {
 		events_in_total:           components.sources.internal_metrics.output.metrics.events_in_total
 		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
-		received_events_total:     components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:     components.sources.internal_metrics.output.metrics.component_received_events_total
 		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}
 }

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -135,6 +135,6 @@ components: sources: statsd: {
 		invalid_record_bytes_total: components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
 		processed_bytes_total:      components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:     components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:      components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/stdin.cue
+++ b/website/cue/reference/components/sources/stdin.cue
@@ -109,7 +109,7 @@ components: sources: stdin: {
 		events_in_total:          components.sources.internal_metrics.output.metrics.events_in_total
 		processed_bytes_total:    components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:   components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:    components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:    components.sources.internal_metrics.output.metrics.component_received_events_total
 		stdin_reads_failed_total: components.sources.internal_metrics.output.metrics.stdin_reads_failed_total
 	}
 }

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -208,7 +208,7 @@ components: sources: syslog: {
 		connection_read_errors_total: components.sources.internal_metrics.output.metrics.connection_read_errors_total
 		processed_bytes_total:        components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:       components.sources.internal_metrics.output.metrics.processed_events_total
-		received_events_total:        components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:        components.sources.internal_metrics.output.metrics.component_received_events_total
 		utf8_convert_errors_total:    components.sources.internal_metrics.output.metrics.utf8_convert_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -124,6 +124,6 @@ components: sources: vector: {
 	telemetry: metrics: {
 		events_in_total:              components.sources.internal_metrics.output.metrics.events_in_total
 		protobuf_decode_errors_total: components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
-		received_events_total:        components.sources.internal_metrics.output.metrics.received_events_total
+		component_received_events_total:        components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -13,10 +13,10 @@ components: transforms: [Name=string]: {
 	telemetry: metrics: {
 		events_in_total:            components.sources.internal_metrics.output.metrics.events_in_total
 		events_out_total:           components.sources.internal_metrics.output.metrics.events_out_total
-		received_events_total:      components.sources.internal_metrics.output.metrics.received_events_total
-		received_event_bytes_total: components.sources.internal_metrics.output.metrics.received_event_bytes_total
+		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
+		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		utilization:                components.sources.internal_metrics.output.metrics.utilization
-		sent_events_total:          components.sources.internal_metrics.output.metrics.sent_events_total
-		sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.sent_event_bytes_total
+		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 	}
 }


### PR DESCRIPTION
As per [the discussion here](https://github.com/vectordotdev/vector/pull/9165#discussion_r711134056), we'd like to introduce prefixes to better organize metrics as instrumentation expands in scope. This PR adds `component_` prefix to existing component metrics.

[rendered view](https://github.com/vectordotdev/vector/blob/2fa827629a2d388be281458cd7b0c717aeee8db3/docs/specs/component.md)

Signed-off-by: 001wwang <will.wang@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
