### PR TITLE
docs: Fix concurrency defaults

### DIFF
--- a/website/cue/reference/components/sinks/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/aws_sqs.cue
@@ -27,7 +27,6 @@ components: sinks: aws_sqs: components._aws & {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                5
 				rate_limit_duration_secs:   1
 				rate_limit_num:             5
 				retry_initial_backoff_secs: 1

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -20,9 +20,8 @@ components: sinks: datadog_events: {
 			encoding: enabled:    false
 			proxy: enabled:       true
 			request: {
-				enabled:              true
-				adaptive_concurrency: true
-				headers:              false
+				enabled: true
+				headers: false
 			}
 			tls: {
 				enabled:                true

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -20,7 +20,6 @@ components: sinks: datadog_metrics: {
 			proxy: enabled:       true
 			request: {
 				enabled:                    true
-				concurrency:                5
 				rate_limit_duration_secs:   1
 				rate_limit_num:             5
 				retry_initial_backoff_secs: 1

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -52,7 +52,6 @@ components: sinks: _humio: {
 			proxy: enabled: true
 			request: {
 				enabled:                    true
-				concurrency:                10
 				rate_limit_duration_secs:   1
 				rate_limit_num:             10
 				retry_initial_backoff_secs: 1

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -28,7 +28,6 @@ components: sinks: prometheus_remote_write: {
 			proxy: enabled:       true
 			request: {
 				enabled:                    true
-				concurrency:                5
 				rate_limit_duration_secs:   1
 				rate_limit_num:             5
 				retry_initial_backoff_secs: 1


### PR DESCRIPTION
Noticed these while looking at
https://github.com/vectordotdev/vector/pull/9723

These sinks just use the default concurrency.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->