### PR TITLE
chore(kubernetes_logs source): Differentiate between stream and invocation desyncs

### DIFF
--- a/src/internal_events/kubernetes/reflector.rs
+++ b/src/internal_events/kubernetes/reflector.rs
@@ -10,11 +10,11 @@ pub struct InvocationDesyncReceived<E> {
 
 impl<E: std::fmt::Debug> InternalEvent for InvocationDesyncReceived<E> {
     fn emit_logs(&self) {
-        warn!(message = "Handling desync.", error = ?self.error);
+        warn!(message = "Handling invocation desync.", reason = ?self.error);
     }
 
     fn emit_metrics(&self) {
-        counter!("k8s_reflector_desyncs_total", 1);
+        counter!("k8s_reflector_desyncs_total", 1, "type" => "invocation");
     }
 }
 
@@ -27,11 +27,11 @@ pub struct StreamDesyncReceived<E> {
 
 impl<E: std::fmt::Debug> InternalEvent for StreamDesyncReceived<E> {
     fn emit_logs(&self) {
-        warn!(message = "Handling desync.", error = ?self.error);
+        warn!(message = "Handling stream desync.", reason = ?self.error);
     }
 
     fn emit_metrics(&self) {
-        counter!("k8s_reflector_desyncs_total", 1);
+        counter!("k8s_reflector_desyncs_total", 1, "type" => "stream");
     }
 }
 
@@ -42,7 +42,7 @@ pub struct InvocationHttpErrorReceived<E> {
 
 impl<E: std::fmt::Debug> InternalEvent for InvocationHttpErrorReceived<E> {
     fn emit_logs(&self) {
-        warn!(message = "Http Error in invocation! Your k8s metadata may be stale. Continuing Loop.", error = ?self.error);
+        warn!(message = "Http Error in invocation! Your k8s metadata may be stale. Continuing Loop.", reason = ?self.error);
     }
 
     fn emit_metrics(&self) {


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Related #10016

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
