### PR TITLE
chore(ci): Bump allowed dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       - "domain: deps"
     commit-message:
       prefix: "chore(deps)"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
A few are blocked right now so it'd be nice to have Dependabot be able to create more. The default is 5.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
