### PR TITLE
fix(kafka sink): Correct the name for the `headers_key` config option

### DIFF
--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -149,7 +149,7 @@ impl GenerateConfig for KafkaSinkConfig {
             socket_timeout_ms: default_socket_timeout_ms(),
             message_timeout_ms: default_message_timeout_ms(),
             librdkafka_options: Default::default(),
-            headers_k: None,
+            headers_key: None,
         })
         .unwrap()
     }

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -31,7 +31,8 @@ pub(crate) struct KafkaSinkConfig {
     pub message_timeout_ms: u64,
     #[serde(default)]
     pub librdkafka_options: HashMap<String, String>,
-    pub headers_field: Option<String>,
+    #[serde(alias = "headers_field")] // accidentally released as `headers_field` in 0.18
+    pub headers_key: Option<String>,
 }
 
 const fn default_socket_timeout_ms() -> u64 {
@@ -148,7 +149,7 @@ impl GenerateConfig for KafkaSinkConfig {
             socket_timeout_ms: default_socket_timeout_ms(),
             message_timeout_ms: default_message_timeout_ms(),
             librdkafka_options: Default::default(),
-            headers_field: None,
+            headers_k: None,
         })
         .unwrap()
     }

--- a/src/sinks/kafka/request_builder.rs
+++ b/src/sinks/kafka/request_builder.rs
@@ -10,7 +10,7 @@ use vector_core::ByteSizeOf;
 
 pub struct KafkaRequestBuilder {
     pub key_field: Option<String>,
-    pub headers_field: Option<String>,
+    pub headers_key: Option<String>,
     pub topic_template: Template,
     pub encoder: EncodingConfig<StandardEncodings>,
     pub log_schema: &'static LogSchema,
@@ -23,7 +23,7 @@ impl KafkaRequestBuilder {
             finalizers: event.take_finalizers(),
             key: get_key(&event, &self.key_field),
             timestamp_millis: get_timestamp_millis(&event, self.log_schema),
-            headers: get_headers(&event, &self.headers_field),
+            headers: get_headers(&event, &self.headers_key),
             topic,
         };
         let mut body = vec![];
@@ -58,10 +58,10 @@ fn get_timestamp_millis(event: &Event, log_schema: &'static LogSchema) -> Option
     .map(|ts| ts.timestamp_millis())
 }
 
-fn get_headers(event: &Event, headers_field: &Option<String>) -> Option<OwnedHeaders> {
-    headers_field.as_ref().and_then(|headers_field| {
+fn get_headers(event: &Event, headers_key: &Option<String>) -> Option<OwnedHeaders> {
+    headers_key.as_ref().and_then(|headers_key| {
         if let Event::Log(log) = event {
-            if let Some(headers) = log.get(headers_field) {
+            if let Some(headers) = log.get(headers_key) {
                 match headers {
                     Value::Map(headers_map) => {
                         let mut owned_headers = OwnedHeaders::new_with_capacity(headers_map.len());
@@ -70,7 +70,7 @@ fn get_headers(event: &Event, headers_field: &Option<String>) -> Option<OwnedHea
                                 owned_headers = owned_headers.add(key, value_bytes.as_ref());
                             } else {
                                 emit!(&KafkaHeaderExtractionFailed {
-                                    header_field: headers_field
+                                    header_field: headers_key
                                 });
                             }
                         }
@@ -78,7 +78,7 @@ fn get_headers(event: &Event, headers_field: &Option<String>) -> Option<OwnedHea
                     }
                     _ => {
                         emit!(&KafkaHeaderExtractionFailed {
-                            header_field: headers_field
+                            header_field: headers_key
                         });
                     }
                 }

--- a/src/sinks/kafka/sink.rs
+++ b/src/sinks/kafka/sink.rs
@@ -37,7 +37,7 @@ pub struct KafkaSink {
     service: KafkaService,
     topic: Template,
     key_field: Option<String>,
-    headers_field: Option<String>,
+    headers_key: Option<String>,
 }
 
 pub fn create_producer(
@@ -55,7 +55,7 @@ impl KafkaSink {
         let producer = create_producer(producer_config)?;
 
         Ok(KafkaSink {
-            headers_field: config.headers_field,
+            headers_key: config.headers_key,
             encoding: config.encoding,
             acker,
             service: KafkaService::new(producer),
@@ -69,7 +69,7 @@ impl KafkaSink {
         let service = ConcurrencyLimit::new(self.service, QUEUED_MIN_MESSAGES as usize);
         let request_builder = KafkaRequestBuilder {
             key_field: self.key_field,
-            headers_field: self.headers_field,
+            headers_key: self.headers_key,
             topic_template: self.topic,
             encoder: self.encoding,
             log_schema: log_schema(),

--- a/src/sinks/kafka/tests.rs
+++ b/src/sinks/kafka/tests.rs
@@ -44,7 +44,7 @@ mod integration_test {
             socket_timeout_ms: 60000,
             message_timeout_ms: 300000,
             librdkafka_options: HashMap::new(),
-            headers_field: None,
+            headers_key: None,
         };
 
         self::sink::healthcheck(config).await.unwrap();
@@ -99,7 +99,7 @@ mod integration_test {
             message_timeout_ms: 300000,
             batch,
             librdkafka_options,
-            headers_field: None,
+            headers_key: None,
         };
         let (acker, _ack_counter) = Acker::new_for_testing();
         config.clone().to_rdkafka(KafkaRole::Consumer)?;
@@ -241,7 +241,7 @@ mod integration_test {
             socket_timeout_ms: 60000,
             message_timeout_ms: 300000,
             librdkafka_options: HashMap::new(),
-            headers_field: Some(headers_key.clone()),
+            headers_key: Some(headers_key.clone()),
         };
         let topic = format!("{}-{}", topic, chrono::Utc::now().format("%Y%m%d"));
         println!("Topic name generated in test: {:?}", topic);

--- a/website/cue/reference/releases/0.18.0.cue
+++ b/website/cue/reference/releases/0.18.0.cue
@@ -26,6 +26,8 @@ releases: "0.18.0": {
 		  that are not valid. Fixed in v0.18.1.
 		- The new `reroute_dropped` feature of `remap` always creates the
 		  `dropped` output even if `reroute_dropped = false`. Fixed in v0.18.1.
+		- The `headers_key` option for the `kafka` sink was inadvertantly
+		  changed to `headers_field`.
 
 		## Features
 


### PR DESCRIPTION
This was accidentally renamed in 9774570

We traditionally use `<field>_key` for these names so I preferred to
revert it to its old name for consistency rather than simply document
the change as breaking in 0.18.0.

Replaces #10221 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
