### PR TITLE
chore: Build images for each soak test 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 *
-!.cargo
 !benches
 !lib
 !proto

--- a/.github/workflows/soak_lib.yml
+++ b/.github/workflows/soak_lib.yml
@@ -5,6 +5,64 @@ name: Soak Infra
 on: push
 
 jobs:
+  vector-soak:
+    name: Build 'soak-vector' container (${{ matrix.target }})
+    runs-on: [self-hosted, linux, x64, general]
+    strategy:
+      matrix:
+        target: [datadog_agent_remap_datadog_logs, syslog_loki, syslog_regex_logs2metric_ddmetrics]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Compute feature flag SHA
+        run: |
+          . "soaks/${{ matrix.target }}/FEATURES"
+          echo "::set-output name=FEATURE_SHA::$(echo -n "${FEATURES}" | sha256sum - | head -c40)"
+        id: flag_sha
+
+      - name: Compute feature flags
+        run: |
+          . "soaks/${{ matrix.target }}/FEATURES"
+          echo "::set-output name=FEATURES::$(echo "${FEATURES}")"
+        id: features
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
+          labels: |
+            soak_test_name=${{ matrix.target }}
+          images: ghcr.io/${{ github.repository }}/soak-vector
+          tags: type=raw, value=${{ steps.flag_sha.outputs.FEATURE_SHA }}-${{ github.sha }}
+
+      - name: Build and push 'soak-vector' image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: soaks/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VECTOR_FEATURES=${{ steps.features.outputs.FEATURES }}
+
   observer:
     name: Build and push 'observer' to Github CR
     runs-on: ubuntu-latest

--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -1,10 +1,13 @@
+ARG RUST_VERSION=1.56
+ARG DEBIAN_VERSION=bullseye
+
 #
 # BUILDER
 #
-FROM docker.io/rust:1.56-buster as builder
+FROM docker.io/rust:${RUST_VERSION}-${DEBIAN_VERSION} as builder
+RUN apt-get -y update && apt-get -y install build-essential cmake libclang-dev libsasl2-dev
 WORKDIR vector
 ARG VECTOR_FEATURES
-RUN apt-get -y update && apt-get -y install build-essential cmake libclang-dev libsasl2-dev
 COPY . .
 RUN cargo build --release --bin vector --no-default-features --features "${VECTOR_FEATURES}"
 

--- a/soaks/Dockerfile.dockerignore
+++ b/soaks/Dockerfile.dockerignore
@@ -1,2 +1,0 @@
-target/
-soaks/


### PR DESCRIPTION
This commit introduces a matrixed workflow to build images for soak
tests. It is not dynamic but does function. Build times are on the
order of 10 minutes per soak and we might want to consider whether
caching between soaks can be improved, though they all have different
feature flags in play. Improving #9547 would also help quite a bit here.

Closes #9531

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>