### PR TITLE
fix(ci): Re-add markdown and cue checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
               - 'scripts/cross/**'
             cue:
               - 'website/cue/**'
+            markdown:
+              - '**/**.md'
             internal_events:
               - 'src/internal_events/**'
             helm:
@@ -391,7 +393,12 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v1.2.6
         with:
           command: check licenses
-
+      - name: Check Cue docs
+        if: needs.changes.outputs.cue == 'true'
+        run: make check-docs
+      - name: Check Markdown
+        if: needs.changes.outputs.markdown == 'true'
+        run: make check-markdown
   master-failure:
     name: master-failure
     if: failure() && github.ref == 'refs/heads/master'

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -34,11 +34,11 @@ Vector adheres to the [Semantic Versioning 2.0] convention. In summary:
 
 ## Public API
 
-Semantic Versioning hinges on Vector's defintion of "public API". By nature of
-Vector - a tool that collects, processes, and routes data from disparate systems
-- it has a very large public surface area. It's not immediately obvious which
-parts are covered under our versioning contract and how they're covered. This
-section aims to remove all ambiguity in this area.
+Semantic Versioning hinges on Vector's defintion of "public API". By the nature
+of Vector -- a tool that collects, processes, and routes data from disparate
+systems -- it has a very large public surface area. It's not immediately obvious
+which parts are covered under our versioning contract and how they're covered.
+This section aims to remove all ambiguity in this area.
 
 ### Areas that *are* covered
 

--- a/rfcs/2021-07-19-8216-multiple-pipelines.md
+++ b/rfcs/2021-07-19-8216-multiple-pipelines.md
@@ -221,10 +221,6 @@ How does this position us for success in the future?
 
 - With this representation, we'll be able add access control by, for example, declaring the pipelines inside the configuration files to limit the reachable components. We would also be able to specify a quota for each pipeline.
 
-## Prior Art
-
-_TODO_
-
 ## Drawbacks
 
 - Why should we not do this?

--- a/rfcs/2021-07-20-8288-csv-enrichment.md
+++ b/rfcs/2021-07-20-8288-csv-enrichment.md
@@ -34,7 +34,7 @@ provided by a CSV file.
 
 To represent the CSV file we have a new top level configuration option.
 
-```
+```toml
 [enrichment_tables.csv_file]
   type = "file"
   encoding = "csv"
@@ -44,22 +44,22 @@ To represent the CSV file we have a new top level configuration option.
 
 The fields available for this section are:
 
-*type*
+#### type
 
 The type of data that the resource represents. Currently only a csv file is
 supported, but this may expand in future to handle other file formats and
 database connections.
 
-*path*
+#### path
 
 The path to the csv file, either an absolute path or one relative to the current
 working directory.
 
-*delimiter*
+#### delimiter
 
 The delimiter used in the csv file to separate fields. Defaults to `","`.
 
-*header_row*
+#### header_row
 
 If true, it assumes the first row in the csv file contains column names. If
 false, columns are named according to their numerical index.
@@ -110,18 +110,18 @@ A metric will be emitted to indicate the lookup time.
 
 #### Parameters
 
-*table*
+##### table
 
 The name of the enrichment table to lookup. This must point to a table specified
 in the config file eg `enrichment_tables.csv_file`. Both functions are generic
 over all table types.
 
-*condition*
+##### condition
 
 `condition` is a single level, key/value object that specifies the fields and
 values to lookup. The fields must all match (AND) for the row to be returned.
 
-*case_sensitive*
+##### case_sensitive
 
 By default the search will be case insensitive, but this can be changed by
 passing `true` to this parameter.
@@ -261,7 +261,7 @@ benefits of the Join transform.
 Instead of using an object to specify the search criteria we could allow the
 user to specify a predicate to determine the row to use for enrichment.
 
-```
+```coffee
 find_table_row(table.csv, |row| row.some_key == .some_field)
 ```
 
@@ -278,7 +278,7 @@ There is nothing that would prevent us from providing both options.
 Instead of using a separate section to specify the enrichment table, we could
 require the filename te be specified within VRL.
 
-```
+```coffee
 find_table_row("/path/to/file.csv", criteria)
 ```
 

--- a/rfcs/2021-08-06-8619-framing-and-codecs-sources.md
+++ b/rfcs/2021-08-06-8619-framing-and-codecs-sources.md
@@ -199,7 +199,7 @@ src = """
 """
 ```
 
-# Alternatives Considered
+## Alternatives Considered
 
 In a previous iteration of this RFC, codecs were implemented on the topology
 level and it was possible to chain multiple codecs to cover a wide range of
@@ -232,13 +232,13 @@ considered in the future, for now this is can be accomplished by the `wasm` or
 - Implement common configuration object
 - Implement common `Decoder` and build methods from configs
 - Integrate `DecodingConfig` into sources that expose framing/decoding to users:
-    - `file` source
-    - `kafka` source
-    - `socket` (TCP, UDP, Unix) source
-    - `stdin` source
+  - `file` source
+  - `kafka` source
+  - `socket` (TCP, UDP, Unix) source
+  - `stdin` source
 - Reuse `Decoder` for sources that internally build an `Event` from bytes
-    - `fluent` source
-    - `logstash` source
-    - `statsd` source
-    - `syslog` source
-    - `vector` source
+  - `fluent` source
+  - `logstash` source
+  - `statsd` source
+  - `syslog` source
+  - `vector` source

--- a/rfcs/2021-08-22-7204-vrl-error-diagnostic-improvements.md
+++ b/rfcs/2021-08-22-7204-vrl-error-diagnostic-improvements.md
@@ -40,15 +40,15 @@ solve the problem.
 
 ## Context
 
-- [RFC 4862 - 2020-11-02 - Remap Language Compile-Time Type Checking v1][#4862]
+* [RFC 4862 - 2020-11-02 - Remap Language Compile-Time Type Checking v1][#4862]
 
 [#4862]: https://github.com/timberio/vector/blob/ab9ff57ddccaa561b84eb3d0139bd764ad655fa6/rfcs/2020-11-02-remap-language-compile-time-type-checking-v1.md
 
 ## Cross cutting concerns
 
-- [Log schemas][#3910]
-- [Improve VRL type checking][#8380]
-- [VRL compiler improvements][#8221]
+* [Log schemas][#3910]
+* [Improve VRL type checking][#8380]
+* [VRL compiler improvements][#8221]
 
 [#3910]: https://github.com/timberio/vector/issues/3910
 [#8380]: https://github.com/timberio/vector/issues/8380
@@ -58,14 +58,14 @@ solve the problem.
 
 ### In scope
 
-- Improve VRL error diagnostics
-- Simplify VRL error codes
-- Update VRL website documentation
+* Improve VRL error diagnostics
+* Simplify VRL error codes
+* Update VRL website documentation
 
 ### Out of scope
 
-- Changes to error handling in VRL itself
-- Non-diagnostics changes to the VRL compiler
+* Changes to error handling in VRL itself
+* Non-diagnostics changes to the VRL compiler
 
 ## Proposed Solutions
 
@@ -98,7 +98,7 @@ upcase(foo)
 There's a typo (`to_strng` instead of `to_string`), which causes the following
 diagnostic message:
 
-```
+```text
 error[E105]: call to undefined function
   ┌─ :1:7
   │
@@ -119,7 +119,7 @@ injected.
 
 This results in the following invalid diagnostic message:
 
-```
+```coffee
 error[E110]: invalid argument type
   ┌─ :1:8
   │
@@ -153,7 +153,7 @@ foo = string!(foo)
 upcase(foo)
 ```
 
