### PR TITLE
chore: Disallow dependabot from running soaks

### DIFF
--- a/.github/workflows/soak_lib.yml
+++ b/.github/workflows/soak_lib.yml
@@ -7,6 +7,7 @@ on: push
 jobs:
   vector-soak:
     name: Build 'soak-vector' container (${{ matrix.target }})
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: [self-hosted, linux, x64, general]
     strategy:
       matrix:


### PR DESCRIPTION
Consistent with [this comment](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544)
the dependabot only has read-only access to the project and can't push
images. We're wasting project resources building an image that can't be pushed.

REF #9515

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
