### PR TITLE
chore(ci): lower `CARGO_BUILD_JOBS` for Windows runner

### DIFF
--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -1,5 +1,6 @@
 if ($env:CI -ne $null) {
     echo "$HOME\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    echo "CARGO_BUILD_JOBS=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 } else {
     $env:Path += ";$HOME\.cargo\bin"
 }


### PR DESCRIPTION
Some Windows CI build are failing because OOM errors (e.g. https://github.com/vectordotdev/vector/runs/4367335521?check_suite_focus=true) 

As per https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources, runners cannot be requested with more ressources. 
And there is not much room to lower the ressource usage as runners have 2 core, hence suggesting to lower the number of parallel cargo jobs to 1.