### PR TITLE
chore: Speed up `LogEvent::rename_key` by 57%

### DIFF
--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -73,3 +73,7 @@ vrl = ["vrl-core", "enrichment"]
 [[bench]]
 name = "lookup"
 harness = false
+
+[[bench]]
+name = "event"
+harness = false

--- a/lib/vector-core/benches/event/log_event.rs
+++ b/lib/vector-core/benches/event/log_event.rs
@@ -1,0 +1,61 @@
+use criterion::{
+    criterion_group, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion, SamplingMode,
+};
+use std::time::Duration;
+use vector_core::event::LogEvent;
+
+fn rename_key_flat(c: &mut Criterion) {
+    let mut group: BenchmarkGroup<WallTime> =
+        c.benchmark_group("vector_core::event::log_event::LogEvent::rename_key_flat");
+    group.sampling_mode(SamplingMode::Auto);
+
+    group.bench_function("rename_flat_key (key is present)", move |b| {
+        b.iter_batched(
+            || {
+                let mut log_event = LogEvent::default();
+                log_event.insert("one", 1);
+                log_event.insert("two", 2);
+                log_event.insert("three", 3);
+                log_event
+            },
+            |mut log_event| {
+                log_event.rename_key_flat("one", "1");
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("rename_flat_key (key is NOT present)", move |b| {
+        b.iter_batched(
+            || {
+                let mut log_event = LogEvent::default();
+                log_event.insert("one", 1);
+                log_event.insert("two", 2);
+                log_event.insert("three", 3);
+                log_event
+            },
+            |mut log_event| {
+                log_event.rename_key_flat("four", "4");
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(5))
+        .measurement_time(Duration::from_secs(120))
+        // degree of noise to ignore in measurements, here 1%
+        .noise_threshold(0.01)
+        // likelihood of noise registering as difference, here 5%
+        .significance_level(0.05)
+        // likelihood of capturing the true runtime, here 95%
+        .confidence_level(0.95)
+        // total number of bootstrap resamples, higher is less noisy but slower
+        .nresamples(100_000)
+        // total samples to collect within the set measurement time
+        .sample_size(150);
+    targets = rename_key_flat
+);

--- a/lib/vector-core/benches/event/main.rs
+++ b/lib/vector-core/benches/event/main.rs
@@ -1,0 +1,5 @@
+use criterion::criterion_main;
+
+mod log_event;
+
+criterion_main!(log_event::benches);

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -137,12 +137,17 @@ impl LogEvent {
         K: AsRef<str> + Into<String> + PartialEq + Display,
     {
         if from_key != to_key {
-            if let Some(val) = self.remove(from_key) {
+            if let Some(val) = self.fields.as_map_mut().remove(from_key.as_ref()) {
                 self.insert_flat(to_key, val);
             }
         }
     }
 
+    /// Insert a key in place without reference to pathing
+    ///
+    /// This function will insert a key in place without reference to any
+    /// pathing information in the key. It will insert over the top of any value
+    /// that exists in the map already.
     #[instrument(level = "trace", skip(self, key), fields(key = %key))]
     pub fn insert_flat<K, V>(&mut self, key: K, value: V)
     where


### PR DESCRIPTION
This commit speeds up the `rename_key` function of `LogEvent` by 57%, avoiding
the use of path iteration code to achieve this. This results in +2MB/s in #8512.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
