### PR TITLE
enhancement(observability, sinks): Emit events for sent events in all HttpSink sinks

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -185,7 +185,7 @@ downstream target regardless if the transmission was successful or not.
     * For files, the total number of bytes written to the file excluding the
       delimiter.
   * `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
-    `unix`, `http`, `file`, etc.)
+    `unix`, `http`, `https`, `file`, etc.)
   * `endpoint` - If relevant, the endpoint that the bytes were sent to. For
     HTTP, this MUST be the host and path only, excluding the query string.
   * `file` - If relevant, the absolute path of the file.

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -185,7 +185,7 @@ downstream target regardless if the transmission was successful or not.
     * For files, the total number of bytes written to the file excluding the
       delimiter.
   * `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
-    `unix`, `http`, `http`, `file`, etc.)
+    `unix`, `http`, `file`, etc.)
   * `endpoint` - If relevant, the endpoint that the bytes were sent to. For
     HTTP, this MUST be the host and path only, excluding the query string.
   * `file` - If relevant, the absolute path of the file.
@@ -193,7 +193,7 @@ downstream target regardless if the transmission was successful or not.
   * MUST increment the `component_sent_bytes_total` counter by the defined value with the
     defined properties as metric tags.
 * Logs
-  * MUST log a `Bytes received.` message at the `trace` level with the
+  * MUST log a `Bytes sent.` message at the `trace` level with the
     defined properties as key-value pairs. It MUST NOT be rate limited.
 
 #### Error

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -41,3 +41,20 @@ impl InternalEvent for EventsSent {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct BytesSent<'a> {
+    pub byte_size: usize,
+    pub protocol: &'a str,
+}
+
+impl<'a> InternalEvent for BytesSent<'a> {
+    fn emit_logs(&self) {
+        trace!(message = "Bytes sent.", byte_size = %self.byte_size, protocol = %self.protocol);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("component_sent_bytes_total", self.byte_size as u64,
+                 "protocol" => self.protocol.to_string());
+    }
+}

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -58,3 +58,29 @@ impl<'a> InternalEvent for BytesSent<'a> {
                  "protocol" => self.protocol.to_string());
     }
 }
