### PR TITLE
chore(splunk_hec sink): Update splunk_hec sink instrumentation

### DIFF
--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -284,7 +284,9 @@ where
                                     Ok(response) => {
                                         trace!(message = "Service call succeeded.", request_id);
                                         finalizers.update_status(response.event_status());
-                                        emit(&response.events_sent());
+                                        if response.event_status() == EventStatus::Delivered {
+                                            emit(&response.events_sent());
+                                        }
                                     }
                                 };
                                 (seq_num, ack_size)

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -14,17 +14,6 @@ mod sink {
     use vector_core::internal_event::InternalEvent;
 
     #[derive(Debug)]
-    pub struct SplunkEventSent {
-        pub byte_size: usize,
-    }
-
-    impl InternalEvent for SplunkEventSent {
-        fn emit_metrics(&self) {
-            counter!("processed_bytes_total", self.byte_size as u64);
-        }
-    }
-
-    #[derive(Debug)]
     pub struct SplunkEventEncodeError {
         pub error: Error,
     }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -35,23 +35,28 @@ mod sink {
     }
 
     #[derive(Debug)]
-    pub(crate) struct SplunkInvalidMetricReceived<'a> {
+    pub(crate) struct SplunkInvalidMetricReceivedError<'a> {
         pub value: &'a MetricValue,
         pub kind: &'a MetricKind,
+        pub error: crate::Error,
     }
 
