### PR TITLE
enhancement(observability, aws_s3 sink): Add event processing metrics

### DIFF
--- a/src/internal_events/aws_s3.rs
+++ b/src/internal_events/aws_s3.rs
@@ -1,6 +1,5 @@
 // ## skip check-events ##
 
-#[cfg(feature = "sources-aws_s3")]
 pub mod source {
     use crate::sources::aws_s3::sqs::ProcessingError;
     use metrics::counter;
@@ -165,25 +164,6 @@ pub mod source {
 
         fn emit_metrics(&self) {
             counter!("sqs_s3_event_record_ignored_total", 1, "ignore_type" => "invalid_event_kind");
-        }
-    }
-}
-
-#[cfg(feature = "sinks-aws_s3")]
-pub mod sink {
-    use metrics::counter;
-
-    use vector_core::internal_event::InternalEvent;
-
-    pub struct S3EventsSent {
-        pub byte_size: usize,
-    }
-
-    impl InternalEvent for S3EventsSent {
-        fn emit_logs(&self) {}
-
-        fn emit_metrics(&self) {
-            counter!("processed_bytes_total", self.byte_size as u64);
         }
     }
 }

--- a/src/internal_events/aws_s3_sink.rs
+++ b/src/internal_events/aws_s3_sink.rs
@@ -1,0 +1,19 @@
+use metrics::counter;
+use vector_core::internal_event::InternalEvent;
+
+pub struct S3EventsSent {
+    pub count: usize,
+    pub byte_size: usize,
+}
+
+impl InternalEvent for S3EventsSent {
+    fn emit_logs(&self) {
+        trace!(message = "Events sent.", count = %self.count, byte_size = %self.byte_size);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("processed_bytes_total", self.byte_size as u64); // deprecated
+        counter!("component_sent_events_total", self.count as u64);
+        counter!("component_sent_event_bytes_total", self.byte_size as u64);
+    }
+}

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -1,6 +1,5 @@
-// ## skip check-events ##
-
 use metrics::counter;
+use rusoto_core::Region;
 use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
@@ -109,6 +108,25 @@ impl<'a> InternalEvent for EndpointBytesSent<'a> {
             "component_sent_bytes_total", self.byte_size as u64,
             "protocol" => self.protocol.to_string(),
             "endpoint" => self.endpoint.to_string()
+        );
+    }
+}
+
+pub struct AwsBytesSent {
+    pub byte_size: usize,
+    pub region: Region,
+}
+
+impl InternalEvent for AwsBytesSent {
+    fn emit_logs(&self) {
+        trace!(message = "Bytes sent.", byte_size = %self.byte_size, region = ?self.region);
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "component_sent_bytes_total", self.byte_size as u64,
+            "protocol" => "https",
+            "region" => self.region.name().to_owned(),
         );
     }
 }

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -1,5 +1,4 @@
 use metrics::counter;
-use rusoto_core::Region;
 use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
@@ -112,11 +111,13 @@ impl<'a> InternalEvent for EndpointBytesSent<'a> {
     }
 }
 
+#[cfg(feature = "rusoto")]
 pub struct AwsBytesSent {
     pub byte_size: usize,
-    pub region: Region,
+    pub region: rusoto_core::Region,
 }
 
