### PR TITLE
chore: Remove top-level pest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7614,8 +7614,6 @@ dependencies = [
  "openssl",
  "openssl-probe",
  "percent-encoding",
- "pest",
- "pest_derive",
  "pin-project 1.0.8",
  "portpicker",
  "postgres-openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,8 +251,6 @@ once_cell = { version = "1.8", default-features = false }
 openssl = { version = "0.10.36", default-features = false }
 openssl-probe = { version = "0.1.4", default-features = false }
 percent-encoding = { version = "2.1.0", default-features = false }
-pest = { version = "2.1.3", default-features = false }
-pest_derive = { version = "2.1.0", default-features = false }
 pin-project = { version = "1.0.8", default-features = false }
 postgres-openssl = { version = "0.5.0", default-features = false, features = ["runtime"], optional = true }
 pulsar = { version = "4.1", default-features = false, features = ["tokio-runtime"], optional = true }


### PR DESCRIPTION
Much like #9535 this commit removes top-level pest from the project. It's still
used elsewhere, especially in core. This has come out of work on #9531.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
