### PR TITLE
chore(ci): Reduce CI cargo jobs to nproc / 2

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -80,6 +80,8 @@ fi
 # by our own Ubuntu 20.04 images, so this is really just make sure the path is configured.
 if [ -n "${CI-}" ] ; then
     echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+    # we often run into OOM issues in CI due to the low memory vs. CPU ratio on c5 instances
+    echo "CARGO_BUILD_JOBS=$(($(nproc) /2))" >> "${GITHUB_ENV}"
 else
     echo "export PATH=\"$HOME/.cargo/bin:\$PATH\"" >> "${HOME}/.bash_profile"
 fi


### PR DESCRIPTION
This mirrors the change made for Windows: https://github.com/vectordotdev/vector/pull/10250

We've been seeing a number of failed benchmark runs recently which seem
to be related to rustc being OOM-killed. This is an experiment to see if
it reduces or eliminates these. A more long term idea might be to split up the
benchmark compilation and running steps. During compilation we typically
need more memory. During running we want compute optimized to match
what users will typically be running under.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
