### PR TITLE
fix(vrl): Correct parse_url's value type

### DIFF
--- a/lib/vrl/stdlib/src/parse_url.rs
+++ b/lib/vrl/stdlib/src/parse_url.rs
@@ -13,7 +13,7 @@ impl Function for ParseUrl {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            kind: kind::ANY,
+            kind: kind::BYTES,
             required: true,
         }]
     }


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
