### PR TITLE
fix(codecs): Update bytes codec to actually read full message

### DIFF
--- a/src/codecs/framers/bytes.rs
+++ b/src/codecs/framers/bytes.rs
@@ -41,7 +41,7 @@ impl Decoder for BytesCodec {
     type Item = Bytes;
     type Error = BoxedFramingError;
 
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+    fn decode(&mut self, _src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.flushed = false;
         Ok(None)
     }


### PR DESCRIPTION
Previously, it would return whatever was in the buffer when `decode` was
called, but there may be still more bytes to read. Instead, we just
return `Ok(None)`, signaling to the caller that it should read more,
until we hit EOF and then return the full payload.

Fixes: #9564
Replaces: #9565

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->