### PR TITLE
fix(datadog_logs sink): always send unix timestamp in milliseconds

### DIFF
--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -167,6 +167,8 @@ pub enum RequestBuildError {
     Io { error: std::io::Error },
 }
 
+const TIMESTAMP_KEY: &str = "timestamp";
+
 impl RequestBuilder {
     fn new(
         encoding: EncodingConfigWithDefault<Encoding>,
@@ -190,8 +192,10 @@ impl RequestBuilder {
             {
                 let log = event.as_mut_log();
                 log.rename_key_flat(self.log_schema_message_key, "message");
-                log.rename_key_flat(self.log_schema_timestamp_key, "date");
                 log.rename_key_flat(self.log_schema_host_key, "host");
+                if let Some(Value::Timestamp(ts)) = log.remove(self.log_schema_timestamp_key) {
+                    log.insert(TIMESTAMP_KEY, Value::Integer(ts.timestamp_millis()));
+                }
                 self.encoding.apply_rules(&mut event);
             }
 

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -194,7 +194,7 @@ impl RequestBuilder {
                 log.rename_key_flat(self.log_schema_message_key, "message");
                 log.rename_key_flat(self.log_schema_host_key, "host");
                 if let Some(Value::Timestamp(ts)) = log.remove(self.log_schema_timestamp_key) {
-                    log.insert(TIMESTAMP_KEY, Value::Integer(ts.timestamp_millis()));
+                    log.insert_flat(TIMESTAMP_KEY, Value::Integer(ts.timestamp_millis()));
                 }
                 self.encoding.apply_rules(&mut event);
             }

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -5,6 +5,7 @@ use crate::{
     test_util::{next_addr, random_lines_with_stream},
 };
 use bytes::Bytes;
+use chrono::Utc;
 use futures::{
     channel::mpsc::{Receiver, TryRecvError},
     stream, StreamExt,
@@ -96,6 +97,15 @@ async fn smoke() {
             .as_str()
             .unwrap();
         assert_eq!(message, expected[i]);
+        let timestamp = json
+            .get(0)
+            .unwrap()
+            .get("timestamp")
+            .unwrap()
+            .as_i64()
+            .unwrap();
+        let delta = Utc::now().timestamp_millis() - timestamp;
+        assert!(delta > 0 && delta < 1000);
     }
 }
 


### PR DESCRIPTION
Currently if users set `encoding.timestamp_format` to `unix` we would produce `date` in seconds, but DD expects unix timestamp in milliseconds.
Also changes `date` to `timestamp`, both fields are [parsed](https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#log-date-remapper) as an event's timestamp by DD, but `timestamp` key is more aligned with the unix timestamp value as well as with Logs API.


Signed-off-by: Vladimir Zhuk <vladimir.zhuk@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
