### PR TITLE
docs(releasing): Add deprecation policy

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,6 +27,7 @@ Vector team member will find this document useful.
          1. [Daily tests](#daily-tests)
       1. [Flakey tests](#flakey-tests)
          1. [Test harness](#test-harness)
+   1. [Deprecations](#deprecations)
 1. [Next steps](#next-steps)
 1. [Legal](#legal)
    1. [CLA](#contributor-license-agreement)
@@ -185,6 +186,10 @@ any pull request with:
 /test -t <name>
 ```
 
+### Deprecations
+
+When deprecating functionality in Vector, see [DEPRECATION.md](DEPRECATION.md).
+
 ## Next steps
 
 As discussed in the [`README`](README.md), you should continue to the following
@@ -192,6 +197,7 @@ documents:
 
 2. **[DEVELOPING.md](DEVELOPING.md)** - Everything necessary to develop
 3. **[DOCUMENTING.md](DOCUMENTING.md)** - Preparing your change for Vector users
+3. **[DEPRECATION.md](DEPRECATION.md)** - Deprecating functionality in Vector
 
 ## Legal
 

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -12,9 +12,9 @@ Vector will retain deprecated configuration or features for at least one minor v
 major version when Vector hits 1.0).
 
 This means that deprecations will be eligible for removal in the next minor release after they are announced; however,
-we will typically aim to support deprecations for a longer time period depending on their maintenance burden. For
-example, a deprecation announced in `v0.16.0` would be eligible to be removed in `v0.17.0` but may be removed later in
-`v0.20.0`.
+we will typically aim to support deprecations for a longer time period depending on their development maintenance
+burden. For example, a deprecation announced in `v0.16.0` would be eligible to be removed in `v0.17.0` but may be
+removed later in `v0.20.0`.
 
 Exceptions can be made for deprecations related to security issues or critical bugs. These may result in removals being
 introduced in a release without being announced in a prior release.

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -27,9 +27,15 @@ Examples of possible deprecations in Vector:
 * Removal or rename of a metric
 * Removal of a feature
 
-## Notice
+## Lifecycle of a deprecation
 
-For deprecations in Vector, we will notify by:
+A deprecation goes through three stages: Deprecation, Migration, and Removal. These are described below.
+
+### Deprecation
+
+A configuration option or feature in Vector is marked as deprecated.
+
+When this happens, we will notify by:
 
 * Listing the deprecation in the Deprecations section of the upgrade guide for the release the deprecation was
   introduced in. This will include instructions on how to transition if applicable.
@@ -39,10 +45,21 @@ For deprecations in Vector, we will notify by:
   `vector validate`, or at runtime, when possible. This log message will lead with the text `DEPRECATED` to make it easy
   to filter for.
 
-For removal of a deprecation, we will notify by:
+### Migration
+
+Users will have 1 or more minor releases to migrate away from using the deprecation using the instructions provided in
+the deprecation notice.
+
+### Removal
+
+A deprecated configuration option or feature in Vector is removed.
+
+When this happens, we will notify by:
 
 * Listing the removal in the Breaking Changes section of upgrade guide for that release. This will include directions on
   how to transition if applicable.
+
+When possible, Vector will error at start-up when a removed configuration option or feature is used.
 
 [configuration]: https://vector.dev/docs/reference/configuration/
 

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -1,0 +1,66 @@
+# Deprecations in Vector
+
+This document covers Vector's deprecation policy and process.
+
+In the course of Vector's development it can be necessary to deprecate configuration and (rarely) features to keep
+Vector maintainable and its configuration interface consistent for users. To avoid breaking compatibility abruptly, we
+follow the following deprecation policy.
+
+## Policy
+
+Vector will retain deprecated configuration or features for at least one minor version (this will transition to one
+major version when Vector hits 1.0).
+
+This means that deprecations will be eligible for removal in the next minor release after they are announced; however,
+we will typically aim to support deprecations for a longer time period depending on their maintenance burden. For
+example, a deprecation announced in `v0.16.0` would be eligible to be removed in `v0.17.0` but may be removed later in
+`v0.20.0`.
+
+Exceptions can be made for deprecations related to security issues or critical bugs. These may result in removals being
+introduced in a release without being announced in a prior release.
+
+### Examples
+
+Examples of possible deprecations in Vector:
+
+* Removal or rename of a configuration option
+* Removal or rename of a metric
+* Removal of a feature
+
+## Notice
+
+For deprecations in Vector, we will notify by:
+
+* Listing the deprecation in the Deprecations section of the upgrade guide for the release the deprecation was
+  introduced in. This will include instructions on how to transition if applicable.
+* Adding a deprecation note to the [documentation site][configuration] alongside the configuration or feature being
+  deprecated.
+* Output a log at the `WARN` level if Vector detects deprecated configuration or features being used on start-up, during
+  `vector validate`, or at runtime, when possible. This log message will lead with the text `DEPRECATED` to make it easy
+  to filter for.
+
+For removal of a deprecation, we will notify by:
+
+* Listing the removal in the Breaking Changes section of upgrade guide for that release. This will include directions on
+  how to transition if applicable.
+
+[configuration]: https://vector.dev/docs/reference/configuration/
+
+## Process
+
+When introducing a deprecation into Vector, the pull request introducing the deprecation should:
+
+* Add a note to the Deprecations section of the upgrade guide for the next release with a description and
+  directions for transitioning if applicable.
+* Add a deprecation note to the docs. Typically this means adding `deprecation: "description of the deprecation"`
+  to the `cue` data for the option or feature. If the `cue` schema does not support `deprecation`  for whatever you
+  are deprecating yet, add it to the schema and open an issue to have it rendered on the website.
+* Add a log message to Vector that is logged at the `WARN` level starting with the word `DEPRECATION` if Vecor detects
+  the deprecated configuration or feature being used (when possible).
+
+When removing a deprecation in a subsequent release, the pull request should:
+
+* Indicate that it is a breaking change by including `!` in the title after the type/scope
+* Remove the deprecation from the documentation
+* Add a note to the Breaking Changes section of the upgrade guide for the next release with a description and directions
+  for transitioning if applicable.


### PR DESCRIPTION
I used the following as examples when developing this policy:

* https://kubernetes.io/docs/reference/using-api/deprecation-policy/
* https://docs.gitlab.com/ee/administration/package_information/deprecation_policy.html


Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
