### PR TITLE
enhancement(enriching): enable enrichment file reload on SIGHUP

### DIFF
--- a/benches/enrichment_tables_file.rs
+++ b/benches/enrichment_tables_file.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use enrichment::Case;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::SystemTime};
 use vector::enrichment_tables::{file::File, Condition, Table};
 use vrl::Value;
 
@@ -38,6 +38,9 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
             .collect::<Vec<_>>();
 
         let mut file = File::new(
+            Default::default(),
+            Default::default(),
+            SystemTime::now(),
             data,
             // Headers.
             (0..10)


### PR DESCRIPTION
This allows the enrichment files to reload the data when Vector receives a SIGHUP.

The implementation may raise some eyebrows as I have put the main functionality into the `clone` method of the `File` struct. 

The issue is that on reload I want to either clone the object or create a new object with the reloaded data. Since enrichment tables are represented in Vector as `Box<dyn Table>`, the trait can't return `Self`. Clone currently  works because of `dyn_clone` which pulls a number of unsafe tricks in order to work.

In order to perform the reload Table also needs to return `Self` in order to return the object representing the reloaded data. Since Clone is the only way to do that, I have had to put the reload functionality there.

It doesn't sit 100% well with me, so if there are any other suggestions I would appreciate it.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
