### PR TITLE
chore(vrl): allow compiling VRL without support for specific expressions

### DIFF
--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -10,9 +10,18 @@ license = "MPL-2.0"
 name = "vrl"
 path = "src/main.rs"
 
+[features]
+default = ["repl", "expressions"]
+repl = ["lazy_static", "prettytable-rs", "regex", "rustyline", "webbrowser"]
+expressions = [
+  "expr-abort",
+]
+expr-abort = ["vrl/expr-abort"]
+
+
 [dependencies]
 shared = { path = "../../shared", default-features = false }
-vrl = { path = "../core" }
+vrl = { path = "../core", default-features = false }
 bytes = "1.1.0"
 exitcode = "1"
 prettytable-rs = { version = "0.8", default-features = false, optional = true }
@@ -28,7 +37,3 @@ indoc = "1.0.3"
 [dependencies.stdlib]
 package = "vrl-stdlib"
 path = "../stdlib"
-
-[features]
-default = ["repl"]
-repl = ["lazy_static", "prettytable-rs", "regex", "rustyline", "webbrowser"]

--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -15,10 +15,12 @@ default = ["repl", "expressions"]
 repl = ["lazy_static", "prettytable-rs", "regex", "rustyline", "webbrowser"]
 expressions = [
   "expr-abort",
+  "expr-if_statement",
   "expr-op",
   "expr-unary",
 ]
 expr-abort = ["vrl/expr-abort"]
+expr-if_statement = ["vrl/expr-if_statement"]
 expr-op = ["vrl/expr-op"]
 expr-unary = ["vrl/expr-unary"]
 

--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -15,8 +15,10 @@ default = ["repl", "expressions"]
 repl = ["lazy_static", "prettytable-rs", "regex", "rustyline", "webbrowser"]
 expressions = [
   "expr-abort",
+  "expr-unary",
 ]
 expr-abort = ["vrl/expr-abort"]
+expr-unary = ["vrl/expr-unary"]
 
 
 [dependencies]

--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -15,9 +15,11 @@ default = ["repl", "expressions"]
 repl = ["lazy_static", "prettytable-rs", "regex", "rustyline", "webbrowser"]
 expressions = [
   "expr-abort",
+  "expr-op",
   "expr-unary",
 ]
 expr-abort = ["vrl/expr-abort"]
+expr-op = ["vrl/expr-op"]
 expr-unary = ["vrl/expr-unary"]
 
 

--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -15,11 +15,13 @@ default = ["repl", "expressions"]
 repl = ["lazy_static", "prettytable-rs", "regex", "rustyline", "webbrowser"]
 expressions = [
   "expr-abort",
+  "expr-function_call",
   "expr-if_statement",
   "expr-op",
   "expr-unary",
 ]
 expr-abort = ["vrl/expr-abort"]
+expr-function_call = ["vrl/expr-function_call"]
 expr-if_statement = ["vrl/expr-if_statement"]
 expr-op = ["vrl/expr-op"]
 expr-unary = ["vrl/expr-unary"]

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -9,10 +9,12 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-if_statement",
   "expr-op",
   "expr-unary",
 ]
 expr-abort = []
+expr-if_statement = []
 expr-op = []
 expr-unary = []
 

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -9,11 +9,13 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-function_call",
   "expr-if_statement",
   "expr-op",
   "expr-unary",
 ]
 expr-abort = []
+expr-function_call = []
 expr-if_statement = []
 expr-op = []
 expr-unary = []

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -9,8 +9,10 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-unary",
 ]
 expr-abort = []
+expr-unary = []
 
 [dependencies]
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -9,9 +9,11 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-op",
   "expr-unary",
 ]
 expr-abort = []
+expr-op = []
 expr-unary = []
 
 [dependencies]

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -5,9 +5,16 @@ authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2021"
 publish = false
 
+[features]
+default = ["expressions"]
+expressions = [
+  "expr-abort",
+]
+expr-abort = []
+
 [dependencies]
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
-parser = { package = "vrl-parser", path = "../parser" }
+parser = { package = "vrl-parser", path = "../parser", default-features = false }
 shared = { path = "../../shared", default-features = false, features = ["conversion"] }
 lookup = { path = "../../lookup" }
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -369,6 +369,7 @@ impl<'a> Compiler<'a> {
         })
     }
 
