### PR TITLE
docs(vrl): Fix split return type

### DIFF
--- a/website/cue/reference/remap/functions/split.cue
+++ b/website/cue/reference/remap/functions/split.cue
@@ -28,7 +28,7 @@ remap: functions: split: {
 	]
 	internal_failure_reasons: []
 	return: {
-		types: ["string"]
+		types: ["array"]
 		rules: [
 			"If `limit` is specified, the remainder of the string is returned unsplit after `limit` has been reached.",
 		]


### PR DESCRIPTION
Closes: #9670
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
