### PR TITLE
docs(remap transform): Missing ` in docs

### DIFF
--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -155,7 +155,7 @@ components: transforms: "remap": {
 				* read-only access to the event's`.type`
 				* read/write access to `kind`, but it can only be set to one of `incremental` or `absolute` and cannot be deleted
 				* read/write access to `name`, but it cannot be deleted
-				* read/write/delete access to `namespace, `timestamp`, and keys in `tags`
+				* read/write/delete access to `namespace`, `timestamp`, and keys in `tags`
 				"""
 		}
 		lazy_event_mutation: {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->