### PR TITLE
chore: Remove no-proxy dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7604,7 +7604,6 @@ dependencies = [
  "mlua",
  "mongodb",
  "nix 0.22.2",
- "no-proxy",
  "nom 7.0.0",
  "notify",
  "num-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,6 @@ md-5 = { version = "0.9", optional = true }
 mlua = { version = "0.6.5", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
 mongodb = { version = "2.0.0", default-features = false, features = ["tokio-runtime"], optional = true }
 async-nats = { version = "0.10.1", default-features = false, optional = true }
-no-proxy = { version  = "0.3.1", default-features = false, features = ["serialize"] }
 nom = { version = "7.0.0", default-features = false, optional = true }
 notify = { version = "4.0.17", default-features = false }
 num_cpus = { version = "1.13.0", default-features = false }


### PR DESCRIPTION
Related to my work on #9531 it turns out we don't actually require the no-proxy
dependency. This does not overly speed up the build.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
