### PR TITLE
chore: Use ttest_ind_from_stats

### DIFF
--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -67,11 +67,6 @@ for exp in csv.experiment.unique():
 
     baseline_outliers = total_outliers(baseline)
     comparison_outliers = total_outliers(comparison)
-    trim = 0.0
-    if baseline_outliers + comparison_outliers > 0:
-        # When we have outliers we perform Yuen's test instead, dropping 10% of
-        # the data to remove the more extreme results.
-        trim = 0.1
 
     # The t-test here is calculating whether the expected mean of our two
     # distributions is equal, or, put another way, whether the samples we have
@@ -83,7 +78,13 @@ for exp in csv.experiment.unique():
     # samples actually have the same mean -- are from the same distribution --
     # and so there's some statistically interesting difference between the two
     # samples. For our purposes here that implies that performance has changed.
-    res = scipy.stats.ttest_ind(baseline['value'], comparison['value'], equal_var=False, trim=trim)
+    res = scipy.stats.ttest_ind_from_stats(baseline_mean,
+                                           baseline_stdev,
+                                           len(baseline),
+                                           comparison_mean,
+                                           comparison_stdev,
+                                           len(comparison),
+                                           equal_var=False)
     ttest_results.append({'experiment': exp,
                           'Δ mean': diff.mean(),
                           'Δ mean %': percent_change,


### PR DESCRIPTION
As seen in #10202 it's possible for ttest_ind to return a nan for the test
p-value. Given that we have the exact data set and don't need to estimate we can
avoid this by using the ttest from stats. This also removes the possibility of
trimming data.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
