### PR TITLE
fix(remap transform): only add dropped output when enabled

### DIFF
--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -763,6 +763,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn check_remap_branching_disabled() {
+        let happy = Event::try_from(serde_json::json!({"hello": "world"})).unwrap();
+        let abort = Event::try_from(serde_json::json!({"hello": "goodbye"})).unwrap();
+        let error = Event::try_from(serde_json::json!({"hello": 42})).unwrap();
+
+        let conf = RemapConfig {
+            source: Some(formatdoc! {r#"
+                if exists(.tags) {{
+                    # metrics
+                    .tags.foo = "bar"
+                    if string!(.tags.hello) == "goodbye" {{
+                      abort
+                    }}
+                }} else {{
+                    # logs
+                    .foo = "bar"
+                    if string!(.hello) == "goodbye" {{
+                      abort
+                    }}
+                }}
+            "#}),
+            drop_on_error: true,
+            drop_on_abort: true,
+            reroute_dropped: false,
+            ..Default::default()
+        };
+
+        assert!(conf.named_outputs().is_empty());
+
+        let context = TransformContext {
+            key: Some(ComponentKey::from("remapper")),
+            ..Default::default()
+        };
+        let mut tform = Remap::new(conf, &context).unwrap();
+
+        let output = transform_one_fallible(&mut tform, happy).unwrap();
+        let log = output.as_log();
+        assert_eq!(log["hello"], "world".into());
+        assert_eq!(log["foo"], "bar".into());
+        assert!(!log.contains("metadata"));
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        tform.transform(&mut out, &mut err, abort);
+        assert!(out.is_empty());
+        assert!(err.is_empty());
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        tform.transform(&mut out, &mut err, error);
+        assert!(out.is_empty());
+        assert!(err.is_empty());
+    }
+
     fn transform_one_fallible(
         ft: &mut dyn FallibleFunctionTransform,
         event: Event,

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -42,11 +42,20 @@ impl_generate_config_from_default!(RemapConfig);
 #[typetag::serde(name = "remap")]
 impl TransformConfig for RemapConfig {
     async fn build(&self, context: &TransformContext) -> Result<Transform> {
-        Remap::new(self.clone(), context).map(Transform::fallible_function)
+        let remap = Remap::new(self.clone(), context)?;
+        Ok(if self.reroute_dropped {
+            Transform::fallible_function(remap)
+        } else {
+            Transform::function(remap)
+        })
     }
 
     fn named_outputs(&self) -> Vec<String> {
-        vec![String::from("dropped")]
+        if self.reroute_dropped {
+            vec![String::from("dropped")]
+        } else {
+            vec![]
+        }
     }
 
     fn input_type(&self) -> DataType {


### PR DESCRIPTION
Closes #10129

This is a bit of a hack, but it's small and should fix a wart that would otherwise have to wait until we do more remodeling of the transform model for branching. It takes advantage of the `impl<T> FunctionTransform for T where T: FallibleFunctionTransform` that was previously only used in tests and simply discards any error outputs. In this case we won't actually do any discarding because we know that the transform itself isn't configured to actually write anything to that output.