### PR TITLE
chore: Remove arc-swap from the top-level crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7527,7 +7527,6 @@ name = "vector"
 version = "0.18.0"
 dependencies = [
  "approx",
- "arc-swap",
  "assert_cmd",
  "async-compression",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,6 @@ vrl-compiler = { path = "lib/vrl/compiler", optional = true }
 lookup = { path = "lib/lookup" }
 
 # External libs
-arc-swap = { version = "1.4.0", default-features = false }
 async-compression = { version = "0.3.7", default-features = false, features = ["tokio", "gzip", "zstd"] }
 avro-rs = { version = "0.13.0", default-features = false, optional = true }
 base64 = { version = "0.13.0", default-features = false, optional = true }


### PR DESCRIPTION
This commit removes arc-swap from top-level as it is only used in
lib/enrichment. Similar to the work done in #9535 and #9537.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
