### PR TITLE
docs: Revert fix whitespace in highlight gut pide for 0.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
             cue:
               - 'website/cue/**'
             markdown:
-              - '**/**.md'
+              - '*/**.md'
             internal_events:
               - 'src/internal_events/**'
             helm:

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -24,7 +24,6 @@ We've removed a long deprecated configuration field from the Splunk HEC Logs
 sink: `host`.
 
 You can migrate your configuration by switching to `endpoint` instead.
-
 ```diff
  [sinks.splunk]
    type = "splunk_hec_logs"


### PR DESCRIPTION
I think this might be breaking CI? We'll see on this PR.

This reverts commit ca9c89dfd805e51957b72689a5e43bd6c4144dd1.
