### PR TITLE
docs(observability): Fix 0.17 note about processed_events_total metric

### DIFF
--- a/website/content/en/highlights/2021-10-08-0-17-upgrade-guide.md
+++ b/website/content/en/highlights/2021-10-08-0-17-upgrade-guide.md
@@ -19,7 +19,6 @@ Vector's 0.17.0 release includes several **breaking changes**:
 1. [The deprecated `wasm` transform was removed](#wasm)
 1. [The `exec` source now has a `decoding` setting](#exec_source)
 1. [The algorithm underlying ARC has been optimized](#arc)
-1. [The `events_processed_total` metric was removed](#events_processed_total)
 
 We cover them below to help you upgrade quickly:
 
@@ -102,7 +101,3 @@ the scale factor applied to this value.
 
 [arc]: /docs/about/under-the-hood/networking/arc/
 [rtt_deviation_scale]: /docs/reference/configuration/sinks/http/#request.adaptive_concurrency.rtt_deviation_scale
-
-### The `events_processed_total` metric was removed {#events_processed_total}
-
-This deprecated metric has been replaced by `component_events_sent_total`.

--- a/website/cue/reference/releases/0.17.0.cue
+++ b/website/cue/reference/releases/0.17.0.cue
@@ -19,6 +19,13 @@ releases: "0.17.0": {
 
 	It also contains a number of additional enhancements and bug fixes. Check out the
 	[highlights](/releases/0.17.0#highlights) and [changelog](/releases/0.17.0#changelog) for more details.
+
+	## Known issues
+
+	- `events_out_total` and `processed_events_total` ceased being published by
+	  sources and transforms. This will be fixed in a subsequent release, but
+	  these metrics have also been replaced by `component_sent_events_total`
+	  which is being implemented for all components.
 	"""
 
 	whats_next: [


### PR DESCRIPTION
Follow-up to https://github.com/vectordotdev/vector/pull/10228

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
