### PR TITLE
fix(observability, sinks): Fix double emit of EventsSent in HttpSink

### DIFF
--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -177,7 +177,6 @@ where
 
     fn start_send(self: Pin<&mut Self>, mut event: Event) -> Result<(), Self::Error> {
         let finalizers = event.metadata_mut().take_finalizers();
-        let byte_size = event.size_of();
         if let Some(item) = self.sink.encode_event(event) {
             *self.project().slot = Some(EncodedEvent { item, finalizers });
         }
@@ -331,7 +330,6 @@ where
 
     fn start_send(self: Pin<&mut Self>, mut event: Event) -> Result<(), Self::Error> {
         let finalizers = event.metadata_mut().take_finalizers();
-        let byte_size = event.size_of();
         if let Some(item) = self.sink.encode_event(event) {
             *self.project().slot = Some(EncodedEvent { item, finalizers });
         }
@@ -390,7 +388,7 @@ where
         let mut http_client = self.inner.clone();
 
         Box::pin(async move {
-            let events_count = body.elements_count();
+            let events_count = body.element_count();
             let events_bytes = body.size_of();
             let request = request_builder(body).await?;
             let byte_size = request.body().len();


### PR DESCRIPTION
This fixes an issue merged with #9503, discovered immediately after
merging, that the old emits of `EventsSent` were left in when the emit
was moved after the events were sent, which will result in the
statistics being double counted.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
