### PR TITLE
chore: Introduce new splunk -> transforms -> splunk|splunk|splunk soak

### DIFF
--- a/soaks/.gitignore
+++ b/soaks/.gitignore
@@ -1,3 +1,4 @@
+.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 .terraform

--- a/soaks/tests/splunk_transforms_splunk3/README.md
+++ b/soaks/tests/splunk_transforms_splunk3/README.md
@@ -1,0 +1,9 @@
+# Splunk -> Transforms -> Multiple Splunk
+
+This soak tests the splunk source feeding into a small collection of transforms
+that then route out into multiple syslog sinks.
+
+## Method
+
+Lading `http_gen` is used to generate splunk load into vector, `http_blackhole`
+acts as a Splunk HEC sink.

--- a/soaks/tests/splunk_transforms_splunk3/terraform/http_blackhole.toml
+++ b/soaks/tests/splunk_transforms_splunk3/terraform/http_blackhole.toml
@@ -1,0 +1,3 @@
+worker_threads = 4
+binding_addr = "0.0.0.0:8080"
+prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/splunk_transforms_splunk3/terraform/http_gen.toml
+++ b/soaks/tests/splunk_transforms_splunk3/terraform/http_gen.toml
@@ -1,0 +1,12 @@
+worker_threads = 2
+prometheus_addr = "0.0.0.0:9090"
+
+[targets.vector]
+target_uri = "http://vector:8282/services/collector/event/1.0"
+bytes_per_second = "120 Mb"
+parallel_connections = 50
+method.type = "Post"
+method.variant = "SplunkHec"
+method.maximum_prebuild_cache_size_bytes = "256 Mb"
+[targets.vector.headers]
+dd-api-key = "DEADBEEF"

--- a/soaks/tests/splunk_transforms_splunk3/terraform/main.tf
+++ b/soaks/tests/splunk_transforms_splunk3/terraform/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      version = "~> 2.5.0"
+      source  = "hashicorp/kubernetes"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+module "monitoring" {
+  source       = "../../../common/terraform/modules/monitoring"
+  type         = var.type
+  vector_image = var.vector_image
+}
+
+resource "kubernetes_namespace" "soak" {
+  metadata {
+    name = "soak"
+  }
+}
+
+module "vector" {
+  source       = "../../../common/terraform/modules/vector"
+  type         = var.type
+  vector_image = var.vector_image
+  test_name    = "syslog_splunk_hec_logs"
+  vector-toml  = file("${path.module}/vector.toml")
+  namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus  = var.vector_cpus
+  depends_on   = [module.monitoring, module.http-blackhole]
+}
+module "http-blackhole" {
+  source              = "../../../common/terraform/modules/lading_http_blackhole"
+  type                = var.type
+  http-blackhole-toml = file("${path.module}/http_blackhole.toml")
+  namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on          = [module.monitoring]
+}
+module "http-gen" {
+  source        = "../../../common/terraform/modules/lading_http_gen"
+  type          = var.type
+  http-gen-toml = file("${path.module}/http_gen.toml")
+  namespace     = kubernetes_namespace.soak.metadata[0].name
+  depends_on    = [module.monitoring, module.vector]
+}

