### PR TITLE
fix: Wire up humio metrics soak correctly

### DIFF
--- a/soaks/syslog_log2metric_humio_metrics/terraform/vector.toml
+++ b/soaks/syslog_log2metric_humio_metrics/terraform/vector.toml
@@ -41,9 +41,9 @@ type = "prometheus_exporter"
 inputs = ["internal_metrics"]
 address = "0.0.0.0:9090"
 
-[sinks.humio_logs]
-type = "humio_logs"
-inputs = ["syslog"]
+[sinks.humio_metrics]
+type = "humio_metrics"
+inputs = ["log2metric"]
 endpoint = "http://http-blackhole:8080"
 encoding = "json"
 token = "humio_token"


### PR DESCRIPTION
😵‍💫 I mis-configured this soak test such that it doesn't actually test `humio_metrics`. I reran it properly configured (using the same branches as when running the soaks in #9738) and got the following results.

| EXPERIMENT (syslog_log2metric_humio_metrics) | VALUE_min      | VALUE_p90      | VALUE_p99      | VALUE_max      | VALUE_skewness | VALUE_kurtosis |
|------------|----------------|----------------|----------------|----------------|----------------|----------------|
| baseline (5d0606d)  | 2824624.068826 | 2861657.707188 | 2864509.417634 | 2864602.708114 | -0.065617      | -0.950137      |
| comparison (25afe8c) | 2730495.131884 | 2982522.440738 | 2989169.514533 | 2989270.289990 | -4.158441      | 23.484397      |
|            |                |                |                |                |                |                |

Results show similar/improved performance. I suspect the soak is limited by the transforms. I'd also expect overall performance of `humio_metrics` to be worse than the equivalent `logs` sink as its underlying implementation relies on a `metric_to_log` transform into a `splunk_hec_logs` sink.