### PR TITLE
chore(external docs): Use CoffeeScript highlighting instead of Ruby for VRL

### DIFF
--- a/lib/vrl/tests/tests/fixme/README.md
+++ b/lib/vrl/tests/tests/fixme/README.md
@@ -4,7 +4,7 @@ This directory contains tests that show a bug in VRL that needs to be resolved.
 
 The first line in these tests should start with:
 
-```ruby
+```coffee
 # SKIP
 ```
 

--- a/website/content/en/blog/vector-remap-language.md
+++ b/website/content/en/blog/vector-remap-language.md
@@ -282,7 +282,7 @@ following log:
 
 Which can be achieved with the following VRL program:
 
-```ruby
+```coffee
 . = parse_common_log!(.log)
 .total_bytes = del(.size)
 .internal_request = ip_cidr_contains("5.86.0.0/16", .host) ?? false
@@ -375,7 +375,7 @@ We want to parse it into this result:
 
 Someone new to VRL might write the following VRL program:
 
-```ruby
+```coffee
 . = parse_common_log(.log)
 .total_bytes = del(.size)
 ```
@@ -408,7 +408,7 @@ three things:
 
 1.  **Handle the error**
 
-    ```ruby
+    ```coffee
     ., err = parse_common_log(.log)
     if err != null {
       .malformed = true
@@ -427,7 +427,7 @@ three things:
 
 2.  **Raise the error and abort**
 
-    ```ruby
+    ```coffee
     . = parse_common_log!(.log)
     .total_bytes = del(.size)
     ```
@@ -442,7 +442,7 @@ three things:
 
 3.  **Specify types**
 
-    ```ruby
+    ```coffee
     .log = to_string!(.log)
 
     ., err = parse_common_log(.log)

--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -58,7 +58,7 @@ conforms to your expectations. VRL provides two assertion functions:
 
 With both functions, you can supply a custom log message to be emitted if the assertion fails:
 
-```ruby
+```coffee
 # Named argument
 assert!(1 == 2, message: "the rules of arithmetic have been violated")
 assert_eq!(1, 2, message: "the rules of arithmetic have been violated")

--- a/website/content/en/docs/reference/vrl/_index.md
+++ b/website/content/en/docs/reference/vrl/_index.md
@@ -57,7 +57,7 @@ You want to apply these changes to each event:
 
 This VRL program would accomplish all of that:
 
-```ruby
+```coffee
 . = parse_json!(string!(.message))
 .timestamp = to_unix_timestamp(to_timestamp!(.timestamp))
 del(.username)

--- a/website/content/en/docs/reference/vrl/errors.md
+++ b/website/content/en/docs/reference/vrl/errors.md
@@ -28,7 +28,7 @@ You have three options for handling errors in VRL:
 
 As documented in the [assignment expression reference], you can **assign** errors when invoking an expression that's fallible. When assigned, runtime errors are simple strings:
 
-```ruby
+```coffee
 structured, err = parse_json("not json")
 if err != null {
   log("Unable to parse JSON: " + err, level: "error")
@@ -39,7 +39,7 @@ if err != null {
 
 If the expression fails, the `ok` assignment target is assigned the "empty" value of its type:
 
-```ruby
+```coffee
 # `.foo` can be `100` or `"not an int"`
 foo, err = to_int(.foo)
 
@@ -72,7 +72,7 @@ Null | `null`
 
 As documented in the [coalesce expression reference][coalesce], you can **coalesce** errors to efficiently step through multiple expressions:
 
-```ruby
+```coffee
 structured = parse_json("not json") ?? parse_syslog("not syslog") ?? {}
 . = merge(., structured)
 ```
@@ -81,7 +81,7 @@ structured = parse_json("not json") ?? parse_syslog("not syslog") ?? {}
 
 As documented in the [function call reference][call], you can **raise** errors to immediately abort the program by adding a `!` to the end of the function name:
 
-```ruby
+```coffee
 structured = parse_json!("not json")
 . = merge(., structured)
 ```

--- a/website/cue/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
+++ b/website/cue/reference/components/transforms/aws_cloudwatch_logs_subscription_parser.cue
@@ -41,7 +41,7 @@ components: transforms: aws_cloudwatch_logs_subscription_parser: {
 			"""
 			\(aws_cloudwatch_logs_subscription_parser._remap_deprecation_notice)
 
-			```ruby
+			```coffee
 			.message = parse_aws_cloudwatch_log_subscription_message(.message)
 			```
 			""",

--- a/website/cue/reference/remap/concepts/event.cue
+++ b/website/cue/reference/remap/concepts/event.cue
@@ -39,7 +39,7 @@ remap: concepts: event: {
 				[Path expressions](\(urls.vrl_path_expressions)) enable you to access values inside
 				the event:
 
-				```ruby
+				```coffee
 				.kubernetes.pod_id
 				```
 				"""

--- a/website/cue/reference/remap/errors/305_divide_by_zero_error.cue
+++ b/website/cue/reference/remap/errors/305_divide_by_zero_error.cue
@@ -14,7 +14,7 @@ remap: errors: "305": {
 		If you know that a value is necessarily zero, don't divide by it. If a value *could* be
 		zero, capture the potential error thrown by the operation:
 
-		```ruby
+		```coffee
 		result, err = 27 / .some_value
 		if err != nil {
 			# Handle error

--- a/website/cue/reference/remap/features/high_quality_error_messages.cue
+++ b/website/cue/reference/remap/features/high_quality_error_messages.cue
@@ -6,7 +6,7 @@ remap: features: high_quality_error_messages: {
 
 		This VRL program, for example...
 
-		```ruby
+		```coffee
 		.foo, err = upcase(.foo)
 		```
 

--- a/website/cue/reference/remap/features/type_safety.cue
+++ b/website/cue/reference/remap/features/type_safety.cue
@@ -20,7 +20,7 @@ remap: features: type_safety: {
 				evaluated, type information is built up and used at compile-time to enforce type-safety. Let's look
 				at an example:
 
-				```ruby
+				```coffee
 				.foo # any
 				.foo = downcase!(.foo) # string
 				.foo = upcase(.foo) # string
@@ -39,7 +39,7 @@ remap: features: type_safety: {
 				To avoid error handling for argument errors, you can specify the types of your fields at the top
 				of your VRL script:
 
-				```ruby
+				```coffee
 				.foo = string!(.foo) # string
 
 				.foo = downcase(.foo) # string

--- a/website/cue/reference/remap/literals/regular_expression.cue
+++ b/website/cue/reference/remap/literals/regular_expression.cue
@@ -42,7 +42,7 @@ remap: literals: regular_expression: {
 				Regular expressions support named capture groups, allowing extractions to be associated with keys.
 				Named captures should be preceded with a `?P<name>` declaration. This regex, for example...
 
-				```ruby
+				```coffee
 				r'(?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2})'
 				```
 

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -805,7 +805,7 @@
         {{ $vrlSourceCode }}
 
         {{ if .raises }}
-        {{ $errorCode := highlight .raises.compiletime "ruby" "" }}
+        {{ $errorCode := highlight .raises.compiletime "rust" "" }}
         <span>
           ...you should see this error:
         </span>
@@ -952,7 +952,7 @@
                   VRL program
                 </span>
 
-                {{ highlight . "ruby" "" }}
+                {{ highlight . "coffee" "" }}
               </div>
               {{ end }}
 
@@ -1000,7 +1000,7 @@
 
       <div class="mt-2 border rounded p-4 dark:border-gray-700">
         <div>
-          {{ highlight .source "ruby" "" }}
+          {{ highlight .source "coffee" "" }}
         </div>
 
         {{ with .definitions }}
@@ -1083,7 +1083,7 @@
             </span>
 
             <div class="mt-1">
-              {{ highlight .source "ruby" "" }}
+              {{ highlight .source "coffee" "" }}
             </div>
           </div>
 
@@ -1180,7 +1180,7 @@
 
         <div class="mt-2 flex flex-col space-y-2 text-sm">
           {{ range . }}
-          {{ highlight . "ruby" "" }}
+          {{ highlight . "coffee" "" }}
           {{ end }}
         </div>
       </div>


### PR DESCRIPTION
A [side-by-side comparison](https://gist.github.com/lucperkins/bdbceef6c210d0f3d17eb27b566a5326), as well as a handful of RFCs, indicate that CoffeeScript syntax highlighting is slightly better for VRL than Ruby highlighting, which we've been using for the website thus far.