### PR TITLE
fix(css website): Fix rendering bug of download matrix in Safari

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -292,3 +292,7 @@
 footer ion-icon[name="logo-github"]:hover {
   @apply dark:text-gray-500
 }
+
+a[type='button'] {
+  -webkit-appearance: unset;
+}

--- a/website/layouts/partials/download/download-matrix.html
+++ b/website/layouts/partials/download/download-matrix.html
@@ -21,7 +21,7 @@
       </span>
     </div>
 
-    <div class="">
+    <div class="w-min">
       {{/* Targets (ARM, x86_64, etc.) */}}
       <div class="flex space-x-1">
         {{ range .options }}


### PR DESCRIPTION
Fix buttons in download matrix for Safari iOS:

- Gives button container width to allow space for buttons.
- Unsets webkit-appearance of type button 

Preview: Check in Safari, light & dark mode
- https://deploy-preview-10303--vector-project.netlify.app/download/
- https://deploy-preview-10303--vector-project.netlify.app/releases/0.18.1/