### PR TITLE
docs(datadog provider): Clarify endpoint examples

### DIFF
--- a/website/cue/reference/components/sinks/datadog.cue
+++ b/website/cue/reference/components/sinks/datadog.cue
@@ -24,16 +24,6 @@ components: sinks: _datadog: {
 				examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 			}
 		}
-		endpoint: {
-			common:        false
-			description:   "The endpoint to send data to."
-			relevant_when: "site is not set"
-			required:      false
-			type: string: {
-				default: null
-				examples: ["127.0.0.1:8080", "example.com:12345"]
-			}
-		}
 		region: {
 			common:        false
 			description:   "The region to send data to."

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -61,12 +61,12 @@ components: sinks: datadog_events: {
 		}
 		endpoint: {
 			common:        false
-			description:   "The endpoint to send data to. Must include the path."
+			description:   "The endpoint to send data to."
 			relevant_when: "site is not set"
 			required:      false
 			type: string: {
 				default: null
-				examples: ["127.0.0.1:8080/api/v1/events", "example.com:12345/api/v1/events"]
+				examples: ["127.0.0.1:8080", "example.com:12345"]
 			}
 		}
 		site:     sinks._datadog.configuration.site

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -59,7 +59,16 @@ components: sinks: datadog_events: {
 				examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 			}
 		}
-		endpoint: sinks._datadog.configuration.endpoint
+		endpoint: {
+			common:        false
+			description:   "The endpoint to send data to. Must include the path."
+			relevant_when: "site is not set"
+			required:      false
+			type: string: {
+				default: null
+				examples: ["127.0.0.1:8080/api/v1/events", "example.com:12345/api/v1/events"]
+			}
+		}
 		site:     sinks._datadog.configuration.site
 	}
 

--- a/website/cue/reference/components/sinks/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/datadog_logs.cue
@@ -67,7 +67,16 @@ components: sinks: datadog_logs: {
 				examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 			}
 		}
-		endpoint: sinks._datadog.configuration.endpoint
+		endpoint: {
+			common:        false
+			description:   "The endpoint to send data to. Must include the path."
+			relevant_when: "site is not set"
+			required:      false
+			type: string: {
+				default: null
+				examples: ["127.0.0.1:8080/api/v2/logs", "example.com:12345/api/v2/logs"]
+			}
+		}
 		region:   sinks._datadog.configuration.region
 		site:     sinks._datadog.configuration.site
 	}

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -52,12 +52,12 @@ components: sinks: datadog_metrics: {
 		api_key:  sinks._datadog.configuration.api_key
 		endpoint: {
 			common:        false
-			description:   "The endpoint to send data to. Must include the path."
+			description:   "The endpoint to send data to."
 			relevant_when: "site is not set"
 			required:      false
 			type: string: {
 				default: null
-				examples: ["127.0.0.1:8080/api/v1/series", "example.com:12345/api/v1/series"]
+				examples: ["127.0.0.1:8080", "example.com:12345"]
 			}
 		}
 		region:   sinks._datadog.configuration.region

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -50,7 +50,16 @@ components: sinks: datadog_metrics: {
 
 	configuration: {
 		api_key:  sinks._datadog.configuration.api_key
-		endpoint: sinks._datadog.configuration.endpoint
+		endpoint: {
+			common:        false
+			description:   "The endpoint to send data to. Must include the path."
+			relevant_when: "site is not set"
+			required:      false
+			type: string: {
+				default: null
+				examples: ["127.0.0.1:8080/api/v1/series", "example.com:12345/api/v1/series"]
+			}
+		}
 		region:   sinks._datadog.configuration.region
 		default_namespace: {
 			common: true


### PR DESCRIPTION
A couple of users have been confused that the path is required when
specifying the endpoint exactly.

Closes: #10155

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
