### PR TITLE
feat(pipelines transform): forbid nesting pipelines transform

### DIFF
--- a/lib/vector-core/src/transform/config.rs
+++ b/lib/vector-core/src/transform/config.rs
@@ -1,6 +1,7 @@
 use crate::config::{ComponentKey, GlobalOptions};
 use async_trait::async_trait;
 use indexmap::IndexMap;
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum DataType {
@@ -61,6 +62,12 @@ pub trait TransformConfig: core::fmt::Debug + Send + Sync + dyn_clone::DynClone 
     }
 
     fn transform_type(&self) -> &'static str;
+
+    /// Allows to detect if a transform can be embedded in another transform.
+    /// It's used by the pipelines transform for now.
+    fn nestable(&self, _parents: &HashSet<&'static str>) -> bool {
+        true
+    }
 
     /// Allows a transform configuration to expand itself into multiple "child"
     /// transformations to replace it. This allows a transform to act as a macro

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,5 +1,6 @@
 use super::{builder::ConfigBuilder, graph::Graph, validation, ComponentKey, Config, OutputId};
 use indexmap::{IndexMap, IndexSet};
+use std::collections::HashSet;
 
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();
@@ -116,9 +117,15 @@ pub(super) fn expand_macros(
     let mut expanded_transforms = IndexMap::new();
     let mut expansions = IndexMap::new();
     let mut errors = Vec::new();
+    let parent_types = HashSet::new();
 
     while let Some((key, transform)) = config.transforms.pop() {
-        if let Err(error) = transform.expand(key, &mut expanded_transforms, &mut expansions) {
+        if let Err(error) = transform.expand(
+            key,
+            &parent_types,
+            &mut expanded_transforms,
+            &mut expansions,
+        ) {
             errors.push(error);
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -446,13 +446,25 @@ impl TransformOuter<String> {
     pub(crate) fn expand(
         mut self,
         key: ComponentKey,
+        parent_types: &HashSet<&'static str>,
         transforms: &mut IndexMap<ComponentKey, TransformOuter<String>>,
         expansions: &mut IndexMap<ComponentKey, Vec<ComponentKey>>,
     ) -> Result<(), String> {
+        if !self.inner.nestable(parent_types) {
+            return Err(format!(
+                "the component {} cannot be nested in {:?}",
+                self.inner.transform_type(),
+                parent_types
+            ));
+        }
+
         let expansion = self
             .inner
             .expand()
             .map_err(|err| format!("failed to expand transform '{}': {}", key, err))?;
+
+        let mut ptypes = parent_types.clone();
+        ptypes.insert(self.inner.transform_type());
 
         if let Some((expanded, expand_type)) = expansion {
             let mut children = Vec::new();
@@ -465,7 +477,7 @@ impl TransformOuter<String> {
                     inputs,
                     inner: content,
                 };
-                child.expand(full_name.clone(), transforms, expansions)?;
+                child.expand(full_name.clone(), &ptypes, transforms, expansions)?;
                 children.push(full_name.clone());
 
                 inputs = match expand_type {
@@ -1144,5 +1156,51 @@ mod resource_tests {
             Some(Format::Toml),
         )
         .is_err());
+    }
+}
+
+#[cfg(all(
+    test,
+    feature = "sources-stdin",
+    feature = "sinks-console",
+    feature = "transforms-pipelines",
+    feature = "transforms-filter"
+))]
+mod pipelines_tests {
+    use super::{load_from_str, Format};
+    use indoc::indoc;
+
+    #[test]
+    fn forbid_pipeline_nesting() {
+        let res = load_from_str(
+            indoc! {r#"
+                [sources.in]
+                  type = "stdin"
+
+                [transforms.processing]
+                  inputs = ["in"]
+                  type = "pipelines"
+
+                  [transforms.processing.logs.pipelines.foo]
+                    name = "foo"
+
+                    [[transforms.processing.logs.pipelines.foo.transforms]]
+                      type = "pipelines"
+
+                      [transforms.processing.logs.pipelines.foo.transforms.logs.pipelines.bar]
+                        name = "bar"
+
+                          [[transforms.processing.logs.pipelines.foo.transforms.logs.pipelines.bar.transforms]]
+                            type = "filter"
+                            condition = ""
+
+                [sinks.out]
+                  type = "console"
+                  inputs = ["processing"]
+                  encoding = "json"
+            "#},
+            Some(Format::Toml),
+        );
+        assert!(res.is_err(), "should error");
     }
 }

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -65,6 +65,7 @@ use crate::config::{
 use crate::transforms::Transform;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 inventory::submit! {
     TransformDescription::new::<PipelinesConfig>("pipelines")
@@ -208,6 +209,11 @@ impl TransformConfig for PipelinesConfig {
     fn transform_type(&self) -> &'static str {
         "pipelines"
     }
+
+    /// The pipelines transform shouldn't be embedded in another pipelines transform.
+    fn nestable(&self, parents: &HashSet<&'static str>) -> bool {
+        !parents.contains(&self.transform_type())
+    }
 }
 
 impl GenerateConfig for PipelinesConfig {
@@ -251,6 +257,7 @@ mod tests {
     use super::{GenerateConfig, PipelinesConfig};
     use crate::config::{ComponentKey, TransformOuter};
     use indexmap::IndexMap;
+    use std::collections::HashSet;
 
     #[test]
     fn generate_config() {
@@ -279,8 +286,9 @@ mod tests {
         let name = ComponentKey::global("foo");
         let mut transforms = IndexMap::new();
         let mut expansions = IndexMap::new();
+        let parents = HashSet::new();
         outer
-            .expand(name, &mut transforms, &mut expansions)
+            .expand(name, &parents, &mut transforms, &mut expansions)
             .unwrap();
         assert_eq!(transforms.len(), 9);
         assert_eq!(


### PR DESCRIPTION
The pipelines transform should not be nested in another pipelines transform.
This PR adds a new `nestable` method to the `TransformConfig` trait to check if a transform can be embedded in some parent transforms.
For now, it's only used by the pipelines transform and the result defaults to `true` for all the other transforms.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>