### PR TITLE
chore(influxdb_logs sink, influxdb_metrics sink): Reduce unneeded string clones

### DIFF
--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -193,7 +193,7 @@ impl HttpSink for InfluxDbLogsSink {
         let mut output = String::new();
         if let Err(error) = influx_line_protocol(
             self.protocol_version,
-            measurement,
+            &measurement,
             "logs",
             Some(tags),
             Some(fields),

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -260,7 +260,7 @@ fn encode_events(
 
         if let Err(error) = influx_line_protocol(
             protocol_version,
-            fullname,
+            &fullname,
             metric_type,
             tags,
             fields,

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -170,7 +170,7 @@ fn healthcheck(
 // https://v2.docs.influxdata.com/v2.0/reference/syntax/line-protocol/
 pub(in crate::sinks) fn influx_line_protocol(
     protocol_version: ProtocolVersion,
-    measurement: String,
+    measurement: &str,
     metric_type: &str,
     tags: Option<BTreeMap<String, String>>,
     fields: Option<HashMap<String, Field>>,
@@ -209,9 +209,9 @@ fn encode_tags(tags: BTreeMap<String, String>, output: &mut String) {
         if key.is_empty() || value.is_empty() {
             continue;
         }
-        encode_string(key.to_string(), output);
+        encode_string(&key, output);
         output.push('=');
-        encode_string(value.to_string(), output);
+        encode_string(&value, output);
         output.push(',');
     }
 
@@ -225,7 +225,7 @@ fn encode_fields(
     output: &mut String,
 ) {
     for (key, value) in fields.into_iter() {
-        encode_string(key.to_string(), output);
+        encode_string(&key, output);
         output.push('=');
         match value {
             Field::String(s) => {
@@ -262,7 +262,7 @@ fn encode_fields(
     output.pop();
 }
 
-fn encode_string(key: String, output: &mut String) {
+fn encode_string(key: &str, output: &mut String) {
     for c in key.chars() {
         if "\\, =".contains(c) {
             output.push('\\');
@@ -726,19 +726,19 @@ mod tests {
     #[test]
     fn test_encode_string() {
         let mut value = String::new();
-        encode_string("measurement_name".to_string(), &mut value);
+        encode_string("measurement_name", &mut value);
         assert_eq!(value, "measurement_name");
 
         let mut value = String::new();
-        encode_string("measurement name".to_string(), &mut value);
+        encode_string("measurement name", &mut value);
         assert_eq!(value, "measurement\\ name");
 
         let mut value = String::new();
-        encode_string("measurement=name".to_string(), &mut value);
+        encode_string("measurement=name", &mut value);
         assert_eq!(value, "measurement\\=name");
 
         let mut value = String::new();
-        encode_string("measurement,name".to_string(), &mut value);
+        encode_string("measurement,name", &mut value);
         assert_eq!(value, "measurement\\,name");
     }
 

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -249,7 +249,7 @@ fn encode_events(
 
         if let Err(error) = influx_line_protocol(
             ProtocolVersion::V1,
-            namespace,
+            &namespace,
             metric_type,
             Some(tags),
             Some(fields),


### PR DESCRIPTION
A small performance optimization in the hot path of the influxdb sinks, discovered while reviewing #10082. I'm sure there are other opportunities here, this was just a quick and easy find.

Signed-off-by: Bruce Guenter <bruce.guenter@datadoghq.com>
