### PR TITLE
chore(deps): Bump `async-graphql` to 3.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.11.3"
+version = "3.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6a9edeab4427f8162ac1ccd49152fa656affab3ccfaed7eeaf8e2f9ce12ee0"
+checksum = "ed5dda87d4742c67d2a6df36e0a0de94d315baf761a2404ea46f57314539151e"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -253,6 +253,7 @@ dependencies = [
  "indexmap",
  "mime",
  "multer",
+ "num-traits",
  "once_cell",
  "pin-project-lite",
  "regex",
@@ -265,13 +266,13 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.11.3"
+version = "3.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8be34933c1bca0b5aedb6d8b66ad3e27045eb8304f198cc1efaed6b6dd87835"
+checksum = "14babc9dfa3279b0a3165cf1919f681c72188c6b1b925932106bf3c153b3e0ba"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling 0.12.4",
+ "darling",
  "proc-macro-crate",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -281,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "2.11.3"
+version = "3.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99841c1f890fda6712054e7e37b207738f4aa97870cb1bffcab2f09f2df0957a"
+checksum = "24f3748ab1d7468dcd2697aa3d98259f5b7d2d5223034780aea43b1bfdc792f5"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -294,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "2.11.3"
+version = "3.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cecac7ab6737364cff7b16e9273dd51fac7cfbd14ab5d84127df5a56ca9d422"
+checksum = "422dc960130eec5354acda269343600fa34279aa97a8843bc45d574ffed6559f"
 dependencies = [
  "bytes 1.1.0",
  "indexmap",
@@ -306,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-warp"
-version = "2.11.3"
+version = "3.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440fd9ea4fc8663a23f8b61f619edde415a2e7b27890baca35e3259cfb6f3f99"
+checksum = "0206a350172ea34012150b35eccd13fd2e3bdfc923965a0ed1604a9796a4334f"
 dependencies = [
  "async-graphql",
  "futures-util",
@@ -1833,36 +1834,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
 dependencies = [
- "darling_core 0.13.0",
- "darling_macro 0.13.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "strsim 0.10.0",
- "syn 1.0.82",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1881,22 +1858,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core 0.12.4",
- "quote 1.0.10",
- "syn 1.0.82",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
- "darling_core 0.13.0",
+ "darling_core",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -6707,7 +6673,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
- "darling 0.13.0",
+ "darling",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "syn 1.0.82",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,8 +185,8 @@ gouth = { version = "0.2.1", default-features = false, optional = true }
 smpl_jwt = { version = "0.6.1", default-features = false, optional = true }
 
 # API
-async-graphql = { version = "2.10.4", default-features = false, optional = true, features = ["chrono"] }
-async-graphql-warp = { version = "2.10.4", default-features = false, optional = true }
+async-graphql = { version = "3.0.15", default-features = false, optional = true, features = ["chrono"] }
+async-graphql-warp = { version = "3.0.15", default-features = false, optional = true }
 itertools = { version = "0.10.3", default-features = false, optional = true }
 
 # API client

--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -1,94 +1,33 @@
 {
   "data": {
     "__schema": {
-      "directives": [
-        {
-          "args": [],
-          "description": "Directs the executor to query only when the field exists.",
-          "locations": [
-            "FIELD"
-          ],
-          "name": "ifdef"
-        },
-        {
-          "args": [
-            {
-              "defaultValue": null,
-              "description": "Included when true.",
-              "name": "if",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "name": "include"
-        },
-        {
-          "args": [
-            {
-              "defaultValue": null,
-              "description": "Skipped when true.",
-              "name": "if",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "name": "skip"
-        }
-      ],
-      "mutationType": null,
       "queryType": {
         "name": "Query"
       },
+      "mutationType": null,
       "subscriptionType": {
         "name": "Subscription"
       },
       "types": [
         {
+          "kind": "SCALAR",
+          "name": "Boolean",
           "description": "The `Boolean` scalar type represents `true` or `false`.",
-          "enumValues": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Boolean",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "Component",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "componentId",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -97,14 +36,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "componentType",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -113,13 +52,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": null,
-          "kind": "INTERFACE",
-          "name": "Component",
+          "enumValues": null,
           "possibleTypes": [
             {
               "kind": "OBJECT",
@@ -139,15 +79,14 @@
           ]
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentConnection",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
               "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -156,14 +95,14 @@
                   "name": "PageInfo",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of edges.",
-              "isDeprecated": false,
               "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -172,14 +111,14 @@
                   "name": "ComponentEdge",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total result set count",
-              "isDeprecated": false,
               "name": "totalCount",
+              "description": "Total result set count",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -188,25 +127,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentConnection",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentEdge",
           "description": "An edge in a connection.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
               "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -215,14 +154,14 @@
                   "name": "Component",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
               "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -231,25 +170,25 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentEdge",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentErrorsTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -258,14 +197,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Errors processed metric",
-              "isDeprecated": false,
               "name": "metric",
+              "description": "Errors processed metric",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -274,25 +213,25 @@
                   "name": "ErrorsTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentErrorsTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentEventsInThroughput",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -301,14 +240,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed throughput",
-              "isDeprecated": false,
               "name": "throughput",
+              "description": "Events processed throughput",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -317,25 +256,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentEventsInThroughput",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentEventsInTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -344,14 +283,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total incoming events metric",
-              "isDeprecated": false,
               "name": "metric",
+              "description": "Total incoming events metric",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -360,25 +299,25 @@
                   "name": "EventsInTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentEventsInTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentEventsOutThroughput",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -387,14 +326,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed throughput",
-              "isDeprecated": false,
               "name": "throughput",
+              "description": "Events processed throughput",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -403,25 +342,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentEventsOutThroughput",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentEventsOutTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -430,14 +369,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events metric",
-              "isDeprecated": false,
               "name": "metric",
+              "description": "Total outgoing events metric",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -446,85 +385,85 @@
                   "name": "EventsOutTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentEventsOutTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "ComponentKind",
           "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "SOURCE"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "TRANSFORM"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "SINK"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "ComponentKind",
+          "enumValues": [
+            {
+              "name": "SOURCE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TRANSFORM",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SINK",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ComponentKindFilter",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "equals",
+              "description": null,
               "type": {
                 "kind": "ENUM",
                 "name": "ComponentKind",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "notEquals",
+              "description": null,
               "type": {
                 "kind": "ENUM",
                 "name": "ComponentKind",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "ComponentKindFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentProcessedBytesThroughput",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -533,14 +472,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed throughput",
-              "isDeprecated": false,
               "name": "throughput",
+              "description": "Bytes processed throughput",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -549,25 +488,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentProcessedBytesThroughput",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentProcessedBytesTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -576,14 +515,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed total metric",
-              "isDeprecated": false,
               "name": "metric",
+              "description": "Bytes processed total metric",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -592,25 +531,25 @@
                   "name": "ProcessedBytesTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentProcessedBytesTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentProcessedEventsThroughput",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -619,14 +558,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed throughput",
-              "isDeprecated": false,
               "name": "throughput",
+              "description": "Events processed throughput",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -635,25 +574,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentProcessedEventsThroughput",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentProcessedEventsTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -662,14 +601,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed total metric",
-              "isDeprecated": false,
               "name": "metric",
+              "description": "Events processed total metric",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -678,25 +617,25 @@
                   "name": "ProcessedEventsTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentProcessedEventsTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentReceivedEventsThroughput",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -705,14 +644,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Received events throughput",
-              "isDeprecated": false,
               "name": "throughput",
+              "description": "Received events throughput",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -721,25 +660,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentReceivedEventsThroughput",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentReceivedEventsTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -748,14 +687,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total received events metric",
-              "isDeprecated": false,
               "name": "metric",
+              "description": "Total received events metric",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -764,25 +703,25 @@
                   "name": "ReceivedEventsTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentReceivedEventsTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentSentEventsThroughput",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -791,14 +730,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed throughput",
-              "isDeprecated": false,
               "name": "throughput",
+              "description": "Events processed throughput",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -807,25 +746,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentSentEventsThroughput",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ComponentSentEventsTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Component id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Component id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -834,14 +773,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events metric",
-              "isDeprecated": false,
               "name": "metric",
+              "description": "Total outgoing events metric",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -850,24 +789,25 @@
                   "name": "SentEventsTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ComponentSentEventsTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ComponentsFilter",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentId",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -880,12 +820,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentKind",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -898,12 +838,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "or",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -916,23 +856,23 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "ComponentsFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ComponentsSortField",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "field",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -941,12 +881,12 @@
                   "name": "ComponentsSortFieldName",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": "ASC",
-              "description": null,
               "name": "direction",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -955,107 +895,46 @@
                   "name": "Direction",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": "ASC"
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "ComponentsSortField",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_KEY"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_KIND"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "kind": "ENUM",
           "name": "ComponentsSortFieldName",
-          "possibleTypes": null
-        },
-        {
           "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "CPU seconds total",
-              "isDeprecated": false,
-              "name": "cpuSecondsTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "CpuMetrics",
-          "possibleTypes": null
-        },
-        {
-          "description": "Implement the DateTime<Utc> scalar\n\nThe input/output is a string in RFC3339 format.",
-          "enumValues": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "SCALAR",
-          "name": "DateTime",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
           "enumValues": [
             {
-              "deprecationReason": null,
+              "name": "COMPONENT_KEY",
               "description": null,
               "isDeprecated": false,
-              "name": "ASC"
+              "deprecationReason": null
             },
             {
-              "deprecationReason": null,
+              "name": "COMPONENT_KIND",
               "description": null,
               "isDeprecated": false,
-              "name": "DESC"
+              "deprecationReason": null
             }
           ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "Direction",
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "CpuMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
+              "name": "cpuSecondsTotal",
+              "description": "CPU seconds total",
               "args": [],
-              "deprecationReason": null,
-              "description": "Total bytes read",
-              "isDeprecated": false,
-              "name": "readBytesTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1064,85 +943,145 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total reads completed",
+              },
               "isDeprecated": false,
-              "name": "readsCompletedTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total bytes written",
-              "isDeprecated": false,
-              "name": "writtenBytesTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total writes completed",
-              "isDeprecated": false,
-              "name": "writesCompletedTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "DiskMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
+          "kind": "SCALAR",
+          "name": "DateTime",
+          "description": "Implement the DateTime<Utc> scalar\n\nThe input/output is a string in RFC3339 format.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "Direction",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiskMetrics",
+          "description": null,
           "fields": [
             {
+              "name": "readBytesTotal",
+              "description": "Total bytes read",
               "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "readsCompletedTotal",
+              "description": "Total reads completed",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "writtenBytesTotal",
+              "description": "Total bytes written",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "writesCompletedTotal",
+              "description": "Total writes completed",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ErrorsTotal",
+          "description": null,
+          "fields": [
+            {
               "name": "timestamp",
+              "description": "Metric timestamp",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total error count",
-              "isDeprecated": false,
               "name": "errorsTotal",
+              "description": "Total error count",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1151,48 +1090,48 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "ErrorsTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "EventEncodingType",
           "description": "Encoding format for the event",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "JSON"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "YAML"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "EventEncodingType",
+          "enumValues": [
+            {
+              "name": "JSON",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "YAML",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "EventNotification",
           "description": "A notification regarding events observation",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Pattern that raised the event",
-              "isDeprecated": false,
               "name": "pattern",
+              "description": "Pattern that raised the event",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1201,14 +1140,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Event notification type",
-              "isDeprecated": false,
               "name": "notification",
+              "description": "Event notification type",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1217,99 +1156,60 @@
                   "name": "EventNotificationType",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "EventNotification",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "EventNotificationType",
           "description": "Event notification type",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "A component was found that matched the provided pattern",
-              "isDeprecated": false,
-              "name": "MATCHED"
-            },
-            {
-              "deprecationReason": null,
-              "description": "There isn't currently a component that matches this pattern",
-              "isDeprecated": false,
-              "name": "NOT_MATCHED"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "EventNotificationType",
+          "enumValues": [
+            {
+              "name": "MATCHED",
+              "description": "A component was found that matched the provided pattern",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NOT_MATCHED",
+              "description": "There isn't currently a component that matches this pattern",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
-              "name": "timestamp",
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total incoming events",
-              "isDeprecated": false,
-              "name": "eventsInTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
           "kind": "OBJECT",
           "name": "EventsInTotal",
-          "possibleTypes": null
-        },
-        {
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
               "name": "timestamp",
+              "description": "Metric timestamp",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "eventsInTotal",
+              "description": "Total incoming events",
               "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events",
-              "isDeprecated": false,
-              "name": "eventsOutTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1318,25 +1218,64 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "EventsOutTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "EventsOutTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
+              "name": "timestamp",
+              "description": "Metric timestamp",
               "args": [],
-              "deprecationReason": null,
-              "description": "File name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
               "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eventsOutTotal",
+              "description": "Total outgoing events",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FileSourceMetricFile",
+          "description": null,
+          "fields": [
+            {
               "name": "name",
+              "description": "File name",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1345,97 +1284,97 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric indicating events processed for the current file",
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": "Metric indicating events processed for the current file",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric indicating bytes processed for the current file",
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": "Metric indicating bytes processed for the current file",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric indicating incoming events for the current file",
-              "isDeprecated": false,
               "name": "eventsInTotal",
+              "description": "Metric indicating incoming events for the current file",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric indicating received events for the current file",
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": "Metric indicating received events for the current file",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric indicating outgoing events for the current file",
-              "isDeprecated": false,
               "name": "eventsOutTotal",
+              "description": "Metric indicating outgoing events for the current file",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric indicating outgoing events for the current file",
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": "Metric indicating outgoing events for the current file",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "FileSourceMetricFile",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "FileSourceMetricFileConnection",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
               "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1444,14 +1383,14 @@
                   "name": "PageInfo",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of edges.",
-              "isDeprecated": false,
               "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1460,14 +1399,14 @@
                   "name": "FileSourceMetricFileEdge",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total result set count",
-              "isDeprecated": false,
               "name": "totalCount",
+              "description": "Total result set count",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1476,25 +1415,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "FileSourceMetricFileConnection",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "FileSourceMetricFileEdge",
           "description": "An edge in a connection.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
               "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1503,14 +1442,14 @@
                   "name": "FileSourceMetricFile",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
               "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1519,24 +1458,25 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "FileSourceMetricFileEdge",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "FileSourceMetricFilesSortField",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "field",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1545,12 +1485,12 @@
                   "name": "FileSourceMetricFilesSortFieldName",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": "ASC",
-              "description": null,
               "name": "direction",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1559,127 +1499,129 @@
                   "name": "Direction",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": "ASC"
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "FileSourceMetricFilesSortField",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "FileSourceMetricFilesSortFieldName",
           "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "NAME"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "PROCESSED_BYTES_TOTAL"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "PROCESSED_EVENTS_TOTAL"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "RECEIVED_EVENTS_TOTAL"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "EVENTS_IN_TOTAL"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "SENT_EVENTS_TOTAL"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "EVENTS_OUT_TOTAL"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "FileSourceMetricFilesSortFieldName",
+          "enumValues": [
+            {
+              "name": "NAME",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROCESSED_BYTES_TOTAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROCESSED_EVENTS_TOTAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RECEIVED_EVENTS_TOTAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EVENTS_IN_TOTAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SENT_EVENTS_TOTAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EVENTS_OUT_TOTAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "FileSourceMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
+              "name": "files",
+              "description": "File metrics",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "after",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "before",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "first",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "last",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "filter",
+                  "description": null,
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "FileSourceMetricsFilesFilter",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "sort",
+                  "description": null,
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -1692,13 +1634,10 @@
                         "ofType": null
                       }
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "File metrics",
-              "isDeprecated": false,
-              "name": "files",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1707,79 +1646,81 @@
                   "name": "FileSourceMetricFileConnection",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed for the current file source",
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": "Events processed for the current file source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed for the current file source",
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": "Bytes processed for the current file source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total incoming events for the current file source",
-              "isDeprecated": false,
               "name": "eventsInTotal",
+              "description": "Total incoming events for the current file source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total received events for the current file source",
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": "Total received events for the current file source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current file source",
-              "isDeprecated": false,
               "name": "eventsOutTotal",
+              "description": "Total outgoing events for the current file source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current file source",
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": "Total outgoing events for the current file source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1790,19 +1731,18 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "FileSourceMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "FileSourceMetricsFilesFilter",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "name",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1815,12 +1755,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "or",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1833,24 +1773,23 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "FileSourceMetricsFilesFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "FileSystemMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Free bytes",
-              "isDeprecated": false,
               "name": "freeBytes",
+              "description": "Free bytes",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1859,14 +1798,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total bytes",
-              "isDeprecated": false,
               "name": "totalBytes",
+              "description": "Total bytes",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1875,14 +1814,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Used bytes",
-              "isDeprecated": false,
               "name": "usedBytes",
+              "description": "Used bytes",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1891,100 +1830,102 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "FileSystemMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "Float",
           "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-          "enumValues": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Float",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "GenericSinkMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed for the current sink",
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": "Events processed for the current sink",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed for the current sink",
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": "Bytes processed for the current sink",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total incoming events for the current sink",
-              "isDeprecated": false,
               "name": "eventsInTotal",
+              "description": "Total incoming events for the current sink",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total received events for the current sink",
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": "Total received events for the current sink",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current sink",
-              "isDeprecated": false,
               "name": "eventsOutTotal",
+              "description": "Total outgoing events for the current sink",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current sink",
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": "Total outgoing events for the current sink",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1995,85 +1936,85 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "GenericSinkMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "GenericSourceMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed for the current source",
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": "Events processed for the current source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed for the current source",
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": "Bytes processed for the current source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total incoming events for the current source",
-              "isDeprecated": false,
               "name": "eventsInTotal",
+              "description": "Total incoming events for the current source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total received events for the current source",
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": "Total received events for the current source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current source",
-              "isDeprecated": false,
               "name": "eventsOutTotal",
+              "description": "Total outgoing events for the current source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current source",
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": "Total outgoing events for the current source",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -2084,85 +2025,85 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "GenericSourceMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "GenericTransformMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Events processed for the current transform",
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": "Events processed for the current transform",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Bytes processed for the current transform",
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": "Bytes processed for the current transform",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total incoming events for the current transform",
-              "isDeprecated": false,
               "name": "eventsInTotal",
+              "description": "Total incoming events for the current transform",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total received events for the current transform",
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": "Total received events for the current transform",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current transform",
-              "isDeprecated": false,
               "name": "eventsOutTotal",
+              "description": "Total outgoing events for the current transform",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total outgoing events for the current transform",
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": "Total outgoing events for the current transform",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -2173,20 +2114,18 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "GenericTransformMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Heartbeat",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "utc",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2195,25 +2134,25 @@
                   "name": "DateTime",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "Heartbeat",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "HostMetrics",
           "description": "Vector host metrics",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Memory metrics",
-              "isDeprecated": false,
               "name": "memory",
+              "description": "Memory metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2222,14 +2161,14 @@
                   "name": "MemoryMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Swap metrics",
-              "isDeprecated": false,
               "name": "swap",
+              "description": "Swap metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2238,14 +2177,14 @@
                   "name": "SwapMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "CPU metrics",
-              "isDeprecated": false,
               "name": "cpu",
+              "description": "CPU metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2254,26 +2193,26 @@
                   "name": "CpuMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Load average metrics (*nix only)",
-              "isDeprecated": false,
               "name": "loadAverage",
+              "description": "Load average metrics (*nix only)",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "LoadAverageMetrics",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Network metrics",
-              "isDeprecated": false,
               "name": "network",
+              "description": "Network metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2282,14 +2221,14 @@
                   "name": "NetworkMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Filesystem metrics",
-              "isDeprecated": false,
               "name": "filesystem",
+              "description": "Filesystem metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2298,14 +2237,14 @@
                   "name": "FileSystemMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Disk metrics",
-              "isDeprecated": false,
               "name": "disk",
+              "description": "Disk metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2314,55 +2253,55 @@
                   "name": "DiskMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "HostMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "kind": "SCALAR",
           "name": "ID",
-          "possibleTypes": null
-        },
-        {
-          "description": "The `Int` scalar type represents non-fractional whole numeric values.",
-          "enumValues": null,
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "Int",
-          "possibleTypes": null
-        },
-        {
-          "description": "Raw JSON data`",
-          "enumValues": null,
+          "description": "The `Int` scalar type represents non-fractional whole numeric values.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Json",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
+          "kind": "SCALAR",
+          "name": "Json",
+          "description": "Raw JSON data`",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LoadAverageMetrics",
+          "description": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Load 1 average",
-              "isDeprecated": false,
               "name": "load1",
+              "description": "Load 1 average",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2371,14 +2310,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Load 5 average",
-              "isDeprecated": false,
               "name": "load5",
+              "description": "Load 5 average",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2387,14 +2326,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Load 15 average",
-              "isDeprecated": false,
               "name": "load15",
+              "description": "Load 15 average",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2403,25 +2342,25 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "LoadAverageMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Log",
           "description": "Log event with fields for querying log data",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Id of the component associated with the log event",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Id of the component associated with the log event",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2430,38 +2369,41 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Log message",
-              "isDeprecated": false,
               "name": "message",
+              "description": "Log message",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Log timestamp",
-              "isDeprecated": false,
               "name": "timestamp",
+              "description": "Log timestamp",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "string",
+              "description": "Log event as an encoded string format",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "encoding",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2470,13 +2412,10 @@
                       "name": "EventEncodingType",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Log event as an encoded string format",
-              "isDeprecated": false,
-              "name": "string",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2485,14 +2424,17 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "json",
+              "description": "Get JSON field data on the log event, by field name",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "field",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2501,179 +2443,176 @@
                       "name": "String",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Get JSON field data on the log event, by field name",
-              "isDeprecated": false,
-              "name": "json",
               "type": {
                 "kind": "SCALAR",
                 "name": "Json",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "Log",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": "Host memory metrics",
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total bytes",
-              "isDeprecated": false,
-              "name": "totalBytes",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Free bytes",
-              "isDeprecated": false,
-              "name": "freeBytes",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Available bytes",
-              "isDeprecated": false,
-              "name": "availableBytes",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Active bytes (Linux/macOS only)",
-              "isDeprecated": false,
-              "name": "activeBytes",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Buffers bytes (Linux only)",
-              "isDeprecated": false,
-              "name": "buffersBytes",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Cached bytes (Linux only)",
-              "isDeprecated": false,
-              "name": "cachedBytes",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Shared bytes (Linux only)",
-              "isDeprecated": false,
-              "name": "sharedBytes",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Used bytes (Linux only)",
-              "isDeprecated": false,
-              "name": "usedBytes",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Inactive bytes (macOS only)",
-              "isDeprecated": false,
-              "name": "inactiveBytes",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Wired bytes (macOS only)",
-              "isDeprecated": false,
-              "name": "wiredBytes",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
           "kind": "OBJECT",
           "name": "MemoryMetrics",
+          "description": "Host memory metrics",
+          "fields": [
+            {
+              "name": "totalBytes",
+              "description": "Total bytes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "freeBytes",
+              "description": "Free bytes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "availableBytes",
+              "description": "Available bytes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activeBytes",
+              "description": "Active bytes (Linux/macOS only)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "buffersBytes",
+              "description": "Buffers bytes (Linux only)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cachedBytes",
+              "description": "Cached bytes (Linux only)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sharedBytes",
+              "description": "Shared bytes (Linux only)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "usedBytes",
+              "description": "Used bytes (Linux only)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inactiveBytes",
+              "description": "Inactive bytes (macOS only)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wiredBytes",
+              "description": "Wired bytes (macOS only)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Meta",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Vector version",
-              "isDeprecated": false,
               "name": "versionString",
+              "description": "Vector version",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2682,48 +2621,49 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Hostname",
-              "isDeprecated": false,
               "name": "hostname",
+              "description": "Hostname",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "Meta",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "MetricType",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "timestamp",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": null,
-          "kind": "INTERFACE",
-          "name": "MetricType",
+          "enumValues": null,
           "possibleTypes": [
             {
               "kind": "OBJECT",
@@ -2743,15 +2683,14 @@
           ]
         },
         {
+          "kind": "OBJECT",
+          "name": "NetworkMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total bytes received",
-              "isDeprecated": false,
               "name": "receiveBytesTotal",
+              "description": "Total bytes received",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2760,14 +2699,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total errors received",
-              "isDeprecated": false,
               "name": "receiveErrsTotal",
+              "description": "Total errors received",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2776,14 +2715,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total packets received",
-              "isDeprecated": false,
               "name": "receivePacketsTotal",
+              "description": "Total packets received",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2792,14 +2731,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total bytes transmitted",
-              "isDeprecated": false,
               "name": "transmitBytesTotal",
+              "description": "Total bytes transmitted",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2808,14 +2747,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total errors transmitted",
-              "isDeprecated": false,
               "name": "transmitErrsTotal",
+              "description": "Total errors transmitted",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2824,47 +2763,48 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total transmission packets dropped (Linux/Windows only)",
-              "isDeprecated": false,
               "name": "transmitPacketsDropTotal",
+              "description": "Total transmission packets dropped (Linux/Windows only)",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total transmission packets (Linux/Windows only)",
-              "isDeprecated": false,
               "name": "transmitPacketsTotal",
+              "description": "Total transmission packets (Linux/Windows only)",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "NetworkMetrics",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "UNION",
+          "name": "OutputEventsPayload",
           "description": "An event or a notification",
-          "enumValues": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "UNION",
-          "name": "OutputEventsPayload",
+          "enumValues": null,
           "possibleTypes": [
             {
               "kind": "OBJECT",
@@ -2879,15 +2819,14 @@
           ]
         },
         {
+          "kind": "OBJECT",
+          "name": "PageInfo",
           "description": "Information about pagination in a connection",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "When paginating backwards, are there more items?",
-              "isDeprecated": false,
               "name": "hasPreviousPage",
+              "description": "When paginating backwards, are there more items?",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2896,14 +2835,14 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "When paginating forwards, are there more items?",
-              "isDeprecated": false,
               "name": "hasNextPage",
+              "description": "When paginating forwards, are there more items?",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2912,106 +2851,61 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "When paginating backwards, the cursor to continue.",
-              "isDeprecated": false,
               "name": "startCursor",
+              "description": "When paginating backwards, the cursor to continue.",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "When paginating forwards, the cursor to continue.",
-              "isDeprecated": false,
               "name": "endCursor",
+              "description": "When paginating forwards, the cursor to continue.",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "PageInfo",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
-              "name": "timestamp",
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total number of bytes processed",
-              "isDeprecated": false,
-              "name": "processedBytesTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "MetricType",
-              "ofType": null
-            }
-          ],
           "kind": "OBJECT",
           "name": "ProcessedBytesTotal",
-          "possibleTypes": null
-        },
-        {
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
               "name": "timestamp",
+              "description": "Metric timestamp",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "processedBytesTotal",
+              "description": "Total number of bytes processed",
               "args": [],
-              "deprecationReason": null,
-              "description": "Total number of events processed",
-              "isDeprecated": false,
-              "name": "processedEventsTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3020,7 +2914,9 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -3031,20 +2927,63 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "ProcessedEventsTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ProcessedEventsTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
+              "name": "timestamp",
+              "description": "Metric timestamp",
               "args": [],
-              "deprecationReason": null,
-              "description": "Returns `true` to denote the GraphQL server is reachable",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
               "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "processedEventsTotal",
+              "description": "Total number of events processed",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "MetricType",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
               "name": "health",
+              "description": "Returns `true` to denote the GraphQL server is reachable",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3053,64 +2992,67 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "components",
+              "description": "Configured components (sources/transforms/sinks)",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "after",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "before",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "first",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "last",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "filter",
+                  "description": null,
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "ComponentsFilter",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "sort",
+                  "description": null,
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -3123,13 +3065,10 @@
                         "ofType": null
                       }
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Configured components (sources/transforms/sinks)",
-              "isDeprecated": false,
-              "name": "components",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3138,64 +3077,67 @@
                   "name": "ComponentConnection",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "sources",
+              "description": "Configured sources",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "after",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "before",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "first",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "last",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "filter",
+                  "description": null,
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SourcesFilter",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "sort",
+                  "description": null,
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -3208,13 +3150,10 @@
                         "ofType": null
                       }
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Configured sources",
-              "isDeprecated": false,
-              "name": "sources",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3223,64 +3162,67 @@
                   "name": "SourceConnection",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "transforms",
+              "description": "Configured transforms",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "after",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "before",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "first",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "last",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "filter",
+                  "description": null,
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "TransformsFilter",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "sort",
+                  "description": null,
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -3293,13 +3235,10 @@
                         "ofType": null
                       }
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Configured transforms",
-              "isDeprecated": false,
-              "name": "transforms",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3308,64 +3247,67 @@
                   "name": "TransformConnection",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "sinks",
+              "description": "Configured sinks",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "after",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "before",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "first",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "last",
+                  "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "filter",
+                  "description": null,
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SinksFilter",
                     "ofType": null
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "sort",
+                  "description": null,
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -3378,13 +3320,10 @@
                         "ofType": null
                       }
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Configured sinks",
-              "isDeprecated": false,
-              "name": "sinks",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3393,14 +3332,17 @@
                   "name": "SinkConnection",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentByComponentKey",
+              "description": "Gets a configured component by component_key",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "componentId",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -3409,25 +3351,22 @@
                       "name": "String",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Gets a configured component by component_key",
-              "isDeprecated": false,
-              "name": "componentByComponentKey",
               "type": {
                 "kind": "INTERFACE",
                 "name": "Component",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Vector host metrics",
-              "isDeprecated": false,
               "name": "hostMetrics",
+              "description": "Vector host metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3436,14 +3375,14 @@
                   "name": "HostMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "meta",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3452,76 +3391,37 @@
                   "name": "Meta",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "Query",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
-              "name": "timestamp",
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total incoming events",
-              "isDeprecated": false,
-              "name": "receivedEventsTotal",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
           "kind": "OBJECT",
           "name": "ReceivedEventsTotal",
-          "possibleTypes": null
-        },
-        {
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
               "name": "timestamp",
+              "description": "Metric timestamp",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "receivedEventsTotal",
+              "description": "Total incoming events",
               "args": [],
-              "deprecationReason": null,
-              "description": "Total sent events",
-              "isDeprecated": false,
-              "name": "sentEventsTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3530,25 +3430,64 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "SentEventsTotal",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SentEventsTotal",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
+              "name": "timestamp",
+              "description": "Metric timestamp",
               "args": [],
-              "deprecationReason": null,
-              "description": "Sink component_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
               "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sentEventsTotal",
+              "description": "Total sent events",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Sink",
+          "description": null,
+          "fields": [
+            {
               "name": "componentId",
+              "description": "Sink component_id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3557,14 +3496,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Sink type",
-              "isDeprecated": false,
               "name": "componentType",
+              "description": "Sink type",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3573,14 +3512,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Source inputs",
-              "isDeprecated": false,
               "name": "sources",
+              "description": "Source inputs",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3597,14 +3536,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Transform inputs",
-              "isDeprecated": false,
               "name": "transforms",
+              "description": "Transform inputs",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3621,14 +3560,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Sink metrics",
-              "isDeprecated": false,
               "name": "metrics",
+              "description": "Sink metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3637,7 +3576,9 @@
                   "name": "SinkMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -3648,20 +3589,18 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "Sink",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SinkConnection",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
               "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3670,14 +3609,14 @@
                   "name": "PageInfo",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of edges.",
-              "isDeprecated": false,
               "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -3686,14 +3625,14 @@
                   "name": "SinkEdge",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total result set count",
-              "isDeprecated": false,
               "name": "totalCount",
+              "description": "Total result set count",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3702,25 +3641,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "SinkConnection",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SinkEdge",
           "description": "An edge in a connection.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
               "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3729,14 +3668,14 @@
                   "name": "Sink",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
               "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3745,96 +3684,97 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "SinkEdge",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "SinkMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": "Use received_events_total instead",
-              "description": null,
-              "isDeprecated": true,
               "name": "eventsInTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use received_events_total instead"
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": "Use sent_events_total instead",
-              "description": null,
-              "isDeprecated": true,
               "name": "eventsOutTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use sent_events_total instead"
             }
           ],
           "inputFields": null,
           "interfaces": null,
-          "kind": "INTERFACE",
-          "name": "SinkMetrics",
+          "enumValues": null,
           "possibleTypes": [
             {
               "kind": "OBJECT",
@@ -3844,14 +3784,14 @@
           ]
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SinksFilter",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentId",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -3864,12 +3804,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentType",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -3882,12 +3822,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "or",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -3900,23 +3840,23 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "SinksFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SinksSortField",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "field",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3925,12 +3865,12 @@
                   "name": "SinksSortFieldName",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": "ASC",
-              "description": null,
               "name": "direction",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3939,47 +3879,46 @@
                   "name": "Direction",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": "ASC"
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "SinksSortField",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "SinksSortFieldName",
           "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_KEY"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_TYPE"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "SinksSortFieldName",
+          "enumValues": [
+            {
+              "name": "COMPONENT_KEY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COMPONENT_TYPE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Source",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Source component_id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Source component_id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3988,14 +3927,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Source type",
-              "isDeprecated": false,
               "name": "componentType",
+              "description": "Source type",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4004,14 +3943,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Source output type",
-              "isDeprecated": false,
               "name": "outputType",
+              "description": "Source output type",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4020,14 +3959,14 @@
                   "name": "SourceOutputType",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Transform outputs",
-              "isDeprecated": false,
               "name": "transforms",
+              "description": "Transform outputs",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4044,14 +3983,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Sink outputs",
-              "isDeprecated": false,
               "name": "sinks",
+              "description": "Sink outputs",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4068,14 +4007,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Source metrics",
-              "isDeprecated": false,
               "name": "metrics",
+              "description": "Source metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4084,7 +4023,9 @@
                   "name": "SourceMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -4095,20 +4036,18 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "Source",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SourceConnection",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
               "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4117,14 +4056,14 @@
                   "name": "PageInfo",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of edges.",
-              "isDeprecated": false,
               "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -4133,14 +4072,14 @@
                   "name": "SourceEdge",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total result set count",
-              "isDeprecated": false,
               "name": "totalCount",
+              "description": "Total result set count",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4149,25 +4088,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "SourceConnection",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SourceEdge",
           "description": "An edge in a connection.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
               "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4176,14 +4115,14 @@
                   "name": "Source",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
               "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4192,96 +4131,97 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "SourceEdge",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "SourceMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": "Use received_events_total instead",
-              "description": null,
-              "isDeprecated": true,
               "name": "eventsInTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use received_events_total instead"
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": "Use sent_events_total instead",
-              "description": null,
-              "isDeprecated": true,
               "name": "eventsOutTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use sent_events_total instead"
             }
           ],
           "inputFields": null,
           "interfaces": null,
-          "kind": "INTERFACE",
-          "name": "SourceMetrics",
+          "enumValues": null,
           "possibleTypes": [
             {
               "kind": "OBJECT",
@@ -4296,74 +4236,74 @@
           ]
         },
         {
+          "kind": "ENUM",
+          "name": "SourceOutputType",
           "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "ANY"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "LOG"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "METRIC"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "SourceOutputType",
+          "enumValues": [
+            {
+              "name": "ANY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LOG",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "METRIC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SourceOutputTypeFilter",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "equals",
+              "description": null,
               "type": {
                 "kind": "ENUM",
                 "name": "SourceOutputType",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "notEquals",
+              "description": null,
               "type": {
                 "kind": "ENUM",
                 "name": "SourceOutputType",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "SourceOutputTypeFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SourcesFilter",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentId",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -4376,12 +4316,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentType",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -4394,12 +4334,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "outputType",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -4412,12 +4352,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "or",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -4430,23 +4370,23 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "SourcesFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SourcesSortField",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "field",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4455,12 +4395,12 @@
                   "name": "SourcesSortFieldName",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": "ASC",
-              "description": null,
               "name": "direction",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4469,134 +4409,136 @@
                   "name": "Direction",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": "ASC"
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "SourcesSortField",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_KEY"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_TYPE"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "OUTPUT_TYPE"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "kind": "ENUM",
           "name": "SourcesSortFieldName",
-          "possibleTypes": null
-        },
-        {
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "enumValues": null,
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "SCALAR",
-          "name": "String",
+          "enumValues": [
+            {
+              "name": "COMPONENT_KEY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COMPONENT_TYPE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OUTPUT_TYPE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
-          "description": "Filter for String values",
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "StringFilter",
+          "description": "Filter for String values",
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "equals",
+              "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "notEquals",
+              "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "contains",
+              "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "notContains",
+              "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "startsWith",
+              "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "endsWith",
+              "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "StringFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Subscription",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
+              "name": "heartbeat",
+              "description": "Heartbeat, containing the UTC timestamp of the last server-sent payload",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4605,13 +4547,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Heartbeat, containing the UTC timestamp of the last server-sent payload",
-              "isDeprecated": false,
-              "name": "heartbeat",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4620,14 +4559,17 @@
                   "name": "Heartbeat",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "uptime",
+              "description": "Metrics for how long the Vector instance has been running",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4636,13 +4578,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Metrics for how long the Vector instance has been running",
-              "isDeprecated": false,
-              "name": "uptime",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4651,14 +4590,17 @@
                   "name": "Uptime",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "processedEventsTotal",
+              "description": "Event processing metrics.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4667,13 +4609,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Event processing metrics.",
-              "isDeprecated": false,
-              "name": "processedEventsTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4682,14 +4621,17 @@
                   "name": "ProcessedEventsTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "processedEventsThroughput",
+              "description": "Event processing throughput sampled over the provided millisecond `interval`.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4698,13 +4640,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Event processing throughput sampled over the provided millisecond `interval`.",
-              "isDeprecated": false,
-              "name": "processedEventsThroughput",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4713,14 +4652,17 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentProcessedEventsThroughputs",
+              "description": "Component event processing throughput metrics over `interval`.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4729,13 +4671,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Component event processing throughput metrics over `interval`.",
-              "isDeprecated": false,
-              "name": "componentProcessedEventsThroughputs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4752,14 +4691,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentProcessedEventsTotals",
+              "description": "Component event processing metrics over `interval`.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4768,13 +4710,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Component event processing metrics over `interval`.",
-              "isDeprecated": false,
-              "name": "componentProcessedEventsTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4791,14 +4730,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "eventsInTotal",
+              "description": "Total incoming events metrics",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4807,13 +4749,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": "Use received_events_total instead",
-              "description": "Total incoming events metrics",
-              "isDeprecated": true,
-              "name": "eventsInTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4822,14 +4761,17 @@
                   "name": "EventsInTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use received_events_total instead"
             },
             {
+              "name": "receivedEventsTotal",
+              "description": "Total received events metrics",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4838,13 +4780,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Total received events metrics",
-              "isDeprecated": false,
-              "name": "receivedEventsTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4853,76 +4792,17 @@
                   "name": "ReceivedEventsTotal",
                   "ofType": null
                 }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": "1000",
-                  "description": null,
-                  "name": "interval",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": "Use received_events_throughput instead",
-              "description": "Total incoming events throughput sampled over the provided millisecond `interval`",
-              "isDeprecated": true,
-              "name": "eventsInThroughput",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": "1000",
-                  "description": null,
-                  "name": "interval",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Total received events throughput sampled over the provided millisecond `interval`",
+              },
               "isDeprecated": false,
-              "name": "receivedEventsThroughput",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
+              "deprecationReason": null
             },
             {
+              "name": "eventsInThroughput",
+              "description": "Total incoming events throughput sampled over the provided millisecond `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4931,13 +4811,72 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": "Use component_received_events_throughputs instead",
-              "description": "Total incoming component events throughput metrics over `interval`",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
               "isDeprecated": true,
+              "deprecationReason": "Use received_events_throughput instead"
+            },
+            {
+              "name": "receivedEventsThroughput",
+              "description": "Total received events throughput sampled over the provided millisecond `interval`",
+              "args": [
+                {
+                  "name": "interval",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "1000"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "componentEventsInThroughputs",
+              "description": "Total incoming component events throughput metrics over `interval`",
+              "args": [
+                {
+                  "name": "interval",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "1000"
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4954,14 +4893,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use component_received_events_throughputs instead"
             },
             {
+              "name": "componentReceivedEventsThroughputs",
+              "description": "Total incoming component events throughput metrics over `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4970,13 +4912,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Total incoming component events throughput metrics over `interval`",
-              "isDeprecated": false,
-              "name": "componentReceivedEventsThroughputs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4993,14 +4932,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentEventsInTotals",
+              "description": "Total incoming component event metrics over `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5009,13 +4951,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": "Use component_received_events_totals instead",
-              "description": "Total incoming component event metrics over `interval`",
-              "isDeprecated": true,
-              "name": "componentEventsInTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5032,14 +4971,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use component_received_events_totals instead"
             },
             {
+              "name": "componentReceivedEventsTotals",
+              "description": "Total received component event metrics over `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5048,13 +4990,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Total received component event metrics over `interval`",
-              "isDeprecated": false,
-              "name": "componentReceivedEventsTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5071,14 +5010,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "eventsOutTotal",
+              "description": "Total outgoing events metrics",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5087,13 +5029,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": "Use sent_events_total instead",
-              "description": "Total outgoing events metrics",
-              "isDeprecated": true,
-              "name": "eventsOutTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5102,14 +5041,17 @@
                   "name": "EventsOutTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use sent_events_total instead"
             },
             {
+              "name": "sentEventsTotal",
+              "description": "Total sent events metrics",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5118,13 +5060,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Total sent events metrics",
-              "isDeprecated": false,
-              "name": "sentEventsTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5133,76 +5072,17 @@
                   "name": "SentEventsTotal",
                   "ofType": null
                 }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": "1000",
-                  "description": null,
-                  "name": "interval",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": "Use sent_events_throughput instead",
-              "description": "Total outgoing events throughput sampled over the provided millisecond `interval`",
-              "isDeprecated": true,
-              "name": "eventsOutThroughput",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": "1000",
-                  "description": null,
-                  "name": "interval",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Total outgoing events throughput sampled over the provided millisecond `interval`",
+              },
               "isDeprecated": false,
-              "name": "sentEventsThroughput",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
+              "deprecationReason": null
             },
             {
+              "name": "eventsOutThroughput",
+              "description": "Total outgoing events throughput sampled over the provided millisecond `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5211,13 +5091,72 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": "Use component_sent_events_throughputs instead",
-              "description": "Total outgoing component event throughput metrics over `interval`",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
               "isDeprecated": true,
+              "deprecationReason": "Use sent_events_throughput instead"
+            },
+            {
+              "name": "sentEventsThroughput",
+              "description": "Total outgoing events throughput sampled over the provided millisecond `interval`",
+              "args": [
+                {
+                  "name": "interval",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "1000"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "componentEventsOutThroughputs",
+              "description": "Total outgoing component event throughput metrics over `interval`",
+              "args": [
+                {
+                  "name": "interval",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "1000"
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5234,14 +5173,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use component_sent_events_throughputs instead"
             },
             {
+              "name": "componentSentEventsThroughputs",
+              "description": "Total outgoing component event throughput metrics over `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5250,13 +5192,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Total outgoing component event throughput metrics over `interval`",
-              "isDeprecated": false,
-              "name": "componentSentEventsThroughputs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5273,14 +5212,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentEventsOutTotals",
+              "description": "Total outgoing component event metrics over `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5289,13 +5231,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": "Use component_sent_events_totals instead",
-              "description": "Total outgoing component event metrics over `interval`",
-              "isDeprecated": true,
-              "name": "componentEventsOutTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5312,14 +5251,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use component_sent_events_totals instead"
             },
             {
+              "name": "componentSentEventsTotals",
+              "description": "Total outgoing component event metrics over `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5328,13 +5270,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Total outgoing component event metrics over `interval`",
-              "isDeprecated": false,
-              "name": "componentSentEventsTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5351,14 +5290,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "processedBytesTotal",
+              "description": "Byte processing metrics.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5367,13 +5309,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Byte processing metrics.",
-              "isDeprecated": false,
-              "name": "processedBytesTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5382,14 +5321,17 @@
                   "name": "ProcessedBytesTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "processedBytesThroughput",
+              "description": "Byte processing throughput sampled over a provided millisecond `interval`.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5398,13 +5340,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Byte processing throughput sampled over a provided millisecond `interval`.",
-              "isDeprecated": false,
-              "name": "processedBytesThroughput",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5413,14 +5352,17 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentProcessedBytesTotals",
+              "description": "Component byte processing metrics over `interval`.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5429,13 +5371,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Component byte processing metrics over `interval`.",
-              "isDeprecated": false,
-              "name": "componentProcessedBytesTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5452,14 +5391,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentProcessedBytesThroughputs",
+              "description": "Component byte processing throughput over `interval`",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5468,13 +5410,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Component byte processing throughput over `interval`",
-              "isDeprecated": false,
-              "name": "componentProcessedBytesThroughputs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5491,14 +5430,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "errorsTotal",
+              "description": "Total error metrics.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5507,13 +5449,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Total error metrics.",
-              "isDeprecated": false,
-              "name": "errorsTotal",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5522,14 +5461,17 @@
                   "name": "ErrorsTotal",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentErrorsTotals",
+              "description": "Component error metrics over `interval`.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5538,13 +5480,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "Component error metrics over `interval`.",
-              "isDeprecated": false,
-              "name": "componentErrorsTotals",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5561,14 +5500,17 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "metrics",
+              "description": "All metrics.",
               "args": [
                 {
-                  "defaultValue": "1000",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5577,13 +5519,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "1000"
                 }
               ],
-              "deprecationReason": null,
-              "description": "All metrics.",
-              "isDeprecated": false,
-              "name": "metrics",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5592,30 +5531,14 @@
                   "name": "MetricType",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Subscribes to all newly added components",
-              "isDeprecated": false,
               "name": "componentAdded",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INTERFACE",
-                  "name": "Component",
-                  "ofType": null
-                }
-              }
-            },
-            {
+              "description": "Subscribes to all newly added components",
               "args": [],
-              "deprecationReason": null,
-              "description": "Subscribes to all removed components",
-              "isDeprecated": false,
-              "name": "componentRemoved",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5624,14 +5547,33 @@
                   "name": "Component",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "componentRemoved",
+              "description": "Subscribes to all removed components",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Component",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "outputEventsByComponentIdPatterns",
+              "description": "A stream of events emitted from matched component ID patterns",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "patterns",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5648,12 +5590,12 @@
                         }
                       }
                     }
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": "500",
-                  "description": null,
                   "name": "interval",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5662,12 +5604,12 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "500"
                 },
                 {
-                  "defaultValue": "100",
-                  "description": null,
                   "name": "limit",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -5676,13 +5618,10 @@
                       "name": "Int",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "100"
                 }
               ],
-              "deprecationReason": null,
-              "description": "A stream of events emitted from matched component ID patterns",
-              "isDeprecated": false,
-              "name": "outputEventsByComponentIdPatterns",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5699,108 +5638,108 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "Subscription",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Swap free bytes",
-              "isDeprecated": false,
-              "name": "freeBytes",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Swap total bytes",
-              "isDeprecated": false,
-              "name": "totalBytes",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Swap used bytes",
-              "isDeprecated": false,
-              "name": "usedBytes",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Swapped in bytes total (not available on Windows)",
-              "isDeprecated": false,
-              "name": "swappedInBytesTotal",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Swapped out bytes total (not available on Windows)",
-              "isDeprecated": false,
-              "name": "swappedOutBytesTotal",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
           "kind": "OBJECT",
           "name": "SwapMetrics",
+          "description": null,
+          "fields": [
+            {
+              "name": "freeBytes",
+              "description": "Swap free bytes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalBytes",
+              "description": "Swap total bytes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "usedBytes",
+              "description": "Swap used bytes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "swappedInBytesTotal",
+              "description": "Swapped in bytes total (not available on Windows)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "swappedOutBytesTotal",
+              "description": "Swapped out bytes total (not available on Windows)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Transform",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Transform component_id",
-              "isDeprecated": false,
               "name": "componentId",
+              "description": "Transform component_id",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5809,14 +5748,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Transform type",
-              "isDeprecated": false,
               "name": "componentType",
+              "description": "Transform type",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5825,14 +5764,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Source inputs",
-              "isDeprecated": false,
               "name": "sources",
+              "description": "Source inputs",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5849,14 +5788,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Transform outputs",
-              "isDeprecated": false,
               "name": "transforms",
+              "description": "Transform outputs",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5873,14 +5812,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Sink outputs",
-              "isDeprecated": false,
               "name": "sinks",
+              "description": "Sink outputs",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5897,14 +5836,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Transform metrics",
-              "isDeprecated": false,
               "name": "metrics",
+              "description": "Transform metrics",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5913,7 +5852,9 @@
                   "name": "TransformMetrics",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -5924,20 +5865,18 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "Transform",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "TransformConnection",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
               "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5946,14 +5885,14 @@
                   "name": "PageInfo",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of edges.",
-              "isDeprecated": false,
               "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -5962,14 +5901,14 @@
                   "name": "TransformEdge",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Total result set count",
-              "isDeprecated": false,
               "name": "totalCount",
+              "description": "Total result set count",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5978,25 +5917,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TransformConnection",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "TransformEdge",
           "description": "An edge in a connection.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
               "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6005,14 +5944,14 @@
                   "name": "Transform",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
               "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6021,96 +5960,97 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TransformEdge",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "TransformMetrics",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "processedEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "processedBytesTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ProcessedBytesTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "receivedEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "ReceivedEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": "Use received_events_total instead",
-              "description": null,
-              "isDeprecated": true,
               "name": "eventsInTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsInTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use received_events_total instead"
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "sentEventsTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "SentEventsTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": "Use sent_events_total instead",
-              "description": null,
-              "isDeprecated": true,
               "name": "eventsOutTotal",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "EventsOutTotal",
                 "ofType": null
-              }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use sent_events_total instead"
             }
           ],
           "inputFields": null,
           "interfaces": null,
-          "kind": "INTERFACE",
-          "name": "TransformMetrics",
+          "enumValues": null,
           "possibleTypes": [
             {
               "kind": "OBJECT",
@@ -6120,14 +6060,14 @@
           ]
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "TransformsFilter",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentId",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6140,12 +6080,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "componentType",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6158,12 +6098,12 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": null,
-              "description": null,
               "name": "or",
+              "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6176,23 +6116,23 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "TransformsFilter",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "TransformsSortField",
           "description": null,
-          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "defaultValue": null,
-              "description": null,
               "name": "field",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6201,12 +6141,12 @@
                   "name": "TransformsSortFieldName",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": null
             },
             {
-              "defaultValue": "ASC",
-              "description": null,
               "name": "direction",
+              "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6215,59 +6155,58 @@
                   "name": "Direction",
                   "ofType": null
                 }
-              }
+              },
+              "defaultValue": "ASC"
             }
           ],
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "TransformsSortField",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "TransformsSortFieldName",
           "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_KEY"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "COMPONENT_TYPE"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "TransformsSortFieldName",
+          "enumValues": [
+            {
+              "name": "COMPONENT_KEY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COMPONENT_TYPE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Uptime",
           "description": null,
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Metric timestamp",
-              "isDeprecated": false,
               "name": "timestamp",
+              "description": "Metric timestamp",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of seconds the Vector instance has been alive",
-              "isDeprecated": false,
               "name": "seconds",
+              "description": "Number of seconds the Vector instance has been alive",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6276,7 +6215,9 @@
                   "name": "Float",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -6287,20 +6228,18 @@
               "ofType": null
             }
           ],
-          "kind": "OBJECT",
-          "name": "Uptime",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__Directive",
           "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "name",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6309,26 +6248,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "description",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "locations",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6345,14 +6284,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "args",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6369,150 +6308,166 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isRepeatable",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Directive",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
           "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a query operation.",
-              "isDeprecated": false,
-              "name": "QUERY"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a mutation operation.",
-              "isDeprecated": false,
-              "name": "MUTATION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a subscription operation.",
-              "isDeprecated": false,
-              "name": "SUBSCRIPTION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a field.",
-              "isDeprecated": false,
-              "name": "FIELD"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a fragment definition.",
-              "isDeprecated": false,
-              "name": "FRAGMENT_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a fragment spread.",
-              "isDeprecated": false,
-              "name": "FRAGMENT_SPREAD"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an inline fragment.",
-              "isDeprecated": false,
-              "name": "INLINE_FRAGMENT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a variable definition.",
-              "isDeprecated": false,
-              "name": "VARIABLE_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a schema definition.",
-              "isDeprecated": false,
-              "name": "SCHEMA"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a scalar definition.",
-              "isDeprecated": false,
-              "name": "SCALAR"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an object type definition.",
-              "isDeprecated": false,
-              "name": "OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a field definition.",
-              "isDeprecated": false,
-              "name": "FIELD_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an argument definition.",
-              "isDeprecated": false,
-              "name": "ARGUMENT_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an interface definition.",
-              "isDeprecated": false,
-              "name": "INTERFACE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a union definition.",
-              "isDeprecated": false,
-              "name": "UNION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an enum definition.",
-              "isDeprecated": false,
-              "name": "ENUM"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an enum value definition.",
-              "isDeprecated": false,
-              "name": "ENUM_VALUE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an input object type definition.",
-              "isDeprecated": false,
-              "name": "INPUT_OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an input object field definition.",
-              "isDeprecated": false,
-              "name": "INPUT_FIELD_DEFINITION"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "__DirectiveLocation",
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VARIABLE_DEFINITION",
+              "description": "Location adjacent to a variable definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
           "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "name",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6521,26 +6476,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "description",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "isDeprecated",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6549,37 +6504,37 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "deprecationReason",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__EnumValue",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__Field",
           "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "name",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6588,26 +6543,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "description",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "args",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6624,14 +6579,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "type",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6640,14 +6595,14 @@
                   "name": "__Type",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "isDeprecated",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6656,37 +6611,37 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "deprecationReason",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Field",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__InputValue",
           "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "name",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6695,26 +6650,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "description",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "type",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6723,37 +6678,37 @@
                   "name": "__Type",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "defaultValue",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__InputValue",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__Schema",
           "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of all types supported by this server.",
-              "isDeprecated": false,
               "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6770,14 +6725,14 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The type that query operations will be rooted at.",
-              "isDeprecated": false,
               "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6786,38 +6741,38 @@
                   "name": "__Type",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-              "isDeprecated": false,
               "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
-              "isDeprecated": false,
               "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of all directives supported by this server.",
-              "isDeprecated": false,
               "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6834,25 +6789,25 @@
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Schema",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__Type",
           "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "kind",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6861,38 +6816,41 @@
                   "name": "__TypeKind",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "name",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": null,
-              "isDeprecated": false,
-              "name": "description",
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
               "args": [
                 {
-                  "defaultValue": "false",
-                  "description": null,
                   "name": "includeDeprecated",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6901,13 +6859,10 @@
                       "name": "Boolean",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "false"
                 }
               ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "fields",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6920,34 +6875,14 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "interfaces",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": null,
-              "isDeprecated": false,
-              "name": "possibleTypes",
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6960,14 +6895,37 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
               "args": [
                 {
-                  "defaultValue": "false",
-                  "description": null,
                   "name": "includeDeprecated",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6976,13 +6934,10 @@
                       "name": "Boolean",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "false"
                 }
               ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "enumValues",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6995,14 +6950,14 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "inputFields",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -7015,85 +6970,150 @@
                     "ofType": null
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "ofType",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "specifiedByURL",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Type",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "__TypeKind",
           "description": "An enum describing what kind of type a given `__Type` is.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a scalar.",
-              "isDeprecated": false,
-              "name": "SCALAR"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-              "isDeprecated": false,
-              "name": "OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-              "isDeprecated": false,
-              "name": "INTERFACE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
-              "isDeprecated": false,
-              "name": "UNION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
-              "isDeprecated": false,
-              "name": "ENUM"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
-              "isDeprecated": false,
-              "name": "INPUT_OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a list. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "name": "LIST"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "name": "NON_NULL"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "__TypeKind",
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
         }
       ]
     }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-graphql = { version = "2.10.4", default-features = false, optional = true }
+async-graphql = { version = "3.0.15", default-features = false, optional = true }
 async-trait = { version = "0.1", default-features = false }
 atomig = { version = "0.3.2", features = ["derive", "serde"] }
 buffers = { path = "buffers", default-features = false }

--- a/src/api/schema/events/mod.rs
+++ b/src/api/schema/events/mod.rs
@@ -8,7 +8,7 @@ use output::OutputEventsPayload;
 
 use crate::{api::tap::TapController, topology::WatchRx};
 
-use async_graphql::{validators::IntRange, Context, Subscription};
+use async_graphql::{Context, Subscription};
 use futures::Stream;
 use itertools::Itertools;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
@@ -26,7 +26,7 @@ impl EventsSubscription {
         ctx: &'a Context<'a>,
         patterns: Vec<String>,
         #[graphql(default = 500)] interval: u32,
-        #[graphql(default = 100, validator(IntRange(min = "1", max = "10_000")))] limit: u32,
+        #[graphql(default = 100, validator(minimum = 1, maximum = 10_000))] limit: u32,
     ) -> impl Stream<Item = Vec<OutputEventsPayload>> + 'a {
         let watch_rx = ctx.data_unchecked::<WatchRx>().clone();
 

--- a/src/api/schema/health.rs
+++ b/src/api/schema/health.rs
@@ -1,4 +1,4 @@
-use async_graphql::{validators::IntRange, Object, SimpleObject, Subscription};
+use async_graphql::{Object, SimpleObject, Subscription};
 use chrono::{DateTime, Utc};
 use tokio::time::Duration;
 use tokio_stream::{wrappers::IntervalStream, Stream, StreamExt};
@@ -33,7 +33,7 @@ impl HealthSubscription {
     /// Heartbeat, containing the UTC timestamp of the last server-sent payload
     async fn heartbeat(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Heartbeat> {
         IntervalStream::new(tokio::time::interval(Duration::from_millis(
             interval as u64,

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -16,7 +16,7 @@ mod host;
 
 use crate::config::ComponentKey;
 
-use async_graphql::{validators::IntRange, Interface, Object, Subscription};
+use async_graphql::{Interface, Object, Subscription};
 use chrono::{DateTime, Utc};
 use tokio_stream::{Stream, StreamExt};
 
@@ -67,7 +67,7 @@ impl MetricsSubscription {
     /// Metrics for how long the Vector instance has been running
     async fn uptime(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Uptime> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "uptime_seconds" => Some(Uptime::new(m)),
@@ -78,7 +78,7 @@ impl MetricsSubscription {
     /// Event processing metrics.
     async fn processed_events_total(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = ProcessedEventsTotal> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "processed_events_total" => Some(ProcessedEventsTotal::new(m)),
@@ -89,7 +89,7 @@ impl MetricsSubscription {
     /// Event processing throughput sampled over the provided millisecond `interval`.
     async fn processed_events_throughput(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "processed_events_total")
             .map(|(_, throughput)| throughput as i64)
@@ -98,7 +98,7 @@ impl MetricsSubscription {
     /// Component event processing throughput metrics over `interval`.
     async fn component_processed_events_throughputs(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentProcessedEventsThroughput>> {
         component_counter_throughputs(interval, &|m| m.name() == "processed_events_total").map(
             |m| {
@@ -117,7 +117,7 @@ impl MetricsSubscription {
     /// Component event processing metrics over `interval`.
     async fn component_processed_events_totals(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentProcessedEventsTotal>> {
         component_counter_metrics(interval, &|m| m.name() == "processed_events_total").map(|m| {
             m.into_iter()
@@ -130,7 +130,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use received_events_total instead")]
     async fn events_in_total(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = EventsInTotal> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "events_in_total" => Some(EventsInTotal::new(m)),
@@ -141,7 +141,7 @@ impl MetricsSubscription {
     /// Total received events metrics
     async fn received_events_total(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = ReceivedEventsTotal> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "component_received_events_total" => Some(ReceivedEventsTotal::new(m)),
@@ -153,7 +153,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use received_events_throughput instead")]
     async fn events_in_throughput(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "events_in_total")
             .map(|(_, throughput)| throughput as i64)
@@ -162,7 +162,7 @@ impl MetricsSubscription {
     /// Total received events throughput sampled over the provided millisecond `interval`
     async fn received_events_throughput(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "component_received_events_total")
             .map(|(_, throughput)| throughput as i64)
@@ -172,7 +172,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use component_received_events_throughputs instead")]
     async fn component_events_in_throughputs(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentEventsInThroughput>> {
         component_counter_throughputs(interval, &|m| m.name() == "events_in_total").map(|m| {
             m.into_iter()
@@ -189,7 +189,7 @@ impl MetricsSubscription {
     /// Total incoming component events throughput metrics over `interval`
     async fn component_received_events_throughputs(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentReceivedEventsThroughput>> {
         component_counter_throughputs(interval, &|m| m.name() == "component_received_events_total")
             .map(|m| {
@@ -208,7 +208,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use component_received_events_totals instead")]
     async fn component_events_in_totals(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentEventsInTotal>> {
         component_counter_metrics(interval, &|m| m.name() == "events_in_total")
             .map(|m| m.into_iter().map(ComponentEventsInTotal::new).collect())
@@ -217,7 +217,7 @@ impl MetricsSubscription {
     /// Total received component event metrics over `interval`
     async fn component_received_events_totals(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentReceivedEventsTotal>> {
         component_counter_metrics(interval, &|m| m.name() == "component_received_events_total").map(
             |m| {
@@ -232,7 +232,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use sent_events_total instead")]
     async fn events_out_total(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = EventsOutTotal> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "events_out_total" => Some(EventsOutTotal::new(m)),
@@ -243,7 +243,7 @@ impl MetricsSubscription {
     /// Total sent events metrics
     async fn sent_events_total(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = SentEventsTotal> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "component_sent_events_total" => Some(SentEventsTotal::new(m)),
@@ -255,7 +255,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use sent_events_throughput instead")]
     async fn events_out_throughput(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "events_out_total")
             .map(|(_, throughput)| throughput as i64)
@@ -264,7 +264,7 @@ impl MetricsSubscription {
     /// Total outgoing events throughput sampled over the provided millisecond `interval`
     async fn sent_events_throughput(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "component_sent_events_total")
             .map(|(_, throughput)| throughput as i64)
@@ -274,7 +274,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use component_sent_events_throughputs instead")]
     async fn component_events_out_throughputs(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentEventsOutThroughput>> {
         component_counter_throughputs(interval, &|m| m.name() == "events_out_total").map(|m| {
             m.into_iter()
@@ -291,7 +291,7 @@ impl MetricsSubscription {
     /// Total outgoing component event throughput metrics over `interval`
     async fn component_sent_events_throughputs(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentSentEventsThroughput>> {
         component_counter_throughputs(interval, &|m| m.name() == "component_sent_events_total").map(
             |m| {
@@ -311,7 +311,7 @@ impl MetricsSubscription {
     #[graphql(deprecation = "Use component_sent_events_totals instead")]
     async fn component_events_out_totals(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentEventsOutTotal>> {
         component_counter_metrics(interval, &|m| m.name() == "events_out_total")
             .map(|m| m.into_iter().map(ComponentEventsOutTotal::new).collect())
@@ -320,7 +320,7 @@ impl MetricsSubscription {
     /// Total outgoing component event metrics over `interval`
     async fn component_sent_events_totals(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentSentEventsTotal>> {
         component_counter_metrics(interval, &|m| m.name() == "component_sent_events_total")
             .map(|m| m.into_iter().map(ComponentSentEventsTotal::new).collect())
@@ -329,7 +329,7 @@ impl MetricsSubscription {
     /// Byte processing metrics.
     async fn processed_bytes_total(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = ProcessedBytesTotal> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "processed_bytes_total" => Some(ProcessedBytesTotal::new(m)),
@@ -340,7 +340,7 @@ impl MetricsSubscription {
     /// Byte processing throughput sampled over a provided millisecond `interval`.
     async fn processed_bytes_throughput(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "processed_bytes_total")
             .map(|(_, throughput)| throughput as i64)
@@ -349,7 +349,7 @@ impl MetricsSubscription {
     /// Component byte processing metrics over `interval`.
     async fn component_processed_bytes_totals(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentProcessedBytesTotal>> {
         component_counter_metrics(interval, &|m| m.name() == "processed_bytes_total").map(|m| {
             m.into_iter()
@@ -361,7 +361,7 @@ impl MetricsSubscription {
     /// Component byte processing throughput over `interval`
     async fn component_processed_bytes_throughputs(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentProcessedBytesThroughput>> {
         component_counter_throughputs(interval, &|m| m.name() == "processed_bytes_total").map(|m| {
             m.into_iter()
@@ -378,7 +378,7 @@ impl MetricsSubscription {
     /// Total error metrics.
     async fn errors_total(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = ErrorsTotal> {
         get_metrics(interval)
             .filter(|m| m.name().ends_with("_errors_total"))
@@ -388,7 +388,7 @@ impl MetricsSubscription {
     /// Component error metrics over `interval`.
     async fn component_errors_totals(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = Vec<ComponentErrorsTotal>> {
         component_counter_metrics(interval, &|m| m.name().ends_with("_errors_total"))
             .map(|m| m.into_iter().map(ComponentErrorsTotal::new).collect())
@@ -397,7 +397,7 @@ impl MetricsSubscription {
     /// All metrics.
     async fn metrics(
         &self,
-        #[graphql(default = 1000, validator(IntRange(min = "10", max = "60_000")))] interval: i32,
+        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
     ) -> impl Stream<Item = MetricType> {
         get_metrics(interval).filter_map(|m| match m.name() {
             "uptime_seconds" => Some(MetricType::Uptime(m.into())),

--- a/src/api/schema/relay.rs
+++ b/src/api/schema/relay.rs
@@ -2,6 +2,7 @@ use async_graphql::{
     connection::{self, Connection, CursorType, Edge, EmptyFields},
     Result, SimpleObject,
 };
+use std::convert::Infallible;
 
 /// Base64 invalid states, used by `Base64Cursor`.
 pub enum Base64CursorError {
@@ -123,7 +124,7 @@ pub async fn query<T, I: ExactSizeIterator<Item = T>>(
     p: Params,
     default_page_size: usize,
 ) -> ConnectionResult<T> {
-    connection::query::<Base64Cursor, T, ConnectionFields, _, _, _>(
+    connection::query::<Base64Cursor, T, ConnectionFields, _, _, _, Infallible>(
         p.after,
         p.before,
         p.first,

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,13 +1,13 @@
 use super::{handler, schema, ShutdownTx};
 use crate::{config, topology};
 use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
+    http::{playground_source, GraphQLPlaygroundConfig, WebSocketProtocols},
     Data, Request, Schema,
 };
-use async_graphql_warp::{graphql_subscription_with_data, Response as GQLResponse};
+use async_graphql_warp::{graphql_protocol, GraphQLResponse, GraphQLWebSocket};
 use std::{convert::Infallible, net::SocketAddr};
 use tokio::sync::oneshot;
-use warp::{filters::BoxedFilter, http::Response, Filter, Reply};
+use warp::{filters::BoxedFilter, http::Response, ws::Ws, Filter, Reply};
 
 pub struct Server {
     _shutdown: ShutdownTx,
@@ -51,9 +51,6 @@ impl Server {
 }
 
 fn make_routes(playground: bool, watch_tx: topology::WatchRx) -> BoxedFilter<(impl Reply,)> {
-    // Build the GraphQL schema.
-    let schema = schema::build_schema().finish();
-
     // Routes...
 
     // Health.
@@ -62,21 +59,48 @@ fn make_routes(playground: bool, watch_tx: topology::WatchRx) -> BoxedFilter<(im
     // 404.
     let not_found = warp::any().and_then(|| async { Err(warp::reject::not_found()) });
 
-    // GraphQL query and subscription handler.
-    let graphql_handler = warp::path("graphql").and(
-        graphql_subscription_with_data(schema.clone(), move |_| async {
-            let mut data = Data::default();
-            data.insert(watch_tx);
-            Ok(data)
-        })
-        .or(async_graphql_warp::graphql(schema).and_then(
-            |(schema, request): (Schema<_, _, _>, Request)| async move {
-                Ok::<_, Infallible>(GQLResponse::from(schema.execute(request).await))
-            },
-        )),
-    );
+    // GraphQL subscription handler. Creates a Warp WebSocket handler and for each connection,
+    // parses the required headers for GraphQL and builds per-connection context based on the
+    // provided `WatchTx` channel sender. This allows GraphQL resolvers to subscribe to
+    // topology changes.
+    let graphql_subscription_handler =
+        warp::ws()
+            .and(graphql_protocol())
+            .map(move |ws: Ws, protocol: WebSocketProtocols| {
+                let schema = schema::build_schema().finish();
+                let watch_tx = watch_tx.clone();
 
-    // GraphQL playground
+                let reply = ws.on_upgrade(move |socket| {
+                    let mut data = Data::default();
+                    data.insert(watch_tx);
+
+                    GraphQLWebSocket::new(socket, schema, protocol.clone())
+                        .with_data(data)
+                        .serve()
+                });
+
+                warp::reply::with_header(
+                    reply,
+                    "Sec-WebSocket-Protocol",
+                    protocol.sec_websocket_protocol(),
+                )
+            });
+
+    // Handle GraphQL queries. Headers will first be parsed to determine whether the query is
+    // a subscription and if so, an attempt will be made to upgrade the connection to WebSockets.
+    // All other queries will fall back to the default HTTP handler.
+    let graphql_handler =
+        warp::path("graphql")
+            .and(graphql_subscription_handler)
+            .or(
+                async_graphql_warp::graphql(schema::build_schema().finish()).and_then(
+                    |(schema, request): (Schema<_, _, _>, Request)| async move {
+                        Ok::<_, Infallible>(GraphQLResponse::from(schema.execute(request).await))
+                    },
+                ),
+            );
+
+    // Provide a playground for executing GraphQL queries/mutations/subscriptions.
     let graphql_playground = if playground {
         warp::path("playground")
             .map(move || {
@@ -91,6 +115,8 @@ fn make_routes(playground: bool, watch_tx: topology::WatchRx) -> BoxedFilter<(im
         not_found.boxed()
     };
 
+    // Wire up the health + GraphQL endpoints. Provides a permissive CORS policy to allow for
+    // cross-origin interaction with the Vector API.
     health
         .or(graphql_handler)
         .or(graphql_playground)

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -74,7 +74,7 @@ fn make_routes(playground: bool, watch_tx: topology::WatchRx) -> BoxedFilter<(im
                     let mut data = Data::default();
                     data.insert(watch_tx);
 
-                    GraphQLWebSocket::new(socket, schema, protocol.clone())
+                    GraphQLWebSocket::new(socket, schema, protocol)
                         .with_data(data)
                         .serve()
                 });


### PR DESCRIPTION
Bumps `async-graphql` to 3.0.15.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
