### PR TITLE
chore: Soak detect regression

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -390,8 +390,6 @@ jobs:
 
       - name: Analyze captures
         run: |
-          # convert the individual artifacts into a folder for each
-          # soak test (containing both comparison/baseline files)
           ./soaks/bin/analyze_experiment --capture-dir ${{ github.event.number }}-${{ github.run_attempt }}-captures/ \
                                          --baseline-sha ${{ needs.compute-soak-meta.outputs.baseline-sha }} \
                                          --comparison-sha ${{ needs.compute-soak-meta.outputs.comparison-sha }} \
@@ -411,3 +409,45 @@ jobs:
           issue-number: ${{ needs.compute-soak-meta.outputs.pr-number }}
           edit-mode: replace
           body: ${{ steps.read-analysis.outputs.content }}
+
+  detect-regressions:
+    name: Regression analysis
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-20.04
+    needs:
+      - compute-soak-meta
+      - soak-baseline-r1
+      - soak-baseline-r2
+      - soak-comparison-r1
+      - soak-comparison-r2
+
+    steps:
+      - name: Set up Python3
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install scipy==1.7.*
+          pip install pandas==1.3.*
+          pip install tabulate==0.8.*
+
+      - name: Check out the repo
+        uses: actions/checkout@v2.4.0
+
+      - name: Download captures artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ github.event.number }}-${{ github.run_attempt }}-captures/
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ github.event.number }}-${{ github.run_attempt }}-captures/
+
+      - name: Detect regressions
+        run: |
+          ./soaks/bin/detect_regressions --capture-dir ${{ github.event.number }}-${{ github.run_attempt }}-captures/ \
+                                         --warmup-seconds 30 \
+                                         --p-value 0.05

--- a/soaks/bin/detect_regressions
+++ b/soaks/bin/detect_regressions
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import pandas as pd
+import scipy.stats
+import argparse
+import math
+import glob
+import os
+import sys
+
+parser = argparse.ArgumentParser(description='t-test experiments with Welch method')
+parser.add_argument('--capture-dir', type=str, help='the directory to search for capture csv files')
+parser.add_argument('--warmup-seconds', type=int, help='the number of seconds to treat as warmup')
+parser.add_argument('--p-value', type=float, default=0.05, help='the p-value for comparing with t-test results, the smaller the more certain')
+parser.add_argument('--mean-drift-percentage', type=float, default=8.87, help='the percentage of mean drift we allow in an experiment, expressed as a value from 0 to 100, default 9th percentile')
+args = parser.parse_args()
+
+capture_paths = glob.glob(os.path.join(args.capture_dir, "**/*.captures"))
+captures = []
+for f in capture_paths:
+    captures.append(pd.read_csv(f))
+csv = pd.concat(captures)
+
+fetch_index_past_warmup = csv['fetch_index'] > args.warmup_seconds
+csv = csv[fetch_index_past_warmup]
+
+# Use Tukey's method to detect values that sit 1.5 times outside the IQR.
+def total_outliers(df):
+    q1 = df['value'].quantile(0.25)
+    q3 = df['value'].quantile(0.75)
+    iqr = q3 - q1
+    scaled_iqr = 1.5 * iqr
+
+    outside_range = lambda b: (b < (q1 - scaled_iqr)) or (b > (q3 + scaled_iqr))
+    return df['value'].apply(outside_range).sum()
+
+ttest_results = []
+for exp in csv.experiment.unique():
+    experiment = csv[csv['experiment'] == exp]
+
+    baseline = experiment[experiment['variant'] == 'baseline']
+    comparison = experiment[experiment['variant'] == 'comparison']
+    baseline_mean = baseline['value'].mean()
+    comparison_mean = comparison['value'].mean()
+    diff =  comparison_mean - baseline_mean
+    percent_change = round(((comparison_mean - baseline_mean) / baseline_mean) * 100, 2)
+
+    baseline_outliers = total_outliers(baseline)
+    comparison_outliers = total_outliers(comparison)
+    trim = 0.0
+    if baseline_outliers + comparison_outliers > 0:
+        # When we have outliers we perform Yuen's test instead, dropping 10% of
+        # the data to remove the more extreme results.
+        trim = 0.1
+
+    # The t-test here is calculating whether the expected mean of our two
+    # distributions is equal, or, put another way, whether the samples we have
+    # here are from identical distributions. The higher the returned p-value by
+    # ttest_ind the more likely it is that the samples _do_ have the same
+    # expected mean.
+    #
+    # If the p-value is below our threshold then it is _unlikely_ that the two
+    # samples actually have the same mean -- are from the same distribution --
+    # and so there's some statistically interesting difference between the two
+    # samples. For our purposes here that implies that performance has changed.
+    res = scipy.stats.ttest_ind(baseline['value'], comparison['value'], equal_var=False, trim=trim)
+    ttest_results.append({'experiment': exp,
+                          'Δ mean': diff.mean(),
+                          'Δ mean %': percent_change,
+                          'baseline mean': baseline_mean,
+                          'comparison mean': comparison_mean,
+                          'p-value': res.pvalue })
+ttest_results = pd.DataFrame.from_records(ttest_results)
+print("Table of test results:")
+print("")
+print("")
+print(ttest_results.to_markdown(index=False, tablefmt='github'))
+
+p_value_violation = ttest_results['p-value'] < args.p_value
+changes = ttest_results[p_value_violation]
+changes = changes[changes['Δ mean %'] <  -args.mean_drift_percentage]
+print("")
+print("Table normalized to only show regressions, {} p-value threshold, {} drift threshold:".format(args.p_value, args.mean_drift_percentage))
+print("")
+print(changes.to_markdown(index=False, tablefmt='github'))
+
+if len(changes) > 0:
+    print("Regressions detected beyond thresholds.")
+    sys.exit(1)


### PR DESCRIPTION
This commit adds a step to the soak workflow that flags regressions in a way
that will trip our CI setup. The thresholds here are the same as for the
analysis step, though they could be set to be more lax or strict as we desire.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>