### PR TITLE
enhancement(vrl): Move rate limiting span to just around log function

### DIFF
--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -41,7 +41,12 @@ impl Function for FindEnrichmentTableRecords {
         &[]
     }
 
-    fn compile(&self, state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let registry = state
             .get_external_context::<TableRegistry>()
             .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticError>)?;

--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -44,7 +44,7 @@ impl Function for FindEnrichmentTableRecords {
     fn compile(
         &self,
         state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let registry = state

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -44,7 +44,7 @@ impl Function for GetEnrichmentTableRecord {
     fn compile(
         &self,
         state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let registry = state

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -41,7 +41,12 @@ impl Function for GetEnrichmentTableRecord {
         &[]
     }
 
-    fn compile(&self, state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let registry = state
             .get_external_context::<TableRegistry>()
             .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticError>)?;

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -1,11 +1,10 @@
 use crate::expression::{levenstein, ExpressionError, FunctionArgument, Noop};
-use crate::function::{ArgumentList, Parameter};
+use crate::function::{ArgumentList, CompileInfo, Parameter};
 use crate::parser::{Ident, Node};
 use crate::{value::Kind, Context, Expression, Function, Resolved, Span, State, TypeDef};
 
 use diagnostic::{DiagnosticError, Label, Note, Urls};
 use std::fmt;
-use tracing::{span, Level};
 
 #[derive(Clone)]
 pub struct FunctionCall {
@@ -163,8 +162,10 @@ impl FunctionCall {
                 })
             })?;
 
+        let compile_info = CompileInfo { span: call_span };
+
         let mut expr = function
-            .compile(state, list)
+            .compile(state, &compile_info, list)
             .map_err(|error| Error::Compilation { call_span, error })?;
 
         // Asking for an infallible function to abort on error makes no sense.
@@ -211,31 +212,29 @@ impl FunctionCall {
 
 impl Expression for FunctionCall {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        span!(Level::ERROR, "remap", vrl_position = &self.span.start()).in_scope(|| {
-            self.expr.resolve(ctx).map_err(|err| match err {
-                ExpressionError::Abort { .. } => {
-                    panic!("abort errors must only be defined by `abort` statement")
-                }
-                ExpressionError::Error {
-                    message,
-                    mut labels,
-                    notes,
-                } => {
-                    labels.push(Label::primary(message.clone(), self.span));
+        self.expr.resolve(ctx).map_err(|err| match err {
+            ExpressionError::Abort { .. } => {
+                panic!("abort errors must only be defined by `abort` statement")
+            }
+            ExpressionError::Error {
+                message,
+                mut labels,
+                notes,
+            } => {
+                labels.push(Label::primary(message.clone(), self.span));
 
-                    ExpressionError::Error {
-                        message: format!(
-                            r#"function call error for "{}" at ({}:{}): {}"#,
-                            self.ident,
-                            self.span.start(),
-                            self.span.end(),
-                            message
-                        ),
-                        labels,
-                        notes,
-                    }
+                ExpressionError::Error {
+                    message: format!(
+                        r#"function call error for "{}" at ({}:{}): {}"#,
+                        self.ident,
+                        self.span.start(),
+                        self.span.end(),
+                        message
+                    ),
+                    labels,
+                    notes,
                 }
-            })
+            }
         })
     }
 

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -1,5 +1,5 @@
 use crate::expression::{levenstein, ExpressionError, FunctionArgument, Noop};
-use crate::function::{ArgumentList, CompileInfo, Parameter};
+use crate::function::{ArgumentList, FunctionCompileContext, Parameter};
 use crate::parser::{Ident, Node};
 use crate::{value::Kind, Context, Expression, Function, Resolved, Span, State, TypeDef};
 
@@ -162,7 +162,7 @@ impl FunctionCall {
                 })
             })?;
 
-        let compile_info = CompileInfo { span: call_span };
+        let compile_info = FunctionCompileContext { span: call_span };
 
         let mut expr = function
             .compile(state, &compile_info, list)

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -39,7 +39,12 @@ pub trait Function: Sync + fmt::Debug {
     ///
     /// At runtime, the `Expression` returned by this function is executed and
     /// resolved to its final [`Value`].
-    fn compile(&self, state: &super::State, arguments: ArgumentList) -> Compiled;
+    fn compile(
+        &self,
+        state: &super::State,
+        info: &CompileInfo,
+        arguments: ArgumentList,
+    ) -> Compiled;
 
     /// An optional list of parameters the function accepts.
     ///
@@ -57,6 +62,11 @@ pub struct Example {
     pub title: &'static str,
     pub source: &'static str,
     pub result: Result<&'static str, &'static str>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct CompileInfo {
+    pub span: Span,
 }
 
 // -----------------------------------------------------------------------------

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -42,7 +42,7 @@ pub trait Function: Sync + fmt::Debug {
     fn compile(
         &self,
         state: &super::State,
-        info: &CompileInfo,
+        info: &FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled;
 
@@ -65,7 +65,7 @@ pub struct Example {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct CompileInfo {
+pub struct FunctionCompileContext {
     pub span: Span,
 }
 

--- a/lib/vrl/compiler/src/test_util.rs
+++ b/lib/vrl/compiler/src/test_util.rs
@@ -122,7 +122,16 @@ macro_rules! test_function {
 #[macro_export]
 macro_rules! __prep_bench_or_test {
     ($func:path, $state:expr, $args:expr, $want:expr) => {{
-        ($func.compile(&$state, $args.into()), $want)
+        (
+            $func.compile(
+                &$state,
+                &$crate::function::FunctionCompileContext {
+                    span: vrl::diagnostic::Span::new(0, 0),
+                },
+                $args.into(),
+            ),
+            $want,
+        )
     }};
 }
 

--- a/lib/vrl/core/src/prelude.rs
+++ b/lib/vrl/core/src/prelude.rs
@@ -24,9 +24,7 @@ pub use std::fmt;
 
 // commonly used function types
 
-pub use compiler::function::{
-    ArgumentList, CompileInfo as FunctionCompileInfo, Compiled, Example, Parameter,
-};
+pub use compiler::function::{ArgumentList, Compiled, Example, FunctionCompileContext, Parameter};
 
 // commonly used macros
 pub use compiler::{

--- a/lib/vrl/core/src/prelude.rs
+++ b/lib/vrl/core/src/prelude.rs
@@ -24,7 +24,9 @@ pub use std::fmt;
 
 // commonly used function types
 
-pub use compiler::function::{ArgumentList, Compiled, Example, Parameter};
+pub use compiler::function::{
+    ArgumentList, CompileInfo as FunctionCompileInfo, Compiled, Example, Parameter,
+};
 
 // commonly used macros
 pub use compiler::{

--- a/lib/vrl/stdlib/src/append.rs
+++ b/lib/vrl/stdlib/src/append.rs
@@ -34,7 +34,7 @@ impl Function for Append {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/append.rs
+++ b/lib/vrl/stdlib/src/append.rs
@@ -31,7 +31,12 @@ impl Function for Append {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let items = arguments.required("items");
 

--- a/lib/vrl/stdlib/src/array.rs
+++ b/lib/vrl/stdlib/src/array.rs
@@ -36,7 +36,7 @@ impl Function for Array {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/array.rs
+++ b/lib/vrl/stdlib/src/array.rs
@@ -33,7 +33,12 @@ impl Function for Array {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ArrayFn { value }))

--- a/lib/vrl/stdlib/src/assert.rs
+++ b/lib/vrl/stdlib/src/assert.rs
@@ -46,7 +46,7 @@ impl Function for Assert {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let condition = arguments.required("condition");

--- a/lib/vrl/stdlib/src/assert.rs
+++ b/lib/vrl/stdlib/src/assert.rs
@@ -43,7 +43,12 @@ impl Function for Assert {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let condition = arguments.required("condition");
         let message = arguments.optional("message");
 

--- a/lib/vrl/stdlib/src/assert_eq.rs
+++ b/lib/vrl/stdlib/src/assert_eq.rs
@@ -53,7 +53,7 @@ impl Function for AssertEq {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let left = arguments.required("left");

--- a/lib/vrl/stdlib/src/assert_eq.rs
+++ b/lib/vrl/stdlib/src/assert_eq.rs
@@ -50,7 +50,12 @@ impl Function for AssertEq {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let left = arguments.required("left");
         let right = arguments.required("right");
         let message = arguments.optional("message");

--- a/lib/vrl/stdlib/src/boolean.rs
+++ b/lib/vrl/stdlib/src/boolean.rs
@@ -36,7 +36,7 @@ impl Function for Boolean {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/boolean.rs
+++ b/lib/vrl/stdlib/src/boolean.rs
@@ -33,7 +33,12 @@ impl Function for Boolean {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(BooleanFn { value }))

--- a/lib/vrl/stdlib/src/ceil.rs
+++ b/lib/vrl/stdlib/src/ceil.rs
@@ -27,7 +27,7 @@ impl Function for Ceil {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ceil.rs
+++ b/lib/vrl/stdlib/src/ceil.rs
@@ -24,7 +24,12 @@ impl Function for Ceil {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let precision = arguments.optional("precision");
 

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -68,7 +68,7 @@ impl Function for Compact {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -65,7 +65,12 @@ impl Function for Compact {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let recursive = arguments.optional("recursive");
         let null = arguments.optional("null");

--- a/lib/vrl/stdlib/src/contains.rs
+++ b/lib/vrl/stdlib/src/contains.rs
@@ -31,7 +31,7 @@ impl Function for Contains {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/contains.rs
+++ b/lib/vrl/stdlib/src/contains.rs
@@ -28,7 +28,12 @@ impl Function for Contains {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
         let case_sensitive = arguments.optional("case_sensitive").unwrap_or(expr!(true));

--- a/lib/vrl/stdlib/src/decode_base64.rs
+++ b/lib/vrl/stdlib/src/decode_base64.rs
@@ -28,7 +28,7 @@ impl Function for DecodeBase64 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/decode_base64.rs
+++ b/lib/vrl/stdlib/src/decode_base64.rs
@@ -25,7 +25,12 @@ impl Function for DecodeBase64 {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let charset = arguments.optional("charset");
 

--- a/lib/vrl/stdlib/src/decode_percent.rs
+++ b/lib/vrl/stdlib/src/decode_percent.rs
@@ -18,7 +18,12 @@ impl Function for DecodePercent {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(DecodePercentFn { value }))

--- a/lib/vrl/stdlib/src/decode_percent.rs
+++ b/lib/vrl/stdlib/src/decode_percent.rs
@@ -21,7 +21,7 @@ impl Function for DecodePercent {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -52,7 +52,7 @@ impl Function for Del {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let query = arguments.required_query("target")?;

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -49,7 +49,12 @@ impl Function for Del {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let query = arguments.required_query("target")?;
 
         Ok(Box::new(DelFn { query }))

--- a/lib/vrl/stdlib/src/downcase.rs
+++ b/lib/vrl/stdlib/src/downcase.rs
@@ -19,7 +19,7 @@ impl Function for Downcase {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/downcase.rs
+++ b/lib/vrl/stdlib/src/downcase.rs
@@ -16,7 +16,12 @@ impl Function for Downcase {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(DowncaseFn { value }))

--- a/lib/vrl/stdlib/src/encode_base64.rs
+++ b/lib/vrl/stdlib/src/encode_base64.rs
@@ -30,7 +30,12 @@ impl Function for EncodeBase64 {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let padding = arguments.optional("padding");
         let charset = arguments.optional("charset");

--- a/lib/vrl/stdlib/src/encode_base64.rs
+++ b/lib/vrl/stdlib/src/encode_base64.rs
@@ -33,7 +33,7 @@ impl Function for EncodeBase64 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/encode_json.rs
+++ b/lib/vrl/stdlib/src/encode_json.rs
@@ -16,7 +16,12 @@ impl Function for EncodeJson {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(EncodeJsonFn { value }))

--- a/lib/vrl/stdlib/src/encode_json.rs
+++ b/lib/vrl/stdlib/src/encode_json.rs
@@ -19,7 +19,7 @@ impl Function for EncodeJson {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -40,7 +40,12 @@ impl Function for EncodeKeyValue {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let fields = arguments.optional("fields_ordering");
 

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -43,7 +43,7 @@ impl Function for EncodeKeyValue {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -27,7 +27,7 @@ impl Function for EncodeLogfmt {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         // The encode_logfmt function is just an alias for `encode_key_value` with the following

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -24,7 +24,12 @@ impl Function for EncodeLogfmt {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         // The encode_logfmt function is just an alias for `encode_key_value` with the following
         // parameters for the delimiters.
         let key_value_delimiter = expr!("=");

--- a/lib/vrl/stdlib/src/encode_percent.rs
+++ b/lib/vrl/stdlib/src/encode_percent.rs
@@ -70,7 +70,7 @@ impl Function for EncodePercent {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let ascii_sets = vec![

--- a/lib/vrl/stdlib/src/encode_percent.rs
+++ b/lib/vrl/stdlib/src/encode_percent.rs
@@ -67,7 +67,12 @@ impl Function for EncodePercent {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let ascii_sets = vec![
             value!("NON_ALPHANUMERIC"),
             value!("CONTROLS"),

--- a/lib/vrl/stdlib/src/ends_with.rs
+++ b/lib/vrl/stdlib/src/ends_with.rs
@@ -31,7 +31,7 @@ impl Function for EndsWith {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ends_with.rs
+++ b/lib/vrl/stdlib/src/ends_with.rs
@@ -28,7 +28,12 @@ impl Function for EndsWith {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
         let case_sensitive = arguments.optional("case_sensitive").unwrap_or(expr!(true));

--- a/lib/vrl/stdlib/src/exists.rs
+++ b/lib/vrl/stdlib/src/exists.rs
@@ -31,7 +31,12 @@ impl Function for Exists {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let query = arguments.required_query("field")?;
 
         Ok(Box::new(ExistsFn { query }))

--- a/lib/vrl/stdlib/src/exists.rs
+++ b/lib/vrl/stdlib/src/exists.rs
@@ -34,7 +34,7 @@ impl Function for Exists {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let query = arguments.required_query("field")?;

--- a/lib/vrl/stdlib/src/find.rs
+++ b/lib/vrl/stdlib/src/find.rs
@@ -40,7 +40,7 @@ impl Function for Find {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/find.rs
+++ b/lib/vrl/stdlib/src/find.rs
@@ -37,7 +37,12 @@ impl Function for Find {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
         let from = arguments.optional("from");

--- a/lib/vrl/stdlib/src/flatten.rs
+++ b/lib/vrl/stdlib/src/flatten.rs
@@ -35,7 +35,7 @@ impl Function for Flatten {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/flatten.rs
+++ b/lib/vrl/stdlib/src/flatten.rs
@@ -32,7 +32,12 @@ impl Function for Flatten {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         Ok(Box::new(FlattenFn { value }))
     }

--- a/lib/vrl/stdlib/src/float.rs
+++ b/lib/vrl/stdlib/src/float.rs
@@ -33,7 +33,12 @@ impl Function for Float {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(FloatFn { value }))

--- a/lib/vrl/stdlib/src/float.rs
+++ b/lib/vrl/stdlib/src/float.rs
@@ -36,7 +36,7 @@ impl Function for Float {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/floor.rs
+++ b/lib/vrl/stdlib/src/floor.rs
@@ -24,7 +24,12 @@ impl Function for Floor {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let precision = arguments.optional("precision");
 

--- a/lib/vrl/stdlib/src/floor.rs
+++ b/lib/vrl/stdlib/src/floor.rs
@@ -27,7 +27,7 @@ impl Function for Floor {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/format_int.rs
+++ b/lib/vrl/stdlib/src/format_int.rs
@@ -28,7 +28,7 @@ impl Function for FormatInt {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/format_int.rs
+++ b/lib/vrl/stdlib/src/format_int.rs
@@ -25,7 +25,12 @@ impl Function for FormatInt {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let base = arguments.optional("base");
 

--- a/lib/vrl/stdlib/src/format_number.rs
+++ b/lib/vrl/stdlib/src/format_number.rs
@@ -34,7 +34,12 @@ impl Function for FormatNumber {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let scale = arguments.optional("scale");
         let decimal_separator = arguments.optional("decimal_separator");

--- a/lib/vrl/stdlib/src/format_number.rs
+++ b/lib/vrl/stdlib/src/format_number.rs
@@ -37,7 +37,7 @@ impl Function for FormatNumber {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/format_timestamp.rs
+++ b/lib/vrl/stdlib/src/format_timestamp.rs
@@ -25,7 +25,12 @@ impl Function for FormatTimestamp {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments.required("format");
 

--- a/lib/vrl/stdlib/src/format_timestamp.rs
+++ b/lib/vrl/stdlib/src/format_timestamp.rs
@@ -28,7 +28,7 @@ impl Function for FormatTimestamp {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/get_env_var.rs
+++ b/lib/vrl/stdlib/src/get_env_var.rs
@@ -27,7 +27,7 @@ impl Function for GetEnvVar {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let name = arguments.required("name");

--- a/lib/vrl/stdlib/src/get_env_var.rs
+++ b/lib/vrl/stdlib/src/get_env_var.rs
@@ -24,7 +24,12 @@ impl Function for GetEnvVar {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let name = arguments.required("name");
 
         Ok(Box::new(GetEnvVarFn { name }))

--- a/lib/vrl/stdlib/src/get_hostname.rs
+++ b/lib/vrl/stdlib/src/get_hostname.rs
@@ -11,7 +11,7 @@ impl Function for GetHostname {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         _: ArgumentList,
     ) -> Compiled {
         Ok(Box::new(GetHostnameFn))

--- a/lib/vrl/stdlib/src/get_hostname.rs
+++ b/lib/vrl/stdlib/src/get_hostname.rs
@@ -8,7 +8,12 @@ impl Function for GetHostname {
         "get_hostname"
     }
 
-    fn compile(&self, _state: &state::Compiler, _: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        _: ArgumentList,
+    ) -> Compiled {
         Ok(Box::new(GetHostnameFn))
     }
 

--- a/lib/vrl/stdlib/src/includes.rs
+++ b/lib/vrl/stdlib/src/includes.rs
@@ -38,7 +38,12 @@ impl Function for Includes {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let item = arguments.required("item");
 

--- a/lib/vrl/stdlib/src/includes.rs
+++ b/lib/vrl/stdlib/src/includes.rs
@@ -41,7 +41,7 @@ impl Function for Includes {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/integer.rs
+++ b/lib/vrl/stdlib/src/integer.rs
@@ -36,7 +36,7 @@ impl Function for Integer {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/integer.rs
+++ b/lib/vrl/stdlib/src/integer.rs
@@ -33,7 +33,12 @@ impl Function for Integer {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IntegerFn { value }))

--- a/lib/vrl/stdlib/src/ip_aton.rs
+++ b/lib/vrl/stdlib/src/ip_aton.rs
@@ -26,7 +26,12 @@ impl Function for IpAton {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IpAtonFn { value }))

--- a/lib/vrl/stdlib/src/ip_aton.rs
+++ b/lib/vrl/stdlib/src/ip_aton.rs
@@ -29,7 +29,7 @@ impl Function for IpAton {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ip_cidr_contains.rs
+++ b/lib/vrl/stdlib/src/ip_cidr_contains.rs
@@ -56,7 +56,7 @@ impl Function for IpCidrContains {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let cidr = arguments.required("cidr");

--- a/lib/vrl/stdlib/src/ip_cidr_contains.rs
+++ b/lib/vrl/stdlib/src/ip_cidr_contains.rs
@@ -53,7 +53,12 @@ impl Function for IpCidrContains {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let cidr = arguments.required("cidr");
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -29,7 +29,7 @@ impl Function for IpNtoa {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -26,7 +26,12 @@ impl Function for IpNtoa {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IpNtoaFn { value }))

--- a/lib/vrl/stdlib/src/ip_subnet.rs
+++ b/lib/vrl/stdlib/src/ip_subnet.rs
@@ -41,7 +41,7 @@ impl Function for IpSubnet {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ip_subnet.rs
+++ b/lib/vrl/stdlib/src/ip_subnet.rs
@@ -38,7 +38,12 @@ impl Function for IpSubnet {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let subnet = arguments.required("subnet");
 

--- a/lib/vrl/stdlib/src/ip_to_ipv6.rs
+++ b/lib/vrl/stdlib/src/ip_to_ipv6.rs
@@ -26,7 +26,12 @@ impl Function for IpToIpv6 {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IpToIpv6Fn { value }))

--- a/lib/vrl/stdlib/src/ip_to_ipv6.rs
+++ b/lib/vrl/stdlib/src/ip_to_ipv6.rs
@@ -29,7 +29,7 @@ impl Function for IpToIpv6 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
+++ b/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
@@ -29,7 +29,7 @@ impl Function for Ipv6ToIpV4 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
+++ b/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
@@ -26,7 +26,12 @@ impl Function for Ipv6ToIpV4 {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(Ipv6ToIpV4Fn { value }))

--- a/lib/vrl/stdlib/src/is_array.rs
+++ b/lib/vrl/stdlib/src/is_array.rs
@@ -39,7 +39,7 @@ impl Function for IsArray {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_array.rs
+++ b/lib/vrl/stdlib/src/is_array.rs
@@ -36,7 +36,12 @@ impl Function for IsArray {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsArrayFn { value }))

--- a/lib/vrl/stdlib/src/is_boolean.rs
+++ b/lib/vrl/stdlib/src/is_boolean.rs
@@ -36,7 +36,12 @@ impl Function for IsBoolean {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsBooleanFn { value }))

--- a/lib/vrl/stdlib/src/is_boolean.rs
+++ b/lib/vrl/stdlib/src/is_boolean.rs
@@ -39,7 +39,7 @@ impl Function for IsBoolean {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_float.rs
+++ b/lib/vrl/stdlib/src/is_float.rs
@@ -39,7 +39,7 @@ impl Function for IsFloat {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_float.rs
+++ b/lib/vrl/stdlib/src/is_float.rs
@@ -36,7 +36,12 @@ impl Function for IsFloat {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsFloatFn { value }))

--- a/lib/vrl/stdlib/src/is_integer.rs
+++ b/lib/vrl/stdlib/src/is_integer.rs
@@ -39,7 +39,7 @@ impl Function for IsInteger {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_integer.rs
+++ b/lib/vrl/stdlib/src/is_integer.rs
@@ -36,7 +36,12 @@ impl Function for IsInteger {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsIntegerFn { value }))

--- a/lib/vrl/stdlib/src/is_null.rs
+++ b/lib/vrl/stdlib/src/is_null.rs
@@ -36,7 +36,12 @@ impl Function for IsNull {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsNullFn { value }))

--- a/lib/vrl/stdlib/src/is_null.rs
+++ b/lib/vrl/stdlib/src/is_null.rs
@@ -39,7 +39,7 @@ impl Function for IsNull {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_nullish.rs
+++ b/lib/vrl/stdlib/src/is_nullish.rs
@@ -29,7 +29,7 @@ impl Function for IsNullish {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_nullish.rs
+++ b/lib/vrl/stdlib/src/is_nullish.rs
@@ -26,7 +26,12 @@ impl Function for IsNullish {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsNullishFn { value }))

--- a/lib/vrl/stdlib/src/is_object.rs
+++ b/lib/vrl/stdlib/src/is_object.rs
@@ -39,7 +39,7 @@ impl Function for IsObject {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_object.rs
+++ b/lib/vrl/stdlib/src/is_object.rs
@@ -36,7 +36,12 @@ impl Function for IsObject {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsObjectFn { value }))

--- a/lib/vrl/stdlib/src/is_regex.rs
+++ b/lib/vrl/stdlib/src/is_regex.rs
@@ -39,7 +39,7 @@ impl Function for IsRegex {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_regex.rs
+++ b/lib/vrl/stdlib/src/is_regex.rs
@@ -36,7 +36,12 @@ impl Function for IsRegex {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsRegexFn { value }))

--- a/lib/vrl/stdlib/src/is_string.rs
+++ b/lib/vrl/stdlib/src/is_string.rs
@@ -39,7 +39,7 @@ impl Function for IsString {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/is_string.rs
+++ b/lib/vrl/stdlib/src/is_string.rs
@@ -36,7 +36,12 @@ impl Function for IsString {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsStringFn { value }))

--- a/lib/vrl/stdlib/src/is_timestamp.rs
+++ b/lib/vrl/stdlib/src/is_timestamp.rs
@@ -36,7 +36,12 @@ impl Function for IsTimestamp {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(IsTimestampFn { value }))

--- a/lib/vrl/stdlib/src/is_timestamp.rs
+++ b/lib/vrl/stdlib/src/is_timestamp.rs
@@ -39,7 +39,7 @@ impl Function for IsTimestamp {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/join.rs
+++ b/lib/vrl/stdlib/src/join.rs
@@ -27,7 +27,7 @@ impl Function for Join {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/join.rs
+++ b/lib/vrl/stdlib/src/join.rs
@@ -24,7 +24,12 @@ impl Function for Join {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let separator = arguments.optional("separator");
 

--- a/lib/vrl/stdlib/src/length.rs
+++ b/lib/vrl/stdlib/src/length.rs
@@ -39,7 +39,7 @@ impl Function for Length {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/length.rs
+++ b/lib/vrl/stdlib/src/length.rs
@@ -36,7 +36,12 @@ impl Function for Length {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(LengthFn { value }))

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -47,7 +47,7 @@ impl Function for Log {
     fn compile(
         &self,
         _state: &state::Compiler,
-        info: &FunctionCompileInfo,
+        info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let levels = vec![

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -44,7 +44,12 @@ impl Function for Log {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let levels = vec![
             "trace".into(),
             "debug".into(),
@@ -62,6 +67,7 @@ impl Function for Log {
         let rate_limit_secs = arguments.optional("rate_limit_secs");
 
         Ok(Box::new(LogFn {
+            span: info.span,
             value,
             level,
             rate_limit_secs,
@@ -71,6 +77,7 @@ impl Function for Log {
 
 #[derive(Debug, Clone)]
 struct LogFn {
+    span: vrl::diagnostic::Span,
     value: Box<dyn Expression>,
     level: Bytes,
     rate_limit_secs: Option<Box<dyn Expression>>,
@@ -85,11 +92,21 @@ impl Expression for LogFn {
         };
 
         match self.level.as_ref() {
-            b"trace" => trace!(message = %value, internal_log_rate_secs = rate_limit_secs),
-            b"debug" => debug!(message = %value, internal_log_rate_secs = rate_limit_secs),
-            b"warn" => warn!(message = %value, internal_log_rate_secs = rate_limit_secs),
-            b"error" => error!(message = %value, internal_log_rate_secs = rate_limit_secs),
-            _ => info!(message = %value, internal_log_rate_secs = rate_limit_secs),
+            b"trace" => {
+                trace!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = self.span.start())
+            }
+            b"debug" => {
+                debug!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = self.span.start())
+            }
+            b"warn" => {
+                warn!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = self.span.start())
+            }
+            b"error" => {
+                error!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = self.span.start())
+            }
+            _ => {
+                info!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = self.span.start())
+            }
         }
 
         Ok(Value::Null)

--- a/lib/vrl/stdlib/src/match.rs
+++ b/lib/vrl/stdlib/src/match.rs
@@ -41,7 +41,7 @@ impl Function for Match {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/match.rs
+++ b/lib/vrl/stdlib/src/match.rs
@@ -38,7 +38,12 @@ impl Function for Match {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
 

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -42,7 +42,7 @@ impl Function for MatchAny {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -39,7 +39,12 @@ impl Function for MatchAny {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let patterns = arguments.required_array("patterns")?;
 

--- a/lib/vrl/stdlib/src/match_array.rs
+++ b/lib/vrl/stdlib/src/match_array.rs
@@ -23,7 +23,12 @@ impl Function for MatchArray {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
         let all = arguments.optional("all");

--- a/lib/vrl/stdlib/src/match_array.rs
+++ b/lib/vrl/stdlib/src/match_array.rs
@@ -26,7 +26,7 @@ impl Function for MatchArray {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/match_datadog_query.rs
+++ b/lib/vrl/stdlib/src/match_datadog_query.rs
@@ -41,7 +41,12 @@ impl Function for MatchDatadogQuery {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let query_value = arguments.required_literal("query")?.to_value();
 

--- a/lib/vrl/stdlib/src/match_datadog_query.rs
+++ b/lib/vrl/stdlib/src/match_datadog_query.rs
@@ -44,7 +44,7 @@ impl Function for MatchDatadogQuery {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/md5.rs
+++ b/lib/vrl/stdlib/src/md5.rs
@@ -28,7 +28,7 @@ impl Function for Md5 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/md5.rs
+++ b/lib/vrl/stdlib/src/md5.rs
@@ -25,7 +25,12 @@ impl Function for Md5 {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(Md5Fn { value }))

--- a/lib/vrl/stdlib/src/merge.rs
+++ b/lib/vrl/stdlib/src/merge.rs
@@ -38,7 +38,12 @@ impl Function for Merge {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let to = arguments.required("to");
         let from = arguments.required("from");
         let deep = arguments.optional("deep").unwrap_or_else(|| expr!(false));

--- a/lib/vrl/stdlib/src/merge.rs
+++ b/lib/vrl/stdlib/src/merge.rs
@@ -41,7 +41,7 @@ impl Function for Merge {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let to = arguments.required("to");

--- a/lib/vrl/stdlib/src/now.rs
+++ b/lib/vrl/stdlib/src/now.rs
@@ -20,7 +20,7 @@ impl Function for Now {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         _: ArgumentList,
     ) -> Compiled {
         Ok(Box::new(NowFn))

--- a/lib/vrl/stdlib/src/now.rs
+++ b/lib/vrl/stdlib/src/now.rs
@@ -17,7 +17,12 @@ impl Function for Now {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, _: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        _: ArgumentList,
+    ) -> Compiled {
         Ok(Box::new(NowFn))
     }
 }

--- a/lib/vrl/stdlib/src/object.rs
+++ b/lib/vrl/stdlib/src/object.rs
@@ -33,7 +33,12 @@ impl Function for Object {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ObjectFn { value }))

--- a/lib/vrl/stdlib/src/object.rs
+++ b/lib/vrl/stdlib/src/object.rs
@@ -36,7 +36,7 @@ impl Function for Object {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/only_fields.rs
+++ b/lib/vrl/stdlib/src/only_fields.rs
@@ -21,7 +21,7 @@ impl Function for OnlyFields {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let mut paths = vec![];

--- a/lib/vrl/stdlib/src/only_fields.rs
+++ b/lib/vrl/stdlib/src/only_fields.rs
@@ -18,7 +18,12 @@ impl Function for OnlyFields {
         }
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let mut paths = vec![];
         paths.push(arguments.required_path("1")?);
 

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -30,7 +30,12 @@ impl Function for ParseApacheLog {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let variants = vec![value!("common"), value!("combined"), value!("error")];
 
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -33,7 +33,7 @@ impl Function for ParseApacheLog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let variants = vec![value!("common"), value!("combined"), value!("error")];

--- a/lib/vrl/stdlib/src/parse_aws_alb_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_alb_log.rs
@@ -27,7 +27,12 @@ impl Function for ParseAwsAlbLog {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseAwsAlbLogFn::new(value)))

--- a/lib/vrl/stdlib/src/parse_aws_alb_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_alb_log.rs
@@ -30,7 +30,7 @@ impl Function for ParseAwsAlbLog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -49,7 +49,7 @@ impl Function for ParseAwsCloudWatchLogSubscriptionMessage {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -46,7 +46,12 @@ impl Function for ParseAwsCloudWatchLogSubscriptionMessage {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseAwsCloudWatchLogSubscriptionMessageFn {

--- a/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
@@ -49,7 +49,7 @@ impl Function for ParseAwsVpcFlowLog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
@@ -46,7 +46,12 @@ impl Function for ParseAwsVpcFlowLog {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments.optional("format");
 

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -25,7 +25,12 @@ impl Function for ParseCommonLog {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let timestamp_format = arguments.optional("timestamp_format");
 

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -28,7 +28,7 @@ impl Function for ParseCommonLog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_csv.rs
+++ b/lib/vrl/stdlib/src/parse_csv.rs
@@ -20,7 +20,7 @@ impl Function for ParseCsv {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_csv.rs
+++ b/lib/vrl/stdlib/src/parse_csv.rs
@@ -17,7 +17,12 @@ impl Function for ParseCsv {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let delimiter = arguments.optional("delimiter").unwrap_or(expr!(","));
         Ok(Box::new(ParseCsvFn { value, delimiter }))

--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -51,7 +51,7 @@ impl Function for ParseDuration {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -48,7 +48,12 @@ impl Function for ParseDuration {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let unit = arguments.required("unit");
 

--- a/lib/vrl/stdlib/src/parse_glog.rs
+++ b/lib/vrl/stdlib/src/parse_glog.rs
@@ -44,7 +44,12 @@ impl Function for ParseGlog {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseGlogFn { value }))

--- a/lib/vrl/stdlib/src/parse_glog.rs
+++ b/lib/vrl/stdlib/src/parse_glog.rs
@@ -47,7 +47,7 @@ impl Function for ParseGlog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -85,7 +85,12 @@ impl Function for ParseGrok {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         let pattern = arguments

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -88,7 +88,7 @@ impl Function for ParseGrok {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_int.rs
+++ b/lib/vrl/stdlib/src/parse_int.rs
@@ -46,7 +46,7 @@ impl Function for ParseInt {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_int.rs
+++ b/lib/vrl/stdlib/src/parse_int.rs
@@ -43,7 +43,12 @@ impl Function for ParseInt {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let base = arguments.optional("base");
 

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -71,7 +71,12 @@ impl Function for ParseJson {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseJsonFn { value }))

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -74,7 +74,7 @@ impl Function for ParseJson {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -77,7 +77,12 @@ impl Function for ParseKeyValue {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         let key_value_delimiter = arguments

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -80,7 +80,7 @@ impl Function for ParseKeyValue {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_klog.rs
+++ b/lib/vrl/stdlib/src/parse_klog.rs
@@ -44,7 +44,12 @@ impl Function for ParseKlog {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseKlogFn { value }))

--- a/lib/vrl/stdlib/src/parse_klog.rs
+++ b/lib/vrl/stdlib/src/parse_klog.rs
@@ -47,7 +47,7 @@ impl Function for ParseKlog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_linux_authorization.rs
+++ b/lib/vrl/stdlib/src/parse_linux_authorization.rs
@@ -35,7 +35,7 @@ impl Function for ParseLinuxAuthorization {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_linux_authorization.rs
+++ b/lib/vrl/stdlib/src/parse_linux_authorization.rs
@@ -32,7 +32,12 @@ impl Function for ParseLinuxAuthorization {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         // The parse_linux_authorization function is just an alias for parse_syslog

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -35,7 +35,7 @@ impl Function for ParseLogFmt {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -32,7 +32,12 @@ impl Function for ParseLogFmt {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         // The parse_logfmt function is just an alias for `parse_key_value` with the following

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -31,7 +31,12 @@ impl Function for ParseNginxLog {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let variants = vec![value!("combined"), value!("error")];
 
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -34,7 +34,7 @@ impl Function for ParseNginxLog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let variants = vec![value!("combined"), value!("error")];

--- a/lib/vrl/stdlib/src/parse_query_string.rs
+++ b/lib/vrl/stdlib/src/parse_query_string.rs
@@ -23,7 +23,12 @@ impl Function for ParseQueryString {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         Ok(Box::new(ParseQueryStringFn { value }))
     }

--- a/lib/vrl/stdlib/src/parse_query_string.rs
+++ b/lib/vrl/stdlib/src/parse_query_string.rs
@@ -26,7 +26,7 @@ impl Function for ParseQueryString {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_regex.rs
+++ b/lib/vrl/stdlib/src/parse_regex.rs
@@ -34,7 +34,7 @@ impl Function for ParseRegex {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_regex.rs
+++ b/lib/vrl/stdlib/src/parse_regex.rs
@@ -31,7 +31,12 @@ impl Function for ParseRegex {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern")?;
         let numeric_groups = arguments

--- a/lib/vrl/stdlib/src/parse_regex_all.rs
+++ b/lib/vrl/stdlib/src/parse_regex_all.rs
@@ -31,7 +31,12 @@ impl Function for ParseRegexAll {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern")?;
         let numeric_groups = arguments

--- a/lib/vrl/stdlib/src/parse_regex_all.rs
+++ b/lib/vrl/stdlib/src/parse_regex_all.rs
@@ -34,7 +34,7 @@ impl Function for ParseRegexAll {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_ruby_hash.rs
+++ b/lib/vrl/stdlib/src/parse_ruby_hash.rs
@@ -38,7 +38,12 @@ impl Function for ParseRubyHash {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         Ok(Box::new(ParseRubyHashFn { value }))
     }

--- a/lib/vrl/stdlib/src/parse_ruby_hash.rs
+++ b/lib/vrl/stdlib/src/parse_ruby_hash.rs
@@ -41,7 +41,7 @@ impl Function for ParseRubyHash {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -41,7 +41,12 @@ impl Function for ParseSyslog {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseSyslogFn { value }))

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -44,7 +44,7 @@ impl Function for ParseSyslog {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_timestamp.rs
+++ b/lib/vrl/stdlib/src/parse_timestamp.rs
@@ -17,7 +17,12 @@ impl Function for ParseTimestamp {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments.required("format");
 

--- a/lib/vrl/stdlib/src/parse_timestamp.rs
+++ b/lib/vrl/stdlib/src/parse_timestamp.rs
@@ -20,7 +20,7 @@ impl Function for ParseTimestamp {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_tokens.rs
+++ b/lib/vrl/stdlib/src/parse_tokens.rs
@@ -19,7 +19,12 @@ impl Function for ParseTokens {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseTokensFn { value }))

--- a/lib/vrl/stdlib/src/parse_tokens.rs
+++ b/lib/vrl/stdlib/src/parse_tokens.rs
@@ -22,7 +22,7 @@ impl Function for ParseTokens {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_url.rs
+++ b/lib/vrl/stdlib/src/parse_url.rs
@@ -37,7 +37,12 @@ impl Function for ParseUrl {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ParseUrlFn { value }))

--- a/lib/vrl/stdlib/src/parse_url.rs
+++ b/lib/vrl/stdlib/src/parse_url.rs
@@ -40,7 +40,7 @@ impl Function for ParseUrl {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_user_agent.rs
+++ b/lib/vrl/stdlib/src/parse_user_agent.rs
@@ -86,7 +86,7 @@ impl Function for ParseUserAgent {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/parse_user_agent.rs
+++ b/lib/vrl/stdlib/src/parse_user_agent.rs
@@ -83,7 +83,12 @@ impl Function for ParseUserAgent {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         let mode = arguments

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -46,7 +46,12 @@ impl Function for ParseXml {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         let trim = arguments.optional("trim");

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -49,7 +49,7 @@ impl Function for ParseXml {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/push.rs
+++ b/lib/vrl/stdlib/src/push.rs
@@ -38,7 +38,12 @@ impl Function for Push {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let item = arguments.required("item");
 

--- a/lib/vrl/stdlib/src/push.rs
+++ b/lib/vrl/stdlib/src/push.rs
@@ -41,7 +41,7 @@ impl Function for Push {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/redact.rs
+++ b/lib/vrl/stdlib/src/redact.rs
@@ -54,7 +54,12 @@ impl Function for Redact {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         let filters = arguments

--- a/lib/vrl/stdlib/src/redact.rs
+++ b/lib/vrl/stdlib/src/redact.rs
@@ -57,7 +57,7 @@ impl Function for Redact {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/replace.rs
+++ b/lib/vrl/stdlib/src/replace.rs
@@ -56,7 +56,7 @@ impl Function for Replace {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/replace.rs
+++ b/lib/vrl/stdlib/src/replace.rs
@@ -53,7 +53,12 @@ impl Function for Replace {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
         let with = arguments.required("with");

--- a/lib/vrl/stdlib/src/round.rs
+++ b/lib/vrl/stdlib/src/round.rs
@@ -44,7 +44,12 @@ impl Function for Round {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let precision = arguments.optional("precision").unwrap_or(expr!(0));
 

--- a/lib/vrl/stdlib/src/round.rs
+++ b/lib/vrl/stdlib/src/round.rs
@@ -47,7 +47,7 @@ impl Function for Round {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/sha1.rs
+++ b/lib/vrl/stdlib/src/sha1.rs
@@ -25,7 +25,12 @@ impl Function for Sha1 {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(Sha1Fn { value }))

--- a/lib/vrl/stdlib/src/sha1.rs
+++ b/lib/vrl/stdlib/src/sha1.rs
@@ -28,7 +28,7 @@ impl Function for Sha1 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/sha2.rs
+++ b/lib/vrl/stdlib/src/sha2.rs
@@ -39,7 +39,12 @@ impl Function for Sha2 {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let variants = vec![
             value!("SHA-224"),
             value!("SHA-256"),

--- a/lib/vrl/stdlib/src/sha2.rs
+++ b/lib/vrl/stdlib/src/sha2.rs
@@ -42,7 +42,7 @@ impl Function for Sha2 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let variants = vec![

--- a/lib/vrl/stdlib/src/sha3.rs
+++ b/lib/vrl/stdlib/src/sha3.rs
@@ -42,7 +42,7 @@ impl Function for Sha3 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let variants = vec![

--- a/lib/vrl/stdlib/src/sha3.rs
+++ b/lib/vrl/stdlib/src/sha3.rs
@@ -39,7 +39,12 @@ impl Function for Sha3 {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let variants = vec![
             value!("SHA3-224"),
             value!("SHA3-256"),

--- a/lib/vrl/stdlib/src/slice.rs
+++ b/lib/vrl/stdlib/src/slice.rs
@@ -52,7 +52,7 @@ impl Function for Slice {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/slice.rs
+++ b/lib/vrl/stdlib/src/slice.rs
@@ -49,7 +49,12 @@ impl Function for Slice {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let start = arguments.required("start");
         let end = arguments.optional("end");

--- a/lib/vrl/stdlib/src/split.rs
+++ b/lib/vrl/stdlib/src/split.rs
@@ -51,7 +51,7 @@ impl Function for Split {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/split.rs
+++ b/lib/vrl/stdlib/src/split.rs
@@ -48,7 +48,12 @@ impl Function for Split {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");
         let limit = arguments.optional("limit").unwrap_or(expr!(999999999));

--- a/lib/vrl/stdlib/src/starts_with.rs
+++ b/lib/vrl/stdlib/src/starts_with.rs
@@ -51,7 +51,7 @@ impl Function for StartsWith {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/starts_with.rs
+++ b/lib/vrl/stdlib/src/starts_with.rs
@@ -48,7 +48,12 @@ impl Function for StartsWith {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
         let case_sensitive = arguments.optional("case_sensitive").unwrap_or(expr!(true));

--- a/lib/vrl/stdlib/src/string.rs
+++ b/lib/vrl/stdlib/src/string.rs
@@ -36,7 +36,7 @@ impl Function for String {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/string.rs
+++ b/lib/vrl/stdlib/src/string.rs
@@ -33,7 +33,12 @@ impl Function for String {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(StringFn { value }))

--- a/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
+++ b/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
@@ -21,7 +21,12 @@ impl Function for StripAnsiEscapeCodes {
         &[]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(StripAnsiEscapeCodesFn { value }))

--- a/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
+++ b/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
@@ -24,7 +24,7 @@ impl Function for StripAnsiEscapeCodes {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/strip_whitespace.rs
+++ b/lib/vrl/stdlib/src/strip_whitespace.rs
@@ -36,7 +36,12 @@ impl Function for StripWhitespace {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(StripWhitespaceFn { value }))

--- a/lib/vrl/stdlib/src/strip_whitespace.rs
+++ b/lib/vrl/stdlib/src/strip_whitespace.rs
@@ -39,7 +39,7 @@ impl Function for StripWhitespace {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/tag_types_externally.rs
+++ b/lib/vrl/stdlib/src/tag_types_externally.rs
@@ -47,7 +47,7 @@ impl Function for TagTypesExternally {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/tag_types_externally.rs
+++ b/lib/vrl/stdlib/src/tag_types_externally.rs
@@ -44,7 +44,12 @@ impl Function for TagTypesExternally {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(TagTypesExternallyFn { value }))

--- a/lib/vrl/stdlib/src/timestamp.rs
+++ b/lib/vrl/stdlib/src/timestamp.rs
@@ -36,7 +36,7 @@ impl Function for Timestamp {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/timestamp.rs
+++ b/lib/vrl/stdlib/src/timestamp.rs
@@ -33,7 +33,12 @@ impl Function for Timestamp {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(TimestampFn { value }))

--- a/lib/vrl/stdlib/src/to_bool.rs
+++ b/lib/vrl/stdlib/src/to_bool.rs
@@ -135,7 +135,7 @@ impl Function for ToBool {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_bool.rs
+++ b/lib/vrl/stdlib/src/to_bool.rs
@@ -132,7 +132,12 @@ impl Function for ToBool {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToBoolFn { value }))

--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -90,7 +90,7 @@ impl Function for ToFloat {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -87,7 +87,12 @@ impl Function for ToFloat {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToFloatFn { value }))

--- a/lib/vrl/stdlib/src/to_int.rs
+++ b/lib/vrl/stdlib/src/to_int.rs
@@ -85,7 +85,12 @@ impl Function for ToInt {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToIntFn { value }))

--- a/lib/vrl/stdlib/src/to_int.rs
+++ b/lib/vrl/stdlib/src/to_int.rs
@@ -88,7 +88,7 @@ impl Function for ToInt {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_regex.rs
+++ b/lib/vrl/stdlib/src/to_regex.rs
@@ -25,7 +25,12 @@ impl Function for ToRegex {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         warn!("`to_regex` is an expensive function that could impact throughput.");
         let value = arguments.required("value");
         Ok(Box::new(ToRegexFn { value }))

--- a/lib/vrl/stdlib/src/to_regex.rs
+++ b/lib/vrl/stdlib/src/to_regex.rs
@@ -28,7 +28,7 @@ impl Function for ToRegex {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         warn!("`to_regex` is an expensive function that could impact throughput.");

--- a/lib/vrl/stdlib/src/to_string.rs
+++ b/lib/vrl/stdlib/src/to_string.rs
@@ -77,7 +77,12 @@ impl Function for ToString {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToStringFn { value }))

--- a/lib/vrl/stdlib/src/to_string.rs
+++ b/lib/vrl/stdlib/src/to_string.rs
@@ -80,7 +80,7 @@ impl Function for ToString {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_syslog_facility.rs
+++ b/lib/vrl/stdlib/src/to_syslog_facility.rs
@@ -36,7 +36,7 @@ impl Function for ToSyslogFacility {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_syslog_facility.rs
+++ b/lib/vrl/stdlib/src/to_syslog_facility.rs
@@ -33,7 +33,12 @@ impl Function for ToSyslogFacility {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToSyslogFacilityFn { value }))

--- a/lib/vrl/stdlib/src/to_syslog_level.rs
+++ b/lib/vrl/stdlib/src/to_syslog_level.rs
@@ -36,7 +36,7 @@ impl Function for ToSyslogLevel {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_syslog_level.rs
+++ b/lib/vrl/stdlib/src/to_syslog_level.rs
@@ -33,7 +33,12 @@ impl Function for ToSyslogLevel {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToSyslogLevelFn { value }))

--- a/lib/vrl/stdlib/src/to_syslog_severity.rs
+++ b/lib/vrl/stdlib/src/to_syslog_severity.rs
@@ -33,7 +33,12 @@ impl Function for ToSyslogSeverity {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToSyslogSeverityFn { value }))

--- a/lib/vrl/stdlib/src/to_syslog_severity.rs
+++ b/lib/vrl/stdlib/src/to_syslog_severity.rs
@@ -36,7 +36,7 @@ impl Function for ToSyslogSeverity {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_timestamp.rs
@@ -92,7 +92,12 @@ impl Function for ToTimestamp {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(ToTimestampFn { value }))

--- a/lib/vrl/stdlib/src/to_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_timestamp.rs
@@ -95,7 +95,7 @@ impl Function for ToTimestamp {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_unix_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_unix_timestamp.rs
@@ -47,7 +47,7 @@ impl Function for ToUnixTimestamp {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_unix_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_unix_timestamp.rs
@@ -44,7 +44,12 @@ impl Function for ToUnixTimestamp {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         let unit = arguments

--- a/lib/vrl/stdlib/src/truncate.rs
+++ b/lib/vrl/stdlib/src/truncate.rs
@@ -48,7 +48,12 @@ impl Function for Truncate {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
         let limit = arguments.required("limit");
         let ellipsis = arguments.optional("ellipsis").unwrap_or(expr!(false));

--- a/lib/vrl/stdlib/src/truncate.rs
+++ b/lib/vrl/stdlib/src/truncate.rs
@@ -51,7 +51,7 @@ impl Function for Truncate {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/unique.rs
+++ b/lib/vrl/stdlib/src/unique.rs
@@ -18,7 +18,12 @@ impl Function for Unique {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(UniqueFn { value }))

--- a/lib/vrl/stdlib/src/unique.rs
+++ b/lib/vrl/stdlib/src/unique.rs
@@ -21,7 +21,7 @@ impl Function for Unique {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/unnest.rs
+++ b/lib/vrl/stdlib/src/unnest.rs
@@ -45,7 +45,7 @@ impl Function for Unnest {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let path = arguments.required_query("path")?;

--- a/lib/vrl/stdlib/src/unnest.rs
+++ b/lib/vrl/stdlib/src/unnest.rs
@@ -42,7 +42,12 @@ impl Function for Unnest {
         ]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let path = arguments.required_query("path")?;
 
         Ok(Box::new(UnnestFn { path }))

--- a/lib/vrl/stdlib/src/upcase.rs
+++ b/lib/vrl/stdlib/src/upcase.rs
@@ -27,7 +27,7 @@ impl Function for Upcase {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/upcase.rs
+++ b/lib/vrl/stdlib/src/upcase.rs
@@ -24,7 +24,12 @@ impl Function for Upcase {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, mut arguments: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
         let value = arguments.required("value");
 
         Ok(Box::new(UpcaseFn { value }))

--- a/lib/vrl/stdlib/src/uuid_v4.rs
+++ b/lib/vrl/stdlib/src/uuid_v4.rs
@@ -17,7 +17,12 @@ impl Function for UuidV4 {
         }]
     }
 
-    fn compile(&self, _state: &state::Compiler, _: ArgumentList) -> Compiled {
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _info: &FunctionCompileInfo,
+        _: ArgumentList,
+    ) -> Compiled {
         Ok(Box::new(UuidV4Fn))
     }
 }

--- a/lib/vrl/stdlib/src/uuid_v4.rs
+++ b/lib/vrl/stdlib/src/uuid_v4.rs
@@ -20,7 +20,7 @@ impl Function for UuidV4 {
     fn compile(
         &self,
         _state: &state::Compiler,
-        _info: &FunctionCompileInfo,
+        _info: &FunctionCompileContext,
         _: ArgumentList,
     ) -> Compiled {
         Ok(Box::new(UuidV4Fn))


### PR DESCRIPTION
Rather than wrapping the full remap transform given we saw a performance
impact from doing this in #8579

Revives the implementation from
https://github.com/vectordotdev/vector/commit/85c67b6d71355802b8b377f0a7431ac476495f61
but adjusts `compile` to just always take the additional argument rather
than having two functions. I added a struct parameter here following
some discussion about this making it easier to add additional function
compilation context in the future without needing to modify the call
signature.

Closes: https://github.com/vectordotdev/vector/issues/9141

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
