### PR TITLE
chore(external docs): Actually run cue and markdown checks on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
         dependencies: ${{ steps.filter.outputs.dependencies }}
         internal_events: ${{ steps.filter.outputs.internal_events }}
         helm: ${{ steps.filter.outputs.helm }}
+        cue: ${{ steps.filter.outputs.cue }}
+        markdown: ${{ steps.filter.outputs.cue }}
       steps:
       - uses: actions/checkout@v2.3.4
       - uses: dorny/paths-filter@v2

--- a/website/cue/reference/components/sinks/logdna.cue
+++ b/website/cue/reference/components/sinks/logdna.cue
@@ -160,8 +160,8 @@ components: sinks: logdna: {
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -205,10 +205,10 @@ components: sinks: loki: {
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
-		processed_bytes_total:   components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-		streams_total:           components.sources.internal_metrics.output.metrics.streams_total
+		processed_bytes_total:            components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
+		streams_total:                    components.sources.internal_metrics.output.metrics.streams_total
 	}
 }

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -171,12 +171,12 @@ components: sinks: splunk_hec_logs: {
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		encode_errors_total:       components.sources.internal_metrics.output.metrics.encode_errors_total
+		encode_errors_total:              components.sources.internal_metrics.output.metrics.encode_errors_total
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
-		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
-		processing_errors_total:   components.sources.internal_metrics.output.metrics.processing_errors_total
-		processed_bytes_total:     components.sources.internal_metrics.output.metrics.processed_bytes_total
-		processed_events_total:    components.sources.internal_metrics.output.metrics.processed_events_total
-		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
+		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
+		processed_bytes_total:            components.sources.internal_metrics.output.metrics.processed_bytes_total
+		processed_events_total:           components.sources.internal_metrics.output.metrics.processed_events_total
+		requests_received_total:          components.sources.internal_metrics.output.metrics.requests_received_total
 	}
 }


### PR DESCRIPTION
Note that this has an intentional missing indentation fix to double check that the cue format check step is actually happening.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>