### PR TITLE
chore: Allow CPU/memory targets to be set by user in soaks

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -66,9 +66,9 @@ jobs:
       comparison-tag: ${{ steps.comparison.outputs.COMPARISON_TAG }}
       baseline-sha: ${{ steps.baseline.outputs.BASELINE_SHA }}
       baseline-tag: ${{ steps.baseline.outputs.BASELINE_TAG }}
-      vector-cpus: ${{ steps.baseline.outputs.VECTOR_CPUS }}
-      soak-cpus: ${{ steps.baseline.outputs.SOAK_CPUS }}
-      soak-memory: ${{ steps.baseline.outputs.SOAK_MEMORY }}
+      vector-cpus: ${{ steps.system.outputs.VECTOR_CPUS }}
+      soak-cpus: ${{ steps.system.outputs.SOAK_CPUS }}
+      soak-memory: ${{ steps.system.outputs.SOAK_MEMORY }}
     steps:
       - uses: actions/checkout@v2.3.5
         with:
@@ -109,7 +109,7 @@ jobs:
           echo "::set-output name=BASELINE_SHA::${BASELINE_SHA}"
 
       - name: Setup system details
-        id: comparison
+        id: system
         run: |
           export SOAK_CPUS="7"
           export SOAK_MEMORY="24g"

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -66,6 +66,9 @@ jobs:
       comparison-tag: ${{ steps.comparison.outputs.COMPARISON_TAG }}
       baseline-sha: ${{ steps.baseline.outputs.BASELINE_SHA }}
       baseline-tag: ${{ steps.baseline.outputs.BASELINE_TAG }}
+      vector-cpus: ${{ steps.baseline.outputs.VECTOR_CPUS }}
+      soak-cpus: ${{ steps.baseline.outputs.SOAK_CPUS }}
+      soak-memory: ${{ steps.baseline.outputs.SOAK_MEMORY }}
     steps:
       - uses: actions/checkout@v2.3.5
         with:
@@ -104,6 +107,21 @@ jobs:
 
           echo "::set-output name=BASELINE_TAG::${BASELINE_TAG}"
           echo "::set-output name=BASELINE_SHA::${BASELINE_SHA}"
+
+      - name: Setup system details
+        id: comparison
+        run: |
+          export SOAK_CPUS="7"
+          export SOAK_MEMORY="24g"
+          export VECTOR_CPUS="4"
+
+          echo "soak cpus total: ${SOAK_CPUS}"
+          echo "soak memory total: ${SOAK_MEMORY}"
+          echo "vector cpus: ${VECTOR_CPUS}"
+
+          echo "::set-output name=SOAK_CPUS::${SOAK_CPUS}"
+          echo "::set-output name=SOAK_MEMORY::${SOAK_MEMORY}"
+          echo "::set-output name=VECTOR_CPUS::${VECTOR_CPUS}"
 
   build-baseline-image:
     name: Build baseline 'soak-vector' container
@@ -211,7 +229,14 @@ jobs:
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/${{ github.event.number }}/${{ matrix.target }}/
-          ./soaks/bin/soak_one.sh "false" ${{ matrix.target }} "baseline" ${{ needs.compute-soak-meta.outputs.baseline-tag }} /tmp/${{ github.event.number }}
+          ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
+                                  --local-image "false" \
+                                  --variant "baseline" \
+                                  --tag ${{ needs.compute-soak-meta.outputs.baseline-tag }} \
+                                  --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \
+                                  --memory ${{ needs.compute-soak-meta.outputs.soak-memory }} \
+                                  --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
+                                  --capture-dir /tmp/${{ github.event.number }}
 
       - name: Upload timing captures
         uses: actions/upload-artifact@v1
@@ -240,7 +265,14 @@ jobs:
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/${{ github.event.number }}/${{ matrix.target }}/
-          ./soaks/bin/soak_one.sh "false" ${{ matrix.target }} "comparison" ${{ needs.compute-soak-meta.outputs.comparison-tag }} /tmp/${{ github.event.number }}
+          ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
+                                  --local-image "false" \
+                                  --variant "comparison" \
+                                  --tag ${{ needs.compute-soak-meta.outputs.comparison-tag }} \
+                                  --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \
+                                  --memory ${{ needs.compute-soak-meta.outputs.soak-memory }} \
+                                  --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
+                                  --capture-dir /tmp/${{ github.event.number }}
 
       - name: Upload timing captures
         uses: actions/upload-artifact@v1
