### PR TITLE
chore(ci): Update how soak tests determine SHA

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Setup comparison variables
         id: comparison
         run: |
-          export COMPARISON_SHA=${{ github.sha }}
-          export COMPARISON_TAG="${{ github.sha }}-${{ github.sha }}"
+          export COMPARISON_SHA=${{ github.event.pull_request.head.sha }}
+          export COMPARISON_TAG="${{ github.event.pull_request.head.sha }}-${{ github.event.pull_request.head.sha }}"
 
           echo "comparison sha is: ${COMPARISON_SHA}"
           echo "comparison tag is: ${COMPARISON_TAG}"
@@ -98,7 +98,7 @@ jobs:
           export BASELINE_SHA=$(git rev-parse HEAD)
           popd
 
-          export BASELINE_TAG="${{ github.sha }}-${BASELINE_SHA}"
+          export BASELINE_TAG="${{ github.event.pull_request.head.sha }}-${BASELINE_SHA}"
           echo "baseline sha is: ${BASELINE_SHA}"
           echo "baseline tag is: ${BASELINE_TAG}"
 


### PR DESCRIPTION
For pull requests, `github.sha`, is actually often the merge commit
Github Actions makes, before running the workflow, if the pull request
branch is out of date with `master`.

Closes: #9940

Ref: https://github.community/t/github-sha-isnt-the-value-expected/17903



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->