### PR TITLE
docs: Remove references to playground.vector.dev

### DIFF
--- a/website/content/en/blog/graphql-api.md
+++ b/website/content/en/blog/graphql-api.md
@@ -30,14 +30,28 @@ This is just the beginning. In the near future, the API will enable you to both
 observe _and_ control Vector remotely, programmatically, and on demand. Stay
 tuned!
 
-## Take it for a spin in our live playground
+## Take it for a spin in the Vector playground
 
-Try our new [**GraphQL public playground
-today**](https://playground.vector.dev:8686/playground), which enables you to
-execute queries against a live Vector instance that we host and manage:
+Start up Vector locally with the following config:
 
-![Vector GraphQL API Public
-Playground](/img/blog/vector-api-public-playground.png)
+```toml
+[api]
+enabled = true
+
+[sources.demo]
+type = "demo_logs"
+format = "json"
+interval = 1.0
+
+[sinks.console]
+type = "console"
+inputs = ["demo"]
+encoding.codec = "text"
+```
+
+You can then access
+[http://localhost:8686/playground](http://localhost:8686/playground) to get
+a live GraphQL playground to experiment with.
 
 Here are a few queries you can try:
 

--- a/website/content/en/docs/reference/api.md
+++ b/website/content/en/docs/reference/api.md
@@ -22,7 +22,6 @@ Vector chose [GraphQL] for its API because GraphQL is self-documenting and type 
 
 ### Playground
 
-Vector's GraphQL API ships with a built-in playground that allows you to explore the available commands and manually run queries against the API. This can be accessed at the `/playground` path. We also offer a [public playground][playground] that you can explore without hosting your own Vector instance.
+Vector's GraphQL API ships with a built-in playground that allows you to explore the available commands and manually run queries against the API. This can be accessed at the `/playground` path.
 
 [graphql]: https://graphql.org
-[playground]: https://playground.vector.dev:8686/playground

--- a/website/content/en/highlights/2020-12-23-graphql-api.md
+++ b/website/content/en/highlights/2020-12-23-graphql-api.md
@@ -40,15 +40,8 @@ For a more in-depth look at the API, check out:
 * Our [official documentation]
 * The [Rust code][code] behind the API
 
-## Try it out
-
-To give the GraphQL API a spin, check out the [Vector GraphQL
-Playground][playground], which lets you run queries against a hosted Vector
-instance.
-
 [code]: https://github.com/vectordotdev/vector/tree/master/src/api
 [docs]: https://vector.dev/docs/reference/api
 [graphql]: https://graphql.org
 [lee]: https://github.com/LeeBenson
-[playground]: https://playground.vector.dev:8686/playground
 [post]: https://vector.dev/blog/graphql-api

--- a/website/cue/reference/api.cue
+++ b/website/cue/reference/api.cue
@@ -5,7 +5,6 @@ package metadata
 
 api: {
 	description:     !=""
-	playground_url:  !=""
 	schema_json_url: !=""
 	configuration:   #Schema
 	endpoints:       #Endpoints
@@ -17,7 +16,6 @@ api: {
 		running Vector instance, enabling introspection and management of
 		Vector in real-time.
 		"""
-	playground_url:  "https://playground.vector.dev:8686/playground"
 	schema_json_url: "https://github.com/vectordotdev/vector/blob/master/lib/vector-api-client/graphql/schema.json"
 	configuration: {
 		enabled: {
@@ -90,10 +88,6 @@ api: {
 					A bundled GraphQL playground that enables you
 					to explore the available queries and manually
 					run queries.
-
-					We offer a [public playground](\(playground_url))
-					that you can explore without hosting your own
-					Vector instance.
 					"""
 				responses: {
 					"200": {

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -516,7 +516,6 @@ urls: {
 	vector_generate_arguments_issue:                          "\(vector_repo)/issues/1966"
 	vector_guides:                                            "/guides/"
 	vector_glibc_benchmarks:                                  "\(vector_repo)/issues/2313"
-	vector_graphql_playground:                                "https://playground.vector.dev:8686/playground"
 	vector_highlights:                                        "/highlights/"
 	vector_host_metrics_source:                               "/docs/reference/configuration/sources/host_metrics"
 	vector_http_auth_token:                                   "/docs/reference/configuration/sinks/http/#token"


### PR DESCRIPTION
The Vector deployment hosted at this domain was stood up manually and
never kept up-to-date. Until we can support it properly, just remove
references to the public playground and encourage users to run Vector
locally.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
