### PR TITLE
enhancement(external docs): Trigger fewer Actions from website changes

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -1,10 +1,14 @@
 name: Environment Suite
 
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - "website/**"
   push:
     branches:
       - master
+    paths-ignore:
+      - "website/**"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,6 +21,8 @@ on:
       - "Makefile"
       - "rust-toolchain"
   pull_request:
+    paths-ignore:
+      - "website/**"
 
 env:
   AUTOINSTALL: true

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -22,6 +22,8 @@ on:
       - "rust-toolchain"
       - "distribution/**"
   pull_request:
+    paths-ignore:
+      - "website/**"
 
 env:
   AUTOINSTALL: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - v0.*
       - v1.*
 
-
 env:
   AUTOINSTALL: true
   VERBOSE: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,14 @@
 name: Test Suite
 
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - "website/**"
   push:
     branches:
       - master
+    paths-ignore:
+      - "website/**"
 
 env:
   AUTOINSTALL: true


### PR DESCRIPTION
This PR follows up on #9871 by removing yet more Actions triggered on the basis of changes to the `website` directory. I'm open to suggestion on the proper mechanism for this, and there are multiple ways of including/excluding changes to files and directories as potential build triggers, but this seems like the best way to me.