### PR TITLE
chore(core): re-write the `Batcher` to remove the Partition requirement

### DIFF
--- a/lib/vector-core/src/partition.rs
+++ b/lib/vector-core/src/partition.rs
@@ -1,5 +1,4 @@
 use std::hash::Hash;
-use std::marker::PhantomData;
 
 /// Calculate partitions for an item
 ///
@@ -15,24 +14,4 @@ pub trait Partitioner {
     /// in such a way that if two distinct `Item` instances partition to the
     /// same key they are mergable if put into the same collection by this key.
     fn partition(&self, item: &Self::Item) -> Self::Key;
-}
-
-/// This always returns `()` as the partition key, effectively disabling partitioning.
-/// This is useful if you want to use the `Batcher` but don't actually need partitioning.
-#[derive(Default)]
-pub struct NullPartitioner<T> {
-    item: PhantomData<T>,
-}
-
-impl<T> NullPartitioner<T> {
-    pub fn new() -> NullPartitioner<T> {
-        NullPartitioner { item: PhantomData }
-    }
-}
-
-impl<T> Partitioner for NullPartitioner<T> {
-    type Item = T;
-    type Key = ();
-
-    fn partition(&self, _item: &T) -> Self::Key {}
 }

--- a/lib/vector-core/src/stream/batcher.rs
+++ b/lib/vector-core/src/stream/batcher.rs
@@ -1,8 +1,8 @@
 use crate::partition::Partitioner;
 use crate::time::KeyedTimer;
 use crate::ByteSizeOf;
-use futures::ready;
-use futures::stream::Stream;
+use futures::{ready, Future, StreamExt};
+use futures::stream::{Stream, Fuse};
 use pin_project::pin_project;
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hash};
@@ -14,729 +14,254 @@ use std::{cmp, mem};
 use tokio_util::time::delay_queue::Key;
 use tokio_util::time::DelayQueue;
 use twox_hash::XxHash64;
+use tokio::time::Sleep;
+use crate::stream::BatcherSettings;
 
