### PR TITLE
chore: Only soak on pull requests

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -14,9 +14,7 @@
 name: Soak
 
 on:
-  push:
-    branches-ignore:
-      - master
+  pull_request:
 
 jobs:
   cancel-previous:


### PR DESCRIPTION
We don't want to soak master/master. Because of this our previous setup was
effectively pull_request only, though we weren't quite intentional about
that. This PR makes that choice intentional.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
