### PR TITLE
enhancement(vrl): suggest null, true or false for undefined variables

### DIFF
--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -117,6 +117,11 @@ impl DiagnosticError for Error {
                 let mut vec = vec![Label::primary("undefined variable", self.span)];
                 let ident_chars = self.ident.as_ref().chars().collect::<Vec<_>>();
 
+                let mut builtin = vec![Ident::new("null"), Ident::new("true"), Ident::new("false")];
+                let mut idents = idents.clone();
+
+                idents.append(&mut builtin);
+
                 if let Some((idx, _)) = idents
                     .iter()
                     .map(|possible| {

--- a/lib/vrl/tests/tests/diagnostics/misnamed_literal_type.vrl
+++ b/lib/vrl/tests/tests/diagnostics/misnamed_literal_type.vrl
@@ -1,0 +1,38 @@
+# result:
+#
+# error[E701]: call to undefined variable
+#   ┌─ :2:1
+#   │
+# 2 │ nil
+#   │ ^^^
+#   │ │
+#   │ undefined variable
+#   │ did you mean "null"?
+#   │
+#   = see language documentation at https://vrl.dev
+#
+# error[E701]: call to undefined variable
+#   ┌─ :3:1
+#   │
+# 3 │ tru
+#   │ ^^^
+#   │ │
+#   │ undefined variable
+#   │ did you mean "true"?
+#   │
+#   = see language documentation at https://vrl.dev
+#
+# error[E701]: call to undefined variable
+#   ┌─ :4:1
+#   │
+# 4 │ fals
+#   │ ^^^^
+#   │ │
+#   │ undefined variable
+#   │ did you mean "false"?
+#   │
+#   = see language documentation at https://vrl.dev
+
+nil
+tru
+fals


### PR DESCRIPTION
As an extension to #8910, and inspired by @mr-karan's issue at https://github.com/vectordotdev/vector/pull/8910#issuecomment-938294890, this PR also suggests `null`, `true` or `false`:

```coffee
nil
```

```
error[E701]: call to undefined variable
  ┌─ :2:1
  │
2 │ nil
  │ ^^^
  │ │
  │ undefined variable
  │ did you mean "null"?
  │
  = see language documentation at https://vrl.dev
```