### PR TITLE
chore: Remove 'anyhow' from top-level vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7526,7 +7526,6 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 name = "vector"
 version = "0.18.0"
 dependencies = [
- "anyhow",
  "approx",
  "arc-swap",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,6 @@ vrl-compiler = { path = "lib/vrl/compiler", optional = true }
 lookup = { path = "lib/lookup" }
 
 # External libs
-anyhow = { version = "1.0.44", default-features = false }
 arc-swap = { version = "1.4.0", default-features = false }
 async-compression = { version = "0.3.7", default-features = false, features = ["tokio", "gzip", "zstd"] }
 avro-rs = { version = "0.13.0", default-features = false, optional = true }

--- a/src/config/unit_test.rs
+++ b/src/config/unit_test.rs
@@ -513,11 +513,7 @@ async fn build_unit_test(
                     );
                 }
                 Err(err) => {
-                    errors.push(format!(
-                        "failed to build transform '{}': {:#}",
-                        id,
-                        anyhow::anyhow!(err)
-                    ));
+                    errors.push(format!("failed to build transform '{}': {:#}", id, err));
                 }
             }
         }


### PR DESCRIPTION
While working on timing our builds for #9531 I noticed we could drop anyhow from
the top-level crate pretty easily. This doesn't materially impact build times
and the dependency is still required by VRL tests, vector-api-client.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
