### PR TITLE
chore: Add documentation on soak CI

### DIFF
--- a/.github/workflows/soak_lib.yml
+++ b/.github/workflows/soak_lib.yml
@@ -10,7 +10,13 @@ jobs:
     runs-on: [self-hosted, linux, x64, general]
     strategy:
       matrix:
-        target: [datadog_agent_remap_datadog_logs, syslog_loki, syslog_regex_logs2metric_ddmetrics]
+        target:
+          - datadog_agent_remap_datadog_logs
+          - syslog_humio_logs
+          - syslog_log2metric_humio_metrics
+          - syslog_loki
+          - syslog_regex_logs2metric_ddmetrics
+          - syslog_splunk_hec_logs
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/soaks/README.md
+++ b/soaks/README.md
@@ -175,3 +175,45 @@ to say they install vector and its lading test peers into 'soak', configuring
 with the `toml` files referenced above. There are a handful of modules available
 for use in soak testing; please add more as your infrastructure needs
 dictate. If at all possible do not require services external to the minikube.
+
+In the near future we'll run soaks automatically in CI. Today this is limited to
+building soak containers. To get container builds going please add your soak
+name to the [`soak_lib.yml`](../.github/workflows/soak_lib.yml) matrix. Say you
+add a soak called `datadog_agent_throttle_blackhole` then you want this:
+
+```toml
+jobs:
+  vector-soak:
+    name: Build 'soak-vector' container (${{ matrix.target }})
+    runs-on: [self-hosted, linux, x64, general]
+    strategy:
+      matrix:
+        target:
+          - datadog_agent_remap_datadog_logs
+          - syslog_humio_logs
+          - syslog_log2metric_humio_metrics
+          - syslog_loki
+          - syslog_regex_logs2metric_ddmetrics
+          - syslog_splunk_hec_logs
+```
+
+to include your soak
+
+```toml
+jobs:
+  vector-soak:
+    name: Build 'soak-vector' container (${{ matrix.target }})
+    runs-on: [self-hosted, linux, x64, general]
+    strategy:
+      matrix:
+        target:
+          - datadog_agent_remap_datadog_logs
+          - datadog_agent_throttle_blackhole
+          - syslog_humio_logs
+          - syslog_log2metric_humio_metrics
+          - syslog_loki
+          - syslog_regex_logs2metric_ddmetrics
+          - syslog_splunk_hec_logs
+```
+
+Note the additional list member.


### PR DESCRIPTION
This commit expands the documentation for soaks to include details on how to get
your containers built, though they don't play into the soaks yet.

REF #9531
REF #9619

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
