### PR TITLE
enhancement(cli): Fix API client subscription drop

### DIFF
--- a/lib/vector-api-client/src/subscription.rs
+++ b/lib/vector-api-client/src/subscription.rs
@@ -243,22 +243,18 @@ pub async fn connect_subscription_client(
 
     // Forwarded received messages back upstream to the GraphQL server
     tokio::spawn(async move {
-        loop {
-            if let Some(p) = send_rx.recv().await {
-                let _ = ws_tx
-                    .send(Message::Text(serde_json::to_string(&p).unwrap()))
-                    .await;
-            }
+        while let Some(p) = send_rx.recv().await {
+            let _ = ws_tx
+                .send(Message::Text(serde_json::to_string(&p).unwrap()))
+                .await;
         }
     });
 
     // Forward received messages to the receiver channel.
     tokio::spawn(async move {
-        loop {
-            if let Some(Ok(Message::Text(m))) = ws_rx.next().await {
-                if let Ok(p) = serde_json::from_str::<Payload>(&m) {
-                    let _ = recv_tx.send(p);
-                }
+        while let Some(Ok(Message::Text(m))) = ws_rx.next().await {
+            if let Ok(p) = serde_json::from_str::<Payload>(&m) {
+                let _ = recv_tx.send(p);
             }
         }
     });

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -148,12 +148,16 @@ pub struct HostMetrics {
 }
 
 impl HostMetrics {
+    #[cfg(not(target_os = "linux"))]
     pub const fn new(config: HostMetricsConfig) -> Self {
-        #[cfg(target_os = "linux")]
+        Self { config }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn new(config: HostMetricsConfig) -> Self {
         let root_cgroup = cgroups::CGroup::root(config.cgroups.base.as_deref());
         Self {
             config,
-            #[cfg(target_os = "linux")]
             root_cgroup,
         }
     }

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -148,7 +148,7 @@ pub struct HostMetrics {
 }
 
 impl HostMetrics {
-    pub fn new(config: HostMetricsConfig) -> Self {
+    pub const fn new(config: HostMetricsConfig) -> Self {
         #[cfg(target_os = "linux")]
         let root_cgroup = cgroups::CGroup::root(config.cgroups.base.as_deref());
         Self {

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -64,11 +64,7 @@ pub async fn cmd(opts: &super::Opts) -> exitcode::ExitCode {
 
     // Initialize the dashboard
     match init_dashboard(url.as_str(), opts, sender).await {
-        // Even though we could return an `exitcode::OK` here, the upstream block_on won't
-        // return due to lingering subscriptions, which manifests as a hung cursor in the
-        // terminal. To work around this for now, exit immediately.
-        // TODO: https://github.com/vectordotdev/vector/issues/9206
-        Ok(_) => std::process::exit(0),
+        Ok(_) => exitcode::OK,
         _ => {
             eprintln!("Your terminal doesn't support building a dashboard. Exiting.");
             exitcode::IOERR

--- a/src/top/state.rs
+++ b/src/top/state.rs
@@ -48,65 +48,63 @@ pub async fn updater(mut state: State, mut event_rx: EventRx) -> StateRx {
     let _ = tx.send(state.clone()).await;
 
     tokio::spawn(async move {
-        loop {
-            if let Some(event_type) = event_rx.recv().await {
-                match event_type {
-                    EventType::EventsInTotals(rows) => {
-                        for (key, v) in rows {
-                            if let Some(r) = state.get_mut(&key) {
-                                r.events_in_total = v;
-                            }
+        while let Some(event_type) = event_rx.recv().await {
+            match event_type {
+                EventType::EventsInTotals(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.get_mut(&key) {
+                            r.events_in_total = v;
                         }
-                    }
-                    EventType::EventsInThroughputs(interval, rows) => {
-                        for (key, v) in rows {
-                            if let Some(r) = state.get_mut(&key) {
-                                r.events_in_throughput_sec =
-                                    (v as f64 * (1000.0 / interval as f64)) as i64;
-                            }
-                        }
-                    }
-                    EventType::EventsOutTotals(rows) => {
-                        for (key, v) in rows {
-                            if let Some(r) = state.get_mut(&key) {
-                                r.events_out_total = v;
-                            }
-                        }
-                    }
-                    EventType::EventsOutThroughputs(interval, rows) => {
-                        for (key, v) in rows {
-                            if let Some(r) = state.get_mut(&key) {
-                                r.events_out_throughput_sec =
-                                    (v as f64 * (1000.0 / interval as f64)) as i64;
-                            }
-                        }
-                    }
-                    EventType::ProcessedBytesTotals(rows) => {
-                        for (key, v) in rows {
-                            if let Some(r) = state.get_mut(&key) {
-                                r.processed_bytes_total = v;
-                            }
-                        }
-                    }
-                    EventType::ProcessedBytesThroughputs(interval, rows) => {
-                        for (key, v) in rows {
-                            if let Some(r) = state.get_mut(&key) {
-                                r.processed_bytes_throughput_sec =
-                                    (v as f64 * (1000.0 / interval as f64)) as i64;
-                            }
-                        }
-                    }
-                    EventType::ComponentAdded(c) => {
-                        let _ = state.insert(c.key.clone(), c);
-                    }
-                    EventType::ComponentRemoved(key) => {
-                        let _ = state.remove(&key);
                     }
                 }
-
-                // Send updated map to listeners
-                let _ = tx.send(state.clone()).await;
+                EventType::EventsInThroughputs(interval, rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.get_mut(&key) {
+                            r.events_in_throughput_sec =
+                                (v as f64 * (1000.0 / interval as f64)) as i64;
+                        }
+                    }
+                }
+                EventType::EventsOutTotals(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.get_mut(&key) {
+                            r.events_out_total = v;
+                        }
+                    }
+                }
+                EventType::EventsOutThroughputs(interval, rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.get_mut(&key) {
+                            r.events_out_throughput_sec =
+                                (v as f64 * (1000.0 / interval as f64)) as i64;
+                        }
+                    }
+                }
+                EventType::ProcessedBytesTotals(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.get_mut(&key) {
+                            r.processed_bytes_total = v;
+                        }
+                    }
+                }
+                EventType::ProcessedBytesThroughputs(interval, rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.get_mut(&key) {
+                            r.processed_bytes_throughput_sec =
+                                (v as f64 * (1000.0 / interval as f64)) as i64;
+                        }
+                    }
+                }
+                EventType::ComponentAdded(c) => {
+                    let _ = state.insert(c.key.clone(), c);
+                }
+                EventType::ComponentRemoved(key) => {
+                    let _ = state.remove(&key);
+                }
             }
+
+            // Send updated map to listeners
+            let _ = tx.send(state.clone()).await;
         }
     });
 


### PR DESCRIPTION
Follow-up to #9139. Closes #9206.

Adds graceful shutdown to API client subscriptions on drop by returning from spawned loops. This prevents `top` from having to hard shut down the process on exit, instead propagating `exitcode::OK` to the top-level.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
