### PR TITLE
fix(ci): Drop `test_name` parameter from soak

### DIFF
--- a/soaks/README.md
+++ b/soaks/README.md
@@ -135,7 +135,6 @@ module "vector" {
   type         = var.type
   vector_image = var.vector_image
   sha          = var.sha
-  test_name    = "datadog_agent_remap_datadog_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   depends_on   = [module.http-blackhole]

--- a/soaks/tests/fluent_elasticsearch/terraform/main.tf
+++ b/soaks/tests/fluent_elasticsearch/terraform/main.tf
@@ -38,7 +38,6 @@ module "vector" {
   source       = "../../../common/terraform/modules/vector"
   type         = var.type
   vector_image = var.vector_image
-  test_name    = "datadog_agent_remap_datadog_logs"
   vector-toml  = file("${path.module}/vector.toml")
   namespace    = kubernetes_namespace.soak.metadata[0].name
   vector_cpus  = var.vector_cpus


### PR DESCRIPTION
This parameter was dropped in https://github.com/vectordotdev/vector/pull/10003

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
