### PR TITLE
docs: Basic release changelog rendering

### DIFF
--- a/website/cue/reference/releases.cue
+++ b/website/cue/reference/releases.cue
@@ -35,7 +35,7 @@ releases: {
 		known_issues: [string, ...string] | *[]
 
 		commits?: [#Commit, ...#Commit]
-		change_log: [#ChangeLogEntry, ...#ChangeLogEntry] | *[]
+		changelog: [#ChangeLogEntry, ...#ChangeLogEntry] | *[]
 		whats_next: #Any
 	}
 

--- a/website/cue/reference/releases.cue
+++ b/website/cue/reference/releases.cue
@@ -35,7 +35,7 @@ releases: {
 		known_issues: [string, ...string] | *[]
 
 		commits?: [#Commit, ...#Commit]
-		changelog: [#ChangeLogEntry, ...#ChangeLogEntry] | *[]
+		changelog:  [#ChangeLogEntry, ...#ChangeLogEntry] | *[]
 		whats_next: #Any
 	}
 

--- a/website/cue/reference/releases/0.18.0.cue
+++ b/website/cue/reference/releases/0.18.0.cue
@@ -14,147 +14,17 @@ releases: "0.18.0": {
 		See the [chart upgrade
 		guide](https://github.com/vectordotdev/helm-charts/blob/develop/charts/vector/README.md#upgrading) for how to
 		transition from the old charts.
-
-		## Known Issues
-		- The `elasticsearch` sink incorrectly prints a message for each
-		  delivered event. Fixed in v0.18.1.
-		- A change to internal telemetry causes aggregated histograms emitted by
-		  the `prometheus_exporter` and `prometheus_remote_write` sinks to be
-		  incorrectly tallied. Fixed in v0.18.1.
-		- The new automatic namespacing feature broke running Vector from the
-		  published RPM due to it trying to load directories from `/etc/vector`
-		  that are not valid. Fixed in v0.18.1.
-		- The new `reroute_dropped` feature of `remap` always creates the
-		  `dropped` output even if `reroute_dropped = false`. Fixed in v0.18.1.
-		- The `headers_key` option for the `kafka` sink was inadvertantly
-		  changed to `headers_field`.
-
-		## Features
-
-		- Initial support for routing failed events from transforms has been added,
-		  starting with the `remap` transform. See [the
-		  highlight](/highlights/2021-11-18-failed-event-routing) for more.
-		- Initial support for enriching events from external data sources has been
-		  added via a new Vector concept, enrichment tables. To start, we've added
-		  support for enriching events with data from a CSV file. See [the
-		  highlight](/highlights/2021-11-18-csv-enrichment) for more.
-		- A new `throttle` transform has been added for controlling costs. See [the
-		  highlight](/highlights/2021-11-12-event-throttle-transform) for more.
-		- Better support for breaking up Vector configuration into multiple files
-		  was added via deriving configuration from file and directory names. See
-		  [the highlight](/highlights/2021-11-18-implicit-namespacing) for more.
-		- A new `aws_sqs` source was added for consuming messages from AWS SQS as log
-		  events.
-
-		## Enhancements
-
-		- Instrumentation has been added to sink buffers to help give more visibility into
-		  their operation. The following metrics have been added:
-		  - `buffer_byte_size` (disk buffer only): The number of bytes in the buffer
-		  - `buffer_events` (in-memory buffer only): The number of events in the buffer
-		  - `buffer_received_event_bytes_total`: The number of bytes that have been
-			received by this buffer. This count does not include discarded events.
-		  - `buffer_sent_event_bytes_total`: The number of bytes that have been sent
-			from the buffer to its associated sink.
-		  - `buffer_received_events_total`: The number of events that have been received
-			by this buffer. This count does not include discarded events.
-		  - `buffer_sent_events_total`: The number of events that have been sent from
-			the buffer to its associated sink.
-		  - `buffer_discarded_events_total`: The number of events that have been
-			discarded from the buffer because it is full (relevant when `when_full` is
-			`drop_newest`)
-		- The `$LOG` environment variable for configuring the Vector log level has
-			been renamed to `$VECTOR_LOG`. `$LOG` is still also accepted for backwards
-			compatibility. This change makes logging configuration more in-line with
-			Vector's other environment variable based options, and isolates Vector from
-			being affected by other generic environment variables.
-		- VRL diagnostic error messages have been improved to suggest `null`, `true`, or
-		  `false` for undefined variables. This helps guide users to realize when they
-		  are trying to use a keyword like `nil` that doesn't actually exist in VRL.
-		- The `log_to_metric` transform now also allows emitting absolute counters
-		  in addition to relative counters via `kind = "absolute"`.
-		- (breaking!) The `status` tag for the `http_client_responses_total` internal
-		  metric was updated to be just the integer (e.g. `200`) rather than including
-		  the text portion of the HTTP response code (e.g. `200 OK`).
-		- The `kubernetes_logs` source now annotates logs with the `pod_owner` when
-		  available.
-		- The `papertrail` sink now allows `process` field to be set to a event field
-		  value the templatable `process` key.
-		- The `aws_s3` sink now has less connections terminated prematurely as it
-		  optimistically terminates connections before AWS's timeout.
-		- The `prometheus_exporter` now expires metrics that haven't been seen since the
-		  last flush (controlled by `flush_interval_secs`) to avoid holding onto stale
-		  metrics indefinitely and consuming increasing amounts of memory.
-		- Added support for end-to-end acknowledgements to the `aws_kinesis_firehose`
-		  source, `journald` source, and `file` sink.
-		- The `utilization` metric for most transforms no longer count time spent
-		  blocked on downstream components as busy. This means they should more
-		  accurately represent the time spent in that specific transform and require
-		  less interpretation to find bottlenecks.
-		- The `datadog_metrics` sink now supports sending distribution data to Datadog
-		  like histograms and aggregated samples.
-		- The `kubernetes_logs` source has been updated to be less demanding on the
-		  Kubernetes API server (and backing etcd cluster) by allowing for slightly
-		  stale data to be used for log enrichment rather than always requesting the
-		  most-up-to-date metadata.
-		- The `generator` source has been renamed to `demo_logs`. We feel this name
-		  better reflects the intent of the source. An alias has been added to maintain
-		  compatibility.
-		- The `framing` and `decoding` options are now available on `heroku_logs`
-		  source. See the [framing and decoding highlight from
-		  v0.17.0](/highlights/2021-10-06-source-codecs/) for more about this new source
-		  feature.
-		- (breaking!) The `upper_limit` field for aggregated summaries from the
-		  `metric_to_log` transform has been renamed to `q` which is a common shorthand
-		  for `quantile`.
-		- We have continued to add additional instrumentation to components with
-		  the goal of having them all match the [Component
-		  Specification](https://github.com/vectordotdev/vector/blob/master/docs/specs/component.md#instrumentation).
-		  Once we have finished this we will post a highlight outlining all of
-		  the added metrics.
-
-		## Bug Fixes:
-
-		- Configuring the number of threads (via `--threads`) for Vector now actually
-		  takes effect again rather than it always using the number of available cores.
-		  This was a regression in v0.13.
-		- Vector no longer crashes when configuration was reloaded that include changes
-		  to both the order of inputs for a component and configuration of one of those
-		  inputs.
-		- (breaking!) The obsolete `event_per_line` configuration option was removed
-		  from the `exec` source. This option became non-functional in 0.17.0 but was
-		  left available to be configured. Instead, the new `framing` option can be used
-		  to choose between interpreting th e output of the subcommand as an event per
-		  line or all at once as one event.
-		- Fix regression in `v0.17.0` for `aws_s3` sink where it would add a `/` to the
-		  prefix provided. The sink no longer adds this `/` to replace previous
-		  behavior.
-		- Fix memory leak that occurred when using Vector as a Windows service.
-		- Fix lock-ups with the `aws_s3`, `loki`, and `datadog_logs` sinks.
-		- Fix naming of the VRL `compact` function's `object` argument to match the
-		  docs. This was incorrectly implemented named `map` in the implementation.
-		- The `component_sent_bytes_total` internal metric is now reported _after_
-		  events are successfully sent to HTTP-based sinks rather than before they are
-		  sent.
-		- The `influxdb_metrics` and `influxdb_logs` sinks now use `/ping` for
-		  heathchecks rather than `/health` to work with Influx DB 2 Cloud.
-
-		## Other changes
-
-		- The deprecated `batch.max_size` parameter has been removed in this release.
-		  See the [upgrade guide](/highlights/2021-11-18-0-18-0-upgrade-guide) for more.
-		- The deprecated `request.in_flight_limit` has been removed in this release.
-		  See the [upgrade guide](/highlights/2021-11-18-0-18-0-upgrade-guide) for more.
-		- The deprecated `host` and `namespace` field on the `datadog_metrics`
-		  sink has been removed. See the [upgrade
-		  guide](/highlights/2021-11-18-0-18-0-upgrade-guide) for more.
 		"""
 
 	known_issues: [
-		"The `elasticsearch` sink incorrectly prints a message for each delivered event",
+		"The `elasticsearch` sink incorrectly prints a message for each delivered event. Fixed in v0.18.1.",
+		"A change to internal telemetry causes aggregated histograms emitted by the `prometheus_exporter` and `prometheus_remote_write` sinks to be incorrectly tallied. Fixed in v0.18.1.",
+		"The new automatic namespacing feature broke running Vector from the published RPM due to it trying to load directories from `/etc/vector` that are not valid. Fixed in v0.18.1.",
+		"The new `reroute_dropped` feature of `remap` always creates the `dropped` output even if `reroute_dropped = false`. Fixed in v0.18.1.",
+		"The `headers_key` option for the `kafka` sink was inadvertantly changed to `headers_field`. Fixed in v0.18.1.",
 	]
 
-	change_log: [
+	changelog: [
 		{
 			type: "feat"
 			scopes: ["remap transform", "config"]
@@ -173,7 +43,7 @@ releases: "0.18.0": {
 				added via a new Vector concept, enrichment tables. To start, we've added
 				support for enriching events with data from a CSV file. See [the
 				highlight](/highlights/2021-11-18-csv-enrichment) for more.
-				"""
+				""", pr_numbers: [1234, 3243]
 		},
 		{
 			type: "feat"

--- a/website/cue/reference/releases/0.18.0.cue
+++ b/website/cue/reference/releases/0.18.0.cue
@@ -43,7 +43,7 @@ releases: "0.18.0": {
 				added via a new Vector concept, enrichment tables. To start, we've added
 				support for enriching events with data from a CSV file. See [the
 				highlight](/highlights/2021-11-18-csv-enrichment) for more.
-				""", pr_numbers: [1234, 3243]
+				"""
 		},
 		{
 			type: "feat"

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -6,7 +6,7 @@
 {{ $version := .File.BaseFileName }}
 {{ $release := index site.Data.docs.releases $version }}
 {{ $highlights := where (where site.RegularPages "Section" "highlights") ".Params.release" "eq" $version }}
-{{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes"}}
+{{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "deprecation" "deprecations"}}
 <div class="max-w-3xl md:max-w-5xl px-6 lg:px-8 mx-auto">
   <div class="my-16">
     <div class="pb-8 md:pb-10 lg:pb-12">
@@ -46,6 +46,65 @@
       </div>
       {{ end }}
 
+      {{ with $release.known_issues }}
+      {{ if gt (len $release.known_issues) 0 }}
+      <div class="mt-8">
+        <div class="prose dark:prose-dark max-w-none">
+          {{ partial "heading.html" (dict "text" "Known issues" "level" 2) }}
+        </div>
+
+        <div class="mt-6 flex flex-col space-y-8">
+          <div>
+            <ul class="list-disc">
+              {{ range . }}
+                <li>
+                  <span class="prose dark:prose-dark">
+                    {{ .| markdownify }}
+                  </span>
+                </li>
+              {{ end }}
+            </ul>
+          </div>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{ with $release.changelog }}
+      {{ if gt (len $release.changelog) 0 }}
+      <div class="mt-8">
+        <div class="prose dark:prose-dark max-w-none">
+          {{ partial "heading.html" (dict "text" "Changelog" "level" 2) }}
+        </div>
+
+        <div class="mt-6 flex flex-col space-y-8">
+          {{ range $k, $v := $groups }}
+          {{ $changes := where $release.changelog ".type" "eq" $k }}
+          {{ if $changes }}
+          {{ $numChanges := len $changes }}
+          {{ $heading := printf "%d %s" $numChanges $v }}
+          <div>
+            <div class="prose dark:prose-dark max-w-none">
+              {{ partial "heading.html" (dict "text" $heading "level" 3 "icon" false) }}
+            </div>
+
+            <ul class="list-disc">
+              {{ range $changes }}
+                <li>
+                  <span class="prose dark:prose-dark">
+                    {{ .description | markdownify }}
+                  </span>
+                </li>
+              {{ end }}
+            </ul>
+          </div>
+          {{ end }}
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+      {{ end }}
+
       {{ with $release.whats_next }}
       <div class="mt-8">
         <span class="prose dark:prose-dark max-w-none">
@@ -67,82 +126,32 @@
         </div>
       </div>
       {{ end }}
-
-      {{ with $release.commits }}
-      {{ if gt (len $release.commits) 0 }}
-      <div class="mt-8">
-        <div class="prose dark:prose-dark max-w-none">
-          {{ partial "heading.html" (dict "text" "Changelog" "level" 2) }}
-        </div>
-
-        <div class="mt-6 flex flex-col space-y-8">
-          {{ range $k, $v := $groups }}
-          {{ $commits := where $release.commits ".type" "eq" $k }}
-          {{ if $commits }}
-          {{ $numCommits := len $commits }}
-          {{ $heading := printf "%d %s" $numCommits $v }}
-          <div>
-            <div class="prose dark:prose-dark max-w-none">
-              {{ partial "heading.html" (dict "text" $heading "level" 3 "icon" false) }}
-            </div>
-
-            <div class="mt-4 flex flex-col space-y-2">
-              {{ range $commits }}
-              {{ template "commit" . }}
-              {{ end }}
-            </div>
-          </div>
-          {{ end }}
-          {{ end }}
-        </div>
-      </div>
-      {{ end }}
-      {{ end }}
     </div>
-      <div class="mt-8">
-        <div class="lg:grid lg:grid-cols-3 gap-8">
-          <div class="col-span-2">
-            <div class="prose">
-              {{ partial "heading.html" (dict "text" (print "Download Version " $version) "level" 2) }}
-            </div>
-      
-            <div class="mt-2 border px-4 py-3 lg:px-6 lg:py-4 rounded-md dark:border-gray-700">
-              {{ partial "download/download-matrix.html" (dict "version" $version) }}
-            </div>
+    <div class="mt-8">
+      <div class="lg:grid lg:grid-cols-3 gap-8">
+        <div class="col-span-2">
+          <div class="prose">
+            {{ partial "heading.html" (dict "text" (print "Download Version " $version) "level" 2) }}
+          </div>
+
+          <div class="mt-2 border px-4 py-3 lg:px-6 lg:py-4 rounded-md dark:border-gray-700">
+            {{ partial "download/download-matrix.html" (dict "version" $version) }}
           </div>
         </div>
       </div>
+    </div>
   </div>
 </div>
 {{ end }}
 
-{{ define "commit" }}
+{{ define "changelog_entry" }}
 <span class="flex items-center justify-between space-x-3">
   <span class="flex items-center space-x-3">
-    {{/* Scopes */}}
-    <span class="flex space-x-1.5">
-      {{ range .scopes }}
-      {{ partial "badge.html" (dict "word" . "color" "blue") }}
-      {{ end }}
-    </span>
-
     {{/* Description */}}
     <span class="prose dark:prose-dark leading-snug flex-shrink prose-sm">
       {{ .description | markdownify }}
     </span>
   </span>
-
-  {{/* Pull request chip */}}
-  {{ with .pr_number }}
-  {{ $link := printf "https://github.com/vectordotdev/vector/pull/%v" . }}
-  <a href="{{ $link }}" class="font-mono flex items-center space-x-1 py-1 px-2 rounded-md bg-gray-100 dark:bg-gray-500 text-dark dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-600" rel="noopener" target="_blank">
-    <ion-icon class="h-3 w-3" name="git-pull-request-sharp"></ion-icon>
-
-    <span class="text-xs p-0">
-      {{ . }}
-    </span>
-  </a>
-  {{ end }}
 </span>
 {{ end }}
 

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -70,7 +70,6 @@
       </div>
       {{ end }}
 
-      {{ with $release.changelog }}
       {{ if gt (len $release.changelog) 0 }}
       <div class="mt-8">
         <div class="prose dark:prose-dark max-w-none">
@@ -102,7 +101,35 @@
           {{ end }}
         </div>
       </div>
-      {{ end }}
+      {{ else }}
+        {{ if gt (len $release.commits) 0 }}
+        <div class="mt-8">
+          <div class="prose dark:prose-dark max-w-none">
+            {{ partial "heading.html" (dict "text" "Changelog" "level" 2) }}
+          </div>
+
+          <div class="mt-6 flex flex-col space-y-8">
+            {{ range $k, $v := $groups }}
+            {{ $commits := where $release.commits ".type" "eq" $k }}
+            {{ if $commits }}
+            {{ $numCommits := len $commits }}
+            {{ $heading := printf "%d %s" $numCommits $v }}
+            <div>
+              <div class="prose dark:prose-dark max-w-none">
+                {{ partial "heading.html" (dict "text" $heading "level" 3 "icon" false) }}
+              </div>
+
+              <div class="mt-4 flex flex-col space-y-2">
+                {{ range $commits }}
+                {{ template "commit" . }}
+                {{ end }}
+              </div>
+            </div>
+            {{ end }}
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
       {{ end }}
 
       {{ with $release.whats_next }}
@@ -152,6 +179,36 @@
       {{ .description | markdownify }}
     </span>
   </span>
+</span>
+{{ end }}
+
+{{ define "commit" }}
+<span class="flex items-center justify-between space-x-3">
+  <span class="flex items-center space-x-3">
+    {{/* Scopes */}}
+    <span class="flex space-x-1.5">
+      {{ range .scopes }}
+      {{ partial "badge.html" (dict "word" . "color" "blue") }}
+      {{ end }}
+    </span>
+
+    {{/* Description */}}
+    <span class="prose dark:prose-dark leading-snug flex-shrink prose-sm">
+      {{ .description | markdownify }}
+    </span>
+  </span>
+
+  {{/* Pull request chip */}}
+  {{ with .pr_number }}
+  {{ $link := printf "https://github.com/vectordotdev/vector/pull/%v" . }}
+  <a href="{{ $link }}" class="font-mono flex items-center space-x-1 py-1 px-2 rounded-md bg-gray-100 dark:bg-gray-500 text-dark dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-600" rel="noopener" target="_blank">
+    <ion-icon class="h-3 w-3" name="git-pull-request-sharp"></ion-icon>
+
+    <span class="text-xs p-0">
+      {{ . }}
+    </span>
+  </a>
+  {{ end }}
 </span>
 {{ end }}
 


### PR DESCRIPTION
This adds basic rendering of changelogs and known issues from release
cue data and removes the old changelog generation.

It does not render scopes or PR tags as I couldn't get those looking
pretty, but I'll open a follow-up issue for that.

Closes part of https://github.com/vectordotdev/vector/issues/10522

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
