### PR TITLE
enhancement(redis sink): Support for redis stream data type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ pulsar = { version = "4.1", default-features = false, features = ["tokio-runtime
 rand = { version = "0.8.4", default-features = false, features = ["small_rng"] }
 rand_distr = { version = "0.4.2", default-features = false }
 rdkafka = { version = "0.27.0", default-features = false, features = ["tokio", "libz", "ssl", "zstd"], optional = true }
-redis = { version = "0.21.4", default-features = false, features = ["connection-manager", "tokio-comp", "tokio-native-tls-comp"], optional = true }
+redis = { version = "0.21.4", default-features = false, features = ["connection-manager", "tokio-comp", "tokio-native-tls-comp", "streams"], optional = true }
 regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
 roaring = { version = "0.8.1", default-features = false, optional = true }
 seahash = { version = "4.1.0", default-features = false, optional = true }

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -682,7 +682,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn redis_sink_list_stream() {
+    async fn redis_sink_stream() {
         trace_init();
 
         let key = format!("test-stream-key-{}", random_string(10));
@@ -753,7 +753,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn redis_sink_list_stream_maxlen() {
+    async fn redis_sink_stream_maxlen() {
         trace_init();
 
         let key = format!("test-stream-key-{}", random_string(10));

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -79,13 +79,14 @@ components: sinks: redis: {
 		}
 		data_type: {
 			common:      false
-			description: "The Redis data type (`list` or `channel`) to use."
+			description: "The Redis data type (`list`, `channel` or `stream`) to use."
 			required:    false
 			type: string: {
 				default: "list"
 				enum: {
 					list:    "Use the Redis `list` data type."
 					channel: "Use the Redis `channel` data type."
+					stream: "Use the Redis `stream` data type."
 				}
 			}
 		}
@@ -107,6 +108,53 @@ components: sinks: redis: {
 								rpush: "Use the `rpush` method to publish messages."
 							}
 						}
+					}
+				}
+			}
+		}
+		stream: {
+			common:      false
+			description: "Options for the Redis `stream` data type."
+			required:    false
+			type: object: {
+				examples: []
+				options: {
+    				field: {
+        				description: "The field used to publish the message when `data_type` is `stream`."
+        				required:    true
+        				type: string: {
+							examples: ["message"]
+						}
+    				}
+    				maxlen: {
+        				common:      false
+        				description: "Object containing maximum length settings for the Redis `stream`."
+        				required:    false
+        				type: object: {
+            				examples: []
+            				options: {
+                				type: {
+	                    			common:      false
+                    				description: "Type of stream [trimming method](\(urls.redis_stream_trimming)) to use."
+                    				required:    false
+                    				type: string: {
+	                        			default: "equals"
+    	                    			enum: {
+                            				equals: "Use exact trimming for this stream."
+                            				approx: "Use almost exact trimming for this stream."
+                        				}
+                    				}
+                				}
+								threshold: {
+									description: "Threshold to be used for trimming."
+									required: true
+									type: uint: {
+										unit: null
+										examples: [1000]
+									}
+								}
+            				}
+        				}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -119,32 +119,32 @@ components: sinks: redis: {
 			type: object: {
 				examples: []
 				options: {
-    				field: {
-        				description: "The field used to publish the message when `data_type` is `stream`."
-        				required:    true
-        				type: string: {
+					field: {
+						description: "The field used to publish the message when `data_type` is `stream`."
+						required:    true
+						type: string: {
 							examples: ["message"]
 						}
-    				}
-    				maxlen: {
-        				common:      false
-        				description: "Object containing maximum length settings for the Redis `stream`."
-        				required:    false
-        				type: object: {
-            				examples: []
-            				options: {
-                				type: {
-	                    			common:      false
-                    				description: "Type of stream [trimming method](\(urls.redis_stream_trimming)) to use."
-                    				required:    false
-                    				type: string: {
-	                        			default: "equals"
-    	                    			enum: {
-                            				equals: "Use exact trimming for this stream."
-                            				approx: "Use almost exact trimming for this stream."
-                        				}
-                    				}
-                				}
+					}
+					maxlen: {
+						common:      false
+						description: "Object containing maximum length settings for the Redis `stream`."
+						required:    false
+						type: object: {
+							examples: []
+							options: {
+								type: {
+									common:      false
+									description: "Type of stream [trimming method](\(urls.redis_stream_trimming)) to use."
+									required:    false
+									type: string: {
+										default: "equals"
+										enum: {
+											equals: "Use exact trimming for this stream."
+											approx: "Use almost exact trimming for this stream."
+										}
+									}
+								}
 								threshold: {
 									description: "Threshold to be used for trimming."
 									required: true
@@ -153,8 +153,8 @@ components: sinks: redis: {
 										examples: [1000]
 									}
 								}
-            				}
-        				}
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -420,6 +420,7 @@ urls: {
 	rustup:                                                   "https://rustup.rs"
 	redis:                                                    "https://redis.io"
 	redis_rs:                                                 "https://github.com/mitsuhiko/redis-rs"
+	redis_stream_trimming:                                    "https://redis.io/commands/XADD#capped-streams"
 	sematext:                                                 "https://sematext.com"
 	sematext_create_logs_app:                                 "https://apps.sematext.com/ui/integrations"
 	sematext_es:                                              "https://sematext.com/docs/logs/index-events-via-elasticsearch-api/"


### PR DESCRIPTION
Closes #10042

This PR adds support for Redis streams in redis sink, using following kind of configuration:

```yaml
  redis:
    type: redis
    inputs:
      - my_source_id
    url: redis://127.0.0.1:6379/0
    key: test:{{source_type}}
    data_type: stream
    stream:
      field: "message"
      maxlen:
        type: equals
        count: 10
```

Added two integration test cases: stream without maxlen parameter, and stream with maxlen parameter

