### PR TITLE
enhancement(internal docs): Add component compliance docs

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -1,5 +1,52 @@
 package metadata
 
+#BytesReceivedEvent: {
+	emits_event:               bool
+	has_bytes_size_property:   bool
+	has_protocol_property:     bool | null
+	has_http_path_property:    bool | null
+	has_socket_property:       bool | null
+	increments_received_bytes: bool
+	logs_bytes_received:       bool
+}
+
+#BytesSentEvent: {
+	emits_event:                 bool
+	has_byte_size_property:      bool
+	has_protocol_property:       bool | null
+	has_endpoint_property:       bool | null
+	has_file_property:           bool | null
+	increments_sent_bytes_total: bool
+	logs_bytes_sent:             bool
+}
+
+#EventsReceivedEvent: {
+	emits_event:                     bool
+	has_count_property:              bool
+	has_byte_size_property:          bool
+	increments_received_events:      bool
+	increments_received_event_bytes: bool
+	logs_events_received:            bool
+}
+
+#EventsSentEvent: {
+	emits_event:                 bool
+	has_count_property:          bool
+	has_byte_size_property:      bool
+	increments_sent_events:      bool
+	increments_sent_event_bytes: bool
+	logs_events_sent:            bool
+}
+
+#ErrorEvents: {
+	have_error_property:              bool
+	have_error_type_property:         bool
+	have_stage_property:              bool
+	increment_errors_total:           bool
+	increment_discarded_events_total: bool | null
+	log_error:                        bool
+}
+
 components: {
 	// `#Classes` represent various `#Components` classifications.
 	#Classes: {
@@ -46,6 +93,8 @@ components: {
 		installation?: {
 			platform_name: string | null
 		}
+
+		spec_compliance: object | *null
 
 		configuration: #Schema
 

--- a/website/cue/reference/components/sinks/logdna.cue
+++ b/website/cue/reference/components/sinks/logdna.cue
@@ -160,8 +160,8 @@ components: sinks: logdna: {
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -205,10 +205,10 @@ components: sinks: loki: {
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
-		processed_bytes_total:   components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-		streams_total:           components.sources.internal_metrics.output.metrics.streams_total
+		processed_bytes_total:            components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
+		streams_total:                    components.sources.internal_metrics.output.metrics.streams_total
 	}
 }

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -171,12 +171,12 @@ components: sinks: splunk_hec_logs: {
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		encode_errors_total:       components.sources.internal_metrics.output.metrics.encode_errors_total
+		encode_errors_total:              components.sources.internal_metrics.output.metrics.encode_errors_total
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
-		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
-		processing_errors_total:   components.sources.internal_metrics.output.metrics.processing_errors_total
-		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
-		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
+		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
+		processed_bytes_total:            components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:           components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_received_total:          components.sources.internal_metrics.output.metrics.requests_received_total
 	}
 }

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -4,6 +4,14 @@ components: sources: [Name=string]: {
 	kind:     "source"
 	features: _
 
+	spec_compliance: {
+		audit_date:            string
+		bytes_received_event:  #BytesReceivedEvent
+		events_received_event: #EventsReceivedEvent
+		// events_sent_event handled in topology
+		error_events: #ErrorEvents
+	}
+
 	configuration: {
 		if features.collect != _|_ {
 			if features.collect.checkpoint.enabled {

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -56,6 +56,35 @@ components: sources: file: {
 		platform_name: null
 	}
 
+	spec_compliance: {
+		audit_date: "2012-09-14"
+		bytes_received_event: {
+			emits_event:               true
+			has_byte_size_property:    true
+			has_protocol_property:     null
+			has_http_path_property:    null
+			has_socket_property:       null
+			increments_received_bytes: true
+			logs_bytes_received:       true
+		}
+		events_received_event: {
+			emits_event:                     true
+			has_count_property:              true
+			has_byte_size_property:          true
+			increments_received_events:      true
+			increments_received_event_bytes: true
+			logs_events_received:            true
+		}
+		error_events: {
+			have_error_property:              true
+			have_error_type_property:         true
+			have_stage_property:              true
+			increment_errors_total:           true
+			increment_discarded_events_total: null
+			log_error:                        true
+		}
+	}
+
 	configuration: {
 		acknowledgements: configuration._acknowledgements
 		exclude: {


### PR DESCRIPTION
I have set up a proposed initial structure in this here: https://github.com/vectordotdev/vector/blob/6bb19695154e8833530571971434a7656ca8fb86/website/cue/reference/components/sources/file.cue#L59
My thinking is to have separately specified compliance stanzas for each of the component types, as the standard code in the topology takes care of some of the standard events. I am at a complete loss as to how this would be specified in the upstream cue code like here: https://github.com/vectordotdev/vector/blob/6bb19695154e8833530571971434a7656ca8fb86/website/cue/reference/components/sources.cue#L7
I need some help from the cue masters to move this forward, and thoughts on if this meets the requirements.

Closes #9017