### PR TITLE
enhancement(external docs): Provide templating for different condition syntax options

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -464,7 +464,7 @@ _values: {
 		]
 	}
 
-	syntax: "file_system_path" | "field_path" | "literal" | "template" | "regex" | "remap_boolean_expression" | "remap_program" | "strftime"
+	syntax: "file_system_path" | "field_path" | "literal" | "template" | "regex" | "vrl_boolean_expression" | "remap_program" | "strftime"
 }
 
 #TypeTimestamp: {

--- a/website/cue/reference/components/transforms/filter.cue
+++ b/website/cue/reference/components/transforms/filter.cue
@@ -46,7 +46,7 @@ components: transforms: filter: {
 				examples: [
 					#".status_code != 200 && !includes(["info", "debug"], .severity)"#,
 				]
-				syntax: "remap_boolean_expression"
+				syntax: "vrl_boolean_expression"
 			}
 		}
 	}

--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -58,7 +58,7 @@ components: transforms: route: {
 							examples: [
 								#".status_code != 200 && !includes(["info", "debug"], .severity)"#,
 							]
-							syntax: "remap_boolean_expression"
+							syntax: "vrl_boolean_expression"
 						}
 					}
 				}

--- a/website/cue/reference/components/transforms/sample.cue
+++ b/website/cue/reference/components/transforms/sample.cue
@@ -64,7 +64,7 @@ components: transforms: sample: {
 				examples: [
 					#".status_code != 200 && !includes(["info", "debug"], .severity)"#,
 				]
-				syntax: "remap_boolean_expression"
+				syntax: "vrl_boolean_expression"
 			}
 		}
 		rate: {

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -39,7 +39,7 @@
           {{ end }}
 
           {{ with $v.syntax }}
-          {{ if eq . "remap_boolean_expression" }}
+          {{ if eq . "vrl_boolean_expression" }}
           {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/vrl#boolean-expressions") }}
           {{ else if eq . "remap_program" }}
           {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/vrl#program") }}


### PR DESCRIPTION
This PR replaces the changes proposed in #9091. It both incorporates those changes and also modifies the CUE schemas and HTML templating to present more granular information about conditions. The templating is a bit quick and dirty but I think it's a clear improvement.

The affected pages:

* https://deploy-preview-9307--vector-project.netlify.app/docs/reference/configuration/transforms/filter
* https://deploy-preview-9307--vector-project.netlify.app/docs/reference/configuration/transforms/route
* https://deploy-preview-9307--vector-project.netlify.app/docs/reference/configuration/transforms/sample