### PR TITLE
chore: Accept either v1 or v2 status codes

### DIFF
--- a/src/sinks/datadog/logs/healthcheck.rs
+++ b/src/sinks/datadog/logs/healthcheck.rs
@@ -17,7 +17,7 @@ pub async fn healthcheck(client: HttpClient, uri: Uri, api_key: String) -> crate
     let body = hyper::body::to_bytes(response.into_body()).await?;
 
     match status {
-        StatusCode::ACCEPTED => Ok(()),
+        StatusCode::ACCEPTED | StatusCode::OK => Ok(()),
         StatusCode::UNAUTHORIZED => {
             let json: serde_json::Value = serde_json::from_slice(&body[..])?;
 

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -134,7 +134,8 @@ impl Service<LogApiRequest> for LogApiService {
                     // From https://docs.datadoghq.com/api/latest/logs/:
                     //
                     // The status codes answered by the HTTP API are:
-                    // 200: OK
+                    // 200: OK (v1)
+                    // 202: Accepted (v2)
                     // 400: Bad request (likely an issue in the payload
                     //      formatting)
                     // 403: Permission issue (likely using an invalid API Key)
@@ -144,7 +145,7 @@ impl Service<LogApiRequest> for LogApiService {
                     match status {
                         StatusCode::BAD_REQUEST => Err(LogApiError::BadRequest),
                         StatusCode::FORBIDDEN => Ok(LogApiResponse::PermissionIssue),
-                        StatusCode::ACCEPTED => Ok(LogApiResponse::Ok),
+                        StatusCode::OK | StatusCode::ACCEPTED => Ok(LogApiResponse::Ok),
                         StatusCode::PAYLOAD_TOO_LARGE => Err(LogApiError::PayloadTooLarge),
                         _ => Err(LogApiError::ServerError),
                     }

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -13,10 +13,40 @@ use futures::{
 use http::request::Parts;
 use hyper::StatusCode;
 use indoc::indoc;
-use pretty_assertions::assert_eq;
 use std::sync::Arc;
 use vector_core::event::Event;
 use vector_core::event::{BatchNotifier, BatchStatus};
+
+// The sink must support v1 and v2 API endpoints which have different codes for
+// signaling status. This enum allows us to signal which API endpoint and what
+// kind of response we want our test to model without getting into the details
+// of exactly what that code is.
+enum ApiStatus {
+    OKv1,
+    OKv2,
+    Forbiddenv1,
+    Forbiddenv2,
+}
+
+fn test_server(
+    addr: std::net::SocketAddr,
+    api_status: ApiStatus,
+) -> (
+    futures::channel::mpsc::Receiver<(http::request::Parts, Bytes)>,
+    stream_cancel::Trigger,
+    impl std::future::Future<Output = Result<(), ()>>,
+) {
+    let status = match api_status {
+        ApiStatus::OKv1 => StatusCode::OK,
+        ApiStatus::OKv2 => StatusCode::ACCEPTED,
+        ApiStatus::Forbiddenv1 | ApiStatus::Forbiddenv2 => StatusCode::FORBIDDEN,
+    };
+
+    // NOTE: we pass `Trigger` out to the caller even though this suite never
+    // uses it as it's being dropped cancels the stream machinery here,
+    // indicating failures that might not be valid.
+    build_test_server_status(addr, status)
+}
 
 fn event_with_api_key(msg: &str, key: &str) -> Event {
     let mut e = Event::from(msg);
@@ -36,7 +66,7 @@ fn event_with_api_key(msg: &str, key: &str) -> Event {
 /// status code faked HTTP responses will have, the second acts as a check on
 /// the `Receiver`'s status before being returned to the caller.
 async fn start_test(
-    http_status: StatusCode,
+    api_status: ApiStatus,
     batch_status: BatchStatus,
 ) -> (Vec<String>, Receiver<(http::request::Parts, Bytes)>) {
     let config = indoc! {r#"
@@ -53,7 +83,7 @@ async fn start_test(
 
     let (sink, _) = config.build(cx).await.unwrap();
 
-    let (rx, _trigger, server) = build_test_server_status(addr, http_status);
+    let (rx, _trigger, server) = test_server(addr, api_status);
     tokio::spawn(server);
 
     let (batch, receiver) = BatchNotifier::new_with_receiver();
@@ -68,11 +98,11 @@ async fn start_test(
 #[tokio::test]
 /// Assert the basic functionality of the sink in good conditions
 ///
-/// This test rigs the sink to return StatusCode::ACCEPTED to responses, checks that
-/// all batches were delivered and then asserts that every message is able to be
+/// This test rigs the sink to return OKv1 to responses, checks that all batches
+/// were delivered and then asserts that every message is able to be
 /// deserialized.
 async fn smoke() {
-    let (expected, rx) = start_test(StatusCode::ACCEPTED, BatchStatus::Delivered).await;
+    let (expected, rx) = start_test(ApiStatus::OKv1, BatchStatus::Delivered).await;
 
     let output = rx.take(expected.len()).collect::<Vec<_>>().await;
 
@@ -110,26 +140,54 @@ async fn smoke() {
 }
 
 #[tokio::test]
-/// Assert delivery error behavior
+/// Assert delivery error behavior for v1 API
 ///
 /// In the event that delivery fails -- in this case becaues it is FORBIDDEN --
 /// there should be no outbound messages from the sink. That is, receiving from
 /// its Receiver must fail.
-async fn handles_failure() {
-    let (_expected, mut rx) = start_test(StatusCode::FORBIDDEN, BatchStatus::Errored).await;
+async fn handles_failure_v1() {
+    let (_expected, mut rx) = start_test(ApiStatus::Forbiddenv1, BatchStatus::Errored).await;
     let res = rx.try_next();
 
     assert!(matches!(res, Err(TryRecvError { .. })));
 }
 
 #[tokio::test]
-/// Assert that metadata API keys are passed correctly
+/// Assert delivery error behavior for v2 API
+///
+/// In the event that delivery fails -- in this case becaues it is FORBIDDEN --
+/// there should be no outbound messages from the sink. That is, receiving from
+/// its Receiver must fail.
+async fn handles_failure_v2() {
+    let (_expected, mut rx) = start_test(ApiStatus::Forbiddenv2, BatchStatus::Errored).await;
+    let res = rx.try_next();
+
+    assert!(matches!(res, Err(TryRecvError { .. })));
+}
+
+#[tokio::test]
+/// Assert that metadata API keys are passed correctly, v2 API
 ///
 /// Datadog sink payloads come with an associated API key. This key can be set
 /// per-event or set in the message for an entire payload. This test asserts
 /// that, for successful transmission, the API key set in metadata is
 /// propagated.
-async fn api_key_in_metadata() {
+async fn api_key_in_metadata_v2() {
+    api_key_in_metadata_inner(ApiStatus::OKv2).await
+}
+
+#[tokio::test]
+/// Assert that metadata API keys are passed correctly, v1 API
+///
+/// Datadog sink payloads come with an associated API key. This key can be set
+/// per-event or set in the message for an entire payload. This test asserts
+/// that, for successful transmission, the API key set in metadata is
+/// propagated.
+async fn api_key_in_metadata_v1() {
+    api_key_in_metadata_inner(ApiStatus::OKv1).await
+}
+
+async fn api_key_in_metadata_inner(api_status: ApiStatus) {
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"
             compression = "none"
@@ -143,7 +201,7 @@ async fn api_key_in_metadata() {
 
     let (sink, _) = config.build(cx).await.unwrap();
 
-    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::ACCEPTED);
+    let (rx, _trigger, server) = test_server(addr, api_status);
     tokio::spawn(server);
 
     let (expected_messages, events) = random_lines_with_stream(100, 10, None);
@@ -187,13 +245,28 @@ async fn api_key_in_metadata() {
 }
 
 #[tokio::test]
-/// Assert that events with explicit keys have those keys preserved
+/// Assert that events with explicit keys have those keys preserved, v1 API
 ///
 /// Datadog sink payloads come with an associated API key. This key can be set
 /// per-event or set in the message for an entire payload. This test asserts
 /// that, for successful transmission, per-event API keys are propagated
 /// correctly.
-async fn multiple_api_keys() {
+async fn multiple_api_keys_v1() {
+    multiple_api_keys_inner(ApiStatus::OKv1).await
+}
+
+#[tokio::test]
+/// Assert that events with explicit keys have those keys preserved, v2 API
+///
+/// Datadog sink payloads come with an associated API key. This key can be set
+/// per-event or set in the message for an entire payload. This test asserts
+/// that, for successful transmission, per-event API keys are propagated
+/// correctly.
+async fn multiple_api_keys_v2() {
+    multiple_api_keys_inner(ApiStatus::OKv2).await
+}
+
+async fn multiple_api_keys_inner(api_status: ApiStatus) {
     let (mut config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"
             compression = "none"
@@ -208,7 +281,7 @@ async fn multiple_api_keys() {
 
     let (sink, _) = config.build(cx).await.unwrap();
 
-    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::ACCEPTED);
+    let (rx, _trigger, server) = test_server(addr, api_status);
     tokio::spawn(server);
 
     let events = vec![
@@ -230,7 +303,30 @@ async fn multiple_api_keys() {
 }
 
 #[tokio::test]
-async fn enterprise_headers() {
+/// Assert that events are sent and the DD-EVP-ORIGIN header is set when
+/// 'enterprise' is flagged on, v2 API
+///
+/// Vector allows for flagging a global 'enterprise' context that indicates
+/// whether we're running in Datadog enterprise mode or not. When this flag is
+/// active we should set the origin header discussed above correctly, as well as
+/// still sending events through the sink.
+async fn enterprise_headers_v2() {
+    enterprise_headers_inner(ApiStatus::OKv2).await
+}
+
+#[tokio::test]
+/// Assert that events are sent and the DD-EVP-ORIGIN header is set when
+/// 'enterprise' is flagged on, v1 API
+///
+/// Vector allows for flagging a global 'enterprise' context that indicates
+/// whether we're running in Datadog enterprise mode or not. When this flag is
+/// active we should set the origin header discussed above correctly, as well as
+/// still sending events through the sink.
+async fn enterprise_headers_v1() {
+    enterprise_headers_inner(ApiStatus::OKv1).await
+}
+
+async fn enterprise_headers_inner(api_status: ApiStatus) {
     let (mut config, mut cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"
             compression = "none"
@@ -245,7 +341,7 @@ async fn enterprise_headers() {
     cx.globals.enterprise = true;
     let (sink, _) = config.build(cx).await.unwrap();
 
-    let (rx, _trigger, server) = build_test_server_status(addr, StatusCode::ACCEPTED);
+    let (rx, _trigger, server) = test_server(addr, api_status);
     tokio::spawn(server);
 
     let (_expected_messages, events) = random_lines_with_stream(100, 10, None);
@@ -267,5 +363,66 @@ async fn enterprise_headers() {
         parts.headers.get("DD-EVP-ORIGIN").unwrap(),
         "vector-enterprise"
     );
+    assert!(parts.headers.get("DD-EVP-ORIGIN-VERSION").is_some());
+}
+
+#[tokio::test]
+/// Assert that events are sent and the DD-EVP-ORIGIN header is not set when
+/// 'enterprise' is flagged off, v2 API
+///
+/// Vector allows for flagging a global 'enterprise' context that indicates
+/// whether we're running in Datadog enterprise mode or not. When this flag is
+/// not active we should not set the origin header discussed above, as well as
+/// still sending events through the sink.
+async fn no_enterprise_headers_v2() {
+    no_enterprise_headers_inner(ApiStatus::OKv2).await
+}
+
+#[tokio::test]
+/// Assert that events are sent and the DD-EVP-ORIGIN header is not set when
+/// 'enterprise' is flagged off, v1 API
+///
+/// Vector allows for flagging a global 'enterprise' context that indicates
+/// whether we're running in Datadog enterprise mode or not. When this flag is
+/// not active we should not set the origin header discussed above, as well as
+/// still sending events through the sink.
+async fn no_enterprise_headers_v1() {
+    no_enterprise_headers_inner(ApiStatus::OKv1).await
+}
+
+async fn no_enterprise_headers_inner(api_status: ApiStatus) {
+    let (mut config, mut cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
+            default_api_key = "atoken"
+            compression = "none"
+        "#})
+    .unwrap();
+
+    let addr = next_addr();
+    // Swap out the endpoint so we can force send it to our local server
+    let endpoint = format!("http://{}", addr);
+    config.endpoint = Some(endpoint.clone());
+
+    cx.globals.enterprise = false;
+    let (sink, _) = config.build(cx).await.unwrap();
+
+    let (rx, _trigger, server) = test_server(addr, api_status);
+    tokio::spawn(server);
+
+    let (_expected_messages, events) = random_lines_with_stream(100, 10, None);
+
+    let api_key = "0xDECAFBAD";
+    let events = events.map(|mut e| {
+        println!("EVENT: {:?}", e);
+        e.as_mut_log()
+            .metadata_mut()
+            .set_datadog_api_key(Some(Arc::from(api_key)));
+        e
+    });
+
+    let () = sink.run(events).await.unwrap();
+    let output: (Parts, Bytes) = rx.take(1).collect::<Vec<_>>().await.pop().unwrap();
+    let parts = output.0;
+
+    assert_eq!(parts.headers.get("DD-EVP-ORIGIN").unwrap(), "vector");
     assert!(parts.headers.get("DD-EVP-ORIGIN-VERSION").is_some());
 }


### PR DESCRIPTION
This commit adjusts the sink code to respond correctly to either the v1 or v2
API's status codes. The vector user is allowed to explicitly set the API
endpoint, meaning the sink must continue to function for v1. Recent changes to
support the v2 API have muddied the implementation somewhat. I have updated 
the comments to reflect which status codes come from what API version and 
have expanded the tests to capture v1 and v2 responses.

I have confirmed that this reports logs into both v1 and v2 live API endpoints by 
direct experimentation. 

Resolves #9484. Strongly suggests we should pursue #8442.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
