### PR TITLE
docs(syslog source): Fix configuration documentation

### DIFF
--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -46,8 +46,64 @@ components: sources: syslog: {
 		platform_name: null
 	}
 
-	configuration: sources.socket.configuration & {
-		"type": "type": string: enum: syslog: "The type of this component."
+	configuration: {
+		address: {
+			description:   "The address to listen for connections on, or `systemd#N` to use the Nth socket passed by systemd socket activation. If an address is used it _must_ include a port."
+			relevant_when: "mode = `tcp` or `udp`"
+			required:      true
+			warnings: []
+			type: string: {
+				examples: ["0.0.0.0:\(_port)", "systemd", "systemd#3"]
+				syntax: "literal"
+			}
+		}
+		host_key: {
+			category:    "Context"
+			common:      false
+			description: """
+				The key name added to each event representing the current host. This can also be globally set via the
+				[global `host_key` option](\(urls.vector_configuration)/global-options#log_schema.host_key).
+				"""
+			required:    false
+			warnings: []
+			type: string: {
+				default: "host"
+				syntax:  "literal"
+			}
+		}
+		max_length: {
+			common:      true
+			description: "The maximum bytes size of incoming messages before they are discarded."
+			required:    false
+			warnings: []
+			type: uint: {
+				default: 102400
+				unit:    "bytes"
+			}
+		}
+		mode: {
+			description: "The type of socket to use."
+			required:    true
+			warnings: []
+			type: string: {
+				enum: {
+					tcp:  "TCP socket."
+					udp:  "UDP socket."
+					unix: "Unix domain stream socket."
+				}
+				syntax: "literal"
+			}
+		}
+		path: {
+			description:   "The unix socket path. *This should be an absolute path*."
+			relevant_when: "mode = `unix`"
+			required:      true
+			warnings: []
+			type: string: {
+				examples: ["/path/to/socket"]
+				syntax: "literal"
+			}
+		}
 	}
 
 	output: logs: line: {


### PR DESCRIPTION
It was using the socket configuration, but there are some differences
(`mode` has different values, `shutdown_timeout_secs` isn't supported).



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->