### PR TITLE
fix(external docs): Fix sink compression options

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -1,9 +1,5 @@
 package metadata
 
-import (
-	"list"
-)
-
 components: sinks: [Name=string]: {
 	kind: "sink"
 
@@ -136,12 +132,22 @@ components: sinks: [Name=string]: {
 					type: string: {
 						default: features.send.compression.default
 						enum: {
-							if list.Contains(features.send.compression.algorithms, "none") {
-								none:   "No compression."
-								syntax: "literal"
-							}
-							if list.Contains(features.send.compression.algorithms, "gzip") {
-								gzip: "[Gzip](\(urls.gzip)) standard DEFLATE compression."
+							for algo in features.send.compression.algorithms {
+								if algo == "none" {
+									none: "No compression."
+								}
+								if algo == "gzip" {
+									gzip: "[Gzip](\(urls.gzip)) standard DEFLATE compression."
+								}
+								if algo == "snappy" {
+									snappy: "[Snappy](\(urls.snappy)) compression."
+								}
+								if algo == "lz4" {
+									lz4: "[lz4](\(urls.lz4)) compression."
+								}
+								if algo == "zstd" {
+									zstd: "[zstd](\(urls.zstd)) compression."
+								}
 							}
 						}
 						syntax: "literal"


### PR DESCRIPTION
Closes #6975

This PR adds proper handling for sink compression options beyond `none` and `gzip`. As a [user noted in discord](https://discord.com/channels/742820443487993987/746107317459877968/905050324014870588), the kafka sink compression section is currently incorrect.

Sample output for the Kafka sink.
```
"compression": {
                        "common": true,
                        "description": "The compression strategy used to compress the encoded event data before transmission.\n\nSome cloud storage API clients and browsers will handle decompression transparently,\nso files may not always appear to be compressed depending how they are accessed.",
                        "name": "compression",
                        "required": false,
                        "warnings": [],
                        "type": {
                            "string": {
                                "default": "none",
                                "enum": {
                                    "none": "No compression.",
                                    "gzip": "[Gzip](https://www.gzip.org/) standard DEFLATE compression.",
                                    "lz4": "[lz4](https://lz4.github.io/lz4/) compression.",
                                    "snappy": "[Snappy](https://google.github.io/snappy/) compression.",
                                    "zstd": "[zstd](https://zstd.net) compression."
                                },
                                "syntax": "literal"
                            }
                        }
                    },
```
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
