### PR TITLE
fix(buffers): update buffer metrics correctly + disk_v2 warning

### DIFF
--- a/lib/vector-core/buffers/benches/sized_records.rs
+++ b/lib/vector-core/buffers/benches/sized_records.rs
@@ -67,28 +67,28 @@ impl Drop for PathGuard {
     }
 }
 
-fn create_disk_v1_variant(_max_events: usize, max_size: usize) -> BufferType {
+fn create_disk_v1_variant(_max_events: usize, max_size: u64) -> BufferType {
     BufferType::DiskV1 {
         max_size,
         when_full: WhenFull::DropNewest,
     }
 }
 
-fn create_disk_v2_variant(_max_events: usize, max_size: usize) -> BufferType {
+fn create_disk_v2_variant(_max_events: usize, max_size: u64) -> BufferType {
     BufferType::DiskV2 {
         max_size,
         when_full: WhenFull::DropNewest,
     }
 }
 
-fn create_in_memory_v1_variant(max_events: usize, _max_size: usize) -> BufferType {
+fn create_in_memory_v1_variant(max_events: usize, _max_size: u64) -> BufferType {
     BufferType::MemoryV1 {
         max_events,
         when_full: WhenFull::DropNewest,
     }
 }
 
-fn create_in_memory_v2_variant(max_events: usize, _max_size: usize) -> BufferType {
+fn create_in_memory_v2_variant(max_events: usize, _max_size: u64) -> BufferType {
     BufferType::MemoryV2 {
         max_events,
         when_full: WhenFull::DropNewest,
@@ -101,7 +101,7 @@ macro_rules! experiment {
         group.sampling_mode(SamplingMode::Auto);
         init_instrumentation();
 
-        let max_events = 1_000;
+        let max_events: usize = 1_000;
         let mut data_dir = DataDir::new($id_slug);
         let rt = Runtime::new().unwrap();
 
@@ -110,7 +110,7 @@ macro_rules! experiment {
             // drops due to reuse of disk buffer's internals between
             // runs. Tempdir has low entropy compared to the number of
             // iterations we make in these benchmarks.
-            let max_size = 1_000_000 * max_events * mem::size_of::<crate::common::Message<$width>>();
+            let max_size = 1_000_000 * max_events as u64 * mem::size_of::<crate::common::Message<$width>>() as u64;
             let bytes = mem::size_of::<crate::common::Message<$width>>();
             group.throughput(Throughput::Elements(max_events as u64));
             group.bench_with_input(

--- a/lib/vector-core/buffers/src/buffer_usage_data.rs
+++ b/lib/vector-core/buffers/src/buffer_usage_data.rs
@@ -28,7 +28,7 @@ impl BufferUsageHandle {
     ///
     /// Limits are exposed as gauges to provide stable values when superimposed on dashboards/graphs
     /// with the "actual" usage amounts.
-    pub fn set_buffer_limits(&self, max_bytes: Option<usize>, max_events: Option<usize>) {
+    pub fn set_buffer_limits(&self, max_bytes: Option<u64>, max_events: Option<usize>) {
         if let Some(max_bytes) = max_bytes {
             self.state
                 .max_size_bytes
@@ -45,7 +45,7 @@ impl BufferUsageHandle {
     /// Increments the number of events (and their total size) received by this buffer component.
     ///
     /// This represents the events being sent into the buffer.
-    pub fn increment_received_event_count_and_byte_size(&self, count: u64, byte_size: usize) {
+    pub fn increment_received_event_count_and_byte_size(&self, count: u64, byte_size: u64) {
         self.state
             .received_event_count
             .fetch_add(count, Ordering::Relaxed);
@@ -57,7 +57,7 @@ impl BufferUsageHandle {
     /// Increments the number of events (and their total size) sent by this buffer component.
     ///
     /// This represents the events being read out of the buffer.
-    pub fn increment_sent_event_count_and_byte_size(&self, count: u64, byte_size: usize) {
+    pub fn increment_sent_event_count_and_byte_size(&self, count: u64, byte_size: u64) {
         self.state
             .sent_event_count
             .fetch_add(count, Ordering::Relaxed);
@@ -80,11 +80,11 @@ impl BufferUsageHandle {
 pub struct BufferUsageData {
     idx: usize,
     received_event_count: AtomicU64,
-    received_byte_size: AtomicUsize,
+    received_byte_size: AtomicU64,
     sent_event_count: AtomicU64,
-    sent_byte_size: AtomicUsize,
+    sent_byte_size: AtomicU64,
     dropped_event_count: Option<AtomicU64>,
-    max_size_bytes: AtomicUsize,
+    max_size_bytes: AtomicU64,
     max_size_events: AtomicUsize,
 }
 
@@ -98,11 +98,11 @@ impl BufferUsageData {
         Self {
             idx,
             received_event_count: AtomicU64::new(0),
-            received_byte_size: AtomicUsize::new(0),
+            received_byte_size: AtomicU64::new(0),
             sent_event_count: AtomicU64::new(0),
-            sent_byte_size: AtomicUsize::new(0),
+            sent_byte_size: AtomicU64::new(0),
             dropped_event_count,
-            max_size_bytes: AtomicUsize::new(0),
+            max_size_bytes: AtomicU64::new(0),
             max_size_events: AtomicUsize::new(0),
         }
     }

--- a/lib/vector-core/buffers/src/config.rs
+++ b/lib/vector-core/buffers/src/config.rs
@@ -290,7 +290,7 @@ impl BufferType {
                 when_full,
                 max_size,
             } => {
-                warn!("!!!! the disk_v2 buffer type is not yet stable, and data loss may be encountered !!!!");
+                warn!("!!!! The `disk_v2` buffer type is not yet stable.  Data loss may be encountered. !!!!");
                 let data_dir = data_dir.ok_or(BufferBuildError::RequiresDataDir)?;
                 builder.stage(DiskV2Buffer::new(id, data_dir, max_size), when_full);
             }

--- a/lib/vector-core/buffers/src/config.rs
+++ b/lib/vector-core/buffers/src/config.rs
@@ -290,6 +290,7 @@ impl BufferType {
                 when_full,
                 max_size,
             } => {
+                warn!("!!!! the disk_v2 buffer type is not yet stable, and data loss may be encountered !!!!");
                 let data_dir = data_dir.ok_or(BufferBuildError::RequiresDataDir)?;
                 builder.stage(DiskV2Buffer::new(id, data_dir, max_size), when_full);
             }

--- a/lib/vector-core/buffers/src/config.rs
+++ b/lib/vector-core/buffers/src/config.rs
@@ -42,7 +42,7 @@ impl BufferTypeVisitor {
     {
         let mut kind: Option<BufferTypeKind> = None;
         let mut max_events: Option<usize> = None;
-        let mut max_size: Option<usize> = None;
+        let mut max_size: Option<u64> = None;
         let mut when_full: Option<WhenFull> = None;
         while let Some(key) = map.next_key::<String>()? {
             match key.as_str() {
@@ -237,14 +237,14 @@ pub enum BufferType {
     /// A buffer stage backed by an on-disk database, powered by LevelDB.
     #[serde(rename = "disk")]
     DiskV1 {
-        max_size: usize,
+        max_size: u64,
         #[serde(default)]
         when_full: WhenFull,
     },
     /// A buffer stage backed by disk.
     #[serde(rename = "disk_v2")]
     DiskV2 {
-        max_size: usize,
+        max_size: u64,
         #[serde(default)]
         when_full: WhenFull,
     },

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/mod.rs
@@ -18,6 +18,7 @@ use leveldb::database::{
 };
 pub use reader::Reader;
 use snafu::ResultExt;
+use std::sync::atomic::AtomicU64;
 use std::{
     collections::VecDeque,
     marker::PhantomData,
@@ -28,7 +29,7 @@ use std::{
 pub use writer::Writer;
 
 /// How much of disk buffer needs to be deleted before we trigger compaction.
-const MAX_UNCOMPACTED_DENOMINATOR: usize = 10;
+const MAX_UNCOMPACTED_DENOMINATOR: u64 = 10;
 
 #[derive(Default)]
 pub struct Buffer<T> {
@@ -51,7 +52,7 @@ pub struct Buffer<T> {
 /// This function does not solve the problem -- leveldb will still map 1000
 /// files if it wants -- but we at least avoid forcing this to happen at the
 /// start of vector.
-fn db_initial_size(path: &Path) -> Result<(usize, u64), DataDirError> {
+fn db_initial_size(path: &Path) -> Result<(u64, u64), DataDirError> {
     let mut options = Options::new();
     options.create_if_missing = true;
     let db: Database<Key> = Database::open(path, options).with_context(|| Open {
@@ -61,7 +62,7 @@ fn db_initial_size(path: &Path) -> Result<(usize, u64), DataDirError> {
     let mut byte_size = 0;
     for v in db.value_iter(ReadOptions::new()) {
         item_size += 1;
-        byte_size += v.len();
+        byte_size += v.len() as u64;
     }
     Ok((byte_size, item_size))
 }
@@ -79,7 +80,7 @@ where
     #[allow(clippy::cast_precision_loss)]
     pub fn build(
         path: &Path,
-        max_size: usize,
+        max_size: u64,
         usage_handle: BufferUsageHandle,
     ) -> Result<(Writer<T>, Reader<T>, Acker), DataDirError> {
         // New `max_size` of the buffer is used for storing the unacked events.
@@ -108,7 +109,7 @@ where
             tail = if iter.valid() { iter.key().0 + 1 } else { 0 };
         }
 
-        let current_size = Arc::new(AtomicUsize::new(initial_byte_size));
+        let current_size = Arc::new(AtomicU64::new(initial_byte_size));
 
         let write_notifier = Arc::new(AtomicWaker::new());
 

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/reader.rs
@@ -9,7 +9,6 @@ use leveldb::database::{
     options::{ReadOptions, WriteOptions},
     Database,
 };
-use std::collections::VecDeque;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -19,13 +18,14 @@ use std::sync::{
 };
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
+use std::{collections::VecDeque, sync::atomic::AtomicU64};
 use tokio::task::JoinHandle;
 
 /// How much time needs to pass between compaction to trigger new one.
 const MIN_TIME_UNCOMPACTED: Duration = Duration::from_secs(60);
 
 /// Minimal size of uncompacted for which a compaction can be triggered.
-const MIN_UNCOMPACTED_SIZE: usize = 4 * 1024 * 1024;
+const MIN_UNCOMPACTED_SIZE: u64 = 4 * 1024 * 1024;
 
 /// The reader side of N to 1 channel through leveldb.
 ///
@@ -60,18 +60,18 @@ pub struct Reader<T> {
     pub(crate) blocked_write_tasks: Arc<Mutex<Vec<Waker>>>,
     /// Size of unread events in bytes.
     /// Shared with Writers.
-    pub(crate) current_size: Arc<AtomicUsize>,
+    pub(crate) current_size: Arc<AtomicU64>,
     /// Number of oldest read, not deleted, events that have been acked by the consumer.
     /// Shared with consumer.
     pub(crate) ack_counter: Arc<AtomicUsize>,
     /// Size of deleted, not compacted, events in bytes.
-    pub(crate) uncompacted_size: usize,
+    pub(crate) uncompacted_size: u64,
     /// Sizes in bytes of read, not acked/deleted, events.
-    pub(crate) unacked_sizes: VecDeque<usize>,
+    pub(crate) unacked_sizes: VecDeque<u64>,
     /// Buffer for internal use.
     pub(crate) buffer: VecDeque<(Key, Vec<u8>)>,
     /// Limit on uncompacted_size after which we trigger compaction.
-    pub(crate) max_uncompacted_size: usize,
+    pub(crate) max_uncompacted_size: u64,
     /// Last time that compaction was triggered.
     pub(crate) last_compaction: Instant,
     // Pending read from the LevelDB datasbase
@@ -149,7 +149,7 @@ where
         }
 
         if let Some((key, value)) = this.buffer.pop_front() {
-            let bytes_read = value.len();
+            let bytes_read = value.len() as u64;
             this.unacked_sizes.push_back(bytes_read);
             this.read_offset = key.0 + 1;
 
@@ -184,7 +184,7 @@ impl<T> Drop for Reader<T> {
 
 impl<T> Reader<T> {
     /// Returns number of bytes to be read.
-    fn delete_acked(&mut self) -> usize {
+    fn delete_acked(&mut self) -> u64 {
         let num_to_delete = self.ack_counter.swap(0, Ordering::Relaxed);
 
         let unread_size = if num_to_delete > 0 {
@@ -207,7 +207,7 @@ impl<T> Reader<T> {
         unread_size
     }
 
-    fn flush(&mut self, unread_size: usize) {
+    fn flush(&mut self, unread_size: u64) {
         if self.acked > 0 {
             let new_offset = self.delete_offset + self.acked;
             assert!(

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/writer.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/writer.rs
@@ -158,7 +158,7 @@ where
         }
 
         self.usage_handle
-            .increment_sent_event_count_and_byte_size(1, event_size);
+            .increment_received_event_count_and_byte_size(1, event_size);
 
         None
     }

--- a/lib/vector-core/buffers/src/disk/leveldb_buffer/writer.rs
+++ b/lib/vector-core/buffers/src/disk/leveldb_buffer/writer.rs
@@ -7,12 +7,12 @@ use leveldb::database::{
     options::WriteOptions,
     Database,
 };
-use std::pin::Pin;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,
 };
 use std::task::{Context, Poll, Waker};
+use std::{pin::Pin, sync::atomic::AtomicU64};
 
 /// The writer side of N to 1 channel through leveldb.
 pub struct Writer<T>
@@ -36,10 +36,10 @@ where
     /// Events in batch.
     pub(crate) batch_size: usize,
     /// Max size of unread events in bytes.
-    pub(crate) max_size: usize,
+    pub(crate) max_size: u64,
     /// Size of unread events in bytes.
     /// Shared with Reader.
-    pub(crate) current_size: Arc<AtomicUsize>,
+    pub(crate) current_size: Arc<AtomicU64>,
     /// Buffer for internal use.
     pub(crate) slot: Option<T>,
     /// Buffer usage data.
@@ -136,7 +136,7 @@ where
     fn try_send(&mut self, event: T) -> Option<T> {
         let mut buffer: BytesMut = BytesMut::with_capacity(64);
         T::encode(event, &mut buffer).unwrap();
-        let event_size = buffer.len();
+        let event_size = buffer.len() as u64;
 
         if self.current_size.fetch_add(event_size, Ordering::Relaxed) + (event_size / 2)
             > self.max_size
@@ -196,7 +196,7 @@ where
             //
             // We can't be picky at the moment so we will allow
             // for the buffer to exceed configured limit.
-            self.max_size = usize::MAX;
+            self.max_size = u64::MAX;
             assert!(self.try_send(event).is_none());
         }
 

--- a/lib/vector-core/buffers/src/disk/mod.rs
+++ b/lib/vector-core/buffers/src/disk/mod.rs
@@ -38,7 +38,7 @@ pub enum DataDirError {
 pub fn open<T>(
     data_dir: &Path,
     name: &str,
-    max_size: usize,
+    max_size: u64,
     usage_handle: BufferUsageHandle,
 ) -> Result<(Writer<T>, Reader<T>, super::Acker), DataDirError>
 where

--- a/lib/vector-core/buffers/src/disk_v2/ledger.rs
+++ b/lib/vector-core/buffers/src/disk_v2/ledger.rs
@@ -367,11 +367,6 @@ impl Ledger {
     /// Tracks the statistics of a successful write.
     pub fn track_write(&self, record_size: u64) {
         self.state().increment_records(record_size);
-
-        // A 4GB record should not be possible to write, at all.
-        let record_size = record_size
-            .try_into()
-            .expect("record size didn't fit into usize; is this a 32-bit platform?");
         self.usage_handle
             .increment_received_event_count_and_byte_size(1, record_size);
     }
@@ -380,11 +375,6 @@ impl Ledger {
     pub fn track_reads(&self, record_len: u64, total_record_size: u64) {
         self.state()
             .decrement_records(record_len, total_record_size);
-
-        // If we're acknowledgeing 4GB of records at a time, then uh... something weird is going on.
-        let total_record_size = total_record_size
-            .try_into()
-            .expect("total record size didn't fit into usize; is this a 32-bit platform?");
         self.usage_handle
             .increment_sent_event_count_and_byte_size(record_len, total_record_size);
     }
@@ -496,11 +486,7 @@ impl Ledger {
 
     fn synchronize_buffer_usage(&self) {
         let initial_buffer_events = self.state().get_total_records();
-        let initial_buffer_size = self
-            .state()
-            .get_total_buffer_size()
-            .try_into()
-            .expect("buffer size greater than usize; is this a 32-bit platform?");
+        let initial_buffer_size = self.state().get_total_buffer_size();
         self.usage_handle
             .increment_received_event_count_and_byte_size(
                 initial_buffer_events,

--- a/lib/vector-core/buffers/src/disk_v2/reader.rs
+++ b/lib/vector-core/buffers/src/disk_v2/reader.rs
@@ -153,8 +153,10 @@ where
                 // so would fail if `usize` was larger than `u64`, meaning we at least will panic if
                 // Vector is running on a 128-bit CPU in the future, storing records that are larger
                 // than 2^64+1. :)
-                #[allow(clippy::cast_possible_truncation)]
-                return Ok(Some(u64::from_be_bytes(length) as usize));
+                let record_len = u64::from_be_bytes(length)
+                    .try_into()
+                    .expect("record length should never exceed usize");
+                return Ok(Some(record_len));
             }
 
             let buf = self.reader.fill_buf().await.context(Io)?;

--- a/lib/vector-core/buffers/src/disk_v2/reader.rs
+++ b/lib/vector-core/buffers/src/disk_v2/reader.rs
@@ -144,11 +144,15 @@ where
                     .expect("the slice is the length of a u64");
                 self.reader.consume(8);
 
-                // We don't actually allow records to be greater than 8MB, which fit will within a
-                // 32-bit value, and so there's no risk of having a u64 length delimiter exceed.
-                // This is also practically irrelevant because the lion's share of Vector usage is
-                // on 64-bit platforms, but we're stuck doing the usize/u64 conversion dance in many
-                // places.
+                // By default, records cannot exceed 8MB in length, so whether our `usize` is a u32
+                // or u64, we're not going to overflow it.  While the maximum record size _can_ be
+                // changed, it's not currently exposed to users.  Even further, if it was exposed to
+                // users, it's currently a `usize`, so again, we know that we're not going to exceed
+                // 64-bit. And even further still, the writer fallibly attempts to get a `u64` of the
+                // record size based on the encoding buffer, which gives its length in `usize`, and
+                // so would fail if `usize` was larger than `u64`, meaning we at least will panic if
+                // Vector is running on a 128-bit CPU in the future, storing records that are larger
+                // than 2^64+1. :)
                 #[allow(clippy::cast_possible_truncation)]
                 return Ok(Some(u64::from_be_bytes(length) as usize));
             }

--- a/lib/vector-core/buffers/src/disk_v2/tests/acknowledgements.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/acknowledgements.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use tokio_test::{assert_pending, assert_ready, task::spawn};
 
-use crate::disk_v2::{acknowledgements::create_disk_v2_acker, ledger::Ledger, DiskBufferConfig};
+use crate::{
+    buffer_usage_data::BufferUsageHandle,
+    disk_v2::{acknowledgements::create_disk_v2_acker, ledger::Ledger, DiskBufferConfig},
+};
 
 use super::with_temp_dir;
 
@@ -13,8 +16,9 @@ async fn ack_updates_ledger_correctly() {
 
         async move {
             // Create a standalone ledger.
+            let usage_handle = BufferUsageHandle::noop();
             let config = DiskBufferConfig::from_path(data_dir).build();
-            let ledger = Ledger::load_or_create(config)
+            let ledger = Ledger::load_or_create(config, usage_handle)
                 .await
                 .expect("ledger should not fail to load/create");
             assert_eq!(ledger.consume_pending_acks(), 0);
@@ -40,8 +44,9 @@ async fn ack_wakes_reader() {
 
         async move {
             // Create a standalone ledger.
+            let usage_handle = BufferUsageHandle::noop();
             let config = DiskBufferConfig::from_path(data_dir).build();
-            let ledger = Ledger::load_or_create(config)
+            let ledger = Ledger::load_or_create(config, usage_handle)
                 .await
                 .expect("ledger should not fail to load/create");
 

--- a/lib/vector-core/buffers/src/disk_v2/tests/mod.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/mod.rs
@@ -12,6 +12,7 @@ use tracing_fluent_assertions::{AssertionRegistry, AssertionsLayer};
 use tracing_subscriber::{filter::LevelFilter, Layer};
 use tracing_subscriber::{layer::SubscriberExt, Registry};
 
+use crate::buffer_usage_data::BufferUsageHandle;
 use crate::disk_v2::{Buffer, DiskBufferConfig, Reader, Writer};
 use crate::encoding::{DecodeBytes, EncodeBytes};
 use crate::{Acker, Bufferable};
@@ -164,7 +165,9 @@ where
     P: AsRef<Path>,
     R: Bufferable,
 {
-    Buffer::from_config_inner(DiskBufferConfig::from_path(data_dir).build())
+    let config = DiskBufferConfig::from_path(data_dir).build();
+    let usage_handle = BufferUsageHandle::noop();
+    Buffer::from_config_inner(config, usage_handle)
         .await
         .expect("should not fail to create buffer")
 }
@@ -181,8 +184,9 @@ where
     // ensures it is a minimum size related to the data file size limit, etc.
     let mut config = DiskBufferConfig::from_path(data_dir).build();
     config.max_buffer_size = max_buffer_size;
+    let usage_handle = BufferUsageHandle::noop();
 
-    Buffer::from_config_inner(config)
+    Buffer::from_config_inner(config, usage_handle)
         .await
         .expect("should not fail to create buffer")
 }
@@ -198,8 +202,9 @@ where
     let config = DiskBufferConfig::from_path(data_dir)
         .max_record_size(max_record_size)
         .build();
+    let usage_handle = BufferUsageHandle::noop();
 
-    Buffer::from_config_inner(config)
+    Buffer::from_config_inner(config, usage_handle)
         .await
         .expect("should not fail to create buffer")
 }
@@ -215,8 +220,9 @@ where
     let config = DiskBufferConfig::from_path(data_dir)
         .max_data_file_size(max_data_file_size)
         .build();
+    let usage_handle = BufferUsageHandle::noop();
 
-    Buffer::from_config_inner(config)
+    Buffer::from_config_inner(config, usage_handle)
         .await
         .expect("should not fail to create buffer")
 }

--- a/lib/vector-core/buffers/src/internal_events.rs
+++ b/lib/vector-core/buffers/src/internal_events.rs
@@ -4,14 +4,14 @@ use metrics::{counter, decrement_gauge, gauge, increment_gauge};
 pub struct BufferEventsReceived {
     pub idx: usize,
     pub count: u64,
-    pub byte_size: usize,
+    pub byte_size: u64,
 }
 
 impl InternalEvent for BufferEventsReceived {
     #[allow(clippy::cast_precision_loss)]
     fn emit_metrics(&self) {
         counter!("buffer_received_events_total", self.count, "stage" => self.idx.to_string());
-        counter!("buffer_received_bytes_total", self.byte_size as u64, "stage" => self.idx.to_string());
+        counter!("buffer_received_bytes_total", self.byte_size, "stage" => self.idx.to_string());
         increment_gauge!("buffer_events", self.count as f64, "stage" => self.idx.to_string());
         increment_gauge!("buffer_byte_size", self.byte_size as f64, "stage" => self.idx.to_string());
     }
@@ -20,14 +20,14 @@ impl InternalEvent for BufferEventsReceived {
 pub struct BufferEventsSent {
     pub idx: usize,
     pub count: u64,
-    pub byte_size: usize,
+    pub byte_size: u64,
 }
 
 impl InternalEvent for BufferEventsSent {
     #[allow(clippy::cast_precision_loss)]
     fn emit_metrics(&self) {
         counter!("buffer_sent_events_total", self.count, "stage" => self.idx.to_string());
-        counter!("buffer_sent_bytes_total", self.byte_size as u64, "stage" => self.idx.to_string());
+        counter!("buffer_sent_bytes_total", self.byte_size, "stage" => self.idx.to_string());
         decrement_gauge!("buffer_events", self.count as f64, "stage" => self.idx.to_string());
         decrement_gauge!("buffer_byte_size", self.byte_size as f64, "stage" => self.idx.to_string());
     }
@@ -57,7 +57,7 @@ impl InternalEvent for EventsCorrupted {
 pub struct BufferCreated {
     pub idx: usize,
     pub max_size_events: Option<usize>,
-    pub max_size_bytes: Option<usize>,
+    pub max_size_bytes: Option<u64>,
 }
 
 impl InternalEvent for BufferCreated {

--- a/lib/vector-core/buffers/src/test/common/variant.rs
+++ b/lib/vector-core/buffers/src/test/common/variant.rs
@@ -33,13 +33,13 @@ pub enum Variant {
         when_full: WhenFull,
     },
     DiskV1 {
-        max_size: usize,
+        max_size: u64,
         when_full: WhenFull,
         data_dir: PathBuf,
         id: String,
     },
     DiskV2 {
-        max_size: usize,
+        max_size: u64,
         when_full: WhenFull,
         data_dir: PathBuf,
         id: String,
@@ -125,8 +125,11 @@ impl Arbitrary for Variant {
         let idx = usize::arbitrary(g) % 4;
 
         // Using a u16 ensures we avoid any allocation errors for our holding buffers, etc.
-        let max_events = NonZeroU16::arbitrary(g).get() as usize;
-        let max_size = max_events;
+        let max_events = NonZeroU16::arbitrary(g)
+            .get()
+            .try_into()
+            .expect("we don't support 16-bit platforms");
+        let max_size = u64::from(NonZeroU16::arbitrary(g).get());
         let when_full = WhenFull::arbitrary(g);
 
         match idx {

--- a/lib/vector-core/buffers/src/test/model/on_disk_v1.rs
+++ b/lib/vector-core/buffers/src/test/model/on_disk_v1.rs
@@ -21,9 +21,9 @@ impl OnDiskV1 {
                 when_full,
                 ..
             } => OnDiskV1 {
-                inner: VecDeque::with_capacity(*max_size),
+                inner: VecDeque::with_capacity((*max_size).try_into().unwrap_or(usize::MAX)),
                 current_bytes: 0,
-                capacity: *max_size,
+                capacity: (*max_size).try_into().unwrap_or(usize::MAX),
                 when_full: *when_full,
             },
             _ => unreachable!(),

--- a/lib/vector-core/buffers/src/test/model/on_disk_v2.rs
+++ b/lib/vector-core/buffers/src/test/model/on_disk_v2.rs
@@ -21,9 +21,9 @@ impl OnDiskV2 {
                 when_full,
                 ..
             } => OnDiskV2 {
-                inner: VecDeque::with_capacity(*max_size),
+                inner: VecDeque::with_capacity((*max_size).try_into().unwrap_or(usize::MAX)),
                 current_bytes: 0,
-                capacity: *max_size,
+                capacity: (*max_size).try_into().unwrap_or(usize::MAX),
                 when_full: *when_full,
             },
             _ => unreachable!(),

--- a/lib/vector-core/buffers/src/topology/channel/receiver.rs
+++ b/lib/vector-core/buffers/src/topology/channel/receiver.rs
@@ -130,7 +130,7 @@ impl<T: Bufferable> Stream for BufferReceiver<T> {
             .map(|result| match result {
                 StrategyResult::Primary(i) => {
                     if let Some(handle) = this.instrumentation {
-                        handle.increment_sent_event_count_and_byte_size(1, i.size_of());
+                        handle.increment_sent_event_count_and_byte_size(1, i.size_of() as u64);
                     }
                     Some(i)
                 }

--- a/lib/vector-core/buffers/src/topology/channel/receiver.rs
+++ b/lib/vector-core/buffers/src/topology/channel/receiver.rs
@@ -130,7 +130,7 @@ impl<T: Bufferable> Stream for BufferReceiver<T> {
             .map(|result| match result {
                 StrategyResult::Primary(i) => {
                     if let Some(handle) = this.instrumentation {
-                        handle.increment_received_event_count_and_byte_size(1, i.size_of());
+                        handle.increment_sent_event_count_and_byte_size(1, i.size_of());
                     }
                     Some(i)
                 }

--- a/lib/vector-core/buffers/src/topology/channel/sender.rs
+++ b/lib/vector-core/buffers/src/topology/channel/sender.rs
@@ -324,8 +324,10 @@ impl<T: Bufferable> Sink<T> for BufferSender<T> {
         };
 
         if let Some(item_size) = item_size {
-            if let Some(handle) = this.instrumentation.as_ref() {
-                handle.increment_sent_event_count_and_byte_size(1, item_size);
+            // Only update our instrumentation if _we_ got the item, not the overflow.
+            let handle = this.instrumentation.as_ref().expect("item_size can't be present without instrumentation");
+            if *this.base_flush {
+                handle.increment_received_event_count_and_byte_size(1, item_size);
             }
         }
 

--- a/lib/vector-core/buffers/src/topology/channel/sender.rs
+++ b/lib/vector-core/buffers/src/topology/channel/sender.rs
@@ -325,9 +325,12 @@ impl<T: Bufferable> Sink<T> for BufferSender<T> {
 
         if let Some(item_size) = item_size {
             // Only update our instrumentation if _we_ got the item, not the overflow.
-            let handle = this.instrumentation.as_ref().expect("item_size can't be present without instrumentation");
+            let handle = this
+                .instrumentation
+                .as_ref()
+                .expect("item_size can't be present without instrumentation");
             if *this.base_flush {
-                handle.increment_received_event_count_and_byte_size(1, item_size);
+                handle.increment_received_event_count_and_byte_size(1, item_size as u64);
             }
         }
 

--- a/lib/vector-core/buffers/src/topology/test_util.rs
+++ b/lib/vector-core/buffers/src/topology/test_util.rs
@@ -67,7 +67,7 @@ pub async fn build_buffer(
             let usage_handle = BufferUsageHandle::noop();
             let channel = Box::new(MemoryV2Buffer::new(capacity));
             let (sender, receiver, _) = channel
-                .into_buffer_parts(&usage_handle)
+                .into_buffer_parts(usage_handle)
                 .await
                 .expect("should not fail to create memory buffer");
             let sender = BufferSender::new(sender, mode);
@@ -80,7 +80,7 @@ pub async fn build_buffer(
                 .expect("overflow_mode must be specified when base is in overflow mode");
             let overflow_channel = Box::new(MemoryV2Buffer::new(capacity));
             let (overflow_sender, overflow_receiver, _) = overflow_channel
-                .into_buffer_parts(&usage_handle)
+                .into_buffer_parts(usage_handle.clone())
                 .await
                 .expect("should not fail to create memory buffer");
             let overflow_sender = BufferSender::new(overflow_sender, overflow_mode);
@@ -88,7 +88,7 @@ pub async fn build_buffer(
 
             let base_channel = Box::new(MemoryV2Buffer::new(capacity));
             let (base_sender, base_receiver, _) = base_channel
-                .into_buffer_parts(&usage_handle)
+                .into_buffer_parts(usage_handle)
                 .await
                 .expect("should not fail to create memory buffer");
             let base_sender = BufferSender::with_overflow(base_sender, overflow_sender);

--- a/lib/vector-core/buffers/src/variant/disk_v1.rs
+++ b/lib/vector-core/buffers/src/variant/disk_v1.rs
@@ -10,11 +10,11 @@ use crate::{disk::open, topology::builder::IntoBuffer, Acker, Bufferable};
 pub struct DiskV1Buffer {
     id: String,
     data_dir: PathBuf,
-    max_size: usize,
+    max_size: u64,
 }
 
 impl DiskV1Buffer {
-    pub fn new(id: String, data_dir: PathBuf, max_size: usize) -> Self {
+    pub fn new(id: String, data_dir: PathBuf, max_size: u64) -> Self {
         DiskV1Buffer {
             id,
             data_dir,

--- a/lib/vector-core/buffers/src/variant/disk_v1.rs
+++ b/lib/vector-core/buffers/src/variant/disk_v1.rs
@@ -28,20 +28,19 @@ impl<T> IntoBuffer<T> for DiskV1Buffer
 where
     T: Bufferable + Clone,
 {
+    fn provides_instrumentation(&self) -> bool {
+        true
+    }
+
     async fn into_buffer_parts(
         self: Box<Self>,
-        usage_handle: &BufferUsageHandle,
+        usage_handle: BufferUsageHandle,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>, Option<Acker>), Box<dyn Error + Send + Sync>>
     {
         usage_handle.set_buffer_limits(Some(self.max_size), None);
 
         // Create the actual buffer subcomponents.
-        let (writer, reader, acker) = open(
-            &self.data_dir,
-            &self.id,
-            self.max_size,
-            usage_handle.clone(),
-        )?;
+        let (writer, reader, acker) = open(&self.data_dir, &self.id, self.max_size, usage_handle)?;
 
         Ok((
             SenderAdapter::opaque(writer),

--- a/lib/vector-core/buffers/src/variant/disk_v2.rs
+++ b/lib/vector-core/buffers/src/variant/disk_v2.rs
@@ -14,16 +14,14 @@ use crate::disk_v2::{Buffer, DiskBufferConfig, Reader, Writer};
 use crate::topology::channel::{ReceiverAdapter, SenderAdapter};
 use crate::{topology::builder::IntoBuffer, Acker, Bufferable};
 
-//const MAX_BUFFERED_ITEMS: usize = 128;
-
 pub struct DiskV2Buffer {
     id: String,
     data_dir: PathBuf,
-    max_size: usize,
+    max_size: u64,
 }
 
 impl DiskV2Buffer {
-    pub fn new(id: String, data_dir: PathBuf, max_size: usize) -> Self {
+    pub fn new(id: String, data_dir: PathBuf, max_size: u64) -> Self {
         Self {
             id,
             data_dir,

--- a/lib/vector-core/buffers/src/variant/disk_v2.rs
+++ b/lib/vector-core/buffers/src/variant/disk_v2.rs
@@ -37,9 +37,13 @@ impl<T> IntoBuffer<T> for DiskV2Buffer
 where
     T: Bufferable + Clone,
 {
+    fn provides_instrumentation(&self) -> bool {
+        true
+    }
+
     async fn into_buffer_parts(
         self: Box<Self>,
-        usage_handle: &BufferUsageHandle,
+        usage_handle: BufferUsageHandle,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>, Option<Acker>), Box<dyn Error + Send + Sync>>
     {
         usage_handle.set_buffer_limits(Some(self.max_size), None);
@@ -49,10 +53,9 @@ where
         let config = DiskBufferConfig::from_path(buffer_path)
             .max_buffer_size(self.max_size as u64)
             .build();
-        let (writer, reader, acker) = Buffer::from_config(config).await?;
+        let (writer, reader, acker) = Buffer::from_config(config, usage_handle).await?;
 
         let wrapped_reader = WrappedReader::new(reader);
-        //let wrapped_writer = WrappedWriter::new(writer);
 
         let (input_tx, input_rx) = channel(1024);
         tokio::spawn(drive_disk_v2_writer(writer, input_rx));
@@ -104,280 +107,6 @@ where
         }
     }
 }
-/*
-#[derive(Debug)]
-enum WriterState<T> {
-    Inconsistent,
-    Idle(Writer<T>),
-    Writing,
-    Flushing,
-}
-
-impl<T> WriterState<T> {
-    fn is_idle(&self) -> bool {
-        matches!(self, WriterState::Idle(..))
-    }
-}
-
-// TODO: it's even less likely that we need to truly kill the writer task for an error
-// unless it's a very specific type of error... we already distinguish failed
-// encoding/serialization which occurs before any actual bytes hit the file at all, or
-// before we update the ledger or any of that.
-//
-// so really we'd be down to like... certain I/O errors that we know we can't recover
-// from.
-//
-// where this could really get tricky is like, if we try to write a record here and the
-// permissions got messed up, so we couldn't write to the file, we could _theoretically_
-// loop and try it again until it works, or we could just drop the event and move on...
-// not sure which one is better.
-#[pin_project]
-struct WrappedWriter<T>
-where
-    T: Bufferable,
-{
-    state: WriterState<T>,
-    buffered: VecDeque<T>,
-    write_future: ReusableBoxFuture<(Writer<T>, Result<usize, WriterError<T>>)>,
-    flush_future: ReusableBoxFuture<(Writer<T>, Result<(), WriterError<T>>)>,
-}
-
-impl<T> WrappedWriter<T>
-where
-    T: Bufferable,
-{
-    pub fn new(writer: Writer<T>) -> Self {
-        Self {
-            state: WriterState::Idle(writer),
-            buffered: VecDeque::new(),
-            write_future: ReusableBoxFuture::new(make_write_future(None, None)),
-            flush_future: ReusableBoxFuture::new(make_flush_future(None)),
-        }
-    }
-
-    fn try_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), WriterError<T>>> {
-        loop {
-            if self.state.is_idle() {
-                return Poll::Ready(Ok(()));
-            }
-
-            if let Err(e) = ready!(self.drive_pending_operation(cx)) {
-                return Poll::Ready(Err(e));
-            }
-        }
-    }
-
-    fn drive_pending_operation(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), WriterError<T>>> {
-        let (writer, result) = match &self.state {
-            WriterState::Writing => ready!(self.drive_write_operation(cx)),
-            WriterState::Flushing => ready!(self.drive_flush_operation(cx)),
-            s => unreachable!("writer state not expected: {:?}", s),
-        };
-
-        self.state = WriterState::Idle(writer);
-        Poll::Ready(result)
-    }
-
-    fn drive_write_operation(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<(Writer<T>, Result<(), WriterError<T>>)> {
-        match &self.state {
-            WriterState::Writing => {
-                let (writer, result) = ready!(self.write_future.poll(cx));
-                // TODO: do we _need_ to reset the future here?
-                Poll::Ready((writer, result.map(|_| ())))
-            }
-            s => unreachable!("writer state not expected: {:?}", s),
-        }
-    }
-
-    fn drive_flush_operation(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<(Writer<T>, Result<(), WriterError<T>>)> {
-        match &self.state {
-            WriterState::Flushing => {
-                let (writer, result) = ready!(self.flush_future.poll(cx));
-                // TODO: do we _need_ to reset the future here?
-                Poll::Ready((writer, result.map(|_| ())))
-            }
-            s => unreachable!("writer state not expected: {:?}", s),
-        }
-    }
-
-    fn enqueue_write_operation(&mut self, record: T) {
-        match mem::replace(&mut self.state, WriterState::Inconsistent) {
-            WriterState::Idle(writer) => {
-                self.write_future
-                    .set(make_write_future(Some(writer), Some(record)));
-                self.state = WriterState::Writing;
-            }
-            s => unreachable!("writer state not expected: {:?}", s),
-        }
-    }
-
-    fn enqueue_flush_operation(&mut self) {
-        match mem::replace(&mut self.state, WriterState::Inconsistent) {
-            WriterState::Idle(writer) => {
-                self.flush_future.set(make_flush_future(Some(writer)));
-                self.state = WriterState::Flushing;
-            }
-            s => unreachable!("writer state not expected: {:?}", s),
-        }
-    }
-}
-
-impl<T> Sink<T> for WrappedWriter<T>
-where
-    T: Bufferable,
-{
-    type Error = ();
-
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Make sure any in-flight operation is completed first.
-        if let Err(e) = ready!(self.as_mut().get_mut().try_ready(cx)) {
-            error!("{}", e);
-            return Poll::Ready(Err(()));
-        }
-
-        // Now make sure our internal buffer isn't too large before accepting another item.
-        if self.buffered.len() < MAX_BUFFERED_ITEMS {
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Pending
-        }
-    }
-
-    fn start_send(mut self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-        // Make sure the caller isn't dodging `poll_ready`.
-        if self.buffered.len() >= MAX_BUFFERED_ITEMS {
-            error!(
-                "`start_send` called without getting a successful result from `poll_ready` first"
-            );
-            return Err(());
-        }
-
-        self.buffered.push_back(item);
-        Ok(())
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Logic:
-        //
-        // loop:
-        //   if !self.buffered.is_empty():
-        //     - drive in-flight operation until ready
-        //     - enqueue write operation
-        //   else:
-        //     - drive in-flight operation
-        //     -- if operation was flush, return when fully driven
-        //     - enqueue flush operation
-        //
-        // Any error at any point gets returned immediately.
-
-        loop {
-            if self.buffered.is_empty() {
-                // We're all out of items to send, so now we need to flush the writer.  We're still
-                // driving the last write operation, though, so we need to make sure that's cleared out.
-                if let WriterState::Writing = &self.state {
-                    if let Err(e) = ready!(self.drive_pending_operation(cx)) {
-                        error!("{}", e);
-                        return Poll::Ready(Err(()));
-                    }
-                }
-
-                // We've got any in-flight write operation out of the way, now it's time to flush.
-                if self.state.is_idle() {
-                    self.enqueue_flush_operation();
-                } else {
-                    let result = ready!(self.drive_pending_operation(cx));
-                    return Poll::Ready(result.map_err(|e| {
-                        error!("{}", e);
-                    }));
-                }
-            } else {
-                // Drive any in-flight operation that we have going on.
-                if !self.state.is_idle() {
-                    if let Err(e) = ready!(self.drive_pending_operation(cx)) {
-                        error!("{}", e);
-                        return Poll::Ready(Err(()));
-                    }
-                }
-
-                // Now we're idle, so enqueue another write operation.
-                let record = self
-                    .buffered
-                    .pop_front()
-                    .expect("buffered items should not be empty");
-                self.enqueue_write_operation(record);
-            }
-        }
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Try to drive any remaining items into the writer, as well as one final flush.
-        if let Err(e) = ready!(self.as_mut().poll_flush(cx)) {
-            return Poll::Ready(Err(e));
-        }
-
-        // Now we can actually close the writer for real.  We leave the state as Inconsistent here
-        // so that any future calls will panic and let us know there's some bad juju happening with
-        // the caller, trying to use a previously-closed writer.
-        match mem::replace(&mut self.state, WriterState::Inconsistent) {
-            WriterState::Idle(mut writer) => {
-                writer.close();
-                Poll::Ready(Ok(()))
-            }
-            s => unreachable!("writer state not expected: {:?}", s),
-        }
-    }
-}
-
-async fn make_write_future<T>(
-    writer: Option<Writer<T>>,
-    record: Option<T>,
-) -> (Writer<T>, Result<usize, WriterError<T>>)
-where
-    T: Bufferable,
-{
-    // TODO: it's even less likely that we need to truly kill the writer task for an error
-    // unless it's a very specific type of error... we already distinguish failed
-    // encoding/serialization which occurs before any actual bytes hit the file at all, or
-    // before we update the ledger or any of that.
-    //
-    // so really we'd be down to like... certain I/O errors that we know we can't recover
-    // from.
-    //
-    // where this could really get tricky is like, if we try to write a record here and the
-    // permissions got messed up, so we couldn't write to the file, we could _theoretically_
-    // loop and try it again until it works, or we could just drop the event and move on...
-    // not sure which one is better.
-    match (writer, record) {
-        (Some(mut writer), Some(record)) => {
-            let result = writer.write_record(record).await;
-            (writer, result)
-        }
-        _ => unreachable!("future should not be called in this state"),
-    }
-}
-
-async fn make_flush_future<T>(writer: Option<Writer<T>>) -> (Writer<T>, Result<(), WriterError<T>>)
-where
-    T: Bufferable,
-{
-    match writer {
-        Some(mut writer) => {
-            let result = writer.flush().await;
-            (writer, result.map_err(Into::into))
-        }
-        None => unreachable!("future should not be called in this state"),
-    }
-}
-*/
 
 async fn make_read_future<T>(reader: Option<Reader<T>>) -> (Reader<T>, Option<T>)
 where

--- a/lib/vector-core/buffers/src/variant/in_memory_v1.rs
+++ b/lib/vector-core/buffers/src/variant/in_memory_v1.rs
@@ -27,13 +27,9 @@ impl<T> IntoBuffer<T> for MemoryV1Buffer
 where
     T: Bufferable,
 {
-    fn provides_instrumentation(&self) -> bool {
-        false
-    }
-
     async fn into_buffer_parts(
         self: Box<Self>,
-        usage_handle: &BufferUsageHandle,
+        usage_handle: BufferUsageHandle,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>, Option<Acker>), Box<dyn Error + Send + Sync>>
     {
         usage_handle.set_buffer_limits(None, Some(self.capacity));

--- a/lib/vector-core/buffers/src/variant/in_memory_v2.rs
+++ b/lib/vector-core/buffers/src/variant/in_memory_v2.rs
@@ -27,13 +27,9 @@ impl<T> IntoBuffer<T> for MemoryV2Buffer
 where
     T: Bufferable,
 {
-    fn provides_instrumentation(&self) -> bool {
-        false
-    }
-
     async fn into_buffer_parts(
         self: Box<Self>,
-        usage_handle: &BufferUsageHandle,
+        usage_handle: BufferUsageHandle,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>, Option<Acker>), Box<dyn Error + Send + Sync>>
     {
         usage_handle.set_buffer_limits(None, Some(self.capacity));

--- a/src/app.rs
+++ b/src/app.rs
@@ -71,6 +71,7 @@ impl Application {
                     "runtime=trace".to_owned(),
                     "tokio=trace".to_owned(),
                     format!("rdkafka={}", level),
+                    format!("buffers={}", level),
                 ]
                 .join(","),
                 #[cfg(not(feature = "tokio-console"))]
@@ -81,6 +82,7 @@ impl Application {
                     format!("file_source={}", level),
                     "tower_limit=trace".to_owned(),
                     format!("rdkafka={}", level),
+                    format!("buffers={}", level),
                 ]
                 .join(","),
             });


### PR DESCRIPTION
This PR accomplishes two main things:
- fixes the usage of `BufferUsageHandle` for both `BufferSender`/`BufferReceiver` and in internally instrumented cases (i.e. the disk buffer v1 code)
- adds a warning message when using `disk_v2`

The warning message is mostly meant to discourage people from using `disk_v2` since it's not ready for prime time yet while still allowing it to be used during testing, soak testing, etc, without a bunch of feature flag changes that slow down the development cycle.

I hand-checked the output of `memory`, `memory_v2`, and `disk_v1`, in terms of metrics, going to Datadog, and all of them report both sent/received metrics and in the right order (i.e. received represents events into the buffer, and sent represents events out of the buffer).

Closes #10426.