### PR TITLE
enhancement(external docs): Serve metadata as JSON

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -75,3 +75,11 @@ from = "https://rustdoc.vector.dev/*"
 to = "https://vector-rustdoc.netlify.app/vector/:splat"
 status = 301
 force = true
+
+# CORS headers for /index.json
+[[headers]]
+for = "/index.json"
+
+[headers.values]
+Access-Control-Allow-Origin = "*"
+

--- a/website/Makefile
+++ b/website/Makefile
@@ -75,8 +75,8 @@ run-production-site-locally:
 	make setup cue-build production-build
 	python -m http.server 8000 --directory ./public --bind 127.0.0.1
 
-# Local dev build with no link checking
-quick-build: clean setup structured-data production-build
+# Local dev build with no link checking and no Yarn dependency fetching
+quick-build: clean structured-data production-build
 
 # Full local builds without Algolia updates (for debugging, link checking, etc.)
 local-production-build: clean setup structured-data production-build run-link-checker

--- a/website/Makefile
+++ b/website/Makefile
@@ -76,6 +76,8 @@ run-production-site-locally:
 	python -m http.server 8000 --directory ./public --bind 127.0.0.1
 
 # Full local builds without Algolia updates (for debugging, link checking, etc.)
+quick-build: clean setup structured-data production-build
+
 local-production-build: clean setup structured-data production-build run-link-checker
 
 local-preview-build: clean setup structured-data preview-build run-link-checker

--- a/website/Makefile
+++ b/website/Makefile
@@ -75,9 +75,10 @@ run-production-site-locally:
 	make setup cue-build production-build
 	python -m http.server 8000 --directory ./public --bind 127.0.0.1
 
-# Full local builds without Algolia updates (for debugging, link checking, etc.)
+# Local dev build with no link checking
 quick-build: clean setup structured-data production-build
 
+# Full local builds without Algolia updates (for debugging, link checking, etc.)
 local-production-build: clean setup structured-data production-build run-link-checker
 
 local-preview-build: clean setup structured-data preview-build run-link-checker

--- a/website/config.toml
+++ b/website/config.toml
@@ -53,6 +53,8 @@ algolia_index_prod = "vector_docs_prod"
 algolia_index_staging = "vector_docs_staging"
 algolia_autocomplete_theme = "classic"
 
+# VRL JSON server
+
 # Generated _redirects file for Netlify
 [mediaTypes."text/netlify"]
 delimiter = ""
@@ -63,7 +65,7 @@ baseName = "_redirects"
 
 # Outputs (including search.json and _redirects files)
 [outputs]
-home = ["HTML", "RSS", "REDIRECTS"]
+home = ["HTML", "JSON", "RSS", "REDIRECTS"]
 
 # CSS generation
 [[params.css]]

--- a/website/layouts/_default/index.json.json
+++ b/website/layouts/_default/index.json.json
@@ -1,5 +1,5 @@
 {{- $data := newScratch -}}
 {{- range site.Data.docs.remap.functions -}}
-{{- $data.SetInMap "vrl" .name (dict "description" .description "arguments" .arguments "category" .category "return" .return) -}}
+{{- $data.SetInMap "vrl_functions" .name (dict "description" .description "arguments" .arguments "category" .category "return" .return) -}}
 {{- end -}}
-{{- $data.Get "vrl" | jsonify -}}
+{{- (dict "vrl" (dict "functions" ($data.Get "vrl_functions"))) | jsonify -}}

--- a/website/layouts/_default/index.json.json
+++ b/website/layouts/_default/index.json.json
@@ -1,0 +1,5 @@
+{{- $data := newScratch -}}
+{{- range site.Data.docs.remap.functions -}}
+{{- $data.SetInMap "vrl" .name (dict "description" .description "arguments" .arguments "category" .category "return" .return) -}}
+{{- end -}}
+{{- $data.Get "vrl" | jsonify -}}


### PR DESCRIPTION
This PR adds a JSON output to the site that will enable us to serve up metadata about Vector to clients. With these changes, the website will serve up VRL function metadata at `/index.json` so that it can be used by the VRL playground. There may be other uses for this in the future.