### PR TITLE
fix: doc(sources): Fix typo in Ruby language name

### DIFF
--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -437,7 +437,7 @@ components: sources: file: {
 				"""
 			sub_sections: [
 				{
-					title: "Example 1: Ruy Exceptions"
+					title: "Example 1: Ruby Exceptions"
 					body: #"""
 						Ruby exceptions, when logged, consist of multiple lines:
 


### PR DESCRIPTION
Single byte typo fix: Ruy => Ruby
