### PR TITLE
docs(logstash source): Fix output timestamp description

### DIFF
--- a/website/cue/reference/components/sources/logstash.cue
+++ b/website/cue/reference/components/sources/logstash.cue
@@ -72,14 +72,14 @@ components: sources: logstash: {
 			}
 			timestamp: fields._current_timestamp & {
 				description: """
-						The timestamp field will be set to the first one found of the following:
+					The timestamp field will be set to the first one found of the following:
 
-						1. The `timestamp` field on the event
-						2. The `@timestamp` field on the event if it can be parsed as a timestamp
-						3. The current timestamp
+					1. The `timestamp` field on the event
+					2. The `@timestamp` field on the event if it can be parsed as a timestamp
+					3. The current timestamp
 
-						The assigned field, `timestamp`, could be different depending if you have configured
-						`log_schema.timestamp_key`.
+					The assigned field, `timestamp`, could be different depending if you have configured
+					`log_schema.timestamp_key`.
 					"""
 			}
 			"*": {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Fix the indent. The description is shown as a code block because of the problematic indent.

![image](https://user-images.githubusercontent.com/7052824/145244282-59e38614-84ce-4c44-adfc-fd127b0e05a4.png)
