### PR TITLE
docs: Add a warning about Aggregator metadata

### DIFF
--- a/website/cue/reference/components/transforms/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/aws_ec2_metadata.cue
@@ -37,7 +37,7 @@ components: transforms: aws_ec2_metadata: {
 		notices: []
 		warnings: [
 			"""
-				Do not enable this transform if you are running Vector in Aggregator mode- tags will be sourced from the Aggregator node's metadata server and will not reflect correctly on input data.
+				Do not enable this transform if you are running Vector as an Aggregator, tags will be sourced from the Aggregator node's metadata server and not the client's.
 				""",
 		]
 	}

--- a/website/cue/reference/components/transforms/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/aws_ec2_metadata.cue
@@ -35,7 +35,11 @@ components: transforms: aws_ec2_metadata: {
 				""",
 		]
 		notices: []
-		warnings: []
+		warnings: [
+			"""
+				Do not enable this transform if you are running Vector in Aggregator mode- tags will be sourced from the Aggregator node's metadata server and will not reflect correctly on input data.
+				""",
+		]
 	}
 
 	configuration: {


### PR DESCRIPTION
## Summary
We've seen customers have issues with Aggregator nodes over-writing log tags if this transform is enabled. This will at least note to people that this isn't a desirable configuration, or to know what they're getting into.

Better verbiage is very welcome.
