### PR TITLE
fix(external docs): Remove spinning globe from main page

### DIFF
--- a/website/assets/js/home.tsx
+++ b/website/assets/js/home.tsx
@@ -3,20 +3,20 @@
 //import "regenerator-runtime/runtime";
 
 // Imports
-import React, { useEffect, useState } from "react";
-import ReactDOM from "react-dom";
-import classnames from "classnames";
-import { useInterval } from "react-use";
-import { useSpring, animated } from "react-spring";
-import { geoOrthographic, geoPath, geoDistance } from "d3-geo";
-import { feature } from "topojson-client";
-
 // types
 import { Topology } from "@types/topojson-specification";
-
+import classnames from "classnames";
+import { geoDistance, geoOrthographic, geoPath } from "d3-geo";
+import React, { useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+import { animated, useSpring } from "react-spring";
+import { useInterval } from "react-use";
+import { feature } from "topojson-client";
 // countryData
 import countryData from "./countries.json";
 import markerData from "./markers.json";
+
+
 
 interface IGlobeProps {
   size?: number;
@@ -316,5 +316,5 @@ function Diagram({className, height, width}) {
 };
 
 // Place the components in the DOM
-ReactDOM.render(<RotatingGlobe size={750} />, document.getElementById("globe"));
+//ReactDOM.render(<RotatingGlobe size={750} />, document.getElementById("globe"));
 ReactDOM.render(<Diagram className="mx-auto" width="100%" />, document.getElementById("diagram"));

--- a/website/layouts/partials/home/community.html
+++ b/website/layouts/partials/home/community.html
@@ -1,6 +1,6 @@
 {{ $comm := .Params.community }}
 {{ $social := site.Menus.community }}
-<div class="pt-12 md:pt-16 lg:pt-20">
+<div class="pt-12 pb-16 md:pt-16 lg:pt-20">
   <div class="text-center mx-auto max-w-7xl px-8 md:px-4 lg:px-0">
     {{ partial "home/heading.html" (dict "title" $comm.title) }}
 
@@ -25,13 +25,6 @@
         {{ template "community-button" . }}
         {{ end }}
       </div>
-    </div>
-  </div>
-
-  {{/* Spinning globe (see assets/js/home.tsx) */}}
-  <div class="mt-20 flex justify-center mx-auto max-w-4xl">
-    <div id="globe-wrapper" class="overflow-hidden" style="margin-bottom: -40%; z-index: -1;">
-      <div id="globe"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I'm submitting this as a draft to see how it impacts loading performance. At the moment, we're paying a pretty heavy performance tax for the globe, as indicated [here](https://vector.dev/reports/lighthouse). I think it may be wise to remove it until we can explore performance-boosting strategies (like memoization or somesuch, but React.js performance is a bit beyond my ken).