### PR TITLE
chore: Correct more local-run soak problems

### DIFF
--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -30,6 +30,7 @@ SOAK_CAPTURE_DIR="${CAPTURE_DIR}/${SOAK_NAME}"
 
 pushd "${__dir}"
 ./boot_minikube.sh
+mkdir -p "${SOAK_CAPTURE_DIR}"
 minikube mount "${SOAK_CAPTURE_DIR}:/captures" &
 minikube cache add "${IMAGE}"
 MOUNT_PID=$!

--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -63,12 +63,11 @@ done
 
 pushd "${__dir}"
 
-capture_dir=$(mktemp -d /tmp/"${SOAK_NAME}".XXXXXX)
+capture_dir=$(mktemp -d /tmp/soak-captures.XXXXXX)
 echo "Captures will be recorded into ${capture_dir}"
 
 ./bin/soak_one.sh "${USE_LOCAL_IMAGE}" "${SOAK_NAME}" "baseline" "${BASELINE}" "${capture_dir}"
 ./bin/soak_one.sh "${USE_LOCAL_IMAGE}" "${SOAK_NAME}" "comparison" "${COMPARISON}" "${capture_dir}"
+./bin/analyze_experiment.sh "${capture_dir}" "${BASELINE}" "${COMPARISON}"
 
 popd
-
-./bin/analyze_experiment.sh "${capture_dir}" "${BASELINE}" "${COMPARISON}"


### PR DESCRIPTION
As the work on the CI workflow got more involved the local soak suffered. In
this case when the directory scheme shifted we did not maintain the same concept
in the local variant. Almost, but not quite. This commit allows the local
variant to go through a whole soak.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
