### PR TITLE
fix(internal docs): Fix typo in component spec

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -42,7 +42,7 @@ outline these rules to guide new component development and ongoing maintenance.
 This specification addresses _direct_ component development and does not cover
 aspects that components inherit "for free". For example, this specification does
 not cover global context, such as `component_id`, that all components receive in
-their telemetry by nature of being a Vector compoent.
+their telemetry by nature of being a Vector component.
 
 ## How to read this document
 


### PR DESCRIPTION
Small typo fix in the component spec.