### PR TITLE
docs(elasticsearch sink): Fix deprecating messages in the cue file

### DIFF
--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -134,7 +134,7 @@ components: sinks: elasticsearch: {
 				Currently, Vector only supports `index` and `create`. `update` and `delete` actions are not supported.
 				"""
 			required:    false
-			warnings: ["This option has been deprecated, the `normal.bulk_action` option should be used."]
+			warnings: ["This option has been deprecated, the `bulk.action` option should be used."]
 			type: string: {
 				default: "index"
 				examples: ["index", "create", "{{ action }}"]
@@ -258,7 +258,7 @@ components: sinks: elasticsearch: {
 			common:      true
 			description: "Index name to write events to."
 			required:    false
-			warnings: ["This option has been deprecated, the `normal.index` option should be used."]
+			warnings: ["This option has been deprecated, the `bulk.index` option should be used."]
 			type: string: {
 				default: "vector-%F"
 				examples: ["application-{{ application_id }}-%Y-%m-%d", "vector-%Y-%m-%d"]


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

`normal.bulk_action` and `normal.index` do not exist. Should be `bulk.action` and `bulk.index`.
