### PR TITLE
enhancement!(vector source, vector sink): Remove default for version

### DIFF
--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -14,7 +14,7 @@ enum V1 {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfigV1 {
-    version: Option<V1>,
+    version: V1,
     #[serde(flatten)]
     config: v1::VectorConfig,
 }

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -16,7 +16,7 @@ enum V1 {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfigV1 {
-    version: Option<V1>,
+    version: V1,
     #[serde(flatten)]
     config: v1::VectorConfig,
 }

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -13,8 +13,9 @@ badges:
 Vector's 0.19.0 release includes **breaking changes**:
 
 1. [Removal of deprecated configuration fields for the Splunk HEC Logs sink: `host`](#splunk-hec-logs-sink-deprecated-fields)
-2. [Updated internal metrics for the Splunk HEC sinks](#splunk-hec-sinks-metrics-update)
-3. [Removal of deprecated configuration fields for the Elasticsearch sink: `host`](#elasticsearch-sink-deprecated-fields)
+1. [Updated internal metrics for the Splunk HEC sinks](#splunk-hec-sinks-metrics-update)
+1. [Removal of deprecated configuration fields for the Elasticsearch sink: `host`](#elasticsearch-sink-deprecated-fields)
+1. [Removal of default for `version` field for Vector source and sink](#vector-version)
 
 We cover them below to help you upgrade quickly:
 
@@ -60,3 +61,50 @@ removed metric, we've added an equivalent alternative.
 | `bulk_action`      | `bulk.action`         |
 | `index`            | `bulk.index`          |
 | `headers`          | `request.headers`     |
+
+### Removal of default for `version` field for Vector source and sink {#vector-version}
+
+In the v0.16.0 release, we have [introduced a new `v2` version of the protocol][vector-v2-announcement] that the
+`vector` source and sink use to communicate. This new protocol offers a number of advantages over our initial `v1`
+protocol implementation including load balancing and better back-pressure handling.
+
+Up until this release, the `vector` source and sink continued defaulting to the `v1` protocol for compatibility. In this
+release, we remove this default and require you to specify the `version` field in the `vector` source and sink
+configuration. The intent of this change is to prompt users to migrate.
+
+If you do not specify a version number, you will see an error like:
+
+```text
+Configuration error. error=data did not match any variant of untagged enum VectorConfig for key `sinks.my_vector_sink` at line 8 column 1
+```
+
+To continue using the `v1` protocol, simply add `version = "1"` to your configuration like:
+
+```toml
+[sinks.vector]
+  type = "vector"
++ version = "1"
+
+[sources.vector]
+  type = "vector"
++ version = "1"
+```
+
+However, we recommend that you transition to the `v2` protocol by setting `version = "2"`:
+
+```toml
+[sinks.vector]
+  type = "vector"
++ version = "2"
+
+[sources.vector]
+  type = "vector"
++ version = "2"
+```
+
+See the [announcement post][vector-v2-announcement] for a guide on how to transition without downtime.
+
+In a subsequent release we will begin defaulting to the `v2` protocol and eventually remove support for the `v1`
+protocol.
+
+[vector-v2-announcement](/highlights/2021-08-24-vector-source-sink/)

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -80,7 +80,7 @@ Configuration error. error=data did not match any variant of untagged enum Vecto
 
 To continue using the `v1` protocol, simply add `version = "1"` to your configuration like:
 
-```toml
+```diff
 [sinks.vector]
   type = "vector"
 + version = "1"
@@ -92,7 +92,7 @@ To continue using the `v1` protocol, simply add `version = "1"` to your configur
 
 However, we recommend that you transition to the `v2` protocol by setting `version = "2"`:
 
-```toml
+```diff
 [sinks.vector]
   type = "vector"
 + version = "2"


### PR DESCRIPTION
Require users to specify the version to prompt them to upgrade as part
of the deprecation, and eventual removal, of the `v1` protocol.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
