### PR TITLE
chore(observability): Revert remove unused alias for `events_processed_total`

### DIFF
--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -137,6 +137,15 @@ impl Controller {
             });
         });
 
+        // Add alias `events_processed_total` for `events_out_total`.
+        for i in 0..metrics.len() {
+            let metric = &metrics[i];
+            if metric.name() == "events_out_total" {
+                let alias = metric.clone().with_name("processed_events_total");
+                metrics.push(alias);
+            }
+        }
+
         let handle = Handle::Counter(Arc::new(Counter::with_count(metrics.len() as u64 + 1)));
         metrics.push(Metric::from_metric_kv(&CARDINALITY_KEY, &handle));
 


### PR DESCRIPTION
This reverts commit 99400f0b0ec7b06080aa6a5de6c0606069070582.

This broke the k8s e2e tests.

Will be replaced by https://github.com/vectordotdev/vector/pull/10228

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
