### PR TITLE
chore(ci): Try out bump allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,6 +297,7 @@ zstd = { version = "0.6", default-features = false, optional = true }
 tonic = { version = "0.6", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls"] }
 data-encoding = { version = "2.2", default-features = false, features = ["std"], optional = true }
 trust-dns-proto = { version = "0.20", features = ["dnssec"], optional = true }
+bump-allocator = "0.1.2"
 
 [target.'cfg(windows)'.dependencies]
 schannel = "0.1.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,8 @@ extern crate vector_core;
 #[cfg(feature = "vrl-cli")]
 extern crate vrl_cli;
 
-#[cfg(feature = "tikv-jemallocator")]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static GLOBAL: bump_allocator::BumpPointer = bump_allocator::BumpPointer;
 
 #[macro_use]
 pub mod config;


### PR DESCRIPTION
Just to get a rough idea of possible performance improvements from
a smarter allocator. As Brian noted, this actually still calls out to
libc to do block allocation, but doesn't deallocate.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
