### PR TITLE
enhancement(external docs): Link to Helm chart repo

### DIFF
--- a/website/content/en/docs/setup/installation/package-managers/helm.md
+++ b/website/content/en/docs/setup/installation/package-managers/helm.md
@@ -151,6 +151,10 @@ To uninstall the Vector helm chart:
 helm uninstall vector --namespace vector
 ```
 
+## View Helm Chart Source
+
+If you'd like to clone the charts, file an Issue or submit a Pull Request, please take a look at [vectordotdev/helm-charts](https://github.com/vectordotdev/helm-charts).
+
 ## Management
 
 {{< jump "/docs/administration/management" "helm" >}}


### PR DESCRIPTION
Add a section pointing to the location of the helm chart source repository at https://github.com/vectordotdev/helm-charts

Took me a little bit to figure out where the new location was, so thought I'd send over a link! If this doesn't match reality (or y'all have other ideas) happy to make some tweaks!