### PR TITLE
chore(ci): set CARGO_BUILD_JOBS to half the number of core for Windows runners

### DIFF
--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -1,6 +1,7 @@
 if ($env:CI -ne $null) {
     echo "$HOME\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    echo "CARGO_BUILD_JOBS=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    $N_JOBS=(((Get-CimInstance -ClassName Win32_ComputerSystem).NumberOfLogicalProcessors / 2),1 | Measure-Object -Max).Maximum
+    echo "CARGO_BUILD_JOBS=$N_JOBS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 } else {
     $env:Path += ";$HOME\.cargo\bin"
 }


### PR DESCRIPTION
Less stupid iteration of #10235 that lowers the number of cargo jobs to half the vcpus/cores found on the system.

Edit:
CI jobs are reporting the correct number of jobs (runners are t3.2xlarge / 8 vcpu):

```
  env:
    AUTOINSTALL: true
    AWS_ACCESS_KEY_ID: dummy
    AWS_SECRET_ACCESS_KEY: dummy
    CONTAINER_TOOL: docker
    RUST_BACKTRACE: full
    RUST_TEST_THREADS: 1
    TEST_LOG: vector=debug
    VERBOSE: true
    CI: true
    PROFILE: debug
    RUSTFLAGS: -D warnings
    CARGO_BUILD_JOBS: 4
    SCCACHE_REDIS: ***
    SCCACHE_IDLE_TIMEOUT: 0
```