### PR TITLE
docs(vector sink): Add batch configuration docs

### DIFF
--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -13,7 +13,7 @@ components: sinks: vector: {
 		commonly_used: false
 		delivery:      "best_effort"
 		development:   "beta"
-		egress_method: "stream"
+		egress_method: "batch"
 		service_providers: []
 		stateful: false
 	}
@@ -21,6 +21,11 @@ components: sinks: vector: {
 		buffer: enabled:      true
 		healthcheck: enabled: true
 		send: {
+			batch: {
+				enabled:      true
+				common:       false
+				timeout_secs: 1
+			}
 			compression: enabled:       false
 			encoding: enabled:          false
 			send_buffer_bytes: enabled: true


### PR DESCRIPTION
This only applies to the `v2` protocol and not the `v1` protocol but
I think it is more important that the docs be accurate for the `v2`
protocol than the `v1` protocol.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->