### PR TITLE
fix(external docs): Provide the correct optionality for the VRL assert message

### DIFF
--- a/website/cue/reference/remap/functions/assert.cue
+++ b/website/cue/reference/remap/functions/assert.cue
@@ -22,18 +22,13 @@ remap: functions: assert: {
 			type: ["boolean"]
 		},
 		{
-			name:        "message"
+			name: "message"
 			description: """
-				The failure message that's reported if `condition` evaluates to `false`. If
-				unspecified, `"assertion failed"` is used as a default failure message. For example,
-				the expression `assert!(1 == 2)` (with no `message` specified) would yield this
-				output:
-
-				```text
-				function call error for "assert" at (0:15): assertion failed
-				```
+				An optional custom error message. If the equality assertion fails, `message` is
+				appended to the default message prefix. See the [examples](#assert-examples) below
+				for a sample fully formed log message.
 				"""
-			required:    false
+			required: false
 			type: ["string"]
 		},
 	]

--- a/website/cue/reference/remap/functions/assert.cue
+++ b/website/cue/reference/remap/functions/assert.cue
@@ -23,8 +23,17 @@ remap: functions: assert: {
 		},
 		{
 			name:        "message"
-			description: "The failure message that's reported if `condition` evaluates to `false`."
-			required:    true
+			description: """
+				The failure message that's reported if `condition` evaluates to `false`. If
+				unspecified, `"assertion failed"` is used as a default failure message. For example,
+				the expression `assert!(1 == 2)` (with no `message` specified) would yield this
+				output:
+
+				```text
+				function call error for "assert" at (0:15): assertion failed
+				```
+				"""
+			required:    false
 			type: ["string"]
 		},
 	]

--- a/website/cue/reference/remap/functions/assert_eq.cue
+++ b/website/cue/reference/remap/functions/assert_eq.cue
@@ -33,8 +33,8 @@ remap: functions: assert_eq: {
 			name: "message"
 			description: """
 				An optional custom error message. If the equality assertion fails, `message` is
-				appended to the default message prefix. See the examples below for a sample fully
-				formed log message.
+				appended to the default message prefix. See the [examples](#assert_eq-examples)
+				below for a sample fully formed log message.
 				"""
 			required: false
 			type: ["string"]


### PR DESCRIPTION
Currently, the docs incorrectly label the `message` field as required when using the `assert` function. This PR corrects that and provides some clarification in the description.