### PR TITLE
fix(observability): Remove duplicate counter emit `events_out_total`

### DIFF
--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -63,7 +63,7 @@ impl InternalEvent for EventsSent {
 
     fn emit_metrics(&self) {
         if self.count > 0 {
-            counter!("events_out_total", self.count as u64);
+            // events_out_total is emitted by `Acker`
             counter!("component_sent_events_total", self.count as u64);
             counter!("component_sent_event_bytes_total", self.byte_size as u64);
         }


### PR DESCRIPTION
This is emitted by the `Acker` too so was double counting for sinks
instrumented by `EventsSent`.

Fixes: #9647


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->