### PR TITLE
enhancement(external docs): Add condition config examples

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -383,6 +383,13 @@ _values: {
 		example:     !=""
 	}
 
+	#ConditionExample: {
+		title: !=""
+		name: "vrl" | "datadog_search"
+		example: !=""
+		vrl_only: bool | *false
+	}
+
 	syntaxes: [#Syntax, ...#Syntax] & [
 			{
 			name:        "vrl"
@@ -426,6 +433,25 @@ _values: {
 			[JSON](\(urls.json)) | `"condition": ".status == 200"`
 			"""
 	}
+
+	condition_examples: [#ConditionExample, ...#ConditionExample] & [
+		{
+			title: "Standard VRL"
+			name: "vrl"
+			example: ".status == 500"
+		},
+		{
+			title: "Datadog Search"
+			name: "datadog_search"
+			example: "*stack"
+		},
+		{
+			title: "VRL shorthand"
+			name: "vrl"
+			example: ".status == 500"
+			vrl_only: true
+		}
+	]
 }
 
 #TypePrimitive: {

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -384,9 +384,9 @@ _values: {
 	}
 
 	#ConditionExample: {
-		title: !=""
-		name: "vrl" | "datadog_search"
-		example: !=""
+		title:    !=""
+		name:     "vrl" | "datadog_search"
+		example:  !=""
 		vrl_only: bool | *false
 	}
 
@@ -435,22 +435,22 @@ _values: {
 	}
 
 	condition_examples: [#ConditionExample, ...#ConditionExample] & [
-		{
-			title: "Standard VRL"
-			name: "vrl"
+				{
+			title:   "Standard VRL"
+			name:    "vrl"
 			example: ".status == 500"
 		},
 		{
-			title: "Datadog Search"
-			name: "datadog_search"
+			title:   "Datadog Search"
+			name:    "datadog_search"
 			example: "*stack"
 		},
 		{
-			title: "VRL shorthand"
-			name: "vrl"
-			example: ".status == 500"
+			title:    "VRL shorthand"
+			name:     "vrl"
+			example:  ".status == 500"
 			vrl_only: true
-		}
+		},
 	]
 }
 

--- a/website/cue/reference/components/transforms/reduce.cue
+++ b/website/cue/reference/components/transforms/reduce.cue
@@ -125,12 +125,7 @@ components: transforms: reduce: {
 				for an event, the previous transaction is flushed (without this event) and a new transaction is started.
 				"""
 			required: false
-			type: string: {
-				default: null
-				examples: [
-					#".status_code != 200 && !includes(["info", "debug"], .severity)"#,
-				]
-			}
+			type: condition: {}
 		}
 	}
 

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -1985,11 +1985,11 @@
 {{ end }}
 
 {{ define "config-condition" }}
-{{ $name := .name }}
+{{ $configName := .name }}
 <div class="mt-4">
   <div class="border rounded dark:border-gray-700 divide-y dark:divide-gray-700">
     {{ range $k, $v := .condition.options }}
-    {{ $id := printf "%s.%s" $name $k }}
+    {{ $id := printf "%s.%s" $configName $k }}
     <div class="py-3 px-5">
       <div>
         {{ partial "heading.html" (dict "text" $id "level" 4 "mono" true) }}
@@ -2052,29 +2052,50 @@
 
     <div class="mt-4">
       <span>
-        {{ partial "heading.html" (dict "text" "Full config examples" "level" 3) }}
+        {{ partial "heading.html" (dict "text" "Condition config examples" "level" 3) }}
       </span>
 
-      <p>
-        The examples below are in TOML format, but JSON and YAML are also supported.
-      </p>
-
-      <div class="flex flex-col space-y-2">
+      <div class="mt-2 flex flex-col space-y-2">
         {{ range .condition.condition_examples }}
+        {{ $name := .name }}
+        {{ $example := .example }}
+        {{ $vrlOnly := .vrl_only }}
         <div class="flex flex-col space-y-2">
           <span>
             {{ partial "heading.html" (dict "text" .title "level" 4) }}
           </span>
 
-          <div>
-            {{ $code := "" }}
-            {{ if .vrl_only }}
-            {{ $code = printf "%s = \"%s\"" $name .example }}
-            {{ else }}
-            {{ $code = printf "%s.type = \"%s\"\n%s.source = \"%s\"" $name .name $name .example }}
+          {{ $formats := slice "toml" "yaml" "json" }}
+          <div class="flex space-x-2">
+            {{ range $formats }}
+            <button @click="$store.global.setFormat('{{ . }}')"
+              :class="{ 'text-secondary dark:text-primary': $store.global.isFormat('{{ . }}') }" class="font-semibold">
+              {{ . | upper }}
+            </button>
             {{ end }}
-            {{ highlight $code "ruby" "" }}
           </div>
+
+          {{ range $formats }}
+          {{ $code := "" }}
+          {{ $shorthand := "" }}
+          {{ if eq . "toml" }}
+          {{ $code = printf "%s = { type = \"%s\", source = \"%s\" }" $configName $name $example }}
+          {{ $shorthand = printf "%s = \"%s\"" $configName $example }}
+          {{ else if eq . "yaml" }}
+          {{ $code = printf "%s:\n  type: \"%s\"\n  source: \"%s\"" $configName $name $example }}
+          {{ $shorthand = printf "%s: \"%s\"" $configName $example }}
+          {{ else if eq . "json" }}
+          {{ $code = printf "\"%s\": {\n  \"type\": \"%s\",\n  \"source\": \"%s\"\n}" $configName $name $example }}
+          {{ $shorthand = printf "\"%s\": \"%s\"" $configName $example }}
+          {{ end }}
+          <div x-show="$store.global.isFormat('{{ . }}')" class="mt-2">
+            {{ if $vrlOnly }}
+            {{ highlight $shorthand . "" }}
+            {{ else }}
+            {{ highlight $code . "" }}
+            {{ end }}
+          </div>
+          {{ end }}
         </div>
         {{ end }}
       </div>

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -84,7 +84,7 @@
 
       {{ range $k, $v := $v.type }}
       {{ if eq $k "condition" }}
-      {{ template "config-condition" (dict "name" $k "condition" $v) }}
+      {{ template "config-condition" (dict "name" $name "condition" $v) }}
       {{ end }}
 
       {{ if eq $k "object" }} {{/* Object (with sub-configs) */}}
@@ -2047,6 +2047,36 @@
 
       <div class="mt-2 prose dark:prose-dark max-w-none">
         {{ .condition.shorthand_explainer.description | markdownify }}
+      </div>
+    </div>
+
+    <div class="mt-4">
+      <span>
+        {{ partial "heading.html" (dict "text" "Full config examples" "level" 3) }}
+      </span>
+
+      <p>
+        The examples below are in TOML format, but JSON and YAML are also supported.
+      </p>
+
+      <div class="flex flex-col space-y-2">
+        {{ range .condition.condition_examples }}
+        <div class="flex flex-col space-y-2">
+          <span>
+            {{ partial "heading.html" (dict "text" .title "level" 4) }}
+          </span>
+
+          <div>
+            {{ $code := "" }}
+            {{ if .vrl_only }}
+            {{ $code = printf "%s = \"%s\"" $name .example }}
+            {{ else }}
+            {{ $code = printf "%s.type = \"%s\"\n%s.source = \"%s\"" $name .name $name .example }}
+            {{ end }}
+            {{ highlight $code "ruby" "" }}
+          </div>
+        </div>
+        {{ end }}
       </div>
     </div>
   </div>

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -84,71 +84,7 @@
 
       {{ range $k, $v := $v.type }}
       {{ if eq $k "condition" }}
-      <div class="mt-4">
-        <div class="border rounded dark:border-gray-700 divide-y dark:divide-gray-700">
-          {{ range $k, $v := $v.options }}
-          {{ $id := printf "%s.%s" $name $k }}
-          <div class="py-3 px-5">
-            <div>
-              {{ partial "heading.html" (dict "text" $id "level" 4 "mono" true) }}
-            </div>
-
-            <div class="mt-2 prose dark:prose-dark max-w-none">
-              {{ $v.description | markdownify }}
-            </div>
-          </div>
-          {{ end }}
-        </div>
-
-        <div class="my-4 ml-2">
-          <span>
-            {{ partial "heading.html" (dict "text" "Available syntaxes" "level" 3 "icon" false "toc_hide" true) }}
-          </span>
-
-          <table class="table-auto">
-            <thead>
-              <tr>
-                <th>
-                  Syntax
-                </th>
-                <th>
-                  Description
-                </th>
-                <th>
-                  Example
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{ range $v.syntaxes }}
-              <tr>
-                <td>
-                  <code>
-                    {{ .name }}
-                  </code>
-                </td>
-                <td>
-                  {{ .description | markdownify }}
-                </td>
-                <td>
-                  <code>{{ .example }}</code>
-                </td>
-              </tr>
-              {{ end }}
-            </tbody>
-          </table>
-
-          <div class="py-3 px-5 border rounded-md border-green-500">
-            <span>
-              {{ partial "heading.html" (dict "text" $v.shorthand_explainer.title "level" 3 "icon" false "toc_hide" true) }}
-            </span>
-
-            <div class="mt-2 prose dark:prose-dark max-w-none">
-              {{ $v.shorthand_explainer.description | markdownify }}
-            </div>
-          </div>
-        </div>
-      </div>
+      {{ template "config-condition" (dict "name" $k "condition" $v) }}
       {{ end }}
 
       {{ if eq $k "object" }} {{/* Object (with sub-configs) */}}
