### PR TITLE
chore(graphql api): Add `received_events_total` to the API

### DIFF
--- a/lib/vector-api-client/graphql/queries/components.graphql
+++ b/lib/vector-api-client/graphql/queries/components.graphql
@@ -15,8 +15,8 @@ query ComponentsQuery($first: Int!) {
                         processedBytesTotal {
                             processedBytesTotal
                         }
-                        eventsInTotal {
-                            eventsInTotal
+                        receivedEventsTotal {
+                            receivedEventsTotal
                         }
                         eventsOutTotal {
                             eventsOutTotal
@@ -32,8 +32,8 @@ query ComponentsQuery($first: Int!) {
                         processedBytesTotal {
                             processedBytesTotal
                         }
-                        eventsInTotal {
-                            eventsInTotal
+                        receivedEventsTotal {
+                            receivedEventsTotal
                         }
                         eventsOutTotal {
                             eventsOutTotal
@@ -49,8 +49,8 @@ query ComponentsQuery($first: Int!) {
                         processedBytesTotal {
                             processedBytesTotal
                         }
-                        eventsInTotal {
-                            eventsInTotal
+                        receivedEventsTotal {
+                            receivedEventsTotal
                         }
                         eventsOutTotal {
                             eventsOutTotal

--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -810,6 +810,116 @@
         {
           "description": null,
           "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Component id",
+              "isDeprecated": false,
+              "name": "componentId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Pipeline id",
+              "isDeprecated": false,
+              "name": "pipelineId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Received events throughput",
+              "isDeprecated": false,
+              "name": "throughput",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ComponentReceivedEventsThroughput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Component id",
+              "isDeprecated": false,
+              "name": "componentId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Pipeline id",
+              "isDeprecated": false,
+              "name": "pipelineId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Total received events metric",
+              "isDeprecated": false,
+              "name": "metric",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ReceivedEventsTotal",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ComponentReceivedEventsTotal",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
@@ -1346,6 +1456,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Metric indicating received events for the current file",
+              "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Metric indicating outgoing events for the current file",
               "isDeprecated": false,
               "name": "eventsOutTotal",
@@ -1528,6 +1650,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "RECEIVED_EVENTS_TOTAL"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "EVENTS_IN_TOTAL"
             },
             {
@@ -1666,6 +1794,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Total received events for the current file source",
+              "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
                 "ofType": null
               }
             },
@@ -1853,6 +1993,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Total received events for the current sink",
+              "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Total outgoing events for the current sink",
               "isDeprecated": false,
               "name": "eventsOutTotal",
@@ -1918,6 +2070,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Total received events for the current source",
+              "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Total outgoing events for the current source",
               "isDeprecated": false,
               "name": "eventsOutTotal",
@@ -1977,6 +2141,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Total received events for the current transform",
+              "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
                 "ofType": null
               }
             },
@@ -3318,6 +3494,45 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Metric timestamp",
+              "isDeprecated": false,
+              "name": "timestamp",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Total incoming events",
+              "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ReceivedEventsTotal",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Sink component_id",
               "isDeprecated": false,
               "name": "componentId",
@@ -3571,6 +3786,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use received_events_total instead",
+              "description": null,
+              "isDeprecated": true,
               "name": "eventsInTotal",
               "type": {
                 "kind": "OBJECT",
@@ -4006,6 +4233,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use received_events_total instead",
+              "description": null,
+              "isDeprecated": true,
               "name": "eventsInTotal",
               "type": {
                 "kind": "OBJECT",
@@ -4388,7 +4627,7 @@
                 }
               ],
               "deprecationReason": null,
-              "description": "Metrics for how long the Vector instance has been running.",
+              "description": "Metrics for how long the Vector instance has been running",
               "isDeprecated": false,
               "name": "uptime",
               "type": {
@@ -4558,9 +4797,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "Use received_events_total instead",
               "description": "Total incoming events metrics",
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "eventsInTotal",
               "type": {
                 "kind": "NON_NULL",
@@ -4590,8 +4829,39 @@
                 }
               ],
               "deprecationReason": null,
-              "description": "Total incoming events throughput sampled over the provided millisecond `interval`",
+              "description": "Total received events metrics",
               "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ReceivedEventsTotal",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "Use received_events_throughput instead",
+              "description": "Total incoming events throughput sampled over the provided millisecond `interval`",
+              "isDeprecated": true,
               "name": "eventsInThroughput",
               "type": {
                 "kind": "NON_NULL",
@@ -4621,8 +4891,39 @@
                 }
               ],
               "deprecationReason": null,
-              "description": "Total incoming component events throughput metrics over `interval`",
+              "description": "Total received events throughput sampled over the provided millisecond `interval`",
               "isDeprecated": false,
+              "name": "receivedEventsThroughput",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "Use component_received_events_throughputs instead",
+              "description": "Total incoming component events throughput metrics over `interval`",
+              "isDeprecated": true,
               "name": "componentEventsInThroughputs",
               "type": {
                 "kind": "NON_NULL",
@@ -4660,8 +4961,47 @@
                 }
               ],
               "deprecationReason": null,
-              "description": "Total incoming component event metrics over `interval`",
+              "description": "Total incoming component events throughput metrics over `interval`",
               "isDeprecated": false,
+              "name": "componentReceivedEventsThroughputs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentReceivedEventsThroughput",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": "Use component_received_events_totals instead",
+              "description": "Total incoming component event metrics over `interval`",
+              "isDeprecated": true,
               "name": "componentEventsInTotals",
               "type": {
                 "kind": "NON_NULL",
@@ -4675,6 +5015,45 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "ComponentEventsInTotal",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "1000",
+                  "description": null,
+                  "name": "interval",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Total received component event metrics over `interval`",
+              "isDeprecated": false,
+              "name": "componentReceivedEventsTotals",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ComponentReceivedEventsTotal",
                       "ofType": null
                     }
                   }
@@ -5543,6 +5922,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "receivedEventsTotal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ReceivedEventsTotal",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use received_events_total instead",
+              "description": null,
+              "isDeprecated": true,
               "name": "eventsInTotal",
               "type": {
                 "kind": "OBJECT",

--- a/lib/vector-api-client/graphql/subscriptions/component_events_in_throughputs.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_events_in_throughputs.graphql
@@ -1,7 +1,0 @@
-subscription ComponentEventsInThroughputsSubscription($interval: Int!) {
-    componentEventsInThroughputs(interval: $interval) {
-        pipelineId
-        componentId
-        throughput
-    }
-}

--- a/lib/vector-api-client/graphql/subscriptions/component_events_in_totals.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_events_in_totals.graphql
@@ -1,9 +1,0 @@
-subscription ComponentEventsInTotalsSubscription($interval: Int!) {
-    componentEventsInTotals(interval: $interval) {
-        pipelineId
-        componentId
-        metric {
-            eventsInTotal
-        }
-    }
-}

--- a/lib/vector-api-client/graphql/subscriptions/component_received_events_throughputs.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_received_events_throughputs.graphql
@@ -1,0 +1,7 @@
+subscription ComponentReceivedEventsThroughputsSubscription($interval: Int!) {
+    componentReceivedEventsThroughputs(interval: $interval) {
+        pipelineId
+        componentId
+        throughput
+    }
+}

--- a/lib/vector-api-client/graphql/subscriptions/component_received_events_totals.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/component_received_events_totals.graphql
@@ -1,0 +1,9 @@
+subscription ComponentReceivedEventsTotalsSubscription($interval: Int!) {
+    componentReceivedEventsTotals(interval: $interval) {
+        pipelineId
+        componentId
+        metric {
+            receivedEventsTotal
+        }
+    }
+}

--- a/lib/vector-api-client/graphql/subscriptions/events_in_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/events_in_throughput.graphql
@@ -1,3 +1,0 @@
-subscription EventsInThroughputSubscription($interval: Int!) {
-    eventsInThroughput(interval: $interval)
-}

--- a/lib/vector-api-client/graphql/subscriptions/events_in_total.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/events_in_total.graphql
@@ -1,5 +1,0 @@
-subscription EventsInTotalSubscription($interval: Int!) {
-  eventsInTotal(interval: $interval) {
-    eventsInTotal
-  }
-}

--- a/lib/vector-api-client/graphql/subscriptions/received_events_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/received_events_throughput.graphql
@@ -1,0 +1,3 @@
+subscription ReceivedEventsThroughputSubscription($interval: Int!) {
+    receivedEventsThroughput(interval: $interval)
+}

--- a/lib/vector-api-client/graphql/subscriptions/received_events_total.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/received_events_total.graphql
@@ -1,0 +1,5 @@
+subscription ReceivedEventsTotalSubscription($interval: Int!) {
+  receivedEventsTotal(interval: $interval) {
+    receivedEventsTotal
+  }
+}

--- a/lib/vector-api-client/src/gql/components.rs
+++ b/lib/vector-api-client/src/gql/components.rs
@@ -114,25 +114,25 @@ impl components_query::ComponentsQueryComponentsEdgesNodeOn {
         }
     }
 
-    pub fn events_in_total(&self) -> i64 {
+    pub fn received_events_total(&self) -> i64 {
         match self {
             components_query::ComponentsQueryComponentsEdgesNodeOn::Source(s) => s
                 .metrics
-                .events_in_total
+                .received_events_total
                 .as_ref()
-                .map(|p| p.events_in_total as i64)
+                .map(|p| p.received_events_total as i64)
                 .unwrap_or(0),
             components_query::ComponentsQueryComponentsEdgesNodeOn::Transform(t) => t
                 .metrics
-                .events_in_total
+                .received_events_total
                 .as_ref()
-                .map(|p| p.events_in_total as i64)
+                .map(|p| p.received_events_total as i64)
                 .unwrap_or(0),
             components_query::ComponentsQueryComponentsEdgesNodeOn::Sink(s) => s
                 .metrics
-                .events_in_total
+                .received_events_total
                 .as_ref()
-                .map(|p| p.events_in_total as i64)
+                .map(|p| p.received_events_total as i64)
                 .unwrap_or(0),
         }
     }

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -43,25 +43,25 @@ pub struct ProcessedEventsThroughputSubscription;
 )]
 pub struct ProcessedBytesThroughputSubscription;
 
-/// EventsInTotalSubscription contains metrics on the number of events
+/// ReceivedEventsTotalSubscription contains metrics on the number of events
 /// that have been accepted for processing by a Vector instance.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/events_in_total.graphql",
+    query_path = "graphql/subscriptions/received_events_total.graphql",
     response_derives = "Debug"
 )]
