### PR TITLE
Transmute between vrl value and vector value

### DIFF
--- a/lib/vrl/compiler/src/value.rs
+++ b/lib/vrl/compiler/src/value.rs
@@ -31,6 +31,17 @@ pub enum Value {
     Regex(Regex),
 }
 
+impl Value {
+    pub fn contains_regex(&self) -> bool {
+        match self {
+            Value::Regex(_) => true,
+            Value::Object(map) => map.iter().any(|(_, value)| value.contains_regex()),
+            Value::Array(arr) => arr.iter().any(|value| value.contains_regex()),
+            _ => false,
+        }
+    }
+}
+
 impl Eq for Value {}
 
 impl fmt::Display for Value {

--- a/lib/vrl/compiler/src/value.rs
+++ b/lib/vrl/compiler/src/value.rs
@@ -24,11 +24,11 @@ pub enum Value {
     Integer(i64),
     Float(NotNan<f64>),
     Boolean(bool),
+    Timestamp(DateTime<Utc>),
     Object(BTreeMap<String, Value>),
     Array(Vec<Value>),
-    Timestamp(DateTime<Utc>),
-    Regex(Regex),
     Null,
+    Regex(Regex),
 }
 
 impl Eq for Value {}


### PR DESCRIPTION
Experimental branch to see if we can just do a quick transmute betweer Vector Value and Vrl Value.

The main issue is that Vrl Value contains an extra `Regex` variant, which cannot be converted to Vector value. Currently, we convert this to a `Bytes`.

This will cause a segfault when converting a Vrl Array or Object containing a Regex to a Vector Value. 

It is a rare occurrence that someone would set a field in Vrl to a Regex. I am just pushing this to see what it does to the soak numbers, and we can perhaps consider ways to handle Regexes if the numbers seem promising enough.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>


