### PR TITLE
chore: Introduce fluent -> remap -> firehose soak

### DIFF
--- a/soaks/tests/fluent_remap_aws_firehose/README.md
+++ b/soaks/tests/fluent_remap_aws_firehose/README.md
@@ -1,0 +1,9 @@
+# Fluent -> Remap -> AWS Firehose
+
+This soak tests fluent source feeding into a very simple VRL transform through
+to AWS Firehose sink. It is a straight pipe.
+
+## Method
+
+Lading `tcp_gen` is used to generate log load into vector, `http_blackhole`
+acts as an AWS Firehose.

--- a/soaks/tests/fluent_remap_aws_firehose/terraform/http_blackhole.toml
+++ b/soaks/tests/fluent_remap_aws_firehose/terraform/http_blackhole.toml
@@ -1,0 +1,3 @@
+worker_threads = 4
+binding_addr = "0.0.0.0:8080"
+prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/fluent_remap_aws_firehose/terraform/main.tf
+++ b/soaks/tests/fluent_remap_aws_firehose/terraform/main.tf
@@ -1,0 +1,60 @@
+# Set up the providers needed to run this soak and other terraform related
+# business. Here we only require 'kubernetes' to interact with the soak
+# minikube.
+terraform {
+  required_providers {
+    kubernetes = {
+      version = "~> 2.5.0"
+      source  = "hashicorp/kubernetes"
+    }
+  }
+}
+
+# Rig the kubernetes provider to communicate with minikube. The details of
+# adjusting `~/.kube/config` are addressed by the soak control scripts.
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+# Setup background monitoring details. These are needed by the soak control to
+# understand what vector et al's running behavior is.
+module "monitoring" {
+  source       = "../../../common/terraform/modules/monitoring"
+  type         = var.type
+  vector_image = var.vector_image
+}
+
+# Setup the soak pieces
+#
+# This soak config sets up a vector soak with lading/http-gen feeding into vector,
+# lading/http-blackhole receiving.
+resource "kubernetes_namespace" "soak" {
+  metadata {
+    name = "soak"
+  }
+}
+
+module "vector" {
+  source       = "../../../common/terraform/modules/vector"
+  type         = var.type
+  vector_image = var.vector_image
+  test_name    = "datadog_agent_remap_datadog_logs"
+  vector-toml  = file("${path.module}/vector.toml")
+  namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus  = var.vector_cpus
+  depends_on   = [module.monitoring, module.http-blackhole]
+}
+module "http-blackhole" {
+  source              = "../../../common/terraform/modules/lading_http_blackhole"
+  type                = var.type
+  http-blackhole-toml = file("${path.module}/http_blackhole.toml")
+  namespace           = kubernetes_namespace.soak.metadata[0].name
+  depends_on          = [module.monitoring]
+}
+module "tcp-gen" {
+  source       = "../../../common/terraform/modules/lading_tcp_gen"
+  type         = var.type
+  tcp-gen-toml = file("${path.module}/tcp_gen.toml")
+  namespace    = kubernetes_namespace.soak.metadata[0].name
+  depends_on   = [module.monitoring, module.vector]
+}

--- a/soaks/tests/fluent_remap_aws_firehose/terraform/tcp_gen.toml
+++ b/soaks/tests/fluent_remap_aws_firehose/terraform/tcp_gen.toml
@@ -1,0 +1,9 @@
+worker_threads = 2
+prometheus_addr = "0.0.0.0:9090"
+
+[targets.vector]
+addr = "vector:8282"
+variant = "Fluent"
+bytes_per_second = "256 Mb"
+block_sizes = ["1Kb", "2Kb", "4Kb", "8Kb", "256Kb", "512Kb", "1024Kb"]
+maximum_prebuild_cache_size_bytes = "512 Mb"

--- a/soaks/tests/fluent_remap_aws_firehose/terraform/variables.tf
+++ b/soaks/tests/fluent_remap_aws_firehose/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "type" {
+  description = "The type of the vector install, whether 'baseline' or 'comparison'"
+  type        = string
+}
+
+variable "vector_image" {
+  description = "The image of vector to use in this investigation"
+  type        = string
+}
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}

--- a/soaks/tests/fluent_remap_aws_firehose/terraform/vector.toml
+++ b/soaks/tests/fluent_remap_aws_firehose/terraform/vector.toml
@@ -1,0 +1,44 @@
+data_dir = "/var/lib/vector"
+
+##
+## Sources
+##
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sources.fluent]
+type = "fluent"
+address = "0.0.0.0:8282"
+
+##
+## Transforms
+##
+
+[transforms.remap]
+type = "remap"
+inputs = ["fluent"]
+source = """
+event = del(.event)
+# set event to message fields, dropping any existing fields
+. = {}
+.event = object!(event)
+"""
+
+##
+## Sinks
+##
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+address = "0.0.0.0:9090"
+
+[sinks.firehose-sink]
+type = "aws_kinesis_firehose"
+inputs = ["remap"]
+stream_name = "soak_fluent_remap_firehose"
+endpoint = "http://http-blackhole:8080"
+healthcheck.enabled = true
+compression = "none"
+encoding = "json"


### PR DESCRIPTION
This commit ports an older soak to the new CI format. There's nothing special
going on here, excepting that it is the first to involve the firehose sink.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
