### PR TITLE
chore: Avoid dinging PRs on erratic soaks

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -394,7 +394,7 @@ jobs:
                                          --baseline-sha ${{ needs.compute-soak-meta.outputs.baseline-sha }} \
                                          --comparison-sha ${{ needs.compute-soak-meta.outputs.comparison-sha }} \
                                          --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
-                                         --warmup-seconds 30 \
+                                         --warmup-seconds 30 --erratic-soaks syslog_loki,http_to_http_acks \
                                          --p-value 0.1 > /tmp/${{ github.event.number}}-${{ github.run_attempt }}-analysis
 
       - name: Read analysis file
@@ -449,5 +449,5 @@ jobs:
       - name: Detect regressions
         run: |
           ./soaks/bin/detect_regressions --capture-dir ${{ github.event.number }}-${{ github.run_attempt }}-captures/ \
-                                         --warmup-seconds 30 \
+                                         --warmup-seconds 30 --erratic-soaks syslog_loki,http_to_http_acks \
                                          --p-value 0.1

--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -23,14 +23,17 @@ def human_bytes(b):
 
 
 parser = argparse.ArgumentParser(description='t-test experiments with Welch method')
-parser.add_argument('--capture-dir', type=str, help='the directory to search for capture csv files')
-parser.add_argument('--warmup-seconds', type=int, help='the number of seconds to treat as warmup')
 parser.add_argument('--baseline-sha', type=str, help='the sha of the baseline experiment')
+parser.add_argument('--capture-dir', type=str, help='the directory to search for capture csv files')
 parser.add_argument('--comparison-sha', type=str, help='the sha of the comparison experiment')
-parser.add_argument('--vector-cpus', type=int, help='the total number of CPUs given to vector during the experiment')
-parser.add_argument('--p-value', type=float, default=0.1, help='the p-value for comparing with t-test results, the smaller the more certain')
+parser.add_argument('--erratic-soaks', type=str, default='', help='a comma separated list of known-erratic experiments, NOT TO BE USED LIGHTLY')
 parser.add_argument('--mean-drift-percentage', type=float, default=8.87, help='the percentage of mean drift we allow in an experiment, expressed as a value from 0 to 100, default 9th percentile')
+parser.add_argument('--p-value', type=float, default=0.1, help='the p-value for comparing with t-test results, the smaller the more certain')
+parser.add_argument('--vector-cpus', type=int, help='the total number of CPUs given to vector during the experiment')
+parser.add_argument('--warmup-seconds', type=int, help='the number of seconds to treat as warmup')
 args = parser.parse_args()
+
+erratic_soaks = args.erratic_soaks.split(',')
 
 capture_paths = glob.glob(os.path.join(args.capture_dir, "**/*.captures"))
 captures = []
@@ -94,7 +97,10 @@ for exp in csv.experiment.unique():
                           'comparison mean': comparison_mean,
                           'comparison stdev': comparison_stdev,
                           'comparison outlier percentage': (comparison_outliers / len(comparison)) * 100,
-                          't-statistic': res.statistic, 'p-value': res.pvalue })
+                          't-statistic': res.statistic,
+                          'p-value': res.pvalue,
+                          'erratic': exp in erratic_soaks
+                          })
 
 ttest_results = pd.DataFrame.from_records(ttest_results)
 
@@ -124,7 +130,8 @@ changes = changes.drop(labels=['t-statistic', 'p-value', 'baseline mean',
                                'baseline stdev', 'comparison mean',
                                'baseline outlier percentage',
                                'comparison outlier percentage',
-                               'comparison stdev'], axis=1)
+                               'comparison stdev', 'erratic'], axis=1)
+changes = changes.loc[~changes['experiment'].isin(erratic_soaks)]
 changes = changes[changes['Δ mean %'].abs() > args.mean_drift_percentage].sort_values('Δ mean', ascending=False)
 changes['Δ mean'] = changes['Δ mean'].apply(human_bytes)
 if len(changes) > 0:

--- a/soaks/bin/detect_regressions
+++ b/soaks/bin/detect_regressions
@@ -9,10 +9,13 @@ import sys
 
 parser = argparse.ArgumentParser(description='t-test experiments with Welch method')
 parser.add_argument('--capture-dir', type=str, help='the directory to search for capture csv files')
-parser.add_argument('--warmup-seconds', type=int, help='the number of seconds to treat as warmup')
-parser.add_argument('--p-value', type=float, default=0.05, help='the p-value for comparing with t-test results, the smaller the more certain')
+parser.add_argument('--erratic-soaks', type=str, default='', help='a comma separated list of known-erratic experiments, NOT TO BE USED LIGHTLY')
 parser.add_argument('--mean-drift-percentage', type=float, default=8.87, help='the percentage of mean drift we allow in an experiment, expressed as a value from 0 to 100, default 9th percentile')
+parser.add_argument('--p-value', type=float, default=0.05, help='the p-value for comparing with t-test results, the smaller the more certain')
+parser.add_argument('--warmup-seconds', type=int, help='the number of seconds to treat as warmup')
 args = parser.parse_args()
+
+erratic_soaks = args.erratic_soaks.split(',')
 
 capture_paths = glob.glob(os.path.join(args.capture_dir, "**/*.captures"))
 captures = []
@@ -68,7 +71,9 @@ for exp in csv.experiment.unique():
                           'Δ mean %': percent_change,
                           'baseline mean': baseline_mean,
                           'comparison mean': comparison_mean,
-                          'p-value': res.pvalue })
+                          'p-value': res.pvalue
+                          'erratic': exp in erratic_soaks
+                          })
 ttest_results = pd.DataFrame.from_records(ttest_results)
 print("Table of test results:")
 print("")
@@ -77,6 +82,7 @@ print(ttest_results.to_markdown(index=False, tablefmt='github'))
 
 p_value_violation = ttest_results['p-value'] < args.p_value
 changes = ttest_results[p_value_violation]
+changes = changes.loc[~changes['experiment'].isin(erratic_soaks)]
 changes = changes[changes['Δ mean %'] <  -args.mean_drift_percentage]
 print("")
 print("Table normalized to only show regressions, {} p-value threshold, {} drift threshold:".format(args.p_value, args.mean_drift_percentage))

--- a/soaks/bin/detect_regressions
+++ b/soaks/bin/detect_regressions
@@ -71,7 +71,7 @@ for exp in csv.experiment.unique():
                           'Δ mean %': percent_change,
                           'baseline mean': baseline_mean,
                           'comparison mean': comparison_mean,
-                          'p-value': res.pvalue
+                          'p-value': res.pvalue,
                           'erratic': exp in erratic_soaks
                           })
 ttest_results = pd.DataFrame.from_records(ttest_results)


### PR DESCRIPTION
When we initially build the soak testing infrastructure we didn't consider that
some configurations of vector would be so erratic that their baseline /
comparison differences would always be statistically distinct. It turns out, we
have two. This commit adds a mechanism to avoid alerting on these erratic
configurations and sets syslog_loki, http_to_http_ack as the first two known
erratic soaks.

This is an important signal for how vector behaves, so adding an erratic soak
should not be done lightly. What this means in practice is our users can't rely
on vector's stablility for these two configurations.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
