### PR TITLE
enhancement(observability): improve transform utilization metrics

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -234,10 +234,10 @@ pub async fn build_pieces(
                 let transform = async move {
                     timer.start_wait();
                     while let Some(events) = input_rx.next().await {
-                        timer.stop_wait();
-                        if last_report.elapsed().as_secs() >= 5 {
+                        let stopped = timer.stop_wait();
+                        if stopped.duration_since(last_report).as_secs() >= 5 {
                             timer.report();
-                            last_report = Instant::now();
+                            last_report = stopped;
                         }
 
                         emit!(&EventsReceived {
@@ -286,10 +286,10 @@ pub async fn build_pieces(
                 let transform = async move {
                     timer.start_wait();
                     while let Some(events) = input_rx.next().await {
-                        timer.stop_wait();
-                        if last_report.elapsed().as_secs() >= 5 {
+                        let stopped = timer.stop_wait();
+                        if stopped.duration_since(last_report).as_secs() >= 5 {
                             timer.report();
-                            last_report = Instant::now();
+                            last_report = stopped;
                         }
 
                         emit!(&EventsReceived {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -21,6 +21,7 @@ use std::{
     collections::HashMap,
     future::ready,
     sync::{Arc, Mutex},
+    time::Instant,
 };
 use stream_cancel::{StreamExt as StreamCancelExt, Trigger, Tripwire};
 use tokio::{
@@ -218,41 +219,53 @@ pub async fn build_pieces(
             tracing::Span::none(),
         )
         .unwrap();
-        let mut input_rx = crate::utilization::wrap(Pin::new(input_rx));
 
         let task = match transform {
             Transform::Function(mut t) => {
-                let (output, control) = Fanout::new();
+                let (mut output, control) = Fanout::new();
 
-                let transform = input_rx
+                let mut input_rx = input_rx
                     .filter(move |event| ready(filter_event_type(event, input_type)))
-                    .ready_chunks(128) // 128 is an arbitrary, smallish constant
-                    .inspect(|events| {
+                    .ready_chunks(128); // 128 is an arbitrary, smallish constant
+
+                let mut timer = crate::utilization::Timer::new();
+                let mut last_report = Instant::now();
+
+                let transform = async move {
+                    timer.start_wait();
+                    while let Some(events) = input_rx.next().await {
+                        timer.stop_wait();
+                        if last_report.elapsed().as_secs() >= 5 {
+                            timer.report();
+                            last_report = Instant::now();
+                        }
+
                         emit!(&EventsReceived {
                             count: events.len(),
                             byte_size: events.size_of(),
                         });
-                    })
-                    .flat_map(move |events| {
-                        let mut output = Vec::with_capacity(events.len());
+
+                        let mut output_buf = Vec::with_capacity(events.len());
                         let mut buf = Vec::with_capacity(4); // also an arbitrary,
                                                              // smallish constant
                         for v in events {
                             t.transform(&mut buf, v);
-                            output.append(&mut buf);
+                            output_buf.append(&mut buf);
                         }
                         emit!(&EventsSent {
-                            count: output.len(),
-                            byte_size: output.size_of(),
+                            count: output_buf.len(),
+                            byte_size: output_buf.size_of(),
                         });
-                        stream::iter(output.into_iter()).map(Ok)
-                    })
-                    .forward(output)
-                    .boxed()
-                    .map_ok(|_| {
-                        debug!("Finished.");
-                        TaskOutput::Transform
-                    });
+
+                        timer.start_wait();
+                        output
+                            .send_all(&mut stream::iter(output_buf.into_iter()).map(Ok))
+                            .await?;
+                    }
+                    debug!("Finished.");
+                    Ok(TaskOutput::Transform)
+                }
+                .boxed();
 
                 outputs.insert(OutputId::from(key), control);
 
@@ -262,31 +275,50 @@ pub async fn build_pieces(
                 let (mut output, control) = Fanout::new();
                 let (mut errors_output, errors_control) = Fanout::new();
 
+                let mut input_rx = input_rx
+                    .filter(move |event| ready(filter_event_type(event, input_type)))
+                    .ready_chunks(128); // 128 is an arbitrary, smallish constant
+
+                let mut timer = crate::utilization::Timer::new();
+                let mut last_report = Instant::now();
+
                 let transform = async move {
-                    while let Some(event) = input_rx.next().await {
-                        if !filter_event_type(&event, input_type) {
-                            continue;
+                    timer.start_wait();
+                    while let Some(events) = input_rx.next().await {
+                        timer.stop_wait();
+                        if last_report.elapsed().as_secs() >= 5 {
+                            timer.report();
+                            last_report = Instant::now();
                         }
+
                         emit!(&EventsReceived {
-                            count: 1,
-                            byte_size: event.size_of(),
+                            count: events.len(),
+                            byte_size: events.size_of(),
                         });
 
+                        let mut output_buf = Vec::with_capacity(events.len());
                         let mut buf = Vec::with_capacity(1);
+                        let mut err_output_buf = Vec::with_capacity(1);
                         let mut err_buf = Vec::with_capacity(1);
 
-                        t.transform(&mut buf, &mut err_buf, event);
+                        for v in events {
+                            t.transform(&mut buf, &mut err_buf, v);
+                            output_buf.append(&mut buf);
+                            err_output_buf.append(&mut err_buf);
+                        }
+
                         // TODO: account for error outputs separately?
                         emit!(&EventsSent {
-                            count: buf.len() + err_buf.len(),
-                            byte_size: buf.size_of() + err_buf.size_of(),
+                            count: output_buf.len() + err_output_buf.len(),
+                            byte_size: output_buf.size_of() + err_output_buf.size_of(),
                         });
 
-                        for event in buf {
+                        timer.start_wait();
+                        for event in output_buf {
                             output.feed(event).await.expect("unit error");
                         }
                         output.flush().await.expect("unit error");
-                        for event in err_buf {
+                        for event in err_output_buf {
                             errors_output.feed(event).await.expect("unit error");
                         }
                         errors_output.flush().await.expect("unit error");
@@ -310,6 +342,8 @@ pub async fn build_pieces(
             }
             Transform::Task(t) => {
                 let (output, control) = Fanout::new();
+
+                let input_rx = crate::utilization::wrap(Pin::new(input_rx));
 
                 let filtered = input_rx
                     .filter(move |event| ready(filter_event_type(event, input_type)))

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -68,7 +68,7 @@ pub fn wrap(inner: Pin<EventStream>) -> Pin<EventStream> {
     Box::pin(utilization)
 }
 
-struct Timer {
+pub struct Timer {
     overall_start: Instant,
     span_start: Instant,
     waiting: bool,
@@ -85,7 +85,7 @@ struct Timer {
 /// to be of uniform length and used to aggregate span data into time-weighted
 /// averages.
 impl Timer {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             overall_start: Instant::now(),
             span_start: Instant::now(),
@@ -96,7 +96,7 @@ impl Timer {
     }
 
     /// Begin a new span representing time spent waiting
-    fn start_wait(&mut self) {
+    pub fn start_wait(&mut self) {
         if !self.waiting {
             self.end_span();
             self.waiting = true;
@@ -104,17 +104,17 @@ impl Timer {
     }
 
     /// Complete the current waiting span and begin a non-waiting span
-    fn stop_wait(&mut self) {
-        assert!(self.waiting);
-
-        self.end_span();
-        self.waiting = false;
+    pub fn stop_wait(&mut self) {
+        if self.waiting {
+            self.end_span();
+            self.waiting = false;
+        }
     }
 
     /// Meant to be called on a regular interval, this method calculates wait
     /// ratio since the last time it was called and reports the resulting
     /// utilization average.
-    fn report(&mut self) {
+    pub fn report(&mut self) {
         // End the current span so it can be accounted for, but do not change
         // whether or not we're in the waiting state. This way the next span
         // inherits the correct status.


### PR DESCRIPTION
Opening this as a draft since I plan to do more testing, but it should be good to review as-is.

This is a relatively naive but straightforward adaptation of our existing utilization `Stream` wrapper to non-async transforms. The benefit is that we can start the "waiting" span sooner than the `Stream` case, as soon as the transform is done processing and begins sending to its output. This will provide a much more accurate view of how much work a transform is doing vs being blocked on downstream components.

As part of this, it was beneficial to make the wrappers for function and fallible function transforms more similar. This includes moving from combinators to an `async` block for the function variant, and adding the `ready_chunks` batching to the fallible variant. It'd be great to share more code here instead of just duplicating, but that felt even more outside of the scope of this change.

One kinda messy bit of this ended up being the `last_report` bookkeeping, which is somewhat annoying to have in this path and also not nearly as precise as the `IntervalStream`-based approach we use in the `Stream` wrapper`. Ultimately I left it for now, with the assumption that it should be able to go away as we move towards centralizing the metric computations. In that case, I'd envision a split between the timer itself and the reporting mechanism, where we can have a separate task responsible for polling the state of the timers on a regular interval.