### PR TITLE
docs(config): Make example in guides/level-up/managing-complex-configs work with Vector 0.18

### DIFF
--- a/website/content/en/guides/level-up/managing-complex-configs.md
+++ b/website/content/en/guides/level-up/managing-complex-configs.md
@@ -181,7 +181,7 @@ individual files, each with its own unit tests.
 
 ## Splitting Configs
 
-If your components start to by used in multiple configuration files, having a
+If your components start to be used in multiple configuration files, having a
 dedicated place to define them can become interesting.
 
 With Vector you can define a component configuration inside a component type folder.

--- a/website/content/en/guides/level-up/managing-complex-configs.md
+++ b/website/content/en/guides/level-up/managing-complex-configs.md
@@ -194,7 +194,6 @@ type = "syslog"
 address = "0.0.0.0:514"
 max_length = 42000
 mode = "tcp"
-path = "/path/to/socket"
 
 [transforms.change_fields]
 type = "remap"
@@ -216,7 +215,6 @@ type = "syslog"
 address = "0.0.0.0:514"
 max_length = 42000
 mode = "tcp"
-path = "/path/to/socket"
 ```
 
 The `change_fields` transform in the file `/etc/vector/transforms/change_fields.toml`

--- a/website/content/en/guides/level-up/managing-complex-configs.md
+++ b/website/content/en/guides/level-up/managing-complex-configs.md
@@ -206,6 +206,7 @@ source = """
 type = "console"
 inputs = ["change_fields"]
 target = "stdout"
+encoding.codec = "json"
 ```
 
 We can extract the `syslog` source in the file `/etc/vector/sources/syslog.toml`


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

I am opening this PR to help new users getting into Vector. I actually wanted to fix https://vector.dev/docs/reference/configuration/sinks/socket/#example-configurations, but I assume that is auto generated with all the required options. I don’t know how that can be fixed. `address` and `path` are not required in all cases, depending on `mode`.