### PR TITLE
enhancement(vrl): Add `tally_value` function

### DIFF
--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -150,6 +150,7 @@ default = [
     "strip_ansi_escape_codes",
     "strip_whitespace",
     "tally",
+    "tally_value",
     "tag_types_externally",
     "timestamp",
     "to_bool",
@@ -272,6 +273,7 @@ strip_ansi_escape_codes = ["bytes", "strip-ansi-escapes"]
 strip_whitespace = []
 tag_types_externally = ["shared/btreemap"]
 tally = []
+tally_value = []
 timestamp = []
 to_bool = ["shared/conversion"]
 to_float = ["shared/conversion"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -110,6 +110,7 @@ criterion_group!(
               strip_ansi_escape_codes,
               strip_whitespace,
               tally,
+              tally_value,
               timestamp,
               to_bool,
               to_float,
@@ -2045,6 +2046,18 @@ bench_function! {
             value: value!(["bar", "foo", "baz", "foo"]),
         ],
         want: Ok(value!({"bar": 1, "foo": 2, "baz": 1})),
+    }
+}
+
+bench_function! {
+    tally_value => vrl_stdlib::TallyValue;
+
+    default {
+        args: func_args![
+            array: value!(["bar", "foo", "baz", "foo"]),
+            value: "foo",
+        ],
+        want: Ok(value!(2)),
     }
 }
 

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -212,6 +212,8 @@ mod strip_whitespace;
 mod tag_types_externally;
 #[cfg(feature = "tally")]
 mod tally;
+#[cfg(feature = "tally_value")]
+mod tally_value;
 #[cfg(feature = "timestamp")]
 mod timestamp;
 #[cfg(feature = "to_bool")]
@@ -453,6 +455,8 @@ pub use strip_whitespace::StripWhitespace;
 pub use tag_types_externally::TagTypesExternally;
 #[cfg(feature = "tally")]
 pub use tally::Tally;
+#[cfg(feature = "tally_value")]
+pub use tally_value::TallyValue;
 #[cfg(feature = "timestamp")]
 pub use timestamp::Timestamp;
 #[cfg(feature = "to_bool")]
@@ -694,6 +698,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(StripWhitespace),
         #[cfg(feature = "tally")]
         Box::new(Tally),
+        #[cfg(feature = "tally_value")]
+        Box::new(TallyValue),
         #[cfg(feature = "tag_types_externally")]
         Box::new(TagTypesExternally),
         #[cfg(feature = "timestamp")]

--- a/lib/vrl/stdlib/src/tally_value.rs
+++ b/lib/vrl/stdlib/src/tally_value.rs
@@ -11,7 +11,7 @@ impl Function for TallyValue {
     fn examples(&self) -> &'static [Example] {
         &[Example {
             title: "count matching values",
-            source: r#"tally_value!(["foo", "bar", "foo", "baz"], "foo")"#,
+            source: r#"tally_value(["foo", "bar", "foo", "baz"], "foo")"#,
             result: Ok("2"),
         }]
     }

--- a/lib/vrl/stdlib/src/tally_value.rs
+++ b/lib/vrl/stdlib/src/tally_value.rs
@@ -1,0 +1,82 @@
+use vrl::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+pub struct TallyValue;
+
+impl Function for TallyValue {
+    fn identifier(&self) -> &'static str {
+        "tally_value"
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "count matching values",
+            source: r#"tally_value!(["foo", "bar", "foo", "baz"], "foo")"#,
+            result: Ok("2"),
+        }]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::Compiler,
+        _ctx: &FunctionCompileContext,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
+        let array = arguments.required("array");
+        let value = arguments.required("value");
+
+        Ok(Box::new(TallyValueFn { array, value }))
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "array",
+                kind: kind::ARRAY,
+                required: true,
+            },
+            Parameter {
+                keyword: "value",
+                kind: kind::ANY,
+                required: true,
+            },
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TallyValueFn {
+    array: Box<dyn Expression>,
+    value: Box<dyn Expression>,
+}
+
+impl Expression for TallyValueFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let array = self.array.resolve(ctx)?.try_array()?;
+        let value = self.value.resolve(ctx)?;
+
+        Ok(array.iter().filter(|&v| v == &value).count().into())
+    }
+
+    fn type_def(&self, _: &state::Compiler) -> TypeDef {
+        TypeDef::new().infallible().integer()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        tally_value => TallyValue;
+
+        default {
+            args: func_args![
+                array: value!(["bar", "foo", "baz", "foo"]),
+                value: value!("foo"),
+            ],
+            want: Ok(value!(2)),
+            tdef: TypeDef::new().infallible().integer(),
+        }
+    ];
+}


### PR DESCRIPTION
We had originally added `tally` upon a user request even though it is
likely to be supplanted by the upcoming VRL iteration work. However,
they are sensitive to increases in RSS and found that `tally` increased
RSS more than they'd like. Their purposes are simpler in that they just
want to count the number of occurrences of a specific value which can be
done in a more memory efficient way.

Thus here I add `tally_value` to accomplish this. This function is also
a prime candidate to be deleted when VRL iteration is added so I left it
undocumented for now. Once iteration is added we can decide if either of
these functions is worth keeping around and publish them then.



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->