-pub struct EventsInTotalSubscription;
+pub struct ReceivedEventsTotalSubscription;
 
-/// EventsInThroughputSubscription contains metrics on the number of events
+/// ReceivedEventsThroughputSubscription contains metrics on the number of events
 /// that have been accepted for processing between `interval` samples.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/events_in_throughput.graphql",
+    query_path = "graphql/subscriptions/received_events_throughput.graphql",
     response_derives = "Debug"
 )]
-pub struct EventsInThroughputSubscription;
+pub struct ReceivedEventsThroughputSubscription;
 
 /// EventsOutTotalSubscription contains metrics on the number of events
 /// that have been emitted by a Vector instance.
@@ -123,25 +123,25 @@ pub struct ComponentProcessedBytesThroughputsSubscription;
 )]
 pub struct ComponentProcessedBytesTotalsSubscription;
 
-/// ComponentEventsInThroughputsSubscription contains metrics on the number of events
+/// ComponentReceivedEventsThroughputsSubscription contains metrics on the number of events
 /// that have been accepted for processing between `interval` samples, against specific components.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/component_events_in_throughputs.graphql",
+    query_path = "graphql/subscriptions/component_received_events_throughputs.graphql",
     response_derives = "Debug"
 )]
-pub struct ComponentEventsInThroughputsSubscription;
+pub struct ComponentReceivedEventsThroughputsSubscription;
 
