### PR TITLE
fix(transforms): add sanity check in route & compound transforms

### DIFF
--- a/src/transforms/compound.rs
+++ b/src/transforms/compound.rs
@@ -43,10 +43,13 @@ impl TransformConfig for CompoundConfig {
     ) -> crate::Result<Option<(IndexMap<String, Box<dyn TransformConfig>>, ExpandType)>> {
         let mut map: IndexMap<String, Box<dyn TransformConfig>> = IndexMap::new();
         for (i, step) in self.steps.iter().enumerate() {
-            if let Some(_) = map.insert(
-                step.id.as_ref().cloned().unwrap_or_else(|| i.to_string()),
-                step.transform.to_owned(),
-            ) {
+            if map
+                .insert(
+                    step.id.as_ref().cloned().unwrap_or_else(|| i.to_string()),
+                    step.transform.to_owned(),
+                )
+                .is_some()
+            {
                 return Err("conflicting id found while expanding transform".into());
             }
         }

--- a/src/transforms/compound.rs
+++ b/src/transforms/compound.rs
@@ -41,22 +41,18 @@ impl TransformConfig for CompoundConfig {
     fn expand(
         &mut self,
     ) -> crate::Result<Option<(IndexMap<String, Box<dyn TransformConfig>>, ExpandType)>> {
-        let steps = &self.steps;
-        if !steps.is_empty() {
-            Ok(Some((
-                steps
-                    .iter()
-                    .enumerate()
-                    .map(|(i, step)| {
-                        let TransformStep { id, transform } = step;
-                        (
-                            id.as_ref().cloned().unwrap_or_else(|| i.to_string()),
-                            transform.to_owned(),
-                        )
-                    })
-                    .collect(),
-                ExpandType::Serial,
-            )))
+        let mut map: IndexMap<String, Box<dyn TransformConfig>> = IndexMap::new();
+        for (i, step) in self.steps.iter().enumerate() {
+            if let Some(_) = map.insert(
+                step.id.as_ref().cloned().unwrap_or_else(|| i.to_string()),
+                step.transform.to_owned(),
+            ) {
+                return Err("conflicting id found while expanding transform".into());
+            }
+        }
+
+        if !map.is_empty() {
+            Ok(Some((map, ExpandType::Serial)))
         } else {
             Err("must specify at least one transform".into())
         }

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -104,7 +104,9 @@ impl TransformConfig for RouteConfig {
         let mut map: IndexMap<String, Box<dyn TransformConfig>> = IndexMap::new();
 
         while let Some((k, v)) = self.route.pop() {
-            map.insert(k.clone(), Box::new(LaneConfig { condition: v }));
+            if let Some(_) = map.insert(k.clone(), Box::new(LaneConfig { condition: v })) {
+                return Err("duplicate route id".into());
+            }
         }
 
         if !map.is_empty() {

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -104,7 +104,10 @@ impl TransformConfig for RouteConfig {
         let mut map: IndexMap<String, Box<dyn TransformConfig>> = IndexMap::new();
 
         while let Some((k, v)) = self.route.pop() {
-            if let Some(_) = map.insert(k.clone(), Box::new(LaneConfig { condition: v })) {
+            if map
+                .insert(k.clone(), Box::new(LaneConfig { condition: v }))
+                .is_some()
+            {
                 return Err("duplicate route id".into());
             }
         }


### PR DESCRIPTION
Sanity check to avoid name-conflict in some expanded transforms (as mentionned #8848).
