### PR TITLE
enhancement(performance): Revert jemalloc (#10443)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,12 +2438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
 name = "fsevent"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,27 +3441,6 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "jobserver"
@@ -8327,7 +8300,6 @@ dependencies = [
  "infer 0.5.0",
  "inventory 0.1.11",
  "itertools",
- "jemallocator",
  "k8s-openapi",
  "lazy_static",
  "libc",
@@ -8700,7 +8672,6 @@ dependencies = [
  "chrono-tz",
  "enrichment",
  "glob",
- "jemallocator",
  "prettydiff",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,6 @@ indexmap = { version = "~1.7.0", default-features = false, features = ["serde"] 
 indoc = { version = "1.0.3", default-features = false }
 inventory = { version = "0.1.10", default-features = false }
 k8s-openapi = { version = "0.13.1", default-features = true, features = ["api", "v1_16"], optional = true }
-jemallocator = { version = "0.3.2", default-features = false, optional = true }
 lazy_static = { version = "1.4.0", default-features = false }
 listenfd = { version = "0.3.5", default-features = false, optional = true }
 logfmt = { version = "0.0.2", default-features = false, optional = true }
@@ -385,7 +384,7 @@ rdkafka-plain = ["rdkafka"]
 rusoto = ["rusoto_core", "rusoto_credential", "rusoto_signature", "rusoto_sts"]
 sasl = ["rdkafka/gssapi"]
 # Enables features that work only on systems providing `cfg(unix)`
-unix = ["jemallocator"]
+unix = []
 # These are **very** useful on Cross compilations!
 vendor-all = ["vendor-libz", "vendor-openssl", "vendor-sasl"]
 vendor-sasl = ["rdkafka/gssapi-vendored"]

--- a/lib/vrl/tests/Cargo.toml
+++ b/lib/vrl/tests/Cargo.toml
@@ -17,7 +17,6 @@ chrono = "0.4"
 chrono-tz = "0.6"
 glob = "0.3"
 prettydiff = "0.5"
-jemallocator = { version = "0.3.0" }
 regex = "1"
 serde = "1"
 serde_json = "1"

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -14,9 +14,6 @@ use vrl::{diagnostic::Formatter, state, Runtime, Terminate, Value};
 
 use vrl_tests::{docs, Test};
 
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 #[derive(Debug, StructOpt)]
 #[structopt(name = "VRL Tests", about = "Vector Remap Language Tests")]
 pub struct Cmd {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,6 @@ extern crate vector_core;
 #[cfg(feature = "vrl-cli")]
 extern crate vrl_cli;
 
-#[cfg(feature = "jemallocator")]
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 #[macro_use]
 pub mod config;
 pub mod cli;


### PR DESCRIPTION
This is breaking Windows tests because the allocator seemingly isn't being
correctly feature flagged for some reason. I will merge it again as https://github.com/vectordotdev/vector/pull/10459

I missed the Windows failure in the PR because I thought it was the transient benchmark failure that was blocking merge.

This reverts commit 5fe1767d3a0b847cfacc855b44164b03574d51a8.
