### PR TITLE
chore(performance): Enable the "union" feature on SmallVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,7 +257,7 @@ redis = { version = "0.21.3", default-features = false, features = ["connection-
 regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
 seahash = { version = "4.1.0", default-features = false, optional = true }
 semver = { version = "1.0.4", default-features = false, features = ["serde", "std"], optional = true }
-smallvec = { version = "1", optional = true }
+smallvec = { version = "1", optional = true, features = ["union"] }
 snafu = { version = "0.6.10", default-features = false, features = ["futures"] }
 snap = { version = "1.0.5", default-features = false, optional = true }
 socket2 = { version = "0.4.2", default-features = false }


### PR DESCRIPTION
This feature is not enabled by default.  From the docs: When the union
feature is enabled smallvec will track its state (inline or spilled)
without the use of an enum tag, reducing the size of the smallvec by one
machine word.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
