### PR TITLE
enhancement(aws_ec2_metadata transform): dont error when receiving a 404 when fetching metadata

### DIFF
--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -312,119 +312,132 @@ impl MetadataClient {
         Ok(token)
     }
 
-    pub async fn get_document(&mut self) -> Result<IdentityDocument, crate::Error> {
-        let body = self.get_metadata(&DYNAMIC_DOCUMENT).await?;
-
-        serde_json::from_slice(&body[..])
-            .context(ParseIdentityDocument {})
-            .map_err(Into::into)
+    pub async fn get_document(&mut self) -> Result<Option<IdentityDocument>, crate::Error> {
+        self.get_metadata(&DYNAMIC_DOCUMENT)
+            .await?
+            .map(|body| {
+                serde_json::from_slice(&body[..])
+                    .context(ParseIdentityDocument {})
+                    .map_err(Into::into)
+            })
+            .transpose()
     }
 
     pub async fn refresh_metadata(&mut self) -> Result<(), crate::Error> {
         let mut state: HashMap<String, Bytes> = HashMap::new();
 
         // Fetch all resources, _then_ add them to the state map.
-        let document = self.get_document().await?;
-
-        if self.fields.contains(AMI_ID_KEY) {
-            state.insert(self.keys.ami_id_key.clone(), document.image_id.into());
-        }
-
-        if self.fields.contains(INSTANCE_ID_KEY) {
-            state.insert(
-                self.keys.instance_id_key.clone(),
-                document.instance_id.into(),
-            );
-        }
-
-        if self.fields.contains(INSTANCE_TYPE_KEY) {
-            state.insert(
-                self.keys.instance_type_key.clone(),
-                document.instance_type.into(),
-            );
-        }
-
-        if self.fields.contains(REGION_KEY) {
-            state.insert(self.keys.region_key.clone(), document.region.into());
-        }
-
-        if self.fields.contains(AVAILABILITY_ZONE_KEY) {
-            let availability_zone = self.get_metadata(&AVAILABILITY_ZONE).await?;
-            state.insert(self.keys.availability_zone_key.clone(), availability_zone);
-        }
-
-        if self.fields.contains(LOCAL_HOSTNAME_KEY) {
-            let local_hostname = self.get_metadata(&LOCAL_HOSTNAME).await?;
-            state.insert(self.keys.local_hostname_key.clone(), local_hostname);
-        }
-
-        if self.fields.contains(LOCAL_IPV4_KEY) {
-            let local_ipv4 = self.get_metadata(&LOCAL_IPV4).await?;
-            state.insert(self.keys.local_ipv4_key.clone(), local_ipv4);
-        }
-
-        if self.fields.contains(PUBLIC_HOSTNAME_KEY) {
-            let public_hostname = self.get_metadata(&PUBLIC_HOSTNAME).await?;
-            state.insert(self.keys.public_hostname_key.clone(), public_hostname);
-        }
-
-        if self.fields.contains(PUBLIC_IPV4_KEY) {
-            let public_ipv4 = self.get_metadata(&PUBLIC_IPV4).await?;
-            state.insert(self.keys.public_ipv4_key.clone(), public_ipv4);
-        }
-
-        if self.fields.contains(SUBNET_ID_KEY) || self.fields.contains(VPC_ID_KEY) {
-            let mac = self.get_metadata(&MAC).await?;
-            let mac = String::from_utf8_lossy(&mac[..]);
-
-            if self.fields.contains(SUBNET_ID_KEY) {
-                let subnet_path = format!(
-                    "/latest/meta-data/network/interfaces/macs/{}/subnet-id",
-                    mac
-                );
-
-                let subnet_path = subnet_path.parse().context(ParsePath {
-                    value: subnet_path.clone(),
-                })?;
-
-                let subnet_id = self.get_metadata(&subnet_path).await?;
-                state.insert(self.keys.subnet_id_key.clone(), subnet_id);
+        if let Some(document) = self.get_document().await? {
+            if self.fields.contains(AMI_ID_KEY) {
+                state.insert(self.keys.ami_id_key.clone(), document.image_id.into());
             }
 
-            if self.fields.contains(VPC_ID_KEY) {
-                let vpc_path = format!("/latest/meta-data/network/interfaces/macs/{}/vpc-id", mac);
-
-                let vpc_path = vpc_path.parse().context(ParsePath {
-                    value: vpc_path.clone(),
-                })?;
-
-                let vpc_id = self.get_metadata(&vpc_path).await?;
-                state.insert(self.keys.vpc_id_key.clone(), vpc_id);
-            }
-        }
-
-        if self.fields.contains(ROLE_NAME_KEY) {
-            let role_names = self.get_metadata(&ROLE_NAME).await?;
-            let role_names = String::from_utf8_lossy(&role_names[..]);
-
-            for (i, role_name) in role_names.lines().enumerate() {
+            if self.fields.contains(INSTANCE_ID_KEY) {
                 state.insert(
-                    format!("{}[{}]", self.keys.role_name_key, i),
-                    role_name.to_string().into(),
+                    self.keys.instance_id_key.clone(),
+                    document.instance_id.into(),
                 );
             }
-        }
 
-        {
-            if let Ok(mut old_state) = self.state.write() {
-                old_state.extend(state);
+            if self.fields.contains(INSTANCE_TYPE_KEY) {
+                state.insert(
+                    self.keys.instance_type_key.clone(),
+                    document.instance_type.into(),
+                );
+            }
+
+            if self.fields.contains(REGION_KEY) {
+                state.insert(self.keys.region_key.clone(), document.region.into());
+            }
+
+            if self.fields.contains(AVAILABILITY_ZONE_KEY) {
+                if let Some(availability_zone) = self.get_metadata(&AVAILABILITY_ZONE).await? {
+                    state.insert(self.keys.availability_zone_key.clone(), availability_zone);
+                }
+            }
+
+            if self.fields.contains(LOCAL_HOSTNAME_KEY) {
+                if let Some(local_hostname) = self.get_metadata(&LOCAL_HOSTNAME).await? {
+                    state.insert(self.keys.local_hostname_key.clone(), local_hostname);
+                }
+            }
+
+            if self.fields.contains(LOCAL_IPV4_KEY) {
+                if let Some(local_ipv4) = self.get_metadata(&LOCAL_IPV4).await? {
+                    state.insert(self.keys.local_ipv4_key.clone(), local_ipv4);
+                }
+            }
+
+            if self.fields.contains(PUBLIC_HOSTNAME_KEY) {
+                if let Some(public_hostname) = self.get_metadata(&PUBLIC_HOSTNAME).await? {
+                    state.insert(self.keys.public_hostname_key.clone(), public_hostname);
+                }
+            }
+
+            if self.fields.contains(PUBLIC_IPV4_KEY) {
+                if let Some(public_ipv4) = self.get_metadata(&PUBLIC_IPV4).await? {
+                    state.insert(self.keys.public_ipv4_key.clone(), public_ipv4);
+                }
+            }
+
+            if self.fields.contains(SUBNET_ID_KEY) || self.fields.contains(VPC_ID_KEY) {
+                if let Some(mac) = self.get_metadata(&MAC).await? {
+                    let mac = String::from_utf8_lossy(&mac[..]);
+
+                    if self.fields.contains(SUBNET_ID_KEY) {
+                        let subnet_path = format!(
+                            "/latest/meta-data/network/interfaces/macs/{}/subnet-id",
+                            mac
+                        );
+
+                        let subnet_path = subnet_path.parse().context(ParsePath {
+                            value: subnet_path.clone(),
+                        })?;
+
+                        if let Some(subnet_id) = self.get_metadata(&subnet_path).await? {
+                            state.insert(self.keys.subnet_id_key.clone(), subnet_id);
+                        }
+                    }
+
+                    if self.fields.contains(VPC_ID_KEY) {
+                        let vpc_path =
+                            format!("/latest/meta-data/network/interfaces/macs/{}/vpc-id", mac);
+
+                        let vpc_path = vpc_path.parse().context(ParsePath {
+                            value: vpc_path.clone(),
+                        })?;
+
+                        if let Some(vpc_id) = self.get_metadata(&vpc_path).await? {
+                            state.insert(self.keys.vpc_id_key.clone(), vpc_id);
+                        }
+                    }
+                }
+            }
+
+            if self.fields.contains(ROLE_NAME_KEY) {
+                if let Some(role_names) = self.get_metadata(&ROLE_NAME).await? {
+                    let role_names = String::from_utf8_lossy(&role_names[..]);
+
+                    for (i, role_name) in role_names.lines().enumerate() {
+                        state.insert(
+                            format!("{}[{}]", self.keys.role_name_key, i),
+                            role_name.to_string().into(),
+                        );
+                    }
+                }
+            }
+
+            {
+                if let Ok(mut old_state) = self.state.write() {
+                    old_state.extend(state);
+                }
             }
         }
 
         Ok(())
     }
 
-    async fn get_metadata(&mut self, path: &PathAndQuery) -> Result<Bytes, crate::Error> {
+    async fn get_metadata(&mut self, path: &PathAndQuery) -> Result<Option<Bytes>, crate::Error> {
         let token = self.get_token().await.with_context(|| FetchToken {})?;
 
         let mut parts = self.host.clone().into_parts();
@@ -439,22 +452,25 @@ impl MetadataClient {
             .header(TOKEN_HEADER.as_ref(), token.as_ref())
             .body(Body::empty())?;
 
-        let res = self
+        match self
             .client
             .send(req)
             .await
             .map_err(crate::Error::from)
             .and_then(|res| match res.status() {
-                StatusCode::OK => Ok(res),
+                StatusCode::OK => Ok(Some(res)),
+                StatusCode::NOT_FOUND => Ok(None),
                 status_code => Err(UnexpectedHttpStatusError {
                     status: status_code,
                 }
                 .into()),
-            })?;
-
-        let body = body_to_bytes(res.into_body()).await?;
-
-        Ok(body)
+            })? {
+            Some(res) => {
+                let body = body_to_bytes(res.into_body()).await?;
+                Ok(Some(body))
+            }
+            None => Ok(None),
+        }
     }
 }
 


### PR DESCRIPTION
Closes #8677 

This stops Vector from erroring if it receives a 404 whilst fetching metadata.

I have *not* changed it to prevent an error if it receives an error when fetching the token. It's not 100% clear from the issue if this needs doing.

I haven't tested this properly against aws, instead I have just knocked up a quick Actix server to send the 404.

So, I am not 100% certain that this is correct and could do with some advice.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>