### PR TITLE
docs(datadog_metrics sink): add missing "site" documentation

### DIFF
--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -52,6 +52,7 @@ components: sinks: datadog_metrics: {
 		api_key:  sinks._datadog.configuration.api_key
 		endpoint: sinks._datadog.configuration.endpoint
 		region:   sinks._datadog.configuration.region
+		site:     sinks._datadog.configuration.site
 		default_namespace: {
 			common: true
 			description: """


### PR DESCRIPTION
The `datadog_metrics` sink supports the "site" option, and mentions it as a non-deprecated alternative to `region`, but the option itself wasn't actually rendered on the page.