+#[cfg(feature = "rusoto")]
 impl InternalEvent for AwsBytesSent {
     fn emit_logs(&self) {
         trace!(message = "Bytes sent.", byte_size = %self.byte_size, region = ?self.region);

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -19,8 +19,10 @@ mod aws_ecs_metrics;
 mod aws_kinesis_firehose;
 #[cfg(feature = "sinks-aws_kinesis_streams")]
 mod aws_kinesis_streams;
-#[cfg(any(feature = "sources-aws_s3", feature = "sinks-aws_s3"))]
+#[cfg(feature = "sources-aws_s3")]
 pub(crate) mod aws_s3;
+#[cfg(feature = "sinks-aws_s3")]
+pub(crate) mod aws_s3_sink;
 #[cfg(feature = "sinks-aws_sqs")]
 mod aws_sqs;
 #[cfg(feature = "sinks-azure_blob")]
@@ -159,6 +161,8 @@ pub use self::aws_ecs_metrics::*;
 pub use self::aws_kinesis_firehose::*;
 #[cfg(feature = "sinks-aws_kinesis_streams")]
 pub use self::aws_kinesis_streams::*;
+#[cfg(feature = "sinks-aws_s3")]
+pub use self::aws_s3_sink::*;
 #[cfg(feature = "sinks-aws_sqs")]
 pub use self::aws_sqs::*;
 pub use self::batch::*;

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -87,9 +87,9 @@ impl GenerateConfig for S3SinkConfig {
 #[typetag::serde(name = "aws_s3")]
 impl SinkConfig for S3SinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.create_client(&cx.proxy)?;
-        let healthcheck = self.build_healthcheck(client.clone())?;
-        let sink = self.build_processor(client, cx)?;
+        let service = self.create_service(&cx.proxy)?;
+        let healthcheck = self.build_healthcheck(service.client())?;
+        let sink = self.build_processor(service, cx)?;
         Ok((sink, healthcheck))
     }
 
@@ -103,7 +103,11 @@ impl SinkConfig for S3SinkConfig {
 }
 
 impl S3SinkConfig {
-    pub fn build_processor(&self, client: S3Client, cx: SinkContext) -> crate::Result<VectorSink> {
+    pub fn build_processor(
+        &self,
+        service: S3Service,
+        cx: SinkContext,
+    ) -> crate::Result<VectorSink> {
         // Build our S3 client/service, which is what we'll ultimately feed
         // requests into in order to ship files to S3.  We build this here in
         // order to configure the client/service with retries, concurrency
@@ -111,7 +115,7 @@ impl S3SinkConfig {
         let request_limits = self.request.unwrap_with(&DEFAULT_REQUEST_LIMITS);
         let service = ServiceBuilder::new()
             .settings(request_limits, S3RetryLogic)
-            .service(S3Service::new(client));
+            .service(service);
 
         // Configure our partitioning/batching.
         let batch_settings = DEFAULT_BATCH_SETTINGS
@@ -154,8 +158,8 @@ impl S3SinkConfig {
         s3_common::config::build_healthcheck(self.bucket.clone(), client)
     }
 
-    pub fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<S3Client> {
-        s3_common::config::create_client(&self.region, &self.auth, self.assume_role.clone(), proxy)
+    pub fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<S3Service> {
+        s3_common::config::create_service(&self.region, &self.auth, self.assume_role.clone(), proxy)
     }
 }
 

--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -48,7 +48,7 @@ impl RequestBuilder<(String, Vec<Event>)> for S3RequestOptions {
         let metadata = S3Metadata {
             partition_key,
             count: events.len(),
-            byte_size: events.iter().map(ByteSizeOf::size_of).sum(),
+            byte_size: events.size_of(),
             finalizers,
         };
 

--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -3,7 +3,7 @@ use std::io;
 use crate::{
     event::Event,
     sinks::{
-        s3_common::{config::S3Options, service::S3Request},
+        s3_common::{config::S3Options, service::S3Metadata, service::S3Request},
         util::{
             encoding::{EncodingConfig, StandardEncodings},
             Compression, RequestBuilder,
@@ -13,7 +13,7 @@ use crate::{
 use bytes::Bytes;
 use chrono::Utc;
 use uuid::Uuid;
-use vector_core::event::{EventFinalizers, Finalizable};
+use vector_core::{event::Finalizable, ByteSizeOf};
 
 #[derive(Clone)]
 pub struct S3RequestOptions {
@@ -27,7 +27,7 @@ pub struct S3RequestOptions {
 }
 
 impl RequestBuilder<(String, Vec<Event>)> for S3RequestOptions {
-    type Metadata = (String, usize, EventFinalizers);
+    type Metadata = S3Metadata;
     type Events = Vec<Event>;
     type Encoder = EncodingConfig<StandardEncodings>;
     type Payload = Bytes;
@@ -45,13 +45,17 @@ impl RequestBuilder<(String, Vec<Event>)> for S3RequestOptions {
     fn split_input(&self, input: (String, Vec<Event>)) -> (Self::Metadata, Self::Events) {
         let (partition_key, mut events) = input;
         let finalizers = events.take_finalizers();
+        let metadata = S3Metadata {
+            partition_key,
+            count: events.len(),
+            byte_size: events.iter().map(ByteSizeOf::size_of).sum(),
+            finalizers,
+        };
 
-        ((partition_key, events.len(), finalizers), events)
+        (metadata, events)
     }
 
     fn build_request(&self, metadata: Self::Metadata, payload: Self::Payload) -> Self::Request {
-        let (key, batch_size, finalizers) = metadata;
-
         let filename = {
             let formatted_ts = Utc::now().format(self.filename_time_format.as_str());
 
@@ -65,13 +69,13 @@ impl RequestBuilder<(String, Vec<Event>)> for S3RequestOptions {
             .as_ref()
             .cloned()
             .unwrap_or_else(|| self.compression.extension().into());
-        let key = format!("{}/{}.{}", key, filename, extension);
+        let key = format!("{}/{}.{}", metadata.partition_key, filename, extension);
 
         // TODO: move this into `.request_builder(...)` closure?
         trace!(
             message = "Sending events.",
             bytes = ?payload.len(),
-            events_len = ?batch_size,
+            events_len = ?metadata.count,
             bucket = ?self.bucket,
             key = ?key
         );
@@ -82,8 +86,9 @@ impl RequestBuilder<(String, Vec<Event>)> for S3RequestOptions {
             key,
             content_encoding: self.compression.content_encoding(),
             options: self.api_options.clone(),
-            batch_size,
-            finalizers,
+            events_count: metadata.count,
+            events_size: metadata.byte_size,
+            finalizers: metadata.finalizers,
         }
     }
 }

--- a/src/sinks/aws_s3/tests.rs
+++ b/src/sinks/aws_s3/tests.rs
@@ -33,8 +33,8 @@ mod integration_tests {
 
         let config = config(&bucket, 1000000);
         let prefix = config.key_prefix.clone();
-        let client = config.create_client(&cx.globals.proxy).unwrap();
-        let sink = config.build_processor(client, cx).unwrap();
+        let service = config.create_service(&cx.globals.proxy).unwrap();
+        let sink = config.build_processor(service, cx).unwrap();
 
         let (lines, events, receiver) = make_events_batch(100, 10);
         sink.run(events).await.unwrap();
@@ -68,8 +68,8 @@ mod integration_tests {
             ..config(&bucket, 10)
         };
         let prefix = config.key_prefix.clone();
-        let client = config.create_client(&cx.globals.proxy).unwrap();
-        let sink = config.build_processor(client, cx).unwrap();
+        let service = config.create_service(&cx.globals.proxy).unwrap();
+        let sink = config.build_processor(service, cx).unwrap();
 
         let (lines, _events) = random_lines_with_stream(100, 30, None);
 
@@ -127,8 +127,8 @@ mod integration_tests {
         };
 
         let prefix = config.key_prefix.clone();
-        let client = config.create_client(&cx.globals.proxy).unwrap();
-        let sink = config.build_processor(client, cx).unwrap();
+        let service = config.create_service(&cx.globals.proxy).unwrap();
+        let sink = config.build_processor(service, cx).unwrap();
 
         let (lines, events, receiver) = make_events_batch(100, batch_size * batch_multiplier);
         sink.run(events).await.unwrap();
@@ -183,8 +183,8 @@ mod integration_tests {
 
         let config = config(&bucket, 1000000);
         let prefix = config.key_prefix.clone();
-        let client = config.create_client(&cx.globals.proxy).unwrap();
-        let sink = config.build_processor(client, cx).unwrap();
+        let service = config.create_service(&cx.globals.proxy).unwrap();
+        let sink = config.build_processor(service, cx).unwrap();
 
         let (lines, events, receiver) = make_events_batch(100, 10);
         sink.run(events).await.unwrap();
@@ -215,8 +215,8 @@ mod integration_tests {
         // Break the bucket name
         config.bucket = format!("BREAK{}IT", config.bucket);
         let prefix = config.key_prefix.clone();
-        let client = config.create_client(&cx.globals.proxy).unwrap();
-        let sink = config.build_processor(client, cx).unwrap();
+        let service = config.create_service(&cx.globals.proxy).unwrap();
+        let sink = config.build_processor(service, cx).unwrap();
 
         let (_lines, events, receiver) = make_events_batch(1, 1);
         sink.run(events).await.unwrap();
@@ -233,15 +233,19 @@ mod integration_tests {
         create_bucket(&bucket, false).await;
 
         let config = config(&bucket, 1);
-        let client = config.create_client(&ProxyConfig::from_env()).unwrap();
-        config.build_healthcheck(client).unwrap();
+        let service = config.create_service(&ProxyConfig::from_env()).unwrap();
+        config.build_healthcheck(service.client()).unwrap();
     }
 
     #[tokio::test]
     async fn s3_healthchecks_invalid_bucket() {
         let config = config("s3_healthchecks_invalid_bucket", 1);
-        let client = config.create_client(&ProxyConfig::from_env()).unwrap();
-        assert!(config.build_healthcheck(client).unwrap().await.is_err());
+        let service = config.create_service(&ProxyConfig::from_env()).unwrap();
+        assert!(config
+            .build_healthcheck(service.client())
+            .unwrap()
+            .await
+            .is_err());
     }
 
     fn client() -> S3Client {

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -321,7 +321,7 @@ impl RequestBuilder<(String, Vec<Event>)> for DatadogS3RequestBuilder {
         let metadata = S3Metadata {
             partition_key,
             count: events.len(),
-            byte_size: events.iter().map(ByteSizeOf::size_of).sum(),
+            byte_size: events.size_of(),
             finalizers,
         };
 

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -1,3 +1,4 @@
+use super::service::S3Service;
 use crate::config::ProxyConfig;
 use crate::rusoto;
 use crate::rusoto::{AwsAuthentication, RegionOrEndpoint};
@@ -112,18 +113,19 @@ pub fn build_healthcheck(bucket: String, client: S3Client) -> crate::Result<Heal
     Ok(healthcheck.boxed())
 }
 
-pub fn create_client(
+pub fn create_service(
     region: &RegionOrEndpoint,
     auth: &AwsAuthentication,
     assume_role: Option<String>,
     proxy: &ProxyConfig,
-) -> crate::Result<S3Client> {
+) -> crate::Result<S3Service> {
     let region = region.try_into()?;
     let client = rusoto::client(proxy)?;
 
     let creds = auth.build(&region, assume_role)?;
 
-    Ok(S3Client::new_with(client, creds, region))
+    let client = S3Client::new_with(client, creds, region.clone());
+    Ok(S3Service::new(client, region))
 }
 
 #[cfg(test)]

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -1,7 +1,10 @@
+use super::config::S3Options;
+use crate::internal_events::{AwsBytesSent, S3EventsSent};
+use crate::serde::to_string;
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream};
 use md5::Digest;
-use rusoto_core::{ByteStream, RusotoError};
+use rusoto_core::{ByteStream, Region, RusotoError};
 use rusoto_s3::{PutObjectError, PutObjectOutput, PutObjectRequest, S3Client, S3};
 use std::task::{Context, Poll};
 use tower::Service;
@@ -11,9 +14,6 @@ use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
 };
 
-use super::config::S3Options;
-use crate::{internal_events::aws_s3::sink::S3EventsSent, serde::to_string};
-
 #[derive(Debug, Clone)]
 pub struct S3Request {
     pub body: Bytes,
@@ -21,13 +21,14 @@ pub struct S3Request {
     pub key: String,
     pub content_encoding: Option<&'static str>,
     pub options: S3Options,
-    pub batch_size: usize,
+    pub events_count: usize,
+    pub events_size: usize,
     pub finalizers: EventFinalizers,
 }
 
 impl Ackable for S3Request {
     fn ack_size(&self) -> usize {
-        self.batch_size
+        self.events_count
     }
 }
 
@@ -35,6 +36,13 @@ impl Finalizable for S3Request {
     fn take_finalizers(&mut self) -> EventFinalizers {
         std::mem::take(&mut self.finalizers)
     }
+}
+
+pub struct S3Metadata {
+    pub partition_key: String,
+    pub count: usize,
+    pub byte_size: usize,
+    pub finalizers: EventFinalizers,
 }
 
 #[derive(Debug)]
@@ -57,11 +65,16 @@ impl AsRef<EventStatus> for S3Response {
 #[derive(Clone)]
 pub struct S3Service {
     client: S3Client,
+    region: Region,
 }
 
 impl S3Service {
-    pub const fn new(client: S3Client) -> S3Service {
-        S3Service { client }
+    pub const fn new(client: S3Client, region: Region) -> S3Service {
+        S3Service { client, region }
+    }
+
+    pub fn client(&self) -> S3Client {
+        self.client.clone()
     }
 }
 
@@ -94,8 +107,10 @@ impl Service<S3Request> for S3Service {
             }
         }
         let tagging = tagging.finish();
+        let count = request.events_count;
+        let byte_size = request.events_size;
 
-        let body_len = request.body.len();
+        let request_size = request.body.len();
         let client = self.client.clone();
         let request = PutObjectRequest {
             body: Some(bytes_to_bytestream(request.body)),
@@ -116,16 +131,20 @@ impl Service<S3Request> for S3Service {
             ..Default::default()
         };
 
+        let region = self.region.clone();
         Box::pin(async move {
-            let result = client.put_object(request).in_current_span().await;
-
-            // TODO: This is fine for testing, but we should have a better
-            // pattern for this.
-            emit!(&S3EventsSent {
-                byte_size: body_len,
-            });
-
-            result.map(|inner| S3Response { inner })
+            client
+                .put_object(request)
+                .in_current_span()
+                .await
+                .map(|inner| {
+                    emit!(&S3EventsSent { count, byte_size });
+                    emit!(&AwsBytesSent {
+                        byte_size: request_size,
+                        region,
+                    });
+                    S3Response { inner }
+                })
         })
     }
 }

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -412,7 +412,10 @@ components: sinks: aws_s3: components._aws & {
 	]
 
 	telemetry: metrics: {
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/datadog_archives.cue
+++ b/website/cue/reference/components/sinks/datadog_archives.cue
@@ -227,7 +227,10 @@ components: sinks: datadog_archives: {
 	]
 
 	telemetry: metrics: {
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -580,16 +580,20 @@ components: sources: internal_metrics: {
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags & {
-				protocol: {
-					description: "The protocol used to send the bytes."
-					required:    true
-				}
 				endpoint: {
-					description: "The endpoint that the bytes were sent to. For HTTP, this will be the host and path only, excluding the query string."
+					description: "The endpoint to which the bytes were sent. For HTTP, this will be the host and path only, excluding the query string."
 					required:    false
 				}
 				file: {
 					description: "The absolute path of the destination file."
+					required:    false
+				}
+				protocol: {
+					description: "The protocol used to send the bytes."
+					required:    true
+				}
+				region: {
+					description: "The AWS region name to which the bytes were sent. In some configurations, this may be a literal hostname."
 					required:    false
 				}
 			}


### PR DESCRIPTION
Closes #9597 

Note that this also adds event processing metrics for the `datadog_archives` sink, but that sink isn't listed in the semantic tags (and github labels).

@tobz Do you see any opportunity to move the `emit!(EventsSent)` up a level so that it could cover all new-style sinks?