### PR TITLE
fix(vrl): reverse if else alternatives before nesting

### DIFF
--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -423,10 +423,10 @@ IfStatement: IfStatement =
     <predicate: Sp<Predicate>>
     NonterminalNewline*
     <consequent: Sp<Block>>
-    <alternatives: (Sp<ElseIf>)*>
+    <mut alternatives: (Sp<ElseIf>)*>
     <alternative: ("else" NonterminalNewline* <Sp<Block>>)?> => {
         let mut alternative = alternative;
-
+        alternatives.reverse();
         for Node { span, mut node } in alternatives {
             node.alternative = alternative;
             let node = Node::new(span, Expr::IfStatement(Node::new(span, node)));

--- a/lib/vrl/tests/tests/expressions/if_statement/nested_if_else.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/nested_if_else.vrl
@@ -1,0 +1,18 @@
+# result: ["1xx", "2xx", "3xx", "4xx", null]
+
+status_code = 150
+a1 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
+
+status_code = 250
+a2 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
+
+status_code = 350
+a3 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
+
+status_code = 450
+a4 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
+
+status_code = 550
+a5 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
+
+[a1, a2, a3, a4, a5]


### PR DESCRIPTION
Closes #8284 

The VRL parser was nesting the alternatives to `if..else` in the order they were parsed, which meant the first `if..else` became the most nested and thus the final predicate checked. This is the wrong order. This PR reverses the alternatives so the last gets nested deepest.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
