### PR TITLE
fix(config): remove warnings when folder isn't expected

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -136,18 +136,7 @@ impl LoadableConfig for ConfigBuilder {
                 self.transforms.extend(transforms);
                 Ok(warnings)
             }
-            Some(name) => {
-                // ignore hidden folders
-                if name.starts_with('.') {
-                    Ok(Vec::new())
-                } else {
-                    Ok(vec![format!(
-                        "Couldn't identify component type for folder {:?}",
-                        path
-                    )])
-                }
-            }
-            None => Ok(Vec::new()),
+            _ => Ok(Vec::new()),
         }
     }
 }
@@ -432,15 +421,9 @@ mod tests {
     }
 
     #[test]
-    fn load_namespacing_failing() {
+    fn load_namespacing_unknown_folders() {
         let path = PathBuf::from(".").join("tests").join("namespacing-fail");
-        let configs = vec![ConfigPath::Dir(path.clone())];
-        let (_, warns) = load_builder_from_paths(&configs).unwrap();
-        assert_eq!(warns.len(), 1);
-        let msg = format!(
-            "Couldn't identify component type for folder {:?}",
-            path.join("foo")
-        );
-        assert_eq!(warns[0], msg);
+        let configs = vec![ConfigPath::Dir(path)];
+        assert!(load_builder_from_paths(&configs).is_ok());
     }
 }


### PR DESCRIPTION
As required [here](https://github.com/vectordotdev/vector/issues/10166#issuecomment-979372404), we'll no longer have a warning if a folder exists in the configuration folder and its name doesn't match any component type.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
