### PR TITLE
docs(vrl): Fix documentation of `end` parameter for `slice`

### DIFF
--- a/website/cue/reference/remap/functions/slice.cue
+++ b/website/cue/reference/remap/functions/slice.cue
@@ -25,7 +25,7 @@ remap: functions: slice: {
 		},
 		{
 			name:        "end"
-			description: "The inclusive end position. A zero-based index that can be negative."
+			description: "The exclusive end position. A zero-based index that can be negative."
 			required:    false
 			default:     "String length"
 			type: ["integer"]


### PR DESCRIPTION
This parameter is actually exclusive. I considered making the behavior
inclusive to match the docs, but I think exclusive is more common
slicing behavior.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->