### PR TITLE
enhancement(compound transform): hide intermediate steps from the topolgy

### DIFF
--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -550,11 +550,17 @@ impl Metric {
                 }
             }
         };
+        let mut labels = MetricTags::new();
 
-        let labels = key
-            .labels()
-            .map(|label| (String::from(label.key()), String::from(label.value())))
-            .collect::<MetricTags>();
+        key.labels().for_each(|label| {
+            let k = String::from(label.key());
+            let v = if let Some(old_v) = labels.get(&k) {
+                format!("{}.{}", label.value(), old_v)
+            } else {
+                String::from(label.value())
+            };
+            labels.insert(k, v);
+        });
 
         Self::new(key.name().to_string(), MetricKind::Absolute, value)
             .with_namespace(Some("vector"))

--- a/src/internal_events/compound.rs
+++ b/src/internal_events/compound.rs
@@ -1,0 +1,13 @@
+use metrics::counter;
+use vector_core::internal_event::InternalEvent;
+
+#[derive(Debug)]
+pub struct CompoundErrorEvents {
+    pub count: usize,
+}
+
+impl InternalEvent for CompoundErrorEvents {
+    fn emit_metrics(&self) {
+        counter!("processing_errors_total", self.count as u64, "error_type" => "transform_failed");
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -32,6 +32,8 @@ mod blackhole;
 #[cfg(feature = "transforms-coercer")]
 mod coercer;
 mod common;
+#[cfg(feature = "transforms-compound")]
+mod compound;
 #[cfg(feature = "transforms-concat")]
 mod concat;
 mod conditions;
@@ -182,6 +184,8 @@ pub use self::blackhole::*;
 #[cfg(feature = "transforms-coercer")]
 pub(crate) use self::coercer::*;
 pub use self::common::*;
+#[cfg(feature = "transforms-compound")]
+pub use self::compound::*;
 #[cfg(feature = "transforms-concat")]
 pub use self::concat::*;
 pub use self::conditions::*;

--- a/src/transforms/compound.rs
+++ b/src/transforms/compound.rs
@@ -1,24 +1,17 @@
 use crate::{
-    config::{
-        DataType, ExpandType, GenerateConfig, TransformConfig, TransformContext,
-        TransformDescription,
-    },
-    transforms::Transform,
+    config::{DataType, GenerateConfig, TransformConfig, TransformContext, TransformDescription},
+    event::Event,
+    internal_events::CompoundErrorEvents,
+    topology::builder::filter_event_type,
+    transforms::{TaskTransform, Transform},
 };
-use indexmap::IndexMap;
+use futures::{stream, Stream, StreamExt};
 use serde::{self, Deserialize, Serialize};
+use std::pin::Pin;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct CompoundConfig {
-    steps: Vec<TransformStep>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct TransformStep {
-    id: Option<String>,
-
-    #[serde(flatten)]
-    transform: Box<dyn TransformConfig>,
+    steps: Vec<Box<dyn TransformConfig>>,
 }
 
 inventory::submit! {
@@ -31,42 +24,47 @@ impl GenerateConfig for CompoundConfig {
     }
 }
 
+impl CompoundConfig {
+    fn consistent_types(&self) -> bool {
+        let mut pairs = self.steps.windows(2).map(|items| match items {
+            [a, b] => (a.output_type(), b.input_type()),
+            _ => unreachable!(),
+        });
+
+        !pairs.any(|pair| {
+            matches!(
+                pair,
+                (DataType::Log, DataType::Metric) | (DataType::Metric, DataType::Log)
+            )
+        })
+    }
+}
+
 #[async_trait::async_trait]
 #[typetag::serde(name = "compound")]
 impl TransformConfig for CompoundConfig {
-    async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Err("this transform must be expanded".into())
-    }
-
-    fn expand(
-        &mut self,
-    ) -> crate::Result<Option<(IndexMap<String, Box<dyn TransformConfig>>, ExpandType)>> {
-        let mut map: IndexMap<String, Box<dyn TransformConfig>> = IndexMap::new();
-        for (i, step) in self.steps.iter().enumerate() {
-            if map
-                .insert(
-                    step.id.as_ref().cloned().unwrap_or_else(|| i.to_string()),
-                    step.transform.to_owned(),
-                )
-                .is_some()
-            {
-                return Err("conflicting id found while expanding transform".into());
-            }
-        }
-
-        if !map.is_empty() {
-            Ok(Some((map, ExpandType::Serial { alias: false })))
+    async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
+        if !self.consistent_types() {
+            Err("Inconsistent type in a compound transform".into())
         } else {
-            Err("must specify at least one transform".into())
+            Compound::new(self.clone(), context)
+                .await
+                .map(Transform::task)
         }
     }
 
     fn input_type(&self) -> DataType {
-        DataType::Any
+        self.steps
+            .first()
+            .map(|t| t.input_type())
+            .unwrap_or(DataType::Any)
     }
 
     fn output_type(&self) -> DataType {
-        DataType::Any
+        self.steps
+            .last()
+            .map(|t| t.output_type())
+            .unwrap_or(DataType::Any)
     }
 
     fn transform_type(&self) -> &'static str {
@@ -74,39 +72,69 @@ impl TransformConfig for CompoundConfig {
     }
 }
 
+pub struct Compound {
+    transforms: Vec<(Transform, DataType)>,
+}
+
+impl Compound {
+    pub async fn new(config: CompoundConfig, context: &TransformContext) -> crate::Result<Self> {
+        let steps = &config.steps;
+        let mut transforms = vec![];
+        if !steps.is_empty() {
+            for transform_config in steps.iter() {
+                let transform = transform_config.build(context).await?;
+                transforms.push((transform, transform_config.input_type()));
+            }
+            Ok(Self { transforms })
+        } else {
+            Err("must specify at least one transform".into())
+        }
+    }
+}
+
+impl TaskTransform for Compound {
+    fn transform(
+        self: Box<Self>,
+        task: Pin<Box<dyn Stream<Item = Event> + Send>>,
+    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    where
+        Self: 'static,
+    {
+        let mut task = task;
+        for t in self.transforms {
+            task = filter_event_type(Box::pin(task), t.1);
+            match t.0 {
+                Transform::Task(t) => {
+                    task = t.transform(task);
+                }
+                Transform::Function(mut t) => {
+                    task = Box::pin(task.flat_map(move |v| {
+                        let mut output = Vec::<Event>::new();
+                        t.transform(&mut output, v);
+                        stream::iter(output)
+                    }));
+                }
+                Transform::FallibleFunction(mut t) => {
+                    task = Box::pin(task.flat_map(move |v| {
+                        let mut output = Vec::<Event>::new();
+                        let mut errors = Vec::<Event>::new();
+                        t.transform(&mut output, &mut errors, v);
+                        emit!(&CompoundErrorEvents {
+                            count: errors.len(),
+                        });
+                        stream::iter(output)
+                    }));
+                }
+            }
+        }
+        task
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::*;
-
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<super::CompoundConfig>();
-    }
-
-    #[test]
-    fn can_serialize_nested_transforms() {
-        // We need to serialize the config to check if a config has
-        // changed when reloading.
-        let config = toml::from_str::<CompoundConfig>(
-            r#"
-            [[steps]]
-            type = "mock"
-            suffix = "step1"
-
-            [[steps]]
-            type = "mock"
-            id = "foo"
-            suffix = "step1"
-        "#,
-        )
-        .unwrap()
-        .expand()
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(
-            serde_json::to_string(&config).unwrap(),
-            r#"[{"0":{"type":"mock"},"foo":{"type":"mock"}},{"Serial":{"alias":false}}]"#
-        );
     }
 }

--- a/src/transforms/compound.rs
+++ b/src/transforms/compound.rs
@@ -101,8 +101,7 @@ impl TaskTransform for Compound {
         Self: 'static,
     {
         let mut task = task;
-        let mut idx = 0;
-        for t in self.transforms {
+        for (idx, t) in self.transforms.into_iter().enumerate() {
             task = filter_event_type(Box::pin(task), t.1);
             match t.0 {
                 Transform::Task(t) => {
@@ -141,7 +140,6 @@ impl TaskTransform for Compound {
                     }));
                 }
             }
-            idx += 1;
         }
         task
     }

--- a/tests/behavior/transforms/compound.toml
+++ b/tests/behavior/transforms/compound.toml
@@ -12,7 +12,6 @@ inputs = ["start"]
     fields.foo = "bar"
     fields.foobar = "baz"
     [[transforms.simple_compound.steps]]
-    id = "final"
     type = "add_fields"
     fields.foo = "barbaz"
     fields.foobarbaz = "qux"
@@ -25,7 +24,7 @@ inputs = ["start"]
     value = "message"
 
     [[tests.outputs]]
-    extract_from = "simple_compound.final"
+    extract_from = "simple_compound"
     [[tests.outputs.conditions]]
         type = "check_fields"
         "foo.equals" = "barbaz"

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1147,6 +1147,7 @@ components: sources: internal_metrics: {
 				"parse_failed":                "The parsing operation failed."
 				"read_failed":                 "The file read operation failed."
 				"render_error":                "The rendering operation failed."
+				"transform_failed":            "The transform failed."
 				"type_conversion_failed":      "The type conversion operating failed."
 				"type_field_does_not_exist":   "The type field does not exist."
 				"type_ip_address_parse_error": "The IP address did not parse."

--- a/website/cue/reference/components/transforms/compound.cue
+++ b/website/cue/reference/components/transforms/compound.cue
@@ -27,23 +27,12 @@ components: transforms: compound: {
 		steps: {
 			description: """
 				A list of transforms configurations' representing the chain of transforms to be applied on incoming
-				events. All transforms in the chain can then be referenced as an input by other components with the name
-				`<transform_name>.<nested_transform_name>`. All transforms in the chain also generate internal metrics
-				as if they were configured separately.
+				events.
 				"""
 			required: true
 			type: array: {
 				items: type: object: {
 					options: {
-						id: {
-							common:      true
-							description: "The ID to use for the transform. This will show up in metrics and logs in the format: `<compound transform id>.<step id>`. If not set, the index of the step will be used as its id."
-							required:    false
-							type: string: {
-								default: null
-								examples: ["my_filter_transform"]
-							}
-						}
 						"*": {
 							description: """
 							Any valid transform configuration. See [transforms documentation](\(urls.vector_transforms))
@@ -110,4 +99,8 @@ components: transforms: compound: {
 			]
 		},
 	]
+
+	telemetry: metrics: {
+		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
+	}
 }


### PR DESCRIPTION
Rework the compound transform to address #8848.

I attempted to keep the expand logic by introducing cardinality constraints in the topology, but it seemed too impacting for such small functional changes. 

closes #8848 