### PR TITLE
enhancement(buffers): Instrument buffer total bytes/events received, sent, dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "criterion",
  "db-key",
  "futures 0.3.17",
+ "internal_event",
  "leveldb",
  "metrics",
  "metrics-exporter-prometheus",

--- a/lib/vector-core/buffers/Cargo.toml
+++ b/lib/vector-core/buffers/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 bytes = { version = "1.1.0", default-features = false }
 db-key = { version = "0.0.5", default-features = false, optional = true }
 futures = { version = "0.3.17", default-features = false, features = ["std"] }
+internal_event = { path = "../internal-event", default-features = false }
 leveldb = { version = "0.8.6", default-features = false, optional = true }
 metrics = { version = "0.17.0", default-features = false, features = ["std"] }
 pin-project = { version = "1.0.8", default-features = false }

--- a/lib/vector-core/buffers/src/internal_events.rs
+++ b/lib/vector-core/buffers/src/internal_events.rs
@@ -1,4 +1,5 @@
 use internal_event::InternalEvent;
+use metrics::{counter, decrement_gauge, increment_gauge};
 
 pub struct EventsReceived {
     pub count: usize,
@@ -8,7 +9,10 @@ pub struct EventsReceived {
 impl InternalEvent for EventsReceived {
     fn emit_logs(&self) {}
 
-    fn emit_metrics(&self) {}
+    fn emit_metrics(&self) {
+        counter!("buffer_received_events_total", self.count as u64);
+        counter!("buffer_received_bytes_total", self.byte_size as u64);
+    }
 }
 
 pub struct EventsSent {
@@ -19,7 +23,10 @@ pub struct EventsSent {
 impl InternalEvent for EventsSent {
     fn emit_logs(&self) {}
 
-    fn emit_metrics(&self) {}
+    fn emit_metrics(&self) {
+        counter!("buffer_sent_events_total", self.count as u64);
+        counter!("buffer_sent_bytes_total", self.byte_size as u64);
+    }
 }
 
 pub struct EventsDropped {
@@ -29,5 +36,7 @@ pub struct EventsDropped {
 impl InternalEvent for EventsDropped {
     fn emit_logs(&self) {}
 
-    fn emit_metrics(&self) {}
+    fn emit_metrics(&self) {
+        counter!("buffer_discarded_events_total", self.count as u64);
+    }
 }

--- a/lib/vector-core/buffers/src/internal_events.rs
+++ b/lib/vector-core/buffers/src/internal_events.rs
@@ -1,5 +1,5 @@
 use internal_event::InternalEvent;
-use metrics::{counter, decrement_gauge, increment_gauge};
+use metrics::counter;
 
 pub struct EventsReceived {
     pub count: usize,

--- a/lib/vector-core/buffers/src/internal_events.rs
+++ b/lib/vector-core/buffers/src/internal_events.rs
@@ -1,0 +1,33 @@
+use internal_event::InternalEvent;
+
+pub struct EventsReceived {
+    pub count: usize,
+    pub byte_size: usize,
+}
+
+impl InternalEvent for EventsReceived {
+    fn emit_logs(&self) {}
+
+    fn emit_metrics(&self) {}
+}
+
+pub struct EventsSent {
+    pub count: usize,
+    pub byte_size: usize,
+}
+
+impl InternalEvent for EventsSent {
+    fn emit_logs(&self) {}
+
+    fn emit_metrics(&self) {}
+}
+
+pub struct EventsDropped {
+    pub count: usize,
+}
+
+impl InternalEvent for EventsDropped {
+    fn emit_logs(&self) {}
+
+    fn emit_metrics(&self) {}
+}

--- a/lib/vector-core/buffers/src/lib.rs
+++ b/lib/vector-core/buffers/src/lib.rs
@@ -21,6 +21,7 @@ mod test;
 mod variant;
 
 use crate::bytes::{DecodeBytes, EncodeBytes};
+use crate::internal_events::EventsDropped;
 pub use acker::Acker;
 use futures::StreamExt;
 use futures::{channel::mpsc, Sink, SinkExt, Stream};
@@ -201,6 +202,7 @@ impl<T, S: Sink<T> + Unpin> Sink<T> for DropWhenFull<S> {
                 message = "Shedding load; dropping event.",
                 internal_log_rate_secs = 10
             );
+            emit(&EventsDropped { count: 1 });
             Ok(())
         } else {
             self.project().inner.start_send(item)

--- a/lib/vector-core/buffers/src/lib.rs
+++ b/lib/vector-core/buffers/src/lib.rs
@@ -15,6 +15,7 @@ mod acker;
 pub mod bytes;
 #[cfg(feature = "disk-buffer")]
 pub mod disk;
+mod internal_events;
 #[cfg(test)]
 mod test;
 mod variant;


### PR DESCRIPTION
Part of #4936. This PR adds the basic `buffer_received_events_total`, `buffer_sent_events_total`, `buffer_received_bytes_total`, `buffer_sent_bytes_total`, and `buffer_discarded_events_total` metrics for buffer instrumentation ([spec](https://github.com/vectordotdev/vector/blob/master/docs/specs/buffer.md)). 

Implementing other metrics has proven slightly more involved and can be worked out separately from these base changes. Thus, to better organize my work and receive initial feedback, I've decided to open this initial PR.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
