### PR TITLE
chore(codecs): Rename `TcpError` -> `StreamDecodingError`

### DIFF
--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -2,7 +2,7 @@ use super::errors::{ParseRecords, RequestError};
 use super::models::{EncodedFirehoseRecord, FirehoseRequest, FirehoseResponse};
 use super::Compression;
 use crate::codecs;
-use crate::sources::util::TcpError;
+use crate::sources::util::StreamDecodingError;
 use crate::{
     config::log_schema,
     event::{BatchStatus, Event},

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -3,7 +3,7 @@ use crate::config::log_schema;
 use crate::event::BatchStatus;
 use crate::event::{BatchNotifier, Event};
 use crate::shutdown::ShutdownSignal;
-use crate::sources::util::TcpError;
+use crate::sources::util::StreamDecodingError;
 use crate::Pipeline;
 use aws_sdk_sqs::model::{DeleteMessageBatchRequestEntry, MessageSystemAttributeName};
 use std::collections::HashMap;

--- a/src/sources/datadog/agent.rs
+++ b/src/sources/datadog/agent.rs
@@ -12,7 +12,7 @@ use crate::{
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::{
         self,
-        util::{ErrorMessage, TcpError},
+        util::{ErrorMessage, StreamDecodingError},
     },
     tls::{MaybeTlsSettings, TlsConfig},
     Pipeline,

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -7,7 +7,7 @@ use crate::{
     internal_events::DemoLogsEventProcessed,
     serde::{default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
-    sources::util::TcpError,
+    sources::util::StreamDecodingError,
     Pipeline,
 };
 use bytes::Bytes;

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     internal_events::{ExecCommandExecuted, ExecEventsReceived, ExecFailed, ExecTimeout},
     serde::{default_decoding, default_framing_stream_based},
     shutdown::ShutdownSignal,
-    sources::util::TcpError,
+    sources::util::StreamDecodingError,
     Pipeline,
 };
 use bytes::Bytes;

--- a/src/sources/fluent.rs
+++ b/src/sources/fluent.rs
@@ -1,4 +1,4 @@
-use super::util::{SocketListenAddr, TcpError, TcpSource};
+use super::util::{SocketListenAddr, StreamDecodingError, TcpSource};
 use crate::{
     config::{
         log_schema, DataType, GenerateConfig, Resource, SourceConfig, SourceContext,
@@ -126,7 +126,7 @@ impl std::fmt::Display for DecodeError {
     }
 }
 
-impl TcpError for DecodeError {
+impl StreamDecodingError for DecodeError {
     fn can_continue(&self) -> bool {
         match self {
             DecodeError::IO(_) => false,

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -11,7 +11,7 @@ use crate::{
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::util::{
-        add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig, TcpError,
+        add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig, StreamDecodingError,
     },
     tls::TlsConfig,
 };

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -13,7 +13,7 @@ use crate::{
     kafka::{KafkaAuthConfig, KafkaStatisticsContext},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
-    sources::util::TcpError,
+    sources::util::StreamDecodingError,
     Pipeline,
 };
 use bytes::Bytes;

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -1,4 +1,4 @@
-use super::util::{SocketListenAddr, TcpError, TcpSource};
+use super::util::{SocketListenAddr, StreamDecodingError, TcpSource};
 use crate::{
     config::{
         log_schema, DataType, GenerateConfig, Resource, SourceConfig, SourceContext,
@@ -158,7 +158,7 @@ pub enum DecodeError {
     DecompressionFailed { source: io::Error },
 }
 
-impl TcpError for DecodeError {
+impl StreamDecodingError for DecodeError {
     fn can_continue(&self) -> bool {
         use DecodeError::*;
 

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -10,7 +10,7 @@ use crate::{
     internal_events::NatsEventsReceived,
     serde::{default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
-    sources::util::TcpError,
+    sources::util::StreamDecodingError,
     Pipeline,
 };
 use bytes::Bytes;

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -9,7 +9,7 @@ use crate::{
     internal_events::{SocketEventsReceived, SocketMode, SocketReceiveError},
     serde::{default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
-    sources::{util::TcpError, Source},
+    sources::{util::StreamDecodingError, Source},
     udp, Pipeline,
 };
 use bytes::{Bytes, BytesMut};

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -4,7 +4,7 @@ use crate::{
     internal_events::StdinEventsReceived,
     serde::{default_decoding, default_framing_stream_based},
     shutdown::ShutdownSignal,
-    sources::util::TcpError,
+    sources::util::StreamDecodingError,
     Pipeline,
 };
 use async_stream::stream;

--- a/src/sources/util/codecs.rs
+++ b/src/sources/util/codecs.rs
@@ -2,12 +2,9 @@
 
 use tokio_util::codec::LinesCodecError;
 
-// TODO: Rename to reflect that this error can generally appear in stream based
-// decoding operations rather than only in TCP streams.
-//
-/// An error that occurs in the context of TCP connections.
-pub trait TcpError {
-    /// Whether it is reasonable to assume that continuing to read from the TCP
+/// An error that occurs while decoding a stream.
+pub trait StreamDecodingError {
+    /// Whether it is reasonable to assume that continuing to read from the
     /// stream in which this error occurred will not result in an indefinite
     /// hang up.
     ///
@@ -16,7 +13,7 @@ pub trait TcpError {
     fn can_continue(&self) -> bool;
 }
 
-impl TcpError for LinesCodecError {
+impl StreamDecodingError for LinesCodecError {
     fn can_continue(&self) -> bool {
         match self {
             LinesCodecError::MaxLineLengthExceeded => true,
@@ -25,7 +22,7 @@ impl TcpError for LinesCodecError {
     }
 }
 
-impl TcpError for std::io::Error {
+impl StreamDecodingError for std::io::Error {
     fn can_continue(&self) -> bool {
         false
     }

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -1,5 +1,10 @@
 #[cfg(any(feature = "sources-http"))]
 mod body_decoding;
+#[cfg(any(
+    all(feature = "sources-utils-tls", feature = "listenfd"),
+    feature = "codecs",
+))]
+mod codecs;
 mod encoding_config;
 #[cfg(any(
     feature = "sources-file",
@@ -20,11 +25,6 @@ mod http;
 pub mod multiline_config;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 mod tcp;
-#[cfg(any(
-    all(feature = "sources-utils-tls", feature = "listenfd"),
-    feature = "codecs",
-))]
-mod tcp_error;
 #[cfg(all(unix, feature = "sources-socket"))]
 mod unix_datagram;
 #[cfg(all(unix, feature = "sources-utils-unix"))]
@@ -47,15 +47,15 @@ pub use self::http::ErrorMessage;
 pub use self::http::HttpSource;
 #[cfg(feature = "sources-utils-http-auth")]
 pub use self::http::HttpSourceAuthConfig;
-pub use encoding_config::EncodingConfig;
-pub use multiline_config::MultilineConfig;
-#[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
-pub use tcp::{SocketListenAddr, TcpSource};
 #[cfg(any(
     all(feature = "sources-utils-tls", feature = "listenfd"),
     feature = "codecs",
 ))]
-pub use tcp_error::TcpError;
+pub use codecs::StreamDecodingError;
+pub use encoding_config::EncodingConfig;
+pub use multiline_config::MultilineConfig;
+#[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
+pub use tcp::{SocketListenAddr, TcpSource};
 #[cfg(all(unix, feature = "sources-socket",))]
 pub use unix_datagram::build_unix_datagram_source;
 #[cfg(all(unix, feature = "sources-utils-unix",))]

--- a/src/sources/util/tcp.rs
+++ b/src/sources/util/tcp.rs
@@ -1,4 +1,4 @@
-use super::{AfterReadExt as _, TcpError};
+use super::{AfterReadExt as _, StreamDecodingError};
 use crate::{
     config::Resource,
     event::Event,
@@ -65,7 +65,7 @@ where
 {
     // Should be default: `std::io::Error`.
     // Right now this is unstable: https://github.com/rust-lang/rust/issues/29661
-    type Error: From<io::Error> + TcpError + std::fmt::Debug + std::fmt::Display + Send;
+    type Error: From<io::Error> + StreamDecodingError + std::fmt::Debug + std::fmt::Display + Send;
     type Item: Into<SmallVec<[Event; 1]>> + Send;
     type Decoder: Decoder<Item = (Self::Item, usize), Error = Self::Error> + Send + 'static;
 
@@ -266,7 +266,7 @@ async fn handle_stream<T>(
                         }
                     }
                     Some(Err(error)) => {
-                        if !<<T as TcpSource>::Error as TcpError>::can_continue(&error) {
+                        if !<<T as TcpSource>::Error as StreamDecodingError>::can_continue(&error) {
                             warn!(message = "Failed to read data from TCP source.", %error);
                             break;
                         }

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -3,7 +3,7 @@ use crate::{
     event::Event,
     internal_events::{SocketMode, SocketReceiveError, UnixSocketFileDeleteError},
     shutdown::ShutdownSignal,
-    sources::{util::tcp_error::TcpError, Source},
+    sources::{util::codecs::StreamDecodingError, Source},
     Pipeline,
 };
 use bytes::{Bytes, BytesMut};

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -4,7 +4,7 @@ use crate::{
     event::Event,
     internal_events::{ConnectionOpen, OpenGauge, UnixSocketError, UnixSocketFileDeleteError},
     shutdown::ShutdownSignal,
-    sources::{util::tcp_error::TcpError, Source},
+    sources::{util::codecs::StreamDecodingError, Source},
     Pipeline,
 };
 use bytes::Bytes;


### PR DESCRIPTION
Addressing the following TODO to better reflect that this error can occur while decoding any stream, not just TCP.

https://github.com/vectordotdev/vector/blob/f8d58c2f0c739165cd3cc2916a9d57218f10970b/src/sources/util/tcp_error.rs#L5-L6