### PR TITLE
fix(ci): fix soak test artifact uploading

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -222,6 +222,7 @@ jobs:
       - name: Run baseline experiment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
+          rm -rf /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
                                   --local-image "false" \
@@ -252,6 +253,7 @@ jobs:
       - name: Run comparison experiment
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
+          rm -rf /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
                                   --local-image "false" \


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vector/issues/9973

The current theory is that for multiple runs of the same job, the `/tmp` directory is not cleared, so there is extra files being uploaded as artifacts that shouldn't be. This just deletes files before a soak is run