### PR TITLE
fix(tests): migrate ES soak test config

### DIFF
--- a/soaks/tests/fluent_elasticsearch/terraform/vector.toml
+++ b/soaks/tests/fluent_elasticsearch/terraform/vector.toml
@@ -28,7 +28,8 @@ address = "0.0.0.0:9090"
 type = "elasticsearch"
 inputs = [ "fluent"]
 endpoint = "http://http-blackhole:8080"
-index = "vector-%F"
-mode = "normal"
+mode = "bulk"
 pipeline = "pipeline-name"
 compression = "none"
+[sinks.elasticsearch.bulk]
+index = "vector-%F"


### PR DESCRIPTION
Soak test was using deprecated ES config, which broke once those deprecated fields were removed.