### PR TITLE
docs(remap transform): Clarify how remap can access metrics

### DIFF
--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -70,7 +70,7 @@ components: transforms: "remap": {
 		file: {
 			description: """
 				File path to the [Vector Remap Language](\(urls.vrl_reference)) (VRL) program to execute for each event.
-				
+
 				If a relative path is provided, its root is the current working directory.
 
 				Required if `source` is missing.
@@ -141,6 +141,22 @@ components: transforms: "remap": {
 				Learn more about Vector's Remap Language in the
 				[Vector Remap Language reference](\#(urls.vrl_reference)).
 				"""#
+		}
+		event_data_model: {
+			title: "Event Data Model"
+			body:  """
+				You can use the `remap` transform with both log and metric events.
+
+				Log events in the `remap` transform correspond directly to Vector's [log schema](\(urls.vector_log)),
+				which means that the transform has access to the whole event.
+
+				With metric events the remap transform has:
+
+				* read-only access to the event's`.type`
+				* read/write access to `kind`, but it can only be set to one of `incremental` or `absolute` and cannot be deleted
+				* read/write access to `name`, but it cannot be deleted
+				* read/write/delete access to `namespace, `timestamp`, and keys in `tags`
+				"""
 		}
 		lazy_event_mutation: {
 			title: "Lazy Event Mutation"

--- a/website/cue/reference/remap.cue
+++ b/website/cue/reference/remap.cue
@@ -254,16 +254,4 @@ remap: #Remap & {
 				"""
 		},
 	]
-
-	how_it_works: {
-		event_data_model: {
-			title: "Event Data Model"
-			body:  """
-				You can use the `remap` transform with both log and metric events. Log events in the `remap` transform
-				correspond directly to Vector's [log schema](\(urls.vector_log)), which means that the transform has
-				access to the whole event. With metric events the remap transform has read access to the event's`.type`,
-				and read/write access to the `.name`, `.namespace`, `.timestamp`, `.kind`, and `.tags`.
-				"""
-		}
-	}
 }


### PR DESCRIPTION
Also move the event_data_model "How it Works" to the `remap` transform
since it is unrendered in its current position.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->