-/// A `KeyedTimer` based on `DelayQueue`.
-pub struct ExpirationQueue<K> {
-    /// The timeout to give each new key entry
-    timeout: Duration,
-    /// The queue of expirations
-    expirations: DelayQueue<K>,
-    /// The Key -> K mapping, allows for resets
-    expiration_map: HashMap<K, Key>,
+
+pub trait ItemBatchSize<T> {
+    /// The size of an individual item in a batch.
+    fn size(&self, item: &T) -> usize;
 }
 
-impl<K> ExpirationQueue<K> {
-    /// Creates a new `ExpirationQueue`.
-    ///
-    /// `timeout` is used for all insertions and resets.
-    pub fn new(timeout: Duration) -> Self {
-        Self {
-            timeout,
-            expirations: DelayQueue::new(),
-            expiration_map: HashMap::default(),
-        }
-    }
-
-    /// The number of current subtimers in the queue.
-    ///
-    /// Includes subtimers which have expired but have not yet been removed via
-    /// calls to `poll_expired`.
-    pub fn len(&self) -> usize {
-        self.expirations.len()
-    }
-
-    /// Returns `true` if the queue has a length of 0.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-impl<K> KeyedTimer<K> for ExpirationQueue<K>
-where
-    K: Eq + Hash + Clone,
-{
-    fn clear(&mut self) {
-        self.expirations.clear();
-        self.expiration_map.clear();
-    }
-
-    fn insert(&mut self, item_key: K) {
-        if let Some(expiration_key) = self.expiration_map.get(&item_key) {
-            // We already have an expiration entry for this item key, so
-            // just reset the expiration.
-            self.expirations.reset(expiration_key, self.timeout);
-        } else {
-            // This is a yet-unseen item key, so create a new expiration
-            // entry.
-            let expiration_key = self.expirations.insert(item_key.clone(), self.timeout);
-            assert!(self
-                .expiration_map
-                .insert(item_key, expiration_key)
-                .is_none());
-        }
-    }
-
-    fn poll_expired(&mut self, cx: &mut Context) -> Poll<Option<K>> {
-        match ready!(self.expirations.poll_expired(cx)) {
-            // No expirations yet.
-            None => Poll::Ready(None),
-            Some(expiration) => match expiration {
-                // We shouldn't really ever hit this error arm, as `DelayQueue`
-                // doesn't actually return ever return an error, but it's part
-                // of the type signature so we must abide.
-                Err(e) => {
-                    error!(
-                        "caught unexpected error while polling for expired batches: {}",
-                        e
-                    );
-                    Poll::Pending
-                }
-                Ok(expiration) => {
-                    // An item has expired, so remove it from the map and return
-                    // it.
-                    assert!(self.expiration_map.remove(expiration.get_ref()).is_some());
-                    Poll::Ready(Some(expiration.into_inner()))
-                }
-            },
-        }
-    }
-}
-
-/// A batch for use by `Batcher`
-///
-/// This structure is a private implementation detail that simplifies the
-/// implementation of `Batcher`. It is the actual store of items that come
-/// through the stream manipulated by `Batcher` plus limit information to signal
-/// when the `Batch` is full.
-struct Batch<I> {
-    /// The total number of `I` bytes stored, does not any overhead in this
-    /// structure.
-    allocated_bytes: usize,
-    /// The maximum number of elements allowed in this structure.
-    element_limit: usize,
-    /// The maximum number of allocated bytes (not including overhead) allowed
-    /// in this structure.
-    allocation_limit: usize,
-    /// The store of `I` elements.
-    elements: Vec<I>,
-}
-
-impl<I> ByteSizeOf for Batch<I> {
-    fn allocated_bytes(&self) -> usize {
-        self.allocated_bytes
-    }
-}
-
-impl<I> Batch<I>
-where
-    I: ByteSizeOf,
-{
-    /// Create a new Batch instance
-    ///
-    /// Creates a new batch instance with specific element and allocation limits. The element limit
-    /// is a maximum cap on the number of `I` instances. The allocation limit is a soft-max on the
-    /// number of allocated bytes stored in this batch, not taking into account overhead from this
-    /// structure itself.
-    ///
-    /// If `allocation_limit` is smaller than the size of `I` as reported by `std::mem::size_of`,
-    /// then the allocation limit will be raised such that the batch can hold a single instance of
-    /// `I`.  Likewise, `element_limit` will be raised such that it is always at least 1, ensuring
-    /// that a new batch can be pushed into.
-    fn new(element_limit: usize, allocation_limit: usize) -> Self {
-        // SAFETY: `element_limit` is always non-zero because `BatcherSettings` can only be
-        // constructed with `NonZeroUsize` versions of allocation limit/item limit.  `Batch` is also
-        // only constructable via `Batcher`.
-
-        // TODO: This may need to be reworked, because it's subtly wrong as-is.
-        // ByteSizeOf::size_of() always returns the size of the type itself, plus any "allocated
-        // bytes".  Thus, there are times when an item will be bigger than simply the size of the
-        // type itself (aka mem::size_of::<I>()) and thus than type of item would never fit in a
-        // batch where the `allocation_limit` is at or lower than the size of that item.
-        //
-        // We're counteracting this here by ensuring that the element limit is always at least 1.
-        let allocation_limit = cmp::max(allocation_limit, mem::size_of::<I>());
-        Self {
-            allocated_bytes: 0,
-            element_limit,
-            allocation_limit,
-            elements: Vec::with_capacity(128),
-        }
-    }
-
-    /// Unconditionally insert an element into the batch
-    ///
-    /// This function is similar to `push` except that the caller does not need
-    /// to call `has_space` prior to calling this and it will never
-    /// panic. Intended to be used only when insertion must not fail.
-    fn with(mut self, value: I) -> Self {
-        self.allocated_bytes += value.size_of();
-        self.elements.push(value);
-        self
-    }
-
-    /// Decompose the batch
-    ///
-    /// Called by the user when they want to get at the internal store of
-    /// items. Returns a tuple, the first element being the allocated size of
-    /// stored items and the second the store of items.
-    fn into_inner(self) -> Vec<I> {
-        self.elements
-    }
-
-    /// Whether the batch has space for a new item
-    ///
-    /// This function returns true of there is space both in terms of item count
-    /// and byte count for the given item, false otherwise.
-    fn has_space(&self, value: &I) -> bool {
-        let too_many_elements = self.elements.len() + 1 > self.element_limit;
-        let too_many_bytes = self.allocated_bytes + value.size_of() > self.allocation_limit;
-        !(too_many_elements || too_many_bytes)
-    }
-
-    /// Push an element into the batch
-    ///
-    /// This function pushes an element into the batch. Callers must be sure to
-    /// call `has_space` prior to calling this function and receive a positive
-    /// result.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if there is not sufficient space in the batch
-    /// for a new element to be inserted.
-    fn push(&mut self, value: I) {
-        assert!(self.has_space(&value));
-        self.allocated_bytes += value.size_of();
-        self.elements.push(value);
-    }
-}
-
-/// Controls the behavior of the batcher in terms of batch size and flush interval.
-///
-/// This is a temporary solution for pushing in a fixed settings structure so we don't have to worry
-/// about misordering parameters and what not.  At some point, we will pull
-/// `BatchConfig`/`BatchSettings`/`BatchSize` out of `vector` and move them into `vector_core`, and
-/// make it more generalized. We can't do that yet, though, until we've converted all of the sinks
-/// with their various specialized batch buffers.
-#[derive(Copy, Clone, Debug)]
-pub struct BatcherSettings {
-    timeout: Duration,
-    size_limit: usize,
-    item_limit: usize,
-}
-
-impl BatcherSettings {
-    pub const fn new(
-        timeout: Duration,
-        size_limit: NonZeroUsize,
-        item_limit: NonZeroUsize,
-    ) -> Self {
-        BatcherSettings {
-            timeout,
-            size_limit: size_limit.get(),
-            item_limit: item_limit.get(),
-        }
+impl<T, F> ItemBatchSize<T> for F
+    where F: Fn(&T) -> usize {
+    fn size(&self, item: &T) -> usize {
+        (self)(item)
     }
 }
 
 #[pin_project]
-pub struct Batcher<St, Prt, KT>
-where
-    Prt: Partitioner,
-{
-    /// The total number of bytes a single batch in this struct is allowed to
-    /// hold.
-    batch_allocation_limit: usize,
-    /// The maximum number of items that are allowed per-batch
+pub struct Batcher<S, I>
+    where S: Stream {
+    /// The total "size" of all items in a batch. Size is intentionally
+    /// vague here since it is user defined, and can vary.
+    ///
+    /// To ensure any individual event can be placed in a batch, the first element in a batch is not
+    /// subject to this limit.
+    batch_size_limit: usize,
+
+    /// Total number of items that will be placed in a single batch.
+    ///
+    /// To ensure any individual event can be placed in a batch, the first element in a batch is not
+    /// subject to this limit.
     batch_item_limit: usize,
-    /// The store of live batches. Note that the key here is an option type,
-    /// on account of the interface of `Prt`.
-    batches: HashMap<Prt::Key, Batch<Prt::Item>, BuildHasherDefault<XxHash64>>,
-    /// The store of 'closed' batches. When this is not empty it will be
-    /// preferentially flushed prior to consuming any new items from the
-    /// underlying stream.
-    closed_batches: Vec<(Prt::Key, Vec<Prt::Item>)>,
-    /// The queue of pending batch expirations
-    timer: KT,
-    /// The partitioner for this `Batcher`
-    partitioner: Prt,
+
+    current_size: usize,
+
+    batch: Vec<S::Item>,
+
     #[pin]
     /// The stream this `Batcher` wraps
-    stream: St,
+    stream: Fuse<S>,
+
+    /// A function to calculate the size of an individual item
+    item_batch_size: I,
+
+    #[pin]
+    timer: Maybe<Sleep>,
+    timeout: Duration,
 }
 
-impl<St, Prt> Batcher<St, Prt, ExpirationQueue<Prt::Key>>
-where
-    St: Stream<Item = Prt::Item>,
-    Prt: Partitioner + Unpin,
-    Prt::Key: Eq + Hash + Clone,
-    Prt::Item: ByteSizeOf,
-{
-    pub fn new(stream: St, partitioner: Prt, settings: BatcherSettings) -> Self {
+/// An `Option`, but with pin projection
+#[pin_project(project = MaybeProj)]
+pub enum Maybe<T> {
+    Some(#[pin] T),
+    None,
+}
+
+impl<S, I> Batcher<S, I>
+    where S: Stream,
+          I: ItemBatchSize<S::Item> {
+    pub fn new(stream: S, settings: BatcherSettings, batch_size_calculator: I) -> Self {
         Self {
-            batch_allocation_limit: settings.size_limit,
+            batch_size_limit: settings.size_limit,
             batch_item_limit: settings.item_limit,
-            batches: HashMap::default(),
-            closed_batches: Vec::default(),
-            timer: ExpirationQueue::new(settings.timeout),
-            partitioner,
-            stream,
+            current_size: 0,
+            batch: vec![],
+            stream: stream.fuse(),
+            item_batch_size: batch_size_calculator,
+            timer: Maybe::None,
+            timeout: settings.timeout,
         }
     }
 }
 
-impl<St, Prt, KT> Batcher<St, Prt, KT>
-where
-    St: Stream<Item = Prt::Item>,
-    Prt: Partitioner + Unpin,
-    Prt::Key: Eq + Hash + Clone,
-    Prt::Item: ByteSizeOf,
-{
-    pub fn with_timer(
-        stream: St,
-        partitioner: Prt,
-        timer: KT,
-        batch_item_limit: NonZeroUsize,
-        batch_allocation_limit: Option<NonZeroUsize>,
-    ) -> Self {
-        Self {
-            batch_allocation_limit: batch_allocation_limit
-                .map_or(usize::max_value(), NonZeroUsize::get),
-            batch_item_limit: batch_item_limit.get(),
-            batches: HashMap::default(),
-            closed_batches: Vec::default(),
-            timer,
-            partitioner,
-            stream,
-        }
+pub struct ByteSizeOfBatchSize;
+
+impl<T: ByteSizeOf> ItemBatchSize<T> for ByteSizeOfBatchSize {
+    fn size(&self, item: &T) -> usize {
+        item.size_of()
     }
 }
 
-impl<St, Prt, KT> Stream for Batcher<St, Prt, KT>
-where
-    St: Stream<Item = Prt::Item>,
-    Prt: Partitioner + Unpin,
-    Prt::Key: Eq + Hash + Clone,
-    Prt::Item: ByteSizeOf,
-    KT: KeyedTimer<Prt::Key>,
-{
-    type Item = (Prt::Key, Vec<Prt::Item>);
+impl<S> Batcher<S, ByteSizeOfBatchSize>
+    where S: Stream,
+          <S as Stream>::Item: ByteSizeOf {
+    /// Creates a `Batcher` using the `ByteSizeOf` trait for calculating the size of an item
+    pub fn new_using_byte_size_of(stream: S, settings: BatcherSettings) -> Self {
+        Self::new(stream, settings, ByteSizeOfBatchSize)
+    }
+}
+
+impl<S, I> Batcher<S, I>
+    where S: Stream,
+          I: ItemBatchSize<S::Item> {
+
+    fn size_fits_in_batch(&self, item_size: usize) -> bool {
+        if self.batch.is_empty() {
+            // make sure any individual item can always fit in a batch
+            return true;
+        }
+        self.current_size + item_size <= self.batch_size_limit
+    }
+
+    /// returns true iff it is not possible for another item to fit in the batch
+    fn is_batch_full(&self) -> bool {
+        self.batch.len() >= self.batch_item_limit
+        || self.current_size >= self.batch_size_limit
+    }
+
+    fn take_batch(self: Pin<&mut Self>) -> Vec<S::Item> {
+        let this = self.project();
+        *this.current_size = 0;
+        std::mem::take(this.batch)
+    }
+
+    fn push_item(self: Pin<&mut Self>, item: S::Item, item_size: usize) {
+        let this = self.project();
+        this.batch.push(item);
+        *this.current_size += item_size;
+    }
+
+    fn reset_timer(self: Pin<&mut Self>) {
+        let timeout = self.timeout;
+        let mut this = self.project();
+        if let MaybeProj::Some(timer) = this.timer.as_mut().project() {
+            timer.reset(tokio::time::Instant::now() + timeout);
+        } else {
+            this.timer.set(Maybe::Some(tokio::time::sleep(timeout)));
+        }
+    }
+
+}
+
+impl<S, I> Stream for Batcher<S, I>
+    where S: Stream,
+          I: ItemBatchSize<S::Item> {
+    type Item = Vec<S::Item>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.as_mut().project().stream.poll_next(cx) {
+                Poll::Ready(None) => {
+                    if self.batch.is_empty() {
+                        return Poll::Ready(None);
+                    } else {
+                        return Poll::Ready(Some(self.take_batch()));
+                    }
+                }
+                Poll::Ready(Some(item)) => {
+                    let item_size = self.item_batch_size.size(&item);
+                    if self.size_fits_in_batch(item_size) {
+                        self.as_mut().push_item(item, item_size);
+                        if self.is_batch_full() {
+                            return Poll::Ready(Some(self.as_mut().take_batch()));
+                        } else if self.batch.len() == 1 {
+                            self.as_mut().reset_timer();
+                        }
+                    }else {
+                        let output = Poll::Ready(Some(self.as_mut().take_batch()));
+                        self.as_mut().push_item(item, item_size);
+                        self.as_mut().reset_timer();
+                        return output;
+                    }
+                }
+                Poll::Pending => {
+                   if let MaybeProj::Some(timer) = self.as_mut().project().timer.project() {
+                       match timer.poll(cx) {
+                           Poll::Ready(()) => {
+                               self.as_mut().project().timer.set(Maybe::None);
+                               return Poll::Ready(Some(self.take_batch()));
+                           }
+                           Poll::Pending => {
+                               return Poll::Pending;
+                           }
+                       }
+                    } else {
+                        return Poll::Pending;
+                   }
+                }
+            }
+        }
+    }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.stream.size_hint()
     }
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut this = self.project();
-        loop {
-            if !this.closed_batches.is_empty() {
-                return Poll::Ready(this.closed_batches.pop());
-            }
-            match this.stream.as_mut().poll_next(cx) {
-                Poll::Pending => match this.timer.poll_expired(cx) {
-                    // Unlike normal streams, `DelayQueue` can return `None`
-                    // here but still be usable later if more entries are added.
-                    Poll::Pending | Poll::Ready(None) => return Poll::Pending,
-                    Poll::Ready(Some(item_key)) => {
-                        let batch = this
-                            .batches
-                            .remove(&item_key)
-                            .expect("batch should exist if it is set to expire");
-                        this.closed_batches.push((item_key, batch.into_inner()));
-
-                        continue;
-                    }
-                },
-                Poll::Ready(None) => {
-                    // Now that the underlying stream is closed, we need to
-                    // clear out our batches, including all expiration
-                    // entries. If we had any batches to hand over, we have to
-                    // continue looping so the caller can drain them all before
-                    // we finish.
-                    if !this.batches.is_empty() {
-                        this.timer.clear();
-                        this.closed_batches.extend(
-                            this.batches
-                                .drain()
-                                .map(|(key, batch)| (key, batch.into_inner())),
-                        );
-                        continue;
-                    }
-                    return Poll::Ready(None);
-                }
-                Poll::Ready(Some(item)) => {
-                    let item_key = this.partitioner.partition(&item);
-                    let item_limit: usize = *this.batch_item_limit;
-                    let alloc_limit: usize = *this.batch_allocation_limit;
-
-                    if let Some(batch) = this.batches.get_mut(&item_key) {
-                        if batch.has_space(&item) {
-                            // When there's space in the partition batch just
-                            // push the item in and loop back around.
-                            batch.push(item);
-                        } else {
-                            let new_batch = Batch::new(item_limit, alloc_limit).with(item);
-                            let batch = mem::replace(batch, new_batch);
-
-                            // The batch for this partition key was set to
-                            // expire, but now it's overflowed and must be
-                            // pushed out, so now we reset the batch timeout.
-                            this.timer.insert(item_key.clone());
-
-                            this.closed_batches.push((item_key, batch.into_inner()));
-                        }
-                    } else {
-                        // We have no batch yet for this partition key, so
-                        // create one and create the expiration entries as well.
-                        // This allows the batch to expire before filling up,
-                        // and vise versa.
-                        let batch = Batch::new(item_limit, alloc_limit).with(item);
-                        this.batches.insert(item_key.clone(), batch);
-                        this.timer.insert(item_key);
-                    }
-                }
-            }
-        }
-    }
 }
+
+
+
+
 
 #[cfg(test)]
 mod test {
-    use crate::partition::Partitioner;
-    use crate::stream::batcher::{Batcher, ExpirationQueue};
-    use crate::time::KeyedTimer;
-    use futures::{stream, Stream};
-    use pin_project::pin_project;
-    use proptest::prelude::*;
-    use std::collections::{HashMap, HashSet};
-    use std::num::{NonZeroU8, NonZeroUsize};
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use std::time::Duration;
-    use tokio::pin;
-    use tokio::time::advance;
+    use super::*;
+    use futures::stream;
 
-    #[derive(Debug)]
-    /// A test keyed timer
-    ///
-    /// This timer implements `KeyedTimer` and is rigged up in such a way that
-    /// it doesn't _actually_ tell time but instead uses a set of canned
-    /// responses for whether deadlines have elapsed or not. This allows us to
-    /// include the notion of time in our property tests below.
-    struct TestTimer {
-        responses: Vec<Poll<Option<u8>>>,
-        valid_keys: HashSet<u8>,
+    #[tokio::test]
+    async fn item_limit() {
+        let stream = stream::iter([1, 2, 3]);
+        let settings = BatcherSettings::new(
+            Duration::from_millis(100),
+            NonZeroUsize::new(10000).unwrap(),
+            NonZeroUsize::new(2).unwrap(),
+        );
+        let batcher = Batcher::new(stream, settings, |x: &u32| { *x as usize });
+        let batches: Vec<_> = batcher.collect().await;
+        assert_eq!(batches, vec![
+            vec![1, 2],
+            vec![3],
+        ])
     }
 
-    impl TestTimer {
-        fn new(responses: Vec<Poll<Option<u8>>>) -> Self {
-            Self {
-                responses,
-                valid_keys: HashSet::new(),
-            }
-        }
+    #[tokio::test]
+    async fn size_limit() {
+        let batcher = Batcher::new(stream::iter([1, 2, 3, 4, 5, 6, 2, 3, 1]), BatcherSettings::new(
+            Duration::from_millis(100),
+            NonZeroUsize::new(5).unwrap(),
+            NonZeroUsize::new(100).unwrap(),
+        ), |x: &u32| { *x as usize });
+        let batches: Vec<_> = batcher.collect().await;
+        assert_eq!(batches, vec![
+            vec![1, 2],
+            vec![3],
+            vec![4],
+            vec![5],
+            vec![6],
+            vec![2, 3],
+            vec![1],
+        ]);
     }
 
-    impl KeyedTimer<u8> for TestTimer {
-        fn clear(&mut self) {
-            self.valid_keys.clear();
-        }
+    #[tokio::test]
+    async fn timeout_limit() {
+        tokio::time::pause();
 
-        fn insert(&mut self, item_key: u8) {
-            self.valid_keys.insert(item_key);
-        }
+        let timeout = Duration::from_millis(100);
+        let stream = stream::iter([1, 2]).chain(stream::pending());
+        let batcher = Batcher::new(stream, BatcherSettings::new(
+            timeout,
+            NonZeroUsize::new(5).unwrap(),
+            NonZeroUsize::new(100).unwrap(),
+        ), |x: &u32| { *x as usize });
 
-        fn poll_expired(&mut self, _cx: &mut Context) -> Poll<Option<u8>> {
-            match self.responses.pop() {
-                Some(Poll::Pending) => unreachable!(),
-                None | Some(Poll::Ready(None)) => Poll::Ready(None),
-                Some(Poll::Ready(Some(k))) => {
-                    if self.valid_keys.contains(&k) {
-                        Poll::Ready(Some(k))
-                    } else {
-                        Poll::Ready(None)
-                    }
-                }
-            }
-        }
-    }
-
-    fn arb_timer() -> impl Strategy<Value = TestTimer> {
-        // The timer always returns a `Poll::Ready` and never a `Poll::Pending`.
-        Vec::<(bool, u8)>::arbitrary()
-            .prop_map(|v| {
-                v.into_iter()
-                    .map(|(b, k)| {
-                        if b {
-                            Poll::Ready(Some(k))
-                        } else {
-                            Poll::Ready(None)
-                        }
-                    })
-                    .collect()
-            })
-            .prop_map(TestTimer::new)
-    }
-
-    /// A test partitioner
-    ///
-    /// This partitioner is nothing special. It has a large-ish key space but
-    /// not so large that we'll never see batches accumulate properly.
-    #[pin_project]
-    #[derive(Debug)]
-    struct TestPartitioner {
-        key_space: NonZeroU8,
-    }
-
-    impl Partitioner for TestPartitioner {
-        type Item = u64;
-        type Key = u8;
-
-        #[allow(clippy::cast_possible_truncation)]
-        fn partition(&self, item: &Self::Item) -> Self::Key {
-            let key = *item % u64::from(self.key_space.get());
-            key as Self::Key
-        }
-    }
-
-    fn arb_partitioner() -> impl Strategy<Value = TestPartitioner> {
-        (1..u8::max_value(),).prop_map(|(ks,)| TestPartitioner {
-            key_space: NonZeroU8::new(ks).unwrap(),
-        })
-    }
-
-    proptest! {
-        #[test]
-        fn size_hint_eq(stream: Vec<u64>,
-                        item_limit in 1..u16::max_value(),
-                        allocation_limit in 8..128,
-                        partitioner in arb_partitioner(),
-                        timer in arb_timer()) {
-            // Asserts that the size hint of the batcher stream is the same as
-            // that of the internal stream. In the future we may want to produce
-            // a tighter bound -- since batching will reduce some streams -- but
-            // this is the worst case where every incoming item maps to a unique
-            // key.
-            let mut stream = stream::iter(stream.into_iter());
-            let stream_size_hint = stream.size_hint();
-
-            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
-            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let batcher = Batcher::with_timer(&mut stream, partitioner, timer,
-                                              item_limit, Some(allocation_limit));
-            let batcher_size_hint = batcher.size_hint();
-
-            assert_eq!(stream_size_hint, batcher_size_hint);
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn batch_item_size_leq_limit(stream: Vec<u64>,
-                                     item_limit in 1..u16::max_value(),
-                                     allocation_limit in 8..128,
-                                     partitioner in arb_partitioner(),
-                                     timer in arb_timer()) {
-            // Asserts that for every received batch the size is always less
-            // than the expected limit.
-            let noop_waker = futures::task::noop_waker();
-            let mut cx = Context::from_waker(&noop_waker);
-
-            let mut stream = stream::iter(stream.into_iter());
-            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
-            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
-                                                  timer, item_limit,
-                                                  Some(allocation_limit));
-            let mut batcher = Pin::new(&mut batcher);
-
-            loop {
-                match batcher.as_mut().poll_next(&mut cx) {
-                    Poll::Pending => {}
-                    Poll::Ready(None) => {
-                        break;
-                    }
-                    Poll::Ready(Some((_, batch))) => {
-                        debug_assert!(
-                            batch.len() <= item_limit.get(),
-                            "{} < {}",
-                            batch.len(),
-                            item_limit.get()
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    /// Separates a stream into partitions
-    ///
-    /// This function separates a stream into partitions, preserving the order
-    /// of the items in reverse. This allows for efficient popping to compare
-    /// ordering of receipt.
-    fn separate_partitions(
-        stream: Vec<u64>,
-        partitioner: &TestPartitioner,
-    ) -> HashMap<u8, Vec<u64>> {
-        let mut map = stream
-            .into_iter()
-            .map(|item| {
-                let key = partitioner.partition(&item);
-                (key, item)
-            })
-            .fold(
-                HashMap::default(),
-                |mut acc: HashMap<u8, Vec<u64>>, (key, item)| {
-                    let arr: &mut Vec<u64> = acc.entry(key).or_insert_with(Vec::default);
-                    arr.push(item);
-                    acc
-                },
-            );
-        for part in map.values_mut() {
-            part.reverse();
-        }
-        map
-    }
-
-    proptest! {
-        #[test]
-        fn batch_does_not_reorder(stream: Vec<u64>,
-                                  item_limit in 1..u16::max_value(),
-                                  allocation_limit in 8..128,
-                                  partitioner in arb_partitioner(),
-                                  timer in arb_timer()) {
-            // Asserts that for every received batch received the elements in
-            // the batch are not reordered within a batch. No claim is made on
-            // when batches themselves will issue, batch sizes etc.
-            let noop_waker = futures::task::noop_waker();
-            let mut cx = Context::from_waker(&noop_waker);
-
-            let mut partitions = separate_partitions(stream.clone(), &partitioner);
-
-            let mut stream = stream::iter(stream.into_iter());
-            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
-            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
-                                                  timer, item_limit,
-                                                  Some(allocation_limit));
-            let mut batcher = Pin::new(&mut batcher);
-
-            loop {
-                match batcher.as_mut().poll_next(&mut cx) {
-                    Poll::Pending => {}
-                    Poll::Ready(None) => {
-                        break;
-                    }
-                    Poll::Ready(Some((key, actual_batch))) => {
-                        let expected_partition = partitions
-                            .get_mut(&key)
-                            .expect("impossible situation");
-                        for item in actual_batch {
-                            assert_eq!(item, expected_partition.pop().unwrap());
-                        }
-                    }
-                }
-            }
-            for v in partitions.values() {
-                assert!(v.is_empty());
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn batch_does_not_lose_items(stream: Vec<u64>,
-                                     item_limit in 1..u16::max_value(),
-                                     allocation_limit in 8..128,
-                                     partitioner in arb_partitioner(),
-                                     timer in arb_timer()) {
-            // Asserts that for every received batch the sum of all batch sizes
-            // equals the number of stream elements.
-            let noop_waker = futures::task::noop_waker();
-            let mut cx = Context::from_waker(&noop_waker);
-
-            let total_items = stream.len();
-            let mut stream = stream::iter(stream.into_iter());
-            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
-            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
-                                                  timer, item_limit,
-                                                  Some(allocation_limit));
-            let mut batcher = Pin::new(&mut batcher);
-
-            let mut observed_items = 0;
-            loop {
-                match batcher.as_mut().poll_next(&mut cx) {
-                    Poll::Pending => {}
-                    Poll::Ready(None) => {
-                        // inner stream has shut down, ensure we passed every
-                        // item through the batch
-                        assert_eq!(observed_items, total_items);
-                        break;
-                    }
-                    Poll::Ready(Some((_, batch))) => {
-                        observed_items += batch.len();
-                        assert!(observed_items <= total_items);
-                    }
-                }
-            }
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    #[allow(clippy::semicolon_if_nothing_returned)] // https://github.com/rust-lang/rust-clippy/issues/7438
-    async fn expiration_queue_impl_keyed_timer() {
-        // Asserts that ExpirationQueue properly implements KeyedTimer. We are
-        // primarily concerned with whether expiration is properly observed.
-        let timeout = Duration::from_millis(100); // 1/10 of a second, an
-                                                  // eternity
-
-        let mut expiration_queue: ExpirationQueue<u8> = ExpirationQueue::new(timeout);
-
-        // If the queue is empty assert that when we poll for expired entries
-        // nothing comes back.
-        assert_eq!(0, expiration_queue.len());
-        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
-        assert_eq!(result, Poll::Ready(None));
-
-        // Insert an item key into the queue. Assert that the size of the queue
-        // has grown, assert that the queue still does not believe the item has expired, and _then_
-        // advance time enough to allow it to expire, and assert that it has.
-        expiration_queue.insert(128);
-        assert_eq!(1, expiration_queue.len());
-
-        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
-        assert_eq!(result, Poll::Pending);
-
-        advance(timeout + Duration::from_nanos(1)).await;
-        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
-        assert_eq!(result, Poll::Ready(Some(128)));
-        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
-        assert_eq!(result, Poll::Ready(None));
-
-        // Now we poll assured that the queue has emptied out again.
-        assert_eq!(0, expiration_queue.len());
-        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
-        assert_eq!(result, Poll::Ready(None));
-
-        // Finally, blitz a handful of items into the queue, assert its size,
-        // clear the queue and assert it as being empty.
-        expiration_queue.insert(128);
-        expiration_queue.insert(64);
-        expiration_queue.insert(32);
-        assert_eq!(3, expiration_queue.len());
-        expiration_queue.clear();
-        assert_eq!(0, expiration_queue.len());
-        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
-        assert_eq!(result, Poll::Ready(None));
-    }
-
-    fn single_poll<T, F>(mut f: F) -> Poll<T>
-    where
-        F: FnMut(&mut Context<'_>) -> Poll<T>,
-    {
-        let noop_waker = futures::task::noop_waker();
-        let mut cx = Context::from_waker(&noop_waker);
-
-        f(&mut cx)
+        tokio::pin!(batcher);
+        let mut next = batcher.next();
+        assert_eq!(futures::poll!(&mut next), Poll::Pending);
+        tokio::time::advance(timeout).await;
+        let batch = next.await;
+        assert_eq!(batch, Some(vec![1, 2]));
     }
 }
+

--- a/lib/vector-core/src/stream/batcher.rs
+++ b/lib/vector-core/src/stream/batcher.rs
@@ -92,17 +92,6 @@ impl<T: ByteSizeOf> ItemBatchSize<T> for ByteSizeOfBatchSize {
     }
 }
 
-impl<S> Batcher<S, ByteSizeOfBatchSize>
-where
-    S: Stream,
-    <S as Stream>::Item: ByteSizeOf,
-{
-    /// Creates a `Batcher` using the `ByteSizeOf` trait for calculating the size of an item
-    pub fn new_using_byte_size_of(stream: S, settings: BatcherSettings) -> Self {
-        Self::new(stream, settings, ByteSizeOfBatchSize)
-    }
-}
-
 impl<S, I> Batcher<S, I>
 where
     S: Stream,

--- a/lib/vector-core/src/stream/batcher.rs
+++ b/lib/vector-core/src/stream/batcher.rs
@@ -1,19 +1,19 @@
-use crate::partition::Partitioner;
-use crate::time::KeyedTimer;
+
+
 use crate::ByteSizeOf;
-use futures::{ready, Future, StreamExt};
+use futures::{Future, StreamExt};
 use futures::stream::{Stream, Fuse};
 use pin_project::pin_project;
-use std::collections::HashMap;
-use std::hash::{BuildHasherDefault, Hash};
-use std::num::NonZeroUsize;
+
+
+
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use std::{cmp, mem};
-use tokio_util::time::delay_queue::Key;
-use tokio_util::time::DelayQueue;
-use twox_hash::XxHash64;
+
+
+
+
 use tokio::time::Sleep;
 use crate::stream::BatcherSettings;
 
@@ -208,6 +208,7 @@ impl<S, I> Stream for Batcher<S, I>
 mod test {
     use super::*;
     use futures::stream;
+    use std::num::NonZeroUsize;
 
     #[tokio::test]
     async fn item_limit() {

--- a/lib/vector-core/src/stream/batcher.rs
+++ b/lib/vector-core/src/stream/batcher.rs
@@ -84,9 +84,9 @@ where
     }
 }
 
-pub struct ByteSizeOfBatchSize;
+pub struct ByteSizeOfItemSize;
 
-impl<T: ByteSizeOf> ItemBatchSize<T> for ByteSizeOfBatchSize {
+impl<T: ByteSizeOf> ItemBatchSize<T> for ByteSizeOfItemSize {
     fn size(&self, item: &T) -> usize {
         item.size_of()
     }

--- a/lib/vector-core/src/stream/mod.rs
+++ b/lib/vector-core/src/stream/mod.rs
@@ -1,11 +1,14 @@
 mod batcher;
+mod partitioned_batcher;
 mod concurrent_map;
 mod driver;
 mod futures_unordered_chunked;
 
 pub use driver::DriverResponse;
 
-pub use batcher::{Batcher, BatcherSettings, ExpirationQueue};
+pub use batcher::{Batcher, ByteSizeOfBatchSize, ItemBatchSize};
+pub use partitioned_batcher::{PartitionedBatcher, BatcherSettings, ExpirationQueue};
+
 pub use concurrent_map::ConcurrentMap;
 pub use driver::Driver;
 pub use futures_unordered_chunked::FuturesUnorderedChunked;

--- a/lib/vector-core/src/stream/mod.rs
+++ b/lib/vector-core/src/stream/mod.rs
@@ -1,13 +1,13 @@
 mod batcher;
-mod partitioned_batcher;
 mod concurrent_map;
 mod driver;
 mod futures_unordered_chunked;
+mod partitioned_batcher;
 
 pub use driver::DriverResponse;
 
 pub use batcher::{Batcher, ByteSizeOfBatchSize, ItemBatchSize};
-pub use partitioned_batcher::{PartitionedBatcher, BatcherSettings, ExpirationQueue};
+pub use partitioned_batcher::{BatcherSettings, ExpirationQueue, PartitionedBatcher};
 
 pub use concurrent_map::ConcurrentMap;
 pub use driver::Driver;

--- a/lib/vector-core/src/stream/mod.rs
+++ b/lib/vector-core/src/stream/mod.rs
@@ -6,7 +6,7 @@ mod partitioned_batcher;
 
 pub use driver::DriverResponse;
 
-pub use batcher::{Batcher, ByteSizeOfBatchSize, ItemBatchSize};
+pub use batcher::{Batcher, ByteSizeOfItemSize, ItemBatchSize};
 pub use partitioned_batcher::{BatcherSettings, ExpirationQueue, PartitionedBatcher};
 
 pub use concurrent_map::ConcurrentMap;

--- a/lib/vector-core/src/stream/partitioned_batcher.rs
+++ b/lib/vector-core/src/stream/partitioned_batcher.rs
@@ -1,0 +1,743 @@
+use crate::partition::Partitioner;
+use crate::time::KeyedTimer;
+use crate::ByteSizeOf;
+use futures::{ready, Future, StreamExt};
+use futures::stream::{Stream, Fuse};
+use pin_project::pin_project;
+use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hash};
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use std::{cmp, mem};
+use tokio_util::time::delay_queue::Key;
+use tokio_util::time::DelayQueue;
+use twox_hash::XxHash64;
+use tokio::time::Sleep;
+
+/// A `KeyedTimer` based on `DelayQueue`.
+pub struct ExpirationQueue<K> {
+    /// The timeout to give each new key entry
+    timeout: Duration,
+    /// The queue of expirations
+    expirations: DelayQueue<K>,
+    /// The Key -> K mapping, allows for resets
+    expiration_map: HashMap<K, Key>,
+}
+
+impl<K> ExpirationQueue<K> {
+    /// Creates a new `ExpirationQueue`.
+    ///
+    /// `timeout` is used for all insertions and resets.
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            expirations: DelayQueue::new(),
+            expiration_map: HashMap::default(),
+        }
+    }
+
+    /// The number of current subtimers in the queue.
+    ///
+    /// Includes subtimers which have expired but have not yet been removed via
+    /// calls to `poll_expired`.
+    pub fn len(&self) -> usize {
+        self.expirations.len()
+    }
+
+    /// Returns `true` if the queue has a length of 0.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<K> KeyedTimer<K> for ExpirationQueue<K>
+    where
+        K: Eq + Hash + Clone,
+{
+    fn clear(&mut self) {
+        self.expirations.clear();
+        self.expiration_map.clear();
+    }
+
+    fn insert(&mut self, item_key: K) {
+        if let Some(expiration_key) = self.expiration_map.get(&item_key) {
+            // We already have an expiration entry for this item key, so
+            // just reset the expiration.
+            self.expirations.reset(expiration_key, self.timeout);
+        } else {
+            // This is a yet-unseen item key, so create a new expiration
+            // entry.
+            let expiration_key = self.expirations.insert(item_key.clone(), self.timeout);
+            assert!(self
+                .expiration_map
+                .insert(item_key, expiration_key)
+                .is_none());
+        }
+    }
+
+    fn poll_expired(&mut self, cx: &mut Context) -> Poll<Option<K>> {
+        match ready!(self.expirations.poll_expired(cx)) {
+            // No expirations yet.
+            None => Poll::Ready(None),
+            Some(expiration) => match expiration {
+                // We shouldn't really ever hit this error arm, as `DelayQueue`
+                // doesn't actually return ever return an error, but it's part
+                // of the type signature so we must abide.
+                Err(e) => {
+                    error!(
+                        "caught unexpected error while polling for expired batches: {}",
+                        e
+                    );
+                    Poll::Pending
+                }
+                Ok(expiration) => {
+                    // An item has expired, so remove it from the map and return
+                    // it.
+                    assert!(self.expiration_map.remove(expiration.get_ref()).is_some());
+                    Poll::Ready(Some(expiration.into_inner()))
+                }
+            },
+        }
+    }
+}
+
+/// A batch for use by `Batcher`
+///
+/// This structure is a private implementation detail that simplifies the
+/// implementation of `Batcher`. It is the actual store of items that come
+/// through the stream manipulated by `Batcher` plus limit information to signal
+/// when the `Batch` is full.
+struct Batch<I> {
+    /// The total number of `I` bytes stored, does not any overhead in this
+    /// structure.
+    allocated_bytes: usize,
+    /// The maximum number of elements allowed in this structure.
+    element_limit: usize,
+    /// The maximum number of allocated bytes (not including overhead) allowed
+    /// in this structure.
+    allocation_limit: usize,
+    /// The store of `I` elements.
+    elements: Vec<I>,
+}
+
+impl<I> ByteSizeOf for Batch<I> {
+    fn allocated_bytes(&self) -> usize {
+        self.allocated_bytes
+    }
+}
+
+impl<I> Batch<I>
+    where
+        I: ByteSizeOf,
+{
+    /// Create a new Batch instance
+    ///
+    /// Creates a new batch instance with specific element and allocation limits. The element limit
+    /// is a maximum cap on the number of `I` instances. The allocation limit is a soft-max on the
+    /// number of allocated bytes stored in this batch, not taking into account overhead from this
+    /// structure itself.
+    ///
+    /// If `allocation_limit` is smaller than the size of `I` as reported by `std::mem::size_of`,
+    /// then the allocation limit will be raised such that the batch can hold a single instance of
+    /// `I`.  Likewise, `element_limit` will be raised such that it is always at least 1, ensuring
+    /// that a new batch can be pushed into.
+    fn new(element_limit: usize, allocation_limit: usize) -> Self {
+        // SAFETY: `element_limit` is always non-zero because `BatcherSettings` can only be
+        // constructed with `NonZeroUsize` versions of allocation limit/item limit.  `Batch` is also
+        // only constructable via `Batcher`.
+
+        // TODO: This may need to be reworked, because it's subtly wrong as-is.
+        // ByteSizeOf::size_of() always returns the size of the type itself, plus any "allocated
+        // bytes".  Thus, there are times when an item will be bigger than simply the size of the
+        // type itself (aka mem::size_of::<I>()) and thus than type of item would never fit in a
+        // batch where the `allocation_limit` is at or lower than the size of that item.
+        //
+        // We're counteracting this here by ensuring that the element limit is always at least 1.
+        let allocation_limit = cmp::max(allocation_limit, mem::size_of::<I>());
+        Self {
+            allocated_bytes: 0,
+            element_limit,
+            allocation_limit,
+            elements: Vec::with_capacity(128),
+        }
+    }
+
+    /// Unconditionally insert an element into the batch
+    ///
+    /// This function is similar to `push` except that the caller does not need
+    /// to call `has_space` prior to calling this and it will never
+    /// panic. Intended to be used only when insertion must not fail.
+    fn with(mut self, value: I) -> Self {
+        self.allocated_bytes += value.size_of();
+        self.elements.push(value);
+        self
+    }
+
+    /// Decompose the batch
+    ///
+    /// Called by the user when they want to get at the internal store of
+    /// items. Returns a tuple, the first element being the allocated size of
+    /// stored items and the second the store of items.
+    fn into_inner(self) -> Vec<I> {
+        self.elements
+    }
+
+    /// Whether the batch has space for a new item
+    ///
+    /// This function returns true of there is space both in terms of item count
+    /// and byte count for the given item, false otherwise.
+    fn has_space(&self, value: &I) -> bool {
+        let too_many_elements = self.elements.len() + 1 > self.element_limit;
+        let too_many_bytes = self.allocated_bytes + value.size_of() > self.allocation_limit;
+        !(too_many_elements || too_many_bytes)
+    }
+
+    /// Push an element into the batch
+    ///
+    /// This function pushes an element into the batch. Callers must be sure to
+    /// call `has_space` prior to calling this function and receive a positive
+    /// result.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there is not sufficient space in the batch
+    /// for a new element to be inserted.
+    fn push(&mut self, value: I) {
+        assert!(self.has_space(&value));
+        self.allocated_bytes += value.size_of();
+        self.elements.push(value);
+    }
+}
+
+/// Controls the behavior of the batcher in terms of batch size and flush interval.
+///
+/// This is a temporary solution for pushing in a fixed settings structure so we don't have to worry
+/// about misordering parameters and what not.  At some point, we will pull
+/// `BatchConfig`/`BatchSettings`/`BatchSize` out of `vector` and move them into `vector_core`, and
+/// make it more generalized. We can't do that yet, though, until we've converted all of the sinks
+/// with their various specialized batch buffers.
+#[derive(Copy, Clone, Debug)]
+pub struct BatcherSettings {
+    pub timeout: Duration,
+    pub size_limit: usize,
+    pub item_limit: usize,
+}
+
+impl BatcherSettings {
+    pub const fn new(
+        timeout: Duration,
+        size_limit: NonZeroUsize,
+        item_limit: NonZeroUsize,
+    ) -> Self {
+        BatcherSettings {
+            timeout,
+            size_limit: size_limit.get(),
+            item_limit: item_limit.get(),
+        }
+    }
+}
+
+#[pin_project]
+pub struct PartitionedBatcher<St, Prt, KT>
+    where
+        Prt: Partitioner,
+{
+    /// The total number of bytes a single batch in this struct is allowed to
+    /// hold.
+    batch_allocation_limit: usize,
+    /// The maximum number of items that are allowed per-batch
+    batch_item_limit: usize,
+    /// The store of live batches. Note that the key here is an option type,
+    /// on account of the interface of `Prt`.
+    batches: HashMap<Prt::Key, Batch<Prt::Item>, BuildHasherDefault<XxHash64>>,
+    /// The store of 'closed' batches. When this is not empty it will be
+    /// preferentially flushed prior to consuming any new items from the
+    /// underlying stream.
+    closed_batches: Vec<(Prt::Key, Vec<Prt::Item>)>,
+    /// The queue of pending batch expirations
+    timer: KT,
+    /// The partitioner for this `Batcher`
+    partitioner: Prt,
+    #[pin]
+    /// The stream this `Batcher` wraps
+    stream: St,
+}
+
+impl<St, Prt> PartitionedBatcher<St, Prt, ExpirationQueue<Prt::Key>>
+    where
+        St: Stream<Item=Prt::Item>,
+        Prt: Partitioner + Unpin,
+        Prt::Key: Eq + Hash + Clone,
+        Prt::Item: ByteSizeOf,
+{
+    pub fn new(stream: St, partitioner: Prt, settings: BatcherSettings) -> Self {
+        Self {
+            batch_allocation_limit: settings.size_limit,
+            batch_item_limit: settings.item_limit,
+            batches: HashMap::default(),
+            closed_batches: Vec::default(),
+            timer: ExpirationQueue::new(settings.timeout),
+            partitioner,
+            stream,
+        }
+    }
+}
+
+impl<St, Prt, KT> PartitionedBatcher<St, Prt, KT>
+    where
+        St: Stream<Item=Prt::Item>,
+        Prt: Partitioner + Unpin,
+        Prt::Key: Eq + Hash + Clone,
+        Prt::Item: ByteSizeOf,
+{
+    pub fn with_timer(
+        stream: St,
+        partitioner: Prt,
+        timer: KT,
+        batch_item_limit: NonZeroUsize,
+        batch_allocation_limit: Option<NonZeroUsize>,
+    ) -> Self {
+        Self {
+            batch_allocation_limit: batch_allocation_limit
+                .map_or(usize::max_value(), NonZeroUsize::get),
+            batch_item_limit: batch_item_limit.get(),
+            batches: HashMap::default(),
+            closed_batches: Vec::default(),
+            timer,
+            partitioner,
+            stream,
+        }
+    }
+}
+
+impl<St, Prt, KT> Stream for PartitionedBatcher<St, Prt, KT>
+    where
+        St: Stream<Item=Prt::Item>,
+        Prt: Partitioner + Unpin,
+        Prt::Key: Eq + Hash + Clone,
+        Prt::Item: ByteSizeOf,
+        KT: KeyedTimer<Prt::Key>,
+{
+    type Item = (Prt::Key, Vec<Prt::Item>);
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        loop {
+            if !this.closed_batches.is_empty() {
+                return Poll::Ready(this.closed_batches.pop());
+            }
+            match this.stream.as_mut().poll_next(cx) {
+                Poll::Pending => match this.timer.poll_expired(cx) {
+                    // Unlike normal streams, `DelayQueue` can return `None`
+                    // here but still be usable later if more entries are added.
+                    Poll::Pending | Poll::Ready(None) => return Poll::Pending,
+                    Poll::Ready(Some(item_key)) => {
+                        let batch = this
+                            .batches
+                            .remove(&item_key)
+                            .expect("batch should exist if it is set to expire");
+                        this.closed_batches.push((item_key, batch.into_inner()));
+
+                        continue;
+                    }
+                },
+                Poll::Ready(None) => {
+                    // Now that the underlying stream is closed, we need to
+                    // clear out our batches, including all expiration
+                    // entries. If we had any batches to hand over, we have to
+                    // continue looping so the caller can drain them all before
+                    // we finish.
+                    if !this.batches.is_empty() {
+                        this.timer.clear();
+                        this.closed_batches.extend(
+                            this.batches
+                                .drain()
+                                .map(|(key, batch)| (key, batch.into_inner())),
+                        );
+                        continue;
+                    }
+                    return Poll::Ready(None);
+                }
+                Poll::Ready(Some(item)) => {
+                    let item_key = this.partitioner.partition(&item);
+                    let item_limit: usize = *this.batch_item_limit;
+                    let alloc_limit: usize = *this.batch_allocation_limit;
+
+                    if let Some(batch) = this.batches.get_mut(&item_key) {
+                        if batch.has_space(&item) {
+                            // When there's space in the partition batch just
+                            // push the item in and loop back around.
+                            batch.push(item);
+                        } else {
+                            let new_batch = Batch::new(item_limit, alloc_limit).with(item);
+                            let batch = mem::replace(batch, new_batch);
+
+                            // The batch for this partition key was set to
+                            // expire, but now it's overflowed and must be
+                            // pushed out, so now we reset the batch timeout.
+                            this.timer.insert(item_key.clone());
+
+                            this.closed_batches.push((item_key, batch.into_inner()));
+                        }
+                    } else {
+                        // We have no batch yet for this partition key, so
+                        // create one and create the expiration entries as well.
+                        // This allows the batch to expire before filling up,
+                        // and vise versa.
+                        let batch = Batch::new(item_limit, alloc_limit).with(item);
+                        this.batches.insert(item_key.clone(), batch);
+                        this.timer.insert(item_key);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::partition::Partitioner;
+    use crate::stream::batcher::{Batcher, ExpirationQueue};
+    use crate::time::KeyedTimer;
+    use futures::{stream, Stream};
+    use pin_project::pin_project;
+    use proptest::prelude::*;
+    use std::collections::{HashMap, HashSet};
+    use std::num::{NonZeroU8, NonZeroUsize};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+    use tokio::pin;
+    use tokio::time::advance;
+
+    #[derive(Debug)]
+    /// A test keyed timer
+    ///
+    /// This timer implements `KeyedTimer` and is rigged up in such a way that
+    /// it doesn't _actually_ tell time but instead uses a set of canned
+    /// responses for whether deadlines have elapsed or not. This allows us to
+    /// include the notion of time in our property tests below.
+    struct TestTimer {
+        responses: Vec<Poll<Option<u8>>>,
+        valid_keys: HashSet<u8>,
+    }
+
+    impl TestTimer {
+        fn new(responses: Vec<Poll<Option<u8>>>) -> Self {
+            Self {
+                responses,
+                valid_keys: HashSet::new(),
+            }
+        }
+    }
+
+    impl KeyedTimer<u8> for TestTimer {
+        fn clear(&mut self) {
+            self.valid_keys.clear();
+        }
+
+        fn insert(&mut self, item_key: u8) {
+            self.valid_keys.insert(item_key);
+        }
+
+        fn poll_expired(&mut self, _cx: &mut Context) -> Poll<Option<u8>> {
+            match self.responses.pop() {
+                Some(Poll::Pending) => unreachable!(),
+                None | Some(Poll::Ready(None)) => Poll::Ready(None),
+                Some(Poll::Ready(Some(k))) => {
+                    if self.valid_keys.contains(&k) {
+                        Poll::Ready(Some(k))
+                    } else {
+                        Poll::Ready(None)
+                    }
+                }
+            }
+        }
+    }
+
+    fn arb_timer() -> impl Strategy<Value = TestTimer> {
+        // The timer always returns a `Poll::Ready` and never a `Poll::Pending`.
+        Vec::<(bool, u8)>::arbitrary()
+            .prop_map(|v| {
+                v.into_iter()
+                    .map(|(b, k)| {
+                        if b {
+                            Poll::Ready(Some(k))
+                        } else {
+                            Poll::Ready(None)
+                        }
+                    })
+                    .collect()
+            })
+            .prop_map(TestTimer::new)
+    }
+
+    /// A test partitioner
+    ///
+    /// This partitioner is nothing special. It has a large-ish key space but
+    /// not so large that we'll never see batches accumulate properly.
+    #[pin_project]
+    #[derive(Debug)]
+    struct TestPartitioner {
+        key_space: NonZeroU8,
+    }
+
+    impl Partitioner for TestPartitioner {
+        type Item = u64;
+        type Key = u8;
+
+        #[allow(clippy::cast_possible_truncation)]
+        fn partition(&self, item: &Self::Item) -> Self::Key {
+            let key = *item % u64::from(self.key_space.get());
+            key as Self::Key
+        }
+    }
+
+    fn arb_partitioner() -> impl Strategy<Value = TestPartitioner> {
+        (1..u8::max_value(),).prop_map(|(ks,)| TestPartitioner {
+            key_space: NonZeroU8::new(ks).unwrap(),
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn size_hint_eq(stream: Vec<u64>,
+                        item_limit in 1..u16::max_value(),
+                        allocation_limit in 8..128,
+                        partitioner in arb_partitioner(),
+                        timer in arb_timer()) {
+            // Asserts that the size hint of the batcher stream is the same as
+            // that of the internal stream. In the future we may want to produce
+            // a tighter bound -- since batching will reduce some streams -- but
+            // this is the worst case where every incoming item maps to a unique
+            // key.
+            let mut stream = stream::iter(stream.into_iter());
+            let stream_size_hint = stream.size_hint();
+
+            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
+            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
+            let batcher = Batcher::with_timer(&mut stream, partitioner, timer,
+                                              item_limit, Some(allocation_limit));
+            let batcher_size_hint = batcher.size_hint();
+
+            assert_eq!(stream_size_hint, batcher_size_hint);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn batch_item_size_leq_limit(stream: Vec<u64>,
+                                     item_limit in 1..u16::max_value(),
+                                     allocation_limit in 8..128,
+                                     partitioner in arb_partitioner(),
+                                     timer in arb_timer()) {
+            // Asserts that for every received batch the size is always less
+            // than the expected limit.
+            let noop_waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&noop_waker);
+
+            let mut stream = stream::iter(stream.into_iter());
+            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
+            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
+            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
+                                                  timer, item_limit,
+                                                  Some(allocation_limit));
+            let mut batcher = Pin::new(&mut batcher);
+
+            loop {
+                match batcher.as_mut().poll_next(&mut cx) {
+                    Poll::Pending => {}
+                    Poll::Ready(None) => {
+                        break;
+                    }
+                    Poll::Ready(Some((_, batch))) => {
+                        debug_assert!(
+                            batch.len() <= item_limit.get(),
+                            "{} < {}",
+                            batch.len(),
+                            item_limit.get()
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Separates a stream into partitions
+    ///
+    /// This function separates a stream into partitions, preserving the order
+    /// of the items in reverse. This allows for efficient popping to compare
+    /// ordering of receipt.
+    fn separate_partitions(
+        stream: Vec<u64>,
+        partitioner: &TestPartitioner,
+    ) -> HashMap<u8, Vec<u64>> {
+        let mut map = stream
+            .into_iter()
+            .map(|item| {
+                let key = partitioner.partition(&item);
+                (key, item)
+            })
+            .fold(
+                HashMap::default(),
+                |mut acc: HashMap<u8, Vec<u64>>, (key, item)| {
+                    let arr: &mut Vec<u64> = acc.entry(key).or_insert_with(Vec::default);
+                    arr.push(item);
+                    acc
+                },
+            );
+        for part in map.values_mut() {
+            part.reverse();
+        }
+        map
+    }
+
+    proptest! {
+        #[test]
+        fn batch_does_not_reorder(stream: Vec<u64>,
+                                  item_limit in 1..u16::max_value(),
+                                  allocation_limit in 8..128,
+                                  partitioner in arb_partitioner(),
+                                  timer in arb_timer()) {
+            // Asserts that for every received batch received the elements in
+            // the batch are not reordered within a batch. No claim is made on
+            // when batches themselves will issue, batch sizes etc.
+            let noop_waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&noop_waker);
+
+            let mut partitions = separate_partitions(stream.clone(), &partitioner);
+
+            let mut stream = stream::iter(stream.into_iter());
+            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
+            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
+            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
+                                                  timer, item_limit,
+                                                  Some(allocation_limit));
+            let mut batcher = Pin::new(&mut batcher);
+
+            loop {
+                match batcher.as_mut().poll_next(&mut cx) {
+                    Poll::Pending => {}
+                    Poll::Ready(None) => {
+                        break;
+                    }
+                    Poll::Ready(Some((key, actual_batch))) => {
+                        let expected_partition = partitions
+                            .get_mut(&key)
+                            .expect("impossible situation");
+                        for item in actual_batch {
+                            assert_eq!(item, expected_partition.pop().unwrap());
+                        }
+                    }
+                }
+            }
+            for v in partitions.values() {
+                assert!(v.is_empty());
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn batch_does_not_lose_items(stream: Vec<u64>,
+                                     item_limit in 1..u16::max_value(),
+                                     allocation_limit in 8..128,
+                                     partitioner in arb_partitioner(),
+                                     timer in arb_timer()) {
+            // Asserts that for every received batch the sum of all batch sizes
+            // equals the number of stream elements.
+            let noop_waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&noop_waker);
+
+            let total_items = stream.len();
+            let mut stream = stream::iter(stream.into_iter());
+            let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
+            let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
+            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
+                                                  timer, item_limit,
+                                                  Some(allocation_limit));
+            let mut batcher = Pin::new(&mut batcher);
+
+            let mut observed_items = 0;
+            loop {
+                match batcher.as_mut().poll_next(&mut cx) {
+                    Poll::Pending => {}
+                    Poll::Ready(None) => {
+                        // inner stream has shut down, ensure we passed every
+                        // item through the batch
+                        assert_eq!(observed_items, total_items);
+                        break;
+                    }
+                    Poll::Ready(Some((_, batch))) => {
+                        observed_items += batch.len();
+                        assert!(observed_items <= total_items);
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[allow(clippy::semicolon_if_nothing_returned)] // https://github.com/rust-lang/rust-clippy/issues/7438
+    async fn expiration_queue_impl_keyed_timer() {
+        // Asserts that ExpirationQueue properly implements KeyedTimer. We are
+        // primarily concerned with whether expiration is properly observed.
+        let timeout = Duration::from_millis(100); // 1/10 of a second, an
+                                                  // eternity
+
+        let mut expiration_queue: ExpirationQueue<u8> = ExpirationQueue::new(timeout);
+
+        // If the queue is empty assert that when we poll for expired entries
+        // nothing comes back.
+        assert_eq!(0, expiration_queue.len());
+        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
+        assert_eq!(result, Poll::Ready(None));
+
+        // Insert an item key into the queue. Assert that the size of the queue
+        // has grown, assert that the queue still does not believe the item has expired, and _then_
+        // advance time enough to allow it to expire, and assert that it has.
+        expiration_queue.insert(128);
+        assert_eq!(1, expiration_queue.len());
+
+        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
+        assert_eq!(result, Poll::Pending);
+
+        advance(timeout + Duration::from_nanos(1)).await;
+        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
+        assert_eq!(result, Poll::Ready(Some(128)));
+        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
+        assert_eq!(result, Poll::Ready(None));
+
+        // Now we poll assured that the queue has emptied out again.
+        assert_eq!(0, expiration_queue.len());
+        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
+        assert_eq!(result, Poll::Ready(None));
+
+        // Finally, blitz a handful of items into the queue, assert its size,
+        // clear the queue and assert it as being empty.
+        expiration_queue.insert(128);
+        expiration_queue.insert(64);
+        expiration_queue.insert(32);
+        assert_eq!(3, expiration_queue.len());
+        expiration_queue.clear();
+        assert_eq!(0, expiration_queue.len());
+        let result = single_poll(|cx| expiration_queue.poll_expired(cx));
+        assert_eq!(result, Poll::Ready(None));
+    }
+
+    fn single_poll<T, F>(mut f: F) -> Poll<T>
+    where
+        F: FnMut(&mut Context<'_>) -> Poll<T>,
+    {
+        let noop_waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&noop_waker);
+
+        f(&mut cx)
+    }
+}

--- a/lib/vector-core/src/stream/partitioned_batcher.rs
+++ b/lib/vector-core/src/stream/partitioned_batcher.rs
@@ -1,8 +1,8 @@
 use crate::partition::Partitioner;
 use crate::time::KeyedTimer;
 use crate::ByteSizeOf;
-use futures::{ready, Future, StreamExt};
-use futures::stream::{Stream, Fuse};
+use futures::{ready, StreamExt};
+use futures::stream::{Stream};
 use pin_project::pin_project;
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hash};
@@ -14,7 +14,7 @@ use std::{cmp, mem};
 use tokio_util::time::delay_queue::Key;
 use tokio_util::time::DelayQueue;
 use twox_hash::XxHash64;
-use tokio::time::Sleep;
+
 
 /// A `KeyedTimer` based on `DelayQueue`.
 pub struct ExpirationQueue<K> {
@@ -403,7 +403,7 @@ impl<St, Prt, KT> Stream for PartitionedBatcher<St, Prt, KT>
 #[cfg(test)]
 mod test {
     use crate::partition::Partitioner;
-    use crate::stream::batcher::{Batcher, ExpirationQueue};
+    use crate::stream::partitioned_batcher::{PartitionedBatcher, ExpirationQueue};
     use crate::time::KeyedTimer;
     use futures::{stream, Stream};
     use pin_project::pin_project;
@@ -522,7 +522,7 @@ mod test {
 
             let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
             let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let batcher = Batcher::with_timer(&mut stream, partitioner, timer,
+            let batcher = PartitionedBatcher::with_timer(&mut stream, partitioner, timer,
                                               item_limit, Some(allocation_limit));
             let batcher_size_hint = batcher.size_hint();
 
@@ -545,7 +545,7 @@ mod test {
             let mut stream = stream::iter(stream.into_iter());
             let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
             let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
+            let mut batcher = PartitionedBatcher::with_timer(&mut stream, partitioner,
                                                   timer, item_limit,
                                                   Some(allocation_limit));
             let mut batcher = Pin::new(&mut batcher);
@@ -616,7 +616,7 @@ mod test {
             let mut stream = stream::iter(stream.into_iter());
             let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
             let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
+            let mut batcher = PartitionedBatcher::with_timer(&mut stream, partitioner,
                                                   timer, item_limit,
                                                   Some(allocation_limit));
             let mut batcher = Pin::new(&mut batcher);
@@ -659,7 +659,7 @@ mod test {
             let mut stream = stream::iter(stream.into_iter());
             let item_limit = NonZeroUsize::new(item_limit as usize).unwrap();
             let allocation_limit = NonZeroUsize::new(allocation_limit as usize).unwrap();
-            let mut batcher = Batcher::with_timer(&mut stream, partitioner,
+            let mut batcher = PartitionedBatcher::with_timer(&mut stream, partitioner,
                                                   timer, item_limit,
                                                   Some(allocation_limit));
             let mut batcher = Pin::new(&mut batcher);

--- a/lib/vector-core/src/stream/partitioned_batcher.rs
+++ b/lib/vector-core/src/stream/partitioned_batcher.rs
@@ -1,8 +1,8 @@
 use crate::partition::Partitioner;
 use crate::time::KeyedTimer;
 use crate::ByteSizeOf;
-use futures::{ready, StreamExt};
-use futures::stream::{Stream};
+use futures::ready;
+use futures::stream::Stream;
 use pin_project::pin_project;
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hash};
@@ -14,7 +14,6 @@ use std::{cmp, mem};
 use tokio_util::time::delay_queue::Key;
 use tokio_util::time::DelayQueue;
 use twox_hash::XxHash64;
-
 
 /// A `KeyedTimer` based on `DelayQueue`.
 pub struct ExpirationQueue<K> {
@@ -53,8 +52,8 @@ impl<K> ExpirationQueue<K> {
 }
 
 impl<K> KeyedTimer<K> for ExpirationQueue<K>
-    where
-        K: Eq + Hash + Clone,
+where
+    K: Eq + Hash + Clone,
 {
     fn clear(&mut self) {
         self.expirations.clear();
@@ -129,8 +128,8 @@ impl<I> ByteSizeOf for Batch<I> {
 }
 
 impl<I> Batch<I>
-    where
-        I: ByteSizeOf,
+where
+    I: ByteSizeOf,
 {
     /// Create a new Batch instance
     ///
@@ -241,8 +240,8 @@ impl BatcherSettings {
 
 #[pin_project]
 pub struct PartitionedBatcher<St, Prt, KT>
-    where
-        Prt: Partitioner,
+where
+    Prt: Partitioner,
 {
     /// The total number of bytes a single batch in this struct is allowed to
     /// hold.
@@ -266,11 +265,11 @@ pub struct PartitionedBatcher<St, Prt, KT>
 }
 
 impl<St, Prt> PartitionedBatcher<St, Prt, ExpirationQueue<Prt::Key>>
-    where
-        St: Stream<Item=Prt::Item>,
-        Prt: Partitioner + Unpin,
-        Prt::Key: Eq + Hash + Clone,
-        Prt::Item: ByteSizeOf,
+where
+    St: Stream<Item = Prt::Item>,
+    Prt: Partitioner + Unpin,
+    Prt::Key: Eq + Hash + Clone,
+    Prt::Item: ByteSizeOf,
 {
     pub fn new(stream: St, partitioner: Prt, settings: BatcherSettings) -> Self {
         Self {
@@ -286,11 +285,11 @@ impl<St, Prt> PartitionedBatcher<St, Prt, ExpirationQueue<Prt::Key>>
 }
 
 impl<St, Prt, KT> PartitionedBatcher<St, Prt, KT>
-    where
-        St: Stream<Item=Prt::Item>,
-        Prt: Partitioner + Unpin,
-        Prt::Key: Eq + Hash + Clone,
-        Prt::Item: ByteSizeOf,
+where
+    St: Stream<Item = Prt::Item>,
+    Prt: Partitioner + Unpin,
+    Prt::Key: Eq + Hash + Clone,
+    Prt::Item: ByteSizeOf,
 {
     pub fn with_timer(
         stream: St,
@@ -313,12 +312,12 @@ impl<St, Prt, KT> PartitionedBatcher<St, Prt, KT>
 }
 
 impl<St, Prt, KT> Stream for PartitionedBatcher<St, Prt, KT>
-    where
-        St: Stream<Item=Prt::Item>,
-        Prt: Partitioner + Unpin,
-        Prt::Key: Eq + Hash + Clone,
-        Prt::Item: ByteSizeOf,
-        KT: KeyedTimer<Prt::Key>,
+where
+    St: Stream<Item = Prt::Item>,
+    Prt: Partitioner + Unpin,
+    Prt::Key: Eq + Hash + Clone,
+    Prt::Item: ByteSizeOf,
+    KT: KeyedTimer<Prt::Key>,
 {
     type Item = (Prt::Key, Vec<Prt::Item>);
 
@@ -403,7 +402,7 @@ impl<St, Prt, KT> Stream for PartitionedBatcher<St, Prt, KT>
 #[cfg(test)]
 mod test {
     use crate::partition::Partitioner;
-    use crate::stream::partitioned_batcher::{PartitionedBatcher, ExpirationQueue};
+    use crate::stream::partitioned_batcher::{ExpirationQueue, PartitionedBatcher};
     use crate::time::KeyedTimer;
     use futures::{stream, Stream};
     use pin_project::pin_project;

--- a/src/sinks/aws_kinesis_firehose/sink.rs
+++ b/src/sinks/aws_kinesis_firehose/sink.rs
@@ -43,7 +43,7 @@ impl KinesisSink {
                     Ok(req) => Some(req),
                 }
             })
-            .batched( self.batch_settings, ByteSizeOfBatchSize)
+            .batched(self.batch_settings, ByteSizeOfBatchSize)
             .into_driver(self.service, self.acker);
 
         sink.run().await

--- a/src/sinks/aws_kinesis_firehose/sink.rs
+++ b/src/sinks/aws_kinesis_firehose/sink.rs
@@ -9,7 +9,7 @@ use crate::Error;
 use futures::stream::BoxStream;
 use tower::util::BoxService;
 use vector_core::sink::StreamSink;
-use vector_core::stream::{BatcherSettings, ByteSizeOfBatchSize};
+use vector_core::stream::{BatcherSettings, ByteSizeOfItemSize};
 
 use crate::sinks::util::SinkBuilderExt;
 use async_trait::async_trait;
@@ -43,7 +43,7 @@ impl KinesisSink {
                     Ok(req) => Some(req),
                 }
             })
-            .batched(self.batch_settings, ByteSizeOfBatchSize)
+            .batched(self.batch_settings, ByteSizeOfItemSize)
             .into_driver(self.service, self.acker);
 
         sink.run().await

--- a/src/sinks/aws_kinesis_firehose/sink.rs
+++ b/src/sinks/aws_kinesis_firehose/sink.rs
@@ -8,9 +8,8 @@ use crate::sinks::aws_kinesis_firehose::service::KinesisResponse;
 use crate::Error;
 use futures::stream::BoxStream;
 use tower::util::BoxService;
-use vector_core::partition::NullPartitioner;
 use vector_core::sink::StreamSink;
-use vector_core::stream::BatcherSettings;
+use vector_core::stream::{BatcherSettings, ByteSizeOfBatchSize};
 
 use crate::sinks::util::SinkBuilderExt;
 use async_trait::async_trait;
@@ -44,8 +43,7 @@ impl KinesisSink {
                     Ok(req) => Some(req),
                 }
             })
-            .batched(NullPartitioner::new(), self.batch_settings)
-            .map(|(_, batch)| batch)
+            .batched( self.batch_settings, ByteSizeOfBatchSize)
             .into_driver(self.service, self.acker);
 
         sink.run().await

--- a/src/sinks/aws_kinesis_streams/sink.rs
+++ b/src/sinks/aws_kinesis_streams/sink.rs
@@ -8,8 +8,7 @@ use rand::random;
 use std::num::NonZeroUsize;
 use tower::util::BoxService;
 use vector_core::buffers::Acker;
-use vector_core::partition::NullPartitioner;
-use vector_core::stream::BatcherSettings;
+use vector_core::stream::{BatcherSettings, ByteSizeOfBatchSize};
 
 use crate::sinks::util::processed_event::ProcessedEvent;
 use crate::sinks::util::{SinkBuilderExt, StreamSink};
@@ -51,8 +50,7 @@ impl KinesisSink {
                     Ok(req) => Some(req),
                 }
             })
-            .batched(NullPartitioner::new(), self.batch_settings)
-            .map(|(_, batch)| batch)
+            .batched( self.batch_settings, ByteSizeOfBatchSize)
             .into_driver(self.service, self.acker);
 
         sink.run().await

--- a/src/sinks/aws_kinesis_streams/sink.rs
+++ b/src/sinks/aws_kinesis_streams/sink.rs
@@ -50,7 +50,7 @@ impl KinesisSink {
                     Ok(req) => Some(req),
                 }
             })
-            .batched( self.batch_settings, ByteSizeOfBatchSize)
+            .batched(self.batch_settings, ByteSizeOfBatchSize)
             .into_driver(self.service, self.acker);
 
         sink.run().await

--- a/src/sinks/aws_kinesis_streams/sink.rs
+++ b/src/sinks/aws_kinesis_streams/sink.rs
@@ -8,7 +8,7 @@ use rand::random;
 use std::num::NonZeroUsize;
 use tower::util::BoxService;
 use vector_core::buffers::Acker;
-use vector_core::stream::{BatcherSettings, ByteSizeOfBatchSize};
+use vector_core::stream::{BatcherSettings, ByteSizeOfItemSize};
 
 use crate::sinks::util::processed_event::ProcessedEvent;
 use crate::sinks::util::{SinkBuilderExt, StreamSink};
@@ -50,7 +50,7 @@ impl KinesisSink {
                     Ok(req) => Some(req),
                 }
             })
-            .batched(self.batch_settings, ByteSizeOfBatchSize)
+            .batched(self.batch_settings, ByteSizeOfItemSize)
             .into_driver(self.service, self.acker);
 
         sink.run().await

--- a/src/sinks/azure_common/sink.rs
+++ b/src/sinks/azure_common/sink.rs
@@ -57,7 +57,7 @@ where
         let request_builder = self.request_builder;
 
         let sink = input
-            .batched(partitioner, settings)
+            .batched_partitioned(partitioner, settings)
             .filter_map(|(key, batch)| async move { key.map(move |k| (k, batch)) })
             .request_builder(builder_limit, request_builder)
             .filter_map(|request| async move {

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -229,7 +229,7 @@ where
         };
 
         let sink = input
-            .batched(partitioner, self.batch_settings)
+            .batched_partitioned(partitioner, self.batch_settings)
             .request_builder(builder_limit, request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/datadog/metrics/sink.rs
+++ b/src/sinks/datadog/metrics/sink.rs
@@ -87,7 +87,7 @@ where
             .normalized::<DatadogMetricsNormalizer>()
             // We batch metrics by their endpoint i.e. series (counter, gauge, set) vs sketch
             // (distributions, aggregated histograms, metrics that are already sketches)
-            .batched(DatadogMetricsTypePartitioner, self.batch_settings)
+            .batched_partitioned(DatadogMetricsTypePartitioner, self.batch_settings)
             // We build our requests "incrementally", which means that for a single batch of
             // metrics, we might generate N requests to send them all, as Datadog has API-level
             // limits on payload size, so we keep adding metrics to a request until we reach the

--- a/src/sinks/elasticsearch/sink.rs
+++ b/src/sinks/elasticsearch/sink.rs
@@ -3,7 +3,6 @@ use crate::sinks::util::{Compression, SinkBuilderExt, StreamSink};
 use futures::stream::BoxStream;
 use std::num::NonZeroUsize;
 use vector_core::buffers::Acker;
-use vector_core::partition::NullPartitioner;
 
 use crate::event::Value;
 use crate::sinks::elasticsearch::encoder::ProcessedEvent;
@@ -16,7 +15,7 @@ use async_trait::async_trait;
 use futures::future;
 use futures::StreamExt;
 use tower::util::BoxService;
-use vector_core::stream::BatcherSettings;
+use vector_core::stream::{BatcherSettings, ByteSizeOfBatchSize};
 use vector_core::ByteSizeOf;
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -63,8 +62,9 @@ impl ElasticSearchSink {
             })
             .filter_map(|x| async move { x })
             .filter_map(move |log| future::ready(process_log(log, &mode, &id_key_field)))
-            .batched(NullPartitioner::new(), self.batch_settings)
-            .map(|(_, batch)| batch)
+            // .batched(NullPartitioner::new(), self.batch_settings)
+            // .map(|(_, batch)| batch)
+            .batched(self.batch_settings, ByteSizeOfBatchSize)
             .request_builder(request_builder_concurrency_limit, self.request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/elasticsearch/sink.rs
+++ b/src/sinks/elasticsearch/sink.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use futures::future;
 use futures::StreamExt;
 use tower::util::BoxService;
-use vector_core::stream::{BatcherSettings, ByteSizeOfBatchSize};
+use vector_core::stream::{BatcherSettings, ByteSizeOfItemSize};
 use vector_core::ByteSizeOf;
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -64,7 +64,7 @@ impl ElasticSearchSink {
             .filter_map(move |log| future::ready(process_log(log, &mode, &id_key_field)))
             // .batched(NullPartitioner::new(), self.batch_settings)
             // .map(|(_, batch)| batch)
-            .batched(self.batch_settings, ByteSizeOfBatchSize)
+            .batched(self.batch_settings, ByteSizeOfItemSize)
             .request_builder(request_builder_concurrency_limit, self.request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/elasticsearch/sink.rs
+++ b/src/sinks/elasticsearch/sink.rs
@@ -62,8 +62,6 @@ impl ElasticSearchSink {
             })
             .filter_map(|x| async move { x })
             .filter_map(move |log| future::ready(process_log(log, &mode, &id_key_field)))
-            // .batched(NullPartitioner::new(), self.batch_settings)
-            // .map(|(_, batch)| batch)
             .batched(self.batch_settings, ByteSizeOfItemSize)
             .request_builder(request_builder_concurrency_limit, self.request_builder)
             .filter_map(|request| async move {

--- a/src/sinks/gcs_common/sink.rs
+++ b/src/sinks/gcs_common/sink.rs
@@ -57,7 +57,7 @@ where
         let request_builder = self.request_builder;
 
         let sink = input
-            .batched(partitioner, settings)
+            .batched_partitioned(partitioner, settings)
             .filter_map(|(key, batch)| async move { key.map(move |k| (k, batch)) })
             .request_builder(builder_limit, request_builder)
             .filter_map(|request| async move {

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -320,7 +320,7 @@ impl LokiSink {
                 let res = filter.filter_record(record);
                 async { res }
             })
-            .batched(RecordPartitionner::default(), self.batch_settings)
+            .batched_partitioned(RecordPartitionner::default(), self.batch_settings)
             .request_builder(NonZeroUsize::new(1), self.request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -59,7 +59,7 @@ where
         let request_builder = self.request_builder;
 
         let sink = input
-            .batched(partitioner, settings)
+            .batched_partitioned(partitioner, settings)
             .filter_map(|(key, batch)| async move { key.map(move |k| (k, batch)) })
             .request_builder(builder_limit, request_builder)
             .filter_map(|request| async move {

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -3,11 +3,10 @@ use std::{fmt, num::NonZeroUsize};
 use async_trait::async_trait;
 use futures_util::{future, stream::BoxStream, StreamExt};
 use tower::Service;
-use vector_core::stream::DriverResponse;
+use vector_core::stream::{DriverResponse, ByteSizeOfBatchSize};
 use vector_core::{
     config::log_schema,
     event::{Event, LogEvent, Value},
-    partition::NullPartitioner,
     sink::StreamSink,
     stream::BatcherSettings,
     ByteSizeOf,
@@ -64,8 +63,7 @@ where
                     indexed_fields,
                 ))
             })
-            .batched(NullPartitioner::new(), self.batch_settings)
-            .map(|(_, batch)| batch)
+            .batched(self.batch_settings, ByteSizeOfBatchSize)
             .request_builder(builder_limit, self.request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -3,7 +3,7 @@ use std::{fmt, num::NonZeroUsize};
 use async_trait::async_trait;
 use futures_util::{future, stream::BoxStream, StreamExt};
 use tower::Service;
-use vector_core::stream::{DriverResponse, ByteSizeOfBatchSize};
+use vector_core::stream::{ByteSizeOfBatchSize, DriverResponse};
 use vector_core::{
     config::log_schema,
     event::{Event, LogEvent, Value},

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -3,7 +3,7 @@ use std::{fmt, num::NonZeroUsize};
 use async_trait::async_trait;
 use futures_util::{future, stream::BoxStream, StreamExt};
 use tower::Service;
-use vector_core::stream::{ByteSizeOfBatchSize, DriverResponse};
+use vector_core::stream::{ByteSizeOfItemSize, DriverResponse};
 use vector_core::{
     config::log_schema,
     event::{Event, LogEvent, Value},
@@ -63,7 +63,7 @@ where
                     indexed_fields,
                 ))
             })
-            .batched(self.batch_settings, ByteSizeOfBatchSize)
+            .batched(self.batch_settings, ByteSizeOfItemSize)
             .request_builder(builder_limit, self.request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/splunk_hec/metrics/sink.rs
+++ b/src/sinks/splunk_hec/metrics/sink.rs
@@ -14,13 +14,13 @@ use futures_util::{future, stream::BoxStream, StreamExt};
 use tower::Service;
 use vector_core::{
     event::{Event, Metric, MetricValue},
-    partition::NullPartitioner,
     sink::StreamSink,
     stream::{BatcherSettings, DriverResponse},
     ByteSizeOf,
 };
 
 use super::request_builder::HecMetricsRequestBuilder;
+use vector_core::stream::ByteSizeOfBatchSize;
 
 pub struct HecMetricsSink<S> {
     pub context: SinkContext,
@@ -62,8 +62,7 @@ where
                     default_namespace,
                 ))
             })
-            .batched(NullPartitioner::new(), self.batch_settings)
-            .map(|(_, batch)| batch)
+            .batched(self.batch_settings, ByteSizeOfBatchSize)
             .request_builder(builder_limit, self.request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/splunk_hec/metrics/sink.rs
+++ b/src/sinks/splunk_hec/metrics/sink.rs
@@ -20,7 +20,7 @@ use vector_core::{
 };
 
 use super::request_builder::HecMetricsRequestBuilder;
-use vector_core::stream::ByteSizeOfBatchSize;
+use vector_core::stream::ByteSizeOfItemSize;
 
 pub struct HecMetricsSink<S> {
     pub context: SinkContext,
@@ -62,7 +62,7 @@ where
                     default_namespace,
                 ))
             })
-            .batched(self.batch_settings, ByteSizeOfBatchSize)
+            .batched(self.batch_settings, ByteSizeOfItemSize)
             .request_builder(builder_limit, self.request_builder)
             .filter_map(|request| async move {
                 match request {

--- a/src/sinks/util/builder.rs
+++ b/src/sinks/util/builder.rs
@@ -40,13 +40,13 @@ pub trait SinkBuilderExt: Stream {
         PartitionedBatcher::new(self, partitioner, settings)
     }
 
-    /// Batches the stream based on the given batch settings and batch size calculator.
+    /// Batches the stream based on the given batch settings and item size calculator.
     ///
     /// The stream will yield batches of events, when either a batch fills
-    /// up or times out. The `batch_size_calculator` determines the "size" of each input
+    /// up or times out. The `item_size_calculator` determines the "size" of each input
     /// in a batch. The units of "size" are intentionally not defined, so you can choose
     /// whatever is needed.
-    fn batched<T>(self, settings: BatcherSettings, batch_size_calculator: T) -> Batcher<Self, T>
+    fn batched<T>(self, settings: BatcherSettings, item_size_calculator: T) -> Batcher<Self, T>
     where
         T: ItemBatchSize<Self::Item>,
         Self: Sized,

--- a/src/sinks/util/builder.rs
+++ b/src/sinks/util/builder.rs
@@ -51,7 +51,7 @@ pub trait SinkBuilderExt: Stream {
         T: ItemBatchSize<Self::Item>,
         Self: Sized,
     {
-        Batcher::new(self, settings, batch_size_calculator)
+        Batcher::new(self, settings, item_size_calculator)
     }
 
     /// Maps the items in the stream concurrently, up to the configured limit.


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/9720

A new `Batcher` was added, and the existing one was renamed to `PartitionedBatcher`.

There are multiple benefits of this re-write:
1. Partitioning is no longer required for the `Batcher`. This cleans up the code a bit, and removed the `NullPartitioner`. It also allows some optimizations such as removing the unnecessary overhead of using a `HashMap`.

2. The previous batcher required the use of the `ByteSizeOf` trait for determining the size of a batch. This implementation allows you to use anything (and an implementation that falls back to `ByteSizeOf` was added for easy migration). This is especially important for types that couldn't directly implement `BytesSizeOf` such as the protobuf types used in the `Vector` sink.

There are a few future improvements that I would like to eventually add, but are out of scope for this PR:
1. There are now 2 `Batcher` implementations. The `PartitionedBatcher` can likely be replaced with a wrapper around the new `Batcher`.
2. The new `Batcher` can be made even more generic. Right now it has a fairly strict definition of what a "batch" is. It's always a `Vec<T>`, and the size is always defined as a single integer. This could be made more generic so it could eventually be used for implementing batching along with encoding, (ex: encode an event, and append it to a batch, but only if it actually fits).