### PR TITLE
chore(observability): Remove unused alias for `events_processed_total`

### DIFF
--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -137,15 +137,6 @@ impl Controller {
             });
         });
 
-        // Add alias `events_processed_total` for `events_out_total`.
-        for i in 0..metrics.len() {
-            let metric = &metrics[i];
-            if metric.name() == "events_out_total" {
-                let alias = metric.clone().with_name("processed_events_total");
-                metrics.push(alias);
-            }
-        }
-
         let handle = Handle::Counter(Arc::new(Counter::with_count(metrics.len() as u64 + 1)));
         metrics.push(Metric::from_metric_kv(&CARDINALITY_KEY, &handle));
 


### PR DESCRIPTION
This alias existed for maintaining compatibility, but when `events_out_total` was updated to `events_sent_total` in b5105d9fb we neglected to update this alias (if only we had had tests 😓).

Given that commit was released in v0.17.0 I'm planning to just update the release docs to mention it was dropped. I'll do this as a separate PR so I can cherry-pick that commit into the release branch to update the docs.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
