### PR TITLE
chore: Add buffer max size metric to buffer specification

### DIFF
--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -35,9 +35,9 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value with `component_id, component_scope` as tags.
   * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value with `component_id, component_scope` as tags.
 
-#### `EventsReceived`
+#### `BufferEventsReceived`
 
-*All buffers* MUST emit an `EventsReceived` event immediately after receiving one or more Vector events.
+*All buffers* MUST emit an `BufferEventsReceived` event immediately after receiving one or more Vector events.
 
 * Properties
   * `count` - the number of received events
@@ -48,9 +48,9 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST increment the `buffer_events` gauge by the defined `count`
   * MUST increment the `buffer_byte_size` gauge by the defined `byte_size`
 
-#### `EventsSent`
+#### `BufferEventsSent`
 
-*All buffers* MUST emit an `EventsSent` event immediately after sending one or more Vector events.
+*All buffers* MUST emit an `BufferEventsSent` event immediately after sending one or more Vector events.
 
 * Properties
   * `count` - the number of sent events

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -16,23 +16,27 @@ interpreted as described in [RFC 2119].
 
 Vector buffers MUST be instrumented for optimal observability and monitoring. This is required to drive various interfaces that Vector users depend on to manage Vector installations in mission critical production environments. This section extends the [Instrumentation Specification].
 
+### Terms and Definitions
+
+`component_metadata` - Refers to the metadata (component id, component scope, component kind, and component type) of the component associated with the buffer. Buffer metrics SHOULD be tagged with all or partial `component_metadata` unless specified otherwise. In most cases, these tags are automatically added from tracing span context and do not need to be included as event properties.
+
 ### Events
 
 #### `BufferCreated`
 
-*All buffers* MUST emit a `BufferCreated` event immediately upon creation.
+*All buffers* MUST emit a `BufferCreated` event immediately upon creation. To avoid stale metrics, this event will be regularly emitted at an interval.
 
 * Properties
   * `max_size_bytes` - the max size of the buffer in bytes
   * `max_size_events` - the max size of the buffer in number of events
   * `initial_events_size` - the number of events in the buffer at creation
   * `initial_bytes_size` - the byte size of the buffer at creation
-  * `component_metadata` - metadata (ID, scope, etc.) of the component associated with the buffer.
+  * `component_metadata` - as defined in [Terms and Definitions](#terms-and-definitions)
 * Metric
-  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) if the defined `max_size_events` value is present with `component_metadata` as tags.
-  * MUST emit the `buffer_max_byte_size` gauge (disk buffers) if the defined `max_size_bytes` value is present with `component_metadata` as tags.
-  * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value with `component_metadata` as tags.
-  * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value with `component_metadata` as tags.
+  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) if the defined `max_size_events` value is present
+  * MUST emit the `buffer_max_byte_size` gauge (disk buffers) if the defined `max_size_bytes` value is present
+  * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value
+  * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value
 
 #### `BufferEventsReceived`
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -23,14 +23,17 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
 *All buffers* MUST emit a `BufferCreated` event immediately upon creation.
 
 * Properties
-  * `max_size` - the maximum number of events or byte size of the buffer
+  * `max_size_bytes` - the max size of the buffer in bytes
+  * `max_size_events` - the max size of the buffer in number of events
   * `initial_events_size` - the number of events in the buffer at creation
   * `initial_bytes_size` - the byte size of the buffer at creation
   * `component_id` - the ID of the component associated with the buffer
+  * `component_scope` - the scope of the component associated with the buffer
 * Metric
-  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) or `buffer_max_byte_size` gauge (disk buffers) with the defined `max_size` value and `component_id` as tag.
-  * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value with `component_id` as tag.
-  * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value with `component_id` as tag.
+  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) if the defined `max_size_events` value is present with `component_id, component_scope` as tags.
+  * MUST emit the `buffer_max_byte_size` gauge (disk buffers) if the defined `max_size_bytes` value is present with `component_id, component_scope` as tags.
+  * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value with `component_id, component_scope` as tags.
+  * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value with `component_id, component_scope` as tags.
 
 #### `EventsReceived`
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -24,9 +24,13 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
 
 * Properties
   * `max_size` - the maximum number of events or byte size of the buffer
-  * `id` - the ID of the component associated with the buffer
+  * `initial_events_size` - the number of events in the buffer at creation
+  * `initial_bytes_size` - the byte size of the buffer at creation
+  * `component_id` - the ID of the component associated with the buffer
 * Metric
