### PR TITLE
chore(vrl): Add benches for type assertion functions

### DIFF
--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -9,8 +9,10 @@ criterion_group!(
     // encapsulates CI noise we saw in
     // https://github.com/timberio/vector/pull/6408
     config = Criterion::default().noise_threshold(0.05);
-    targets = assert,
+    targets = array,
+              assert,
               assert_eq,
+              r#bool,
               ceil,
               compact,
               contains,
@@ -30,6 +32,7 @@ criterion_group!(
               find,
               flatten,
               floor,
+              float,
               format_int,
               format_number,
               format_timestamp,
@@ -37,6 +40,7 @@ criterion_group!(
               get_env_var,
               get_hostname,
               includes,
+              int,
               ip_aton,
               ip_cidr_contains,
               ip_ntoa,
@@ -64,6 +68,7 @@ criterion_group!(
               merge,
               // TODO: value is dynamic so we cannot assert equality
               //now,
+              object,
               parse_apache_log,
               parse_aws_alb_log,
               parse_aws_cloudwatch_log_subscription_message,
@@ -101,9 +106,11 @@ criterion_group!(
               slice,
               split,
               starts_with,
+              string,
               strip_ansi_escape_codes,
               strip_whitespace,
               tally,
+              timestamp,
               to_bool,
               to_float,
               to_int,
@@ -134,6 +141,15 @@ bench_function! {
 }
 
 bench_function! {
+    array => vrl_stdlib::Array;
+
+    array {
+        args: func_args![value: value!([1,2,3])],
+        want: Ok(value!([1,2,3])),
+    }
+}
+
+bench_function! {
     assert => vrl_stdlib::Assert;
 
     literal {
@@ -147,6 +163,15 @@ bench_function! {
 
     literal {
         args: func_args![left: value!(true), right: value!(true), message: "must be true"],
+        want: Ok(value!(true)),
+    }
+}
+
+bench_function! {
+    r#bool => vrl_stdlib::Boolean;
+
+    r#bool {
+        args: func_args![value: value!(true)],
         want: Ok(value!(true)),
     }
 }
@@ -393,6 +418,15 @@ bench_function! {
 }
 
 bench_function! {
+    float => vrl_stdlib::Float;
+
+    float {
+        args: func_args![value: value!(1.2)],
+        want: Ok(value!(1.2)),
+    }
+}
+
+bench_function! {
     floor  => vrl_stdlib::Floor;
 
     literal {
@@ -482,6 +516,15 @@ bench_function! {
     indexing {
         args: func_args![value: value!([0, 42, 91]), path: vec![3], data: 1],
         want: Ok(value!([0, 42, 91, 1])),
+    }
+}
+
+bench_function! {
+    int => vrl_stdlib::Integer;
+
+    int {
+        args: func_args![value: value!(1)],
+        want: Ok(value!(1)),
     }
 }
 
@@ -980,6 +1023,15 @@ bench_function! {
                 "grandchild2": "val2",
             },
         }))
+    }
+}
+
+bench_function! {
+    object => vrl_stdlib::Object;
+
+    object {
+        args: func_args![value: value!({"foo": "bar"})],
+        want: Ok(value!({"foo": "bar"})),
     }
 }
 
@@ -1888,6 +1940,15 @@ bench_function! {
 }
 
 bench_function! {
+    string => vrl_stdlib::String;
+
+    string {
+        args: func_args![value: "2"],
+        want: Ok("2")
+    }
+}
+
+bench_function! {
     strip_ansi_escape_codes => vrl_stdlib::StripAnsiEscapeCodes;
 
     literal {
@@ -1985,7 +2046,15 @@ bench_function! {
         ],
         want: Ok(value!({"bar": 1, "foo": 2, "baz": 1})),
     }
+}
 
+bench_function! {
+    timestamp => vrl_stdlib::Timestamp;
+
+    timestamp {
+        args: func_args![value: Utc.ymd(2021, 1, 1).and_hms_milli(0, 0, 0, 0)],
+        want: Ok(value!(Utc.ymd(2021, 1, 1).and_hms_milli(0, 0, 0, 0))),
+    }
 }
 
 bench_function! {


### PR DESCRIPTION
These were missing.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->