-    impl<'a> InternalEvent for SplunkInvalidMetricReceived<'a> {
+    impl<'a> InternalEvent for SplunkInvalidMetricReceivedError<'a> {
         fn emit_logs(&self) {
-            warn!(
-                message = "Invalid metric received kind; dropping event.",
+            error!(
+                message = "Invalid metric received kind.",
+                error = ?self.error,
                 value = ?self.value,
                 kind = ?self.kind,
+                error_type = "invalid_metric",
+                stage = "processing",
                 internal_log_rate_secs = 30,
             )
         }
 
         fn emit_metrics(&self) {
             counter!("processing_errors_total", 1, "error_type" => "invalid_metric_kind");
+            counter!("component_errors_total", 1, "stage" => "processing", "error_type" => "invalid_metric");
         }
     }
 

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -44,7 +44,7 @@ mod sink {
     impl<'a> InternalEvent for SplunkInvalidMetricReceivedError<'a> {
         fn emit_logs(&self) {
             error!(
-                message = "Invalid metric received kind.",
+                message = "Invalid metric received.",
                 error = ?self.error,
                 value = ?self.value,
                 kind = ?self.kind,

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -56,6 +56,7 @@ mod sink {
 
         fn emit_metrics(&self) {
             counter!("component_errors_total", 1, "stage" => "processing", "error_type" => "invalid_metric");
+            counter!("component_discarded_events_total", 1);
         }
     }
 

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -55,7 +55,6 @@ mod sink {
         }
 
         fn emit_metrics(&self) {
-            counter!("processing_errors_total", 1, "error_type" => "invalid_metric_kind");
             counter!("component_errors_total", 1, "stage" => "processing", "error_type" => "invalid_metric");
         }
     }

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -31,7 +31,6 @@ mod sink {
 
         fn emit_metrics(&self) {
             counter!("component_errors_total", 1, "error_type" => "encode_failed", "stage" => "processing");
-            counter!("encode_errors_total", 1);
         }
     }
 

--- a/src/sinks/splunk_hec/logs/encoder.rs
+++ b/src/sinks/splunk_hec/logs/encoder.rs
@@ -3,7 +3,7 @@ use std::io;
 use vector_core::{config::log_schema, event::LogEvent};
 
 use crate::{
-    internal_events::{SplunkEventEncodeError, SplunkEventSent},
+    internal_events::SplunkEventEncodeError,
     sinks::util::encoding::{Encoder, EncodingConfiguration},
 };
 use serde::{Deserialize, Serialize};
@@ -81,12 +81,7 @@ impl HecLogsEncoder {
         hec_data.sourcetype = metadata.sourcetype;
 
         match serde_json::to_vec(&hec_data) {
-            Ok(value) => {
-                emit!(&SplunkEventSent {
-                    byte_size: value.len()
-                });
-                Some(value)
-            }
+            Ok(value) => Some(value),
             Err(error) => {
                 emit!(&SplunkEventEncodeError { error });
                 None

--- a/src/sinks/splunk_hec/metrics/encoder.rs
+++ b/src/sinks/splunk_hec/metrics/encoder.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use std::{collections::BTreeMap, io, iter};
 
 use crate::{
-    internal_events::{SplunkEventEncodeError, SplunkEventSent},
+    internal_events::SplunkEventEncodeError,
     sinks::util::encoding::{Encoder, EncodingConfiguration},
 };
 
@@ -82,12 +82,7 @@ impl HecMetricsEncoder {
         hec_data.sourcetype = metadata.sourcetype;
 
         match serde_json::to_vec(&hec_data) {
-            Ok(value) => {
-                emit!(&SplunkEventSent {
-                    byte_size: value.len()
-                });
-                Some(value)
-            }
+            Ok(value) => Some(value),
             Err(error) => {
                 emit!(&SplunkEventEncodeError { error });
                 None

--- a/src/sinks/splunk_hec/metrics/sink.rs
+++ b/src/sinks/splunk_hec/metrics/sink.rs
@@ -2,7 +2,7 @@ use std::{fmt, num::NonZeroUsize};
 
 use crate::{
     config::SinkContext,
-    internal_events::SplunkInvalidMetricReceived,
+    internal_events::SplunkInvalidMetricReceivedError,
     sinks::{
         splunk_hec::common::{render_template_string, request::HecRequest},
         util::{encode_namespace, processed_event::ProcessedEvent, SinkBuilderExt},
@@ -123,9 +123,10 @@ impl HecMetricsProcessedEventMetadata {
             MetricValue::Counter { value } => Some(value),
             MetricValue::Gauge { value } => Some(value),
             _ => {
-                emit!(&SplunkInvalidMetricReceived {
+                emit!(&SplunkInvalidMetricReceivedError {
                     value: metric.value(),
                     kind: &metric.kind(),
+                    error: "Metric kind not supported.".into(),
                 });
                 None
             }

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -13,6 +13,7 @@ badges:
 Vector's 0.19.0 release includes **breaking changes**:
 
 1. [Removal of deprecated configuration fields for the Splunk HEC Logs sink: `host`](#splunk-hec-logs-sink-deprecated-fields)
+1. [Updated internal metrics for the Splunk HEC sinks](#splunk-hec-sinks-metrics-update)
 
 We cover them below to help you upgrade quickly:
 
@@ -24,6 +25,7 @@ We've removed a long deprecated configuration field from the Splunk HEC Logs
 sink: `host`.
 
 You can migrate your configuration by switching to `endpoint` instead.
+
 ```diff
  [sinks.splunk]
    type = "splunk_hec_logs"
@@ -31,3 +33,19 @@ You can migrate your configuration by switching to `endpoint` instead.
 +  endpoint = "http://splunk-endpoint"
    ...
 ```
+
+### Updated internal metrics for the Splunk HEC sinks {#splunk-hec-sinks-metrics-update}
+
+As part of moving towards more consistent Vector component instrumentation,
+we've updated the following internal metrics in the Splunk HEC sinks. For any
+removed metric, we've added an equivalent alternative.
+
+- Removed `encode_errors_total`
+  - Instead, use `component_errors_total` with the tag `error_type = encode_failed`.
+- Removed `processing_errors_total` with tag `error_type = invalid_metric_kind`
+  - Instead, use `component_errors_total` with the tag `error_type = invalid_metric`.
+- Removed `processed_bytes_total`
+  - Instead, use `component_received_event_bytes_total` and `component_sent_event_bytes_total`.
+- Added `components_discarded_events_total`
+  - Previously, no metric was emitted when an encoding error occurred and an
+    event was dropped.

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -156,7 +156,6 @@ components: sinks: splunk_hec_logs: {
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
 		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
 		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-		processed_bytes_total:            components.sources.internal_metrics.output.metrics.processed_bytes_total
 		processed_events_total:           components.sources.internal_metrics.output.metrics.processed_events_total
 		requests_received_total:          components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -149,6 +149,7 @@ components: sinks: splunk_hec_logs: {
 	}
 
 	telemetry: metrics: {
+		component_discarded_events_total: components.sources.internal_metrics.output.metrics.component_discarded_events_total
 		component_errors_total:           components.sources.internal_metrics.output.metrics.component_errors_total
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -149,13 +149,12 @@ components: sinks: splunk_hec_logs: {
 	}
 
 	telemetry: metrics: {
+		component_errors_total:           components.sources.internal_metrics.output.metrics.component_errors_total
 		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		encode_errors_total:              components.sources.internal_metrics.output.metrics.encode_errors_total
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
 		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 		processed_events_total:           components.sources.internal_metrics.output.metrics.processed_events_total
 		requests_received_total:          components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -509,6 +509,12 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		component_discarded_events_total: {
+			description:       "The number of events dropped by this component."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
 		component_received_bytes_total: {
 			description:       "The number of raw bytes accepted by this component from source origins."
 			type:              "counter"


### PR DESCRIPTION
Closes #10349 

Todo:
- [x] Update 0.19.0 upgrade guide with details

Following up on instrumentation-related feedback in #10135, this PR:
- Removes the `SplunkEventSent` event. This event was emitted in the wrong place, and `EventsSent` is already emitted by the driver.
- Removes `encode_errors_total` metric to avoid redundancy.
- Updates `SplunkInvalidMetricReceived` to adhere to component error spec.
- Updates the sink `Driver` to emit `EventsSent` only on successful event status


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
