### PR TITLE
fix(external docs): Fix configuration reference

### DIFF
--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -173,8 +173,6 @@ sinks:
 To use this configuration file, specify it with the `--config` flag when
 starting Vector:
 
-{{< tabs default="TOML" >}} {{< tab title="TOML" >}}
-
 {{< tabs default="TOML" >}}
 {{< tab title="TOML" >}}
 


### PR DESCRIPTION
Remove extra tab for TOML, since [it breaks the page](https://vector.dev/docs/reference/configuration/#reference) otherwise.

Signed-off-by: Joe Smith <yasumoto7@gmail.com>
