### PR TITLE
chore(influxdb_logs sink): Allow to exclude `metric_type` tag

### DIFF
--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -332,7 +332,7 @@ mod tests {
             "host=aws.cloud.eur", line_protocol.1,
             "metric_type tag should be excluded"
         );
-        assert_fields(line_protocol.2.to_string(), ["message=\"hello\""].to_vec());
+        assert_fields(line_protocol.2, ["message=\"hello\""].to_vec());
     }
 
     #[test]

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -328,7 +328,10 @@ mod tests {
         let bytes = sink.encode_event(event.clone()).unwrap();
         let string = std::str::from_utf8(&bytes).unwrap();
         let line_protocol = split_line_protocol(string);
-        assert_eq!("host=aws.cloud.eur", line_protocol.1, "metric_type tag should be excluded");
+        assert_eq!(
+            "host=aws.cloud.eur", line_protocol.1,
+            "metric_type tag should be excluded"
+        );
         assert_fields(line_protocol.2.to_string(), ["message=\"hello\""].to_vec());
     }
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -102,6 +102,7 @@ impl SinkConfig for InfluxDbLogsConfig {
         let mut tags: HashSet<String> = self.tags.clone().into_iter().collect();
         tags.insert(log_schema().host_key().to_string());
         tags.insert(log_schema().source_type_key().to_string());
+        tags.insert("metric_type".to_string());
 
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(tls_settings, cx.proxy())?;
@@ -161,9 +162,10 @@ impl HttpSink for InfluxDbLogsSink {
     type Input = Vec<u8>;
     type Output = Vec<u8>;
 
-    fn encode_event(&self, mut event: Event) -> Option<Self::Input> {
-        self.encoding.apply_rules(&mut event);
+    fn encode_event(&self, event: Event) -> Option<Self::Input> {
         let mut event = event.into_log();
+        event.insert("metric_type".to_string(), "logs".to_string());
+        self.encoding.apply_rules(&mut event);
 
         // Timestamp
         let timestamp = encode_timestamp(match event.remove(log_schema().timestamp_key()) {
@@ -186,7 +188,6 @@ impl HttpSink for InfluxDbLogsSink {
         if let Err(error) = influx_line_protocol(
             self.protocol_version,
             &self.measurement,
-            "logs",
             Some(tags),
             Some(fields),
             timestamp,
@@ -310,11 +311,11 @@ mod tests {
             "my-token",
             ProtocolVersion::V1,
             "vector",
-            vec![],
+            ["metric_type", "host"].to_vec(),
         );
         sink.encoding.except_fields = Some(vec!["host".into()]);
 
-        let bytes = sink.encode_event(event).unwrap();
+        let bytes = sink.encode_event(event.clone()).unwrap();
         let string = std::str::from_utf8(&bytes).unwrap();
 
         let line_protocol = split_line_protocol(string);
@@ -322,6 +323,13 @@ mod tests {
         assert_eq!("metric_type=logs", line_protocol.1);
         assert_fields(line_protocol.2.to_string(), ["message=\"hello\""].to_vec());
         assert_eq!("1542182950000000011\n", line_protocol.3);
+
+        sink.encoding.except_fields = Some(vec!["metric_type".into()]);
+        let bytes = sink.encode_event(event.clone()).unwrap();
+        let string = std::str::from_utf8(&bytes).unwrap();
+        let line_protocol = split_line_protocol(string);
+        assert_eq!("host=aws.cloud.eur", line_protocol.1, "metric_type tag should be excluded");
+        assert_fields(line_protocol.2.to_string(), ["message=\"hello\""].to_vec());
     }
 
     #[test]
@@ -341,7 +349,7 @@ mod tests {
             "my-token",
             ProtocolVersion::V1,
             "vector",
-            ["source_type", "host"].to_vec(),
+            ["source_type", "host", "metric_type"].to_vec(),
         );
 
         let bytes = sink.encode_event(event).unwrap();
@@ -385,7 +393,7 @@ mod tests {
             "my-token",
             ProtocolVersion::V2,
             "vector",
-            ["source_type", "host"].to_vec(),
+            ["source_type", "host", "metric_type"].to_vec(),
         );
 
         let bytes = sink.encode_event(event).unwrap();
@@ -424,7 +432,7 @@ mod tests {
             "my-token",
             ProtocolVersion::V2,
             "vector",
-            [].to_vec(),
+            ["metric_type"].to_vec(),
         );
 
         let bytes = sink.encode_event(event).unwrap();
@@ -461,7 +469,7 @@ mod tests {
             "my-token",
             ProtocolVersion::V2,
             "vector",
-            [].to_vec(),
+            ["metric_type"].to_vec(),
         );
 
         let bytes = sink.encode_event(event).unwrap();
@@ -498,7 +506,7 @@ mod tests {
             "my-token",
             ProtocolVersion::V2,
             "vector",
-            ["as_a_tag", "not_exists_field", "source_type"].to_vec(),
+            ["as_a_tag", "not_exists_field", "source_type", "metric_type"].to_vec(),
         );
 
         let bytes = sink.encode_event(event).unwrap();

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -23,6 +23,7 @@ use crate::{
     tls::{TlsOptions, TlsSettings},
 };
 use bytes::Bytes;
+use indoc::indoc;
 use futures::{future::BoxFuture, stream, SinkExt};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -408,6 +409,17 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<InfluxDbConfig>();
+    }
+
+    #[test]
+    fn test_config_with_tags() {
+        let config = indoc! {r#"
+            namespace = "vector"
+            endpoint = "http://localhost:9999"
+            tags = {region="us-west-1"}
+        "#};
+
+        toml::from_str::<InfluxDbConfig>(config).unwrap();
     }
 
     #[test]

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -23,8 +23,8 @@ use crate::{
     tls::{TlsOptions, TlsSettings},
 };
 use bytes::Bytes;
-use indoc::indoc;
 use futures::{future::BoxFuture, stream, SinkExt};
+use indoc::indoc;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -259,11 +259,12 @@ fn encode_events(
         let tags = merge_tags(&event, tags);
         let (metric_type, fields) = get_type_and_fields(event.value(), quantiles);
 
+        let mut unwrapped_tags = tags.unwrap_or_default();
+        unwrapped_tags.insert("metric_type".to_owned(), metric_type.to_owned());
         if let Err(error) = influx_line_protocol(
             protocol_version,
             &fullname,
-            metric_type,
-            tags,
+            Some(unwrapped_tags),
             fields,
             ts,
             &mut output,

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::{future::BoxFuture, stream, SinkExt};
-use indoc::indoc;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -405,6 +404,7 @@ mod tests {
     use super::*;
     use crate::event::metric::{Metric, MetricKind, MetricValue, StatisticKind};
     use crate::sinks::influxdb::test_util::{assert_fields, split_line_protocol, tags, ts};
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -171,7 +171,6 @@ fn healthcheck(
 pub(in crate::sinks) fn influx_line_protocol(
     protocol_version: ProtocolVersion,
     measurement: &str,
-    metric_type: &str,
     tags: Option<BTreeMap<String, String>>,
     fields: Option<HashMap<String, Field>>,
     timestamp: i64,
@@ -188,8 +187,7 @@ pub(in crate::sinks) fn influx_line_protocol(
     line_protocol.push(',');
 
     // Tags
-    let mut unwrapped_tags = tags.unwrap_or_else(BTreeMap::new);
-    unwrapped_tags.insert("metric_type".to_owned(), metric_type.to_owned());
+    let unwrapped_tags = tags.unwrap_or_default();
     encode_tags(unwrapped_tags, line_protocol);
     line_protocol.push(' ');
 

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -240,17 +240,17 @@ fn encode_events(
         // Authentication in Sematext is by inserting the token as a tag.
         let mut tags = series.tags.unwrap_or_default();
         tags.insert("token".into(), token.into());
-
         let (metric_type, fields) = match data.value {
             MetricValue::Counter { value } => ("counter", to_fields(label, value)),
             MetricValue::Gauge { value } => ("gauge", to_fields(label, value)),
             _ => unreachable!(), // handled by SematextMetricNormalize
         };
 
+        tags.insert("metric_type".into(), metric_type.into());
+
         if let Err(error) = influx_line_protocol(
             ProtocolVersion::V1,
             &namespace,
-            metric_type,
             Some(tags),
             Some(fields),
             ts,

--- a/website/cue/reference/components/sinks/influxdb.cue
+++ b/website/cue/reference/components/sinks/influxdb.cue
@@ -91,19 +91,6 @@ components: sinks: _influxdb: {
 				examples: ["autogen", "one_day_only"]
 			}
 		}
-		tags: {
-			common:      false
-			description: "A set of additional fields that will be attached to each LineProtocol as a tag. Note: If the set of tag values has high cardinality this also increase cardinality in InfluxDB."
-			groups: ["v1", "v2"]
-			required: false
-			type: array: {
-				default: null
-				items: type: string: {
-					examples: ["field1", "parent.child_field"]
-					syntax: "field_path"
-				}
-			}
-		}
 		token: {
 			category:    "Auth"
 			description: "[Authentication token](\(urls.influxdb_authentication_token)) for InfluxDB 2."

--- a/website/cue/reference/components/sinks/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/influxdb_logs.cue
@@ -64,6 +64,19 @@ components: sinks: influxdb_logs: {
 				examples: ["service"]
 			}
 		}
+		tags: {
+			required: false
+			common:   false
+			description: "The set of fields that will be attached to each LineProtocol as tags. Note: If the set of tag values has high cardinality this also increase cardinality in InfluxDB."
+			groups: ["v1", "v2"]
+			type: array: {
+				default: null
+				items: type: string: {
+					examples: ["field1", "parent.child_field"]
+					syntax: "field_path"
+				}
+			}
+		}
 	}
 
 	input: {

--- a/website/cue/reference/components/sinks/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/influxdb_logs.cue
@@ -65,8 +65,8 @@ components: sinks: influxdb_logs: {
 			}
 		}
 		tags: {
-			required: false
-			common:   false
+			required:    false
+			common:      false
 			description: "The set of fields that will be attached to each LineProtocol as tags. Note: If the set of tag values has high cardinality this also increase cardinality in InfluxDB."
 			groups: ["v1", "v2"]
 			type: array: {

--- a/website/cue/reference/components/sinks/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/influxdb_metrics.cue
@@ -56,8 +56,8 @@ components: sinks: influxdb_metrics: {
 			}
 		}
 		tags: {
-			required: false
-			common:   false
+			required:    false
+			common:      false
 			description: "A map of additional key-value pairs that will be attached to each LineProtocol as tags."
 			groups: ["v1", "v2"]
 			type: object: {

--- a/website/cue/reference/components/sinks/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/influxdb_metrics.cue
@@ -55,6 +55,15 @@ components: sinks: influxdb_metrics: {
 				examples: ["service"]
 			}
 		}
+		tags: {
+			required: false
+			common:   false
+			description: "A map of additional key-value pairs that will be attached to each LineProtocol as tags."
+			groups: ["v1", "v2"]
+			type: object: {
+				examples: [{region: "us-west-1"}]
+			}
+		}
 	}
 
 	input: {


### PR DESCRIPTION
### Context

The `influxdb_logs` sink hard-encoded `metric_type=log` tag in the influxdb line protocol, e.g.

```
req,host=example.com,metric_type=logs count=42,bytes=64 1572642947000000000
```
The tag is nothing special in the inflxudb protocol. Yet it was not possible to remove the tag, even by encoding rule `encoding.except_fields=["metric_type"]`.

The sink actually is general enough to sink any kind of event, other than just logs. So it is preferable to allow exclude the tag. See #7183 .

### Proposed Changes

* Apply `metric_type` as a general tag in the influxdb_line_protocol; 
* Internally insert `metric_type` **before** applying encoding rules, so to allow exclude the tag.

### Test

```
cargo test --lib  -- sinks::influxdb
test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 1287 filtered out; finished in 3.13s
```

Close #7183
