### PR TITLE
chore: Clean unused images from soak machines

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -220,7 +220,6 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Run baseline experiment
-        if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
           rm -rf /tmp/${{ github.event.number }}-${{ github.run_attempt }}/
           mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
@@ -239,6 +238,10 @@ jobs:
           name: ${{ github.event.number }}-${{ github.run_attempt }}-${{ matrix.target }}-baseline
           path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/baseline.captures
 
+      - name: Clear up unused images
+        run: |
+          docker system prune --all
+
   soak-comparison:
     name: Soak (${{ matrix.target }}) - comparison
     if: ${{ github.actor != 'dependabot[bot]' }}
@@ -251,7 +254,6 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Run comparison experiment
-        if: steps.cache-primes.outputs.cache-hit != 'true'
         run: |
           rm -rf /tmp/${{ github.event.number }}-${{ github.run_attempt }}/
           mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
@@ -269,6 +271,10 @@ jobs:
         with:
           name: ${{ github.event.number }}-${{ github.run_attempt }}-${{ matrix.target }}-comparison
           path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/comparison.captures
+
+      - name: Clear up unused images
+        run: |
+          docker system prune --all
 
   analyze-results:
     name: Soak analysis

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Clear up unused images
         run: |
-          docker system prune --all
+          docker system prune --all --volumes --force
 
   soak-comparison:
     name: Soak (${{ matrix.target }}) - comparison
@@ -274,7 +274,7 @@ jobs:
 
       - name: Clear up unused images
         run: |
-          docker system prune --all
+          docker system prune --all --volumes --force
 
   analyze-results:
     name: Soak analysis


### PR DESCRIPTION
This commit removes unused docker images from the soak machines after running an
experiment. We have found that the machines get gradually more slow as time
wears on and one hypothesis is that this has to do with the number of unused
images sitting around. In any event this will help our soak machines not run out
of disk space so quickly.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
