### PR TITLE
chore: Fix older vector soak builds

### DIFF
--- a/soaks/bin/build_container.sh
+++ b/soaks/bin/build_container.sh
@@ -3,11 +3,11 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -o xtrace
+#set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="${__dir}/../../"
-SOAK_ROOT="${ROOT}/soaks"
+SOAK_ROOT="${__dir}/../"
 
 display_usage() {
     echo ""

--- a/soaks/bin/build_container.sh
+++ b/soaks/bin/build_container.sh
@@ -3,10 +3,11 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-#set -o xtrace
+set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SOAK_ROOT="${__dir}/.."
+ROOT="${__dir}/../../"
+SOAK_ROOT="${ROOT}/soaks"
 
 display_usage() {
     echo ""
@@ -25,6 +26,10 @@ build_vector() {
         git remote add origin https://github.com/vectordotdev/vector.git
         git fetch --depth 1 origin "${SHA}"
         git checkout FETCH_HEAD
+        # Overwrite any .dockerignore in the build context. Docker can't, uh,
+        # ignore its own ignore file and older vectors had an overly strict
+        # ignore file, meaning we can't build vector in that setup.
+        cp "${ROOT}/.dockerignore" .
         popd
     fi
 


### PR DESCRIPTION
Older versions of vector have a very strict .dockerignore file in them which
docker builder is unable to ignore. This commit "ignores" that ignore file by
overwritting it with one that is present in the current SHA.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
