### PR TITLE
chore(ci): Soak test PR merge commit for comparisons

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -46,6 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.5
         with:
+          path: comparison-vector
+
+      - uses: actions/checkout@v2.3.5
+        with:
           ref: ${{ github.base_ref }}
           path: baseline-vector
 
@@ -59,8 +63,13 @@ jobs:
       - name: Setup comparison variables
         id: comparison
         run: |
-          export COMPARISON_SHA=${{ github.event.pull_request.head.sha }}
-          export COMPARISON_TAG="${{ github.event.pull_request.head.sha }}-${{ github.event.pull_request.head.sha }}"
+          pushd baseline-vector
+          export COMPARISON_SHA=$(git rev-parse HEAD)
+          # push up merge ref to Github so that it is linkable there
+          git push origin pr-${{ github.event.number }}-$COMPARISON_SHA
+          popd
+
+          export COMPARISON_TAG="${{ github.sha }}-${{ github.sha }}"
 
           echo "comparison sha is: ${COMPARISON_SHA}"
           echo "comparison tag is: ${COMPARISON_TAG}"
@@ -75,7 +84,7 @@ jobs:
           export BASELINE_SHA=$(git rev-parse HEAD)
           popd
 
-          export BASELINE_TAG="${{ github.event.pull_request.head.sha }}-${BASELINE_SHA}"
+          export BASELINE_TAG="${{ github.sha }}-${BASELINE_SHA}"
           echo "baseline sha is: ${BASELINE_SHA}"
           echo "baseline tag is: ${BASELINE_TAG}"
 

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -44,6 +44,7 @@ jobs:
       soak-cpus: ${{ steps.system.outputs.SOAK_CPUS }}
       soak-memory: ${{ steps.system.outputs.SOAK_MEMORY }}
     steps:
+      # checks out the PR with the base ref merged in
       - uses: actions/checkout@v2.3.5
         with:
           path: comparison-vector
@@ -66,8 +67,8 @@ jobs:
           pushd comparison-vector
           export COMPARISON_SHA=$(git rev-parse HEAD)
           # push up merge ref to Github so that it is linkable there
-          git checkout -b pr/${{ github.event.number }}/$COMPARISON_SHA
-          git push origin pr/${{ github.event.number }}/$COMPARISON_SHA
+          git checkout -b pr/${{ github.event.number }}/run/${{ github.run_number }}/attempt/${{ github.run_attempt }}
+          git push origin pr/${{ github.event.number }}/run/${{ github.run_number }}/attempt/${{ github.run_attempt }}
           popd
 
           export COMPARISON_TAG="${{ github.sha }}-${{ github.sha }}"

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -63,10 +63,11 @@ jobs:
       - name: Setup comparison variables
         id: comparison
         run: |
-          pushd baseline-vector
+          pushd comparison-vector
           export COMPARISON_SHA=$(git rev-parse HEAD)
           # push up merge ref to Github so that it is linkable there
-          git push origin pr-${{ github.event.number }}-$COMPARISON_SHA
+          git checkout -b pr/${{ github.event.number }}/$COMPARISON_SHA
+          git push origin pr/${{ github.event.number }}/$COMPARISON_SHA
           popd
 
           export COMPARISON_TAG="${{ github.sha }}-${{ github.sha }}"


### PR DESCRIPTION
We've observed that we sometimes get misleading soak test results in PRs
because of them being out-of-date with changes on master. For example:

https://github.com/vectordotdev/vector/pull/10532#issuecomment-998896860

Shows a regression, but this is because the [comparison SHA](https://github.com/vectordotdev/vector/commit/0652cb5a6a042d37d0aa61475f08e9162a595a09) doesn't
include some changes from the [baseline SHA](https://github.com/vectordotdev/vector/commit/e4d391e3a3fc823328a57d86b7ec11cd4434df4a).

Github Actions, when it checks out a PR, will merge in the base ref if
possible. The update below changes the soak tests to test this. It also
pushes up this merge commit so that it is linked in the Github UI rather
than being an apparent invalid commit.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
