### PR TITLE
fix(external docs): Fix SVG text color issue in dark mode

### DIFF
--- a/website/assets/sass/unpurged.sass
+++ b/website/assets/sass/unpurged.sass
@@ -42,11 +42,14 @@ svg
 html
   &.dark
     svg
-      [fill="#000000"]
+      [fill="#000000"],
+      [fill="black"]
         fill: $dark-mode-gray
-      [stroke="#000000"]
+      [stroke="#000000"],
+      [stroke="black"]
         stroke: $dark-mode-gray
-      [stop-color="#000000"]
+      [stop-color="#000000"],
+      [stop-color="black"]
         stop-color: $dark-mode-gray
       [fill="#FFFFFF"],
       [fill="#FFF"]


### PR DESCRIPTION
The SVG on the [Pipeline Model](https://vector.dev/docs/about/under-the-hood/architecture/pipeline-model/) page currently has invisible text in dark mode. This PR addresses that.

Here's the fixed version:

https://deploy-preview-9653--vector-project.netlify.app/docs/about/under-the-hood/architecture/pipeline-model/