-/// ComponentEventsInTotalsSubscription contains metrics on the number of events
+/// ComponentReceivedEventsTotalsSubscription contains metrics on the number of events
 /// that have been accepted for processing by a Vector instance, against specific components.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
 #[graphql(
     schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/component_events_in_totals.graphql",
+    query_path = "graphql/subscriptions/component_received_events_totals.graphql",
     response_derives = "Debug"
 )]
-pub struct ComponentEventsInTotalsSubscription;
+pub struct ComponentReceivedEventsTotalsSubscription;
 
 /// ComponentEventsOutThroughputsSubscription contains metrics on the number of events
 /// that have been emitted between `interval` samples, against specific components.
@@ -186,17 +186,17 @@ pub trait MetricsSubscriptionExt {
         interval: i64,
     ) -> crate::BoxedSubscription<ProcessedBytesThroughputSubscription>;
 
-    /// Executes an events in metrics subscription
-    fn events_in_total_subscription(
+    /// Executes a received events total metrics subscription
+    fn received_events_total_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<EventsInTotalSubscription>;
+    ) -> crate::BoxedSubscription<ReceivedEventsTotalSubscription>;
 
-    /// Executes an events in throughput subscription.
-    fn events_in_throughput_subscription(
+    /// Executes a received events throughput subscription.
+    fn received_events_throughput_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<EventsInThroughputSubscription>;
+    ) -> crate::BoxedSubscription<ReceivedEventsThroughputSubscription>;
 
     /// Executes an events out metrics subscription.
     fn events_out_total_subscription(
@@ -234,17 +234,17 @@ pub trait MetricsSubscriptionExt {
         interval: i64,
     ) -> crate::BoxedSubscription<ComponentProcessedBytesThroughputsSubscription>;
 
-    /// Executes an component events in totals subscription.
-    fn component_events_in_totals_subscription(
+    /// Executes a component received events totals subscription.
+    fn component_received_events_totals_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<ComponentEventsInTotalsSubscription>;
+    ) -> crate::BoxedSubscription<ComponentReceivedEventsTotalsSubscription>;
 
     /// Executes an component events in throughputs subscription.
-    fn component_events_in_throughputs_subscription(
+    fn component_received_events_throughputs_subscription(
         &self,
         interval: i64,
-    ) -> crate::BoxedSubscription<ComponentEventsInThroughputsSubscription>;
+    ) -> crate::BoxedSubscription<ComponentReceivedEventsThroughputsSubscription>;
 
     /// Executes an component events out totals subscription.
     fn component_events_out_totals_subscription(
@@ -303,29 +303,28 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         self.start::<ProcessedBytesThroughputSubscription>(&request_body)
     }
 
-    /// Executes an events in metrics subscription.
-    fn events_in_total_subscription(
+    /// Executes a received events total metrics subscription.
+    fn received_events_total_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<EventsInTotalSubscription> {
-        let request_body =
-            EventsInTotalSubscription::build_query(events_in_total_subscription::Variables {
-                interval,
-            });
-
-        self.start::<EventsInTotalSubscription>(&request_body)
-    }
-
-    /// Executes an events in throughput subscription.
-    fn events_in_throughput_subscription(
-        &self,
-        interval: i64,
-    ) -> BoxedSubscription<EventsInThroughputSubscription> {
-        let request_body = EventsInThroughputSubscription::build_query(
-            events_in_throughput_subscription::Variables { interval },
+    ) -> BoxedSubscription<ReceivedEventsTotalSubscription> {
+        let request_body = ReceivedEventsTotalSubscription::build_query(
+            received_events_total_subscription::Variables { interval },
         );
 
-        self.start::<EventsInThroughputSubscription>(&request_body)
+        self.start::<ReceivedEventsTotalSubscription>(&request_body)
+    }
+
+    /// Executes a received events throughput subscription.
+    fn received_events_throughput_subscription(
+        &self,
+        interval: i64,
+    ) -> BoxedSubscription<ReceivedEventsThroughputSubscription> {
+        let request_body = ReceivedEventsThroughputSubscription::build_query(
+            received_events_throughput_subscription::Variables { interval },
+        );
+
+        self.start::<ReceivedEventsThroughputSubscription>(&request_body)
     }
 
     /// Executes an events out metrics subscription.
@@ -401,28 +400,28 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         self.start::<ComponentProcessedBytesThroughputsSubscription>(&request_body)
     }
 
-    /// Executes an all component events in totals subscription.
-    fn component_events_in_totals_subscription(
+    /// Executes an all component received events totals subscription.
+    fn component_received_events_totals_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<ComponentEventsInTotalsSubscription> {
-        let request_body = ComponentEventsInTotalsSubscription::build_query(
-            component_events_in_totals_subscription::Variables { interval },
+    ) -> BoxedSubscription<ComponentReceivedEventsTotalsSubscription> {
+        let request_body = ComponentReceivedEventsTotalsSubscription::build_query(
+            component_received_events_totals_subscription::Variables { interval },
         );
 
-        self.start::<ComponentEventsInTotalsSubscription>(&request_body)
+        self.start::<ComponentReceivedEventsTotalsSubscription>(&request_body)
     }
 
-    /// Executes an all component events in throughputs subscription.
-    fn component_events_in_throughputs_subscription(
+    /// Executes an all component received events throughputs subscription.
+    fn component_received_events_throughputs_subscription(
         &self,
         interval: i64,
-    ) -> BoxedSubscription<ComponentEventsInThroughputsSubscription> {
-        let request_body = ComponentEventsInThroughputsSubscription::build_query(
-            component_events_in_throughputs_subscription::Variables { interval },
+    ) -> BoxedSubscription<ComponentReceivedEventsThroughputsSubscription> {
+        let request_body = ComponentReceivedEventsThroughputsSubscription::build_query(
+            component_received_events_throughputs_subscription::Variables { interval },
         );
 
-        self.start::<ComponentEventsInThroughputsSubscription>(&request_body)
+        self.start::<ComponentReceivedEventsThroughputsSubscription>(&request_body)
     }
 
     /// Executes an all component events out totals subscription.

--- a/lib/vector-api-client/tests/queries/file_source_metrics.graphql
+++ b/lib/vector-api-client/tests/queries/file_source_metrics.graphql
@@ -14,8 +14,8 @@ query FileSourceMetricsQuery($after: String, $before: String, $first: Int, $last
                                     processedEventsTotal {
                                         processedEventsTotal
                                     }
-                                    eventsInTotal {
-                                        eventsInTotal
+                                    receivedEventsTotal {
+                                        receivedEventsTotal
                                     }
                                 }
                             }

--- a/src/api/schema/metrics/filter.rs
+++ b/src/api/schema/metrics/filter.rs
@@ -72,7 +72,10 @@ impl<'a> MetricsFilter<'a> for Vec<Metric> {
     }
 
     fn received_events_total(&self) -> Option<ReceivedEventsTotal> {
-        let sum = sum_metrics(self.iter().filter(|m| m.name() == "received_events_total"))?;
+        let sum = sum_metrics(
+            self.iter()
+                .filter(|m| m.name() == "component_received_events_total"),
+        )?;
 
         Some(ReceivedEventsTotal::new(sum))
     }
@@ -108,7 +111,7 @@ impl<'a> MetricsFilter<'a> for Vec<&'a Metric> {
     fn received_events_total(&self) -> Option<ReceivedEventsTotal> {
         let sum = sum_metrics(
             self.iter()
-                .filter(|m| m.name() == "received_events_total")
+                .filter(|m| m.name() == "component_received_events_total")
                 .copied(),
         )?;
 

--- a/src/api/schema/metrics/filter.rs
+++ b/src/api/schema/metrics/filter.rs
@@ -1,4 +1,6 @@
-use super::{EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal};
+use super::{
+    EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal, ReceivedEventsTotal,
+};
 use crate::{
     config::ComponentKey,
     event::{Metric, MetricValue},
@@ -45,6 +47,7 @@ fn sum_metrics_owned<I: IntoIterator<Item = Metric>>(metrics: I) -> Option<Metri
 pub trait MetricsFilter<'a> {
     fn processed_events_total(&self) -> Option<ProcessedEventsTotal>;
     fn processed_bytes_total(&self) -> Option<ProcessedBytesTotal>;
+    fn received_events_total(&self) -> Option<ReceivedEventsTotal>;
     fn events_in_total(&self) -> Option<EventsInTotal>;
     fn events_out_total(&self) -> Option<EventsOutTotal>;
 }
@@ -66,6 +69,12 @@ impl<'a> MetricsFilter<'a> for Vec<Metric> {
         let sum = sum_metrics(self.iter().filter(|m| m.name() == "events_in_total"))?;
 
         Some(EventsInTotal::new(sum))
+    }
+
+    fn received_events_total(&self) -> Option<ReceivedEventsTotal> {
+        let sum = sum_metrics(self.iter().filter(|m| m.name() == "received_events_total"))?;
+
+        Some(ReceivedEventsTotal::new(sum))
     }
 
     fn events_out_total(&self) -> Option<EventsOutTotal> {
@@ -94,6 +103,16 @@ impl<'a> MetricsFilter<'a> for Vec<&'a Metric> {
         )?;
 
         Some(ProcessedBytesTotal::new(sum))
+    }
+
+    fn received_events_total(&self) -> Option<ReceivedEventsTotal> {
+        let sum = sum_metrics(
+            self.iter()
+                .filter(|m| m.name() == "received_events_total")
+                .copied(),
+        )?;
+
+        Some(ReceivedEventsTotal::new(sum))
     }
 
     fn events_in_total(&self) -> Option<EventsInTotal> {

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -4,6 +4,7 @@ mod events_out;
 pub mod filter;
 mod processed_bytes;
 mod processed_events;
+mod received_events;
 mod sink;
 pub mod source;
 mod transform;
@@ -27,6 +28,9 @@ pub use processed_bytes::{
 };
 pub use processed_events::{
     ComponentProcessedEventsThroughput, ComponentProcessedEventsTotal, ProcessedEventsTotal,
+};
+pub use received_events::{
+    ComponentReceivedEventsThroughput, ComponentReceivedEventsTotal, ReceivedEventsTotal,
 };
 pub use sink::{IntoSinkMetrics, SinkMetrics};
 pub use source::{IntoSourceMetrics, SourceMetrics};
@@ -58,7 +62,7 @@ pub struct MetricsSubscription;
 
 #[Subscription]
 impl MetricsSubscription {
-    /// Metrics for how long the Vector instance has been running.
+    /// Metrics for how long the Vector instance has been running
     async fn uptime(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -124,6 +128,7 @@ impl MetricsSubscription {
     }
 
     /// Total incoming events metrics
+    #[graphql(deprecation = "Use received_events_total instead")]
     async fn events_in_total(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -134,7 +139,19 @@ impl MetricsSubscription {
         })
     }
 
+    /// Total received events metrics
+    async fn received_events_total(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = ReceivedEventsTotal> {
+        get_metrics(interval).filter_map(|m| match m.name() {
+            "received_events_total" => Some(ReceivedEventsTotal::new(m)),
+            _ => None,
+        })
+    }
+
     /// Total incoming events throughput sampled over the provided millisecond `interval`
+    #[graphql(deprecation = "Use received_events_throughput instead")]
     async fn events_in_throughput(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -143,7 +160,17 @@ impl MetricsSubscription {
             .map(|(_, throughput)| throughput as i64)
     }
 
+    /// Total received events throughput sampled over the provided millisecond `interval`
+    async fn received_events_throughput(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = i64> {
+        counter_throughput(interval, &|m| m.name() == "received_events_total")
+            .map(|(_, throughput)| throughput as i64)
+    }
+
     /// Total incoming component events throughput metrics over `interval`
+    #[graphql(deprecation = "Use component_received_events_throughputs instead")]
     async fn component_events_in_throughputs(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
@@ -163,13 +190,46 @@ impl MetricsSubscription {
         })
     }
 
+    /// Total incoming component events throughput metrics over `interval`
+    async fn component_received_events_throughputs(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = Vec<ComponentReceivedEventsThroughput>> {
+        component_counter_throughputs(interval, &|m| m.name() == "received_events_total").map(|m| {
+            m.into_iter()
+                .map(|(m, throughput)| {
+                    ComponentReceivedEventsThroughput::new(
+                        ComponentKey::from((
+                            m.tag_value("pipeline_id"),
+                            m.tag_value("component_id").unwrap(),
+                        )),
+                        throughput as i64,
+                    )
+                })
+                .collect()
+        })
+    }
+
     /// Total incoming component event metrics over `interval`
+    #[graphql(deprecation = "Use component_received_events_totals instead")]
     async fn component_events_in_totals(
         &self,
         #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentEventsInTotal>> {
         component_counter_metrics(interval, &|m| m.name() == "events_in_total")
             .map(|m| m.into_iter().map(ComponentEventsInTotal::new).collect())
+    }
+
+    /// Total received component event metrics over `interval`
+    async fn component_received_events_totals(
+        &self,
+        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+    ) -> impl Stream<Item = Vec<ComponentReceivedEventsTotal>> {
+        component_counter_metrics(interval, &|m| m.name() == "received_events_total").map(|m| {
+            m.into_iter()
+                .map(ComponentReceivedEventsTotal::new)
+                .collect()
+        })
     }
 
     /// Total outgoing events metrics

--- a/src/api/schema/metrics/received_events.rs
+++ b/src/api/schema/metrics/received_events.rs
@@ -1,0 +1,114 @@
+use crate::config::ComponentKey;
+use crate::event::{Metric, MetricValue};
+use async_graphql::Object;
+use chrono::{DateTime, Utc};
+
+pub struct ReceivedEventsTotal(Metric);
+
+impl ReceivedEventsTotal {
+    pub const fn new(m: Metric) -> Self {
+        Self(m)
+    }
+
+    pub fn get_timestamp(&self) -> Option<DateTime<Utc>> {
+        self.0.timestamp()
+    }
+
+    pub fn get_received_events_total(&self) -> f64 {
+        match self.0.value() {
+            MetricValue::Counter { value } => *value,
+            _ => 0.00,
+        }
+    }
+}
+
+#[Object]
+impl ReceivedEventsTotal {
+    /// Metric timestamp
+    pub async fn timestamp(&self) -> Option<DateTime<Utc>> {
+        self.get_timestamp()
+    }
+
+    /// Total incoming events
+    pub async fn received_events_total(&self) -> f64 {
+        self.get_received_events_total()
+    }
+}
+
+impl From<Metric> for ReceivedEventsTotal {
+    fn from(m: Metric) -> Self {
+        Self(m)
+    }
+}
+
+pub struct ComponentReceivedEventsTotal {
+    component_key: ComponentKey,
+    metric: Metric,
+}
+
+impl ComponentReceivedEventsTotal {
+    /// Returns a new `ComponentReceivedEventsTotal` struct, which is a GraphQL type. The
+    /// component id is hoisted for clear field resolution in the resulting payload.
+    pub fn new(metric: Metric) -> Self {
+        let component_key = metric.tag_value("component_id").expect(
+            "Returned a metric without a `component_id`, which shouldn't happen. Please report.",
+        );
+        let component_key = ComponentKey::from((metric.tag_value("pipeline_id"), component_key));
+
+        Self {
+            component_key,
+            metric,
+        }
+    }
+}
+
+#[Object]
+impl ComponentReceivedEventsTotal {
+    /// Component id
+    async fn component_id(&self) -> &str {
+        self.component_key.id()
+    }
+
+    /// Pipeline id
+    async fn pipeline_id(&self) -> Option<&str> {
+        self.component_key.pipeline_str()
+    }
+
+    /// Total received events metric
+    async fn metric(&self) -> ReceivedEventsTotal {
+        ReceivedEventsTotal::new(self.metric.clone())
+    }
+}
+
+pub struct ComponentReceivedEventsThroughput {
+    component_key: ComponentKey,
+    throughput: i64,
+}
+
+impl ComponentReceivedEventsThroughput {
+    /// Returns a new `ComponentReceivedEventsThroughput`, set to the provided id/throughput values.
+    pub const fn new(component_key: ComponentKey, throughput: i64) -> Self {
+        Self {
+            component_key,
+            throughput,
+        }
+    }
+}
+
+#[Object]
+impl ComponentReceivedEventsThroughput {
+    /// Component id
+    async fn component_id(&self) -> &str {
+        self.component_key.id()
+    }
+
+    /// Pipeline id
+    async fn pipeline_id(&self) -> Option<&str> {
+        self.component_key.pipeline_str()
+    }
+
+    /// Received events throughput
+    async fn throughput(&self) -> i64 {
+        self.throughput
+    }
+}

--- a/src/api/schema/metrics/sink/generic.rs
+++ b/src/api/schema/metrics/sink/generic.rs
@@ -30,6 +30,11 @@ impl GenericSinkMetrics {
         self.0.events_in_total()
     }
 
+    /// Total received events for the current sink
+    pub async fn received_events_total(&self) -> Option<metrics::ReceivedEventsTotal> {
+        self.0.received_events_total()
+    }
+
     /// Total outgoing events for the current sink
     pub async fn events_out_total(&self) -> Option<metrics::EventsOutTotal> {
         self.0.events_out_total()

--- a/src/api/schema/metrics/sink/mod.rs
+++ b/src/api/schema/metrics/sink/mod.rs
@@ -1,6 +1,8 @@
 mod generic;
 
-use super::{EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal};
+use super::{
+    EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal, ReceivedEventsTotal,
+};
 use crate::event::Metric;
 use async_graphql::Interface;
 
@@ -8,7 +10,12 @@ use async_graphql::Interface;
 #[graphql(
     field(name = "processed_events_total", type = "Option<ProcessedEventsTotal>"),
     field(name = "processed_bytes_total", type = "Option<ProcessedBytesTotal>"),
-    field(name = "events_in_total", type = "Option<EventsInTotal>"),
+    field(name = "received_events_total", type = "Option<ReceivedEventsTotal>"),
+    field(
+        name = "events_in_total",
+        type = "Option<EventsInTotal>",
+        deprecation = "Use received_events_total instead"
+    ),
     field(name = "events_out_total", type = "Option<EventsOutTotal>")
 )]
 pub enum SinkMetrics {

--- a/src/api/schema/metrics/source/file.rs
+++ b/src/api/schema/metrics/source/file.rs
@@ -50,6 +50,11 @@ impl<'a> FileSourceMetricFile<'a> {
         self.metrics.events_in_total()
     }
 
+    /// Metric indicating received events for the current file
+    async fn received_events_total(&self) -> Option<metrics::ReceivedEventsTotal> {
+        self.metrics.received_events_total()
+    }
+
     /// Metric indicating outgoing events for the current file
     async fn events_out_total(&self) -> Option<metrics::EventsOutTotal> {
         self.metrics.events_out_total()
@@ -83,6 +88,7 @@ pub enum FileSourceMetricFilesSortFieldName {
     Name,
     ProcessedBytesTotal,
     ProcessedEventsTotal,
+    ReceivedEventsTotal,
     EventsInTotal,
     EventsOutTotal,
 }
@@ -111,6 +117,17 @@ impl sort::SortableByField<FileSourceMetricFilesSortFieldName> for FileSourceMet
                 &rhs.metrics
                     .processed_events_total()
                     .map(|m| m.get_processed_events_total() as i64)
+                    .unwrap_or(0),
+            ),
+            FileSourceMetricFilesSortFieldName::ReceivedEventsTotal => Ord::cmp(
+                &self
+                    .metrics
+                    .received_events_total()
+                    .map(|m| m.get_received_events_total() as i64)
+                    .unwrap_or(0),
+                &rhs.metrics
+                    .received_events_total()
+                    .map(|m| m.get_received_events_total() as i64)
                     .unwrap_or(0),
             ),
             FileSourceMetricFilesSortFieldName::EventsInTotal => Ord::cmp(
@@ -199,6 +216,11 @@ impl FileSourceMetrics {
     /// Total incoming events for the current file source
     pub async fn events_in_total(&self) -> Option<metrics::EventsInTotal> {
         self.0.events_in_total()
+    }
+
+    /// Total received events for the current file source
+    pub async fn received_events_total(&self) -> Option<metrics::ReceivedEventsTotal> {
+        self.0.received_events_total()
     }
 
     /// Total outgoing events for the current file source

--- a/src/api/schema/metrics/source/generic.rs
+++ b/src/api/schema/metrics/source/generic.rs
@@ -30,6 +30,11 @@ impl GenericSourceMetrics {
         self.0.events_in_total()
     }
 
+    /// Total received events for the current source
+    pub async fn received_events_total(&self) -> Option<metrics::ReceivedEventsTotal> {
+        self.0.received_events_total()
+    }
+
     /// Total outgoing events for the current source
     pub async fn events_out_total(&self) -> Option<metrics::EventsOutTotal> {
         self.0.events_out_total()

--- a/src/api/schema/metrics/source/mod.rs
+++ b/src/api/schema/metrics/source/mod.rs
@@ -1,7 +1,9 @@
 pub mod file;
 mod generic;
 
-use super::{EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal};
+use super::{
+    EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal, ReceivedEventsTotal,
+};
 use crate::event::Metric;
 use async_graphql::Interface;
 
@@ -9,7 +11,12 @@ use async_graphql::Interface;
 #[graphql(
     field(name = "processed_events_total", type = "Option<ProcessedEventsTotal>"),
     field(name = "processed_bytes_total", type = "Option<ProcessedBytesTotal>"),
-    field(name = "events_in_total", type = "Option<EventsInTotal>"),
+    field(name = "received_events_total", type = "Option<ReceivedEventsTotal>"),
+    field(
+        name = "events_in_total",
+        type = "Option<EventsInTotal>",
+        deprecation = "Use received_events_total instead"
+    ),
     field(name = "events_out_total", type = "Option<EventsOutTotal>")
 )]
 pub enum SourceMetrics {

--- a/src/api/schema/metrics/transform/generic.rs
+++ b/src/api/schema/metrics/transform/generic.rs
@@ -30,6 +30,11 @@ impl GenericTransformMetrics {
         self.0.events_in_total()
     }
 
+    /// Total received events for the current transform
+    pub async fn received_events_total(&self) -> Option<metrics::ReceivedEventsTotal> {
+        self.0.received_events_total()
+    }
+
     /// Total outgoing events for the current transform
     pub async fn events_out_total(&self) -> Option<metrics::EventsOutTotal> {
         self.0.events_out_total()

--- a/src/api/schema/metrics/transform/mod.rs
+++ b/src/api/schema/metrics/transform/mod.rs
@@ -1,6 +1,8 @@
 mod generic;
 
-use super::{EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal};
+use super::{
+    EventsInTotal, EventsOutTotal, ProcessedBytesTotal, ProcessedEventsTotal, ReceivedEventsTotal,
+};
 use crate::event::Metric;
 use async_graphql::Interface;
 
@@ -8,7 +10,12 @@ use async_graphql::Interface;
 #[graphql(
     field(name = "processed_events_total", type = "Option<ProcessedEventsTotal>"),
     field(name = "processed_bytes_total", type = "Option<ProcessedBytesTotal>"),
-    field(name = "events_in_total", type = "Option<EventsInTotal>"),
+    field(name = "received_events_total", type = "Option<ReceivedEventsTotal>"),
+    field(
+        name = "events_in_total",
+        type = "Option<EventsInTotal>",
+        deprecation = "Use received_events_total instead"
+    ),
     field(name = "events_out_total", type = "Option<EventsOutTotal>")
 )]
 pub enum TransformMetrics {

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -156,7 +156,7 @@ impl<'a> Widgets<'a> {
             ];
 
             let formatted_metrics = [
-                match r.events_in_total {
+                match r.received_events_total {
                     0 => "N/A".to_string(),
                     v => format!(
                         "{} ({}/s)",
@@ -165,7 +165,7 @@ impl<'a> Widgets<'a> {
                         } else {
                             v.thousands_format()
                         },
-                        r.events_in_throughput_sec.human_format()
+                        r.received_events_throughput_sec.human_format()
                     ),
                 },
                 match r.events_out_total {

--- a/src/top/metrics.rs
+++ b/src/top/metrics.rs
@@ -24,8 +24,8 @@ async fn component_added(client: Arc<SubscriptionClient>, tx: state::EventTx) {
                     key,
                     kind: c.on.to_string(),
                     component_type: c.component_type,
-                    events_in_total: 0,
-                    events_in_throughput_sec: 0,
+                    received_events_total: 0,
+                    received_events_throughput_sec: 0,
                     events_out_total: 0,
                     events_out_throughput_sec: 0,
                     processed_bytes_total: 0,
@@ -54,8 +54,12 @@ async fn component_removed(client: Arc<SubscriptionClient>, tx: state::EventTx) 
     }
 }
 
-async fn events_in_totals(client: Arc<SubscriptionClient>, tx: state::EventTx, interval: i64) {
-    let res = client.component_events_in_totals_subscription(interval);
+async fn received_events_totals(
+    client: Arc<SubscriptionClient>,
+    tx: state::EventTx,
+    interval: i64,
+) {
+    let res = client.component_received_events_totals_subscription(interval);
 
     tokio::pin! {
         let stream = res.stream();
@@ -63,14 +67,14 @@ async fn events_in_totals(client: Arc<SubscriptionClient>, tx: state::EventTx, i
 
     while let Some(Some(res)) = stream.next().await {
         if let Some(d) = res.data {
-            let c = d.component_events_in_totals;
+            let c = d.component_received_events_totals;
             let _ = tx
-                .send(state::EventType::EventsInTotals(
+                .send(state::EventType::ReceivedEventsTotals(
                     c.into_iter()
                         .map(|c| {
                             (
                                 ComponentKey::from(&c.component_id),
-                                c.metric.events_in_total as i64,
+                                c.metric.received_events_total as i64,
                             )
                         })
                         .collect(),
@@ -80,8 +84,12 @@ async fn events_in_totals(client: Arc<SubscriptionClient>, tx: state::EventTx, i
     }
 }
 
-async fn events_in_throughputs(client: Arc<SubscriptionClient>, tx: state::EventTx, interval: i64) {
-    let res = client.component_events_in_throughputs_subscription(interval);
+async fn received_events_throughputs(
+    client: Arc<SubscriptionClient>,
+    tx: state::EventTx,
+    interval: i64,
+) {
+    let res = client.component_received_events_throughputs_subscription(interval);
 
     tokio::pin! {
         let stream = res.stream();
@@ -89,9 +97,9 @@ async fn events_in_throughputs(client: Arc<SubscriptionClient>, tx: state::Event
 
     while let Some(Some(res)) = stream.next().await {
         if let Some(d) = res.data {
-            let c = d.component_events_in_throughputs;
+            let c = d.component_received_events_throughputs;
             let _ = tx
-                .send(state::EventType::EventsInThroughputs(
+                .send(state::EventType::ReceivedEventsThroughputs(
                     interval,
                     c.into_iter()
                         .map(|c| (ComponentKey::from(&c.component_id), c.throughput))
@@ -217,8 +225,12 @@ pub fn subscribe(client: SubscriptionClient, tx: state::EventTx, interval: i64) 
 
     tokio::spawn(component_added(Arc::clone(&client), tx.clone()));
     tokio::spawn(component_removed(Arc::clone(&client), tx.clone()));
-    tokio::spawn(events_in_totals(Arc::clone(&client), tx.clone(), interval));
-    tokio::spawn(events_in_throughputs(
+    tokio::spawn(received_events_totals(
+        Arc::clone(&client),
+        tx.clone(),
+        interval,
+    ));
+    tokio::spawn(received_events_throughputs(
         Arc::clone(&client),
         tx.clone(),
         interval,
@@ -266,8 +278,8 @@ pub async fn init_components(client: &Client) -> Result<state::State, ()> {
                         key,
                         kind: d.on.to_string(),
                         component_type: d.component_type,
-                        events_in_total: d.on.events_in_total(),
-                        events_in_throughput_sec: 0,
+                        received_events_total: d.on.received_events_total(),
+                        received_events_throughput_sec: 0,
                         events_out_total: d.on.events_out_total(),
                         events_out_throughput_sec: 0,
                         processed_bytes_total: d.on.processed_bytes_total(),

--- a/src/top/state.rs
+++ b/src/top/state.rs
@@ -6,9 +6,9 @@ type IdentifiedMetric = (ComponentKey, i64);
 
 #[derive(Debug)]
 pub enum EventType {
-    EventsInTotals(Vec<IdentifiedMetric>),
+    ReceivedEventsTotals(Vec<IdentifiedMetric>),
     /// Interval in ms + identified metric
-    EventsInThroughputs(i64, Vec<IdentifiedMetric>),
+    ReceivedEventsThroughputs(i64, Vec<IdentifiedMetric>),
     EventsOutTotals(Vec<IdentifiedMetric>),
     /// Interval in ms + identified metric
     EventsOutThroughputs(i64, Vec<IdentifiedMetric>),
@@ -31,8 +31,8 @@ pub struct ComponentRow {
     pub component_type: String,
     pub processed_bytes_total: i64,
     pub processed_bytes_throughput_sec: i64,
-    pub events_in_total: i64,
-    pub events_in_throughput_sec: i64,
+    pub received_events_total: i64,
+    pub received_events_throughput_sec: i64,
     pub events_out_total: i64,
     pub events_out_throughput_sec: i64,
     pub errors: i64,
@@ -50,17 +50,17 @@ pub async fn updater(mut state: State, mut event_rx: EventRx) -> StateRx {
     tokio::spawn(async move {
         while let Some(event_type) = event_rx.recv().await {
             match event_type {
-                EventType::EventsInTotals(rows) => {
+                EventType::ReceivedEventsTotals(rows) => {
                     for (key, v) in rows {
                         if let Some(r) = state.get_mut(&key) {
-                            r.events_in_total = v;
+                            r.received_events_total = v;
                         }
                     }
                 }
-                EventType::EventsInThroughputs(interval, rows) => {
+                EventType::ReceivedEventsThroughputs(interval, rows) => {
                     for (key, v) in rows {
                         if let Some(r) = state.get_mut(&key) {
-                            r.events_in_throughput_sec =
+                            r.received_events_throughput_sec =
                                 (v as f64 * (1000.0 / interval as f64)) as i64;
                         }
                     }


### PR DESCRIPTION
Adds the `EventsReceived` side to the API per #9132. Deprecates `events_in_total` and related fields.

Will tackle `EventsSent` metrics in a separate PR.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
