### PR TITLE
enhancement(vrl): Allow `to_float` to take timestamps

### DIFF
--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -58,8 +58,8 @@ impl Function for ToFloat {
             },
             Example {
                 title: "timestamp",
-                source: "to_float!(t'2020-01-01T00:00:00Z')",
-                result: Ok("1577836800"),
+                source: "to_float!(t'2020-01-01T00:00:00.100Z')",
+                result: Ok("1577836800.1"),
             },
             Example {
                 title: "array",

--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -113,7 +113,7 @@ impl Expression for ToFloatFn {
             Integer(v) => Ok((v as f64).into()),
             Boolean(v) => Ok(NotNan::new(if v { 1.0 } else { 0.0 }).unwrap().into()),
             Null => Ok(0.0.into()),
-            Timestamp(v) => Ok((v.timestamp_nanos() as f64 / 1_000_000_000 as f64).into()),
+            Timestamp(v) => Ok((v.timestamp_nanos() as f64 / 1_000_000_000_f64).into()),
             Bytes(v) => Conversion::Float
                 .convert(v)
                 .map_err(|e| e.to_string().into()),

--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -59,9 +59,7 @@ impl Function for ToFloat {
             Example {
                 title: "timestamp",
                 source: "to_float!(t'2020-01-01T00:00:00Z')",
-                result: Err(
-                    r#"function call error for "to_float" at (0:34): unable to coerce "timestamp" into "float""#,
-                ),
+                result: Ok("1577836800"),
             },
             Example {
                 title: "array",
@@ -115,6 +113,7 @@ impl Expression for ToFloatFn {
             Integer(v) => Ok((v as f64).into()),
             Boolean(v) => Ok(NotNan::new(if v { 1.0 } else { 0.0 }).unwrap().into()),
             Null => Ok(0.0.into()),
+            Timestamp(v) => Ok((v.timestamp_nanos() as f64 / 1_000_000_000 as f64).into()),
             Bytes(v) => Conversion::Float
                 .convert(v)
                 .map_err(|e| e.to_string().into()),
@@ -125,9 +124,9 @@ impl Expression for ToFloatFn {
     fn type_def(&self, state: &state::Compiler) -> TypeDef {
         TypeDef::new()
             .with_fallibility(
-                self.value.type_def(state).has_kind(
-                    Kind::Bytes | Kind::Timestamp | Kind::Array | Kind::Object | Kind::Regex,
-                ),
+                self.value
+                    .type_def(state)
+                    .has_kind(Kind::Bytes | Kind::Array | Kind::Object | Kind::Regex),
             )
             .float()
     }
@@ -136,6 +135,7 @@ impl Expression for ToFloatFn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::prelude::*;
 
     test_function![
         to_float => ToFloat;
@@ -150,6 +150,12 @@ mod tests {
             args: func_args![value: 20],
             want: Ok(20.0),
             tdef: TypeDef::new().infallible().float(),
+        }
+
+        timestamp {
+             args: func_args![value: Utc.ymd(2014, 7, 8).and_hms_milli(9, 10, 11, 12)],
+             want: Ok(1404810611.012),
+             tdef: TypeDef::new().infallible().float(),
         }
     ];
 }

--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -58,7 +58,7 @@ impl Function for ToFloat {
             },
             Example {
                 title: "timestamp",
-                source: "to_float!(t'2020-01-01T00:00:00.100Z')",
+                source: "to_float(t'2020-01-01T00:00:00.100Z')",
                 result: Ok("1577836800.1"),
             },
             Example {

--- a/website/cue/reference/remap/functions/to_float.cue
+++ b/website/cue/reference/remap/functions/to_float.cue
@@ -13,7 +13,7 @@ remap: functions: to_float: {
 				The value to convert to a float. Must be convertible to a float, otherwise an error is raised.
 				"""
 			required: true
-			type: ["float", "integer", "boolean", "string"]
+			type: ["integer", "float", "boolean", "string", "timestamp"]
 		},
 	]
 	internal_failure_reasons: [
@@ -22,8 +22,11 @@ remap: functions: to_float: {
 	return: {
 		types: ["float"]
 		rules: [
+			"If `value` is a float, it will be returned as-is.",
+			"If `value` is an integer, it will be returned as as a float.",
 			"If `value` is a string, it must be the string representation of an float or else an error is raised.",
 			"If `value` is a boolean, `0.0` is returned for `false` and `1.0` is returned for `true`.",
+			"If `value` is a timestamp, a [Unix timestamp](\(urls.unix_timestamp)) with fractional seconds is returned.",
 		]
 	}
 
@@ -34,6 +37,13 @@ remap: functions: to_float: {
 				to_float!("3.145")
 				"""
 			return: 3.145
+		},
+		{
+			title: "Coerce to a float (timestamp)"
+			source: """
+				to_int(t'2020-12-30T22:20:53.824727Z')
+				"""
+			return: 1609366853.824727
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/to_float.cue
+++ b/website/cue/reference/remap/functions/to_float.cue
@@ -41,7 +41,7 @@ remap: functions: to_float: {
 		{
 			title: "Coerce to a float (timestamp)"
 			source: """
-				to_int(t'2020-12-30T22:20:53.824727Z')
+				to_float(t'2020-12-30T22:20:53.824727Z')
 				"""
 			return: 1609366853.824727
 		},


### PR DESCRIPTION
Closes: #5731

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
