### PR TITLE
enhancement(syslog source): Remove escapes from structured data in syslog message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6675,9 +6675,9 @@ dependencies = [
 
 [[package]]
 name = "syslog_loose"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc28ec47233cf71236a9e0a43a2079da9bc57ac128dd76e37558f6015492747"
+checksum = "8417c2dcaef3d8016608956f3a5b70ad9cf4efe44b5546c93ca4934903c16749"
 dependencies = [
  "chrono",
  "nom 7.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ stream-cancel = { version = "0.8.1", default-features = false }
 strip-ansi-escapes = { version = "0.1.1", default-features = false }
 structopt = { version = "0.3.25", default-features = false }
 syslog = { version = "5.0.0", default-features = false, optional = true }
-syslog_loose = { version = "0.15.0", default-features = false, optional = true }
+syslog_loose = { version = "0.16.0", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.4", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 toml = { version = "0.5.8", default-features = false }
 typetag = { version = "0.1.7", default-features = false }

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -33,7 +33,7 @@ sha-2 = { package = "sha2", version = "0.9", optional = true }
 sha-3 = { package = "sha3", version = "0.9", optional = true }
 shared = { path = "../../shared", default-features = false, optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
-syslog_loose = { version = "0.15", optional = true }
+syslog_loose = { version = "0.16", optional = true }
 tracing = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -134,9 +134,9 @@ fn message_to_value(message: Message<&str>) -> Value {
     }
 
     for element in message.structured_data.into_iter() {
-        for (name, value) in element.params.into_iter() {
+        for (name, value) in element.params() {
             let key = format!("{}.{}", element.id, name);
-            result.insert(key, value.to_string().into());
+            result.insert(key, value.into());
         }
     }
 
@@ -257,6 +257,54 @@ mod tests {
                 "severity" => "err",
                 "timestamp" => chrono::Utc.ymd(2021, 6, 8).and_hms_milli(11, 54, 8, 0),
                 "message" => "[Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message",
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
+
+        escapes_in_structured_data_quote {
+            args: func_args![value: r#"<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 key="hello \"test\""] An application event log entry..."#],
+            want: Ok(btreemap!{
+                "appname" => "evntslog",
+                "exampleSDID@32473.key" => r#"hello "test""#,
+                "facility" => "local4",
+                "hostname" => "mymachine.example.com",
+                "message" => "An application event log entry...",
+                "msgid" => "ID47",
+                "severity" => "notice",
+                "timestamp" => chrono::Utc.ymd(2003, 10, 11).and_hms_milli(22,14,15,3),
+                "version" => 1
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
+
+        escapes_in_structured_data_slash {
+            args: func_args![value: r#"<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 key="hello a\\b"] An application event log entry..."#],
+            want: Ok(btreemap!{
+                "appname" => "evntslog",
+                "exampleSDID@32473.key" => r#"hello a\b"#,
+                "facility" => "local4",
+                "hostname" => "mymachine.example.com",
+                "message" => "An application event log entry...",
+                "msgid" => "ID47",
+                "severity" => "notice",
+                "timestamp" => chrono::Utc.ymd(2003, 10, 11).and_hms_milli(22,14,15,3),
+                "version" => 1
+            }),
+            tdef: TypeDef::new().fallible().object(type_def()),
+        }
+
+        escapes_in_structured_data_bracket {
+            args: func_args![value: r#"<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 key="hello [bye\]"] An application event log entry..."#],
+            want: Ok(btreemap!{
+                "appname" => "evntslog",
+                "exampleSDID@32473.key" => "hello [bye]",
+                "facility" => "local4",
+                "hostname" => "mymachine.example.com",
+                "message" => "An application event log entry...",
+                "msgid" => "ID47",
+                "severity" => "notice",
+                "timestamp" => chrono::Utc.ymd(2003,10,11).and_hms_milli(22,14,15,3),
+                "version" => 1
             }),
             tdef: TypeDef::new().fallible().object(type_def()),
         }

--- a/src/codecs/parsers/syslog.rs
+++ b/src/codecs/parsers/syslog.rs
@@ -93,9 +93,9 @@ fn insert_fields_from_syslog(event: &mut Event, parsed: Message<&str>) {
     }
 
     for element in parsed.structured_data.into_iter() {
-        for (name, value) in element.params.into_iter() {
+        for (name, value) in element.params() {
             let key = format!("{}.{}", element.id, name);
-            log.insert(key, value.to_string());
+            log.insert(key, value);
         }
     }
 }


### PR DESCRIPTION
Closes #9824 

This removes the escapes from the values in structured data fields - `/`.

See also https://github.com/StephenWakely/syslog-loose/commit/0db6ee4736acf624b2cd3a58cb3bdddc4d43dbd7 which updates `syslog_loose`.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

