### PR TITLE
docs: Remove use of `check_fields` from guides

### DIFF
--- a/website/content/en/guides/level-up/managing-complex-configs.md
+++ b/website/content/en/guides/level-up/managing-complex-configs.md
@@ -147,8 +147,10 @@ output in order to turn it into a regression test:
   [[tests.outputs]]
     extract_from = "foo"
     [[tests.outputs.conditions]]
-      type = "check_fields"
-      "message.equals" = "Sorry, I'm busy this week Cecil"
+      type = "vrl"
+      source = """
+        assert_eq!(.message, "Sorry, I'm busy this week Cecil")
+      """
 
   # And we add a new output without conditions for inspecting
   # a new transform

--- a/website/content/en/guides/level-up/managing-schemas.md
+++ b/website/content/en/guides/level-up/managing-schemas.md
@@ -142,14 +142,12 @@ type = "json_parser"
 [transforms.not_gdpr]
 type = "filter"
 inputs = ["parse"]
-condition.type = "check_fields"
-condition."gdpr.eq" = "false"
+condition = ".gdpr == false"
 
 [transforms.gdpr_to_strip]
 type = "filter"
 inputs = ["parse"]
-condition.type = "check_fields"
-condition."gdpr.eq" = "true"
+condition = ".gdpr == true"
 
 [transforms.gdpr_stripped]
 type = "remap"


### PR DESCRIPTION
This is deprecated in-lieu of VRL conditions.

A [user was confused by
this](https://discord.com/channels/742820443487993987/746107317459877968/913850313730052187)

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
