### PR TITLE
fix(external docs): Change dark mode code block default color

### DIFF
--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -113,9 +113,8 @@ module.exports = {
               'border-bottom-color': theme('colors.gray.700'),
             },
             code: {
-              color: theme('colors.primary', 'currentColor'),
+              color: theme('colors.gray.100', 'currentColor'),
               '&:not([class^="language-"])': {
-                color: theme('colors.gray.100'),
                 'background-color': theme('colors.gray.700'),
               }
             },


### PR DESCRIPTION
Current:

<img width="556" alt="Screen Shot 2021-10-16 at 12 56 40 PM" src="https://user-images.githubusercontent.com/1523104/137600637-b673f4e7-b565-4081-83d7-1c2589a81ed1.png">

Proposed in this PR:

![image](https://user-images.githubusercontent.com/1523104/137600627-569d6f8c-ea2b-4241-b1f9-33b36f40947a.png)