@@ -267,7 +299,10 @@ jobs:
 
       - name: Analyze captures
         run: |
-          ./soaks/bin/analyze_experiment.sh ${{ github.event.number }}-captures/ ${{ needs.compute-soak-meta.outputs.baseline-sha }} ${{ needs.compute-soak-meta.outputs.comparison-sha }} > /tmp/${{ github.event.number}}-${{ github.run_number }}-analysis
+          ./soaks/bin/analyze_experiment.sh --capture-dir ${{ github.event.number }}-captures/ \
+                                            --baseline ${{ needs.compute-soak-meta.outputs.baseline-sha }} \
+                                            --comparison ${{ needs.compute-soak-meta.outputs.comparison-sha }} \
+                                            --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} > /tmp/${{ github.event.number}}-${{ github.run_number }}-analysis
 
       - name: Read analysis file
         id: read-analysis

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -216,19 +216,13 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.compute-test-plan.outputs.matrix) }}
     steps:
-      - uses: actions/cache@v2
-        with:
-          key: ${{ needs.compute-soak-meta.outputs.baseline-tag }}-${{ matrix.target }}
-          path: |
-            /tmp/${{ github.event.number }}/${{ matrix.target }}
-
       - name: Check out the repo
         uses: actions/checkout@v2.4.0
 
       - name: Run baseline experiment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
-          mkdir -p /tmp/${{ github.event.number }}/${{ matrix.target }}/
+          mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
                                   --local-image "false" \
                                   --variant "baseline" \
@@ -236,13 +230,13 @@ jobs:
                                   --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \
                                   --memory ${{ needs.compute-soak-meta.outputs.soak-memory }} \
                                   --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
-                                  --capture-dir /tmp/${{ github.event.number }}
+                                  --capture-dir /tmp/${{ github.event.number }}-${{ github.run_attempt }}
 
       - name: Upload timing captures
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ github.event.number }}-captures
-          path: /tmp/${{ github.event.number }}
+          name: ${{ github.event.number }}-${{ github.run_attempt }}-captures
+          path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}
 
   soak-comparison:
     name: Soak (${{ matrix.target }}) - comparison
@@ -252,19 +246,13 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.compute-test-plan.outputs.matrix) }}
     steps:
-      - uses: actions/cache@v2
-        with:
-          key: ${{ needs.compute-soak-meta.outputs.comparison-tag }}-${{ matrix.target }}
-          path: |
-            /tmp/${{ github.event.number }}/${{ matrix.target }}
-
       - name: Check out the repo
         uses: actions/checkout@v2.4.0
 
       - name: Run comparison experiment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
-          mkdir -p /tmp/${{ github.event.number }}/${{ matrix.target }}/
+          mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
                                   --local-image "false" \
                                   --variant "comparison" \
@@ -272,13 +260,13 @@ jobs:
                                   --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \
                                   --memory ${{ needs.compute-soak-meta.outputs.soak-memory }} \
                                   --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
-                                  --capture-dir /tmp/${{ github.event.number }}
+                                  --capture-dir /tmp/${{ github.event.number }}-${{ github.run_attempt }}
 
       - name: Upload timing captures
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ github.event.number }}-captures
-          path: /tmp/${{ github.event.number }}
+          name: ${{ github.event.number }}-${{ github.run_attempt }}-captures
+          path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}
 
   analyze-results:
     name: Soak analysis
@@ -295,20 +283,20 @@ jobs:
       - name: Download captures artifact
         uses: actions/download-artifact@v1
         with:
-          name: ${{ github.event.number }}-captures
+          name: ${{ github.event.number }}-${{ github.run_attempt }}-captures
 
       - name: Analyze captures
         run: |
-          ./soaks/bin/analyze_experiment.sh --capture-dir ${{ github.event.number }}-captures/ \
+          ./soaks/bin/analyze_experiment.sh --capture-dir ${{ github.event.number }}-${{ github.run_attempt }}-captures/ \
                                             --baseline ${{ needs.compute-soak-meta.outputs.baseline-sha }} \
                                             --comparison ${{ needs.compute-soak-meta.outputs.comparison-sha }} \
-                                            --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} > /tmp/${{ github.event.number}}-${{ github.run_number }}-analysis
+                                            --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} > /tmp/${{ github.event.number}}-${{ github.run_attempt }}-analysis
 
       - name: Read analysis file
         id: read-analysis
         uses: juliangruber/read-file-action@v1
         with:
