### PR TITLE
docs: Fix link to aliased `generator` source

### DIFF
--- a/website/content/en/highlights/2021-10-08-0-17-upgrade-guide.md
+++ b/website/content/en/highlights/2021-10-08-0-17-upgrade-guide.md
@@ -62,7 +62,7 @@ fast as it can. In version 0.17.0, the default for `interval` is now `1.0`, whic
 outputs one batch per second. To specify no delay between batches you now need to explicit set
 `interval` to `0.0`.
 
-[generator]: /docs/reference/configuration/sources/generator
+[generator]: /docs/reference/configuration/sources/demo_logs
 
 ### The deprecated `wasm` transform was removed {#wasm}
 


### PR DESCRIPTION
This was moved to `demo_logs`

There is a redirect for this, but the link checker isn't aware of that:

https://github.com/vectordotdev/vector/blob/master/website/layouts/index.redirects#L33

Currently is breaking master: https://app.netlify.com/sites/vector-project/deploys/6192c95ee78d5e00079456cd

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