-  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) or `buffer_max_byte_size` gauge (disk buffers) with the defined `max_size` value and `id` as tag.
+  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) or `buffer_max_byte_size` gauge (disk buffers) with the defined `max_size` value and `component_id` as tag.
+  * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value with `component_id` as tag.
+  * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value with `component_id` as tag.
 
 #### `EventsReceived`
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -18,6 +18,16 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
 
 ### Events
 
+#### `BufferCreated`
+
+*All buffers* MUST emit a `BufferCreated` event immediately upon creation.
+
+* Properties
+  * `max_size` - the maximum number of events or byte size of the buffer
+  * `id` - the ID of the component associated with the buffer
+* Metric
+  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) or `buffer_max_byte_size` gauge (disk buffers) with the defined `max_size` value and `id` as tag.
+
 #### `EventsReceived`
 
 *All buffers* MUST emit an `EventsReceived` event immediately after receiving one or more Vector events.
@@ -30,7 +40,6 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST increment the `buffer_received_bytes_total` counter by the defined `byte_size`
   * MUST increment the `buffer_events` gauge by the defined `count`
   * MUST increment the `buffer_byte_size` gauge by the defined `byte_size`
-  * MUST update the `buffer_usage_percentage` gauge which measures the current buffer space utilization (number of events/bytes) over total space available (max number of events/bytes)
 
 #### `EventsSent`
 
@@ -44,7 +53,6 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST increment the `buffer_sent_bytes_total` counter by the defined `byte_size`
   * MUST decrement the `buffer_events` gauge by the defined `count`
   * MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
-  * MUST update the `buffer_usage_percentage` gauge
 
 #### `EventsDropped`
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -27,13 +27,12 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * `max_size_events` - the max size of the buffer in number of events
   * `initial_events_size` - the number of events in the buffer at creation
   * `initial_bytes_size` - the byte size of the buffer at creation
-  * `component_id` - the ID of the component associated with the buffer
-  * `component_scope` - the scope of the component associated with the buffer
+  * `component_metadata` - metadata (ID, scope, etc.) of the component associated with the buffer.
 * Metric
-  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) if the defined `max_size_events` value is present with `component_id, component_scope` as tags.
-  * MUST emit the `buffer_max_byte_size` gauge (disk buffers) if the defined `max_size_bytes` value is present with `component_id, component_scope` as tags.
-  * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value with `component_id, component_scope` as tags.
-  * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value with `component_id, component_scope` as tags.
+  * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) if the defined `max_size_events` value is present with `component_metadata` as tags.
+  * MUST emit the `buffer_max_byte_size` gauge (disk buffers) if the defined `max_size_bytes` value is present with `component_metadata` as tags.
+  * MUST emit the `buffer_received_events_total` counter with the defined `initial_events_size` value with `component_metadata` as tags.
+  * MUST emit the `buffer_received_bytes_total` counter with the defined `initial_bytes_size` value with `component_metadata` as tags.
 
 #### `BufferEventsReceived`
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -18,13 +18,13 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
 
 ### Terms and Definitions
 
-`component_metadata` - Refers to the metadata (component id, component scope, component kind, and component type) of the component associated with the buffer. Buffer metrics SHOULD be tagged with all or partial `component_metadata` unless specified otherwise. In most cases, these tags are automatically added from tracing span context and do not need to be included as event properties.
+`component_metadata` - Refers to the metadata (component id, component scope, component kind, and component type) of the component associated with the buffer. Buffer metrics MUST be tagged with all or partial `component_metadata` unless specified otherwise. In most cases, these tags are automatically added from tracing span context and do not need to be included as event properties.
 
 ### Events
 
 #### `BufferCreated`
 
-*All buffers* MUST emit a `BufferCreated` event immediately upon creation. To avoid stale metrics, this event will be regularly emitted at an interval.
+*All buffers* MUST emit a `BufferCreated` event immediately upon creation. To avoid stale metrics, this event MUST be regularly emitted at an interval.
 
 * Properties
   * `max_size_bytes` - the max size of the buffer in bytes


### PR DESCRIPTION
While implementing, I've realized calculating `buffer_usage_percentage` is tricky as determining current buffer size is difficult and it requires keeping track of `max_size`. 

Using a `buffer_max_{event, byte}_size` metric instead simplifies implementation and allows end users to derive `buffer_usage_percentage` relatively easily (e.g. `(buffer_received_events_total - buffer_sent_events_total) / buffer_max_event_size`).
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
