### PR TITLE
chore: Add additional label so Vector service works in soak tests

### DIFF
--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -16,6 +16,7 @@ resource "kubernetes_service" "vector" {
   }
   spec {
     selector = {
+      app = "vector"
       type      = var.type
     }
     session_affinity = "ClientIP"
@@ -39,6 +40,7 @@ resource "kubernetes_deployment" "vector" {
     name      = "vector"
     namespace = var.namespace
     labels = {
+      app = "vector"
       type      = var.type
     }
   }
@@ -48,6 +50,7 @@ resource "kubernetes_deployment" "vector" {
 
     selector {
       match_labels = {
+        app = "vector"
         type      = var.type
       }
     }
@@ -55,6 +58,7 @@ resource "kubernetes_deployment" "vector" {
     template {
       metadata {
         labels = {
+          app = "vector"
           type      = var.type
         }
         annotations = {

--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -16,8 +16,8 @@ resource "kubernetes_service" "vector" {
   }
   spec {
     selector = {
-      app = "vector"
-      type      = var.type
+      app  = "vector"
+      type = var.type
     }
     session_affinity = "ClientIP"
     port {
@@ -40,8 +40,8 @@ resource "kubernetes_deployment" "vector" {
     name      = "vector"
     namespace = var.namespace
     labels = {
-      app = "vector"
-      type      = var.type
+      app  = "vector"
+      type = var.type
     }
   }
 
@@ -50,16 +50,16 @@ resource "kubernetes_deployment" "vector" {
 
     selector {
       match_labels = {
-        app = "vector"
-        type      = var.type
+        app  = "vector"
+        type = var.type
       }
     }
 
     template {
       metadata {
         labels = {
-          app = "vector"
-          type      = var.type
+          app  = "vector"
+          type = var.type
         }
         annotations = {
           "prometheus.io/scrape" = true
@@ -91,7 +91,7 @@ resource "kubernetes_deployment" "vector" {
             # memory consumption we only make a request here on memory. This
             # avoids vector crashing for want of a malloc.
             limits = {
-              cpu    = var.vector_cpus
+              cpu = var.vector_cpus
             }
             requests = {
               cpu    = var.vector_cpus


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Without this label the service selector was overly broad and included endpoints for any Pod with the baseline/comparison label - this then caused some resolutions to link to the wrong pod.