### PR TITLE
chore: Correct s3 integration tests

### DIFF
--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -202,7 +202,7 @@ where
                         let status = match result {
                             Err(error) => {
                                 error!("Sink IO failed with error: {}.", error);
-                                EventStatus::Failed
+                                EventStatus::Errored
                             },
                             Ok(response) => { *response.as_ref() }
                         };


### PR DESCRIPTION
It turns out I introduced a breaking change in #9203. This commit fixes
it. Where the original implementation issued an 'Errored' for `Err` conditions
I'd adjusted it to be 'Failed'.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
