### PR TITLE
feat(config): update component key

### DIFF
--- a/lib/vector-core/src/config/id.rs
+++ b/lib/vector-core/src/config/id.rs
@@ -17,7 +17,7 @@ impl ComponentKey {
         &self.id
     }
 
-    pub fn create_child(&self, name: &str) -> Self {
+    pub fn join<D: fmt::Display>(&self, name: D) -> Self {
         Self {
             id: format!("{}.{}", self.id, name),
         }

--- a/lib/vector-core/src/config/id.rs
+++ b/lib/vector-core/src/config/id.rs
@@ -8,43 +8,33 @@ use std::{
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct ComponentKey {
-    id: String,
-}
+pub struct ComponentKey(String);
 
 impl ComponentKey {
-    pub fn global<T: Into<String>>(id: T) -> Self {
-        Self { id: id.into() }
+    pub fn id(&self) -> &str {
+        &self.0
     }
 
-    pub fn id(&self) -> &str {
-        self.id.as_str()
+    pub fn create_child(&self, name: &str) -> Self {
+        Self::from(format!("{}.{}", self.0, name))
     }
 }
 
 impl From<String> for ComponentKey {
     fn from(value: String) -> Self {
-        Self::from(value.as_str())
+        Self(value)
     }
 }
 
 impl From<&str> for ComponentKey {
     fn from(value: &str) -> Self {
-        Self {
-            id: value.to_string(),
-        }
-    }
-}
-
-impl<T: ToString> From<&T> for ComponentKey {
-    fn from(value: &T) -> Self {
-        Self::from(value.to_string())
+        Self::from(value.to_owned())
     }
 }
 
 impl fmt::Display for ComponentKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.id.fmt(f)
+        self.0.fmt(f)
     }
 }
 
@@ -59,7 +49,7 @@ impl Serialize for ComponentKey {
 
 impl Ord for ComponentKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.id.cmp(&other.id)
+        self.0.cmp(&other.0)
     }
 }
 
@@ -82,7 +72,7 @@ impl<'de> Visitor<'de> for ComponentKeyVisitor {
     where
         E: de::Error,
     {
-        Ok(ComponentKey::global(value))
+        Ok(ComponentKey::from(value))
     }
 }
 
@@ -102,7 +92,7 @@ mod tests {
     #[test]
     fn deserialize_string() {
         let result: ComponentKey = serde_json::from_str("\"foo\"").unwrap();
-        assert_eq!(result.id, "foo");
+        assert_eq!(result.id(), "foo");
     }
 
     #[test]

--- a/lib/vector-core/src/config/id.rs
+++ b/lib/vector-core/src/config/id.rs
@@ -85,8 +85,12 @@ impl Ord for ComponentKey {
         let other_scope = other.scope();
         if self_scope == other_scope {
             self.id.cmp(&other.id)
+        } else if self.is_global() {
+            Ordering::Greater
+        } else if other.is_global() {
+            Ordering::Less
         } else {
-            self_scope.cmp(&other_scope)
+            self_scope.cmp(other_scope)
         }
     }
 }

--- a/lib/vector-core/src/config/id.rs
+++ b/lib/vector-core/src/config/id.rs
@@ -7,12 +7,9 @@ use std::{
     fmt,
 };
 
-pub const GLOBAL_SCOPE: &str = "global";
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ComponentKey {
     id: String,
-    scope_len: usize,
 }
 
 impl ComponentKey {
@@ -20,41 +17,16 @@ impl ComponentKey {
         &self.id
     }
 
-    pub fn name(&self) -> &str {
-        if self.is_global() {
-            &self.id
-        } else {
-            &self.id[(self.scope_len + 1)..]
-        }
-    }
-
-    pub fn scope(&self) -> &str {
-        if self.is_global() {
-            GLOBAL_SCOPE
-        } else {
-            &self.id[0..self.scope_len]
-        }
-    }
-
-    pub fn is_global(&self) -> bool {
-        self.scope_len == 0
-    }
-
     pub fn create_child(&self, name: &str) -> Self {
         Self {
             id: format!("{}.{}", self.id, name),
-            scope_len: self.id.len(),
         }
     }
 }
 
 impl From<String> for ComponentKey {
-    fn from(value: String) -> Self {
-        let scope_len = value.rfind('.').unwrap_or(0);
-        Self {
-            id: value,
-            scope_len,
-        }
+    fn from(id: String) -> Self {
+        Self { id }
     }
 }
 
@@ -81,17 +53,7 @@ impl Serialize for ComponentKey {
 
 impl Ord for ComponentKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        let self_scope = self.scope();
-        let other_scope = other.scope();
-        if self_scope == other_scope {
-            self.id.cmp(&other.id)
-        } else if self.is_global() {
-            Ordering::Greater
-        } else if other.is_global() {
-            Ordering::Less
-        } else {
-            self_scope.cmp(other_scope)
-        }
+        self.id.cmp(&other.id)
     }
 }
 

--- a/lib/vector-core/src/config/id.rs
+++ b/lib/vector-core/src/config/id.rs
@@ -7,43 +7,18 @@ use std::{
     fmt,
 };
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum ComponentScope {
-    Global,
-}
-
-impl fmt::Display for ComponentScope {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Global => write!(f, "global"),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ComponentKey {
     id: String,
-    scope: ComponentScope,
 }
 
 impl ComponentKey {
     pub fn global<T: Into<String>>(id: T) -> Self {
-        Self {
-            id: id.into(),
-            scope: ComponentScope::Global,
-        }
+        Self { id: id.into() }
     }
 
     pub fn id(&self) -> &str {
         self.id.as_str()
-    }
-
-    pub const fn scope(&self) -> &ComponentScope {
-        &self.scope
-    }
-
-    pub const fn is_global(&self) -> bool {
-        matches!(self.scope, ComponentScope::Global)
     }
 }
 
@@ -57,7 +32,6 @@ impl From<&str> for ComponentKey {
     fn from(value: &str) -> Self {
         Self {
             id: value.to_string(),
-            scope: ComponentScope::Global,
         }
     }
 }
@@ -85,11 +59,7 @@ impl Serialize for ComponentKey {
 
 impl Ord for ComponentKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.scope == other.scope {
-            self.id.cmp(&other.id)
-        } else {
-            self.scope.cmp(&other.scope)
-        }
+        self.id.cmp(&other.id)
     }
 }
 

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -4,5 +4,5 @@ mod log_schema;
 pub mod proxy;
 
 pub use global_options::GlobalOptions;
-pub use id::{ComponentKey, ComponentScope};
+pub use id::ComponentKey;
 pub use log_schema::{init_log_schema, log_schema, LogSchema};

--- a/src/api/schema/components/mod.rs
+++ b/src/api/schema/components/mod.rs
@@ -208,7 +208,7 @@ impl ComponentsQuery {
 
     /// Gets a configured component by component_key
     async fn component_by_component_key(&self, component_id: String) -> Option<Component> {
-        let key = ComponentKey::global(&component_id);
+        let key = ComponentKey::from(component_id);
         component_by_component_key(&key)
     }
 }

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -250,7 +250,7 @@ async fn tap_handler(
 
                             // Attempt to connect the sink.
                             match control_tx
-                                .send(fanout::ControlMessage::Add(ComponentKey::from(&sink_id), Box::new(sink)))
+                                .send(fanout::ControlMessage::Add(ComponentKey::from(sink_id.as_str()), Box::new(sink)))
                                 .await
                             {
                                 Ok(_) => {
@@ -261,7 +261,7 @@ async fn tap_handler(
                                     // Create a sink shutdown trigger to remove the sink
                                     // when matched components change.
                                     sinks
-                                        .insert(output_id.clone(), shutdown_trigger(control_tx.clone(), ComponentKey::global(&sink_id)));
+                                        .insert(output_id.clone(), shutdown_trigger(control_tx.clone(), ComponentKey::from(sink_id.as_str())));
                                 }
                                 Err(error) => {
                                     error!(
@@ -348,7 +348,7 @@ mod tests {
     async fn sink_log_events() {
         let pattern_matched = "tes*";
         let pattern_not_matched = "xyz";
-        let id = OutputId::from(&ComponentKey::global("test"));
+        let id = OutputId::from(&ComponentKey::from("test"));
 
         let (mut fanout, control_tx) = fanout::Fanout::new();
         let mut outputs = HashMap::new();

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -537,7 +537,7 @@ mod test {
         let mut graph = Graph::default();
         // these all look like "foo.bar", but should only yield one error
         graph.nodes.insert(
-            ComponentKey::global("foo.bar"),
+            ComponentKey::from("foo.bar"),
             Node::Source { ty: DataType::Any },
         );
         graph.nodes.insert(
@@ -559,7 +559,7 @@ mod test {
             Node::Source { ty: DataType::Any },
         );
         graph.nodes.insert(
-            ComponentKey::global("baz"),
+            ComponentKey::from("baz"),
             Node::Transform {
                 in_ty: DataType::Any,
                 out_ty: DataType::Any,

--- a/src/config/id.rs
+++ b/src/config/id.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-pub use vector_core::config::{ComponentKey, ComponentScope};
+pub use vector_core::config::ComponentKey;
 
 // Unlike `ComponentKey`, we never deserialize these directly out of user configs, so it's fine to
 // use the derive. They should really only be triggered by our hacky roundtrip-through-serde clone.

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -413,7 +413,13 @@ where
     format::deserialize(&with_vars, format).map(|builder| (builder, warnings))
 }
 
-#[cfg(all(test, feature = "transforms-pipelines"))]
+#[cfg(all(
+    test,
+    feature = "sinks-elasticsearch",
+    feature = "transforms-pipelines",
+    feature = "transforms-regex_parser",
+    feature = "transforms-sample"
+))]
 mod tests {
     use super::load_builder_from_paths;
     use crate::config::{ComponentKey, ConfigPath};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -41,7 +41,7 @@ pub mod watcher;
 pub use builder::ConfigBuilder;
 pub use diff::ConfigDiff;
 pub use format::{Format, FormatHint};
-pub use id::{ComponentKey, ComponentScope, OutputId};
+pub use id::{ComponentKey, OutputId};
 pub use loading::{
     load, load_builder_from_paths, load_from_paths, load_from_paths_with_provider, load_from_str,
     merge_path_lists, process_paths, CONFIG_PATHS,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -465,7 +465,7 @@ impl TransformOuter<String> {
             let mut inputs = self.inputs.clone();
 
             for (name, content) in expanded {
-                let full_name = ComponentKey::global(format!("{}.{}", key, name));
+                let full_name = key.create_child(name.as_str());
 
                 let child = TransformOuter {
                     inputs,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -465,7 +465,7 @@ impl TransformOuter<String> {
             let mut inputs = self.inputs.clone();
 
             for (name, content) in expanded {
-                let full_name = key.create_child(name.as_str());
+                let full_name = key.join(name);
 
                 let child = TransformOuter {
                     inputs,

--- a/src/top/metrics.rs
+++ b/src/top/metrics.rs
@@ -48,7 +48,7 @@ async fn component_removed(client: Arc<SubscriptionClient>, tx: state::EventTx) 
     while let Some(Some(res)) = stream.next().await {
         if let Some(d) = res.data {
             let c = d.component_removed;
-            let id = ComponentKey::from(&c.component_id);
+            let id = ComponentKey::from(c.component_id.as_str());
             let _ = tx.send(state::EventType::ComponentRemoved(id)).await;
         }
     }
@@ -73,7 +73,7 @@ async fn received_events_totals(
                     c.into_iter()
                         .map(|c| {
                             (
-                                ComponentKey::from(&c.component_id),
+                                ComponentKey::from(c.component_id.as_str()),
                                 c.metric.received_events_total as i64,
                             )
                         })
@@ -102,7 +102,7 @@ async fn received_events_throughputs(
                 .send(state::EventType::ReceivedEventsThroughputs(
                     interval,
                     c.into_iter()
-                        .map(|c| (ComponentKey::from(&c.component_id), c.throughput))
+                        .map(|c| (ComponentKey::from(c.component_id.as_str()), c.throughput))
                         .collect(),
                 ))
                 .await;
@@ -125,7 +125,7 @@ async fn sent_events_totals(client: Arc<SubscriptionClient>, tx: state::EventTx,
                     c.into_iter()
                         .map(|c| {
                             (
-                                ComponentKey::from(&c.component_id),
+                                ComponentKey::from(c.component_id.as_str()),
                                 c.metric.sent_events_total as i64,
                             )
                         })
@@ -154,7 +154,7 @@ async fn sent_events_throughputs(
                 .send(state::EventType::SentEventsThroughputs(
                     interval,
                     c.into_iter()
-                        .map(|c| (ComponentKey::from(&c.component_id), c.throughput))
+                        .map(|c| (ComponentKey::from(c.component_id.as_str()), c.throughput))
                         .collect(),
                 ))
                 .await;
@@ -181,7 +181,7 @@ async fn processed_bytes_totals(
                     c.into_iter()
                         .map(|c| {
                             (
-                                ComponentKey::from(&c.component_id),
+                                ComponentKey::from(c.component_id.as_str()),
                                 c.metric.processed_bytes_total as i64,
                             )
                         })
@@ -210,7 +210,7 @@ async fn processed_bytes_throughputs(
                 .send(state::EventType::ProcessedBytesThroughputs(
                     interval,
                     c.into_iter()
-                        .map(|c| (ComponentKey::from(&c.component_id), c.throughput))
+                        .map(|c| (ComponentKey::from(c.component_id.as_str()), c.throughput))
                         .collect(),
                 ))
                 .await;

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -407,6 +407,7 @@ pub async fn build_pieces(
                 "sink",
                 component_kind = "sink",
                 component_id = %key.id(),
+                component_scope = %key.scope(),
                 component_type = typetag,
                 component_name = %key.id(),
                 buffer_type = buffer_type,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -407,7 +407,6 @@ pub async fn build_pieces(
                 "sink",
                 component_kind = "sink",
                 component_id = %key.id(),
-                component_scope = %key.scope(),
                 component_type = typetag,
                 component_name = %key.id(),
                 buffer_type = buffer_type,

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -1,4 +1,4 @@
-use crate::config::{ComponentKey, ComponentScope};
+use crate::config::ComponentKey;
 use futures::{future::BoxFuture, FutureExt};
 use pin_project::pin_project;
 use std::{
@@ -49,10 +49,6 @@ impl Task {
         self.key.id()
     }
 
-    pub const fn scope(&self) -> &ComponentScope {
-        self.key.scope()
-    }
-
     pub fn typetag(&self) -> &str {
         &self.typetag
     }
@@ -71,7 +67,6 @@ impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Task")
             .field("id", &self.key.id().to_string())
-            .field("scope", &self.scope().to_string())
             .field("typetag", &self.typetag)
             .finish()
     }

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -49,10 +49,6 @@ impl Task {
         self.key.id()
     }
 
-    pub fn scope(&self) -> &str {
-        self.key.scope()
-    }
-
     pub fn typetag(&self) -> &str {
         &self.typetag
     }
@@ -71,7 +67,6 @@ impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Task")
             .field("id", &self.key.id().to_string())
-            .field("scope", &self.scope().to_string())
             .field("typetag", &self.typetag)
             .finish()
     }

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -49,6 +49,10 @@ impl Task {
         self.key.id()
     }
 
+    pub fn scope(&self) -> &str {
+        self.key.scope()
+    }
+
     pub fn typetag(&self) -> &str {
         &self.typetag
     }
@@ -67,6 +71,7 @@ impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Task")
             .field("id", &self.key.id().to_string())
+            .field("scope", &self.scope().to_string())
             .field("typetag", &self.typetag)
             .finish()
     }

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -326,7 +326,7 @@ mod tests {
             inputs: Vec::<String>::new(),
             inner: Box::new(config),
         };
-        let name = ComponentKey::global("foo");
+        let name = ComponentKey::from("foo");
         let mut transforms = IndexMap::new();
         let mut expansions = IndexMap::new();
         let parents = HashSet::new();


### PR DESCRIPTION
### Why

The couple `ComponentKey` and `ComponentScope` have been introduced when we implemented the `Pipeline` v1. It has then be reverted but the `ComponentKey` and the `ComponentScope` stayed. It is, for now, not used for the `Pipeline` v2 feature.
Since then, all the components are using `ComponentScope::Global` and this field became useless.
This PR changes the way the `ComponentScope` is implemented and adapts it to `Pipeline` v2

### What it does

Just removes the notion of scope considering it's used nowhere.
It keeps the notion of `ComponentKey` for further updates.

### What it used to do

When creating a `Pipelines` transform, we end up with the following component ids:
- `processing.logs.filter`
- `processing.logs.pipelines.foo.filter`
- `processing.logs.pipelines.foo.transforms.0`
And, in the existing implementation, they are all using `ComponentScope::Global`.
But if we read the ids, we can have, for the id `processing.logs.filter`, the scope being `processing.logs`.
In the current PR, we replace the `ComponentScope` enum by an index, in the `id` of where the `scope` name stops.
Therefore, for `transforms.logs.filter` will have a `scope_len` of `15`. This allows to have a small memory footprint and to be able to return the scope just by returning `id[0..scope_len]`.
For global components, the `scope_len` ends up being 0 (no scope), and the returned scope will be `"global"`.

### Food for thoughts

```text
 processing.logs.filter <= id
^               ^      ^
|     scope     | name |
```

Shouldn't we replace the [`component_name`](https://github.com/vectordotdev/vector/blob/master/src/topology/builder.rs#L413) by its real name (here `filter`) ?

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
