### PR TITLE
enhancement(observability): Adjust component spec and sinks to reflect sent bytes and events only after sending successfully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 [[package]]
 name = "core_common"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "cpufeatures"

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -155,9 +155,8 @@ or receiving one or more Vector events.
 
 #### EventsSent
 
-*All components* MUST emit an `EventsSent` event immediately before sending the
-event down stream. This should happen before any transmission preparation, such
-as encoding.
+*All components* MUST emit an `EventsSent` event immediately after
+sending the events down stream, if the transmission was successful.
 
 * Properties
   * `count` - The count of Vector events.
@@ -174,7 +173,7 @@ as encoding.
 #### BytesSent
 
 *Sinks* MUST emit a `BytesSent` event immediately after sending bytes to the
-downstream target regardless if the transmission was successful or not.
+downstream target, if the transmission was successful.
 
 * Properties
   * `byte_size`

--- a/lib/vector-core/core-common/Cargo.toml
+++ b/lib/vector-core/core-common/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2018"
 publish = false
+
+[dependencies]
+serde_json = { version = "1.0.68", default-features = false, features = ["raw_value"] }

--- a/lib/vector-core/core-common/src/byte_size_of.rs
+++ b/lib/vector-core/core-common/src/byte_size_of.rs
@@ -1,3 +1,4 @@
+use serde_json::{value::RawValue, Value};
 use std::{
     collections::{BTreeMap, BTreeSet},
     mem,
@@ -91,3 +92,20 @@ num!(i64);
 num!(i128);
 num!(f32);
 num!(f64);
+
+impl ByteSizeOf for Box<RawValue> {
+    fn allocated_bytes(&self) -> usize {
+        self.get().len()
+    }
+}
+
+impl ByteSizeOf for Value {
+    fn allocated_bytes(&self) -> usize {
+        match self {
+            Value::Null | Value::Bool(_) | Value::Number(_) => 0,
+            Value::String(s) => s.len(),
+            Value::Array(a) => a.iter().map(ByteSizeOf::size_of).sum(),
+            Value::Object(o) => o.iter().map(|(k, v)| k.size_of() + v.size_of()).sum(),
+        }
+    }
+}

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -56,7 +56,12 @@ impl Pipeline {
                 Poll::Ready(Ok(())) => {
                     // continue to send below
                 }
-                Poll::Ready(Err(_error)) => return Poll::Ready(Err(ClosedError)),
+                Poll::Ready(Err(_error)) => {
+                    if sent.count > 0 {
+                        emit!(&sent);
+                    }
+                    return Poll::Ready(Err(ClosedError));
+                }
             }
 
             let event_bytes = event.size_of();

--- a/src/sinks/datadog/events.rs
+++ b/src/sinks/datadog/events.rs
@@ -22,6 +22,7 @@ use indoc::indoc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{sync::Arc, time::Duration};
+use vector_core::ByteSizeOf;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -74,7 +75,7 @@ impl DatadogEventsConfig {
         timeout: Duration,
     ) -> crate::Result<(VectorSink, Healthcheck)>
     where
-        O: 'static,
+        O: ByteSizeOf + 'static,
         B: Batch<Output = Vec<O>> + std::marker::Send + 'static,
         B::Output: std::marker::Send + Clone,
         B::Input: std::marker::Send,

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -1,5 +1,5 @@
 use super::super::batch::{Batch, BatchConfig, BatchError, BatchSettings, PushResult};
-use super::super::EventCount;
+use super::super::ElementCount;
 use vector_core::ByteSizeOf;
 
 pub trait Partition<K> {
@@ -99,8 +99,8 @@ impl<T: ByteSizeOf, K> ByteSizeOf for PartitionInnerBuffer<T, K> {
     }
 }
 
-impl<T: EventCount, K> EventCount for PartitionInnerBuffer<T, K> {
-    fn event_count(&self) -> usize {
-        self.inner.event_count()
+impl<T: ElementCount, K> ElementCount for PartitionInnerBuffer<T, K> {
+    fn element_count(&self) -> usize {
+        self.inner.element_count()
     }
 }

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -1,4 +1,6 @@
-use crate::sinks::util::batch::{Batch, BatchConfig, BatchError, BatchSettings, PushResult};
+use super::super::batch::{Batch, BatchConfig, BatchError, BatchSettings, PushResult};
+use super::super::EventCount;
+use vector_core::ByteSizeOf;
 
 pub trait Partition<K> {
     fn partition(&self) -> K;
@@ -83,5 +85,22 @@ where
 {
     fn partition(&self) -> K {
         self.key.clone()
+    }
+}
+
+impl<T: ByteSizeOf, K> ByteSizeOf for PartitionInnerBuffer<T, K> {
+    // This ignores the size of the key, as it does not represent actual data size.
+    fn size_of(&self) -> usize {
+        self.inner.size_of()
+    }
+
+    fn allocated_bytes(&self) -> usize {
+        self.inner.allocated_bytes()
+    }
+}
+
+impl<T: EventCount, K> EventCount for PartitionInnerBuffer<T, K> {
+    fn event_count(&self) -> usize {
+        self.inner.event_count()
     }
 }

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -1,7 +1,7 @@
 use super::{
     retries::{RetryAction, RetryLogic},
     sink::{self, ServiceLogic},
-    Batch, EncodedEvent, EventCount, Partition, TowerBatchedSink, TowerPartitionSink,
+    Batch, ElementCount, EncodedEvent, Partition, TowerBatchedSink, TowerPartitionSink,
     TowerRequestConfig, TowerRequestSettings,
 };
 use crate::{
@@ -59,7 +59,7 @@ pub struct BatchedHttpSink<
     SL = sink::StdServiceLogic<http::Response<Bytes>>,
 > where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     RL: RetryLogic<Response = http::Response<Bytes>> + Send + 'static,
     SL: ServiceLogic<Response = http::Response<Bytes>> + Send + 'static,
 {
@@ -80,7 +80,7 @@ pub struct BatchedHttpSink<
 impl<T, B> BatchedHttpSink<T, B>
 where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     T: HttpSink<Input = B::Input, Output = B::Output>,
 {
     pub fn new(
@@ -107,7 +107,7 @@ where
 impl<T, B, RL, SL> BatchedHttpSink<T, B, RL, SL>
 where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     RL: RetryLogic<Response = http::Response<Bytes>, Error = HttpError> + Send + 'static,
     SL: ServiceLogic<Response = http::Response<Bytes>> + Send + 'static,
     T: HttpSink<Input = B::Input, Output = B::Output>,
@@ -152,7 +152,7 @@ where
 impl<T, B, RL, SL> Sink<Event> for BatchedHttpSink<T, B, RL, SL>
 where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     T: HttpSink<Input = B::Input, Output = B::Output>,
     RL: RetryLogic<Response = http::Response<Bytes>> + Send + 'static,
     SL: ServiceLogic<Response = http::Response<Bytes>> + Send + 'static,
@@ -209,7 +209,7 @@ where
 pub struct PartitionHttpSink<T, B, K, RL = HttpRetryLogic>
 where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     B::Input: Partition<K>,
     K: Hash + Eq + Clone + Send + 'static,
     RL: RetryLogic<Response = http::Response<Bytes>> + Send + 'static,
@@ -230,7 +230,7 @@ where
 impl<T, B, K> PartitionHttpSink<T, B, K, HttpRetryLogic>
 where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     B::Input: Partition<K>,
     K: Hash + Eq + Clone + Send + 'static,
     T: HttpSink<Input = B::Input, Output = B::Output>,
@@ -258,7 +258,7 @@ where
 impl<T, B, K, RL> PartitionHttpSink<T, B, K, RL>
 where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     B::Input: Partition<K>,
     K: Hash + Eq + Clone + Send + 'static,
     RL: RetryLogic<Response = http::Response<Bytes>, Error = HttpError> + Send + 'static,
@@ -309,7 +309,7 @@ where
 impl<T, B, K, RL> Sink<Event> for PartitionHttpSink<T, B, K, RL>
 where
     B: Batch,
-    B::Output: ByteSizeOf + EventCount + Clone + Send + 'static,
+    B::Output: ByteSizeOf + ElementCount + Clone + Send + 'static,
     B::Input: Partition<K>,
     K: Hash + Eq + Clone + Send + 'static,
     T: HttpSink<Input = B::Input, Output = B::Output>,
@@ -383,7 +383,7 @@ impl<F, B> HttpBatchService<F, B> {
 impl<F, B> Service<B> for HttpBatchService<F, B>
 where
     F: Future<Output = crate::Result<hyper::Request<Vec<u8>>>> + Send + 'static,
-    B: ByteSizeOf + EventCount + Send + 'static,
+    B: ByteSizeOf + ElementCount + Send + 'static,
 {
     type Response = http::Response<Bytes>;
     type Error = crate::Error;
@@ -399,7 +399,7 @@ where
 
         Box::pin(async move {
             let events_sent = EventsSent {
-                count: body.event_count(),
+                count: body.element_count(),
                 byte_size: body.size_of(),
             };
             let request = request_builder(body).await?;

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -414,13 +414,16 @@ where
                 .unwrap_or_else(|_| unreachable!())
                 .to_string();
 
-            emit!(&EndpointBytesSent {
-                byte_size,
-                protocol: scheme.unwrap_or(Scheme::HTTP).as_str(),
-                endpoint: &endpoint
-            });
-
             let response = http_client.call(request).await?;
+
+            if response.status().is_success() {
+                emit!(&EndpointBytesSent {
+                    byte_size,
+                    protocol: scheme.unwrap_or(Scheme::HTTP).as_str(),
+                    endpoint: &endpoint
+                });
+            }
+
             let (parts, body) = response.into_parts();
             let mut body = body::aggregate(body).await?;
             Ok(hyper::Response::from_parts(

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -132,18 +132,18 @@ pub fn encode_namespace<'a>(
 }
 
 /// Marker trait for types that can hold a batch of events
-pub trait EventCount {
-    fn event_count(&self) -> usize;
+pub trait ElementCount {
+    fn element_count(&self) -> usize;
 }
 
-impl<T> EventCount for Vec<T> {
-    fn event_count(&self) -> usize {
+impl<T> ElementCount for Vec<T> {
+    fn element_count(&self) -> usize {
         self.len()
     }
 }
 
-impl EventCount for serde_json::Value {
-    fn event_count(&self) -> usize {
+impl ElementCount for serde_json::Value {
+    fn element_count(&self) -> usize {
         1
     }
 }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -130,3 +130,20 @@ pub fn encode_namespace<'a>(
         .map(|namespace| format!("{}{}{}", namespace, delimiter, name))
         .unwrap_or_else(|| name.into_owned())
 }
+
+/// Marker trait for types that can hold a batch of events
+pub trait EventCount {
+    fn event_count(&self) -> usize;
+}
+
+impl<T> EventCount for Vec<T> {
+    fn event_count(&self) -> usize {
+        self.len()
+    }
+}
+
+impl EventCount for serde_json::Value {
+    fn event_count(&self) -> usize {
+        1
+    }
+}


### PR DESCRIPTION
This primarily affects the topology code and a few sinks. This is scoped down from the previous pull request, as only the `HttpSink` sinks actually send the events currently. Another pull request or two will be coming with new implementations.

Closes #9362 