### PR TITLE
chore: Make zstd an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,7 +279,7 @@ twox-hash = { version = "1.6.1", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 uuid = { version = "0.8.2", default-features = false, features = ["serde", "v4"], optional = true }
 warp = { version = "0.3.1", default-features = false, optional = true }
-zstd = { version = "0.6", default-features = false }
+zstd = { version = "0.6", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", default-features = false }
 tonic = { version = "0.5", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls"] }
 data-encoding = { version = "2.2", default-features = false, features = ["std"], optional = true }
@@ -445,7 +445,7 @@ sources-metrics = [
 sources-apache_metrics = []
 sources-aws_ecs_metrics = []
 sources-aws_kinesis_firehose = ["base64", "infer", "sources-utils-tls", "warp", "codecs"]
-sources-aws_s3 = ["rusoto", "rusoto_s3", "rusoto_sqs", "semver", "uuid", "codecs"]
+sources-aws_s3 = ["rusoto", "rusoto_s3", "rusoto_sqs", "semver", "uuid", "codecs", "zstd"]
 sources-datadog = ["snap", "sources-utils-tls", "warp", "sources-utils-http-error", "codecs"]
 sources-dnstap = ["base64", "data-encoding", "trust-dns-proto", "dnsmsg-parser", "tonic-build", "prost-build"]
 sources-docker_logs = ["docker"]
@@ -634,7 +634,7 @@ sinks-honeycomb = []
 sinks-http = []
 sinks-humio = ["sinks-splunk_hec", "transforms-metric_to_log"]
 sinks-influxdb = []
-sinks-kafka = ["rdkafka"]
+sinks-kafka = ["rdkafka", "zstd"]
 sinks-logdna = []
 sinks-loki = ["uuid"]
 sinks-nats = ["async-nats"]

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -305,6 +305,7 @@ pub fn lines_from_gzip_file<P: AsRef<Path>>(path: P) -> Vec<String> {
     output.lines().map(|s| s.to_owned()).collect()
 }
 
+#[cfg(feature = "sources-aws_s3")]
 pub fn lines_from_zst_file<P: AsRef<Path>>(path: P) -> Vec<String> {
     trace!(message = "Reading zst file.", path = %path.as_ref().display());
     let mut file = File::open(path).unwrap();


### PR DESCRIPTION
This commit makes zstd an optional dependency, shaving 12 seconds off a
`--no-default-features` build. Discovered while working on #9515. Relates to:

* #9538
* #9537
* #9535

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