--- a/soaks/tests/splunk_transforms_splunk3/terraform/variables.tf
+++ b/soaks/tests/splunk_transforms_splunk3/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "type" {
+  description = "The type of the vector install, whether 'baseline' or 'comparison'"
+  type        = string
+}
+
+variable "vector_image" {
+  description = "The image of vector to use in this investigation"
+  type        = string
+}
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/splunk_transforms_splunk3/terraform/vector.toml
+++ b/soaks/tests/splunk_transforms_splunk3/terraform/vector.toml
@@ -1,0 +1,135 @@
+data_dir = "/var/lib/vector"
+
+##
+## Sources
+##
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sources.internal_logs]
+type = "internal_logs"
+
+[sources.splunk]
+address = "0.0.0.0:8282"
+type = "splunk_hec"
+
+##
+## Transforms
+##
+
+[transforms.timestamp_field]
+type = "remap"
+inputs = ["splunk"]
+source = '''
+.Timestamp = del(.timestamp)
+'''
+
+[transforms.splunk_fields]
+type = "remap"
+inputs = ["splunk"]
+
+source = '''
+# deletes unnecessary fields
+del(.attrs.c2cComponent)
+del(.attrs.c2cGroup)
+
+# renames fields to fit current state in splunk
+.attrs.type = del(.attrs.c2cContainerType)
+.attrs.partition = del(.attrs.c2cPartition)
+.attrs.role = del(.attrs.c2cRole)
+.attrs.service = del(.attrs.c2cService)
+.attrs.stage = del(.attrs.c2cStage)
+.attrs.version = del(.attrs.c2cVersion)
+if exists(.message) {
+  .line = del(.message)
+}
+
+.host = join!([.attrs.partition, .attrs.stage, "platform", .attrs.c2cRuntimePlatformName], separator: "-")
+.splunk_source = join!([.splunk_source, .task_id], separator: "_")
+
+del(.task_id)
+del(.lx_version)
+del(.source_type)
+del(.attrs.c2cRuntimePlatformName)
+'''
+
+[transforms.container_type]
+type = "route"
+inputs = ["timestamp_field"]
+[transforms.container_type.route]
+service = '.attrs.c2cContainerType == "service"'
+ingress = '.attrs.c2cContainerType == "ingress"'
+other_sidecar = '.attrs.c2cContainerType != "service" && .attrs.c2cContainerType != "ingress"'
+
+[transforms.splunk_dest]
+type = "route"
+inputs = ["splunk_fields"]
+route.production= """
+!includes(["staging", "performance", "playground"], .attrs.stage)
+"""
+route.staging="""
+includes(["staging", "performance", "playground"], .attrs.stage)
+"""
+route.cloud="""
+includes(["splunk"], .attrs.systemid)
+"""
+
+[transforms.connection_closed]
+type = "filter"
+inputs = ["internal_logs"]
+condition = 'contains!(.message, "connection closed before message completed", case_sensitive: false)'
+
+[transforms.connection_closed_metric]
+type = "log_to_metric"
+inputs = [ "connection_closed" ]
+[[transforms.connection_closed_metric.metrics]]
+type = "counter"
+field = "timestamp"
+name = "errors_connection_closed"
+namespace = "vector"
+
+##
+## Sinks
+##
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["internal_metrics", "connection_closed_metric"]
+address = "0.0.0.0:9090"
+
+[sinks.splunk_cloud]
+type = "splunk_hec_logs"
+inputs = ["splunk_dest.cloud"]
+endpoint = "http://http-blackhole:8080"
+buffer.type = "memory"
+buffer.when_full = "drop_newest"
+encoding.codec = "json"
+encoding.timestamp_format = "rfc3339"
+encoding.except_fields = ["splunk_source", "host", "splunk_sourcetype", "splunk_index", "source"]
+token = "abcd1234"
+healthcheck.enabled = false
+
+[sinks.splunk_production]
+type = "splunk_hec_logs"
+inputs = ["splunk_dest.production"]
+endpoint = "http://http-blackhole:8080"
+buffer.type = "memory"
+buffer.when_full = "drop_newest"
+encoding.codec = "json"
+encoding.timestamp_format = "rfc3339"
+encoding.except_fields = ["splunk_source", "host", "splunk_sourcetype", "splunk_index", "source"]
+token = "abcd1234"
+healthcheck.enabled = false
+
+[sinks.splunk_staging]
+type = "splunk_hec_logs"
+inputs = ["splunk_dest.staging"]
+endpoint = "http://http-blackhole:8080"
+buffer.type = "memory"
+buffer.when_full = "drop_newest"
+encoding.codec = "json"
+encoding.timestamp_format = "rfc3339"
+encoding.except_fields = ["splunk_source", "host", "splunk_sourcetype", "splunk_index", "source"]
+token = "abcd1234"
+healthcheck.enabled = false


### PR DESCRIPTION
This commit introduces a new soak that introduces a multi-way split
configuration with parsing in between to accomplish the split.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
