### PR TITLE
chore: Introduce splunk_hec -> route -> s3 soak

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -112,7 +112,7 @@ jobs:
         id: system
         run: |
           export SOAK_CPUS="7"
-          export SOAK_MEMORY="24g"
+          export SOAK_MEMORY="30g"
           export VECTOR_CPUS="4"
 
           echo "soak cpus total: ${SOAK_CPUS}"

--- a/soaks/common/terraform/modules/monitoring/observer.tf
+++ b/soaks/common/terraform/modules/monitoring/observer.tf
@@ -52,7 +52,7 @@ resource "kubernetes_deployment" "observer" {
 
           volume_mount {
             mount_path = "/captures"
-            name = "captures"
+            name       = "captures"
           }
 
           volume_mount {

--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -87,6 +87,9 @@ resource "kubernetes_deployment" "vector" {
           }
 
           resources {
+            # Because we do not have the ability to self-constrain vector's
+            # memory consumption we only make a request here on memory. This
+            # avoids vector crashing for want of a malloc.
             limits = {
               cpu    = var.vector_cpus
               memory = "512Mi"

--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -92,7 +92,6 @@ resource "kubernetes_deployment" "vector" {
             # avoids vector crashing for want of a malloc.
             limits = {
               cpu    = var.vector_cpus
-              memory = "512Mi"
             }
             requests = {
               cpu    = var.vector_cpus

--- a/soaks/tests/splunk_hec_route_s3/README.md
+++ b/soaks/tests/splunk_hec_route_s3/README.md
@@ -1,0 +1,10 @@
+# Splunk HEC -> Route Transform -> s3
+
+This soak tests the splunk_heck source into the routing transform, dropping into
+two s3 sinks. The main area of concern here is the routing transform which is of
+high cardinality.
+
+## Method
+
+Lading `http_gen` is used to generate load into vector. `http_blackhole`
+mascarades as s3 for the purposes of this soak.

--- a/soaks/tests/splunk_hec_route_s3/terraform/http_blackhole.toml
+++ b/soaks/tests/splunk_hec_route_s3/terraform/http_blackhole.toml
@@ -1,0 +1,3 @@
+worker_threads = 4
+binding_addr = "0.0.0.0:8080"
+prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/splunk_hec_route_s3/terraform/http_gen.toml
+++ b/soaks/tests/splunk_hec_route_s3/terraform/http_gen.toml
@@ -1,0 +1,12 @@
+worker_threads = 2
+prometheus_addr = "0.0.0.0:9090"
+
+[targets.vector]
+target_uri = "http://vector:8282/services/collector/event/1.0"
+bytes_per_second = "120 Mb"
+parallel_connections = 50
+method.type = "Post"
+method.variant = "SplunkHec"
+method.maximum_prebuild_cache_size_bytes = "256 Mb"
+[targets.vector.headers]
+dd-api-key = "DEADBEEF"

--- a/soaks/tests/splunk_hec_route_s3/terraform/main.tf
+++ b/soaks/tests/splunk_hec_route_s3/terraform/main.tf
@@ -19,7 +19,7 @@ provider "kubernetes" {
 # Setup background monitoring details. These are needed by the soak control to
 # understand what vector et al's running behavior is.
 module "monitoring" {
-  source        = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -41,18 +41,20 @@ module "vector" {
   test_name    = "datadog_agent_remap_blackhole"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on = [module.http-blackhole]
+  vector_cpus  = var.vector_cpus
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on          = [module.monitoring]
 }
 module "http-gen" {
   source        = "../../../common/terraform/modules/lading_http_gen"
   type          = var.type
   http-gen-toml = file("${path.module}/http_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
-  depends_on = [module.vector]
+  depends_on    = [module.monitoring, module.vector]
 }

--- a/soaks/tests/splunk_hec_route_s3/terraform/main.tf
+++ b/soaks/tests/splunk_hec_route_s3/terraform/main.tf
@@ -1,0 +1,58 @@
+# Set up the providers needed to run this soak and other terraform related
+# business. Here we only require 'kubernetes' to interact with the soak
+# minikube.
+terraform {
+  required_providers {
+    kubernetes = {
+      version = "~> 2.5.0"
+      source  = "hashicorp/kubernetes"
+    }
+  }
+}
+
+# Rig the kubernetes provider to communicate with minikube. The details of
+# adjusting `~/.kube/config` are addressed by the soak control scripts.
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+# Setup background monitoring details. These are needed by the soak control to
+# understand what vector et al's running behavior is.
+module "monitoring" {
+  source        = "../../../common/terraform/modules/monitoring"
+  type         = var.type
+  vector_image = var.vector_image
+}
+
+# Setup the soak pieces
+#
+# This soak config sets up a vector soak with lading/http-gen feeding into vector,
+# lading/http-blackhole receiving.
+resource "kubernetes_namespace" "soak" {
+  metadata {
+    name = "soak"
+  }
+}
+
+module "vector" {
+  source       = "../../../common/terraform/modules/vector"
+  type         = var.type
+  vector_image = var.vector_image
+  test_name    = "datadog_agent_remap_blackhole"
+  vector-toml  = file("${path.module}/vector.toml")
+  namespace    = kubernetes_namespace.soak.metadata[0].name
+  depends_on = [module.http-blackhole]
+}
+module "http-blackhole" {
+  source              = "../../../common/terraform/modules/lading_http_blackhole"
+  type                = var.type
+  http-blackhole-toml = file("${path.module}/http_blackhole.toml")
+  namespace           = kubernetes_namespace.soak.metadata[0].name
+}
+module "http-gen" {
+  source        = "../../../common/terraform/modules/lading_http_gen"
+  type          = var.type
+  http-gen-toml = file("${path.module}/http_gen.toml")
+  namespace     = kubernetes_namespace.soak.metadata[0].name
+  depends_on = [module.vector]
+}

--- a/soaks/tests/splunk_hec_route_s3/terraform/variables.tf
+++ b/soaks/tests/splunk_hec_route_s3/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "type" {
+  description = "The type of the vector install, whether 'baseline' or 'comparison'"
+  type        = string
+}
+
+variable "vector_image" {
+  description = "The image of vector to use in this investigation"
+  type        = string
+}

--- a/soaks/tests/splunk_hec_route_s3/terraform/variables.tf
+++ b/soaks/tests/splunk_hec_route_s3/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/splunk_hec_route_s3/terraform/vector.toml
+++ b/soaks/tests/splunk_hec_route_s3/terraform/vector.toml
@@ -1,0 +1,63 @@
+data_dir = "/var/lib/vector"
+
+##
+## Sources
+##
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sources.splunk]
+address = "0.0.0.0:8282"
+type = "splunk_hec"
+
+##
+## Transforms
+##
+
+[transforms.container_type]
+type = "route"
+inputs = ["splunk"]
+
+[transforms.container_type.route]
+service = '.attrs.c2cContainerType == "service"'
+sidecar = '.attrs.c2cContainerType != "service"'
+
+##
+## Sinks
+##
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+address = "0.0.0.0:9090"
+
+[sinks.s3_sidecar]
+type = "aws_s3"
+inputs = ["container_type.sidecar"]
+
+endpoint = "http://http-blackhole:8080"
+bucket = "vector-soak-sidecar"
+
+encoding.codec = "ndjson"
+encoding.except_fields = ["timestamp"]
+key_prefix = "v1/source_type/sidecar/aws_account_id/{{attrs.aws_account}}/system_id/{{attrs.systemid}}/service/{{attrs.c2cService}}/partition/{{attrs.c2cPartition}}/stage/{{attrs.c2cStage}}/year/%Y/month/%m/day/%d/hour/%H"
+
+[sinks.s3_sidecar.auth]
+access_key_id = "BADDCAFE"
+secret_access_key = "BADDCAFE"
+
+[sinks.s3_service]
+type = "aws_s3"
+inputs = ["container_type.service"]
+
+endpoint = "http://http-blackhole:8080"
+bucket = "vector-soak-service"
+
+encoding.codec = "ndjson"
+encoding.except_fields = ["timestamp"]
+key_prefix = "v1/source_type/app/system_id/{{attrs.systemid}}/service/{{attrs.c2cService}}/partition/{{attrs.c2cPartition}}/stage/{{attrs.c2cStage}}/year/%Y/month/%m/day/%d/hour/%H"
+
+[sinks.s3_service.auth]
+access_key_id = "BADDCAFE"
+secret_access_key = "BADDCAFE"


### PR DESCRIPTION
This commit introduces a soak for the above configuration. Interestingly vector
crashes owing to being too memory hungry and the soak does not run as a result.

REF #9515 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
