### PR TITLE
docs(datadog_agent source): Fix description rendering

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -51,7 +51,7 @@ components: {
 
 		// `description` describes the components with a single paragraph.
 		// It is used for SEO purposes and should be full of relevant keywords.
-		description?: =~"[.]$"
+		description?: string
 
 		env_vars: #EnvVars
 

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -49,9 +49,10 @@ components: {
 
 		configuration: #Schema
 
-		// `description` describes the components with a single paragraph.
-		// It is used for SEO purposes and should be full of relevant keywords.
-		description?: string
+		// `description` describes the components with a single paragraph. It
+		// should be 1-3 sentences.  It is used for SEO purposes and should be
+		// full of relevant keywords.
+		description?: =~"[.]$"
 
 		env_vars: #EnvVars
 

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -15,9 +15,9 @@ components: sources: datadog_agent: {
 		```yaml
 		logs_config:
 			dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"
-			use_v2_api = false # source does not yet support new v2 API
-			use_http = true # this source only supports HTTP/HTTPS
-			logs_no_ssl = true|false # should match source SSL configuration.
+			use_v2_api: false # source does not yet support new v2 API
+			use_http: true # this source only supports HTTP/HTTPS
+			logs_no_ssl: true|false # should match source SSL configuration.
 		```
 		"""
 

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -12,11 +12,12 @@ components: sources: datadog_agent: {
 		To send logs from a Datadog Agent to this source, the [Datadog Agent](\(urls.datadog_agent_doc)) configuration
 		must be updated to use:
 
-		```
+		```toml
 		logs_config.dd_url = "<VECTOR_HOST>:<SOURCE_PORT>"
 		logs_config.use_v2_api = false # source does not yet support new v2 API
 		logs_config.use_http = true # this source only supports HTTP/HTTPS
 		logs_config.logs_no_ssl = true|false # should match source SSL configuration.
+		```
 		"""
 
 	classes: {

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -12,11 +12,12 @@ components: sources: datadog_agent: {
 		To send logs from a Datadog Agent to this source, the [Datadog Agent](\(urls.datadog_agent_doc)) configuration
 		must be updated to use:
 
-		```toml
-		logs_config.dd_url = "<VECTOR_HOST>:<SOURCE_PORT>"
-		logs_config.use_v2_api = false # source does not yet support new v2 API
-		logs_config.use_http = true # this source only supports HTTP/HTTPS
-		logs_config.logs_no_ssl = true|false # should match source SSL configuration.
+		```yaml
+		logs_config:
+			dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"
+			use_v2_api = false # source does not yet support new v2 API
+			use_http = true # this source only supports HTTP/HTTPS
+			logs_no_ssl = true|false # should match source SSL configuration.
 		```
 		"""
 

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -8,17 +8,6 @@ components: sources: datadog_agent: {
 	description: """
 		Receives observability data from a Datadog Agent over HTTP or HTTPS. For now, this is limited to logs, but will
 		be expanded in the future to cover metrics and traces.
-
-		To send logs from a Datadog Agent to this source, the [Datadog Agent](\(urls.datadog_agent_doc)) configuration
-		must be updated to use:
-
-		```yaml
-		logs_config:
-			dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"
-			use_v2_api: false # source does not yet support new v2 API
-			use_http: true # this source only supports HTTP/HTTPS
-			logs_no_ssl: true|false # should match source SSL configuration.
-		```
 		"""
 
 	classes: {
@@ -129,6 +118,24 @@ components: sources: datadog_agent: {
 					syntax: "literal"
 				}
 			}
+		}
+	}
+
+	how_it_works: {
+		decompression: {
+			title: "Configuring the Datadog Agent"
+			body:  """
+				To send logs from a Datadog Agent to this source, the [Datadog Agent](\(urls.datadog_agent_doc)) configuration
+				must be updated to use:
+
+				```yaml
+				logs_config:
+					dd_url: "<VECTOR_HOST>:<SOURCE_PORT>"
+					use_v2_api: false # source does not yet support new v2 API
+					use_http: true # this source only supports HTTP/HTTPS
+					logs_no_ssl: true|false # should match source SSL configuration.
+				```
+				"""
 		}
 	}
 }


### PR DESCRIPTION
Component descriptions were being limited in allowed characters. This
relaxes it to just allow strings. I'm unsure if there was a reason we
were restricting this though @binarylogic do you know?

Fixes: #9408 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
