### PR TITLE
fix(buffers): Use tokio runtime in buffer benchmarks

### DIFF
--- a/lib/vector-core/buffers/benches/common.rs
+++ b/lib/vector-core/buffers/benches/common.rs
@@ -5,6 +5,7 @@ use futures::task::{noop_waker, Context, Poll};
 use futures::{Sink, Stream};
 use std::fmt;
 use std::pin::Pin;
+use tokio::runtime::Runtime;
 
 #[derive(Clone, Copy)]
 pub struct Message<const N: usize> {
@@ -114,9 +115,7 @@ fn consume<T>(mut stream: Pin<&mut (dyn Stream<Item = T> + Unpin + Send)>, conte
 // behind an abstract interface. As a happy consequence of this our benchmark
 // measurements are common. "Write Then Read" writes all messages into the
 // buffer and then reads them out. "Write And Read" writes a message and then
-// reads it from the buffer. Measurement is done without a runtime avoiding
-// conflating the overhead of the runtime with our buffer code. This,
-// admittedly, is tough to read.
+// reads it from the buffer.
 //
 
 #[allow(clippy::type_complexity)]
@@ -127,23 +126,26 @@ pub fn wtr_measurement<const N: usize>(
         Vec<Message<N>>,
     ),
 ) {
-    {
-        let waker = noop_waker();
-        let mut context = Context::from_waker(&waker);
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async move {
+        {
+            let waker = noop_waker();
+            let mut context = Context::from_waker(&waker);
 
-        let mut sink = input.0;
-        for msg in input.2.into_iter() {
-            send_msg(msg, sink.as_mut(), &mut context)
+            let mut sink = input.0;
+            for msg in input.2.into_iter() {
+                send_msg(msg, sink.as_mut(), &mut context)
+            }
         }
-    }
 
-    {
-        let waker = noop_waker();
-        let mut context = Context::from_waker(&waker);
+        {
+            let waker = noop_waker();
+            let mut context = Context::from_waker(&waker);
 
-        let mut stream = input.1;
-        consume(stream.as_mut(), &mut context)
-    }
+            let mut stream = input.1;
+            consume(stream.as_mut(), &mut context)
+        }
+    })
 }
 
 #[allow(clippy::type_complexity)]
@@ -154,16 +156,19 @@ pub fn war_measurement<const N: usize>(
         Vec<Message<N>>,
     ),
 ) {
-    let snd_waker = noop_waker();
-    let mut snd_context = Context::from_waker(&snd_waker);
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async move {
+        let snd_waker = noop_waker();
+        let mut snd_context = Context::from_waker(&snd_waker);
 
-    let rcv_waker = noop_waker();
-    let mut rcv_context = Context::from_waker(&rcv_waker);
+        let rcv_waker = noop_waker();
+        let mut rcv_context = Context::from_waker(&rcv_waker);
 
-    let mut stream = input.1;
-    let mut sink = input.0;
-    for msg in input.2.into_iter() {
-        send_msg(msg, sink.as_mut(), &mut snd_context);
-        consume(stream.as_mut(), &mut rcv_context)
-    }
+        let mut stream = input.1;
+        let mut sink = input.0;
+        for msg in input.2.into_iter() {
+            send_msg(msg, sink.as_mut(), &mut snd_context);
+            consume(stream.as_mut(), &mut rcv_context)
+        }
+    })
 }


### PR DESCRIPTION
Since switching from `block_in_place` to `spawn_blocking` in the disk buffer implementation ([see here](https://github.com/vectordotdev/vector/commit/70199c45637a7e3b665c3f80d0f95f47403f0d29#diff-0b6049db13528339ffd7add0386d3b413f5e79782faca2e69223aeb1f16c281dL111)), a runtime is now required for benchmarking. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
