### PR TITLE
fix: actually batch TCP source decoder outputs

### DIFF
--- a/src/codecs/mod.rs
+++ b/src/codecs/mod.rs
@@ -7,6 +7,7 @@ pub mod decoding;
 pub mod encoding;
 mod format;
 mod framing;
+mod ready_frames;
 
 pub use decoding::Decoder;
 pub use format::{
@@ -19,3 +20,4 @@ pub use framing::{
     LengthDelimitedDecoder, LengthDelimitedDecoderConfig, NewlineDelimitedDecoder,
     NewlineDelimitedDecoderConfig, OctetCountingDecoder, OctetCountingDecoderConfig,
 };
+pub use ready_frames::ReadyFrames;

--- a/src/codecs/ready_frames.rs
+++ b/src/codecs/ready_frames.rs
@@ -34,7 +34,8 @@ where
     /// Create a new `ReadyChunks` with a specified capacity by wrapping a decoder stream, most
     /// commonly a `FramedRead`.
     ///
-    /// The specified capacity is a soft limit, and chunks may be returned that exceed that size.
+    /// The specified capacity is a soft limit, and chunks may be returned that contain more than
+    /// that number of items.
     pub fn with_capacity(inner: T, cap: usize) -> Self {
         Self {
             inner,

--- a/src/codecs/ready_frames.rs
+++ b/src/codecs/ready_frames.rs
@@ -1,0 +1,101 @@
+use std::pin::Pin;
+
+use futures::{
+    task::{Context, Poll},
+    {Stream, StreamExt},
+};
+
+/// A stream combinator aimed at improving the performance of decoder streams under load.
+///
+/// This is similar in spirit to `StreamExt::ready_chunks`, but built specifically for the
+/// particular result tuple returned by decoding streams. The more general `FoldReady` is left as
+/// an exercise to the reader.
+pub struct ReadyFrames<T, U, E> {
+    inner: T,
+    enqueued: Vec<U>,
+    enqueued_size: usize,
+    error_slot: Option<E>,
+}
+
+impl<T, U, E> ReadyFrames<T, U, E>
+where
+    T: Stream<Item = Result<(U, usize), E>> + Unpin,
+    U: Unpin,
+    E: Unpin,
+{
+    /// Create a new `ReadyChunks` by wrapping a decoder stream, most commonly a `FramedRead`.
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            enqueued: Vec::with_capacity(128),
+            enqueued_size: 0,
+            error_slot: None,
+        }
+    }
+
+    /// Returns a reference to the underlying stream.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the underlying stream.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    fn flush(&mut self) -> (Vec<U>, usize) {
+        let frames = std::mem::take(&mut self.enqueued);
+        let size = self.enqueued_size;
+        self.enqueued_size = 0;
+        (frames, size)
+    }
+}
+
+impl<T, U, E> Stream for ReadyFrames<T, U, E>
+where
+    T: Stream<Item = Result<(U, usize), E>> + Unpin,
+    U: Unpin,
+    E: Unpin,
+{
+    type Item = Result<(Vec<U>, usize), E>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(error) = self.error_slot.take() {
+            return Poll::Ready(Some(Err(error)));
+        }
+
+        loop {
+            match self.inner.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok((frame, size)))) => {
+                    self.enqueued.push(frame);
+                    self.enqueued_size += size;
+                    if self.enqueued.len() >= 1024 {
+                        return Poll::Ready(Some(Ok(self.flush())));
+                    }
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    if self.enqueued.is_empty() {
+                        return Poll::Ready(Some(Err(error)));
+                    } else {
+                        self.error_slot = Some(error);
+                        return Poll::Ready(Some(Ok(self.flush())));
+                    }
+                }
+                Poll::Ready(None) => {
+                    if !self.enqueued.is_empty() {
+                        return Poll::Ready(Some(Ok(self.flush())));
+                    } else {
+                        return Poll::Ready(None);
+                    }
+                }
+                Poll::Pending => {
+                    if !self.enqueued.is_empty() {
+                        return Poll::Ready(Some(Ok(self.flush())));
+                    } else {
+                        return Poll::Pending;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -221,7 +221,7 @@ impl From<io::Error> for DecodeError {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy)]
 enum LogstashProtocolVersion {
     V1, // 1
     V2, // 2

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -130,7 +130,7 @@ impl TcpSource for RawTcpSource {
         }
     }
 
-    fn build_acker(&self, _: &Self::Item) -> Self::Acker {
+    fn build_acker(&self, _: &[Self::Item]) -> Self::Acker {
         TcpNullAcker
     }
 }

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -224,7 +224,7 @@ impl TcpSource for StatsdTcpSource {
         )
     }
 
