### PR TITLE
fix(datadog_logs sink): expect ACCEPTED(202) instead of OK(200) 

### DIFF
--- a/src/sinks/datadog/logs/healthcheck.rs
+++ b/src/sinks/datadog/logs/healthcheck.rs
@@ -17,7 +17,7 @@ pub async fn healthcheck(client: HttpClient, uri: Uri, api_key: String) -> crate
     let body = hyper::body::to_bytes(response.into_body()).await?;
 
     match status {
-        StatusCode::OK => Ok(()),
+        StatusCode::ACCEPTED => Ok(()),
         StatusCode::UNAUTHORIZED => {
             let json: serde_json::Value = serde_json::from_slice(&body[..])?;
 

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -144,7 +144,7 @@ impl Service<LogApiRequest> for LogApiService {
                     match status {
                         StatusCode::BAD_REQUEST => Err(LogApiError::BadRequest),
                         StatusCode::FORBIDDEN => Ok(LogApiResponse::PermissionIssue),
-                        StatusCode::OK => Ok(LogApiResponse::Ok),
+                        StatusCode::ACCEPTED => Ok(LogApiResponse::Ok),
                         StatusCode::PAYLOAD_TOO_LARGE => Err(LogApiError::PayloadTooLarge),
                         _ => Err(LogApiError::ServerError),
                     }

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -67,11 +67,11 @@ async fn start_test(
 #[tokio::test]
 /// Assert the basic functionality of the sink in good conditions
 ///
-/// This test rigs the sink to return StatusCode::OK to responses, checks that
+/// This test rigs the sink to return StatusCode::ACCEPTED to responses, checks that
 /// all batches were delivered and then asserts that every message is able to be
 /// deserialized.
 async fn smoke() {
-    let (expected, rx) = start_test(StatusCode::OK, BatchStatus::Delivered).await;
+    let (expected, rx) = start_test(StatusCode::ACCEPTED, BatchStatus::Delivered).await;
 
     let output = rx.take(expected.len()).collect::<Vec<_>>().await;
 
@@ -133,7 +133,7 @@ async fn api_key_in_metadata() {
 
     let (sink, _) = config.build(cx).await.unwrap();
 
-    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::OK);
+    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::ACCEPTED);
     tokio::spawn(server);
 
     let (expected_messages, events) = random_lines_with_stream(100, 10, None);
@@ -198,7 +198,7 @@ async fn multiple_api_keys() {
 
     let (sink, _) = config.build(cx).await.unwrap();
 
-    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::OK);
+    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::ACCEPTED);
     tokio::spawn(server);
 
     let events = vec![
@@ -235,7 +235,7 @@ async fn enterprise_headers() {
     cx.globals.enterprise = true;
     let (sink, _) = config.build(cx).await.unwrap();
 
-    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::OK);
+    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::ACCEPTED);
     tokio::spawn(server);
 
     let (_expected_messages, events) = random_lines_with_stream(100, 10, None);


### PR DESCRIPTION
V2 API replies with 202(Accepted) status code instead of 200.

Signed-off-by: Vladimir Zhuk <vladimir.zhuk@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
