### PR TITLE
chore: Update component spec for aggregate pull-based sinks

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -156,8 +156,12 @@ or receiving one or more Vector events.
 
 #### EventsSent
 
-*All components* MUST emit an `EventsSent` event immediately after
-sending the events down stream, if the transmission was successful.
+*All components* that send events down stream, and delete them in Vector, MUST
+emit an `EventsSent` event immediately after sending, if the transmission was
+successful.
+
+Note that for sinks that simply expose data, but don't delete the data after
+sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
 
 * Properties
   * `count` - The count of Vector events.
@@ -173,8 +177,12 @@ sending the events down stream, if the transmission was successful.
 
 #### BytesSent
 
-*Sinks* MUST emit a `BytesSent` event immediately after sending bytes to the
-downstream target, if the transmission was successful.
+*Sinks* that send events down stream, and delete them in Vector, MUST emit
+a `BytesSent` event immediately after sending bytes to the downstream target, if
+the transmission was successful.
+
+Note that for sinks that simply expose data, but don't delete the data after
+sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
 
 * Properties
   * `byte_size`


### PR DESCRIPTION
These sinks, just `prometheus_exporter` at the moment, should not
publish the `events_sent_total` and `bytes_sent_total` metrics.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