-    fn build_acker(&self, _: &Self::Item) -> Self::Acker {
+    fn build_acker(&self, _: &[Self::Item]) -> Self::Acker {
         TcpNullAcker
     }
 }

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -192,7 +192,7 @@ impl TcpSource for SyslogTcpSource {
         handle_events(events, &self.host_key, Some(host), byte_size);
     }
 
-    fn build_acker(&self, _: &Self::Item) -> Self::Acker {
+    fn build_acker(&self, _: &[Self::Item]) -> Self::Acker {
         TcpNullAcker
     }
 }
@@ -258,13 +258,9 @@ fn handle_events(
     default_host: Option<Bytes>,
     byte_size: usize,
 ) {
-    assert_eq!(
-        events.len(),
-        1,
-        "Syslog parser parses exactly one message from a byte string.",
-    );
-
-    enrich_syslog_event(&mut events[0], host_key, default_host, byte_size);
+    for event in events {
+        enrich_syslog_event(event, host_key, default_host.clone(), byte_size);
+    }
 }
 
 fn enrich_syslog_event(

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -117,7 +117,7 @@ impl TcpSource for VectorSource {
         )
     }
 
-    fn build_acker(&self, _: &Self::Item) -> Self::Acker {
+    fn build_acker(&self, _: &[Self::Item]) -> Self::Acker {
         TcpNullAcker
     }
 }


### PR DESCRIPTION
This came out of some strange soak test behavior in #10432. Essentially, we had reduced the change down to what should have been insignificant performance-wise (roughly, one additional allocation per batch via `ready_chunks` vs `enqueued`), but were still seeing a ~10% penalty on certain soaks.

The theory was that for those tests to be so hyper-sensitive to the performance of `send_all`, they must be heavily bottlenecked by it. Given that it's not supposed to be a method that things should bottleneck on, I looked into why that might be. They all were based on the `TcpSource` trait and utilized our new codec work to implement their respective protocols. 

The interesting bit ended up being roughly [here](https://github.com/vectordotdev/vector/blob/21e252598300e0777ca412f0ae72e36b3dd3b1fb/src/sources/util/tcp.rs#L278-L288) where we treat the output of the decoder stream as a "batch", setting up acks, annotating events, emitting metrics, and sending upstream for each "batch". The problem is that these are often (always in the case of syslog) not actually batches at all but single events wrapped in a `SmallVec`, which means we're doing all of the work mentioned previously for every single event as it comes through. This is significantly less efficient than amortizing those costs over an actual good-sized batch of events.

The solution ended up being quite a bit more complicated than I'd have liked, primarily due to the way that `TcpSource` has grown into a bit of a nightmare-ish piece of complexity with all of our small additions over the years. The biggest hurdle way the way that it ties acknowledgements to the generic frame type, such that we can't accumulate events across frames without keeping those frames accessible to later build acks. This was addressed by tweaking the acking trait to to build acks from groups of frames instead of individual frames, allowing us to accumulate frames themselves in a new stream combinator (`ReadyFrames`) before passing them into the existing logic. This leaves the basic structure intact, but ensures that we're actually trying to group up a significant number of events per batch when we're under load.

I do want to emphasize that this is not a design flaw with our codec system, and the `SmallVec` pattern still seems to me like a good one. It's also very likely that we had essentially equivalent behavior prior to the introduction of codecs, so I don't believe they introduced a performance regression. The problem is really that the way we integrated codecs into sources like these gives the impression that batching is happening when it's not. This wouldn't have been a terribly surprising finding if we'd looked at the code and seen that we were obviously sending single events at a time, but at a glance the code here did look like it was doing the right thing with respect to batching.

It's likely that there's more relatively low-hanging performance fruit in some of the sources that have been around longest, and we'll just need to keep this pattern in mind as we look for it, since it's not as obvious as it would be otherwise. I'm thinking about patterns and tools for detecting situations like this automatically, but a lot of it would be significantly improved by simply revisiting some of these sources and straightening out some of the old-style code that's been added to incrementally over quite a long period.