### PR TITLE
chore(ci): Revert PR 9872

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -1,14 +1,10 @@
 name: Environment Suite
 
 on:
-  pull_request:
-    paths-ignore:
-      - "website/**"
+  pull_request: {}
   push:
     branches:
       - master
-    paths-ignore:
-      - "website/**"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,8 +21,6 @@ on:
       - "Makefile"
       - "rust-toolchain"
   pull_request:
-    paths-ignore:
-      - "website/**"
 
 env:
   AUTOINSTALL: true

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -22,8 +22,6 @@ on:
       - "rust-toolchain"
       - "distribution/**"
   pull_request:
-    paths-ignore:
-      - "website/**"
 
 env:
   AUTOINSTALL: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - v0.*
       - v1.*
 
+
 env:
   AUTOINSTALL: true
   VERBOSE: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,10 @@
 name: Test Suite
 
 on:
-  pull_request:
-    paths-ignore:
-      - "website/**"
+  pull_request: {}
   push:
     branches:
       - master
-    paths-ignore:
-      - "website/**"
 
 env:
   AUTOINSTALL: true


### PR DESCRIPTION
This PR reverts #9872. For reasons that are quite murky to all involved, somehow using `paths-ignore` causes workflows to not _run_ but it doesn't change the _requirement_ that they be run. So we've ended up in a state where people submit website-only PRs and numerous ostensibly required checks are listed as unfulfilled... even though those checks should be simply ignored by GitHub Actions based on the supplied configuration. A counter-intuitive and, indeed, frustrating problem, but at the moment I don't see any way around it. I'll report to the proper authorities.

Note: both this and #9912 fail the DCO check. It's not clear to me, however, that a DCO would be necessary in this case. But if it is, I'm happy to close these and re-submit them as standard PRs rather than as GitHub auto-PRs.