### PR TITLE
chore: Store captures in a single artifact

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -173,15 +173,15 @@ jobs:
 
       - name: Run baseline experiment
         run: |
-          rm -rf /tmp/${{ matrix.target }}/
-          mkdir -p /tmp/${{ matrix.target }}/
-          ./soaks/bin/soak_one.sh "false" ${{ matrix.target }} "baseline" `cat baseline-soak/tag` /tmp/${{ matrix.target }}
+          rm -rf /tmp/${{ github.event.number }}/${{ matrix.target }}/
+          mkdir -p /tmp/${{ github.event.number }}/${{ matrix.target }}/
+          ./soaks/bin/soak_one.sh "false" ${{ matrix.target }} "baseline" `cat baseline-soak/tag` /tmp/${{ github.event.number }}/${{ matrix.target }}
 
       - name: Upload timing captures
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ matrix.target}}-captures
-          path: /tmp/${{ matrix.target }}
+          name: ${{ github.event.number }}-captures
+          path: /tmp/${{ github.event.number }}
 
   soak-comparison:
     name: Soak (${{ matrix.target }}) - comparison
@@ -201,15 +201,15 @@ jobs:
 
       - name: Run comparison experiment
         run: |
-          rm -rf /tmp/${{ matrix.target }}/
-          mkdir -p /tmp/${{ matrix.target }}/
-          ./soaks/bin/soak_one.sh "false" ${{ matrix.target }} "comparison" "${{ github.sha }}-${{ github.sha }}" /tmp/${{ matrix.target }}
+          rm -rf /tmp/${{ github.event.number }}/${{ matrix.target }}/
+          mkdir -p /tmp/${{ github.event.number }}/${{ matrix.target }}/
+          ./soaks/bin/soak_one.sh "false" ${{ matrix.target }} "comparison" "${{ github.sha }}-${{ github.sha }}" /tmp/${{ github.event.number }}/${{ matrix.target }}
 
       - name: Upload timing captures
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ matrix.target}}-captures
-          path: /tmp/${{ matrix.target }}
+          name: ${{ github.event.number }}-captures
+          path: /tmp/${{ github.event.number }}
 
   analyze-results:
     name: Soak analysis (${{ matrix.target }})
@@ -225,11 +225,11 @@ jobs:
       - name: Download captures artifact
         uses: actions/download-artifact@v1
         with:
-          name: ${{ matrix.target }}-captures
+          name: ${{ github.event.number }}-captures
 
       - name: Analyze captures
         run: |
-          ./soaks/bin/analyze_experiment.sh ${{ matrix.target }}-captures
+          ./soaks/bin/analyze_experiment.sh ${{ github.event.number }}-captures/${{ matrix.target }}
 
   observer:
     name: Build and push 'observer' to Github CR


### PR DESCRIPTION
This commit attempts to store soak captures in a single artifact, ideally
allowing us to process them in one shot in the service of #9622. Even if that
doesn't pan out these will still be easier to pull for later analysis in a
single artifact.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
