### PR TITLE
fix(buffers): try and fix another flaky assertion in disk v2 tests

### DIFF
--- a/lib/vector-core/buffers/src/disk_v2/tests/size_limits.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/size_limits.rs
@@ -159,9 +159,9 @@ async fn writer_waits_when_buffer_is_full() {
             // can at least handle the pending acknowledgements logic, but it won't actually be ready,
             // because the second write hasn't completed yet:
             acker.acknowledge_records(1);
-            assert_pending!(second_record_read.poll());
-            deleted_first_data_file.assert();
-            got_past_wait_for_waiter.assert();
+            while !deleted_first_data_file.try_assert() && !got_past_wait_for_waiter.try_assert() {
+                assert_pending!(second_record_read.poll());
+            }
 
             // And now the writer should be woken up since the acknowledgement was processed, and
             // the blocked write should be able to complete:


### PR DESCRIPTION
CI uncovered another indeterministic area of one of the disk buffer v2 unit tests.  This PR tries to better handle that indeterminism.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>