### PR TITLE
chore(deps): Revert upgrade to Rust 1.57

### DIFF
--- a/benches/enrichment_tables_file.rs
+++ b/benches/enrichment_tables_file.rs
@@ -39,6 +39,7 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
 
         let mut file = File::new(
             Default::default(),
+            Default::default(),
             SystemTime::now(),
             data,
             // Headers.

--- a/lib/datadog/grok/src/parse_grok_rules.rs
+++ b/lib/datadog/grok/src/parse_grok_rules.rs
@@ -302,7 +302,7 @@ fn index_repeated_fields(grok_patterns: Vec<GrokPattern>) -> Vec<GrokPattern> {
 /// - `inflight_parsed_aliases` - names of the aliases that are being currently parsed(aliases can refer to other aliases) to catch circular dependencies
 fn purify_grok_pattern(
     pattern: &GrokPattern,
-    fields: &mut HashMap<String, GrokField>,
+    mut fields: &mut HashMap<String, GrokField>,
     aliases: &BTreeMap<String, String>,
     parsed_aliases: &mut HashMap<String, ParsedGrokRule>,
     inflight_parsed_aliases: &mut Vec<String>,
@@ -349,14 +349,14 @@ fn purify_grok_pattern(
             } else {
                 res.push_str("(?:"); // non-capturing group
             }
-            res.push_str(resolves_match_function(fields, pattern)?.as_str());
+            res.push_str(resolves_match_function(&mut fields, pattern)?.as_str());
             res.push(')');
         }
         None => {
             // these will be converted to "pure" grok patterns %{PATTERN:DESTINATION} but without filters
             res.push_str("%{");
 
-            res.push_str(resolves_match_function(fields, pattern)?.as_str());
+            res.push_str(resolves_match_function(&mut fields, pattern)?.as_str());
 
             if let Some(destination) = &pattern.destination {
                 if destination.path.is_empty() {

--- a/lib/datadog/search-syntax/src/grammar.rs
+++ b/lib/datadog/search-syntax/src/grammar.rs
@@ -280,7 +280,9 @@ impl QueryVisitor {
                         _ => unreachable!(),
                     }
                 }
-                Rule::query => return Self::visit_query(item, field.unwrap_or(default_field)),
+                Rule::query => {
+                    return Self::visit_query(item, field.as_deref().unwrap_or(default_field))
+                }
                 // We've covered all the cases, so this should never happen
                 _ => unreachable!(),
             }

--- a/lib/k8s-test-framework/src/pod.rs
+++ b/lib/k8s-test-framework/src/pod.rs
@@ -4,7 +4,15 @@ use std::{ffi::OsStr, process::Stdio};
 use tokio::process::Command;
 
 #[derive(Debug)]
-pub struct CommandBuilder {}
+pub struct Config {
+    pod_name: String,
+}
+
+#[derive(Debug)]
+pub struct CommandBuilder {
+    kubctl_command: String,
+    config: Config,
+}
 
 fn prepare_base_command<Cmd, NS, Pod>(
     kubectl_command: Cmd,

--- a/lib/k8s-test-framework/src/temp_file.rs
+++ b/lib/k8s-test-framework/src/temp_file.rs
@@ -1,8 +1,9 @@
 use std::path::{Path, PathBuf};
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 
 #[derive(Debug)]
 pub struct TempFile {
+    dir: TempDir,
     path: PathBuf,
 }
 
@@ -11,7 +12,7 @@ impl TempFile {
         let dir = tempdir()?;
         let path = dir.path().join(file_name);
         std::fs::write(&path, data)?;
-        Ok(Self { path })
+        Ok(Self { dir, path })
     }
 
     pub fn path(&self) -> &Path {

--- a/lib/soak/src/bin/observer.rs
+++ b/lib/soak/src/bin/observer.rs
@@ -114,12 +114,14 @@ struct QueryResult {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct QueryData {
+    result_type: String,
     result: Vec<QueryResult>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct QueryResponse {
+    status: Status,
     data: QueryData,
 }
 

--- a/lib/vector-core/buffers/src/acker.rs
+++ b/lib/vector-core/buffers/src/acker.rs
@@ -53,6 +53,6 @@ where
     T: Ackable,
 {
     fn ack_size(&self) -> usize {
-        self.iter().map(Ackable::ack_size).sum()
+        self.iter().map(|x| x.ack_size()).sum()
     }
 }

--- a/lib/vector-core/core-common/src/byte_size_of.rs
+++ b/lib/vector-core/core-common/src/byte_size_of.rs
@@ -66,7 +66,7 @@ where
     T: ByteSizeOf,
 {
     fn allocated_bytes(&self) -> usize {
-        self.as_ref().map_or(0, ByteSizeOf::allocated_bytes)
+        self.as_ref().map_or(0, |x| x.allocated_bytes())
     }
 }
 

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -417,6 +417,6 @@ impl DecodeBytes<Event> for Event {
     where
         B: Buf,
     {
-        proto::EventWrapper::decode(buffer).map(Into::into)
+        proto::EventWrapper::decode(buffer).map(|wrp| wrp.into())
     }
 }

--- a/lib/vector-core/src/event/test/size_of.rs
+++ b/lib/vector-core/src/event/test/size_of.rs
@@ -113,7 +113,7 @@ fn log_operation_maintains_size() {
             match action {
                 Action::InsertFlat { key, value } => {
                     let new_value_sz = value.size_of();
-                    let old_value_sz = log_event.get_flat(&key).map_or(0, ByteSizeOf::size_of);
+                    let old_value_sz = log_event.get_flat(&key).map_or(0, |x| x.size_of());
                     if !log_event.contains(&key) {
                         current_size += key.size_of();
                     }

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -211,7 +211,7 @@ impl vrl_core::Target for VrlTarget {
                     }))
                 } else {
                     log.remove(path, compact)
-                        .map(|val| val.map(Into::into))
+                        .map(|val| val.map(|val| val.into()))
                         .map_err(|err| err.to_string())
                 }
             }

--- a/lib/vector-core/src/mapping/mod.rs
+++ b/lib/vector-core/src/mapping/mod.rs
@@ -143,8 +143,6 @@ impl Function for Noop {
 
 #[derive(Debug)]
 pub struct Mapping {
-    // this whole module needs to go away but I had trouble untangling it from what is _actually_ used by the legacy lookups
-    #[allow(dead_code)]
     assignments: Vec<Box<dyn Function>>,
 }
 

--- a/lib/vector-core/src/metrics/handle.rs
+++ b/lib/vector-core/src/metrics/handle.rs
@@ -25,7 +25,7 @@ impl AtomicF64 {
     {
         let res = self.inner.fetch_update(set_order, fetch_order, |x| {
             let opt: Option<f64> = f(f64::from_bits(x));
-            opt.map(f64::to_bits)
+            opt.map(|i| i.to_bits())
         });
 
         res.map(f64::from_bits).map_err(f64::from_bits)

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -287,7 +287,7 @@ impl<'a> Compiler<'a> {
             }
         };
 
-        Assignment::new(node, self.state).unwrap_or_else(|err| {
+        Assignment::new(node, &mut self.state).unwrap_or_else(|err| {
             self.state.rollback();
             self.errors.push(Box::new(err));
             Assignment::noop()

--- a/lib/vrl/compiler/src/context.rs
+++ b/lib/vrl/compiler/src/context.rs
@@ -34,7 +34,7 @@ impl<'a> Context<'a> {
 
     /// Get a mutable reference to the [`runtime state`](Runtime).
     pub fn state_mut(&mut self) -> &mut Runtime {
-        self.state
+        &mut self.state
     }
 
     /// Get a reference to the [`TimeZone`]

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -19,7 +19,7 @@ impl Assignment {
         node: Node<Variant<Node<ast::AssignmentTarget>, Node<Expr>>>,
         state: &mut State,
     ) -> Result<Self, Error> {
-        let (_, variant) = node.take();
+        let (span, variant) = node.take();
 
         let variant = match variant {
             Variant::Single { target, expr } => {
@@ -35,6 +35,7 @@ impl Assignment {
                             target.to_string(),
                             expr.to_string(),
                         ),
+                        span,
                         expr_span,
                         assignment_span,
                     });
@@ -44,6 +45,7 @@ impl Assignment {
                 if matches!(target.as_ref(), ast::AssignmentTarget::Noop) {
                     return Err(Error {
                         variant: ErrorVariant::UnnecessaryNoop(target_span),
+                        span,
                         expr_span,
                         assignment_span,
                     });
@@ -80,6 +82,7 @@ impl Assignment {
                             ok_span,
                             err_span,
                         ),
+                        span,
                         expr_span,
                         assignment_span,
                     });
@@ -92,6 +95,7 @@ impl Assignment {
                 if ok_noop && err_noop {
                     return Err(Error {
                         variant: ErrorVariant::UnnecessaryNoop(ok_span),
+                        span,
                         expr_span,
                         assignment_span,
                     });
@@ -319,6 +323,7 @@ impl TryFrom<ast::AssignmentTarget> for Target {
                     _ => {
                         return Err(Error {
                             variant: ErrorVariant::InvalidTarget(span),
+                            span,
                             expr_span: span,
                             assignment_span: span,
                         })
@@ -425,6 +430,7 @@ pub(crate) struct Details {
 #[derive(Debug)]
 pub struct Error {
     variant: ErrorVariant,
+    span: Span,
     expr_span: Span,
     assignment_span: Span,
 }

--- a/lib/vrl/compiler/src/expression/predicate.rs
+++ b/lib/vrl/compiler/src/expression/predicate.rs
@@ -20,6 +20,7 @@ impl Predicate {
             return Err(Error {
                 variant: ErrorVariant::NonBoolean(type_def.kind()),
                 span,
+                labels: vec![],
             });
         }
 
@@ -107,6 +108,7 @@ pub struct Error {
     pub(crate) variant: ErrorVariant,
 
     span: Span,
+    labels: Vec<Label>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/lib/vrl/compiler/src/value/arithmetic.rs
+++ b/lib/vrl/compiler/src/value/arithmetic.rs
@@ -84,7 +84,7 @@ impl Value {
         self,
         mut rhs: impl FnMut() -> Result<Self, ExpressionError>,
     ) -> Result<Self, Error> {
-        let err = Error::Or;
+        let err = |err| Error::Or(err);
 
         match self {
             Value::Null => rhs().map_err(err),

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -161,7 +161,6 @@ impl IntoIterator for Program {
 // root expression
 // -----------------------------------------------------------------------------
 
-#[allow(clippy::large_enum_variant)] // discovered during Rust upgrade to 1.57; just allowing for now since we did previously
 #[derive(PartialEq)]
 pub enum RootExpr {
     Expr(Node<Expr>),

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -29,6 +29,9 @@ pub struct Cmd {
     #[structopt(short, long)]
     no_diff: bool,
 
+    #[structopt(long)]
+    skip_functions: bool,
+
     /// When enabled, any log output at the INFO or above level is printed
     /// during the test run.
     #[structopt(short, long)]

--- a/lib/vrl/tests/src/test.rs
+++ b/lib/vrl/tests/src/test.rs
@@ -129,21 +129,17 @@ fn test_category(path: &Path) -> String {
     path.to_string_lossy()
         .strip_prefix("tests/")
         .expect("test")
-        .rsplit_once('/')
-        .map_or(
-            path.to_string_lossy()
-                .strip_prefix("tests/")
-                .unwrap()
-                .to_owned(),
-            |x| x.0.to_owned(),
-        )
+        .rsplitn(2, '/')
+        .nth(1)
+        .unwrap()
+        .to_owned()
 }
 
 fn test_name(path: &Path) -> String {
     path.to_string_lossy()
-        .rsplit_once('/')
+        .rsplitn(2, '/')
+        .next()
         .unwrap()
-        .1
         .trim_end_matches(".vrl")
         .replace("_", " ")
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.57.0"
+channel = "1.56.1"
 profile = "default"

--- a/src/aws/rusoto/mod.rs
+++ b/src/aws/rusoto/mod.rs
@@ -109,7 +109,6 @@ impl ProvideAwsCredentials for CustomChainProvider {
 }
 
 // A place-holder for the types of AWS credentials we support
-#[allow(clippy::large_enum_variant)] // discovered during Rust upgrade to 1.57; just allowing for now since we did previously
 pub enum AwsCredentialsProvider {
     Default(AutoRefreshingProvider<CustomChainProvider>),
     Role(AutoRefreshingProvider<StsAssumeRoleSessionCredentialsProvider>),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -380,10 +380,10 @@ pub trait SinkConfig: core::fmt::Debug + Send + Sync {
 
 #[derive(Debug, Clone)]
 pub struct SinkContext {
-    pub acker: Acker,
-    pub healthcheck: SinkHealthcheckOptions,
-    pub globals: GlobalOptions,
-    pub proxy: ProxyConfig,
+    pub(super) acker: Acker,
+    pub(super) healthcheck: SinkHealthcheckOptions,
+    pub(super) globals: GlobalOptions,
+    pub(super) proxy: ProxyConfig,
 }
 
 impl SinkContext {

--- a/src/config/unit_test.rs
+++ b/src/config/unit_test.rs
@@ -114,7 +114,7 @@ fn events_to_string(name: &str, events: &[Event]) -> String {
             name,
             events
                 .iter()
-                .map(event_to_string)
+                .map(|e| event_to_string(e))
                 .collect::<Vec<_>>()
                 .join("\n    ")
         )

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -167,7 +167,13 @@ impl EnrichmentTableConfig for FileConfig {
     ) -> crate::Result<Box<dyn Table + Send + Sync>> {
         let (headers, data, modified) = self.load_file(globals.timezone)?;
 
-        Ok(Box::new(File::new(self.clone(), modified, data, headers)))
+        Ok(Box::new(File::new(
+            self.clone(),
+            globals.timezone,
+            modified,
+            data,
+            headers,
+        )))
     }
 }
 
@@ -180,6 +186,7 @@ impl_generate_config_from_default!(FileConfig);
 #[derive(Clone)]
 pub struct File {
     config: FileConfig,
+    timezone: TimeZone,
     last_modified: SystemTime,
     data: Vec<Vec<Value>>,
     headers: Vec<String>,
@@ -193,12 +200,14 @@ pub struct File {
 impl File {
     pub fn new(
         config: FileConfig,
+        timezone: TimeZone,
         last_modified: SystemTime,
         data: Vec<Vec<Value>>,
         headers: Vec<String>,
     ) -> Self {
         Self {
             config,
+            timezone,
             last_modified,
             data,
             headers,
@@ -605,6 +614,7 @@ mod tests {
     fn finds_row() {
         let file = File::new(
             Default::default(),
+            shared::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec!["zip".into(), "zup".into()],
@@ -631,6 +641,7 @@ mod tests {
     fn duplicate_indexes() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             Vec::new(),
             vec![
@@ -651,6 +662,7 @@ mod tests {
     fn errors_on_missing_columns() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             Vec::new(),
             vec![
@@ -671,6 +683,7 @@ mod tests {
     fn finds_row_with_index() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec!["zip".into(), "zup".into()],
@@ -699,6 +712,7 @@ mod tests {
     fn finds_rows_with_index_case_sensitive() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec!["zip".into(), "zup".into()],
@@ -750,6 +764,7 @@ mod tests {
     fn selects_columns() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec!["zip".into(), "zup".into(), "zoop".into()],
@@ -794,6 +809,7 @@ mod tests {
     fn finds_rows_with_index_case_insensitive() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec!["zip".into(), "zup".into()],
@@ -854,6 +870,7 @@ mod tests {
     fn finds_row_with_dates() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec![
@@ -895,6 +912,7 @@ mod tests {
     fn doesnt_find_row() {
         let file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec!["zip".into(), "zup".into()],
@@ -918,6 +936,7 @@ mod tests {
     fn doesnt_find_row_with_index() {
         let mut file = File::new(
             Default::default(),
+            shared::datetime::TimeZone::Local,
             SystemTime::now(),
             vec![
                 vec!["zip".into(), "zup".into()],

--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -302,7 +302,6 @@ mod tests {
     }
 
     // A helper enum to encode expected mock watcher stream.
-    #[allow(clippy::large_enum_variant)] // discovered during Rust upgrade to 1.57; just allowing for now since we did previously
     enum ExpStmRes {
         Item(WatchEvent<Pod>),
         Desync,

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -8,7 +8,6 @@ pub type SignalRx = mpsc::Receiver<SignalTo>;
 
 #[derive(Debug)]
 /// Control messages used by Vector to drive topology and shutdown events.
-#[allow(clippy::large_enum_variant)] // discovered during Rust upgrade to 1.57; just allowing for now since we did previously
 pub enum SignalTo {
     /// Signal to reload config from a string.
     ReloadFromConfigBuilder(ConfigBuilder),

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -35,6 +35,7 @@ use super::util::SinkBatchSettings;
 #[derive(Clone)]
 pub struct CloudWatchMetricsSvc {
     client: CloudWatchClient,
+    config: CloudWatchMetricsSinkConfig,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -145,7 +146,7 @@ impl CloudWatchMetricsSvc {
             ..Default::default()
         });
 
-        let cloudwatch_metrics = CloudWatchMetricsSvc { client };
+        let cloudwatch_metrics = CloudWatchMetricsSvc { client, config };
 
         let svc = request.service(CloudWatchMetricsRetryLogic, cloudwatch_metrics);
 
@@ -312,7 +313,7 @@ mod tests {
     fn svc() -> CloudWatchMetricsSvc {
         let config = config();
         let client = config.create_client(&ProxyConfig::from_env()).unwrap();
-        CloudWatchMetricsSvc { client }
+        CloudWatchMetricsSvc { client, config }
     }
 
     #[test]

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -659,7 +659,6 @@ timestamp_format = "unix""#,
     }
 
     #[derive(Debug, Deserialize)]
-    #[allow(dead_code)] // deserialize all fields
     struct QueryResponse {
         data: Vec<Value>,
         meta: Vec<Value>,
@@ -668,7 +667,6 @@ timestamp_format = "unix""#,
     }
 
     #[derive(Debug, Deserialize)]
-    #[allow(dead_code)] // deserialize all fields
     struct Stats {
         bytes_read: usize,
         elapsed: f64,

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -366,7 +366,6 @@ mod integration_tests {
 
     #[derive(Debug, Deserialize)]
     #[allow(non_snake_case)]
-    #[allow(dead_code)] // deserialize all fields
     struct PullMessageOuter {
         ackId: String,
         message: PullMessage,
@@ -374,7 +373,6 @@ mod integration_tests {
 
     #[derive(Debug, Deserialize)]
     #[allow(non_snake_case)]
-    #[allow(dead_code)] // deserialize all fields
     struct PullMessage {
         data: String,
         messageId: String,

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -351,7 +351,6 @@ mod tests {
 
         #[derive(Deserialize, Debug)]
         #[serde(deny_unknown_fields)]
-        #[allow(dead_code)] // deserialize all fields
         struct ExpectedEvent {
             message: String,
             timestamp: chrono::DateTime<chrono::Utc>,

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -373,7 +373,6 @@ mod integration_tests {
     }
 
     #[derive(Clone, Deserialize)]
-    #[allow(dead_code)] // deserialize all fields
     struct HumioLog {
         #[serde(rename = "#repo")]
         humio_repo: String,

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -501,7 +501,7 @@ fn spawn_reader_thread<R: 'static + AsyncRead + Unpin + std::marker::Send>(
     sender: Sender<((SmallVec<[Event; 1]>, usize), &'static str)>,
 ) {
     // Start the green background thread for collecting
-    let _ = Box::pin(tokio::spawn(async move {
+    Box::pin(tokio::spawn(async move {
         debug!("Start capturing {} command output.", origin);
 
         let mut stream = FramedRead::new(reader, decoder);

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -331,7 +331,7 @@ pub fn file_source(
     Box::pin(async move {
         info!(message = "Starting file server.", include = ?include, exclude = ?exclude);
 
-        let mut encoding_decoder = encoding_charset.map(Decoder::new);
+        let mut encoding_decoder = encoding_charset.map(|e| Decoder::new(e));
 
         // sizing here is just a guess
         let (tx, rx) = futures::channel::mpsc::channel::<Vec<Line>>(2);

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -425,7 +425,10 @@ impl FilterList {
     #[cfg(test)]
     fn contains_test(&self, value: Option<&str>) -> bool {
         let result = self.contains_str(value);
-        assert_eq!(result, self.contains_path(value.map(std::path::Path::new)));
+        assert_eq!(
+            result,
+            self.contains_path(value.map(|value| std::path::Path::new(value)))
+        );
         result
     }
 }

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -227,7 +227,6 @@ struct MetadataClient {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)] // deserialize all fields
 struct IdentityDocument {
     account_id: String,
     architecture: String,

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -829,8 +829,8 @@ mod test {
         let mut merger = get_value_merger(initial, strategy)?;
         merger.add(additional)?;
         let mut output = Event::new_empty_log();
-        let output = output.as_mut_log();
-        merger.insert_into("out".into(), output)?;
+        let mut output = output.as_mut_log();
+        merger.insert_into("out".into(), &mut output)?;
         Ok(output.remove("out").unwrap())
     }
 }


### PR DESCRIPTION
This appears to have broken k8s tests:

https://github.com/vectordotdev/vector/runs/4437594689?check_suite_focus=true

This reverts commit 5d0cddc76b556f324c138958c9df9a31036dbf1c.
