### PR TITLE
fix(external docs): Remove errant unit test example

### DIFF
--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -236,7 +236,6 @@ insert_at = "add_metadata"
 
 [tests.inputs.log_fields]
 message = "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
-tags = { environment = "production" }
 ```
 
 ### Outputs


### PR DESCRIPTION
Given the issue I pointed out in #9386, the example link I'm removing here wouldn't work in a real unit test.