### PR TITLE
fix(ci): Pin prometheus to 2.31.0

### DIFF
--- a/scripts/setup_integration/prometheus_integration_env.sh
+++ b/scripts/setup_integration/prometheus_integration_env.sh
@@ -21,7 +21,7 @@ ACTION=$1
 start () {
   "${CONTAINER_TOOL}" run -d --name vector_prometheus --net=host \
 	 --volume "$(pwd)"/tests/data:/etc/vector:ro \
-	 prom/prometheus --config.file=/etc/vector/prometheus.yaml
+	 prom/prometheus:v2.31.0 --config.file=/etc/vector/prometheus.yaml
 }
 
 stop () {


### PR DESCRIPTION
2.32.0 seems to have introduced an incompatible change as Vector no
longer recieves events via `prometheus_remote_write`.

I'll open a separate issue to investigate this.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
