### PR TITLE
fix(config): only log warnings when folders invalid

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -141,7 +141,7 @@ impl LoadableConfig for ConfigBuilder {
                 if name.starts_with('.') {
                     Ok(Vec::new())
                 } else {
-                    Err(vec![format!(
+                    Ok(vec![format!(
                         "Couldn't identify component type for folder {:?}",
                         path
                     )])
@@ -435,12 +435,12 @@ mod tests {
     fn load_namespacing_failing() {
         let path = PathBuf::from(".").join("tests").join("namespacing-fail");
         let configs = vec![ConfigPath::Dir(path.clone())];
-        let errors = load_builder_from_paths(&configs).unwrap_err();
-        assert_eq!(errors.len(), 1);
+        let (_, warns) = load_builder_from_paths(&configs).unwrap();
+        assert_eq!(warns.len(), 1);
         let msg = format!(
             "Couldn't identify component type for folder {:?}",
             path.join("foo")
         );
-        assert_eq!(errors[0], msg);
+        assert_eq!(warns[0], msg);
     }
 }


### PR DESCRIPTION
Since vector is loading namespaces automagically, every folder in the `--config-dir` folder not corresponding to a type of component generates an error.
When Vector is installed with a `rpm`, an `example` folder is created in the default Vector's config directory and this makes Vector not being able to start properly.
This PR converts this error into a warning so that these folders are ignored, allowing Vector to start properly, but still logged so that users are aware of potential errors (creating a `tranforms` folder instead of `transforms` for example).

Fixes #10166 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