-          path: /tmp/${{ github.event.number }}-${{ github.run_number }}-analysis
+          path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}-analysis
 
       - name: Post Results To PR
         uses: peter-evans/create-or-update-comment@v1

--- a/soaks/bin/analyze_experiment.sh
+++ b/soaks/bin/analyze_experiment.sh
@@ -3,22 +3,68 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-#set -o xtrace
+# set -o xtrace
 
 display_usage() {
     echo ""
-    echo "Usage: $0  CAPTURE_DIR BASELINE_SHA COMPARISON_SHA"
+    echo "Usage: analyze_experiment [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --help: display this information"
+    echo "  --capture-dir: the directory in which to write captures"
+    echo "  --baseline: the baseline SHA to compare against"
+    echo "  --comparison: the SHA to compare against 'baseline'"
+    echo "  --vector-cpus: the total number of CPUs to give to soaked vector, default 4"
+    echo ""
 }
 
-CAPTURE_DIR="${1}"
-BASELINE_SHA="${2}"
-COMPARISON_SHA="${3}"
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+      --soak)
+          SOAK_NAME=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --baseline)
+          BASELINE_SHA=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --comparison)
+          COMPARISON_SHA=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --vector-cpus)
+          VECTOR_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --capture-dir)
+          CAPTURE_DIR=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --help)
+          display_usage
+          exit 0
+          ;;
+      *)
+          echo "unknown option: ${key}"
+          display_usage
+          exit 1
+          ;;
+  esac
+done
 
 echo "# Soak Test Results"
 echo "Baseline: ${BASELINE_SHA}"
 echo "Comparison: ${COMPARISON_SHA}"
+echo "Total Vector CPUs: ${VECTOR_CPUS}"
 echo ""
