### PR TITLE
chore(buffers): Add ByteSizeOf for buffer items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,7 @@ name = "buffers"
 version = "0.1.0"
 dependencies = [
  "bytes 1.1.0",
+ "core_common",
  "criterion",
  "db-key",
  "futures 0.3.17",

--- a/lib/vector-core/buffers/Cargo.toml
+++ b/lib/vector-core/buffers/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 bytes = { version = "1.1.0", default-features = false }
 db-key = { version = "0.0.5", default-features = false, optional = true }
 futures = { version = "0.3.17", default-features = false, features = ["std"] }
+core_common = { path = "../core-common", default-features = false }
 leveldb = { version = "0.8.6", default-features = false, optional = true }
 metrics = { version = "0.17.0", default-features = false, features = ["std"] }
 pin-project = { version = "1.0.8", default-features = false }

--- a/lib/vector-core/buffers/benches/common.rs
+++ b/lib/vector-core/buffers/benches/common.rs
@@ -1,6 +1,7 @@
 use buffers::bytes::{DecodeBytes, EncodeBytes};
 use buffers::{self, Variant};
 use bytes::{Buf, BufMut};
+use core_common::byte_size_of::ByteSizeOf;
 use futures::task::{noop_waker, Context, Poll};
 use futures::{Sink, Stream};
 use std::fmt;
@@ -19,6 +20,12 @@ impl<const N: usize> Message<N> {
             id,
             _padding: [0; N],
         }
+    }
+}
+
+impl<const N: usize> ByteSizeOf for Message<N> {
+    fn allocated_bytes(&self) -> usize {
+        self.id.size_of() + self._padding.iter().fold(0, |acc, v| acc + v.size_of())
     }
 }
 

--- a/lib/vector-core/buffers/examples/soak.rs
+++ b/lib/vector-core/buffers/examples/soak.rs
@@ -7,6 +7,7 @@ use buffers::{
     Variant, WhenFull,
 };
 use bytes::{Buf, BufMut};
+use core_common::byte_size_of::ByteSizeOf;
 use futures::{SinkExt, StreamExt};
 use metrics::{counter, increment_counter};
 use metrics_exporter_prometheus::PrometheusBuilder;
@@ -19,6 +20,12 @@ use tokio::{
 pub struct Message<const N: usize> {
     id: u64,
     _padding: [u64; N],
+}
+
+impl<const N: usize> ByteSizeOf for Message<N> {
+    fn allocated_bytes(&self) -> usize {
+        self.id.size_of() + self._padding.iter().fold(0, |acc, v| acc + v.size_of())
+    }
 }
 
 impl<const N: usize> Message<N> {

--- a/lib/vector-core/buffers/src/lib.rs
+++ b/lib/vector-core/buffers/src/lib.rs
@@ -21,6 +21,7 @@ mod variant;
 
 use crate::bytes::{DecodeBytes, EncodeBytes};
 pub use acker::{Ackable, Acker};
+use core_common::byte_size_of::ByteSizeOf;
 use futures::{channel::mpsc, Sink, SinkExt, Stream};
 use pin_project::pin_project;
 #[cfg(test)]
@@ -49,7 +50,7 @@ pub fn build<'a, T>(
     String,
 >
 where
-    T: 'a + Send + Sync + Unpin + Clone + EncodeBytes<T> + DecodeBytes<T>,
+    T: 'a + ByteSizeOf + Send + Sync + Unpin + Clone + EncodeBytes<T> + DecodeBytes<T>,
     <T as EncodeBytes<T>>::Error: Debug,
     <T as DecodeBytes<T>>::Error: Debug + Display,
 {
@@ -124,7 +125,7 @@ where
 
 impl<'a, T> BufferInputCloner<T>
 where
-    T: 'a + Send + Sync + Unpin + Clone + EncodeBytes<T> + DecodeBytes<T>,
+    T: 'a + ByteSizeOf + Send + Sync + Unpin + Clone + EncodeBytes<T> + DecodeBytes<T>,
     <T as EncodeBytes<T>>::Error: Debug,
     <T as DecodeBytes<T>>::Error: Debug + Display,
 {
@@ -168,7 +169,7 @@ impl<S> DropWhenFull<S> {
     }
 }
 
-impl<T, S: Sink<T> + Unpin> Sink<T> for DropWhenFull<S> {
+impl<T: ByteSizeOf, S: Sink<T> + Unpin> Sink<T> for DropWhenFull<S> {
     type Error = S::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/lib/vector-core/buffers/src/test/common/message.rs
+++ b/lib/vector-core/buffers/src/test/common/message.rs
@@ -1,5 +1,6 @@
 use crate::bytes::{DecodeBytes, EncodeBytes};
 use bytes::{Buf, BufMut};
+use core_common::byte_size_of::ByteSizeOf;
 use quickcheck::{Arbitrary, Gen};
 use std::{fmt, mem};
 
@@ -11,6 +12,12 @@ pub struct Message {
 impl Message {
     pub(crate) fn new(id: u64) -> Self {
         Message { id }
+    }
+}
+
+impl ByteSizeOf for Message {
+    fn allocated_bytes(&self) -> usize {
+        self.id.size_of()
     }
 }
 


### PR DESCRIPTION
To slim down the number of changes in #9327, I am breaking out smaller pieces into their own PR.

This PR adds `ByteSizeOf` trait bound for buffer items and makes associated changes.