### PR TITLE
fix(external docs): Fix CSS purging issue

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -77,7 +77,6 @@ post_process = true
 [[params.css]]
 input = "sass/unpurged.sass"
 output = "css/unpurged.css"
-postcss = true
 
 [[params.css]]
 input = "sass/home.sass"


### PR DESCRIPTION
With some recent changes I inadvertently re-introduced CSS purging for a file that shouldn't be purged. This PR addresses that and, with it, some rendering glitches.