### PR TITLE
fix(windows platform): call `Application::run` when running vector as a service on windows instead of manually handling the topology life cycle.

### DIFF
--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -1,5 +1,6 @@
 use crate::app::Application;
-use std::{ffi::OsString, sync::mpsc, time::Duration};
+use crate::signal::SignalTo;
+use std::{ffi::OsString, time::Duration};
 use windows_service::service::{
     ServiceControl, ServiceExitCode, ServiceState, ServiceStatus, ServiceType,
 };
@@ -362,29 +363,28 @@ pub fn run() -> Result<()> {
 }
 
 fn run_service(_arguments: Vec<OsString>) -> Result<()> {
-    let (shutdown_tx, shutdown_rx) = mpsc::channel();
-
-    let event_handler = move |control_event| -> ServiceControlHandlerResult {
-        match control_event {
-            // Notifies a service to report its current status information to the service
-            // control manager. Always return NoError even if not implemented.
-            ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
-
-            // Handle stop
-            ServiceControl::Stop => {
-                shutdown_tx.send(()).unwrap();
-                ServiceControlHandlerResult::NoError
-            }
-
-            _ => ServiceControlHandlerResult::NotImplemented,
-        }
-    };
-    let status_handle =
-        windows_service::service_control_handler::register(SERVICE_NAME, event_handler)?;
-
-    let application = Application::prepare();
-    let code = match application {
+    match Application::prepare() {
         Ok(app) => {
+            let signal_tx = app.config.signal_handler.clone_tx();
+            let event_handler = move |control_event| -> ServiceControlHandlerResult {
+                match control_event {
+                    // Notifies a service to report its current status information to the service
+                    // control manager. Always return NoError even if not implemented.
+                    ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+
+                    // Handle stop
+                    ServiceControl::Stop => {
+                        while let Err(_) = signal_tx.try_send(SignalTo::Shutdown) {}
+                        ServiceControlHandlerResult::NoError
+                    }
+
+                    _ => ServiceControlHandlerResult::NotImplemented,
+                }
+            };
+
+            let status_handle =
+                windows_service::service_control_handler::register(SERVICE_NAME, event_handler)?;
+
             status_handle.set_service_status(ServiceStatus {
                 service_type: SERVICE_TYPE,
                 current_state: ServiceState::Running,
@@ -395,28 +395,21 @@ fn run_service(_arguments: Vec<OsString>) -> Result<()> {
                 process_id: None,
             })?;
 
-            let rt = app.runtime;
-            let topology = app.config.topology;
+            app.run();
 
-            rt.block_on(async move {
-                shutdown_rx.recv().unwrap();
-                topology.stop().await;
-                ServiceExitCode::Win32(NO_ERROR)
-            })
+            // Tell the system that service has stopped.
+            status_handle.set_service_status(ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: ServiceState::Stopped,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::Win32(NO_ERROR),
+                checkpoint: 0,
+                wait_hint: Duration::default(),
+                process_id: None,
+            })?;
+
+            Ok(())
         }
-        Err(e) => ServiceExitCode::ServiceSpecific(e as u32),
-    };
-
-    // Tell the system that service has stopped.
-    status_handle.set_service_status(ServiceStatus {
-        service_type: SERVICE_TYPE,
-        current_state: ServiceState::Stopped,
-        controls_accepted: ServiceControlAccept::empty(),
-        exit_code: code,
-        checkpoint: 0,
-        wait_hint: Duration::default(),
-        process_id: None,
-    })?;
-
-    Ok(())
+        _ => Ok(()),
+    }
 }


### PR DESCRIPTION
On Windows, prior to this commit, the topology life cycle was handled separately from the main application running logic.
This meant that the windows service running logic did not benefit from improvement made inside the main application running logic.

That behavior was causing a memory-leak when running vector as a service on Windows because the "early buffering" mechanism that
was introduced for internal events was not properly stopped inside the windows running logic.

To make it future-proof, vector now directly calls `Application::run` inside the windows running logic.

This addresses #9207 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
