### PR TITLE
feat(kubernetes_logs source): Use resource_version of 0 to use cache

### DIFF
--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -359,7 +359,7 @@ mod tests {
         drop(reflector);
     }
 
-    // Test the properties of the normal  execution flow.
+    // Test the properties of the normal execution flow.
     #[tokio::test]
     async fn flow_test() {
         trace_init();
@@ -367,7 +367,7 @@ mod tests {
         let invocations = vec![
             (
                 vec![],
-                None,
+                Some("0".to_owned()),
                 ExpInvRes::Stream(vec![
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid0", "10"))),
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid1", "15"))),
@@ -419,7 +419,7 @@ mod tests {
         let invocations = vec![
             (
                 vec![],
-                None,
+                Some("0".to_owned()),
                 ExpInvRes::Stream(vec![
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid0", "10"))),
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid1", "15"))),
@@ -460,7 +460,7 @@ mod tests {
         let invocations = vec![
             (
                 vec![],
-                None,
+                Some("0".to_owned()),
                 ExpInvRes::Stream(vec![
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid0", "10"))),
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid1", "15"))),
@@ -499,7 +499,7 @@ mod tests {
         let invocations = vec![
             (
                 vec![],
-                None,
+                Some("0".to_owned()),
                 ExpInvRes::Stream(vec![
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid0", "10"))),
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid1", "15"))),
@@ -543,7 +543,7 @@ mod tests {
         let invocations = vec![
             (
                 vec![],
-                None,
+                Some("0".to_owned()),
                 ExpInvRes::Stream(vec![
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid0", "10"))),
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid1", "15"))),
@@ -584,7 +584,7 @@ mod tests {
         let invocations = vec![
             (
                 vec![],
-                None,
+                Some("0".to_owned()),
                 ExpInvRes::Stream(vec![
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid0", "10"))),
                     ExpStmRes::Item(WatchEvent::Added(make_pod("uid1", "15"))),
@@ -681,7 +681,7 @@ mod tests {
                     field_selector: Some("fields".to_owned()),
                     label_selector: Some("labels".to_owned()),
                     pretty: None,
-                    resource_version: None,
+                    resource_version: Some("0".to_owned()),
                     timeout_seconds: Some(290),
                 }
             );
@@ -1084,7 +1084,7 @@ mod tests {
         // Prepare reflector.
         let pause_between_requests = Duration::from_secs(60 * 60); // 1 hour
         let mut reflector =
-            Reflector::new(watcher, state_writer, None, None, pause_between_requests);
+            Reflector::new(watcher, state_writer, None, Some("0".to_owned()), pause_between_requests);
 
         // Run test logic.
         let logic = tokio::spawn(async move {

--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -1083,8 +1083,13 @@ mod tests {
 
         // Prepare reflector.
         let pause_between_requests = Duration::from_secs(60 * 60); // 1 hour
-        let mut reflector =
-            Reflector::new(watcher, state_writer, None, Some("0".to_owned()), pause_between_requests);
+        let mut reflector = Reflector::new(
+            watcher,
+            state_writer,
+            None,
+            Some("0".to_owned()),
+            pause_between_requests,
+        );
 
         // Run test logic.
         let logic = tokio::spawn(async move {

--- a/src/kubernetes/resource_version.rs
+++ b/src/kubernetes/resource_version.rs
@@ -10,7 +10,7 @@ pub struct State(Option<String>);
 impl State {
     /// Create a new resource version [`State`].
     pub fn new() -> Self {
-        Self(Some("0".to_string()))
+        Self(Some("0".to_owned()))
     }
 
     /// Update the resource version from a candidate obtained earlier.

--- a/src/kubernetes/resource_version.rs
+++ b/src/kubernetes/resource_version.rs
@@ -9,8 +9,8 @@ pub struct State(Option<String>);
 
 impl State {
     /// Create a new resource version [`State`].
-    pub const fn new() -> Self {
-        Self(None)
+    pub fn new() -> Self {
+        Self(Some("0".to_string()))
     }
 
     /// Update the resource version from a candidate obtained earlier.


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #7943

I had to remove the const to set it like this, if there's a better alternative let me know. Setting this to 0 rather than None should allow us to use cached values from the apiserver rather than getting the freshest results from etcd directly.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