-```
+```text
 error[E620]: can't abort infallible function
   ┌─ :1:7
   │
@@ -292,7 +292,7 @@ upcase(bar)
 This program fails, because `to_string` takes one argument `value`, not
 `invalid`:
 
-```
+```text
 error[E108]: unknown function argument keyword
   ┌─ :1:17
   │
@@ -411,7 +411,7 @@ occurs when a root level expression is considered fallible:
 to_string(.foo)
 ```
 
-```
+```text
 error[E100]: unhandled error
   ┌─ :1:1
   │
@@ -482,7 +482,7 @@ Take this example:
 "foo" + .bar + baz[1]
 ```
 
-```
+```text
 error[E100]: unhandled error
   ┌─ :1:1
   │
@@ -509,19 +509,19 @@ instead of highlighting the entire chain of expressions.
 
 Given the following nested expressions:
 
-```
+```text
 A ( B ( C ( D ) ) )
 ```
 
 Where:
 
-- `A` is the root expression
-- `C` is fallible
-- `D` is infallible
+* `A` is the root expression
+* `C` is fallible
+* `D` is infallible
 
 The compiler must return a diagnostic similar to this:
 
-```
+```text
 error[E100]: unhandled error
   ┌─ :1:1
   │
@@ -534,16 +534,16 @@ error[E100]: unhandled error
 
 Here's what the compiler will do:
 
-- Compile the nested expressions, from `D` to `A`
-- `D` is infallible, and thus valid
-- `C` is fallible
-  - But it might become infallible by a parent expression
-  - Set `C` as the source of fallibility for this expression chain
-- `B` is fallible
-- `A` is fallible
-  - This is the root expression, and thus the fallibility of `C` remains
+* Compile the nested expressions, from `D` to `A`
+* `D` is infallible, and thus valid
+* `C` is fallible
+  * But it might become infallible by a parent expression
+  * Set `C` as the source of fallibility for this expression chain
+* `B` is fallible
+* `A` is fallible
+  * This is the root expression, and thus the fallibility of `C` remains
     unhandled
-- Show the error diagnostic specific to the unhandled fallibility of `C`
+* Show the error diagnostic specific to the unhandled fallibility of `C`
 
 The compiler has a `compile_root_exprs` function:
 
@@ -706,7 +706,7 @@ expects, and which types the argument can expand to at runtime.
 
 Something similar to this:
 
-```
+```text
 error[E100]: argument type might be invalid at runtime
   ┌─ :1:8
   │
@@ -742,8 +742,8 @@ error codes is still accurate, and remove any error codes that aren't useful.
 
 ### Update VRL Website Documentation
 
-- Make sure all diagnostic errors are covered on the website
-- Update function documentation, to make it clear that an infallible function
+* Make sure all diagnostic errors are covered on the website
+* Update function documentation, to make it clear that an infallible function
   can become fallible if its arguments are potentially invalid.
 
 ## Rationale
@@ -774,18 +774,18 @@ None.
 
 ## Plan Of Attack
 
-- [ ] Prevent Incorrect Error Diagnostics
-- [ ] Recover From Non-Fatal Expression Errors
-- [ ] Remove Generic "Expression Can Result in Runtime Error" Diagnostic
-- [ ] Correctly Diagnose Invalid Function Argument Types
-- [ ] Update VRL Error Codes
-- [ ] Update VRL Website Documentation
+* [ ] Prevent Incorrect Error Diagnostics
+* [ ] Recover From Non-Fatal Expression Errors
+* [ ] Remove Generic "Expression Can Result in Runtime Error" Diagnostic
+* [ ] Correctly Diagnose Invalid Function Argument Types
+* [ ] Update VRL Error Codes
+* [ ] Update VRL Website Documentation
 
 ## Future Improvements
 
-- `vrl check` subcommand
-- `vrl fix` subcommand to auto-fix errors
-- improve error diagnostic visuals
-- undefined variable checking
-- non-error diagnostics (for example when using functions that can be slow)
-- more/better "try" solutions in error diagnostics
+* `vrl check` subcommand
+* `vrl fix` subcommand to auto-fix errors
+* improve error diagnostic visuals
+* undefined variable checking
+* non-error diagnostics (for example when using functions that can be slow)
+* more/better "try" solutions in error diagnostics

--- a/scripts/check-markdown.sh
+++ b/scripts/check-markdown.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-markdown.sh
+#
+# SUMMARY
+#
+#   Checks the markdown format within the Vector repo.
+#   This ensures that markdown is consistent and easy to read across the
+#   entire Vector repo.
+
+markdownlint \
+  --config scripts/.markdownlintrc \
+  --ignore scripts/node_modules \
+  --ignore website/node_modules \
+  --ignore target \
+  .

--- a/website/content/en/blog/vector-remap-language.md
+++ b/website/content/en/blog/vector-remap-language.md
@@ -109,6 +109,7 @@ Parsing this log, without VRL, looks like this:
 
 {{< tabs default="Vector" >}}
 {{< tab title="Vector" >}}
+
 ```toml title="vector.toml"
 # ... sources ...
 
@@ -135,8 +136,10 @@ types.bytes_out = "int"
 
 # ... sinks ...
 ```
+
 {{< /tab >}}
 {{< tab title="Logstash" >}}
+
 ```text title="logstash.conf"
 # ... inputs ...
 
