### PR TITLE
chore(architecture): refactor PathIter to avoid regex + allocations (plus a bonus change)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8352,18 +8352,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2 1.0.29",
  "quote 1.0.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6497,6 +6497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7751,6 +7760,7 @@ dependencies = [
  "serde_json",
  "shared",
  "snafu",
+ "substring",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
 shared = { path = "../shared" }
 snafu = { version = "0.6.10", default-features = false }
+substring = { version = "1.4", default-features = false }
 tokio = { version = "1.12.0", default-features = false }
 tokio-stream = { version = "0.1", default-features = false, optional = true }
 tokio-util = { version = "0.6.8", default-features = false, features = ["time"] }
@@ -77,4 +78,8 @@ harness = false
 
 [[bench]]
 name = "event"
+harness = false
+
+[[bench]]
+name = "path_iter"
 harness = false

--- a/lib/vector-core/benches/path_iter.rs
+++ b/lib/vector-core/benches/path_iter.rs
@@ -1,0 +1,55 @@
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
+};
+use std::time::Duration;
+use vector_core::event::PathIter;
+
+fn path_iter(c: &mut Criterion) {
+    let mut group: BenchmarkGroup<WallTime> = c.benchmark_group("vector_core::event::util::log");
+    group.sampling_mode(SamplingMode::Auto);
+
+    group.bench_function("PathIter (flat)", move |b| {
+        b.iter_with_large_drop(|| {
+            let iter = PathIter::new("message");
+            iter.collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("PathIter (nested)", move |b| {
+        b.iter_with_large_drop(|| {
+            let iter = PathIter::new("obj.message");
+            iter.collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("PathIter (nested array)", move |b| {
+        b.iter_with_large_drop(|| {
+            let iter = PathIter::new("obj.messages[2]");
+            iter.collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("PathIter (nested escaped)", move |b| {
+        b.iter_with_large_drop(|| {
+            let iter = PathIter::new("obj.\\messages[]\\");
+            iter.collect::<Vec<_>>()
+        })
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        // degree of noise to ignore in measurements, here 1%
+        .noise_threshold(0.01)
+        // likelihood of noise registering as difference, here 5%
+        .significance_level(0.05)
+        // likelihood of capturing the true runtime, here 95%
+        .confidence_level(0.95)
+        // total number of bootstrap resamples, higher is less noisy but slower
+        .nresamples(100_000)
+        // total samples to collect within the set measurement time
+        .sample_size(150);
+    targets = path_iter
+);
+criterion_main!(benches);

--- a/lib/vector-core/benches/path_iter.rs
+++ b/lib/vector-core/benches/path_iter.rs
@@ -1,7 +1,6 @@
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
-use std::time::Duration;
 use vector_core::event::PathIter;
 
 fn path_iter(c: &mut Criterion) {

--- a/lib/vector-core/build.rs
+++ b/lib/vector-core/build.rs
@@ -1,8 +1,8 @@
 fn main() {
     println!("cargo:rerun-if-changed=proto/event.proto");
-    let mut prost_build = prost_build::Config::new();
-    prost_build.btree_map(&["."]);
-    prost_build
+    let _ = prost_build::Config::new()
+        .btree_map(&["."])
+        .bytes(&["raw_bytes"])
         .compile_protos(&["proto/event.proto"], &["proto/"])
         .unwrap();
 }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -237,7 +237,7 @@ impl From<event::Event> for WithMetadata<EventWrapper> {
 
 fn decode_value(input: Value) -> Option<event::Value> {
     match input.kind {
-        Some(value::Kind::RawBytes(data)) => Some(event::Value::Bytes(data.into())),
+        Some(value::Kind::RawBytes(data)) => Some(event::Value::Bytes(data)),
         Some(value::Kind::Timestamp(ts)) => Some(event::Value::Timestamp(
             chrono::Utc.timestamp(ts.seconds, ts.nanos as u32),
         )),

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -281,7 +281,7 @@ fn decode_array(items: Vec<Value>) -> Option<event::Value> {
 fn encode_value(value: event::Value) -> Value {
     Value {
         kind: match value {
-            event::Value::Bytes(b) => Some(value::Kind::RawBytes(b.to_vec())),
+            event::Value::Bytes(b) => Some(value::Kind::RawBytes(b)),
             event::Value::Timestamp(ts) => Some(value::Kind::Timestamp(prost_types::Timestamp {
                 seconds: ts.timestamp(),
                 nanos: ts.timestamp_subsec_nanos() as i32,

--- a/lib/vector-core/src/event/util/log/contains.rs
+++ b/lib/vector-core/src/event/util/log/contains.rs
@@ -6,7 +6,7 @@ pub fn contains(fields: &BTreeMap<String, Value>, path: &str) -> bool {
     let mut path_iter = PathIter::new(path);
 
     match path_iter.next() {
-        Some(PathComponent::Key(key)) => match fields.get(&key) {
+        Some(PathComponent::Key(key)) => match fields.get(key.as_ref()) {
             None => false,
             Some(value) => value_contains(value, path_iter),
         },
@@ -14,14 +14,14 @@ pub fn contains(fields: &BTreeMap<String, Value>, path: &str) -> bool {
     }
 }
 
-fn value_contains<I>(mut value: &Value, mut path_iter: I) -> bool
+fn value_contains<'a, I>(mut value: &Value, mut path_iter: I) -> bool
 where
-    I: Iterator<Item = PathComponent>,
+    I: Iterator<Item = PathComponent<'a>>,
 {
     loop {
         value = match (path_iter.next(), value) {
             (None, _) => return true,
-            (Some(PathComponent::Key(ref key)), Value::Map(map)) => match map.get(key) {
+            (Some(PathComponent::Key(key)), Value::Map(map)) => match map.get(key.as_ref()) {
                 None => return false,
                 Some(nested_value) => nested_value,
             },

--- a/lib/vector-core/src/event/util/log/get.rs
+++ b/lib/vector-core/src/event/util/log/get.rs
@@ -6,7 +6,7 @@ pub fn get<'a>(fields: &'a BTreeMap<String, Value>, path: &str) -> Option<&'a Va
     let mut path_iter = PathIter::new(path);
 
     match path_iter.next() {
-        Some(PathComponent::Key(key)) => match fields.get(&key) {
+        Some(PathComponent::Key(key)) => match fields.get(key.as_ref()) {
             None => None,
             Some(value) => get_value(value, path_iter),
         },
@@ -15,14 +15,14 @@ pub fn get<'a>(fields: &'a BTreeMap<String, Value>, path: &str) -> Option<&'a Va
 }
 
 /// Returns a reference to a field value specified by a path iter.
-pub fn get_value<I>(mut value: &Value, mut path_iter: I) -> Option<&Value>
+pub fn get_value<'a, I>(mut value: &Value, mut path_iter: I) -> Option<&Value>
 where
-    I: Iterator<Item = PathComponent>,
+    I: Iterator<Item = PathComponent<'a>>,
 {
     loop {
         match (path_iter.next(), value) {
             (None, _) => return Some(value),
-            (Some(PathComponent::Key(ref key)), Value::Map(map)) => match map.get(key) {
+            (Some(PathComponent::Key(key)), Value::Map(map)) => match map.get(key.as_ref()) {
                 None => return None,
                 Some(nested_value) => {
                     value = nested_value;

--- a/lib/vector-core/src/event/util/log/get_mut.rs
+++ b/lib/vector-core/src/event/util/log/get_mut.rs
@@ -6,7 +6,7 @@ pub fn get_mut<'a>(fields: &'a mut BTreeMap<String, Value>, path: &str) -> Optio
     let mut path_iter = PathIter::new(path);
 
     match path_iter.next() {
-        Some(PathComponent::Key(key)) => match fields.get_mut(&key) {
+        Some(PathComponent::Key(key)) => match fields.get_mut(key.as_ref()) {
             None => None,
             Some(value) => get_mut_value(value, path_iter),
         },
@@ -14,14 +14,14 @@ pub fn get_mut<'a>(fields: &'a mut BTreeMap<String, Value>, path: &str) -> Optio
     }
 }
 
-fn get_mut_value<I>(mut value: &mut Value, mut path_iter: I) -> Option<&mut Value>
+fn get_mut_value<'a, I>(mut value: &mut Value, mut path_iter: I) -> Option<&mut Value>
 where
-    I: Iterator<Item = PathComponent>,
+    I: Iterator<Item = PathComponent<'a>>,
 {
     loop {
         match (path_iter.next(), value) {
             (None, value) => return Some(value),
-            (Some(PathComponent::Key(ref key)), Value::Map(map)) => match map.get_mut(key) {
+            (Some(PathComponent::Key(key)), Value::Map(map)) => match map.get_mut(key.as_ref()) {
                 None => return None,
                 Some(nested_value) => {
                     value = nested_value;

--- a/lib/vector-core/src/event/util/log/path_iter.rs
+++ b/lib/vector-core/src/event/util/log/path_iter.rs
@@ -1,26 +1,34 @@
-use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::{mem, str::Chars};
-
-thread_local! {
-    pub static FAST_RE: Regex = Regex::new(r"\A\w+(\.\w+)*\z").unwrap();
-}
+use std::{borrow::Cow, mem, str::Chars};
+use substring::Substring;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub enum PathComponent {
+pub enum PathComponent<'a> {
     /// For example, in `a.b[0].c[2]` the keys are "a", "b", and "c".
-    Key(String),
+    Key(Cow<'a, str>),
     /// For example, in `a.b[0].c[2]` the indexes are 0 and 2.
     Index(usize),
     /// Indicates that a parsing error occurred.
     Invalid,
 }
 
+impl<'a> PathComponent<'a> {
+    pub fn into_static(self) -> PathComponent<'static> {
+        match self {
+            PathComponent::Key(k) => PathComponent::<'static>::Key(k.into_owned().into()),
+            PathComponent::Index(u) => PathComponent::<'static>::Index(u),
+            PathComponent::Invalid => PathComponent::Invalid,
+        }
+    }
+}
+
 /// Iterator over components of paths specified in form `a.b[0].c[2]`.
 pub struct PathIter<'a> {
     path: &'a str,
     chars: Chars<'a>,
-    state: PathIterState<'a>,
+    state: State,
+    temp: String,
+    pos: usize,
 }
 
 impl<'a> PathIter<'a> {
@@ -30,18 +38,17 @@ impl<'a> PathIter<'a> {
             path,
             chars: path.chars(),
             state: Default::default(),
+            temp: String::default(),
+            pos: 0,
         }
     }
 }
 
-/// The parsing is implemented using a state machine. The idea of using Rust
-/// enums to model states is taken from [Pretty State Machine Patterns in
-/// Rust](https://hoverbear.org/blog/rust-state-machine-pattern/).
-enum PathIterState<'a> {
+enum State {
     Start,
-    Fast(std::str::Split<'a, char>),
-    Key(String),
-    KeyEscape(String), // escape mode inside keys entered into after `\` character
+    Key(usize),
+    Escape,
+    EscapedKey,
     Index(usize),
     Dot,
     OpeningBracket,
@@ -50,29 +57,20 @@ enum PathIterState<'a> {
     Invalid,
 }
 
-impl PathIterState<'_> {
-    fn is_start(&self) -> bool {
-        matches!(self, Self::Start)
-    }
-}
-
-impl<'a> Default for PathIterState<'a> {
-    fn default() -> PathIterState<'a> {
-        PathIterState::Start
+impl Default for State {
+    fn default() -> State {
+        State::Start
     }
 }
 
 impl<'a> Iterator for PathIter<'a> {
-    type Item = PathComponent;
+    type Item = PathComponent<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        use PathIterState::{
-            ClosingBracket, Dot, End, Fast, Index, Invalid, Key, KeyEscape, OpeningBracket, Start,
+        use State::{
+            ClosingBracket, Dot, End, Escape, EscapedKey, Index, Invalid, Key, OpeningBracket,
+            Start,
         };
-
-        if self.state.is_start() && FAST_RE.with(|re| re.is_match(self.path)) {
-            self.state = Fast(self.path.split('.'));
-        }
 
         let mut res = None;
         loop {
@@ -84,33 +82,65 @@ impl<'a> Iterator for PathIter<'a> {
             self.state = match mem::take(&mut self.state) {
                 Start => match c {
                     Some('.') | Some('[') | Some(']') | None => Invalid,
-                    Some('\\') => KeyEscape(String::new()),
-                    Some(c) => Key(c.to_string()),
+                    Some('\\') => Escape,
+                    Some(_) => Key(self.pos),
                 },
-                Key(mut s) => match c {
+                Key(start) => match c {
                     Some('.') => {
-                        res = Some(Some(PathComponent::Key(s)));
+                        res = Some(Some(PathComponent::Key(
+                            self.path.substring(start, self.pos).into(),
+                        )));
                         Dot
                     }
                     Some('[') => {
-                        res = Some(Some(PathComponent::Key(s)));
+                        res = Some(Some(PathComponent::Key(
+                            self.path.substring(start, self.pos).into(),
+                        )));
                         OpeningBracket
                     }
                     Some(']') => Invalid,
-                    Some('\\') => KeyEscape(s),
+                    Some('\\') => {
+                        self.temp.push_str(self.path.substring(start, self.pos));
+                        Escape
+                    }
+                    Some(_) => Key(start),
                     None => {
-                        res = Some(Some(PathComponent::Key(s)));
+                        res = Some(Some(PathComponent::Key(
+                            self.path.substring(start, self.pos).into(),
+                        )));
                         End
                     }
+                },
+                EscapedKey => match c {
+                    Some('.') => {
+                        res = Some(Some(PathComponent::Key(
+                            std::mem::take(&mut self.temp).into(),
+                        )));
+                        Dot
+                    }
+                    Some('[') => {
+                        res = Some(Some(PathComponent::Key(
+                            std::mem::take(&mut self.temp).into(),
+                        )));
+                        OpeningBracket
+                    }
+                    Some(']') => Invalid,
+                    Some('\\') => Escape,
                     Some(c) => {
-                        s.push(c);
-                        Key(s)
+                        self.temp.push(c);
+                        EscapedKey
+                    }
+                    None => {
+                        res = Some(Some(PathComponent::Key(
+                            std::mem::take(&mut self.temp).into(),
+                        )));
+                        End
                     }
                 },
-                KeyEscape(mut s) => match c {
+                Escape => match c {
                     Some(c) if c == '.' || c == '[' || c == ']' || c == '\\' => {
-                        s.push(c);
-                        Key(s)
+                        self.temp.push(c);
+                        EscapedKey
                     }
                     _ => Invalid,
                 },
@@ -126,8 +156,8 @@ impl<'a> Iterator for PathIter<'a> {
                 },
                 Dot => match c {
                     Some('.') | Some('[') | Some(']') | None => Invalid,
-                    Some('\\') => KeyEscape(String::new()),
-                    Some(c) => Key(c.to_string()),
+                    Some('\\') => Escape,
+                    Some(_) => Key(self.pos),
                 },
                 OpeningBracket => match c {
                     Some(c) if ('0'..='9').contains(&c) => Index(c as usize - '0' as usize),
@@ -147,11 +177,8 @@ impl<'a> Iterator for PathIter<'a> {
                     res = Some(Some(PathComponent::Invalid));
                     End
                 }
-                Fast(mut iter) => {
-                    res = Some(iter.next().map(|s| PathComponent::Key(s.to_string())));
-                    Fast(iter)
-                }
-            }
+            };
+            self.pos += 1;
         }
     }
 }
@@ -162,7 +189,7 @@ mod test {
 
     #[test]
     fn path_iter_elementary() {
-        let actual: Vec<_> = PathIter::new(&"squirrel".to_string()).collect();
+        let actual: Vec<_> = PathIter::new("squirrel").collect();
         let expected = vec![PathComponent::Key("squirrel".into())];
         assert_eq!(actual, expected);
     }

--- a/lib/vector-core/src/event/util/log/remove.rs
+++ b/lib/vector-core/src/event/util/log/remove.rs
@@ -43,13 +43,13 @@ fn remove_map(
 ) -> Option<(Value, bool)> {
     match path.next()? {
         PathComponent::Key(key) => match path.peek() {
-            None => fields.remove(&key).map(|v| (v, fields.is_empty())),
+            None => fields.remove(key.as_ref()).map(|v| (v, fields.is_empty())),
             Some(_) => {
                 let (result, empty) = fields
-                    .get_mut(&key)
+                    .get_mut(key.as_ref())
                     .and_then(|value| remove_rec(value, path, prune))?;
                 if prune && empty {
-                    fields.remove(&key);
+                    fields.remove(key.as_ref());
                 }
                 Some((result, fields.is_empty()))
             }

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -126,6 +126,10 @@ pub struct Runtime {
 }
 
 impl Runtime {
+    pub fn is_empty(&self) -> bool {
+        self.variables.is_empty()
+    }
+
     pub fn clear(&mut self) {
         self.variables.clear();
     }

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -126,6 +126,10 @@ pub struct Runtime {
 }
 
 impl Runtime {
+    pub fn clear(&mut self) {
+        self.variables.clear();
+    }
+
     pub fn variable(&self, ident: &Ident) -> Option<&Value> {
         self.variables.get(ident)
     }

--- a/lib/vrl/core/src/runtime.rs
+++ b/lib/vrl/core/src/runtime.rs
@@ -49,6 +49,10 @@ impl Runtime {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.state.is_empty()
+    }
+
     pub fn clear(&mut self) {
         self.state.clear();
     }

--- a/lib/vrl/core/src/runtime.rs
+++ b/lib/vrl/core/src/runtime.rs
@@ -9,6 +9,7 @@ pub type RuntimeResult = Result<Value, Terminate>;
 #[derive(Debug, Default)]
 pub struct Runtime {
     state: state::Runtime,
+    root_lookup: LookupBuf,
 }
 
 /// The error raised if the runtime is terminated.
@@ -42,7 +43,14 @@ impl Error for Terminate {
 
 impl Runtime {
     pub fn new(state: state::Runtime) -> Self {
-        Self { state }
+        Self {
+            state,
+            root_lookup: LookupBuf::root(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.state.clear();
     }
 
     /// Given the provided [`Target`], resolve the provided [`Program`] to
@@ -57,7 +65,7 @@ impl Runtime {
         //
         // VRL technically supports any `Value` object as the root, but the
         // assumption is people are expected to use it to query objects.
-        match target.get(&LookupBuf::root()) {
+        match target.get(&self.root_lookup) {
             Ok(Some(Value::Object(_))) => {}
             Ok(Some(value)) => {
                 return Err(Terminate::Error(

--- a/src/sinks/datadog/events.rs
+++ b/src/sinks/datadog/events.rs
@@ -171,7 +171,7 @@ impl DatadogEventsService {
                     "title",
                 ]
                 .iter()
-                .map(|field| vec![PathComponent::Key(field.to_string())])
+                .map(|field| vec![PathComponent::Key((*field).into())])
                 .collect(),
             ),
             // DataDog Event API requires unix timestamp.

--- a/src/sinks/util/encoding/config.rs
+++ b/src/sinks/util/encoding/config.rs
@@ -26,7 +26,7 @@ pub struct EncodingConfig<E> {
     pub(crate) schema: Option<String>,
     // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
-    pub(crate) only_fields: Option<Vec<Vec<PathComponent>>>,
+    pub(crate) only_fields: Option<Vec<Vec<PathComponent<'static>>>>,
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) except_fields: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
@@ -41,7 +41,7 @@ impl<E> EncodingConfiguration<E> for EncodingConfig<E> {
         &self.schema
     }
     // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-    fn only_fields(&self) -> &Option<Vec<Vec<PathComponent>>> {
+    fn only_fields(&self) -> &Option<Vec<Vec<PathComponent<'static>>>> {
         &self.only_fields
     }
     fn except_fields(&self) -> &Option<Vec<String>> {
@@ -156,7 +156,11 @@ where
             only_fields: inner.only_fields.map(|fields| {
                 fields
                     .iter()
-                    .map(|only| PathIter::new(only).collect())
+                    .map(|only| {
+                        PathIter::new(only)
+                            .map(|component| component.into_static())
+                            .collect()
+                    })
                     .collect()
             }),
             except_fields: inner.except_fields,

--- a/src/sinks/util/encoding/with_default.rs
+++ b/src/sinks/util/encoding/with_default.rs
@@ -27,7 +27,7 @@ pub struct EncodingConfigWithDefault<E: Default + PartialEq> {
     /// Keep only the following fields of the message. (Items mutually exclusive with `except_fields`)
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-    pub(crate) only_fields: Option<Vec<Vec<PathComponent>>>,
+    pub(crate) only_fields: Option<Vec<Vec<PathComponent<'static>>>>,
     /// Remove the following fields of the message. (Items mutually exclusive with `only_fields`)
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) except_fields: Option<Vec<String>>,
@@ -44,7 +44,7 @@ impl<E: Default + PartialEq> EncodingConfiguration<E> for EncodingConfigWithDefa
         &self.schema
     }
     // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-    fn only_fields(&self) -> &Option<Vec<Vec<PathComponent>>> {
+    fn only_fields(&self) -> &Option<Vec<Vec<PathComponent<'static>>>> {
         &self.only_fields
     }
     fn except_fields(&self) -> &Option<Vec<String>> {
@@ -133,7 +133,11 @@ where
             only_fields: inner.only_fields.map(|fields| {
                 fields
                     .iter()
-                    .map(|only| PathIter::new(only).collect())
+                    .map(|only| {
+                        PathIter::new(only)
+                            .map(|component| component.into_static())
+                            .collect()
+                    })
                     .collect()
             }),
             except_fields: inner.except_fields,

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -285,7 +285,7 @@ impl<'a> DnstapParser<'a> {
 
             if dnstap_message.query_message != None {
                 self.parent_key_path
-                    .push(PathComponent::Key(request_message_key.clone().into()));
+                    .push(PathComponent::Key(request_message_key.into()));
 
                 let time_key_name = if dnstap_message_type_id <= MAX_DNSTAP_QUERY_MESSAGE_TYPE_ID {
                     self.event_schema.dns_query_message_schema().time()
@@ -342,7 +342,7 @@ impl<'a> DnstapParser<'a> {
 
             if dnstap_message.response_message != None {
                 self.parent_key_path
-                    .push(PathComponent::Key(response_message_key.clone().into()));
+                    .push(PathComponent::Key(response_message_key.into()));
 
                 let time_key_name = if dnstap_message_type_id <= MAX_DNSTAP_QUERY_MESSAGE_TYPE_ID {
                     self.event_schema.dns_query_message_schema().time()
@@ -376,11 +376,11 @@ impl<'a> DnstapParser<'a> {
             1..=12 => {
                 if let Some(query_message) = dnstap_message.query_message {
                     let mut query_message_parser = DnsMessageParser::new(query_message);
-                    if let Err(error) = self
-                        .parse_dns_query_message(&request_message_key, &mut query_message_parser)
+                    if let Err(error) =
+                        self.parse_dns_query_message(request_message_key, &mut query_message_parser)
                     {
                         self.log_raw_dns_message(
-                            &request_message_key,
+                            request_message_key,
                             query_message_parser.raw_message(),
                         );
 
@@ -390,12 +390,11 @@ impl<'a> DnstapParser<'a> {
 
                 if let Some(response_message) = dnstap_message.response_message {
                     let mut response_message_parser = DnsMessageParser::new(response_message);
-                    if let Err(error) = self.parse_dns_query_message(
-                        &response_message_key,
-                        &mut response_message_parser,
-                    ) {
+                    if let Err(error) = self
+                        .parse_dns_query_message(response_message_key, &mut response_message_parser)
+                    {
                         self.log_raw_dns_message(
-                            &response_message_key,
+                            response_message_key,
                             response_message_parser.raw_message(),
                         );
 
@@ -408,11 +407,11 @@ impl<'a> DnstapParser<'a> {
                     let mut update_request_message_parser =
                         DnsMessageParser::new(update_request_message);
                     if let Err(error) = self.parse_dns_update_message(
-                        &request_message_key,
+                        request_message_key,
                         &mut update_request_message_parser,
                     ) {
                         self.log_raw_dns_message(
-                            &request_message_key,
+                            request_message_key,
                             update_request_message_parser.raw_message(),
                         );
 
@@ -424,11 +423,11 @@ impl<'a> DnstapParser<'a> {
                     let mut update_response_message_parser =
                         DnsMessageParser::new(update_response_message);
                     if let Err(error) = self.parse_dns_update_message(
-                        &response_message_key,
+                        response_message_key,
                         &mut update_response_message_parser,
                     ) {
                         self.log_raw_dns_message(
-                            &response_message_key,
+                            response_message_key,
                             update_response_message_parser.raw_message(),
                         );
 

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -68,7 +68,7 @@ lazy_static! {
 
 pub struct DnstapParser<'a> {
     event_schema: &'a DnstapEventSchema,
-    parent_key_path: Vec<PathComponent>,
+    parent_key_path: Vec<PathComponent<'static>>,
     log_event: &'a mut LogEvent,
 }
 
@@ -94,7 +94,7 @@ impl<'a> DnstapParser<'a> {
         V: Into<Value> + Debug,
     {
         let mut node_path = self.parent_key_path.clone();
-        node_path.push(PathComponent::Key(key.to_string()));
+        node_path.push(PathComponent::Key(key.into()));
         self.log_event.insert_path(node_path, value)
     }
 
@@ -256,16 +256,8 @@ impl<'a> DnstapParser<'a> {
             to_dnstap_message_type(dnstap_message_type_id),
         );
 
-        let request_message_key = self
-            .event_schema
-            .dnstap_message_schema()
-            .request_message()
-            .to_string();
-        let response_message_key = self
-            .event_schema
-            .dnstap_message_schema()
-            .response_message()
-            .to_string();
+        let request_message_key = self.event_schema.dnstap_message_schema().request_message();
+        let response_message_key = self.event_schema.dnstap_message_schema().response_message();
 
         if let Some(query_time_sec) = dnstap_message.query_time_sec {
             let (time_in_nanosec, query_time_nsec) = match dnstap_message.query_time_nsec {
@@ -293,7 +285,7 @@ impl<'a> DnstapParser<'a> {
 
             if dnstap_message.query_message != None {
                 self.parent_key_path
-                    .push(PathComponent::Key(request_message_key.clone()));
+                    .push(PathComponent::Key(request_message_key.clone().into()));
 
                 let time_key_name = if dnstap_message_type_id <= MAX_DNSTAP_QUERY_MESSAGE_TYPE_ID {
                     self.event_schema.dns_query_message_schema().time()
@@ -350,7 +342,7 @@ impl<'a> DnstapParser<'a> {
 
             if dnstap_message.response_message != None {
                 self.parent_key_path
-                    .push(PathComponent::Key(response_message_key.clone()));
+                    .push(PathComponent::Key(response_message_key.clone().into()));
 
                 let time_key_name = if dnstap_message_type_id <= MAX_DNSTAP_QUERY_MESSAGE_TYPE_ID {
                     self.event_schema.dns_query_message_schema().time()
@@ -468,9 +460,9 @@ impl<'a> DnstapParser<'a> {
         self.insert(time_precision_key, time_precision.to_string());
     }
 
-    fn log_raw_dns_message(&mut self, key_prefix: &str, raw_dns_message: &[u8]) {
+    fn log_raw_dns_message(&mut self, key_prefix: &'static str, raw_dns_message: &[u8]) {
         self.parent_key_path
-            .push(PathComponent::Key(key_prefix.to_string()));
+            .push(PathComponent::Key(key_prefix.into()));
 
         self.insert(
             self.event_schema.dns_query_message_schema().raw_data(),
@@ -482,13 +474,13 @@ impl<'a> DnstapParser<'a> {
 
     fn parse_dns_query_message(
         &mut self,
-        key_prefix: &str,
+        key_prefix: &'static str,
         dns_message_parser: &mut DnsMessageParser,
     ) -> Result<()> {
         let msg = dns_message_parser.parse_as_query_message()?;
 
         self.parent_key_path
-            .push(PathComponent::Key(key_prefix.to_string()));
+            .push(PathComponent::Key(key_prefix.into()));
 
         self.insert(
             self.event_schema.dns_query_message_schema().response_code(),
@@ -546,9 +538,9 @@ impl<'a> DnstapParser<'a> {
         Ok(())
     }
 
-    fn log_dns_query_message_header(&mut self, parent_key: &str, header: &QueryHeader) {
+    fn log_dns_query_message_header(&mut self, parent_key: &'static str, header: &QueryHeader) {
         self.parent_key_path
-            .push(PathComponent::Key(parent_key.to_string()));
+            .push(PathComponent::Key(parent_key.into()));
 
         self.insert(
             self.event_schema.dns_query_header_schema().id(),
@@ -627,9 +619,13 @@ impl<'a> DnstapParser<'a> {
         self.parent_key_path.pop();
     }
 
-    fn log_dns_query_message_query_section(&mut self, key_path: &str, questions: &[QueryQuestion]) {
+    fn log_dns_query_message_query_section(
+        &mut self,
+        key_path: &'static str,
+        questions: &[QueryQuestion],
+    ) {
         self.parent_key_path
-            .push(PathComponent::Key(key_path.to_string()));
+            .push(PathComponent::Key(key_path.into()));
 
         for (i, query) in questions.iter().enumerate() {
             self.parent_key_path.push(PathComponent::Index(i));
@@ -667,13 +663,13 @@ impl<'a> DnstapParser<'a> {
 
     fn parse_dns_update_message(
         &mut self,
-        key_prefix: &str,
+        key_prefix: &'static str,
         dns_message_parser: &mut DnsMessageParser,
     ) -> Result<()> {
         let msg = dns_message_parser.parse_as_update_message()?;
 
         self.parent_key_path
-            .push(PathComponent::Key(key_prefix.to_string()));
+            .push(PathComponent::Key(key_prefix.into()));
 
         self.insert(
             self.event_schema
@@ -724,9 +720,9 @@ impl<'a> DnstapParser<'a> {
         Ok(())
     }
 
-    fn log_dns_update_message_header(&mut self, key_prefix: &str, header: &UpdateHeader) {
+    fn log_dns_update_message_header(&mut self, key_prefix: &'static str, header: &UpdateHeader) {
         self.parent_key_path
-            .push(PathComponent::Key(key_prefix.to_string()));
+            .push(PathComponent::Key(key_prefix.into()));
 
         self.insert(
             self.event_schema.dns_update_header_schema().id(),
@@ -775,9 +771,9 @@ impl<'a> DnstapParser<'a> {
         self.parent_key_path.pop();
     }
 
-    fn log_dns_update_message_zone_section(&mut self, key_path: &str, zone: &ZoneInfo) {
+    fn log_dns_update_message_zone_section(&mut self, key_path: &'static str, zone: &ZoneInfo) {
         self.parent_key_path
-            .push(PathComponent::Key(key_path.to_string()));
+            .push(PathComponent::Key(key_path.into()));
 
         self.insert(
             self.event_schema.dns_update_zone_info_schema().zone_name(),
@@ -803,9 +799,9 @@ impl<'a> DnstapParser<'a> {
         self.parent_key_path.pop();
     }
 
-    fn log_edns(&mut self, key_prefix: &str, opt_section: &Option<OptPseudoSection>) {
+    fn log_edns(&mut self, key_prefix: &'static str, opt_section: &Option<OptPseudoSection>) {
         self.parent_key_path
-            .push(PathComponent::Key(key_prefix.to_string()));
+            .push(PathComponent::Key(key_prefix.into()));
 
         if let Some(edns) = opt_section {
             self.insert(
@@ -843,9 +839,9 @@ impl<'a> DnstapParser<'a> {
         self.parent_key_path.pop();
     }
 
-    fn log_edns_options(&mut self, key_path: &str, options: &[EdnsOptionEntry]) {
+    fn log_edns_options(&mut self, key_path: &'static str, options: &[EdnsOptionEntry]) {
         self.parent_key_path
-            .push(PathComponent::Key(key_path.to_string()));
+            .push(PathComponent::Key(key_path.into()));
 
         options.iter().enumerate().for_each(|(i, opt)| {
             self.parent_key_path.push(PathComponent::Index(i));
@@ -871,9 +867,9 @@ impl<'a> DnstapParser<'a> {
         );
     }
 
-    fn log_dns_message_record_section(&mut self, key_path: &str, records: &[DnsRecord]) {
+    fn log_dns_message_record_section(&mut self, key_path: &'static str, records: &[DnsRecord]) {
         self.parent_key_path
-            .push(PathComponent::Key(key_path.to_string()));
+            .push(PathComponent::Key(key_path.into()));
 
         for (i, record) in records.iter().enumerate() {
             self.parent_key_path.push(PathComponent::Index(i));

--- a/src/sources/dnstap/schema.rs
+++ b/src/sources/dnstap/schema.rs
@@ -1,4 +1,4 @@
-use getset::{Getters, MutGetters, Setters};
+use getset::{CopyGetters, Getters, MutGetters, Setters};
 
 #[derive(Getters, MutGetters, Default, Debug, Clone)]
 #[get = "pub"]
@@ -35,8 +35,8 @@ impl DnstapEventSchema {
     }
 }
 
-#[derive(Getters, Setters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Setters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnstapRootDataSchema {
     server_identity: &'static str,
     server_version: &'static str,
@@ -68,8 +68,8 @@ impl Default for DnstapRootDataSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnstapMessageSchema {
     socket_family: &'static str,
     socket_protocol: &'static str,
@@ -102,8 +102,8 @@ impl Default for DnstapMessageSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsMessageCommonSchema {
     response_code: &'static str,
     response: &'static str,
@@ -126,8 +126,8 @@ impl Default for DnsMessageCommonSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsQueryMessageSchema {
     response_code: &'static str,
     response: &'static str,
@@ -161,8 +161,8 @@ impl Default for DnsQueryMessageSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsUpdateMessageSchema {
     response_code: &'static str,
     response: &'static str,
@@ -194,8 +194,8 @@ impl Default for DnsUpdateMessageSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsMessageHeaderCommonSchema {
     id: &'static str,
     opcode: &'static str,
@@ -214,8 +214,8 @@ impl Default for DnsMessageHeaderCommonSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsQueryHeaderSchema {
     id: &'static str,
     opcode: &'static str,
@@ -255,8 +255,8 @@ impl Default for DnsQueryHeaderSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsUpdateHeaderSchema {
     id: &'static str,
     opcode: &'static str,
@@ -284,8 +284,8 @@ impl Default for DnsUpdateHeaderSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsMessageOptPseudoSectionSchema {
     extended_rcode: &'static str,
     version: &'static str,
@@ -306,8 +306,8 @@ impl Default for DnsMessageOptPseudoSectionSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsMessageOptionSchema {
     opt_code: &'static str,
     opt_name: &'static str,
@@ -324,8 +324,8 @@ impl Default for DnsMessageOptionSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsRecordSchema {
     name: &'static str,
     record_type: &'static str,
@@ -350,8 +350,8 @@ impl Default for DnsRecordSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsQueryQuestionSchema {
     name: &'static str,
     question_type: &'static str,
@@ -370,8 +370,8 @@ impl Default for DnsQueryQuestionSchema {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
-#[get = "pub"]
+#[derive(CopyGetters, Debug, Clone)]
+#[get_copy = "pub"]
 pub struct DnsUpdateZoneInfoSchema {
     zone_name: &'static str,
     zone_class: &'static str,

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -888,7 +888,7 @@ impl ContainerLogInfo {
                 let prefix_path = PathIter::new("label").collect::<Vec<_>>();
                 for (key, value) in self.metadata.labels.iter() {
                     let mut path = prefix_path.clone();
-                    path.push(PathComponent::Key(key.clone()));
+                    path.push(PathComponent::Key(key.clone().into()));
                     log_event.insert_path(path, value.clone());
                 }
             }

--- a/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
@@ -63,7 +63,7 @@ fn annotate_from_metadata(log: &mut LogEvent, fields_spec: &FieldsSpec, metadata
     if let Some(labels) = &metadata.labels {
         for (key, val) in labels.iter() {
             let mut path = prefix_path.clone();
-            path.push(PathComponent::Key(key.clone()));
+            path.push(PathComponent::Key(key.clone().into()));
             log.insert_path(path, val.to_owned());
         }
     }

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -138,7 +138,7 @@ fn annotate_from_metadata(log: &mut LogEvent, fields_spec: &FieldsSpec, metadata
         let prefix_path = PathIter::new(fields_spec.pod_labels.as_ref()).collect::<Vec<_>>();
         for (key, val) in labels.iter() {
             let mut path = prefix_path.clone();
-            path.push(PathComponent::Key(key.clone()));
+            path.push(PathComponent::Key(key.clone().into()));
             log.insert_path(path, val.to_owned());
         }
     }
@@ -147,7 +147,7 @@ fn annotate_from_metadata(log: &mut LogEvent, fields_spec: &FieldsSpec, metadata
         let prefix_path = PathIter::new(fields_spec.pod_annotations.as_ref()).collect::<Vec<_>>();
         for (key, val) in annotations.iter() {
             let mut path = prefix_path.clone();
-            path.push(PathComponent::Key(key.clone()));
+            path.push(PathComponent::Key(key.clone().into()));
             log.insert_path(path, val.to_owned());
         }
     }

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -87,7 +87,7 @@ pub struct GrokParser {
     field: String,
     drop_field: bool,
     types: HashMap<String, Conversion>,
-    paths: HashMap<String, Vec<PathComponent>>,
+    paths: HashMap<String, Vec<PathComponent<'static>>>,
 }
 
 impl Clone for GrokParser {
@@ -119,7 +119,9 @@ impl FunctionTransform for GrokParser {
                             if let Some(path) = self.paths.get(name) {
                                 event.insert_path(path.to_vec(), value);
                             } else {
-                                let path = PathIter::new(name).collect::<Vec<_>>();
+                                let path = PathIter::new(name)
+                                    .map(|component| component.into_static())
+                                    .collect::<Vec<_>>();
                                 self.paths.insert(name.to_string(), path.clone());
                                 event.insert_path(path, value);
                             }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -102,6 +102,7 @@ impl Remap {
         })
     }
 
+    #[cfg(test)]
     fn runtime(&self) -> &Runtime {
         &self.runtime
     }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -101,6 +101,10 @@ impl Remap {
             drop_on_abort: config.drop_on_abort,
         })
     }
+
+    fn runtime(&self) -> &Runtime {
+        &self.runtime
+    }
 }
 
 impl Clone for Remap {
@@ -136,10 +140,10 @@ impl FunctionTransform for Remap {
 
         let mut target: VrlTarget = event.into();
 
-        self.runtime.clear();
         let result = self
             .runtime
             .resolve(&mut target, &self.program, &self.timezone);
+        self.runtime.clear();
 
         match result {
             Ok(_) => {
@@ -248,6 +252,7 @@ mod tests {
             drop_on_abort: false,
         };
         let mut tform = Remap::new(conf, &Default::default()).unwrap();
+        assert!(tform.runtime().is_empty());
 
         let event1 = {
             let mut event1 = LogEvent::from("event1");
@@ -259,6 +264,7 @@ mod tests {
         assert_eq!(get_field_string(&result1, "message"), "event1");
         assert_eq!(get_field_string(&result1, "foo"), "bar");
         assert_eq!(result1.metadata(), &metadata1);
+        assert!(tform.runtime().is_empty());
 
         let event2 = {
             let event2 = LogEvent::from("event2");
@@ -269,6 +275,7 @@ mod tests {
         assert_eq!(get_field_string(&result2, "message"), "event2");
         assert_eq!(result2.as_log().get("foo"), Some(&Value::Null));
         assert_eq!(result2.metadata(), &metadata2);
+        assert!(tform.runtime().is_empty());
     }
 
     #[test]

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -261,14 +261,13 @@ mod tests {
         assert_eq!(result1.metadata(), &metadata1);
 
         let event2 = {
-            let mut event2 = LogEvent::from("event2");
-            event2.insert("sentinel", "quux");
+            let event2 = LogEvent::from("event2");
             Event::from(event2)
         };
         let metadata2 = event2.metadata().clone();
         let result2 = transform_one(&mut tform, event2).unwrap();
         assert_eq!(get_field_string(&result2, "message"), "event2");
-        assert_eq!(get_field_string(&result2, "foo"), "quux");
+        assert_eq!(result2.as_log().get("foo"), Some(&Value::Null));
         assert_eq!(result2.metadata(), &metadata2);
     }
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -54,9 +54,10 @@ impl TransformConfig for RemapConfig {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Remap {
     program: Program,
+    runtime: Runtime,
     timezone: TimeZone,
     drop_on_error: bool,
     drop_on_abort: bool,
@@ -94,10 +95,23 @@ impl Remap {
 
         Ok(Remap {
             program,
+            runtime: Runtime::default(),
             timezone: config.timezone,
             drop_on_error: config.drop_on_error,
             drop_on_abort: config.drop_on_abort,
         })
+    }
+}
+
+impl Clone for Remap {
+    fn clone(&self) -> Self {
+        Self {
+            program: self.program.clone(),
+            runtime: Runtime::default(),
+            timezone: self.timezone.clone(),
+            drop_on_error: self.drop_on_error,
+            drop_on_abort: self.drop_on_abort,
+        }
     }
 }
 
@@ -122,9 +136,10 @@ impl FunctionTransform for Remap {
 
         let mut target: VrlTarget = event.into();
 
-        let mut runtime = Runtime::default();
-
-        let result = runtime.resolve(&mut target, &self.program, &self.timezone);
+        self.runtime.clear();
+        let result = self
+            .runtime
+            .resolve(&mut target, &self.program, &self.timezone);
 
         match result {
             Ok(_) => {

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -103,7 +103,7 @@ impl Remap {
     }
 
     #[cfg(test)]
-    fn runtime(&self) -> &Runtime {
+    const fn runtime(&self) -> &Runtime {
         &self.runtime
     }
 }

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -65,7 +65,7 @@ impl TransformConfig for TokenizerConfig {
 
 #[derive(Clone, Debug)]
 pub struct Tokenizer {
-    field_names: Vec<(String, Vec<PathComponent>, Conversion)>,
+    field_names: Vec<(String, Vec<PathComponent<'static>>, Conversion)>,
     field: String,
     drop_field: bool,
 }
@@ -81,7 +81,9 @@ impl Tokenizer {
             .into_iter()
             .map(|name| {
                 let conversion = types.get(&name).unwrap_or(&Conversion::Bytes).clone();
-                let path: Vec<PathComponent> = PathIter::new(&name).collect();
+                let path: Vec<PathComponent<'static>> = PathIter::new(name.as_str())
+                    .map(|component| component.into_static())
+                    .collect();
                 (name, path, conversion)
             })
             .collect();


### PR DESCRIPTION
We've reworked `PathIter` to avoid allocations where possible, as well as using the regular expression "fast path".

In profiling when investigating an issue reported by a user -- unexpectedly high memory usage (RSS specifically) -- it was determined that the bulk of allocations in their workload came from using the `remap` transform.  This was due to the nature of `PathIter`, allocating strings as it parsed paths, as well as running a regular expression over the input path to determine if a "fast path" could be taken.

We've reworked `PathIter` to remove this regular expression, as well as the fast path.  Instead, we parameterized `PathIter` over the lifetime of the input path, such that we can optimally return borrowed substrings when possible, only falling back to allocating when skipping characters is required, such as within escaped sequences.

A benchmark was written to demonstrate the performance gains, as evidenced below:

```
vector_core::event::util::log/PathIterOld (flat)                                                                            
                        time:   [98.540 ns 98.722 ns 98.930 ns]
vector_core::event::util::log/PathIterOld (nested)                                                                            
                        time:   [172.81 ns 173.00 ns 173.21 ns]
vector_core::event::util::log/PathIterOld (nested array)                                                                            
                        time:   [293.00 ns 293.58 ns 294.45 ns]
vector_core::event::util::log/PathIterOld (nested escaped)                                                                            
                        time:   [163.77 ns 164.12 ns 164.52 ns]

vector_core::event::util::log/PathIterNew (flat)                                                                            
                        time:   [57.294 ns 57.636 ns 57.993 ns]
vector_core::event::util::log/PathIterNew (nested)                                                                            
                        time:   [106.08 ns 106.26 ns 106.45 ns]
vector_core::event::util::log/PathIterNew (nested array)                                                                            
                        time:   [122.74 ns 123.29 ns 123.88 ns]
vector_core::event::util::log/PathIterNew (nested escaped)                                                                            
                        time:   [77.494 ns 77.729 ns 77.981 ns]
```

The results are fairly impressive: at the very low end, the new version is 60% faster, with some tests showing a staggering improvement of nearly 250%.  As well, we've significantly reduced allocations.  In the case of a path without escaped sequences, we perform no extra allocations in order to return the path components.  In the case of escaped sequences, we allocate a single `String` to serve as temporary storage, which likely will grow once or twice depending on the overall path length, but is reused for subsequent components.

As further evidence, this change was able to help reduce the RSS usage of aforementioned use case by around 15-20%.

## Bonus change: more efficient encoding for the `vector` v2 sink

We've also improved the efficiency of the `vector` v2 sink by configuring `prost` to use `Bytes` as the underlying storage for for the `raw_bytes` field when encoding `Value::Bytes`.  This lets us avoid an allocation to create a `Vec<u8>`, since we already use `Bytes` as the internal representation.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>