### PR TITLE
fix(throttle transform): Add alias for `window_secs`

### DIFF
--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -19,6 +19,7 @@ use crate::{
 #[serde(deny_unknown_fields, default)]
 pub struct ThrottleConfig {
     threshold: u32,
+    #[serde(alias = "window")]
     window_secs: f64,
     key_field: Option<Template>,
     exclude: Option<AnyCondition>,


### PR DESCRIPTION
I renamed this in https://github.com/vectordotdev/vector/pull/10095 but
that didn't make 0.18.0 so I aliased it here for compatibility.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
