### PR TITLE
chore(sinks): make StreamSink::run take self

### DIFF
--- a/lib/vector-core/src/sink.rs
+++ b/lib/vector-core/src/sink.rs
@@ -15,13 +15,13 @@ impl VectorSink {
     /// # Errors
     ///
     /// It is unclear under what conditions this function will error.
-    pub async fn run<S>(mut self, input: S) -> Result<(), ()>
+    pub async fn run<S>(self, input: S) -> Result<(), ()>
     where
         S: Stream<Item = Event> + Send,
     {
         match self {
             Self::Sink(sink) => input.map(Ok).forward(sink).await,
-            Self::Stream(ref mut s) => s.run(Box::pin(input)).await,
+            Self::Stream(s) => s.run(Box::pin(input)).await,
         }
     }
 
@@ -48,5 +48,5 @@ impl fmt::Debug for VectorSink {
 
 #[async_trait]
 pub trait StreamSink {
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()>;
+    async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()>;
 }

--- a/src/sinks/blackhole.rs
+++ b/src/sinks/blackhole.rs
@@ -91,7 +91,7 @@ impl BlackholeSink {
 
 #[async_trait]
 impl StreamSink for BlackholeSink {
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         // Spin up a task that does the periodic reporting.  This is decoupled from the main sink so
         // that rate limiting support can be added more simply without having to interleave it with
         // the printing.
@@ -167,7 +167,7 @@ mod tests {
             print_interval_secs: 10,
             rate: None,
         };
-        let mut sink = BlackholeSink::new(config, Acker::Null);
+        let sink = Box::new(BlackholeSink::new(config, Acker::Null));
 
         let (_input_lines, events) = random_events_with_stream(100, 10, None);
         let _ = sink.run(Box::pin(events)).await.unwrap();

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -132,7 +132,7 @@ struct WriterSink {
 
 #[async_trait]
 impl StreamSink for WriterSink {
-    async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         while let Some(event) = input.next().await {
             self.acker.ack(1);
             if let Some(mut buf) = encode_event(event, &self.encoding) {

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -105,9 +105,9 @@ impl<S> LogSinkBuilder<S> {
     pub fn build(self) -> LogSink<S> {
         LogSink {
             default_api_key: self.default_api_key,
-            encoding: Some(self.encoding),
-            acker: Some(self.context.acker()),
-            service: Some(self.service),
+            encoding: self.encoding,
+            acker: self.context.acker(),
+            service: self.service,
             timeout: self.timeout.unwrap_or(BATCH_DEFAULT_TIMEOUT),
             compression: self.compression.unwrap_or_default(),
             log_schema: self.log_schema.unwrap_or_else(|| log_schema()),
@@ -124,16 +124,16 @@ pub struct LogSink<S> {
     /// case we batch them by this default.
     default_api_key: Arc<str>,
     /// The ack system for this sink to vector's buffer mechanism
-    acker: Option<Acker>,
+    acker: Acker,
     /// The API service
-    service: Option<S>,
+    service: S,
     /// The encoding of payloads
     ///
     /// This struct always generates JSON payloads. However we do, technically,
     /// allow the user to set the encoding to a single value -- JSON -- and this
     /// encoding comes with rules on sanitizing the payload which must be
     /// applied.
-    encoding: Option<EncodingConfigWithDefault<Encoding>>,
+    encoding: EncodingConfigWithDefault<Encoding>,
     /// The compression technique to use when building the request body
     compression: Compression,
     /// The total duration before a flush is forced
@@ -254,26 +254,14 @@ where
     S::Response: AsRef<EventStatus> + Send + 'static,
     S::Error: Debug + Into<crate::Error> + Send,
 {
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         let io_bandwidth = 64;
         let (io_tx, io_rx) = channel(io_bandwidth);
-        let service = self
-            .service
-            .take()
-            .expect("same sink should not be run twice");
-        let acker = self
-            .acker
-            .take()
-            .expect("same sink should not be run twice");
-        let encoding = self
-            .encoding
-            .take()
-            .expect("same sink should not be run twice");
+        let encoding = self.encoding;
         let default_api_key = Arc::clone(&self.default_api_key);
         let compression = self.compression;
         let log_schema = self.log_schema;
-
-        let io = run_io(io_rx, service, acker).in_current_span();
+        let io = run_io(io_rx, self.service, self.acker).in_current_span();
         let _ = tokio::spawn(io);
 
         let batcher = Batcher::new(

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -336,8 +336,8 @@ async fn write_event_to_file(
 
 #[async_trait]
 impl StreamSink for FileSink {
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
-        FileSink::run(self, input).await.expect("file sink error");
+    async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        FileSink::run(&mut self, input).await.expect("file sink error");
         Ok(())
     }
 }

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -337,7 +337,9 @@ async fn write_event_to_file(
 #[async_trait]
 impl StreamSink for FileSink {
     async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
-        FileSink::run(&mut self, input).await.expect("file sink error");
+        FileSink::run(&mut self, input)
+            .await
+            .expect("file sink error");
         Ok(())
     }
 }

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -152,8 +152,8 @@ impl From<&NatsSinkConfig> for NatsOptions {
 
 #[async_trait]
 impl StreamSink for NatsSink {
-    async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let nats_options: async_nats::Options = self.options.clone().into();
+    async fn run(self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+        let nats_options: async_nats::Options = self.options.into();
 
         let nc = nats_options.connect(&self.url).await.map_err(|_| ())?;
 

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -270,7 +270,7 @@ mod integration_tests {
 
         // Publish events.
         let (acker, ack_counter) = Acker::new_for_testing();
-        let mut sink = Box::new(NatsSink::new(cnf.clone(), acker).unwrap());
+        let sink = Box::new(NatsSink::new(cnf.clone(), acker).unwrap());
         let num_events = 1_000;
         let (input, events) = random_lines_with_stream(100, num_events, None);
 

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -270,7 +270,7 @@ mod integration_tests {
 
         // Publish events.
         let (acker, ack_counter) = Acker::new_for_testing();
-        let mut sink = NatsSink::new(cnf.clone(), acker).unwrap();
+        let mut sink = Box::new(NatsSink::new(cnf.clone(), acker).unwrap());
         let num_events = 1_000;
         let (input, events) = random_lines_with_stream(100, num_events, None);
 

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -288,7 +288,7 @@ impl PrometheusExporter {
 
 #[async_trait]
 impl StreamSink for PrometheusExporter {
-    async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         self.start_server_if_needed().await;
         while let Some(event) = input.next().await {
             let item = event.into_metric();
@@ -591,7 +591,7 @@ mod tests {
         };
         let cx = SinkContext::new_test();
 
-        let mut sink = PrometheusExporter::new(config, cx.acker());
+        let sink = Box::new(PrometheusExporter::new(config, cx.acker()));
 
         let m1 = Metric::new(
             "absolute",
@@ -616,11 +616,13 @@ mod tests {
             Event::Metric(m1.clone().with_value(MetricValue::Counter { value: 40. })),
         ];
 
+        let internal_metrics = sink.metrics.clone();
+
         sink.run(Box::pin(futures::stream::iter(metrics)))
             .await
             .unwrap();
 
-        let map = &sink.metrics.read().unwrap().map;
+        let map = &internal_metrics.read().unwrap().map;
 
         assert_eq!(
             map.get_full(&MetricEntry(m1)).unwrap().1.value(),

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -616,7 +616,7 @@ mod tests {
             Event::Metric(m1.clone().with_value(MetricValue::Counter { value: 40. })),
         ];
 
-        let internal_metrics = sink.metrics.clone();
+        let internal_metrics = Arc::clone(&sink.metrics);
 
         sink.run(Box::pin(futures::stream::iter(metrics)))
             .await

--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -95,11 +95,7 @@ where
         let (io_tx, io_rx) = channel(64);
         let io_barrier = Arc::new(Barrier::new(2));
 
-        let io = run_io(io_rx,
-                   Arc::clone(&io_barrier),
-                   self.service,
-                   self.acker
-            ).in_current_span();
+        let io = run_io(io_rx, Arc::clone(&io_barrier), self.service, self.acker).in_current_span();
         let _ = tokio::spawn(io);
 
         let batcher = Batcher::new(

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -249,7 +249,7 @@ impl TcpSink {
 
 #[async_trait]
 impl StreamSink for TcpSink {
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         // We need [Peekable](https://docs.rs/futures/0.3.6/futures/stream/struct.Peekable.html) for initiating
         // connection only when we have something to send.
         let encode_event = Arc::clone(&self.encode_event);

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -247,7 +247,7 @@ impl UdpSink {
 
 #[async_trait]
 impl StreamSink for UdpSink {
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         let mut input = input.peekable();
 
         while Pin::new(&mut input).peek().await.is_some() {

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -133,7 +133,7 @@ impl UnixSink {
 #[async_trait]
 impl StreamSink for UnixSink {
     // Same as TcpSink, more details there.
-    async fn run(&mut self, input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         let encode_event = Arc::clone(&self.encode_event);
         let mut input = input
             .map(|mut event| {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -354,7 +354,7 @@ where
     S: Sink<Event> + Send + std::marker::Unpin,
     <S as Sink<Event>>::Error: std::fmt::Display,
 {
-    async fn run(&mut self, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         while let Some(event) = input.next().await {
             if let Err(error) = self.sink.send(event).await {
                 error!(message = "Ingesting an event failed at mock sink.", %error);


### PR DESCRIPTION
Signed-off-by: Nathan Fox <fuchsnj@gmail.com>

closes #9328 

Pros:
- `StreamSink::run` is now enforced by the compiler to only run once, removing the need to "Option unwrap" or do runtime checks if ownership is actually needed

Cons:
- `StreamSink::run` can now _only_ be called from a Boxed trait. This is all we currently do though, and probably not a large downside


