### PR TITLE
fix(kubernetes_logs source): Revert read older files first (#10218)

### DIFF
--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -378,9 +378,13 @@ impl Source {
                 max_line_length: max_line_bytes,
                 ignore_not_found: true,
             },
-            // We'd like to consume rotated pod log files first to release our file handle and let
-            // the space be reclaimed
-            oldest_first: true,
+            // We expect the files distribution to not be a concern because of
+            // the way we pick files for gathering: for each container, only the
+            // last log file is currently picked. Thus there's no need for
+            // ordering, as each logical log stream is guaranteed to start with
+            // just one file, makis it impossible to interleave with other
+            // relevant log lines in the absence of such relevant log lines.
+            oldest_first: false,
             // We do not remove the log files, `kubelet` is responsible for it.
             remove_after: None,
             // The standard emitter.


### PR DESCRIPTION
This reverts commit 72067bb8eee63ea058526dd7005332503306fbaa.

This caused CI failures. Reverting to fix master and then I'll look into
the test failure.
