### PR TITLE
fix(external docs): Add JS fingerprint

### DIFF
--- a/website/layouts/partials/javascript/below.html
+++ b/website/layouts/partials/javascript/below.html
@@ -1,4 +1,4 @@
 {{ $js      := "js/below.js"}}
 {{ $jsOpts  := dict "targetPath" $js "minify" true }}
-{{ $builtJs := resources.Get $js | resources.ExecuteAsTemplate $js . | js.Build $jsOpts }}
+{{ $builtJs := resources.Get $js | resources.ExecuteAsTemplate $js . | js.Build $jsOpts | fingerprint "sha256" }}
 <script type="text/javascript" src="{{ $builtJs.RelPermalink }}" integrity="{{ $builtJs.Data.Integrity }}"></script>

--- a/website/layouts/partials/javascript/head.html
+++ b/website/layouts/partials/javascript/head.html
@@ -3,8 +3,8 @@
 {{ $appJsOptions := dict "targetPath" $appJsPath "minify" true }}
 {{ $ddLogsRumJsOptions := dict "targetPath" $ddLogsRumPath "minify" true }}
 
-{{ $app := resources.Get $appJsPath | resources.ExecuteAsTemplate $appJsPath . | js.Build $appJsOptions }}
-{{ $ddLogsRum := resources.Get $ddLogsRumPath | resources.ExecuteAsTemplate $ddLogsRumPath . | js.Build $ddLogsRumJsOptions }}
+{{ $app := resources.Get $appJsPath | resources.ExecuteAsTemplate $appJsPath . | js.Build $appJsOptions | fingerprint "sha256" }}
+{{ $ddLogsRum := resources.Get $ddLogsRumPath | resources.ExecuteAsTemplate $ddLogsRumPath . | js.Build $ddLogsRumJsOptions | fingerprint "sha256" }}
 
 <script type="text/javascript" src="{{ $ddLogsRum.RelPermalink }}" integrity="{{ $ddLogsRum.Data.Integrity }}"></script>
 <script type="text/javascript" src="{{ $app.RelPermalink }}" integrity="{{ $app.Data.Integrity }}"></script>

--- a/website/layouts/partials/javascript/home.html
+++ b/website/layouts/partials/javascript/home.html
@@ -1,5 +1,5 @@
 {{ $homeJs := "js/home.tsx" }}
 {{ $jsOpts := dict "defines" (dict "process.env.NODE_ENV" "\"development\"") }}
 {{ $babelOpts := dict "noComments" true }}
-{{ $compiled := resources.Get $homeJs | js.Build $jsOpts | babel $babelOpts }}
+{{ $compiled := resources.Get $homeJs | js.Build $jsOpts | babel $babelOpts | fingerprint "sha256" }}
 <script src="{{ $compiled.RelPermalink }}"></script>

--- a/website/layouts/partials/javascript/search.html
+++ b/website/layouts/partials/javascript/search.html
@@ -9,5 +9,5 @@
   "process.env.ALGOLIA_PUBLIC_API_KEY" $apiKey
   "process.env.ALGOLIA_INDEX_NAME" $index) }}
 {{ $babelOpts := dict "noComments" true }}
-{{ $compiled := resources.Get $searchJs | js.Build $jsOpts | babel $babelOpts }}
+{{ $compiled := resources.Get $searchJs | js.Build $jsOpts | babel $babelOpts | fingerprint "sha256" }}
 <script src="{{ $compiled.RelPermalink }}"></script>


### PR DESCRIPTION
Apparently Hugo doesn't automatically add a subresource integrity fingerprint to JavaScript artifacts the way that it does to Sass/CSS artifacts. This PR fixes that. Just a small nit.