### PR TITLE
chore(releasing): Remove breaking change note for `VECTOR_LOG`

### DIFF
--- a/website/content/en/highlights/2021-11-16-0-18-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-11-16-0-18-0-upgrade-guide.md
@@ -15,9 +15,9 @@ Vector's 0.18.0 release includes **breaking changes**:
 1. [`batch.max_size` no longer valid for sinks](#batch-max-size)
 1. [`request.in_flight_limit` no longer valid for sources and sinks](#request-in-flight-limit)
 1. [`http_client_responses_total` now labels status with only numeric code](#http_client_responses_total)
-1. [`LOG` environment variable renamed to `VECTOR_LOG`](#VECTOR_LOG)
 1. [Field name change for aggregated summaries in `metric_to_log` transform](#agg_summary_metric_to_log)
 1. [Removal of deprecated configuration fields for the Datadog metrics sink: `host` and `namespace`](#dd_metrics_sink_deprecated_fields)
+
 We cover them below to help you upgrade quickly:
 
 ## Upgrade guide
@@ -57,14 +57,6 @@ canonical reason.
 
 Having only the numeric value makes it easier to group status codes (for example
 all `2xx` level status codes) in downstream metrics systems.
-
-### `LOG` environment variable renamed to `VECTOR_LOG` {#VECTOR_LOG}
-
-The `LOG` environment variable we have used to set Vector's logging level has been renamed to instead
-be `VECTOR_LOG`. This change makes logging configuration more in-line with Vector's other environment
-variable based options, and isolates Vector from being affected by other generic environment variables.
-
-When upgrading, simply rename your environment variable from `LOG` to `VECTOR_LOG`.
 
 ### Field name change for aggregated summaries in `metric_to_log` transform {#agg_summary_metric_to_log}
 


### PR DESCRIPTION
Compatibility was preserved here and so will be noted in the general
release notes.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