+    #[cfg(feature = "expr-unary")]
     fn compile_unary(&mut self, node: Node<ast::Unary>) -> Unary {
         use ast::Unary::*;
 
@@ -379,6 +380,18 @@ impl<'a> Compiler<'a> {
         Unary::new(variant)
     }
 
+    #[cfg(not(feature = "expr-unary"))]
+    fn compile_unary(&mut self, node: Node<ast::Unary>) -> Noop {
+        use ast::Unary::*;
+
+        let span = match node.into_inner() {
+            Not(node) => node.take().1.take().0,
+        };
+
+        self.handle_missing_feature_error(span.span(), "expr-unary")
+    }
+
+    #[cfg(feature = "expr-unary")]
     fn compile_not(&mut self, node: Node<ast::Not>) -> Not {
         let (not, expr) = node.into_inner().take();
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -159,6 +159,7 @@ impl<'a> Compiler<'a> {
         Object::new(exprs)
     }
 
+    #[cfg(feature = "expr-if_statement")]
     fn compile_if_statement(&mut self, node: Node<ast::IfStatement>) -> IfStatement {
         let ast::IfStatement {
             predicate,
@@ -184,6 +185,14 @@ impl<'a> Compiler<'a> {
         }
     }
 
+    #[cfg(not(feature = "expr-if_statement"))]
+    fn compile_if_statement(&mut self, node: Node<ast::IfStatement>) -> Noop {
+        self.handle_missing_feature_error(node.span(), "expr-if_statement");
+
+        Noop
+    }
+
+    #[cfg(feature = "expr-if_statement")]
     fn compile_predicate(&mut self, node: Node<ast::Predicate>) -> predicate::Result {
         use ast::Predicate::*;
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -9,6 +9,7 @@ use std::convert::TryFrom;
 pub type Errors = Vec<Box<dyn DiagnosticError>>;
 
 pub struct Compiler<'a> {
+    #[allow(dead_code)]
     fns: &'a [Box<dyn Function>],
     state: &'a mut State,
     errors: Errors,
@@ -359,6 +360,7 @@ impl<'a> Compiler<'a> {
         }
     }
 
+    #[cfg(feature = "expr-function_call")]
     fn compile_function_call(&mut self, node: Node<ast::FunctionCall>) -> FunctionCall {
         let call_span = node.span();
         let ast::FunctionCall {
@@ -390,6 +392,13 @@ impl<'a> Compiler<'a> {
         })
     }
 
+    #[cfg(not(feature = "expr-function_call"))]
+    fn compile_function_call(&mut self, node: Node<ast::FunctionCall>) -> Noop {
+        self.handle_missing_feature_error(node.span(), "expr-function_call");
+        Noop
+    }
+
+    #[cfg(feature = "expr-function_call")]
     fn compile_function_argument(&mut self, node: Node<ast::FunctionArgument>) -> FunctionArgument {
         let ast::FunctionArgument { ident, expr } = node.into_inner();
         let expr = Node::new(expr.span(), self.compile_expr(expr));

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -12,9 +12,11 @@ mod group;
 mod if_statement;
 mod levenstein;
 mod noop;
+#[cfg(feature = "expr-unary")]
 mod not;
 mod object;
 mod op;
+#[cfg(feature = "expr-unary")]
 mod unary;
 mod variable;
 
@@ -38,12 +40,14 @@ pub use group::Group;
 pub use if_statement::IfStatement;
 pub use literal::Literal;
 pub use noop::Noop;
+#[cfg(feature = "expr-unary")]
 pub use not::Not;
 pub use object::Object;
 pub use op::Op;
 pub use predicate::Predicate;
 pub use query::Query;
 pub use query::Target;
+#[cfg(feature = "expr-unary")]
 pub use unary::Unary;
 pub use variable::Variable;
 
@@ -98,6 +102,7 @@ pub enum Expr {
     FunctionCall(FunctionCall),
     Variable(Variable),
     Noop(Noop),
+    #[cfg(feature = "expr-unary")]
     Unary(Unary),
     #[cfg(feature = "expr-abort")]
     Abort(Abort),
@@ -123,6 +128,7 @@ impl Expr {
             FunctionCall(..) => "function call",
             Variable(..) => "variable call",
             Noop(..) => "noop",
+            #[cfg(feature = "expr-unary")]
             Unary(..) => "unary operation",
             #[cfg(feature = "expr-abort")]
             Abort(..) => "abort operation",
@@ -144,6 +150,7 @@ impl Expression for Expr {
             FunctionCall(v) => v.resolve(ctx),
             Variable(v) => v.resolve(ctx),
             Noop(v) => v.resolve(ctx),
+            #[cfg(feature = "expr-unary")]
             Unary(v) => v.resolve(ctx),
             #[cfg(feature = "expr-abort")]
             Abort(v) => v.resolve(ctx),
@@ -163,6 +170,7 @@ impl Expression for Expr {
             FunctionCall(v) => Expression::as_value(v),
             Variable(v) => Expression::as_value(v),
             Noop(v) => Expression::as_value(v),
+            #[cfg(feature = "expr-unary")]
             Unary(v) => Expression::as_value(v),
             #[cfg(feature = "expr-abort")]
             Abort(v) => Expression::as_value(v),
@@ -182,6 +190,7 @@ impl Expression for Expr {
             FunctionCall(v) => v.type_def(state),
             Variable(v) => v.type_def(state),
             Noop(v) => v.type_def(state),
+            #[cfg(feature = "expr-unary")]
             Unary(v) => v.type_def(state),
             #[cfg(feature = "expr-abort")]
             Abort(v) => v.type_def(state),
@@ -203,6 +212,7 @@ impl fmt::Display for Expr {
             FunctionCall(v) => v.fmt(f),
             Variable(v) => v.fmt(f),
             Noop(v) => v.fmt(f),
+            #[cfg(feature = "expr-unary")]
             Unary(v) => v.fmt(f),
             #[cfg(feature = "expr-abort")]
             Abort(v) => v.fmt(f),
@@ -266,6 +276,7 @@ impl From<Noop> for Expr {
     }
 }
 
+#[cfg(feature = "expr-unary")]
 impl From<Unary> for Expr {
     fn from(unary: Unary) -> Self {
         Expr::Unary(unary)

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -24,6 +24,7 @@ mod variable;
 
 pub(crate) mod assignment;
 pub(crate) mod container;
+#[cfg(feature = "expr-function_call")]
 pub(crate) mod function_call;
 pub(crate) mod literal;
 #[cfg(feature = "expr-if_statement")]
@@ -38,6 +39,7 @@ pub use block::Block;
 pub use container::Container;
 pub use container::Variant;
 pub use function_argument::FunctionArgument;
+#[cfg(feature = "expr-function_call")]
 pub use function_call::FunctionCall;
 pub use group::Group;
 #[cfg(feature = "expr-if_statement")]
@@ -107,6 +109,7 @@ pub enum Expr {
     Op(Op),
     Assignment(Assignment),
     Query(Query),
+    #[cfg(feature = "expr-function_call")]
     FunctionCall(FunctionCall),
     Variable(Variable),
     Noop(Noop),
@@ -135,6 +138,7 @@ impl Expr {
             Op(..) => "operation",
             Assignment(..) => "assignment",
             Query(..) => "query",
+            #[cfg(feature = "expr-function_call")]
             FunctionCall(..) => "function call",
             Variable(..) => "variable call",
             Noop(..) => "noop",
@@ -159,6 +163,7 @@ impl Expression for Expr {
             Op(v) => v.resolve(ctx),
             Assignment(v) => v.resolve(ctx),
             Query(v) => v.resolve(ctx),
+            #[cfg(feature = "expr-function_call")]
             FunctionCall(v) => v.resolve(ctx),
             Variable(v) => v.resolve(ctx),
             Noop(v) => v.resolve(ctx),
@@ -181,6 +186,7 @@ impl Expression for Expr {
             Op(v) => Expression::as_value(v),
             Assignment(v) => Expression::as_value(v),
             Query(v) => Expression::as_value(v),
+            #[cfg(feature = "expr-function_call")]
             FunctionCall(v) => Expression::as_value(v),
             Variable(v) => Expression::as_value(v),
             Noop(v) => Expression::as_value(v),
@@ -203,6 +209,7 @@ impl Expression for Expr {
             Op(v) => v.type_def(state),
             Assignment(v) => v.type_def(state),
             Query(v) => v.type_def(state),
+            #[cfg(feature = "expr-function_call")]
             FunctionCall(v) => v.type_def(state),
             Variable(v) => v.type_def(state),
             Noop(v) => v.type_def(state),
@@ -227,6 +234,7 @@ impl fmt::Display for Expr {
             Op(v) => v.fmt(f),
             Assignment(v) => v.fmt(f),
             Query(v) => v.fmt(f),
+            #[cfg(feature = "expr-function_call")]
             FunctionCall(v) => v.fmt(f),
             Variable(v) => v.fmt(f),
             Noop(v) => v.fmt(f),
@@ -278,6 +286,7 @@ impl From<Query> for Expr {
     }
 }
 
+#[cfg(feature = "expr-function_call")]
 impl From<FunctionCall> for Expr {
     fn from(function_call: FunctionCall) -> Self {
         Expr::FunctionCall(function_call)

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -9,6 +9,7 @@ mod array;
 mod block;
 mod function_argument;
 mod group;
+#[cfg(feature = "expr-if_statement")]
 mod if_statement;
 mod levenstein;
 mod noop;
@@ -25,6 +26,7 @@ pub(crate) mod assignment;
 pub(crate) mod container;
 pub(crate) mod function_call;
 pub(crate) mod literal;
+#[cfg(feature = "expr-if_statement")]
 pub(crate) mod predicate;
 pub(crate) mod query;
 
@@ -38,6 +40,7 @@ pub use container::Variant;
 pub use function_argument::FunctionArgument;
 pub use function_call::FunctionCall;
 pub use group::Group;
+#[cfg(feature = "expr-if_statement")]
 pub use if_statement::IfStatement;
 pub use literal::Literal;
 pub use noop::Noop;
@@ -46,6 +49,7 @@ pub use not::Not;
 pub use object::Object;
 #[cfg(feature = "expr-op")]
 pub use op::Op;
+#[cfg(feature = "expr-if_statement")]
 pub use predicate::Predicate;
 pub use query::Query;
 pub use query::Target;
@@ -97,6 +101,7 @@ clone_trait_object!(Expression);
 pub enum Expr {
     Literal(Literal),
     Container(Container),
+    #[cfg(feature = "expr-if_statement")]
     IfStatement(IfStatement),
     #[cfg(feature = "expr-op")]
     Op(Op),
@@ -124,6 +129,7 @@ impl Expr {
                 Array(..) => "array",
                 Object(..) => "object",
             },
+            #[cfg(feature = "expr-if_statement")]
             IfStatement(..) => "if-statement",
             #[cfg(feature = "expr-op")]
             Op(..) => "operation",
@@ -147,6 +153,7 @@ impl Expression for Expr {
         match self {
             Literal(v) => v.resolve(ctx),
             Container(v) => v.resolve(ctx),
+            #[cfg(feature = "expr-if_statement")]
             IfStatement(v) => v.resolve(ctx),
             #[cfg(feature = "expr-op")]
             Op(v) => v.resolve(ctx),
@@ -168,6 +175,7 @@ impl Expression for Expr {
         match self {
             Literal(v) => Expression::as_value(v),
             Container(v) => Expression::as_value(v),
+            #[cfg(feature = "expr-if_statement")]
             IfStatement(v) => Expression::as_value(v),
             #[cfg(feature = "expr-op")]
             Op(v) => Expression::as_value(v),
@@ -189,6 +197,7 @@ impl Expression for Expr {
         match self {
             Literal(v) => v.type_def(state),
             Container(v) => v.type_def(state),
+            #[cfg(feature = "expr-if_statement")]
             IfStatement(v) => v.type_def(state),
             #[cfg(feature = "expr-op")]
             Op(v) => v.type_def(state),
@@ -212,6 +221,7 @@ impl fmt::Display for Expr {
         match self {
             Literal(v) => v.fmt(f),
             Container(v) => v.fmt(f),
+            #[cfg(feature = "expr-if_statement")]
             IfStatement(v) => v.fmt(f),
             #[cfg(feature = "expr-op")]
             Op(v) => v.fmt(f),
@@ -242,6 +252,7 @@ impl From<Container> for Expr {
     }
 }
 
+#[cfg(feature = "expr-if_statement")]
 impl From<IfStatement> for Expr {
     fn from(if_statement: IfStatement) -> Self {
         Expr::IfStatement(if_statement)

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -15,6 +15,7 @@ mod noop;
 #[cfg(feature = "expr-unary")]
 mod not;
 mod object;
+#[cfg(feature = "expr-op")]
 mod op;
 #[cfg(feature = "expr-unary")]
 mod unary;
@@ -43,6 +44,7 @@ pub use noop::Noop;
 #[cfg(feature = "expr-unary")]
 pub use not::Not;
 pub use object::Object;
+#[cfg(feature = "expr-op")]
 pub use op::Op;
 pub use predicate::Predicate;
 pub use query::Query;
@@ -96,6 +98,7 @@ pub enum Expr {
     Literal(Literal),
     Container(Container),
     IfStatement(IfStatement),
+    #[cfg(feature = "expr-op")]
     Op(Op),
     Assignment(Assignment),
     Query(Query),
@@ -122,6 +125,7 @@ impl Expr {
                 Object(..) => "object",
             },
             IfStatement(..) => "if-statement",
+            #[cfg(feature = "expr-op")]
             Op(..) => "operation",
             Assignment(..) => "assignment",
             Query(..) => "query",
@@ -144,6 +148,7 @@ impl Expression for Expr {
             Literal(v) => v.resolve(ctx),
             Container(v) => v.resolve(ctx),
             IfStatement(v) => v.resolve(ctx),
+            #[cfg(feature = "expr-op")]
             Op(v) => v.resolve(ctx),
             Assignment(v) => v.resolve(ctx),
             Query(v) => v.resolve(ctx),
@@ -164,6 +169,7 @@ impl Expression for Expr {
             Literal(v) => Expression::as_value(v),
             Container(v) => Expression::as_value(v),
             IfStatement(v) => Expression::as_value(v),
+            #[cfg(feature = "expr-op")]
             Op(v) => Expression::as_value(v),
             Assignment(v) => Expression::as_value(v),
             Query(v) => Expression::as_value(v),
@@ -184,6 +190,7 @@ impl Expression for Expr {
             Literal(v) => v.type_def(state),
             Container(v) => v.type_def(state),
             IfStatement(v) => v.type_def(state),
+            #[cfg(feature = "expr-op")]
             Op(v) => v.type_def(state),
             Assignment(v) => v.type_def(state),
             Query(v) => v.type_def(state),
@@ -206,6 +213,7 @@ impl fmt::Display for Expr {
             Literal(v) => v.fmt(f),
             Container(v) => v.fmt(f),
             IfStatement(v) => v.fmt(f),
+            #[cfg(feature = "expr-op")]
             Op(v) => v.fmt(f),
             Assignment(v) => v.fmt(f),
             Query(v) => v.fmt(f),
@@ -240,6 +248,7 @@ impl From<IfStatement> for Expr {
     }
 }
 
+#[cfg(feature = "expr-op")]
 impl From<Op> for Expr {
     fn from(op: Op) -> Self {
         Expr::Op(op)

--- a/lib/vrl/compiler/src/expression/function_argument.rs
+++ b/lib/vrl/compiler/src/expression/function_argument.rs
@@ -1,6 +1,6 @@
 use crate::expression::Expr;
 use crate::parser::{Ident, Node};
-use crate::{Parameter, Span};
+use crate::Parameter;
 use std::fmt;
 use std::ops::Deref;
 
@@ -12,6 +12,7 @@ pub struct FunctionArgument {
 }
 
 impl FunctionArgument {
+    #[cfg(feature = "expr-function_call")]
     pub(crate) fn new(ident: Option<Node<Ident>>, expr: Node<Expr>) -> Self {
         Self {
             ident,
@@ -20,11 +21,13 @@ impl FunctionArgument {
         }
     }
 
+    #[cfg(feature = "expr-function_call")]
     pub(crate) fn keyword(&self) -> Option<&str> {
         self.ident.as_ref().map(|node| node.as_ref().as_ref())
     }
 
-    pub(crate) fn keyword_span(&self) -> Option<Span> {
+    #[cfg(feature = "expr-function_call")]
+    pub(crate) fn keyword_span(&self) -> Option<crate::Span> {
         self.ident.as_ref().map(|node| node.span())
     }
 

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -213,6 +213,7 @@ impl FunctionCall {
 impl Expression for FunctionCall {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         self.expr.resolve(ctx).map_err(|err| match err {
+            #[cfg(feature = "expr-abort")]
             ExpressionError::Abort { .. } => {
                 panic!("abort errors must only be defined by `abort` statement")
             }

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -1,4 +1,4 @@
-use crate::expression::{assignment, Container, FunctionCall, Resolved, Variable};
+use crate::expression::{assignment, Container, Resolved, Variable};
 use crate::parser::ast::Ident;
 use crate::{Context, Expression, State, TypeDef, Value};
 use lookup::LookupBuf;
@@ -135,7 +135,10 @@ impl fmt::Debug for Query {
 pub enum Target {
     Internal(Variable),
     External,
-    FunctionCall(FunctionCall),
+    #[cfg(feature = "expr-function_call")]
+    FunctionCall(crate::expression::FunctionCall),
+    #[cfg(not(feature = "expr-function_call"))]
+    FunctionCall(crate::expression::Noop),
     Container(Container),
 }
 

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -246,10 +246,12 @@ impl ArgumentList {
         Ok(required(self.optional_array(keyword)?))
     }
 
+    #[cfg(feature = "expr-function_call")]
     pub(crate) fn keywords(&self) -> Vec<&'static str> {
         self.0.keys().copied().collect::<Vec<_>>()
     }
 
+    #[cfg(feature = "expr-function_call")]
     pub(crate) fn insert(&mut self, k: &'static str, v: Expr) {
         self.0.insert(k, v);
     }

--- a/lib/vrl/core/Cargo.toml
+++ b/lib/vrl/core/Cargo.toml
@@ -9,11 +9,13 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-function_call",
   "expr-if_statement",
   "expr-op",
   "expr-unary",
 ]
 expr-abort = ["compiler/expr-abort"]
+expr-function_call = ["compiler/expr-function_call"]
 expr-if_statement = ["compiler/expr-if_statement"]
 expr-op = ["compiler/expr-op"]
 expr-unary = ["compiler/expr-unary"]

--- a/lib/vrl/core/Cargo.toml
+++ b/lib/vrl/core/Cargo.toml
@@ -9,8 +9,10 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-unary",
 ]
 expr-abort = ["compiler/expr-abort"]
+expr-unary = ["compiler/expr-unary"]
 
 [dependencies]
 compiler = { package = "vrl-compiler", path = "../compiler", default-features = false }

--- a/lib/vrl/core/Cargo.toml
+++ b/lib/vrl/core/Cargo.toml
@@ -9,9 +9,11 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-op",
   "expr-unary",
 ]
 expr-abort = ["compiler/expr-abort"]
+expr-op = ["compiler/expr-op"]
 expr-unary = ["compiler/expr-unary"]
 
 [dependencies]

--- a/lib/vrl/core/Cargo.toml
+++ b/lib/vrl/core/Cargo.toml
@@ -9,10 +9,12 @@ publish = false
 default = ["expressions"]
 expressions = [
   "expr-abort",
+  "expr-if_statement",
   "expr-op",
   "expr-unary",
 ]
 expr-abort = ["compiler/expr-abort"]
+expr-if_statement = ["compiler/expr-if_statement"]
 expr-op = ["compiler/expr-op"]
 expr-unary = ["compiler/expr-unary"]
 

--- a/lib/vrl/core/Cargo.toml
+++ b/lib/vrl/core/Cargo.toml
@@ -5,10 +5,17 @@ authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2021"
 publish = false
 
+[features]
+default = ["expressions"]
+expressions = [
+  "expr-abort",
+]
+expr-abort = ["compiler/expr-abort"]
+
 [dependencies]
-compiler = { package = "vrl-compiler", path = "../compiler" }
+compiler = { package = "vrl-compiler", path = "../compiler", default-features = false }
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
-parser = { package = "vrl-parser", path = "../parser" }
+parser = { package = "vrl-parser", path = "../parser", default-features = false }
 lookup = { path = "../../lookup" }
 shared = { path = "../../shared", default-features = false }
 bytes = "1.1.0"

--- a/lib/vrl/core/src/runtime.rs
+++ b/lib/vrl/core/src/runtime.rs
@@ -99,6 +99,7 @@ impl Runtime {
             .iter()
             .map(|expr| {
                 expr.resolve(&mut context).map_err(|err| match err {
+                    #[cfg(feature = "expr-abort")]
                     ExpressionError::Abort { .. } => Terminate::Abort(err),
                     err @ ExpressionError::Error { .. } => Terminate::Error(err),
                 })

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -742,13 +742,13 @@ impl FromStr for Opcode {
 pub enum Assignment {
     Single {
         target: Node<AssignmentTarget>,
-        op: AssignmentOp,
+        op: Node<AssignmentOp>,
         expr: Box<Node<Expr>>,
     },
     Infallible {
         ok: Node<AssignmentTarget>,
         err: Node<AssignmentTarget>,
-        op: AssignmentOp,
+        op: Node<AssignmentOp>,
         expr: Box<Node<Expr>>,
     },
     // TODO

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -253,9 +253,9 @@ Assignment: Node<Assignment> = {
     Sp<AssignmentInfallible>,
 };
 
-AssignmentOp: AssignmentOp = {
-    "=" => AssignmentOp::Assign,
-    "|=" => AssignmentOp::Merge,
+AssignmentOp: Node<AssignmentOp> = {
+    Sp<"="> => Node::new(<>.span(), AssignmentOp::Assign),
+    Sp<"|="> => Node::new(<>.span(), AssignmentOp::Merge),
 }
 
 AssignmentSingle: Assignment = {

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MPL-2.0"
 
 [dependencies]
-vrl = { path = "../core" }
+vrl = { path = "../core", default-features = false }
 lookup_lib = {package = "lookup", path = "../../lookup" }
 datadog-search-syntax = { path = "../../datadog/search-syntax", optional = true }
 


### PR DESCRIPTION
This is a work-in-progress PR to allow compiling VRL without support for some (or any) expression types.

This isn't something that's used in production, but it allows for faster iterative development when working with core types such as `trait Expression`, by allowing you to make the change, enable a single expression type and change that type to match the new trait signature, and validate that the core idea of a change can work. Only then would you re-enable other expressions one-by-one, updating them as you go, and allowing yourself to test VRL continuously as you progress.

This is similar in nature to how we allow disabling any/all functions provided by VRL itself.

It clutters the code a bit with cfg-conditionals, but it's fairly self-contained to imports and the respective `compile_<expression>` functions (except for a few cases where expressions are shared between themselves), so I considered it a worthwhile trade-off.

The compiler throws a specific error if an expression is used that isn't valid:

```
error[E900]: expression type unavailable
  ┌─ :1:1
  │
1 │ upcase(.foo)
  │ ^^^^^^^^^^^^
  │ │
  │ expression type is disabled in this version of vrl
  │ build vrl using the `expr-function_call` feature to enable it
  │
  = see language documentation at https://vrl.dev
```

I did this for two reasons: (1) it allows us to not re-compile the parser every time a feature is enabled/disabled, which results in much faster development cycles, (2) this error clearly explains what's going on, as opposed to getting a general parser error that a given expression was unexpected (could indicate a parser bug that you introduced during development).