### PR TITLE
fix(remap): update `array` filter for `parse_groks` function to suppo…

### DIFF
--- a/lib/datadog/grok/src/filters/array.rs
+++ b/lib/datadog/grok/src/filters/array.rs
@@ -17,6 +17,8 @@ use crate::{
     grok_filter::GrokFilter,
     parse_grok_rules::Error as GrokStaticError,
 };
+use nom::bytes::complete::take_until1;
+use nom::combinator::eof;
 
 pub fn filter_from_function(f: &Function) -> Result<GrokFilter, GrokStaticError> {
     let args = f.args.as_ref();
@@ -68,23 +70,21 @@ pub fn filter_from_function(f: &Function) -> Result<GrokFilter, GrokStaticError>
         return Err(GrokStaticError::InvalidFunctionArguments(f.name.clone()));
     }
 
-    let brackets = match brackets {
+    let brackets = match &brackets {
+        None => None,
+        Some(b) if b.is_empty() => Some(("", "")),
         Some(b) if b.len() == 1 => {
-            let char = b.chars().next().unwrap();
+            let char = &b[..1];
             Some((char, char))
         }
-        Some(b) if b.len() == 2 => {
-            let mut chars = b.chars();
-            Some((chars.next().unwrap(), chars.next().unwrap()))
-        }
-        None => None,
+        Some(b) if b.len() == 2 => Some((&b[..1], &b[1..2])),
         _ => {
             return Err(GrokStaticError::InvalidFunctionArguments(f.name.clone()));
         }
     };
 
     Ok(GrokFilter::Array(
-        brackets,
+        brackets.map(|(start, end)| (start.to_string(), end.to_string())),
         delimiter,
         Box::new(value_filter),
     ))
@@ -94,7 +94,7 @@ type SResult<'a, O> = IResult<&'a str, O, (&'a str, nom::error::ErrorKind)>;
 
 pub fn parse<'a>(
     input: &'a str,
-    brackets: Option<(char, char)>,
+    brackets: Option<(&'a str, &'a str)>,
     delimiter: Option<&'a str>,
 ) -> Result<Vec<Value>, String> {
     let result = parse_array(brackets, delimiter)(input)
@@ -110,39 +110,43 @@ pub fn parse<'a>(
 }
 
 fn parse_array<'a>(
-    brackets: Option<(char, char)>,
+    brackets: Option<(&'a str, &'a str)>,
     delimiter: Option<&'a str>,
 ) -> impl Fn(&'a str) -> SResult<Vec<Value>> {
-    let brackets = brackets.unwrap_or(('[', ']'));
+    let brackets = brackets.unwrap_or(("[", "]"));
+    let delimiter = delimiter.unwrap_or(",");
     move |input| {
-        preceded(
-            char(brackets.0),
-            terminated(cut(parse_array_values(delimiter)), char(brackets.1)),
+        if brackets.0.is_empty() {
+            // no enclosed brackets
+            separated_list0(tag(delimiter), parse_value_no_brackets(delimiter))(input)
+        } else {
+            preceded(
+                tag(brackets.0),
+                terminated(
+                    separated_list0(tag(delimiter), parse_value(delimiter, brackets.1)),
+                    tag(brackets.1),
+                ),
+            )(input)
+        }
+    }
+}
+
+fn parse_value_no_brackets<'a>(delimiter: &'a str) -> impl Fn(&'a str) -> SResult<Value> {
+    move |input| {
+        map(
+            alt((take_until(delimiter), take(input.len()))),
+            |value: &str| Value::Bytes(Bytes::copy_from_slice(value.as_bytes())),
         )(input)
     }
 }
 
