### PR TITLE
fix(generator source): Give the generator source a default interval

### DIFF
--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -103,7 +103,7 @@ struct TestParams {
     requests: usize,
 
     // The time interval between requests.
-    interval: Option<f64>,
+    interval: f64,
 
     // The delay is the base time every request takes return.
     delay: f64,

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -103,6 +103,7 @@ struct TestParams {
     requests: usize,
 
     // The time interval between requests.
+    #[serde(default = "default_interval")]
     interval: f64,
 
     // The delay is the base time every request takes return.
@@ -123,6 +124,10 @@ struct TestParams {
 
     #[serde(default = "default_concurrency")]
     concurrency: Concurrency,
+}
+
+const fn default_interval() -> f64 {
+    0.0
 }
 
 const fn default_concurrency() -> Concurrency {

--- a/src/sources/generator.rs
+++ b/src/sources/generator.rs
@@ -23,7 +23,7 @@ pub struct GeneratorConfig {
     format: OutputFormat,
 }
 
-fn default_interval() -> f64 {
+const fn default_interval() -> f64 {
     1.0
 }
 

--- a/src/topology/test/source_finished.rs
+++ b/src/topology/test/source_finished.rs
@@ -9,7 +9,7 @@ use tokio::time::{timeout, Duration};
 #[tokio::test]
 async fn sources_finished() {
     let mut old_config = Config::builder();
-    let generator = GeneratorConfig::repeat(vec!["text".to_owned()], 1, None);
+    let generator = GeneratorConfig::repeat(vec!["text".to_owned()], 1, 0.0);
     old_config.add_source("in", generator);
     old_config.add_sink(
         "out",

--- a/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
+++ b/website/content/en/highlights/2021-10-05-0-17-upgrade-guide.md
@@ -49,3 +49,13 @@ which also writes to stdout by default.  Following some discussion in
 that stdout can be processed separately.
 
 If you were previously depending on Vector's logs appearing in stdout, you should now look for them in stderr.
+
+### The `generator` source now has a default `interval` setting
+
+Previously, the [`generator`][generator] source had no default `interval`, which meant that if you
+started Vector without setting an `interval`, the `generator` would output batches of test events as
+fast as it can. In version 0.17.0, the default for `interval` is now `1.0`, which means that Vector
+outputs one batch per second. To specify no delay between batches you now need to explicit set
+`interval` to `0.0`.
+
+[generator]: /docs/reference/configuration/sources/generator

--- a/website/cue/reference/components/sources/generator.cue
+++ b/website/cue/reference/components/sources/generator.cue
@@ -64,7 +64,7 @@ components: sources: generator: {
 			description: """
 				The amount of time, in seconds, to pause between each batch of output lines. The
 				default is one batch per second. In order to remove the delay and output batches as
-				quickly as possible, set `interval` to `0.01.
+				quickly as possible, set `interval` to `0.0`.
 				"""
 			required:    false
 			warnings: []

--- a/website/cue/reference/components/sources/generator.cue
+++ b/website/cue/reference/components/sources/generator.cue
@@ -61,11 +61,15 @@ components: sources: generator: {
 		}
 		interval: {
 			common:      false
-			description: "The amount of time, in seconds, to pause between each batch of output lines. If not set, there is no delay."
+			description: """
+				The amount of time, in seconds, to pause between each batch of output lines. The
+				default is one batch per second. In order to remove the delay and output batches as
+				quickly as possible, set `interval` to `0.01.
+				"""
 			required:    false
 			warnings: []
 			type: float: {
-				default: null
+				default: 1.0
 				examples: [1.0, 0.1, 0.01]
 			}
 		}

--- a/website/cue/reference/components/sources/generator.cue
+++ b/website/cue/reference/components/sources/generator.cue
@@ -60,13 +60,13 @@ components: sources: generator: {
 			}
 		}
 		interval: {
-			common:      false
+			common: false
 			description: """
 				The amount of time, in seconds, to pause between each batch of output lines. The
 				default is one batch per second. In order to remove the delay and output batches as
 				quickly as possible, set `interval` to `0.0`.
 				"""
-			required:    false
+			required: false
 			warnings: []
 			type: float: {
 				default: 1.0


### PR DESCRIPTION
This may be somewhat controversial, in which case I'll retract it. But I feel like the default behavior of the `generator` source is probably not in line with users' expectations. As it stands, running the `generator` without specifying `interval` means that your terminal is *flooded* with a dizzying stream of events. Making the default behavior a steady trickle seems better to me. The 1.0 figure is purely arbitrary but seems intuitive enough.

I'm happy to retract this if others think that zero delay is indeed aligned with user expectations.