### PR TITLE
fix(loki sink): Allow any 2xx code as success

### DIFF
--- a/src/sinks/loki/service.rs
+++ b/src/sinks/loki/service.rs
@@ -105,12 +105,13 @@ impl Service<LokiRequest> for LokiService {
                 Ok(response) => {
                     let status = response.status();
 
-                    match status {
-                        StatusCode::NO_CONTENT => Ok(LokiResponse {
+                    if status.is_success() {
+                        Ok(LokiResponse {
                             batch_size,
                             events_byte_size,
-                        }),
-                        code => Err(LokiError::ServerError { code }),
+                        })
+                    } else {
+                        Err(LokiError::ServerError { code: status })
                     }
                 }
                 Err(error) => Err(LokiError::HttpError { error }),


### PR DESCRIPTION
Loki returns 204 for successful responses, but cLoki (a
Clickhouse-backed Loki-compatible storage) was returning 200s. They
fixed this, but I think it is reasonable to interpret any 200-level
status code as a successful publish. Prior to the sink rewrite in #9506
we were allowing any success code (due to how `HttpSource` handled
responses).

Closes: #10195

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