@@ -2003,6 +1939,10 @@
     </div>
     {{ end }}
 
+    {{ if eq $k "condition" }}
+    {{ template "config-condition" (dict "name" "*" "condition" $v) }}
+    {{ end }}
+
     {{ with $v.enum }}
     <div class="mt-4">
       <span class="font-semibold">
@@ -2042,4 +1982,73 @@
 {{ else }} {{/* If just a plain old string, use Ruby syntax highlighting as a best guess */}}
 {{ highlight . "ruby" "" }}
 {{ end }}
+{{ end }}
+
+{{ define "config-condition" }}
+{{ $name := .name }}
+<div class="mt-4">
+  <div class="border rounded dark:border-gray-700 divide-y dark:divide-gray-700">
+    {{ range $k, $v := .condition.options }}
+    {{ $id := printf "%s.%s" $name $k }}
+    <div class="py-3 px-5">
+      <div>
+        {{ partial "heading.html" (dict "text" $id "level" 4 "mono" true) }}
+      </div>
+
+      <div class="mt-2 prose dark:prose-dark max-w-none">
+        {{ $v.description | markdownify }}
+      </div>
+    </div>
+    {{ end }}
+  </div>
+
+  <div class="my-4 ml-2">
+    <span>
+      {{ partial "heading.html" (dict "text" "Available syntaxes" "level" 3 "icon" false "toc_hide" true) }}
+    </span>
+
+    <table class="table-auto">
+      <thead>
+        <tr>
+          <th>
+            Syntax
+          </th>
+          <th>
+            Description
+          </th>
+          <th>
+            Example
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .condition.syntaxes }}
+        <tr>
+          <td>
+            <code>
+              {{ .name }}
+            </code>
+          </td>
+          <td>
+            {{ .description | markdownify }}
+          </td>
+          <td>
+            <code>{{ .example }}</code>
+          </td>
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+
+    <div class="py-3 px-5 border rounded-md border-green-500">
+      <span>
+        {{ partial "heading.html" (dict "text" .condition.shorthand_explainer.title "level" 3 "icon" false "toc_hide" true) }}
+      </span>
+
+      <div class="mt-2 prose dark:prose-dark max-w-none">
+        {{ .condition.shorthand_explainer.description | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>
 {{ end }}


### PR DESCRIPTION
I don't super love this but I think it does help to clarify the standard vs. shorthand distinction by providing full-fledged config examples.