### PR TITLE
fix(internal_logs source): Associate pid and hostname with all logs

### DIFF
--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use futures::{stream, SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast::error::RecvError;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -50,39 +50,37 @@ async fn run(
     host_key: String,
     pid_key: String,
     out: Pipeline,
-    mut shutdown: ShutdownSignal,
+    shutdown: ShutdownSignal,
 ) -> Result<(), ()> {
-    let mut out = out.sink_map_err(|error| error!(message = "Error sending log.", %error));
-    let subscription = trace::subscribe();
-    let mut rx = subscription.receiver;
-
     let hostname = crate::get_hostname();
     let pid = std::process::id();
 
-    out.send_all(&mut stream::iter(subscription.buffer).map(|mut log| {
-        if let Ok(hostname) = &hostname {
-            log.insert(host_key.clone(), hostname.to_owned());
-        }
-        log.insert(pid_key.clone(), pid);
-        log.try_insert(log_schema().source_type_key(), Bytes::from("internal_logs"));
-        log.try_insert(log_schema().timestamp_key(), Utc::now());
-        Ok(Event::from(log))
-    }))
-    .await?;
+    let mut out = out.sink_map_err(|error| error!(message = "Error sending log.", %error));
+    let subscription = trace::subscribe();
+
+    // chain the logs emitted before the source started first
+    let mut rx = stream::iter(subscription.buffer)
+        .map(|log| Ok(log))
+        .chain(tokio_stream::wrappers::BroadcastStream::new(
+            subscription.receiver,
+        ))
+        .take_until(shutdown);
 
     // Note: This loop, or anything called within it, MUST NOT generate
     // any logs that don't break the loop, as that could cause an
     // infinite loop since it receives all such logs.
-    loop {
-        tokio::select! {
-            receive = rx.recv() => {
-                match receive {
-                    Ok(event) => out.send(Event::from(event)).await?,
-                    Err(RecvError::Lagged(_)) => (),
-                    Err(RecvError::Closed) => break,
+    while let Some(res) = rx.next().await {
+        match res {
+            Ok(mut log) => {
+                if let Ok(hostname) = &hostname {
+                    log.insert(host_key.clone(), hostname.to_owned());
                 }
+                log.insert(pid_key.clone(), pid);
+                log.try_insert(log_schema().source_type_key(), Bytes::from("internal_logs"));
+                log.try_insert(log_schema().timestamp_key(), Utc::now());
+                out.send(Event::from(log)).await?;
             }
-            _ = &mut shutdown => break,
+            Err(BroadcastStreamRecvError::Lagged(_)) => (),
         }
     }
 

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -60,7 +60,7 @@ async fn run(
 
     // chain the logs emitted before the source started first
     let mut rx = stream::iter(subscription.buffer)
-        .map(|log| Ok(log))
+        .map(Ok)
         .chain(tokio_stream::wrappers::BroadcastStream::new(
             subscription.receiver,
         ))


### PR DESCRIPTION
I previously introduced this functionality to enrich internal logs with
pid and hostname, but accidentally _only_ applied it to buffered events.
All internal logs after start-up were then missing these tags.

I refactored the event handling to be unified accross buffered and
subscribed events to make it less likely this issue would crop in the
future where we only modify one.

Fixes: #10403

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
