### PR TITLE
chore: Allow local soak runner to run one, some or all soaks

### DIFF
--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -13,7 +13,7 @@ display_usage() {
     echo ""
     echo "Options:"
     echo "  --help: display this information"
-    echo "  --soak: the experiment to run"
+    echo "  --soak: the experiment to run, default all; space delimited"
     echo "  --remote-image|--local-image: whether to use a local vector image or remote"
     echo "  --baseline: the baseline SHA to compare against"
     echo "  --comparison: the SHA to compare against 'baseline'"
@@ -28,13 +28,14 @@ SOAK_CPUS="7"
 SOAK_MEMORY="8g"
 VECTOR_CPUS="4"
 WARMUP_SECONDS="60"
+SOAKS=""
 
 while [[ $# -gt 0 ]]; do
   key="$1"
 
   case $key in
       --soak)
-          SOAK_NAME=$2
+          SOAKS=$2
           shift # past argument
           shift # past value
           ;;
@@ -88,24 +89,35 @@ pushd "${__dir}"
 capture_dir=$(mktemp -d /tmp/soak-captures.XXXXXX)
 echo "Captures will be recorded into ${capture_dir}"
 
-./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
-                  --soak "${SOAK_NAME}" \
-                  --variant "baseline" \
-                  --tag "${BASELINE}" \
-                  --capture-dir "${capture_dir}" \
-                  --cpus "${SOAK_CPUS}" \
-                  --memory "${SOAK_MEMORY}" \
-                  --vector-cpus "${VECTOR_CPUS}" \
-                  --warmup-seconds "${WARMUP_SECONDS}"
-./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
-                  --soak "${SOAK_NAME}" \
-                  --variant "comparison" \
-                  --tag "${COMPARISON}" \
-                  --capture-dir "${capture_dir}" \
-                  --cpus "${SOAK_CPUS}" \
-                  --memory "${SOAK_MEMORY}" \
-                  --vector-cpus "${VECTOR_CPUS}" \
-                  --warmup-seconds "${WARMUP_SECONDS}"
+if [ -z "${SOAKS}" ]; then
+    SOAKS=$(ls tests/)
+fi
+
+for SOAK_NAME in ${SOAKS}; do
+    echo "########"
+    echo "########"
+    echo "########    ${SOAK_NAME}"
+    echo "########"
+    echo "########"
+    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+                      --soak "${SOAK_NAME}" \
+                      --variant "baseline" \
+                      --tag "${BASELINE}" \
+                      --capture-dir "${capture_dir}" \
+                      --cpus "${SOAK_CPUS}" \
+                      --memory "${SOAK_MEMORY}" \
+                      --vector-cpus "${VECTOR_CPUS}" \
+                      --warmup-seconds "${WARMUP_SECONDS}"
+    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+                      --soak "${SOAK_NAME}" \
+                      --variant "comparison" \
+                      --tag "${COMPARISON}" \
+                      --capture-dir "${capture_dir}" \
+                      --cpus "${SOAK_CPUS}" \
+                      --memory "${SOAK_MEMORY}" \
+                      --vector-cpus "${VECTOR_CPUS}" \
+                      --warmup-seconds "${WARMUP_SECONDS}"
+done
 
 # Aggregate all captures and analyze them.
 ./bin/analyze_experiment --capture-dir "${capture_dir}" \


### PR DESCRIPTION
This commit changes the local soak runner to, by default, run all soak tests and
if --soak is specified to run only those experiments listed. This resolves
PR #10497.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
