### PR TITLE
chore(dev): Avoid unnecessary cargo check/clippy rebuilds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,4 @@
-[target.'cfg(feature = "cargo-clippy")']
+[target.'cfg(all)']
 rustflags = [
   "-Dclippy::print_stdout",
   "-Dclippy::print_stderr",


### PR DESCRIPTION
The changes introduced in 7f8e41c0 (chore(dev): Have clippy catch debug
statements (#10125)) caused cargo to use different `rustflags` between
runs of `cargo clippy` and all other builds. This ended up causing
running `cargo clippy` to clear cached data for the other builds and
vice versa, resulting in some check cycles taking longer than necessary.
Since these flags are just defines, they can be turned on for all
targets, eliminating the problem.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
