### PR TITLE
enhancement(humio_logs sink): add support for sub-milliseconds timestamps

### DIFF
--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -33,10 +33,16 @@ pub struct HumioLogsConfig {
     #[serde(default)]
     pub(in crate::sinks::humio) batch: BatchConfig<SplunkHecDefaultBatchSettings>,
     pub(in crate::sinks::humio) tls: Option<TlsOptions>,
+    #[serde(default = "timestamp_nanos_key")]
+    pub(in crate::sinks::humio) timestamp_nanos_key: Option<String>,
 }
 
 inventory::submit! {
     SinkDescription::new::<HumioLogsConfig>("humio_logs")
+}
+
+pub fn timestamp_nanos_key() -> Option<String> {
+    Some("@timestamp.nanos".to_string())
 }
 
 impl GenerateConfig for HumioLogsConfig {
@@ -54,6 +60,7 @@ impl GenerateConfig for HumioLogsConfig {
             request: TowerRequestConfig::default(),
             batch: BatchConfig::default(),
             tls: None,
+            timestamp_nanos_key: None,
         })
         .unwrap()
     }
@@ -87,6 +94,7 @@ impl HumioLogsConfig {
             index: self.index.clone(),
             sourcetype: self.event_type.clone(),
             source: self.source.clone(),
+            timestamp_nanos_key: self.timestamp_nanos_key.clone(),
             encoding: self.encoding.clone().into_encoding(),
             compression: self.compression,
             batch: self.batch,

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -92,6 +92,7 @@ impl SinkConfig for HumioMetricsConfig {
             request: self.request,
             batch: self.batch,
             tls: self.tls.clone(),
+            timestamp_nanos_key: None,
         };
 
         let (sink, healthcheck) = sink.clone().build(cx).await?;

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -40,6 +40,7 @@ pub struct HecSinkLogsConfig {
     pub index: Option<Template>,
     pub sourcetype: Option<Template>,
     pub source: Option<Template>,
+    pub timestamp_nanos_key: Option<String>,
     pub encoding: EncodingConfig<HecLogsEncoder>,
     #[serde(default)]
     pub compression: Compression,
@@ -49,6 +50,7 @@ pub struct HecSinkLogsConfig {
     pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
 }
+
 
 impl GenerateConfig for HecSinkLogsConfig {
     fn generate_config() -> toml::Value {
@@ -60,6 +62,7 @@ impl GenerateConfig for HecSinkLogsConfig {
             index: None,
             sourcetype: None,
             source: None,
+            timestamp_nanos_key: None,
             encoding: HecLogsEncoder::Text.into(),
             compression: Compression::default(),
             batch: BatchConfig::default(),
@@ -124,6 +127,7 @@ impl HecSinkLogsConfig {
             index: self.index.clone(),
             indexed_fields: self.indexed_fields.clone(),
             host: self.host_key.clone(),
+            timestamp_nanos_key: self.timestamp_nanos_key.clone(),
         };
 
         Ok(VectorSink::Stream(Box::new(sink)))

--- a/src/sinks/splunk_hec/logs/encoder.rs
+++ b/src/sinks/splunk_hec/logs/encoder.rs
@@ -65,6 +65,7 @@ impl HecLogsEncoder {
     pub fn encode_event(&self, processed_event: HecProcessedEvent) -> Option<Vec<u8>> {
         let log = processed_event.event;
         let metadata = processed_event.metadata;
+
         let event = match self {
             HecLogsEncoder::Json => HecEvent::Json(log),
             HecLogsEncoder::Text => HecEvent::Text(

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -33,6 +33,7 @@ pub struct HecLogsSink<S> {
     pub index: Option<Template>,
     pub indexed_fields: Vec<String>,
     pub host: String,
+    pub timestamp_nanos_key: Option<String>,
 }
 
 impl<S> HecLogsSink<S>
@@ -48,6 +49,7 @@ where
         let index = self.index.as_ref();
         let indexed_fields = self.indexed_fields.as_slice();
         let host = self.host.as_ref();
+        let timestamp_nanos_key = self.timestamp_nanos_key.as_ref();
 
         let builder_limit = NonZeroUsize::new(64);
         let sink = input
@@ -61,6 +63,7 @@ where
                     index,
                     host,
                     indexed_fields,
+                    timestamp_nanos_key,
                 ))
             })
             .batched(self.batch_settings.into_byte_size_config())
@@ -124,6 +127,7 @@ pub fn process_log(
     index: Option<&Template>,
     host_key: &str,
     indexed_fields: &[String],
+    timestamp_nanos_key: Option<&String>,
 ) -> Option<HecProcessedEvent> {
     let sourcetype =
         sourcetype.and_then(|sourcetype| render_template_string(sourcetype, &log, "sourcetype"));
@@ -138,6 +142,11 @@ pub fn process_log(
         Some(Value::Timestamp(ts)) => ts,
         _ => chrono::Utc::now(),
     };
+
+    if let Some(key) = timestamp_nanos_key {
+        log.try_insert_flat(key, timestamp.timestamp_subsec_nanos() % 1_000_000);
+    }
+
     let timestamp = (timestamp.timestamp_millis() as f64) / 1000f64;
 
     let fields = indexed_fields

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -2,7 +2,7 @@ use crate::event::Event;
 use crate::sinks::splunk_hec::logs::encoder::HecLogsEncoder;
 use crate::sinks::splunk_hec::logs::sink::process_log;
 use crate::template::Template;
-use chrono::Utc;
+use chrono::{Utc, TimeZone};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
@@ -15,7 +15,7 @@ use super::sink::HecProcessedEvent;
 #[derive(Deserialize, Debug)]
 struct HecEventJson {
     time: f64,
-    event: BTreeMap<String, String>,
+    event: BTreeMap<String, serde_json::Value>,
     fields: BTreeMap<String, String>,
     source: Option<String>,
     sourcetype: Option<String>,
@@ -45,12 +45,15 @@ fn get_processed_event() -> HecProcessedEvent {
     event.as_mut_log().insert("event_field1", "test_value1");
     event.as_mut_log().insert("event_field2", "test_value2");
     event.as_mut_log().insert("key", "value");
+    event.as_mut_log().insert("int_val", 123);
+    event.as_mut_log().insert(log_schema().timestamp_key(), Utc.timestamp_nanos(1638366107111456123));
     let event_byte_size = event.size_of();
 
     let sourcetype = Template::try_from("{{ event_sourcetype }}".to_string()).ok();
     let source = Template::try_from("{{ event_source }}".to_string()).ok();
     let index = Template::try_from("{{ event_index }}".to_string()).ok();
     let indexed_fields = vec!["event_field1".to_string(), "event_field2".to_string()];
+    let timestamp_nanos_key = Some(String::from("ts_nanos_key"));
 
     process_log(
         event.into_log(),
@@ -60,6 +63,7 @@ fn get_processed_event() -> HecProcessedEvent {
         index.as_ref(),
         "host_key",
         indexed_fields.as_slice(),
+        timestamp_nanos_key.as_ref(),
     )
     .unwrap()
 }
@@ -85,10 +89,11 @@ fn splunk_encode_log_event_json() {
     let hec_data = serde_json::from_slice::<HecEventJson>(&bytes[..]).unwrap();
     let event = hec_data.event;
 
-    assert_eq!(event.get("key").unwrap(), "value");
+    assert_eq!(event.get("key").unwrap(), &serde_json::Value::from("value"));
+    assert_eq!(event.get("int_val").unwrap(), &serde_json::Value::from(123));
     assert_eq!(
         event.get(&log_schema().message_key().to_string()).unwrap(),
-        "hello world"
+        &serde_json::Value::from("hello world")
     );
     assert!(event
         .get(&log_schema().timestamp_key().to_string())
@@ -101,14 +106,8 @@ fn splunk_encode_log_event_json() {
 
     assert_eq!(hec_data.fields.get("event_field1").unwrap(), "test_value1");
 
-    let now = Utc::now().timestamp_millis() as f64 / 1000f64;
-    assert!(
-        (hec_data.time - now).abs() < 0.2,
-        "hec_data.time = {}, now = {}",
-        hec_data.time,
-        now
-    );
-    assert_eq!((hec_data.time * 1000f64).fract(), 0f64);
+    assert_eq!(hec_data.time, 1638366107.111);
+    assert_eq!(event.get("ts_nanos_key").unwrap(), &serde_json::Value::from(456123));
 }
 
 #[test]
@@ -127,12 +126,5 @@ fn splunk_encode_log_event_text() {
 
     assert_eq!(hec_data.fields.get("event_field1").unwrap(), "test_value1");
 
-    let now = Utc::now().timestamp_millis() as f64 / 1000f64;
-    assert!(
-        (hec_data.time - now).abs() < 0.2,
-        "hec_data.time = {}, now = {}",
-        hec_data.time,
-        now
-    );
-    assert_eq!((hec_data.time * 1000f64).fract(), 0f64);
+    assert_eq!(hec_data.time, 1638366107.111);
 }

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -141,6 +141,18 @@ components: sinks: splunk_hec_logs: {
 				examples: ["${SPLUNK_HEC_TOKEN}", "A94A8FE5CCB19BA61C4C08"]
 			}
 		}
+		timestamp_nanos_key: {
+			common:      false
+			description: """
+				The number of nanoseconds within the event timestamp millisecond will be added to the event
+				at the specified key value. If unset nothing happens.
+				"""
+			required:    false
+			type: string: {
+				default: null
+				examples: ["@timestamp.nanos"]
+			}
+		}
 	}
 
 	input: {


### PR DESCRIPTION
resolves #10203

Slight modification to allow sub-ms parts of timestamps to be added to event sent by the splunk-hec sink and derivatives.
It is disabled for splunk, but comes with the right config for the `humio-logs` sinks (as per https://library.humio.com/stable/docs/parsers/parsing-timestamps/#sub-millisecond-precision-of-timestamps).

Tested against https://cloud.community.humio.com/services/collector/event.