### PR TITLE
enhancement(prometheus_scrape source): Allowing tagging metrics with instance and endpoint

### DIFF
--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -195,17 +195,12 @@ fn prometheus(
             }
 
             let instance_info = instance_tag.as_ref().map(|tag| {
-                let instance = format!("{}:{}", url.host().unwrap_or_default(), url.port_u16().unwrap_or_else(|| {
-                    let scheme = url.scheme();
-                    // cannot use match because `Scheme` does not derive the needed traits
-                    if url.scheme() == Some(&http::uri::Scheme::HTTP) {
-                        80
-                    } else if scheme == Some(&http::uri::Scheme::HTTPS) {
-                        443
-                    } else {
-                        0
+                let instance = format!("{}:{}", url.host().unwrap_or_default(), url.port_u16().unwrap_or_else(|| match url.scheme() {
+                        Some(scheme) if scheme == &http::uri::Scheme::HTTP => 80,
+                        Some(scheme) if scheme == &http::uri::Scheme::HTTPS => 443,
+                        _ => 0,
                     }
-                }));
+                ));
                 InstanceInfo { tag: tag.to_string(), instance, honor_label: honor_labels }
             });
             let endpoint_info = endpoint_tag.as_ref().map(|tag| {

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -399,7 +399,7 @@ mod test {
         tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr).into()],
+            endpoints: vec![format!("http://{}/metrics", in_addr)],
             scrape_interval_secs: 1,
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
@@ -449,7 +449,7 @@ mod test {
         tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr).into()],
+            endpoints: vec![format!("http://{}/metrics", in_addr)],
             scrape_interval_secs: 1,
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -45,6 +45,7 @@ struct PrometheusScrapeConfig {
     scrape_interval_secs: u64,
     instance_tag: Option<String>,
     endpoint_tag: Option<String>,
+    #[serde(default = "crate::serde::default_false")]
     honor_labels: bool,
     tls: Option<TlsOptions>,
     auth: Option<Auth>,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -337,7 +337,7 @@ fn prometheus(
                                 {
                                     // https://github.com/timberio/vector/pull/3801#issuecomment-700723178
                                     warn!(
-                                        message = PARSE_ERROR_NO_PATH,
+                                        message = NOT_FOUND_NO_PATH,
                                         endpoint = %url,
                                     );
                                 }
@@ -634,6 +634,7 @@ mod integration_tests {
             scrape_interval_secs: 1,
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
+            honor_labels: false,
             auth: None,
             tls: None,
         };

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -196,7 +196,7 @@ fn prometheus(
 
             let instance_info = instance_tag.as_ref().map(|tag| {
                 let instance = format!("{}:{}", url.host().unwrap_or_default(), url.port_u16().unwrap_or_else(|| match url.scheme() {
-                        Some(scheme) if scheme == &http::uri::Scheme::HTTP => 80,
+                            Some(scheme) if scheme == &http::uri::Scheme::HTTP => 80,
                         Some(scheme) if scheme == &http::uri::Scheme::HTTPS => 443,
                         _ => 0,
                     }
@@ -393,7 +393,7 @@ mod test {
         let dummy_endpoint = warp::path!("metrics").map(|| {
                 r#"
                     promhttp_metric_handler_requests_total{endpoint="http://example.com", instance="localhost:9999", code="200"} 100 1612411516789
-                    "#
+                "#
         });
 
         tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -121,6 +121,7 @@ struct PrometheusCompatConfig {
     endpoints: Vec<String>,
     instance_tag: Option<String>,
     endpoint_tag: Option<String>,
+    #[serde(default = "crate::serde::default_false")]
     honor_labels: bool,
     #[serde(default = "default_scrape_interval_secs")]
     scrape_interval_secs: u64,

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -83,6 +83,20 @@ components: sources: prometheus_scrape: {
 				unit:    "seconds"
 			}
 		}
+		instance_key: {
+			category: "Context"
+			common:   true
+			description: """
+				The key name added to each event representing the scraped instance's host:port.
+				"""
+			required: false
+			warnings: []
+			type: string: {
+				default: null
+				syntax:  "literal"
+				examples: ["instance"]
+			}
+		}
 		auth: configuration._http_auth & {_args: {
 			password_example: "${PROMETHEUS_PASSWORD}"
 			username_example: "${PROMETHEUS_USERNAME}"
@@ -90,10 +104,26 @@ components: sources: prometheus_scrape: {
 	}
 
 	output: metrics: {
-		counter:   output._passthrough_counter
-		gauge:     output._passthrough_gauge
-		histogram: output._passthrough_histogram
-		summary:   output._passthrough_summary
+		_extra_tags: {
+			"instance": {
+				description: "Any host:port of the scraped instance. Only present if `instance_key` is set.."
+				examples: [_values.instance]
+				required: false
+			}
+		}
+
+		counter: output._passthrough_counter & {
+			tags: _extra_tags
+		}
+		gauge: output._passthrough_gauge & {
+			tags: _extra_tags
+		}
+		histogram: output._passthrough_histogram & {
+			tags: _extra_tags
+		}
+		summary: output._passthrough_summary & {
+			tags: _extra_tags
+		}
 	}
 
 	telemetry: metrics: {

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -83,11 +83,11 @@ components: sources: prometheus_scrape: {
 				unit:    "seconds"
 			}
 		}
-		instance_key: {
+		instance_tag: {
 			category: "Context"
 			common:   true
 			description: """
-				The key name added to each event representing the scraped instance's host:port.
+				The tag name added to each event representing the scraped instance's host:port.
 				"""
 			required: false
 			warnings: []
@@ -95,6 +95,20 @@ components: sources: prometheus_scrape: {
 				default: null
 				syntax:  "literal"
 				examples: ["instance"]
+			}
+		}
+		endpoint_tag: {
+			category: "Context"
+			common:   true
+			description: """
+				The tag name added to each event representing the scraped instance's endpoint.
+				"""
+			required: false
+			warnings: []
+			type: string: {
+				default: null
+				syntax:  "literal"
+				examples: ["endpoint"]
 			}
 		}
 		auth: configuration._http_auth & {_args: {
@@ -106,8 +120,13 @@ components: sources: prometheus_scrape: {
 	output: metrics: {
 		_extra_tags: {
 			"instance": {
-				description: "Any host:port of the scraped instance. Only present if `instance_key` is set.."
-				examples: [_values.instance]
+				description: "The host:port of the scraped instance. Only present if `instance_tag` is set."
+				examples: ["localhost:9090"]
+				required: false
+			}
+			"endpoint": {
+				description: "Any endpoint of the scraped instance. Only present if `endpoint_tag` is set."
+				examples: ["http://localhost:9090/metrics"]
 				required: false
 			}
 		}

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -111,6 +111,21 @@ components: sources: prometheus_scrape: {
 				examples: ["endpoint"]
 			}
 		}
+		honor_labels: {
+			category: "Context"
+			common:   true
+			description: """
+				Controls how tag conflicts are handled if the scraped source has tags that Vector would add. If true,
+				Vector will not add the new tag if the scraped metric has the tag already. If false, Vector will rename
+				the conflicting tag by adding `exported_` to it.  This matches Prometheus's `honor_labels`
+				configuration.
+				"""
+			required: false
+			warnings: []
+			type: bool: {
+				default: false
+			}
+		}
 		auth: configuration._http_auth & {_args: {
 			password_example: "${PROMETHEUS_PASSWORD}"
 			username_example: "${PROMETHEUS_USERNAME}"


### PR DESCRIPTION
This adds a new configuration, `instance_key`, to the
`prometheus_scrape` source. If set, it will tag scraped metrics with their
instance in the same fashion as the prometheus scraper.

I opted to let users opt into this as this source has been around for
a while and I could see the extra tag causing some users some surprise
as Prometheus, when scraping, if the metric already has `instance`, will
avoid resetting it based on its `honor_labels` configuration.

Ref: https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series

Closes: #9322
Closes: #6953



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->