### PR TITLE
chore(buffers): Fix compilation issues when disk buffers are not enabled

### DIFF
--- a/lib/vector-core/buffers/src/lib.rs
+++ b/lib/vector-core/buffers/src/lib.rs
@@ -37,6 +37,7 @@ pub use variant::*;
 ///
 /// This function will fail only when creating a new disk buffer. Because of
 /// legacy reasons the error is not a type but a `String`.
+#[allow(clippy::needless_pass_by_value)]
 pub fn build<'a, T>(
     variant: Variant,
 ) -> Result<

--- a/lib/vector-core/buffers/src/variant/memory_only.rs
+++ b/lib/vector-core/buffers/src/variant/memory_only.rs
@@ -2,7 +2,7 @@ use crate::WhenFull;
 #[cfg(test)]
 use quickcheck::{Arbitrary, Gen};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum Variant {
     Memory {
         max_events: usize,


### PR DESCRIPTION
Found by running `cargo clippy --workspace --all-targets --no-default-features` which does not enable the disk buffer path. Running `make check-clippy` runs with all features enabled, so this no-disk-buffer path is never tested by default.

Closes #9309 

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>