### PR TITLE
feat(datadog_logs sink): use v2 endpoint for logs

### DIFF
--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -77,12 +77,12 @@ impl DatadogLogsConfig {
             .or_else(|| {
                 self.site
                     .as_ref()
-                    .map(|s| format!("https://http-intake.logs.{}/v1/input", s))
+                    .map(|s| format!("https://http-intake.logs.{}/api/v2/logs", s))
             })
             .unwrap_or_else(|| match self.region {
-                Some(Region::Eu) => "https://http-intake.logs.datadoghq.eu/v1/input".to_string(),
+                Some(Region::Eu) => "https://http-intake.logs.datadoghq.eu/api/v2/logs".to_string(),
                 None | Some(Region::Us) => {
-                    "https://http-intake.logs.datadoghq.com/v1/input".to_string()
+                    "https://http-intake.logs.datadoghq.com/api/v2/logs".to_string()
                 }
             });
         http::Uri::try_from(endpoint).expect("URI not valid")

--- a/src/sinks/datadog/logs/mod.rs
+++ b/src/sinks/datadog/logs/mod.rs
@@ -14,6 +14,10 @@
 //! other major constraints we have to follow in this implementation. The sink
 //! is careful to always send the maximum payload size excepting where we
 //! violate the size constraint.
+//!
+//! The endpoint used to send the payload is currently being migrated from
+//! `/v1/input` to `/api/v2/logs`, but the content of the above documentation
+//! still applies for `/api/v2/logs`.
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
fixes #9179

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
