### PR TITLE
chore: Continue to soak in the presence of failures

### DIFF
--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -99,6 +99,7 @@ for SOAK_NAME in ${SOAKS}; do
     echo "########    ${SOAK_NAME}"
     echo "########"
     echo "########"
+    # shellcheck disable=SC2015
     ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "baseline" \

--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -107,7 +107,7 @@ for SOAK_NAME in ${SOAKS}; do
                       --cpus "${SOAK_CPUS}" \
                       --memory "${SOAK_MEMORY}" \
                       --vector-cpus "${VECTOR_CPUS}" \
-                      --warmup-seconds "${WARMUP_SECONDS}"
+                      --warmup-seconds "${WARMUP_SECONDS}" && \
     ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "comparison" \
@@ -116,7 +116,7 @@ for SOAK_NAME in ${SOAKS}; do
                       --cpus "${SOAK_CPUS}" \
                       --memory "${SOAK_MEMORY}" \
                       --vector-cpus "${VECTOR_CPUS}" \
-                      --warmup-seconds "${WARMUP_SECONDS}"
+                      --warmup-seconds "${WARMUP_SECONDS}" || true
 done
 
 # Aggregate all captures and analyze them.


### PR DESCRIPTION
This commit makes a small adjustment to the local soak runner to allow for
soaking to continue if one run fails. This can happen, for instance, if we go
backward in time far enough and a bit of configuration is not properly supported
in an older version of vector.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
