### PR TITLE
fix(enriching): parse the schema columns using Conversion

### DIFF
--- a/lib/shared/src/conversion.rs
+++ b/lib/shared/src/conversion.rs
@@ -89,7 +89,7 @@ impl Conversion {
     ///  * `"timestamp|FORMAT"` => Timestamp using the given format
     pub fn parse(s: impl AsRef<str>, tz: TimeZone) -> Result<Self, ConversionError> {
         let s = s.as_ref();
-        let mut split = s.splitn(2, "|").map(|segment| segment.trim());
+        let mut split = s.splitn(2, '|').map(|segment| segment.trim());
         match (split.next(), split.next()) {
             (Some("asis"), None) | (Some("bytes"), None) | (Some("string"), None) => {
                 Ok(Self::Bytes)

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -60,7 +60,7 @@ impl FileConfig {
 
         Ok(match self.schema.get(column) {
             Some(format) => {
-                let mut split = format.splitn(2, "|").map(|segment| segment.trim());
+                let mut split = format.splitn(2, '|').map(|segment| segment.trim());
 
                 match (split.next(), split.next()) {
                     (Some("date"), None) => Value::Timestamp(
@@ -80,7 +80,7 @@ impl FileConfig {
                     (Some("date"), Some(format)) => Value::Timestamp(
                         chrono::FixedOffset::east(0)
                             .from_utc_datetime(
-                                &chrono::NaiveDate::parse_from_str(value, &format)
+                                &chrono::NaiveDate::parse_from_str(value, format)
                                     .map_err(|_| {
                                         format!(
                                             "unable to parse date {} found in row {}",


### PR DESCRIPTION
Reported by a user, it wasn't possible to specify format strings for Timestamp schema columns.

This PR defers the parsing to the `Conversion` struct that handles this.

I have also added the ability to specify a format string for `Date` columns. Date columns are handled separately since this is not handled by `Conversion`. It is a requirement to be able to specify dates without times in the enrichment file.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

