### PR TITLE
fix(aws_s3 sink): Remove unintentional prefix

### DIFF
--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -69,7 +69,7 @@ impl RequestBuilder<(String, Vec<Event>)> for S3RequestOptions {
             .as_ref()
             .cloned()
             .unwrap_or_else(|| self.compression.extension().into());
-        metadata.partition_key = format!("{}/{}.{}", metadata.partition_key, filename, extension);
+        metadata.partition_key = format!("{}{}.{}", metadata.partition_key, filename, extension);
 
         // TODO: move this into `.request_builder(...)` closure?
         trace!(

--- a/src/sinks/aws_s3/tests.rs
+++ b/src/sinks/aws_s3/tests.rs
@@ -45,8 +45,8 @@ mod integration_tests {
         assert_eq!(keys.len(), 1);
 
         let key = keys[0].clone();
-        let key_parts = key.split("/").collect::<Vec<_>>();
-        assert!(key_parts.len() == 1);
+        let key_parts = key.split('/');
+        assert!(key_parts.count() == 1);
         assert!(key.starts_with("test-prefix"));
         assert!(key.ends_with(".log"));
 
@@ -79,9 +79,9 @@ mod integration_tests {
         assert_eq!(keys.len(), 1);
 
         let key = keys[0].clone();
-        let key_parts = key.split("/").collect::<Vec<_>>();
+        let key_parts = key.split('/').collect::<Vec<_>>();
         assert!(key_parts.len() == 2);
-        assert!(key_parts.get(0).unwrap().to_string() == "test-prefix");
+        assert!(*key_parts.get(0).unwrap() == "test-prefix");
         assert!(key.ends_with(".log"));
 
         let obj = get_object(&bucket, key).await;

--- a/src/sinks/aws_s3/tests.rs
+++ b/src/sinks/aws_s3/tests.rs
@@ -50,7 +50,6 @@ mod integration_tests {
         assert!(key.starts_with("test-prefix"));
         assert!(key.ends_with(".log"));
 
-
         let obj = get_object(&bucket, key).await;
         assert_eq!(obj.content_encoding, Some("identity".to_string()));
 


### PR DESCRIPTION
Credits to: [Alex-OH on discord](https://discord.com/channels/742820443487993987/746070591097798688/904789992281362524) for pointing out this issue.

This PR removes an unintended `/` when building the `partition_key` path. In accordance with[ documented behavior](https://vector.dev/docs/reference/configuration/sinks/aws_s3/#key_prefix), users should specify `/` explicitly.
