### PR TITLE
chore: Do not soak documentation changes

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -16,6 +16,8 @@ name: Soak
 on:
   pull_request:
     paths-ignore:
+      - "docs/**"
+      - "rfcs/**"
       - "website/**"
 
 jobs:


### PR DESCRIPTION
This commit expands the class of ignored paths for soaking. RFCs and docs
changes don't change code and don't need a comparison run.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