@@ -163,8 +166,10 @@ filter {
 
 # ... outputs ...
 ```
+
 {{< /tab >}}
 {{< tab title="Fluentd" >}}
+
 ```text title="fluentd.conf"
 <source>
   # ... source options ...
@@ -186,6 +191,7 @@ filter {
 
 # ... outputs ...
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/components/_index.md
+++ b/website/content/en/components/_index.md
@@ -10,4 +10,4 @@ criteria: [
   { "Sink functions": ["Exposes", "Send"] },
   { "Operating systems": ["Linux", "Windows", "macOS"] }
 ]
-----
+---

--- a/website/content/en/docs/administration/management.md
+++ b/website/content/en/docs/administration/management.md
@@ -21,16 +21,20 @@ To manage the Vector executable directly, without a process manager:
 
 {{< tabs default="Start" >}}
 {{< tab title="Start" >}}
+
 ```bash
 vector --config /etc/vector/vector.toml
 
 # Or supply a JSON or YAML config file
 ```
+
 {{< /tab >}}
 {{< tab title="Reload" >}}
+
 ```bash
 killall -s SIGHUP vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -42,24 +46,32 @@ If you've installed Vector using [APT], [dpkg], [RPM], or [YUM], you can manage 
 
 {{< tabs default="Start" >}}
 {{< tab title="Start" >}}
+
 ```bash
 sudo systemctl start vector
 ```
+
 {{< /tab >}}
 {{< tab title="Stop" >}}
+
 ```bash
 sudo systemctl stop vector
 ```
+
 {{< /tab >}}
 {{< tab title="Reload" >}}
+
 ```bash
 systemctl kill -s HUP --kill-who=main vector.service
 ```
+
 {{< /tab >}}
 {{< tab title="Restart" >}}
+
 ```bash
 sudo systemctl restart vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -79,24 +91,32 @@ If you've installed Vector using [Homebrew], you can manage it using Homebrew's 
 
 {{< tabs default="Start" >}}
 {{< tab title="Start" >}}
+
 ```bash
 brew services start vector
 ```
+
 {{< /tab >}}
 {{< tab title="Stop" >}}
+
 ```bash
 brew services stop vector
 ```
+
 {{< /tab >}}
 {{< tab title="Reload" >}}
+
 ```bash
 killall -S SIGHUP vector
 ```
+
 {{< /tab >}}
 {{< tab title="Restart" >}}
+
 ```bash
 brew services restart vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -106,12 +126,14 @@ If you're running Vector on Windows (perhaps you installed it using [MSI]), you 
 
 {{< tabs default="Start" >}}
 {{< tab title="Start" >}}
+
 ```powershell
 C:\Program Files\Vector\bin\vector \
   --config C:\Program Files\Vector\config\vector.toml
 
 # Or supply a JSON or YAML config file
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -121,6 +143,7 @@ If you're running Vector using [Docker], the command interface is the same acros
 
 {{< tabs default="Start" >}}
 {{< tab title="Start" >}}
+
 ```bash
 docker run \
   -d \
@@ -128,21 +151,28 @@ docker run \
   -p 8686:8686 \
   timberio/vector:{{< version >}}-alpine
 ```
+
 {{< /tab >}}
 {{< tab title="Stop" >}}
+
 ```bash
 docker stop timberio/vector
 ```
+
 {{< /tab >}}
 {{< tab title="Reload" >}}
+
 ```bash
 docker kill --signal=HUP timberio/vector
 ```
+
 {{< /tab >}}
 {{< tab title="Restart" >}}
+
 ```bash
 docker restart -f $(docker ps -aqf "name=vector")
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -165,14 +195,18 @@ Once Vector is running in Kubernetes, you can manage it using [kubectl]:
 
 {{< tabs default="Restart Agent" >}}
 {{< tab title="Restart Agent" >}}
+
 ```shell
 kubectl rollout restart --namespace vector daemonset/vector-agent
 ```
+
 {{< /tab >}}
 {{< tab title="Restart Aggregator" >}}
+
 ```shell
 kubectl rollout restart --namespace vector statefulset/vector-aggregator
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -13,6 +13,7 @@ The following is an example of a popular Vector configuration that ingests logs 
 
 {{< tabs default="vector.toml" >}}
 {{< tab title="vector.toml" >}}
+
 ```toml
 # Set global options
 data_dir = "/var/lib/vector"
@@ -61,8 +62,10 @@ compression  = "gzip"                        # compress final objects
 encoding     = "ndjson"                      # new line delimited JSON
 batch.max_size   = 10000000                  # 10mb uncompressed
 ```
+
 {{< /tab >}}
 {{< tab title="vector.yaml" >}}
+
 ```yaml
 data_dir: /var/lib/vector
 sources:
@@ -102,8 +105,10 @@ sinks:
     batch:
       max_size: 10000000
 ```
+
 {{< /tab >}}
 {{< tab title="vector.json" >}}
+
 ```json
 {
    "data_dir": "/var/lib/vector",
@@ -158,6 +163,7 @@ sinks:
    }
 }
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -165,19 +171,25 @@ To use this configuration file, specify it with the `--config` flag when startin
 
 {{< tabs default="TOML" >}}
 {{< tab title="TOML" >}}
+
 ```shell
 vector --config /etc/vector/vector.toml
 ```
+
 {{< /tab >}}
 {{< tab title="YAML" >}}
+
 ```shell
 vector --config /etc/vector/vector.yaml
 ```
+
 {{< /tab >}}
 {{< tab title="JSON" >}}
+
 ```shell
 vector --config /etc/vector/vector.json
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "cloudwatch", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "cloudwatch", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "cloudwatch", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "cloudwatch", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_kinesis_firehose.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_kinesis_firehose.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "kinesis", "firehose", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_kinesis_firehose.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_kinesis_firehose.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "kinesis", "firehose", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_kinesis_streams.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_kinesis_streams.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "kinesis", "streams", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_kinesis_streams.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_kinesis_streams.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "kinesis", "streams", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_s3.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_s3.md
@@ -7,6 +7,6 @@ tags: ["aws", "s3", "component", "sink", "storage"]
 aliases: ["/docs/reference/sinks/s3"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_s3.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_s3.md
@@ -7,6 +7,9 @@ tags: ["aws", "s3", "component", "sink", "storage"]
 aliases: ["/docs/reference/sinks/s3"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_sqs.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_sqs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "sqs", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/aws_sqs.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_sqs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "sqs", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/azure_blob.md
+++ b/website/content/en/docs/reference/configuration/sinks/azure_blob.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["azure", "blob", "storage", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/azure_blob.md
+++ b/website/content/en/docs/reference/configuration/sinks/azure_blob.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["azure", "blob", "storage", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/azure_monitor_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/azure_monitor_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["azure", "monitor", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/azure_monitor_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/azure_monitor_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["azure", "monitor", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/blackhole.md
+++ b/website/content/en/docs/reference/configuration/sinks/blackhole.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["blackhole", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/blackhole.md
+++ b/website/content/en/docs/reference/configuration/sinks/blackhole.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["blackhole", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/clickhouse.md
+++ b/website/content/en/docs/reference/configuration/sinks/clickhouse.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["clickhole", "component", "sink", "storage", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/clickhouse.md
+++ b/website/content/en/docs/reference/configuration/sinks/clickhouse.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["clickhole", "component", "sink", "storage", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/console.md
+++ b/website/content/en/docs/reference/configuration/sinks/console.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["console", "component", "sink", "debug"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/console.md
+++ b/website/content/en/docs/reference/configuration/sinks/console.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["console", "component", "sink", "debug"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_archives.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_archives.md
@@ -7,6 +7,9 @@ tags: ["datadog", "s3", "component", "sink", "storage"]
 aliases: ["/docs/reference/sinks/datadog_archives"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_archives.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_archives.md
@@ -7,6 +7,6 @@ tags: ["datadog", "s3", "component", "sink", "storage"]
 aliases: ["/docs/reference/sinks/datadog_archives"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_events.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_events.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["datadog", "component", "sink", "events"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_events.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_events.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["datadog", "component", "sink", "events"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["datadog", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["datadog", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["datadog", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/datadog_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["datadog", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/elasticsearch.md
+++ b/website/content/en/docs/reference/configuration/sinks/elasticsearch.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["elasticsearch", "component", "sink", "search", "storage"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/elasticsearch.md
+++ b/website/content/en/docs/reference/configuration/sinks/elasticsearch.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["elasticsearch", "component", "sink", "search", "storage"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/file.md
+++ b/website/content/en/docs/reference/configuration/sinks/file.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["file", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/file.md
+++ b/website/content/en/docs/reference/configuration/sinks/file.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["file", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_cloud_storage.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_cloud_storage.md
@@ -7,6 +7,6 @@ layout: component
 tags: ["gcp", "gcs", "cloud storage", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_cloud_storage.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_cloud_storage.md
@@ -7,6 +7,9 @@ layout: component
 tags: ["gcp", "gcs", "cloud storage", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_pubsub.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_pubsub.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["gcp", "pubsub", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_pubsub.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_pubsub.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["gcp", "pubsub", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_logs.md
@@ -7,6 +7,9 @@ layout: component
 tags: ["gcp", "stackdriver", "operations", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_logs.md
@@ -7,6 +7,6 @@ layout: component
 tags: ["gcp", "stackdriver", "operations", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["gcp", "stackdriver", "operations", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["gcp", "stackdriver", "operations", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/honeycomb.md
+++ b/website/content/en/docs/reference/configuration/sinks/honeycomb.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["honeycomb", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/honeycomb.md
+++ b/website/content/en/docs/reference/configuration/sinks/honeycomb.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["honeycomb", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/http.md
+++ b/website/content/en/docs/reference/configuration/sinks/http.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["http", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/http.md
+++ b/website/content/en/docs/reference/configuration/sinks/http.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["http", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/humio_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/humio_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["humio", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/humio_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/humio_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["humio", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/humio_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/humio_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["humio", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/humio_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/humio_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["humio", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/influxdb_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/influxdb_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["influxdb", "influx", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/influxdb_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/influxdb_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["influxdb", "influx", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/influxdb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/influxdb_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["influxdb", "influx", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/influxdb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/influxdb_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["influxdb", "influx", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/kafka.md
+++ b/website/content/en/docs/reference/configuration/sinks/kafka.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["kafka", "apache", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/kafka.md
+++ b/website/content/en/docs/reference/configuration/sinks/kafka.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["kafka", "apache", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/logdna.md
+++ b/website/content/en/docs/reference/configuration/sinks/logdna.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["logdna", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/logdna.md
+++ b/website/content/en/docs/reference/configuration/sinks/logdna.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["logdna", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/loki.md
+++ b/website/content/en/docs/reference/configuration/sinks/loki.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["loki", "grafana", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/loki.md
+++ b/website/content/en/docs/reference/configuration/sinks/loki.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["loki", "grafana", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/nats.md
+++ b/website/content/en/docs/reference/configuration/sinks/nats.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["nats", "pubsub", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/nats.md
+++ b/website/content/en/docs/reference/configuration/sinks/nats.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["nats", "pubsub", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/new_relic_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/new_relic_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["new relic", "newrelic", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/new_relic_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/new_relic_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["new relic", "newrelic", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/papertrail.md
+++ b/website/content/en/docs/reference/configuration/sinks/papertrail.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["papertrail", "solarwinds", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/papertrail.md
+++ b/website/content/en/docs/reference/configuration/sinks/papertrail.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["papertrail", "solarwinds", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/prometheus_exporter.md
+++ b/website/content/en/docs/reference/configuration/sinks/prometheus_exporter.md
@@ -7,6 +7,9 @@ tags: ["prometheus", "exporter", "component", "sink", "metrics"]
 aliases: ["/docs/reference/sinks/prometheus"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/prometheus_exporter.md
+++ b/website/content/en/docs/reference/configuration/sinks/prometheus_exporter.md
@@ -7,6 +7,6 @@ tags: ["prometheus", "exporter", "component", "sink", "metrics"]
 aliases: ["/docs/reference/sinks/prometheus"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/prometheus_remote_write.md
+++ b/website/content/en/docs/reference/configuration/sinks/prometheus_remote_write.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["prometheus", "remote write", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/prometheus_remote_write.md
+++ b/website/content/en/docs/reference/configuration/sinks/prometheus_remote_write.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["prometheus", "remote write", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/pulsar.md
+++ b/website/content/en/docs/reference/configuration/sinks/pulsar.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["pulsar", "apache", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/pulsar.md
+++ b/website/content/en/docs/reference/configuration/sinks/pulsar.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["pulsar", "apache", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/redis.md
+++ b/website/content/en/docs/reference/configuration/sinks/redis.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["redis", "pubsub", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/redis.md
+++ b/website/content/en/docs/reference/configuration/sinks/redis.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["redis", "pubsub", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/sematext_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/sematext_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["sematext", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/sematext_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/sematext_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["sematext", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/sematext_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/sematext_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["sematext", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/sematext_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/sematext_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["sematext", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/socket.md
+++ b/website/content/en/docs/reference/configuration/sinks/socket.md
@@ -7,6 +7,6 @@ tags: ["socket", "remote", "component", "sink", "logs"]
 aliases: ["/docs/reference/sinks/tcp"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/socket.md
+++ b/website/content/en/docs/reference/configuration/sinks/socket.md
@@ -7,6 +7,9 @@ tags: ["socket", "remote", "component", "sink", "logs"]
 aliases: ["/docs/reference/sinks/tcp"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/splunk_hec_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/splunk_hec_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["splunk", "hec", "http event collector", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/splunk_hec_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/splunk_hec_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["splunk", "hec", "http event collector", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/splunk_hec_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/splunk_hec_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["splunk", "hec", "http event collector", "component", "sink", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/splunk_hec_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/splunk_hec_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["splunk", "hec", "http event collector", "component", "sink", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/statsd.md
+++ b/website/content/en/docs/reference/configuration/sinks/statsd.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["statsd", "component", "sink", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/statsd.md
+++ b/website/content/en/docs/reference/configuration/sinks/statsd.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["statsd", "component", "sink", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sinks/vector.md
+++ b/website/content/en/docs/reference/configuration/sinks/vector.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["vector", "instance", "component", "sink"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sinks/vector.md
+++ b/website/content/en/docs/reference/configuration/sinks/vector.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["vector", "instance", "component", "sink"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/apache_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/apache_metrics.md
@@ -7,6 +7,6 @@ layout: component
 tags: ["apache", "http", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/apache_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/apache_metrics.md
@@ -7,6 +7,9 @@ layout: component
 tags: ["apache", "http", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/aws_ecs_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_ecs_metrics.md
@@ -8,6 +8,6 @@ layout: component
 tags: ["aws", "ecs", "docker", "fargate", "container", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/aws_ecs_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_ecs_metrics.md
@@ -8,6 +8,9 @@ layout: component
 tags: ["aws", "ecs", "docker", "fargate", "container", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/aws_kinesis_firehose.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_kinesis_firehose.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "kinesis", "firehose", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/aws_kinesis_firehose.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_kinesis_firehose.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "kinesis", "firehose", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/aws_s3.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_s3.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "s3", "storage", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/aws_s3.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_s3.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "s3", "storage", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/datadog_agent.md
+++ b/website/content/en/docs/reference/configuration/sources/datadog_agent.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["datadog", "agent", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/datadog_agent.md
+++ b/website/content/en/docs/reference/configuration/sources/datadog_agent.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["datadog", "agent", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/dnstap.md
+++ b/website/content/en/docs/reference/configuration/sources/dnstap.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["dnstap", "dns", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/dnstap.md
+++ b/website/content/en/docs/reference/configuration/sources/dnstap.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["dnstap", "dns", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/docker_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/docker_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["docker", "container", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/docker_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/docker_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["docker", "container", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/eventstoredb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/eventstoredb_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["eventstore", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/eventstoredb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/eventstoredb_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["eventstore", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/exec.md
+++ b/website/content/en/docs/reference/configuration/sources/exec.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["exec", "process", "component", "source"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/exec.md
+++ b/website/content/en/docs/reference/configuration/sources/exec.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["exec", "process", "component", "source"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/file.md
+++ b/website/content/en/docs/reference/configuration/sources/file.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["file", "component", "source"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/file.md
+++ b/website/content/en/docs/reference/configuration/sources/file.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["file", "component", "source"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/fluent.md
+++ b/website/content/en/docs/reference/configuration/sources/fluent.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["fluentd", "fluent", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/fluent.md
+++ b/website/content/en/docs/reference/configuration/sources/fluent.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["fluentd", "fluent", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/generator.md
+++ b/website/content/en/docs/reference/configuration/sources/generator.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["generator", "random", "fake", "component", "source"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/generator.md
+++ b/website/content/en/docs/reference/configuration/sources/generator.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["generator", "random", "fake", "component", "source"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/heroku_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/heroku_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["heroku", "logplex", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/heroku_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/heroku_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["heroku", "logplex", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/host_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/host_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["vector", "host", "local", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/host_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/host_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["vector", "host", "local", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/http.md
+++ b/website/content/en/docs/reference/configuration/sources/http.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["http", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/http.md
+++ b/website/content/en/docs/reference/configuration/sources/http.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["http", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/internal_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/internal_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["vector", "instance", "local", "internal", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/internal_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/internal_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["vector", "instance", "local", "internal", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/internal_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/internal_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["vector", "instance", "local", "internal", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/internal_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/internal_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["vector", "instance", "local", "internal", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/journald.md
+++ b/website/content/en/docs/reference/configuration/sources/journald.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["journald", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/journald.md
+++ b/website/content/en/docs/reference/configuration/sources/journald.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["journald", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/kafka.md
+++ b/website/content/en/docs/reference/configuration/sources/kafka.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["kafka", "apache", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/kafka.md
+++ b/website/content/en/docs/reference/configuration/sources/kafka.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["kafka", "apache", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/kubernetes_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/kubernetes_logs.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["kubernetes", "k8s", "node", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/kubernetes_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/kubernetes_logs.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["kubernetes", "k8s", "node", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/logstash.md
+++ b/website/content/en/docs/reference/configuration/sources/logstash.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["logstash", "elastic", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/logstash.md
+++ b/website/content/en/docs/reference/configuration/sources/logstash.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["logstash", "elastic", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/mongodb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/mongodb_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["mongodb", "mongo", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/mongodb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/mongodb_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["mongodb", "mongo", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/nats.md
+++ b/website/content/en/docs/reference/configuration/sources/nats.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["nats", "component", "source"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/nats.md
+++ b/website/content/en/docs/reference/configuration/sources/nats.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["nats", "component", "source"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/nginx_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/nginx_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["nginx", "http", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/nginx_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/nginx_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["nginx", "http", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/postgresql_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/postgresql_metrics.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["postgresql", "postgres", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/postgresql_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/postgresql_metrics.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["postgresql", "postgres", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/prometheus_remote_write.md
+++ b/website/content/en/docs/reference/configuration/sources/prometheus_remote_write.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["prometheus", "remote write", "component", "source", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/prometheus_remote_write.md
+++ b/website/content/en/docs/reference/configuration/sources/prometheus_remote_write.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["prometheus", "remote write", "component", "source", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/prometheus_scrape.md
+++ b/website/content/en/docs/reference/configuration/sources/prometheus_scrape.md
@@ -7,6 +7,6 @@ tags: ["prometheus", "scrape", "component", "source", "metrics"]
 aliases: ["/docs/reference/sources/prometheus"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/prometheus_scrape.md
+++ b/website/content/en/docs/reference/configuration/sources/prometheus_scrape.md
@@ -7,6 +7,9 @@ tags: ["prometheus", "scrape", "component", "source", "metrics"]
 aliases: ["/docs/reference/sources/prometheus"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/socket.md
+++ b/website/content/en/docs/reference/configuration/sources/socket.md
@@ -7,6 +7,6 @@ tags: ["socket", "component", "source", "logs"]
 aliases: ["/docs/reference/sources/tcp", "/docs/reference/sources/udp"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/socket.md
+++ b/website/content/en/docs/reference/configuration/sources/socket.md
@@ -7,6 +7,9 @@ tags: ["socket", "component", "source", "logs"]
 aliases: ["/docs/reference/sources/tcp", "/docs/reference/sources/udp"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/splunk_hec.md
+++ b/website/content/en/docs/reference/configuration/sources/splunk_hec.md
@@ -7,6 +7,9 @@ layout: component
 tags: ["splunk", "hec", "http event collector", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/splunk_hec.md
+++ b/website/content/en/docs/reference/configuration/sources/splunk_hec.md
@@ -7,6 +7,6 @@ layout: component
 tags: ["splunk", "hec", "http event collector", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/statsd.md
+++ b/website/content/en/docs/reference/configuration/sources/statsd.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["statsd", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/statsd.md
+++ b/website/content/en/docs/reference/configuration/sources/statsd.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["statsd", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/stdin.md
+++ b/website/content/en/docs/reference/configuration/sources/stdin.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["stdin", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/stdin.md
+++ b/website/content/en/docs/reference/configuration/sources/stdin.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["stdin", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/syslog.md
+++ b/website/content/en/docs/reference/configuration/sources/syslog.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["syslog", "component", "source", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/sources/syslog.md
+++ b/website/content/en/docs/reference/configuration/sources/syslog.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["syslog", "component", "source", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/vector.md
+++ b/website/content/en/docs/reference/configuration/sources/vector.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["vector", "instance", "component", "source"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/sources/vector.md
+++ b/website/content/en/docs/reference/configuration/sources/vector.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["vector", "instance", "component", "source"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/template-syntax.md
+++ b/website/content/en/docs/reference/configuration/template-syntax.md
@@ -29,7 +29,7 @@ Notice that Vector allows direct field references as well as strftime specifiers
 
 The value of the key_prefix option would equal:
 
-```
+```text
 application_id=1/date=2020-02-14
 ```
 

--- a/website/content/en/docs/reference/configuration/transforms/aggregate.md
+++ b/website/content/en/docs/reference/configuration/transforms/aggregate.md
@@ -5,6 +5,9 @@ layout: component
 tags: ["aggregate", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/aggregate.md
+++ b/website/content/en/docs/reference/configuration/transforms/aggregate.md
@@ -5,6 +5,6 @@ layout: component
 tags: ["aggregate", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/aws_cloudwatch_logs_subscription_parser.md
+++ b/website/content/en/docs/reference/configuration/transforms/aws_cloudwatch_logs_subscription_parser.md
@@ -7,6 +7,9 @@ layout: component
 tags: []
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/aws_cloudwatch_logs_subscription_parser.md
+++ b/website/content/en/docs/reference/configuration/transforms/aws_cloudwatch_logs_subscription_parser.md
@@ -7,6 +7,6 @@ layout: component
 tags: []
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/aws_ec2_metadata.md
+++ b/website/content/en/docs/reference/configuration/transforms/aws_ec2_metadata.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["aws", "ec2", "metadata", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/aws_ec2_metadata.md
+++ b/website/content/en/docs/reference/configuration/transforms/aws_ec2_metadata.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["aws", "ec2", "metadata", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/dedupe.md
+++ b/website/content/en/docs/reference/configuration/transforms/dedupe.md
@@ -7,6 +7,6 @@ layout: component
 tags: ["dedupe", "deduplicate", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/dedupe.md
+++ b/website/content/en/docs/reference/configuration/transforms/dedupe.md
@@ -7,6 +7,9 @@ layout: component
 tags: ["dedupe", "deduplicate", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/filter.md
+++ b/website/content/en/docs/reference/configuration/transforms/filter.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["filter", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/filter.md
+++ b/website/content/en/docs/reference/configuration/transforms/filter.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["filter", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/geoip.md
+++ b/website/content/en/docs/reference/configuration/transforms/geoip.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["geo", "geoip", "enrich", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/geoip.md
+++ b/website/content/en/docs/reference/configuration/transforms/geoip.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["geo", "geoip", "enrich", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/log_to_metric.md
+++ b/website/content/en/docs/reference/configuration/transforms/log_to_metric.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["log to metric", "convert", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/log_to_metric.md
+++ b/website/content/en/docs/reference/configuration/transforms/log_to_metric.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["log to metric", "convert", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/lua.md
+++ b/website/content/en/docs/reference/configuration/transforms/lua.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["lua", "runtime", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/lua.md
+++ b/website/content/en/docs/reference/configuration/transforms/lua.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["lua", "runtime", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/metric_to_log.md
+++ b/website/content/en/docs/reference/configuration/transforms/metric_to_log.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["metric to log", "convert", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/metric_to_log.md
+++ b/website/content/en/docs/reference/configuration/transforms/metric_to_log.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["metric to log", "convert", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/reduce.md
+++ b/website/content/en/docs/reference/configuration/transforms/reduce.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["filter", "multiline", "component", "transform", "logs"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/reduce.md
+++ b/website/content/en/docs/reference/configuration/transforms/reduce.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["filter", "multiline", "component", "transform", "logs"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/remap.md
+++ b/website/content/en/docs/reference/configuration/transforms/remap.md
@@ -9,6 +9,9 @@ weight: 1
 tags: ["remap", "vrl", "vector remap language", "modify", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/remap.md
+++ b/website/content/en/docs/reference/configuration/transforms/remap.md
@@ -9,6 +9,6 @@ weight: 1
 tags: ["remap", "vrl", "vector remap language", "modify", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/route.md
+++ b/website/content/en/docs/reference/configuration/transforms/route.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["route", "swimlanes", "split", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/route.md
+++ b/website/content/en/docs/reference/configuration/transforms/route.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["route", "swimlanes", "split", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/sample.md
+++ b/website/content/en/docs/reference/configuration/transforms/sample.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["sample", "component", "transform"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/reference/configuration/transforms/sample.md
+++ b/website/content/en/docs/reference/configuration/transforms/sample.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["sample", "component", "transform"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/tag_cardinality_limit.md
+++ b/website/content/en/docs/reference/configuration/transforms/tag_cardinality_limit.md
@@ -6,6 +6,9 @@ layout: component
 tags: ["tag", "cardinality", "component", "transform", "metrics"]
 ---
 
-{{/*This doc is generated using:
-     1. The template in layouts/docs/component.html
-2. The relevant CUE data in cue/reference/components/...*/}}
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/content/en/docs/reference/configuration/transforms/tag_cardinality_limit.md
+++ b/website/content/en/docs/reference/configuration/transforms/tag_cardinality_limit.md
@@ -6,6 +6,6 @@ layout: component
 tags: ["tag", "cardinality", "component", "transform", "metrics"]
 ---
 
-{{/* This doc is generated using:
+{{/*This doc is generated using:
      1. The template in layouts/docs/component.html
-     2. The relevant CUE data in cue/reference/components/... */}}
+2. The relevant CUE data in cue/reference/components/...*/}}

--- a/website/content/en/docs/setup/installation/manual/from-source.md
+++ b/website/content/en/docs/setup/installation/manual/from-source.md
@@ -224,7 +224,7 @@ In addition, it is possible to pick only a subset of Vector's components for the
 {{< details title="Click to see all component features" >}}
 <!-- TODO: create a dedicated shortcode for this -->
 
-**Vector component features**
+#### Vector component features
 
 Name | Description
 :----|:-----------

--- a/website/content/en/docs/setup/installation/package-managers/apt.md
+++ b/website/content/en/docs/setup/installation/package-managers/apt.md
@@ -34,14 +34,18 @@ sudo apt-get install vector
 
 {{< tabs default="Upgrade Vector" >}}
 {{< tab title="Upgrade Vector" >}}
+
 ```bash
 sudo apt-get upgrade vector
 ```
+
 {{< /tab >}}
 {{< tab title="Uninstall Vector" >}}
+
 ```bash
 sudo apt remove vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/setup/installation/package-managers/dpkg.md
+++ b/website/content/en/docs/setup/installation/package-managers/dpkg.md
@@ -21,14 +21,18 @@ sudo dpkg -i vector-{{< version >}}-amd64.deb
 
 {{< tabs default="Upgrade Vector" >}}
 {{< tab title="Upgrade Vector" >}}
+
 ```shell
 dpkg -i vector-{{< version >}}-amd64
 ```
+
 {{< /tab >}}
 {{< tab title="Uninstall Vector" >}}
+
 ```shell
 dpkg -r vector-{{< version >}}-amd64
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/setup/installation/package-managers/homebrew.md
+++ b/website/content/en/docs/setup/installation/package-managers/homebrew.md
@@ -16,14 +16,18 @@ brew tap vectordotdev/brew && brew install vector
 
 {{< tabs default="Upgrade Vector" >}}
 {{< tab title="Upgrade Vector" >}}
+
 ```shell
 brew update && brew upgrade vector
 ```
+
 {{< /tab >}}
 {{< tab title="Uninstall Vector" >}}
+
 ```shell
 brew remove vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/setup/installation/package-managers/nix.md
+++ b/website/content/en/docs/setup/installation/package-managers/nix.md
@@ -28,15 +28,19 @@ Vector is an end-to-end observability data pipeline designed to deploy under var
 
 {{< tabs default="Upgrade Vector" >}}
 {{< tab title="Upgrade Vector" >}}
+
 ```shell
 nix-env --upgrade vector \
   --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz
 ```
+
 {{< /tab >}}
 {{< tab title="Uninstall Vector" >}}
+
 ```shell
 nix-env --uninstall vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/setup/installation/package-managers/rpm.md
+++ b/website/content/en/docs/setup/installation/package-managers/rpm.md
@@ -22,9 +22,11 @@ Make sure to replace `{arch}` with one of the following:
 
 {{< tabs default="Uninstall Vector" >}}
 {{< tab title="Uninstall Vector" >}}
+
 ```shell
 sudo rpm -e vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/setup/installation/package-managers/yum.md
+++ b/website/content/en/docs/setup/installation/package-managers/yum.md
@@ -27,14 +27,18 @@ sudo yum install vector
 
 {{< tabs default="Upgrade Vector" >}}
 {{< tab title="Upgrade Vector" >}}
+
 ```shell
 sudo yum upgrade vector
 ```
+
 {{< /tab >}}
 {{< tab title="Uninstall Vector" >}}
+
 ```shell
 sudo yum remove vector
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/docs/setup/quickstart.md
+++ b/website/content/en/docs/setup/quickstart.md
@@ -120,6 +120,7 @@ Lastly, we've updated the ID of our sink component to `emit_syslog`, updated the
 
 Let's re-run Vector. This time we don't need to echo any data to it; just run in on the command line. It'll process
 100 lines of generated Syslog data, emit the processed data as JSON, and exit:
+
 ```shell
 vector --config ./vector.toml
 ```

--- a/website/content/en/guides/advanced/cloudwatch-logs-firehose.md
+++ b/website/content/en/guides/advanced/cloudwatch-logs-firehose.md
@@ -9,6 +9,7 @@ tags: ["aws", "cloudwatch", "logs", "firehose", "advanced", "guides", "guide"]
 ---
 
 {{< requirement title="Pre-requisites" >}}
+
 * You have logs in [AWS CloudWatch Logs][AWS CloudWatch Logs] that you'd like to
   consume.
 * You are able to deploy Vector with a publicly exposed HTTPS endpoint.
@@ -25,11 +26,11 @@ running Vector instances over HTTPS.
 
 You will learn how to:
 
-- Configure Vector to consume AWS CloudWatch Log events via the
+* Configure Vector to consume AWS CloudWatch Log events via the
  [`aws_kinesis_firehose`][aws_kinesis_firehose]] source and
  [`aws_cloudwatch_logs_subscription_parser`][aws_cloudwatch_logs_subscription_parser]
  transform
-- Configure [AWS Kinesis Firehose][AWS Kinesis Firehose] to forward events to
+* Configure [AWS Kinesis Firehose][AWS Kinesis Firehose] to forward events to
   a remotely running Vector instance (or instances)
 
 Once completed, you'll have a setup that will receive events written to
@@ -49,13 +50,13 @@ Why use [AWS CloudWatch Logs subscriptions][AWS CloudWatch Logs subscriptions]
 and [AWS Kinesis Firehose][AWS Kinesis Firehose] to forward logs to Vector? This
 pipeline:
 
-- Is tolerant of downtime
-    - Firehose will retry requests for a configurable period
-    - Firehose will dead-letter events that cannot be sent to S3
-- Allows you to load balance the log ingestion
-    - You can put multiple `vector` instances behind a load balancer
-- Allows to ingest logs from multiple log groups
-    - You can use one Firehose delivery stream as the destination for multiple
+* Is tolerant of downtime
+  * Firehose will retry requests for a configurable period
+  * Firehose will dead-letter events that cannot be sent to S3
+* Allows you to load balance the log ingestion
+  * You can put multiple `vector` instances behind a load balancer
+* Allows to ingest logs from multiple log groups
+  * You can use one Firehose delivery stream as the destination for multiple
       CloudWatch Logs subscription filters
 
 ## Setup
@@ -542,12 +543,12 @@ This will take the above event and output two new events:
 Here we can see the individual events are extracted along with some additional
 context:
 
-- `id`: the ID of the log event
-- `log_group` the log_group of the log event
-- `log_stream` the log_stream of the log event
-- `owner` the AWS account ID of the owner of the log event
-- `subcription_filters` the filters that matched to send the event
-- `timestamp` is overwritten with the timestamp from the log event
+* `id`: the ID of the log event
+* `log_group` the log_group of the log event
+* `log_stream` the log_stream of the log event
+* `owner` the AWS account ID of the owner of the log event
+* `subcription_filters` the filters that matched to send the event
+* `timestamp` is overwritten with the timestamp from the log event
 
 This is pretty good, but, our original events are also JSON, so let's parse
 those out using the [`json_parser`][json_parser] transform:

--- a/website/content/en/guides/advanced/merge-multiline-logs-with-lua.md
+++ b/website/content/en/guides/advanced/merge-multiline-logs-with-lua.md
@@ -9,6 +9,7 @@ tags: ["lua", "merge", "multiline", "multi-line", "advanced", "guides", "guide"]
 ---
 
 {{< requirement title="Pre-requisites" >}}
+
 * You understand the [basic Lua concepts][docs.transforms.lua].
 * You understand the [basic Vector concepts][docs.about.concepts] and understand [how to set up a basic pipeline][docs.setup.quickstart].
 * You know how to [parse CSV logs with Lua][guides.parsing-csv-logs-with-lua].

--- a/website/content/en/guides/advanced/parsing-csv-logs-with-lua.md
+++ b/website/content/en/guides/advanced/parsing-csv-logs-with-lua.md
@@ -9,6 +9,7 @@ tags: ["lua", "csv", "logs", "transform", "advanced", "guides", "guide"]
 ---
 
 {{< requirement title="Pre-requisites" >}}
+
 * You understand the [basic Lua concepts][docs.transforms.lua].
 * You understand the [basic Vector concepts][docs.about.concepts] and understand [how to set up a pipeline][docs.setup.quickstart].
 {{< /requirement >}}

--- a/website/content/en/guides/advanced/wasm-hello.md
+++ b/website/content/en/guides/advanced/wasm-hello.md
@@ -18,6 +18,7 @@ It can be used with Vector versions prior to its removal.
 {{< /warning >}}
 
 {{< requirement title="Pre-requisites" >}}
+
 * You understand the [basic Vector concepts][docs.about.concepts] and understand [how to set up a pipeline][docs.setup.quickstart].
 * You must be using a Linux system (or WSL2 for Windows users) for WASM related work right now.
 
@@ -124,16 +125,19 @@ With your machine provisioned, it's time to hack!
   ```bash
   rustup target add wasm32-wasi
   ```
+
 1. Build Vector:  **(This will take a bit!)**
 
   ```bash
    cargo build --features wasm --release
    ```
+
 1. Verify your handiwork, make sure the `wasm` component is loaded:
 
   ```bash
   ./target/release/vector list | grep wasm
   ```
+
 1. Build the test WASM module Vector uses:
 
   ```bash
@@ -222,6 +226,7 @@ examples in the `tests/data/wasm/` folder of Vector.
 Some things to note:
 
 * Accessing a chunk of guest memory as mutable slice can be done via:
+
   ```rust
   let data = unsafe {
     std::ptr::slice_from_raw_parts_mut(data as *mut u8, length.try_into().unwrap())
@@ -229,7 +234,9 @@ Some things to note:
         .unwrap()
   };
   ```
+
 * `OnceCell` is useful for one-time initializers. Eg.
+
   ```rust
   static FIELDS: OnceCell<HashMap<String, Value>> = OnceCell::new();
 
@@ -239,6 +246,7 @@ Some things to note:
       // ...
   }
   ```
+
 * Vector will reinitialize panicked modules, so panicing is safe so long as you're fine losing your working data.
 * By default, the heap size is 10MB.
 

--- a/website/content/en/guides/advanced/wasm-multiline.md
+++ b/website/content/en/guides/advanced/wasm-multiline.md
@@ -18,6 +18,7 @@ It can be used with Vector versions prior to its removal.
 {{< /warning >}}
 
 {{< requirement title="Pre-requisites" >}}
+
 * You understand the [basic Vector concepts][docs.about.concepts] and understand [how to set up a pipeline][docs.setup.quickstart].
 * You must be using a Linux system (or WSL2 for Windows users) for WASM related work right now.
 * You read the [Hello, WASM World][wasm_guide] guide and feel comfortable with the topics it discussed.

--- a/website/content/en/guides/level-up/troubleshooting.md
+++ b/website/content/en/guides/level-up/troubleshooting.md
@@ -33,6 +33,7 @@ a utility like `tail` to access your logs:
 ```shell
 tail /var/log/vector.log
 ```
+
 {{< /tab >}}
 
 {{< tab title="Systemd" >}}
@@ -41,6 +42,7 @@ Tail logs:
 ```shell
 sudo journalctl -fu vector
 ```
+
 {{< /tab >}}
 
 {{< tab title="Initd" >}}
@@ -49,6 +51,7 @@ Tail logs:
 ```shell
 tail -f /var/log/vector.log
 ```
+
 {{< /tab >}}
 {{< tab title="Homebrew" >}}
 Tail logs:
@@ -56,6 +59,7 @@ Tail logs:
 ```shell
 tail -f /usr/local/var/log/vector.log
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -88,14 +92,18 @@ Vector rate limits logs in the hot path. As a result, dropping to the
 
 {{< tabs default="Env Var" >}}
 {{< tab title="Env Var" >}}
+
 ```shell
 LOG=debug vector --config=/etc/vector/vector.toml
 ```
+
 {{< /tab >}}
 {{< tab title="Flag" >}}
+
 ```bash
 vector --verbose --config=/etc/vector/vector.toml
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/website/content/en/guides/level-up/unit-testing.md
+++ b/website/content/en/guides/level-up/unit-testing.md
@@ -187,6 +187,7 @@ Side note: We would have also caught this particular issue with:
 ```shell
 vector validate --topology ./example.toml
 ```
+
 {{< /info >}}
 
 The fix is easy, we simply change the input of `baz` from `foo` to `bar`:

--- a/website/content/en/highlights/2020-03-11-tag-cardinality-limit-transform.md
+++ b/website/content/en/highlights/2020-03-11-tag-cardinality-limit-transform.md
@@ -30,6 +30,7 @@ Getting started is easy. Simply add this component to your pipeline:
 ```
 
 {{< success >}}
+
 - The `limit_exceeded_action` described the behavior when the `value_limit` is reached.
 - The `mode` enables you to switch between `exact` and `probabilistic` algorithms to trade performance for memory efficiency.
 - The `value` limit allows you to select exactly how many unique tag values you're willing to accept.

--- a/website/content/en/highlights/2020-04-07-use-external-tagging-for-metrics-serialization.md
+++ b/website/content/en/highlights/2020-04-07-use-external-tagging-for-metrics-serialization.md
@@ -50,5 +50,6 @@ It now serialized like:
 ```
 
 ## Upgrade Guide
+
 Upgrading should involve handling changes in any systems that are consuming
 metrics data from the `console` sink.

--- a/website/content/en/highlights/2021-07-13-helm-customConfig.md
+++ b/website/content/en/highlights/2021-07-13-helm-customConfig.md
@@ -20,7 +20,9 @@ method.
 The new `customConfig` key will take precedence over the existing configuration options, if `customConfig` is
 set then no default configurations will be rendered.
 
-**You do not need to upgrade immediately. The deprecated keys will not be removed before Vector hits 1.0**
+{{< warning >}}
+You do not need to upgrade immediately. The deprecated keys will not be removed before Vector hits 1.0
+{{< /warning >}}
 
 ## Upgrade Guide
 

--- a/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
+++ b/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
@@ -49,4 +49,3 @@ which also writes to stdout by default.  Following some discussion in
 that stdout can be processed separately.
 
 If you were previously depending on Vector's logs appearing in stdout, you should now look for them in stderr.
-=======


### PR DESCRIPTION
These were (accidentally?) removed in
https://github.com/vectordotdev/vector/pull/7368

Includes markdown fixes.

Closes: #9270



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->