### PR TITLE
fix(external docs): Remove soak testing for website changes

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -15,6 +15,8 @@ name: Soak
 
 on:
   pull_request:
+    paths-ignore:
+      - "website/**"
 
 jobs:
   cancel-previous:


### PR DESCRIPTION
We could probably afford a more comprehensive audit of what runs when, but this PR applies a restriction that should make iterating on the site/docs more speedy.

I haven't verified that this rule for Actions actually works but [the docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-ignoring-paths) do seem to suggest so.