### PR TITLE
fix(external docs): Fix VRL code sample highlighting

### DIFF
--- a/website/content/en/docs/reference/vrl/_index.md
+++ b/website/content/en/docs/reference/vrl/_index.md
@@ -92,7 +92,7 @@ Conditions can also be more multifaceted. This condition would filter out all
 events for which the `severity` field is `"info"`, the `status_code` field is
 greater than or equal to 400, and the `host` field isn't set:
 
-```vrl
+```coffee
 condition = '.severity != "info" && .status_code < 400 && exists(.host)
 ```
 

--- a/website/cue/reference/components/transforms/add_fields.cue
+++ b/website/cue/reference/components/transforms/add_fields.cue
@@ -31,7 +31,7 @@ components: transforms: add_fields: {
 			"""
 			\(add_fields._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.severity = "crit"
 			.status = 200
 			.success_codes = [200, 201, 202, 204]

--- a/website/cue/reference/components/transforms/add_tags.cue
+++ b/website/cue/reference/components/transforms/add_tags.cue
@@ -31,7 +31,7 @@ components: transforms: add_tags: {
 			"""
 			\(add_tags._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			#".tag = "value""#
 			```
 			""",

--- a/website/cue/reference/components/transforms/ansi_stripper.cue
+++ b/website/cue/reference/components/transforms/ansi_stripper.cue
@@ -34,7 +34,7 @@ components: transforms: ansi_stripper: {
 			"""
 			\(ansi_stripper._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = strip_ansi_escape_codes(.message)
 			```
 			""",

--- a/website/cue/reference/components/transforms/coercer.cue
+++ b/website/cue/reference/components/transforms/coercer.cue
@@ -34,7 +34,7 @@ components: transforms: coercer: {
 			"""
 			\(coercer._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.bool = to_bool("false")
 			.float = to_float("1.0")
 			.int = to_int("1")

--- a/website/cue/reference/components/transforms/concat.cue
+++ b/website/cue/reference/components/transforms/concat.cue
@@ -34,7 +34,7 @@ components: transforms: concat: {
 			"""
 			\(concat._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = "The severity level is " + .level
 			```
 			""",

--- a/website/cue/reference/components/transforms/grok_parser.cue
+++ b/website/cue/reference/components/transforms/grok_parser.cue
@@ -40,7 +40,7 @@ components: transforms: grok_parser: {
 			"""
 			\(grok_parser._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = parse_grok(.message, "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}")
 			```
 			""",

--- a/website/cue/reference/components/transforms/json_parser.cue
+++ b/website/cue/reference/components/transforms/json_parser.cue
@@ -40,7 +40,7 @@ components: transforms: json_parser: {
 			"""
 			\(json_parser._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = parse_json(.message)
 			```
 			""",

--- a/website/cue/reference/components/transforms/key_value_parser.cue
+++ b/website/cue/reference/components/transforms/key_value_parser.cue
@@ -40,7 +40,7 @@ components: transforms: key_value_parser: {
 			"""
 			\(key_value_parser._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = parse_key_value(.message)
 			```
 			""",

--- a/website/cue/reference/components/transforms/logfmt_parser.cue
+++ b/website/cue/reference/components/transforms/logfmt_parser.cue
@@ -40,7 +40,7 @@ components: transforms: logfmt_parser: {
 			"""
 			\(logfmt_parser._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = parse_key_value(.message)
 			```
 			""",

--- a/website/cue/reference/components/transforms/regex_parser.cue
+++ b/website/cue/reference/components/transforms/regex_parser.cue
@@ -40,7 +40,7 @@ components: transforms: regex_parser: {
 			"""
 			\(regex_parser._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = parse_regex(.message, r'(?P<number>.*?) group')
 			```
 			""",

--- a/website/cue/reference/components/transforms/remove_fields.cue
+++ b/website/cue/reference/components/transforms/remove_fields.cue
@@ -34,7 +34,7 @@ components: transforms: remove_fields: {
 			"""
 			\(remove_fields._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			del(.level)
 			```
 			""",

--- a/website/cue/reference/components/transforms/remove_tags.cue
+++ b/website/cue/reference/components/transforms/remove_tags.cue
@@ -34,7 +34,7 @@ components: transforms: remove_tags: {
 			"""
 			\(remove_tags._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			del(.tag)
 			```
 			""",

--- a/website/cue/reference/components/transforms/rename_fields.cue
+++ b/website/cue/reference/components/transforms/rename_fields.cue
@@ -34,7 +34,7 @@ components: transforms: rename_fields: {
 			"""
 			\(rename_fields._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.new_name = del(.old_name)
 			```
 			""",

--- a/website/cue/reference/components/transforms/split.cue
+++ b/website/cue/reference/components/transforms/split.cue
@@ -34,7 +34,7 @@ components: transforms: split: {
 			"""
 			\(split._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = split(.message)
 			```
 			""",

--- a/website/cue/reference/components/transforms/tokenizer.cue
+++ b/website/cue/reference/components/transforms/tokenizer.cue
@@ -40,7 +40,7 @@ components: transforms: tokenizer: {
 			"""
 			\(tokenizer._remap_deprecation_notice)
 
-			```vrl
+			```coffee
 			.message = parse_tokens(.message)
 			```
 			""",

--- a/website/cue/reference/remap/concepts/event.cue
+++ b/website/cue/reference/remap/concepts/event.cue
@@ -4,7 +4,7 @@ remap: concepts: event: {
 		VRL programs operate on observability [events](\(urls.vector_data_model)). This VRL program,
 		for example, adds a field to a log event:
 
-		```vrl
+		```coffee
 		.new_field = "new value"
 		```
 
@@ -18,7 +18,7 @@ remap: concepts: event: {
 
 		This expression, for example...
 
-		```vrl
+		```coffee
 		. = ["hello", 1, true, { "foo": "bar" }]
 		```
 

--- a/website/cue/reference/remap/errors/651_unnecessary_error_coalescing_operation.cue
+++ b/website/cue/reference/remap/errors/651_unnecessary_error_coalescing_operation.cue
@@ -10,7 +10,7 @@ remap: errors: "651": {
 		Error coalescing operations are useful when you want to specify what happens if an operation
 		fails. Here's an example:
 
-		```vrl
+		```coffee
 		result = op1 ?? op2
 		```
 

--- a/website/cue/reference/remap/expressions/assignment.cue
+++ b/website/cue/reference/remap/expressions/assignment.cue
@@ -36,20 +36,20 @@ remap: expressions: assignment: {
 					"=": """
 						Simple assignment operator. Assigns the result from the right-hand side to the left-hand side:
 
-						```vrl
+						```coffee
 						.field = "value"
 						```
 						"""
 					"|=": """
 						Object merge assignment operator. Assigns the result of the right-hand side, merged with the left-hand side, to the left-hand side:
 
-						```vrl
+						```coffee
 						.field |= {"foo": "bar"}
 						```
 
 						This is equivalent to using the `merge` function:
 
-						```vrl
+						```coffee
 						.field = merge(.field, {"foo": "bar"})
 						```
 
@@ -59,7 +59,7 @@ remap: expressions: assignment: {
 						Assigns _only_ if the right-hand side doesn't error. This is useful when invoking fallible
 						functions on the right-hand side:
 
-						```vrl
+						```coffee
 						.structured ??= parse_json(.message)
 						```
 						"""

--- a/website/cue/reference/remap/expressions/function_call.cue
+++ b/website/cue/reference/remap/expressions/function_call.cue
@@ -28,13 +28,13 @@ remap: expressions: function_call: {
 					`abort` represents a literal `!` that can optionally be used with fallible functions to abort
 					the program when the function fails:
 
-					```vrl
+					```coffee
 					result = f!()
 					```
 
 					Otherwise, errors must be handled:
 
-					```vrl
+					```coffee
 					result, err = f()
 					```
 
@@ -55,7 +55,7 @@ remap: expressions: function_call: {
 							_All_ function arguments in VRL are assigned names, including required leading arguments.
 							Named arguments are suffixed with a colon (`:`), with the value proceeding the name:
 
-							```vrl
+							```coffee
 							argument_name: "value"
 							argument_name: (1 + 2)
 							```
@@ -69,7 +69,7 @@ remap: expressions: function_call: {
 							Function calls support nameless positional arguments. Arguments must be supplied in the order
 							they are documented:
 
-							```vrl
+							```coffee
 							f(1, 2)
 							```
 							"""
@@ -79,13 +79,13 @@ remap: expressions: function_call: {
 						description: """
 							Function arguments enforce type safety when the type of the value supplied is known:
 
-							```vrl
+							```coffee
 							round("not a number") # fails at compile time
 							```
 
 							If the type of the value is not known, you need to handle the potential argument error:
 
-							```vrl
+							```coffee
 							number = int(.message) ?? 0
 							round(number)
 							```

--- a/website/cue/reference/remap/expressions/path.cue
+++ b/website/cue/reference/remap/expressions/path.cue
@@ -33,7 +33,7 @@ remap: expressions: path: {
 						description: """
 							Array elements can be accessed by their index:
 
-							```vrl
+							```coffee
 							.array[0]
 							```
 							"""
@@ -45,7 +45,7 @@ remap: expressions: path: {
 							particularly useful when working with
 							[externally tagged](\(urls.externally_tagged_representation)) data:
 
-							```vrl
+							```coffee
 							.grand_parent.(parent1 | parent2).child
 							```
 							"""
@@ -61,7 +61,7 @@ remap: expressions: path: {
 						description: """
 							Nested object values are accessed by delimiting each ancestor path with `.`:
 
-							```vrl
+							```coffee
 							.parent.child
 							```
 							"""
@@ -78,7 +78,7 @@ remap: expressions: path: {
 							Path segments can be quoted to include special characters, such as spaces, periods, and
 							others:
 
-							```vrl
+							```coffee
 							."parent.key.with.special \"characters\"".child
 							```
 							"""#


### PR DESCRIPTION
The CoffeeScript highlighter for VRL isn't *perfect* but I do think that it's better than no highlighting, which is what we end up with using the `vrl` syntax (which isn't recognized by Chroma).