-echo "What follows is a statistical summary of the soak captures between the SHAs given above. Units are bytes/second, except for 'skewness' and 'kurtosis'. Higher numbers in 'comparison' is generally better. Higher skewness or kurtosis numbers indicate a lack of consistency in behavior, making predictions of fitness in the field challenging."
+echo "What follows is a statistical summary of the soak captures between the SHAs given above. Units are bytes/second/CPU, except for 'skewness' and 'kurtosis'. Higher numbers in 'comparison' is generally better. Higher skewness or kurtosis numbers indicate a lack of consistency in behavior, making predictions of fitness in the field challenging."
 echo ""
 for soak_dir in "${CAPTURE_DIR}"/*; do
     SOAK_NAME=$(basename "${soak_dir}")
@@ -31,12 +77,14 @@ for soak_dir in "${CAPTURE_DIR}"/*; do
         mlr --itsv --ocsv \
             --from "${soak_dir}/baseline.captures" \
             --from "${soak_dir}/comparison.captures" \
-            stats1 -a 'min,p90,p99,max,skewness,kurtosis' -g EXPERIMENT -f VALUE | \
-        numfmt --header=1 --to=iec-i --format="%.2f" --field="2-5" --delimiter="," | \
-        numfmt --header=1 --to=none  --format="%.2f" --field="6-7" --delimiter=","
+            stats1 -a 'min,p90,p99,max,skewness,kurtosis' -g EXPERIMENT -f VALUE
     )
     HEADER=$(echo "${OUTPUT}" | head -n1)
-    BODY=$(echo "${OUTPUT}" | tail -n+2)
+    BODY=$(echo "${OUTPUT}" | tail -n+2 | \
+           awk -v cpus="${VECTOR_CPUS}" 'BEGIN {FS=",";OFS=",";OFMT="%f"} {print $1,$2/cpus,$3/cpus,$4/cpus,$5/cpus,$6,$7}' | \
+           numfmt --to=iec-i --format="%.2f" --field="2-5" --delimiter="," | \
+           numfmt --to=none  --format="%.2f" --field="6-7" --delimiter=","
+    )
 
     echo "${HEADER}" | sed 's/,/\ \|\ /g' | sed 's/^/|\ /g' | sed 's/$/\ |/g'
     echo "| --- | --- | --- | --- | --- | --- | --- |"

--- a/soaks/bin/boot_minikube.sh
+++ b/soaks/bin/boot_minikube.sh
@@ -5,6 +5,42 @@ set -o pipefail
 set -o nounset
 #set -o xtrace
 
+display_usage() {
+    echo ""
+    echo "Usage: boot_minikube [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --cpus: the total number of CPUs to dedicate to the soak minikube, default 7"
+    echo "  --memory: the total amount of memory dedicate to the soak minikube, default 8g"
+    echo ""
+}
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+      --cpus)
+          SOAK_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --memory)
+          SOAK_MEMORY=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --help)
+          display_usage
+          exit 0
+          ;;
+      *)
+          echo "unknown option"
+          display_usage
+          exit 1
+          ;;
+  esac
+done
+
 minikube stop || true
 minikube delete || true
-minikube start --cpus=7 --memory=8g --driver=docker
+minikube start --cpus="${SOAK_CPUS}" --memory="${SOAK_MEMORY}" --driver=docker

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -o xtrace
+#set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOAK_ROOT="${__dir}/.."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -10,26 +10,78 @@ SOAK_ROOT="${__dir}/.."
 
 display_usage() {
     echo ""
-    echo "Usage: $0 CAPTURE_DIR VARIANT IMAGE SOAK_NAME"
+    echo "Usage: run_experiment [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --help: display this information"
+    echo "  --soak: the experiment to run"
+    echo "  --local-image: whether to use a local vector image or remote, local if true"
+    echo "  --variant: the variation of test in play, either 'baseline' or 'comparison'"
+    echo "  --tag: the tag this test covers"
+    echo "  --capture-dir: the directory in which to write captures"
+    echo "  --cpus: the total number of CPUs to dedicate to the soak minikube, default 7"
+    echo "  --memory: the total amount of memory dedicate to the soak minikube, default 8g"
+    echo "  --vector-cpus: the total number of CPUs to give to soaked vector"
+    echo ""
 }
 
-CAPTURE_DIR="${1}"
-VARIANT="${2}"
-IMAGE="${3}"
-SOAK_NAME="${4}"
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+      --soak)
+          SOAK_NAME=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --variant)
+          VARIANT=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --image)
+          IMAGE=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --capture-dir)
+          CAPTURE_DIR=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --vector-cpus)
+          VECTOR_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --cpus)
+          SOAK_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --memory)
+          SOAK_MEMORY=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --help)
+          display_usage
+          exit 0
+          ;;
+      *)
+          echo "unknown option: ${key}"
+          display_usage
+          exit 1
+          ;;
+  esac
+done
+
 WARMUP_GRACE=90
 TOTAL_SAMPLES=120
-
-if [  $# -le 1 ]
-then
-    display_usage
-    exit 1
-fi
-
 SOAK_CAPTURE_DIR="${CAPTURE_DIR}/${SOAK_NAME}"
 
 pushd "${__dir}"
-./boot_minikube.sh
+./boot_minikube.sh --cpus "${SOAK_CPUS}" --memory "${SOAK_MEMORY}"
 mkdir -p "${SOAK_CAPTURE_DIR}"
 minikube mount "${SOAK_CAPTURE_DIR}:/captures" &
 minikube cache add "${IMAGE}"
@@ -38,7 +90,7 @@ popd
 
 pushd "${SOAK_ROOT}/tests/${SOAK_NAME}/terraform"
 terraform init
-terraform apply -var "type=${VARIANT}" -var "vector_image=${IMAGE}" -auto-approve -compact-warnings -input=false -no-color -parallelism=20
+terraform apply -var "type=${VARIANT}" -var "vector_image=${IMAGE}" -var "vector_cpus=${VECTOR_CPUS}" -auto-approve -compact-warnings -input=false -no-color
 echo "[${VARIANT}] Captures will be recorded into ${SOAK_CAPTURE_DIR}"
 echo "[${VARIANT}] Sleeping for ${WARMUP_GRACE} seconds to allow warm-up"
 sleep "${WARMUP_GRACE}"

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-#set -o xtrace
+set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOAK_ROOT="${__dir}/.."

--- a/soaks/bin/soak_one.sh
+++ b/soaks/bin/soak_one.sh
@@ -9,14 +9,79 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 display_usage() {
     echo ""
-    echo "Usage: $0 USE_LOCAL_IMAGE SOAK_NAME VARIANT TAG CAPTURE_DIR"
+    echo "Usage: soak_one [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --help: display this information"
+    echo "  --soak: the experiment to run"
+    echo "  --local-image: whether to use a local vector image or remote, local if true"
+    echo "  --variant: the variation of test in play, either 'baseline' or 'comparison'"
+    echo "  --tag: the tag this test covers"
+    echo "  --capture-dir: the directory in which to write captures"
+    echo "  --cpus: the total number of CPUs to dedicate to the soak minikube, default 7"
+    echo "  --memory: the total amount of memory dedicate to the soak minikube, default 8g"
+    echo "  --vector-cpus: the total number of CPUs to give to soaked vector"
+    echo ""
 }
 
-USE_LOCAL_IMAGE="${1}"
-SOAK_NAME="${2}"
-VARIANT="${3}"
-TAG="${4}"
-CAPTURE_DIR="${5}"
+
+USE_LOCAL_IMAGE="true"
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+      --soak)
+          SOAK_NAME=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --variant)
+          VARIANT=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --tag)
+          TAG=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --local-image)
+          USE_LOCAL_IMAGE=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --capture-dir)
+          CAPTURE_DIR=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --vector-cpus)
+          VECTOR_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --cpus)
+          SOAK_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --memory)
+          SOAK_MEMORY=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --help)
+          display_usage
+          exit 0
+          ;;
+      *)
+          echo "unknown option: ${key}"
+          display_usage
+          exit 1
+          ;;
+  esac
+done
 
 pushd "${__dir}"
 
@@ -31,6 +96,12 @@ else
     docker image tag "${REMOTE_IMAGE}" "${IMAGE}"
 fi
 
-./run_experiment.sh "${CAPTURE_DIR}" "${VARIANT}" "${IMAGE}" "${SOAK_NAME}"
+./run_experiment.sh --capture-dir "${CAPTURE_DIR}" \
+                    --variant "${VARIANT}" \
+                    --image "${IMAGE}" \
+                    --soak "${SOAK_NAME}" \
+                    --cpus "${SOAK_CPUS}" \
+                    --memory "${SOAK_MEMORY}" \
+                    --vector-cpus "${VECTOR_CPUS}"
 
 popd

--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -88,11 +88,11 @@ resource "kubernetes_deployment" "vector" {
 
           resources {
             limits = {
-              cpu    = "4"
+              cpu    = var.vector_cpus
               memory = "512Mi"
             }
             requests = {
-              cpu    = "4"
+              cpu    = var.vector_cpus
               memory = "512Mi"
             }
           }

--- a/soaks/common/terraform/modules/vector/variables.tf
+++ b/soaks/common/terraform/modules/vector/variables.tf
@@ -22,3 +22,8 @@ variable "namespace" {
   description = "The namespace in which to run"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -17,10 +17,16 @@ display_usage() {
     echo "  --remote-image|--local-image: whether to use a local vector image or remote"
     echo "  --baseline: the baseline SHA to compare against"
     echo "  --comparison: the SHA to compare against 'baseline'"
+    echo "  --cpus: the total number of CPUs to dedicate to the soak minikube, default 7"
+    echo "  --memory: the total amount of memory dedicate to the soak minikube, default 8g"
+    echo "  --vector-cpus: the total number of CPUs to give to soaked vector, default 4"
     echo ""
 }
 
 USE_LOCAL_IMAGE="true"
+SOAK_CPUS="7"
+SOAK_MEMORY="8g"
+VECTOR_CPUS="4"
 
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -49,6 +55,21 @@ while [[ $# -gt 0 ]]; do
           USE_LOCAL_IMAGE="true"
           shift # past argument
           ;;
+      --vector-cpus)
+          VECTOR_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --cpus)
+          SOAK_CPUS=$2
+          shift # past argument
+          shift # past value
+          ;;
+      --memory)
+          SOAK_MEMORY=$2
+          shift # past argument
+          shift # past value
+          ;;
       --help)
           display_usage
           exit 0
@@ -66,8 +87,26 @@ pushd "${__dir}"
 capture_dir=$(mktemp -d /tmp/soak-captures.XXXXXX)
 echo "Captures will be recorded into ${capture_dir}"
 
-./bin/soak_one.sh "${USE_LOCAL_IMAGE}" "${SOAK_NAME}" "baseline" "${BASELINE}" "${capture_dir}"
-./bin/soak_one.sh "${USE_LOCAL_IMAGE}" "${SOAK_NAME}" "comparison" "${COMPARISON}" "${capture_dir}"
-./bin/analyze_experiment.sh "${capture_dir}" "${BASELINE}" "${COMPARISON}"
+./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+                  --soak "${SOAK_NAME}" \
+                  --variant "baseline" \
+                  --tag "${BASELINE}" \
+                  --capture-dir "${capture_dir}" \
+                  --cpus "${SOAK_CPUS}" \
+                  --memory "${SOAK_MEMORY}" \
+                  --vector-cpus "${VECTOR_CPUS}"
+./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+                  --soak "${SOAK_NAME}" \
+                  --variant "comparison" \
+                  --tag "${COMPARISON}" \
+                  --capture-dir "${capture_dir}" \
+                  --cpus "${SOAK_CPUS}" \
+                  --memory "${SOAK_MEMORY}" \
+                  --vector-cpus "${VECTOR_CPUS}"
+
+./bin/analyze_experiment.sh --capture-dir "${capture_dir}" \
+                            --baseline "${BASELINE}" \
+                            --comparison "${COMPARISON}" \
+                            --vector-cpus "${VECTOR_CPUS}"
 
 popd

--- a/soaks/tests/datadog_agent_remap_blackhole/terraform/main.tf
+++ b/soaks/tests/datadog_agent_remap_blackhole/terraform/main.tf
@@ -19,7 +19,7 @@ provider "kubernetes" {
 # Setup background monitoring details. These are needed by the soak control to
 # understand what vector et al's running behavior is.
 module "monitoring" {
-  source        = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -41,13 +41,13 @@ module "vector" {
   test_name    = "datadog_agent_remap_blackhole"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  vector_cpus = var.vector_cpus
-  depends_on = [module.monitoring]
+  vector_cpus  = var.vector_cpus
+  depends_on   = [module.monitoring]
 }
 module "http-gen" {
   source        = "../../../common/terraform/modules/lading_http_gen"
   type          = var.type
   http-gen-toml = file("${path.module}/http_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
-  depends_on = [module.monitoring, module.vector]
+  depends_on    = [module.monitoring, module.vector]
 }

--- a/soaks/tests/datadog_agent_remap_blackhole/terraform/main.tf
+++ b/soaks/tests/datadog_agent_remap_blackhole/terraform/main.tf
@@ -41,10 +41,13 @@ module "vector" {
   test_name    = "datadog_agent_remap_blackhole"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus = var.vector_cpus
+  depends_on = [module.monitoring]
 }
 module "http-gen" {
   source        = "../../../common/terraform/modules/lading_http_gen"
   type          = var.type
   http-gen-toml = file("${path.module}/http_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
+  depends_on = [module.monitoring, module.vector]
 }

--- a/soaks/tests/datadog_agent_remap_blackhole/terraform/variables.tf
+++ b/soaks/tests/datadog_agent_remap_blackhole/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
+++ b/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
@@ -19,7 +19,7 @@ provider "kubernetes" {
 # Setup background monitoring details. These are needed by the soak control to
 # understand what vector et al's running behavior is.
 module "monitoring" {
-  source        = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -41,7 +41,7 @@ module "vector" {
   test_name    = "datadog_agent_remap_datadog_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  vector_cpus = var.vector_cpus
+  vector_cpus  = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
@@ -49,12 +49,12 @@ module "http-blackhole" {
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
-  depends_on = [module.monitoring]
+  depends_on          = [module.monitoring]
 }
 module "http-gen" {
   source        = "../../../common/terraform/modules/lading_http_gen"
   type          = var.type
   http-gen-toml = file("${path.module}/http_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
-  depends_on = [module.monitoring, module.vector]
+  depends_on    = [module.monitoring, module.vector]
 }

--- a/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
+++ b/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
@@ -41,6 +41,7 @@ module "vector" {
   test_name    = "datadog_agent_remap_datadog_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {

--- a/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
+++ b/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
@@ -41,17 +41,19 @@ module "vector" {
   test_name    = "datadog_agent_remap_datadog_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.http-blackhole]
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on = [module.monitoring]
 }
 module "http-gen" {
   source        = "../../../common/terraform/modules/lading_http_gen"
   type          = var.type
   http-gen-toml = file("${path.module}/http_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
+  depends_on = [module.monitoring, module.vector]
 }

--- a/soaks/tests/datadog_agent_remap_datadog_logs/terraform/variables.tf
+++ b/soaks/tests/datadog_agent_remap_datadog_logs/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/syslog_humio_logs/terraform/main.tf
+++ b/soaks/tests/syslog_humio_logs/terraform/main.tf
@@ -12,7 +12,7 @@ provider "kubernetes" {
 }
 
 module "monitoring" {
-  source = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -30,7 +30,7 @@ module "vector" {
   test_name    = "syslog_humio_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  vector_cpus = var.vector_cpus
+  vector_cpus  = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
@@ -38,12 +38,12 @@ module "http-blackhole" {
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.monitoring]
+  depends_on          = [module.monitoring]
 }
 module "tcp-gen" {
-  source        = "../../../common/terraform/modules/lading_tcp_gen"
-  type          = var.type
+  source       = "../../../common/terraform/modules/lading_tcp_gen"
+  type         = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
-  namespace     = kubernetes_namespace.soak.metadata[0].name
+  namespace    = kubernetes_namespace.soak.metadata[0].name
   depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_humio_logs/terraform/main.tf
+++ b/soaks/tests/syslog_humio_logs/terraform/main.tf
@@ -30,6 +30,7 @@ module "vector" {
   test_name    = "syslog_humio_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {

--- a/soaks/tests/syslog_humio_logs/terraform/main.tf
+++ b/soaks/tests/syslog_humio_logs/terraform/main.tf
@@ -30,18 +30,19 @@ module "vector" {
   test_name    = "syslog_humio_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.http-blackhole]
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on   = [module.monitoring]
 }
 module "tcp-gen" {
   source        = "../../../common/terraform/modules/lading_tcp_gen"
   type          = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.vector]
+  depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_humio_logs/terraform/variables.tf
+++ b/soaks/tests/syslog_humio_logs/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
@@ -30,6 +30,7 @@ module "vector" {
   test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {

--- a/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
@@ -12,7 +12,7 @@ provider "kubernetes" {
 }
 
 module "monitoring" {
-  source = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -30,7 +30,7 @@ module "vector" {
   test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  vector_cpus = var.vector_cpus
+  vector_cpus  = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
@@ -38,12 +38,12 @@ module "http-blackhole" {
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.monitoring]
+  depends_on          = [module.monitoring]
 }
 module "tcp-gen" {
-  source        = "../../../common/terraform/modules/lading_tcp_gen"
-  type          = var.type
+  source       = "../../../common/terraform/modules/lading_tcp_gen"
+  type         = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
-  namespace     = kubernetes_namespace.soak.metadata[0].name
+  namespace    = kubernetes_namespace.soak.metadata[0].name
   depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
@@ -30,18 +30,19 @@ module "vector" {
   test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.http-blackhole]
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on   = [module.monitoring]
 }
 module "tcp-gen" {
   source        = "../../../common/terraform/modules/lading_tcp_gen"
   type          = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.vector]
+  depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_log2metric_humio_metrics/terraform/variables.tf
+++ b/soaks/tests/syslog_log2metric_humio_metrics/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
@@ -30,6 +30,7 @@ module "vector" {
   test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {

--- a/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
@@ -12,7 +12,7 @@ provider "kubernetes" {
 }
 
 module "monitoring" {
-  source = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -30,7 +30,7 @@ module "vector" {
   test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  vector_cpus = var.vector_cpus
+  vector_cpus  = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
@@ -38,12 +38,12 @@ module "http-blackhole" {
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.monitoring]
+  depends_on          = [module.monitoring]
 }
 module "tcp-gen" {
-  source        = "../../../common/terraform/modules/lading_tcp_gen"
-  type          = var.type
+  source       = "../../../common/terraform/modules/lading_tcp_gen"
+  type         = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
-  namespace     = kubernetes_namespace.soak.metadata[0].name
+  namespace    = kubernetes_namespace.soak.metadata[0].name
   depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
@@ -30,18 +30,19 @@ module "vector" {
   test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.http-blackhole]
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on   = [module.monitoring]
 }
 module "tcp-gen" {
   source        = "../../../common/terraform/modules/lading_tcp_gen"
   type          = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.vector]
+  depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/variables.tf
+++ b/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/syslog_loki/terraform/main.tf
+++ b/soaks/tests/syslog_loki/terraform/main.tf
@@ -19,7 +19,7 @@ provider "kubernetes" {
 # Setup background monitoring details. These are needed by the soak control to
 # understand what vector et al's running behavior is.
 module "monitoring" {
-  source = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -41,7 +41,7 @@ module "vector" {
   test_name    = "syslog_loki"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  vector_cpus = var.vector_cpus
+  vector_cpus  = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
@@ -49,7 +49,7 @@ module "http-blackhole" {
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.monitoring]
+  depends_on          = [module.monitoring]
 }
 module "tcp-gen" {
   source       = "../../../common/terraform/modules/lading_tcp_gen"

--- a/soaks/tests/syslog_loki/terraform/main.tf
+++ b/soaks/tests/syslog_loki/terraform/main.tf
@@ -41,18 +41,19 @@ module "vector" {
   test_name    = "syslog_loki"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.http-blackhole]
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on   = [module.monitoring]
 }
 module "tcp-gen" {
   source       = "../../../common/terraform/modules/lading_tcp_gen"
   type         = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.vector]
+  depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_loki/terraform/main.tf
+++ b/soaks/tests/syslog_loki/terraform/main.tf
@@ -41,6 +41,7 @@ module "vector" {
   test_name    = "syslog_loki"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {

--- a/soaks/tests/syslog_loki/terraform/variables.tf
+++ b/soaks/tests/syslog_loki/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
+++ b/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
@@ -41,18 +41,19 @@ module "vector" {
   test_name    = "syslog_regex_logs2metric_ddmetrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.http-blackhole]
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on   = [module.monitoring]
 }
 module "tcp-gen" {
   source       = "../../../common/terraform/modules/lading_tcp_gen"
   type         = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.vector]
+  depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
+++ b/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
@@ -19,7 +19,7 @@ provider "kubernetes" {
 # Setup background monitoring details. These are needed by the soak control to
 # understand what vector et al's running behavior is.
 module "monitoring" {
-  source = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -48,7 +48,7 @@ module "http-blackhole" {
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.monitoring]
+  depends_on          = [module.monitoring]
 }
 module "tcp-gen" {
   source       = "../../../common/terraform/modules/lading_tcp_gen"

--- a/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
+++ b/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
@@ -41,6 +41,7 @@ module "vector" {
   test_name    = "syslog_regex_logs2metric_ddmetrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus  = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {

--- a/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/variables.tf
+++ b/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
+++ b/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
@@ -30,18 +30,19 @@ module "vector" {
   test_name    = "syslog_splunk_hec_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.http-blackhole]
+  depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
   source              = "../../../common/terraform/modules/lading_http_blackhole"
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on   = [module.monitoring]
 }
 module "tcp-gen" {
   source        = "../../../common/terraform/modules/lading_tcp_gen"
   type          = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
   namespace     = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.vector]
+  depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
+++ b/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
@@ -12,7 +12,7 @@ provider "kubernetes" {
 }
 
 module "monitoring" {
-  source = "../../../common/terraform/modules/monitoring"
+  source       = "../../../common/terraform/modules/monitoring"
   type         = var.type
   vector_image = var.vector_image
 }
@@ -30,7 +30,7 @@ module "vector" {
   test_name    = "syslog_splunk_hec_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
-  vector_cpus = var.vector_cpus
+  vector_cpus  = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {
@@ -38,12 +38,12 @@ module "http-blackhole" {
   type                = var.type
   http-blackhole-toml = file("${path.module}/http_blackhole.toml")
   namespace           = kubernetes_namespace.soak.metadata[0].name
-  depends_on   = [module.monitoring]
+  depends_on          = [module.monitoring]
 }
 module "tcp-gen" {
-  source        = "../../../common/terraform/modules/lading_tcp_gen"
-  type          = var.type
+  source       = "../../../common/terraform/modules/lading_tcp_gen"
+  type         = var.type
   tcp-gen-toml = file("${path.module}/tcp_gen.toml")
-  namespace     = kubernetes_namespace.soak.metadata[0].name
+  namespace    = kubernetes_namespace.soak.metadata[0].name
   depends_on   = [module.monitoring, module.vector]
 }

--- a/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
+++ b/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
@@ -30,6 +30,7 @@ module "vector" {
   test_name    = "syslog_splunk_hec_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus = var.vector_cpus
   depends_on   = [module.monitoring, module.http-blackhole]
 }
 module "http-blackhole" {

--- a/soaks/tests/syslog_splunk_hec_logs/terraform/variables.tf
+++ b/soaks/tests/syslog_splunk_hec_logs/terraform/variables.tf
@@ -7,3 +7,8 @@ variable "vector_image" {
   description = "The image of vector to use in this investigation"
   type        = string
 }
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}


### PR DESCRIPTION
This commit allows the user to set CPU/memory targets for the soak environment
and the CPU limit for vector. This allows us to provide more memory than
developers are expected to have in CI and also to adjust the units of our
analysis to bytes/second/CPU.

Closes #9939
REF #9926
REF #9942

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
