### PR TITLE
chore(ci): Install bundler on OSX

### DIFF
--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -5,6 +5,8 @@ brew update
 
 brew install ruby@2.7 coreutils cue-lang/tap/cue
 
+gem install bundler
+
 echo "export PATH=\"/usr/local/opt/ruby/bin:\$PATH\"" >> "$HOME/.bash_profile"
 
 if [ -n "${CI-}" ] ; then


### PR DESCRIPTION
CI started failing inexplicably due to bundler not being found.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
