### PR TITLE
docs: Clarify that `/etc/vector` just includes configuration

### DIFF
--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -355,6 +355,9 @@ configuration: {
 			body: """
 				The location of your Vector configuration file depends on your installation method. For most Linux
 				based systems, the file can be found at `/etc/vector/vector.toml`.
+
+				All files in `/etc/vector` are user configuration files and can be safely overridden with to craft your
+				desired Vector configuration.
 				"""
 		}
 		multiple: {

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -356,7 +356,7 @@ configuration: {
 				The location of your Vector configuration file depends on your installation method. For most Linux
 				based systems, the file can be found at `/etc/vector/vector.toml`.
 
-				All files in `/etc/vector` are user configuration files and can be safely overridden with to craft your
+				All files in `/etc/vector` are user configuration files and can be safely overridden to craft your
 				desired Vector configuration.
 				"""
 		}


### PR DESCRIPTION
There was [some concern in
dokku](https://github.com/dokku/dokku/issues/4971) that it might contain
other files necessary for Vector operation and so couldn't safely be
mounted over for containers.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
