### PR TITLE
chore: Remove unused 'test_name' variable in vector module

### DIFF
--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -41,7 +41,6 @@ resource "kubernetes_deployment" "vector" {
     namespace = var.namespace
     labels = {
       type      = var.type
-      soak_test = var.test_name
     }
   }
 
@@ -51,7 +50,6 @@ resource "kubernetes_deployment" "vector" {
     selector {
       match_labels = {
         type      = var.type
-        soak_test = var.test_name
       }
     }
 
@@ -59,7 +57,6 @@ resource "kubernetes_deployment" "vector" {
       metadata {
         labels = {
           type      = var.type
-          soak_test = var.test_name
         }
         annotations = {
           "prometheus.io/scrape" = true

--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -17,7 +17,6 @@ resource "kubernetes_service" "vector" {
   spec {
     selector = {
       type      = var.type
-      soak_test = kubernetes_deployment.vector.metadata.0.labels.soak_test
     }
     session_affinity = "ClientIP"
     port {

--- a/soaks/common/terraform/modules/vector/variables.tf
+++ b/soaks/common/terraform/modules/vector/variables.tf
@@ -8,11 +8,6 @@ variable "vector_image" {
   type        = string
 }
 
-variable "test_name" {
-  description = "The name of the soak test"
-  type        = string
-}
-
 variable "vector-toml" {
   description = "The rendered vector.toml for this test"
   type        = string

--- a/soaks/tests/datadog_agent_remap_blackhole/terraform/main.tf
+++ b/soaks/tests/datadog_agent_remap_blackhole/terraform/main.tf
@@ -38,7 +38,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "datadog_agent_remap_blackhole"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
+++ b/soaks/tests/datadog_agent_remap_datadog_logs/terraform/main.tf
@@ -38,7 +38,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "datadog_agent_remap_datadog_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/fluent_remap_aws_firehose/terraform/main.tf
+++ b/soaks/tests/fluent_remap_aws_firehose/terraform/main.tf
@@ -38,7 +38,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "datadog_agent_remap_datadog_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/splunk_hec_route_s3/terraform/main.tf
+++ b/soaks/tests/splunk_hec_route_s3/terraform/main.tf
@@ -38,7 +38,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "datadog_agent_remap_blackhole"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/splunk_transforms_splunk3/terraform/main.tf
+++ b/soaks/tests/splunk_transforms_splunk3/terraform/main.tf
@@ -27,7 +27,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "syslog_splunk_hec_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/syslog_humio_logs/terraform/main.tf
+++ b/soaks/tests/syslog_humio_logs/terraform/main.tf
@@ -27,7 +27,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "syslog_humio_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_humio_metrics/terraform/main.tf
@@ -27,7 +27,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
+++ b/soaks/tests/syslog_log2metric_splunk_hec_metrics/terraform/main.tf
@@ -27,7 +27,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "syslog_log2metric_humio_metrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/syslog_loki/terraform/main.tf
+++ b/soaks/tests/syslog_loki/terraform/main.tf
@@ -38,7 +38,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "syslog_loki"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
+++ b/soaks/tests/syslog_regex_logs2metric_ddmetrics/terraform/main.tf
@@ -38,7 +38,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "syslog_regex_logs2metric_ddmetrics"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus

--- a/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
+++ b/soaks/tests/syslog_splunk_hec_logs/terraform/main.tf
@@ -27,7 +27,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "syslog_splunk_hec_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus


### PR DESCRIPTION
This commit follows-up on [this
comment](https://github.com/vectordotdev/vector/pull/9997#discussion_r747630811)
and removes unused `test_name`. The label has no value and is a hold over from
an earlier form these soak tests took.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
