### PR TITLE
chore: Remove doubled-up per-cpu adjustment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test Suite
 
 on:
   pull_request:
-    paths-ignore:
-      - "soaks/**"
   push:
     branches:
       - master

--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -42,8 +42,6 @@ fetch_index_past_warmup = csv['fetch_index'] > args.warmup_seconds
 csv = csv[fetch_index_past_warmup]
 csv['value'] = csv['value'].div(args.vector_cpus)
 
-adjust_per_cpu = lambda b: b/args.vector_cpus
-
 # Use Tukey's method to detect values that sit 1.5 times outside the IQR.
 def total_outliers(df):
     q1 = df['value'].quantile(0.25)
@@ -122,7 +120,7 @@ changes = changes.drop(labels=['t-statistic', 'p-value', 'baseline mean',
                                'comparison outlier percentage',
                                'comparison stdev'], axis=1)
 changes = changes[changes['Δ mean %'].abs() > args.mean_drift_percentage].sort_values('Δ mean', ascending=False)
-changes['Δ mean'] = changes['Δ mean'].apply(adjust_per_cpu).apply(human_bytes)
+changes['Δ mean'] = changes['Δ mean'].apply(human_bytes)
 if len(changes) > 0:
     print("")
     print("This table lists those experiments that have experienced a", end=' ')
@@ -140,11 +138,11 @@ print("<details>")
 print("<summary>Fine details of change detection per experiment.</summary>")
 print("")
 ttest_results = ttest_results.sort_values('Δ mean', ascending=False)
-ttest_results['Δ mean'] = ttest_results['Δ mean'].apply(adjust_per_cpu).apply(human_bytes)
-ttest_results['baseline mean'] = ttest_results['baseline mean'].apply(adjust_per_cpu).apply(human_bytes)
-ttest_results['baseline stdev'] = ttest_results['baseline stdev'].apply(adjust_per_cpu).apply(human_bytes)
-ttest_results['comparison mean'] = ttest_results['comparison mean'].apply(adjust_per_cpu).apply(human_bytes)
-ttest_results['comparison stdev'] = ttest_results['comparison stdev'].apply(adjust_per_cpu).apply(human_bytes)
+ttest_results['Δ mean'] = ttest_results['Δ mean'].apply(human_bytes)
+ttest_results['baseline mean'] = ttest_results['baseline mean'].apply(human_bytes)
+ttest_results['baseline stdev'] = ttest_results['baseline stdev'].apply(human_bytes)
+ttest_results['comparison mean'] = ttest_results['comparison mean'].apply(human_bytes)
+ttest_results['comparison stdev'] = ttest_results['comparison stdev'].apply(human_bytes)
 print(ttest_results.to_markdown(index=False, tablefmt='github'))
 print("</details>")
 
@@ -155,14 +153,14 @@ describe = csv.groupby(['experiment', 'variant'])['value'].describe(percentiles=
 describe = describe.rename(columns={'50%': 'average', '95%': 'p95', '90%': 'p90', '99%': 'p99'})
 describe = describe.sort_values('mean', ascending=False)
 describe['skewness'] = csv.groupby(['experiment', 'variant'])['value'].skew()
-describe['mean'] = describe['mean'].apply(adjust_per_cpu).apply(human_bytes)
-describe['std'] = describe['std'].apply(adjust_per_cpu).apply(human_bytes)
-describe['min'] = describe['min'].apply(adjust_per_cpu).apply(human_bytes)
-describe['average'] = describe['average'].apply(adjust_per_cpu).apply(human_bytes)
-describe['p90'] = describe['p90'].apply(adjust_per_cpu).apply(human_bytes)
-describe['p95'] = describe['p95'].apply(adjust_per_cpu).apply(human_bytes)
-describe['p99'] = describe['p99'].apply(adjust_per_cpu).apply(human_bytes)
-describe['max'] = describe['max'].apply(adjust_per_cpu).apply(human_bytes)
+describe['mean'] = describe['mean'].apply(human_bytes)
+describe['std'] = describe['std'].apply(human_bytes)
+describe['min'] = describe['min'].apply(human_bytes)
+describe['average'] = describe['average'].apply(human_bytes)
+describe['p90'] = describe['p90'].apply(human_bytes)
+describe['p95'] = describe['p95'].apply(human_bytes)
+describe['p99'] = describe['p99'].apply(human_bytes)
+describe['max'] = describe['max'].apply(human_bytes)
 print(describe.to_markdown(index=True,
                            tablefmt='github',
                            headers=['(experiment, variant)', 'total samples',


### PR DESCRIPTION
The line `csv['value'] = csv['value'].div(args.vector_cpus)` adjusts the
experiment value to a per-cpu unit. This means that any of the applications of
`adjust_per_cpu` were inappropriately doubling the number of CPUs that the
experimental values were being compared against.

This commit corrects the problem.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
