### PR TITLE
fix(throttle transform): Rename `window` parameter

### DIFF
--- a/website/cue/reference/components/transforms/throttle.cue
+++ b/website/cue/reference/components/transforms/throttle.cue
@@ -66,7 +66,7 @@ components: transforms: throttle: {
 				unit: null
 			}
 		}
-		window: {
+		window_secs: {
 			description: """
 				The time frame in which the configured `threshold` is applied.
 				"""


### PR DESCRIPTION
For duration parameters we always add a suffix with the unit to make it
easy to tell what unit the parameter is in without checking the docs.

This is mentioned in the [configuration spec](https://github.com/vectordotdev/vector/blob/master/docs/specs/configuration.md#option-naming).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