+
+#[derive(Debug)]
+pub struct EndpointBytesSent<'a> {
+    pub byte_size: usize,
+    pub protocol: &'a str,
+    pub endpoint: &'a str,
+}
+
+impl<'a> InternalEvent for EndpointBytesSent<'a> {
+    fn emit_logs(&self) {
+        trace!(
+            message = "Bytes sent.",
+            byte_size = %self.byte_size,
+            protocol = %self.protocol,
+            endpoint = %self.endpoint
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "component_sent_bytes_total", self.byte_size as u64,
+            "protocol" => self.protocol.to_string(),
+            "endpoint" => self.endpoint.to_string()
+        );
+    }
+}

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -179,7 +179,7 @@ where
         let finalizers = event.metadata_mut().take_finalizers();
         let byte_size = event.size_of();
         if let Some(item) = self.sink.encode_event(event) {
-            emit!(EventsSent {
+            emit!(&EventsSent {
                 count: 1,
                 byte_size
             });
@@ -337,7 +337,7 @@ where
         let finalizers = event.metadata_mut().take_finalizers();
         let byte_size = event.size_of();
         if let Some(item) = self.sink.encode_event(event) {
-            emit!(EventsSent {
+            emit!(&EventsSent {
                 count: 1,
                 byte_size
             });
@@ -414,7 +414,7 @@ where
                 .unwrap_or_else(|_| unreachable!())
                 .to_string();
 
-            emit!(EndpointBytesSent {
+            emit!(&EndpointBytesSent {
                 byte_size,
                 protocol: scheme.unwrap_or(Scheme::HTTP).as_str(),
                 endpoint: &endpoint

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use bytes::{Buf, Bytes};
 use futures::{future::BoxFuture, ready, Sink};
-use http::{uri::PathAndQuery, StatusCode, Uri};
+use http::{uri::PathAndQuery, uri::Scheme, StatusCode, Uri};
 use hyper::{body, Body};
 use indexmap::IndexMap;
 use pin_project::pin_project;
@@ -409,13 +409,14 @@ where
                     .parse::<PathAndQuery>()
                     .unwrap_or_else(|_| unreachable!())
             });
+            let scheme = parts.scheme.clone();
             let endpoint = Uri::from_parts(parts)
                 .unwrap_or_else(|_| unreachable!())
                 .to_string();
 
             emit!(EndpointBytesSent {
                 byte_size,
-                protocol: "http",
+                protocol: scheme.unwrap_or(Scheme::HTTP).as_str(),
                 endpoint: &endpoint
             });
 

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -627,10 +627,13 @@ components: sinks: [Name=string]: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:                      components.sources.internal_metrics.output.metrics.events_in_total
-		events_out_total:                     components.sources.internal_metrics.output.metrics.events_out_total
 		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
+		component_sent_bytes_total:           components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_in_total:                      components.sources.internal_metrics.output.metrics.events_in_total
+		events_out_total:                     components.sources.internal_metrics.output.metrics.events_out_total
 		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 	}
 }

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -629,11 +629,7 @@ components: sinks: [Name=string]: {
 	telemetry: metrics: {
 		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_sent_bytes_total:           components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		events_in_total:                      components.sources.internal_metrics.output.metrics.events_in_total
-		events_out_total:                     components.sources.internal_metrics.output.metrics.events_out_total
 		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 	}
 }

--- a/website/cue/reference/components/sinks/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/azure_monitor_logs.cue
@@ -126,4 +126,11 @@ components: sinks: azure_monitor_logs: {
 		logs:    true
 		metrics: null
 	}
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/clickhouse.cue
+++ b/website/cue/reference/components/sinks/clickhouse.cue
@@ -128,4 +128,11 @@ components: sinks: clickhouse: {
 		logs:    true
 		metrics: null
 	}
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -69,4 +69,11 @@ components: sinks: datadog_events: {
 		logs:    true
 		metrics: null
 	}
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -362,7 +362,11 @@ components: sinks: elasticsearch: {
 	}
 
 	telemetry: metrics: {
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/gcp_pubsub.cue
@@ -150,4 +150,11 @@ components: sinks: gcp_pubsub: {
 			]
 		},
 	]
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -282,4 +282,11 @@ components: sinks: gcp_stackdriver_logs: {
 			]
 		},
 	]
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -173,4 +173,11 @@ components: sinks: gcp_stackdriver_metrics: {
 			]
 		},
 	]
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/honeycomb.cue
+++ b/website/cue/reference/components/sinks/honeycomb.cue
@@ -104,4 +104,11 @@ components: sinks: honeycomb: {
 				"""
 		}
 	}
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -122,9 +122,13 @@ components: sinks: http: {
 	}
 
 	telemetry: metrics: {
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
-		http_bad_requests_total: components.sources.internal_metrics.output.metrics.http_bad_requests_total
-		processed_bytes_total:   components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:  components.sources.internal_metrics.output.metrics.processed_events_total
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
+		http_bad_requests_total:          components.sources.internal_metrics.output.metrics.http_bad_requests_total
+		processed_bytes_total:            components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:           components.sources.internal_metrics.output.metrics.processed_events_total
 	}
 }

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -174,4 +174,11 @@ components: sinks: _humio: {
 			}
 		}
 	}
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/humio_logs.cue
+++ b/website/cue/reference/components/sinks/humio_logs.cue
@@ -7,6 +7,7 @@ components: sinks: humio_logs: {
 	features:      sinks._humio.features
 	support:       sinks._humio.support
 	configuration: sinks._humio.configuration
+	telemetry:     sinks._humio.telemetry
 
 	input: {
 		logs:    true

--- a/website/cue/reference/components/sinks/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/humio_metrics.cue
@@ -7,6 +7,7 @@ components: sinks: humio_metrics: {
 	features:      sinks._humio.features
 	support:       sinks._humio.support
 	configuration: sinks._humio.configuration
+	telemetry:     sinks._humio.telemetry
 
 	input: {
 		logs: false

--- a/website/cue/reference/components/sinks/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/influxdb_logs.cue
@@ -116,4 +116,11 @@ components: sinks: influxdb_logs: {
 			]
 		}
 	}
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+	}
 }

--- a/website/cue/reference/components/sinks/logdna.cue
+++ b/website/cue/reference/components/sinks/logdna.cue
@@ -157,7 +157,11 @@ components: sinks: logdna: {
 	}
 
 	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
 		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -202,9 +202,11 @@ components: sinks: loki: {
 	}
 
 	telemetry: metrics: {
-		events_in_total:         components.sources.internal_metrics.output.metrics.events_in_total
-		events_out_total:        components.sources.internal_metrics.output.metrics.events_out_total
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
 		processed_bytes_total:   components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
 		streams_total:           components.sources.internal_metrics.output.metrics.streams_total

--- a/website/cue/reference/components/sinks/new_relic_logs.cue
+++ b/website/cue/reference/components/sinks/new_relic_logs.cue
@@ -117,4 +117,6 @@ components: sinks: new_relic_logs: {
 		logs:    true
 		metrics: null
 	}
+
+	telemetry: components.sinks.http.telemetry
 }

--- a/website/cue/reference/components/sinks/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/sematext_logs.cue
@@ -71,4 +71,6 @@ components: sinks: sematext_logs: {
 				"""
 		}
 	}
+
+	telemetry: components.sinks.elasticsearch.telemetry
 }

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -168,7 +168,11 @@ components: sinks: splunk_hec_logs: {
 	}
 
 	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		encode_errors_total:       components.sources.internal_metrics.output.metrics.encode_errors_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
 		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
 		processing_errors_total:   components.sources.internal_metrics.output.metrics.processing_errors_total
 		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total

--- a/website/cue/reference/components/sinks/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_metrics.cue
@@ -167,9 +167,5 @@ components: sinks: splunk_hec_metrics: {
 		}
 	}
 
-	telemetry: metrics: {
-		encode_errors_total:     components.sources.internal_metrics.output.metrics.encode_errors_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-		processed_bytes_total:   components.sources.internal_metrics.output.metrics.processed_bytes_total
-	}
+	telemetry: components.sinks.splunk_hec_logs.telemetry
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -527,6 +527,25 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              component_received_events_total.tags
 		}
+		component_sent_bytes_total: {
+			description:       "The number of raw bytes sent by this component to destination sinks."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags & {
+				protocol: {
+					description: "The protocol used to send the bytes."
+					required:    true
+				}
+				endpoint: {
+					description: "The endpoint that the bytes were sent to. For HTTP, this will be the host and path only, excluding the query string."
+					required:    false
+				}
+				file: {
+					description: "The absolute path of the destination file."
+					required:    false
+				}
+			}
+		}
 		component_sent_events_total: {
 			description:       "The total number of events emitted by this component."
 			type:              "counter"


### PR DESCRIPTION
This ended up being pretty simple, as the events flow through only two paths for all these sinks.

After going in to add the metric documentation into each sink, I decided to move it into the common sink documentation, since it will eventually be added to all sinks, and the `events_out_total` is already documented there. If this is not appropriate, I can move it back to each individual sink.

Closes #9225 