### PR TITLE
fix(external docs): Fix broken link in preview build

### DIFF
--- a/website/content/en/highlights/2021-11-16-0-18-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-11-16-0-18-0-upgrade-guide.md
@@ -34,7 +34,7 @@ If you're currently setting this, you will need to switch to either `batch.max_b
 use `batch.max_bytes`.  Otherwise, if you're trying to limit the size of the batch in terms of
 events, you should use `batch.max_events`.
 
-### `request.in_flight_limit` no longer valid for sources and sinks
+### `request.in_flight_limit` no longer valid for sources and sinks {#request-in-flight-limit}
 
 Similarly to `batch.max_size`, we've had support for adjusting the concurrency of sources and sinks
 via `request.concurrency` for some time now.  This is the preferred field to set, and is referenced


### PR DESCRIPTION
This PR addresses a broken link in the current preview build. A few days ago this would've gone undetected, but link checking in preview builds has now been activated.