### PR TITLE
enhancement(vrl): Allow multiline strings

### DIFF
--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -1095,14 +1095,16 @@ impl<'input> Lexer<'input> {
         self.peek().as_ref().map_or(self.input.len(), |l| l.0)
     }
 
-    fn escape_code(&mut self, start: usize) -> Result<char, Error> {
+    /// Returns Ok if the next char is a valid escape code.
+    fn escape_code(&mut self, start: usize) -> Result<(), Error> {
         match self.bump() {
-            Some((_, '\'')) => Ok('\''),
-            Some((_, '"')) => Ok('"'),
-            Some((_, '\\')) => Ok('\\'),
-            Some((_, 'n')) => Ok('\n'),
-            Some((_, 'r')) => Ok('\r'),
-            Some((_, 't')) => Ok('\t'),
+            Some((_, '\n')) => Ok(()),
+            Some((_, '\'')) => Ok(()),
+            Some((_, '"')) => Ok(()),
+            Some((_, '\\')) => Ok(()),
+            Some((_, 'n')) => Ok(()),
+            Some((_, 'r')) => Ok(()),
+            Some((_, 't')) => Ok(()),
             Some((start, ch)) => Err(Error::EscapeChar {
                 start,
                 ch: Some(ch),
@@ -1148,19 +1150,32 @@ pub fn is_operator(ch: char) -> bool {
 fn unescape_string_literal(mut s: &str) -> String {
     let mut string = String::with_capacity(s.len());
     while let Some(i) = s.bytes().position(|b| b == b'\\') {
-        let c = match s.as_bytes()[i + 1] {
-            b'\'' => '\'',
-            b'"' => '"',
-            b'\\' => '\\',
-            b'n' => '\n',
-            b'r' => '\r',
-            b't' => '\t',
-            _ => unimplemented!("invalid escape"),
-        };
+        let next = s.as_bytes()[i + 1];
+        if next == b'\n' {
+            // Remove the \n and any ensuing spaces or tabs
+            string.push_str(&s[..i]);
+            let remaining = &s[i + 2..];
+            let whitespace: usize = remaining
+                .chars()
+                .take_while(|c| c.is_whitespace())
+                .map(|c| c.len_utf8())
+                .sum();
+            s = &s[i + whitespace + 2..];
+        } else {
+            let c = match next {
+                b'\'' => '\'',
+                b'"' => '"',
+                b'\\' => '\\',
+                b'n' => '\n',
+                b'r' => '\r',
+                b't' => '\t',
+                _ => unimplemented!("invalid escape"),
+            };
 
-        string.push_str(&s[..i]);
-        string.push(c);
-        s = &s[i + 2..];
+            string.push_str(&s[..i]);
+            string.push(c);
+            s = &s[i + 2..];
+        }
     }
 
     string.push_str(s);
@@ -1241,6 +1256,18 @@ mod test {
             ],
         );
         assert_eq!(StringLiteral::Escaped(r#"\"\""#).unescape(), r#""""#);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn multiline_string_literals() {
+        let mut lexer = lexer(r#""foo \
+                                  bar""#);
+
+        match lexer.next() {
+            Some(Ok((_, Token::StringLiteral(s), _))) => assert_eq!("foo bar", s.unescape()),
+            _ => panic!("Not a string literal"),
+        }
     }
 
     #[test]

--- a/lib/vrl/tests/tests/expressions/literal/string.vrl
+++ b/lib/vrl/tests/tests/expressions/literal/string.vrl
@@ -1,3 +1,7 @@
-# result: "foo \"bar\""
+# result: ["foo \"bar\"", "foo bar"]
 
-"foo \"bar\""
+[
+  "foo \"bar\"",
+  "foo \
+   bar"
+]

--- a/website/cue/reference/remap/literals/string.cue
+++ b/website/cue/reference/remap/literals/string.cue
@@ -10,7 +10,7 @@ remap: literals: string: {
 		no special meaning and the string may contain newlines.
 
 		**Interpreted string** literals are character sequences between double quotes (`"..."`). Within the quotes,
-		any character may appear except newline and unescaped double quote. The text between the quotes forms the result
+		any character may appear except unescaped newline and unescaped double quote. The text between the quotes forms the result
 		of the literal, with backslash escapes interpreted as defined below.
 		"""
 
@@ -20,6 +20,10 @@ remap: literals: string: {
 			"""#,
 		#"""
 			"Hello, world! \\u1F30E"
+			"""#,
+		#"""
+			"Hello, \
+			 world!"
 			"""#,
 		#"""
 			s'Hello, world!'

--- a/website/cue/reference/remap/literals/string.cue
+++ b/website/cue/reference/remap/literals/string.cue
@@ -50,6 +50,14 @@ remap: literals: string: {
 				"`\\'`":       "Single quote"
 			}
 		}
+		multiline_strings: {
+			title: "Multiline strings"
+			description: """
+				Long strings can be split over multiple lines by adding a backslash just before the
+				newline. The newline and any whitespace at the start of the ensuing line is not
+				included in the string.
+				"""
+		}
 		concatenation: {
 			title: "Concatenation"
 			description: """


### PR DESCRIPTION
Closes #7519

This allows multiline strings in Vrl by escaping the new line as per the following:

```
.thing = "foo \
          bar"

assert(.thing == "foo bar")
```


All whitespace at the start of the ensuing line is removed.