### PR TITLE
chore(influxdata service): use /ping endpoint to check health of InfluxDB 2

### DIFF
--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -111,7 +111,7 @@ impl InfluxDbSettings for InfluxDb2Settings {
     }
 
     fn healthcheck_uri(&self, endpoint: String) -> crate::Result<Uri> {
-        encode_uri(&endpoint, "health", &[])
+        encode_uri(&endpoint, "ping", &[])
     }
 
     fn token(&self) -> String {
@@ -599,7 +599,7 @@ mod tests {
         let uri = settings
             .healthcheck_uri("http://localhost:9999".to_owned())
             .unwrap();
-        assert_eq!("http://localhost:9999/health", uri.to_string())
+        assert_eq!("http://localhost:9999/ping", uri.to_string())
     }
 
     #[test]


### PR DESCRIPTION
Use `/ping` endpoint to check health of InfluxDB 2. The `/ping`  can be used for both InfluxDB 2 OSS and InfluxDB 2 Cloud.

The `/health` endpoint doesn't work for InfluxDB 2 Cloud:

```
curl -i -X GET https://us-west-2-1.aws.cloud2.influxdata.com/health
```

- https://docs.influxdata.com/influxdb/cloud/api/#tag/Ping
- https://docs.influxdata.com/influxdb/v2.0/api/#tag/Ping