-fn parse_array_values<'a>(delimiter: Option<&'a str>) -> impl Fn(&'a str) -> SResult<Vec<Value>> {
-    move |input| {
-        let delimiter = delimiter.unwrap_or(",");
-        // skip the last closing character
-        separated_list0(tag(delimiter), cut(parse_value(delimiter)))(&input[..input.len() - 1]).map(
-            |(rest, values)| {
-                if rest.is_empty() {
-                    // return the closing character
-                    (&input[input.len() - 1..], values)
-                } else {
-                    (rest, values) // will fail upstream
-                }
-            },
-        )
-    }
-}
-
-fn parse_value<'a>(delimiter: &'a str) -> impl Fn(&'a str) -> SResult<Value> {
+fn parse_value<'a>(
+    delimiter: &'a str,
+    close_bracket: &'a str,
+) -> impl Fn(&'a str) -> SResult<Value> {
     move |input| {
         map(
-            alt((take_until(delimiter), take(input.len()))),
+            alt((take_until(delimiter), take_until(close_bracket))),
             |value: &str| Value::Bytes(Bytes::copy_from_slice(value.as_bytes())),
         )(input)
     }
@@ -160,7 +164,7 @@ mod tests {
 
     #[test]
     fn parses_with_non_default_brackets() {
-        let result = parse("{1,2}", Some(('{', '}')), None).unwrap();
+        let result = parse("{1,2}", Some(("{", "}")), None).unwrap();
         assert_eq!(result, vec!["1".into(), "2".into()]);
     }
 

--- a/lib/datadog/grok/src/filters/array.rs
+++ b/lib/datadog/grok/src/filters/array.rs
@@ -1,24 +1,19 @@
-use std::convert::TryFrom;
-
-use bytes::Bytes;
-use nom::{
-    branch::alt,
-    bytes::complete::{tag, take, take_until},
-    character::complete::char,
-    combinator::{cut, map},
-    multi::separated_list0,
-    sequence::{preceded, terminated},
-    IResult,
-};
-use vrl_compiler::Value;
-
 use crate::{
     ast::{Function, FunctionArgument},
     grok_filter::GrokFilter,
     parse_grok_rules::Error as GrokStaticError,
 };
-use nom::bytes::complete::take_until1;
-use nom::combinator::eof;
+use bytes::Bytes;
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take, take_until},
+    combinator::map,
+    multi::separated_list0,
+    sequence::{preceded, terminated},
+    IResult,
+};
+use std::convert::TryFrom;
+use vrl_compiler::Value;
 
 pub fn filter_from_function(f: &Function) -> Result<GrokFilter, GrokStaticError> {
     let args = f.args.as_ref();

--- a/lib/datadog/grok/src/grok_filter.rs
+++ b/lib/datadog/grok/src/grok_filter.rs
@@ -27,7 +27,7 @@ pub enum GrokFilter {
     Uppercase,
     Json,
     Array(
-        Option<(char, char)>,
+        Option<(String, String)>,
         Option<String>,
         Box<Option<GrokFilter>>,
     ),
@@ -180,7 +180,9 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
         GrokFilter::Array(brackets, delimiter, value_filter) => match value {
             Value::Bytes(bytes) => array::parse(
                 String::from_utf8_lossy(bytes).as_ref(),
-                brackets.to_owned(),
+                brackets
+                    .as_ref()
+                    .map(|(start, end)| (start.as_str(), end.as_str())),
                 delimiter.as_ref().map(|s| s.as_str()),
             )
             .map_err(|_e| {

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -554,6 +554,11 @@ mod tests {
                 Ok(Value::Array(vec!["1".into(), "2".into()])),
             ),
             (
+                r#"%{data:field:array("","-")}"#,
+                "1-2",
+                Ok(Value::Array(vec!["1".into(), "2".into()])),
+            ),
+            (
                 "%{data:field:array(integer)}",
                 "[1,2]",
                 Ok(Value::Array(vec![1.into(), 2.into()])),


### PR DESCRIPTION
`array` filter for `parse_groks` function should support arrays without brackets, if empty string is provided as brackets:
 `%{data:field:array("", "-")}`: "a-b" -> ["a", "b"]
