### PR TITLE
enhancement(log_to_metric transform): add absolute_kind to log_to_metric counters

### DIFF
--- a/website/cue/reference/components/transforms/log_to_metric.cue
+++ b/website/cue/reference/components/transforms/log_to_metric.cue
@@ -64,6 +64,19 @@ components: transforms: log_to_metric: {
 							default: false
 						}
 					}
+					absolute_kind: {
+						description: """
+							If `true` the metric will be of kind `absolute`.
+							If `false` the metric will be of kind `incremental`.
+							"""
+						required: false
+						common:   false
+						warnings: []
+						relevant_when: #"type = "counter""#
+						type: bool: {
+							default: false
+						}
+					}
 					name: {
 						description: "The name of the metric. Defaults to `<field>_total` for `counter` and `<field>` for `gauge`."
 						required:    false


### PR DESCRIPTION
Closes #6612 

This adds a new parameter to the `log_to_metric` transform to allow counters to be set with a kind `Absolute`.

```toml
[[transforms.logmetric.metrics]]
field = "total"
name = "total"
namespace = "thing"
type = "counter"
increment_by_value = true
absolute_kind = true
```

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
