### PR TITLE
chore: Relax blackhole limits

### DIFF
--- a/soaks/common/terraform/modules/lading_http_blackhole/main.tf
+++ b/soaks/common/terraform/modules/lading_http_blackhole/main.tf
@@ -83,8 +83,8 @@ resource "kubernetes_deployment" "http-blackhole" {
 
           resources {
             limits = {
-              cpu    = "100m"
-              memory = "32Mi"
+              cpu    = "1"
+              memory = "64Mi"
             }
             requests = {
               cpu    = "100m"

--- a/soaks/tests/datadog_agent_remap_datadog_logs/terraform/http_blackhole.toml
+++ b/soaks/tests/datadog_agent_remap_datadog_logs/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/fluent_remap_aws_firehose/terraform/http_blackhole.toml
+++ b/soaks/tests/fluent_remap_aws_firehose/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/splunk_hec_route_s3/terraform/http_blackhole.toml
+++ b/soaks/tests/splunk_hec_route_s3/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/splunk_transforms_splunk3/terraform/http_blackhole.toml
+++ b/soaks/tests/splunk_transforms_splunk3/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/syslog_humio_logs/terraform/http_blackhole.toml
+++ b/soaks/tests/syslog_humio_logs/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/syslog_log2metric_humio_metrics/terraform/http_blackhole.toml
+++ b/soaks/tests/syslog_log2metric_humio_metrics/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/http_blackhole.toml
+++ b/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/syslog_loki/terraform/http_blackhole.toml
+++ b/soaks/tests/syslog_loki/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/http_blackhole.toml
+++ b/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"

--- a/soaks/tests/syslog_splunk_hec_logs/terraform/http_blackhole.toml
+++ b/soaks/tests/syslog_splunk_hec_logs/terraform/http_blackhole.toml
@@ -1,3 +1,3 @@
-worker_threads = 4
+worker_threads = 1
 binding_addr = "0.0.0.0:8080"
 prometheus_addr = "0.0.0.0:9090"


### PR DESCRIPTION
This commit relaxes the limits we put on http_blackhole. It hasn't come up but
in more throughput oriented experiments we've found that the blackhole will
crash after it triggers its CPU limit.

REF #9997

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
