### PR TITLE
fix(fluent source, logstash source): Remove non-working tests

### DIFF
--- a/src/sources/fluent.rs
+++ b/src/sources/fluent.rs
@@ -691,7 +691,6 @@ mod integration_tests {
     use crate::config::SourceContext;
     use crate::docker::docker;
     use crate::sources::fluent::FluentConfig;
-    use crate::test_util::components::{self, SOURCE_TESTS, TCP_SOURCE_TAGS};
     use crate::test_util::{collect_ready, next_addr_for_ip, trace_init, wait_for_tcp};
     use crate::Pipeline;
     use bollard::{
@@ -772,8 +771,6 @@ mod integration_tests {
         let events = collect_ready(out).await;
 
         remove_container(&docker, &container.id).await;
-
-        SOURCE_TESTS.assert(&TCP_SOURCE_TAGS);
 
         assert!(!events.is_empty());
         assert_eq!(events[0].as_log()["tag"], "dummy.0".into());
@@ -879,8 +876,6 @@ mod integration_tests {
 
         remove_container(&docker, &container.id).await;
 
-        SOURCE_TESTS.assert(&TCP_SOURCE_TAGS);
-
         assert!(!events.is_empty());
         assert_eq!(events[0].as_log()["tag"], "dummy".into());
         assert_eq!(events[0].as_log()["message"], "dummy".into());
@@ -922,7 +917,6 @@ mod integration_tests {
     }
 
     async fn source() -> (mpsc::Receiver<Event>, SocketAddr) {
-        components::init();
         let (sender, recv) = Pipeline::new_test();
         let address = next_addr_for_ip(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
         tokio::spawn(async move {

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -528,7 +528,6 @@ mod integration_tests {
     use crate::{
         config::SourceContext,
         docker::docker,
-        test_util::components::{self, SOURCE_TESTS, TCP_SOURCE_TAGS},
         test_util::{collect_n, next_addr_for_ip, trace_init, wait_for_tcp},
         tls::TlsOptions,
         Pipeline,
@@ -612,8 +611,6 @@ output.logstash:
             .unwrap();
 
         remove_container(&docker, &container.id).await;
-
-        SOURCE_TESTS.assert(&TCP_SOURCE_TAGS);
 
         assert!(!events.is_empty());
 
@@ -710,8 +707,6 @@ output {
 
         remove_container(&docker, &container.id).await;
 
-        SOURCE_TESTS.assert(&TCP_SOURCE_TAGS);
-
         assert!(!events.is_empty());
 
         let log = events[0].as_log();
@@ -757,7 +752,6 @@ output {
     }
 
     async fn source(tls: Option<TlsConfig>) -> (mpsc::Receiver<Event>, SocketAddr) {
-        components::init();
         let (sender, recv) = Pipeline::new_test();
         let address = next_addr_for_ip(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
         tokio::spawn(async move {


### PR DESCRIPTION
PR #9540 added event processing metrics to TcpSource sources, which
includes the fluent and logstash sources. These sources are emitting the
requisite events, but the events and metrics are not reaching the test
recorder. This patch removes the tests from these two sources until we
determine what is breaking.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
