### PR TITLE
chore: Use memchr for haystack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8290,6 +8290,7 @@ dependencies = [
  "matches",
  "maxminddb",
  "md-5 0.10.0",
+ "memchr",
  "metrics",
  "metrics-tracing-context",
  "metrics-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ indoc = { version = "1.0.3", default-features = false }
 inventory = { version = "0.1.10", default-features = false }
 k8s-openapi = { version = "0.13.1", default-features = true, features = ["api", "v1_16"], optional = true }
 lazy_static = { version = "1.4.0", default-features = false }
+memchr = { version = "2.4", default-features = false }
 listenfd = { version = "0.3.5", default-features = false, optional = true }
 logfmt = { version = "0.0.2", default-features = false, optional = true }
 lru = { version = "0.7.1", default-features = false, optional = true }

--- a/src/codecs/framing/character_delimited.rs
+++ b/src/codecs/framing/character_delimited.rs
@@ -91,9 +91,8 @@ impl Decoder for CharacterDelimitedDecoder {
             // there's no max_length set, we'll read to the end of the buffer.
             let read_to = cmp::min(self.max_length.saturating_add(1), buf.len());
 
-            let newline_pos = buf[self.next_index..read_to]
-                .iter()
-                .position(|b| *b as char == self.delimiter);
+            // TODO this coercion to u8 is not always safe.
+            let newline_pos = memchr::memchr(self.delimiter as u8, &buf[self.next_index..read_to]);
 
             match (self.is_discarding, newline_pos) {
                 (true, Some(offset)) => {


### PR DESCRIPTION
The CharacterDelimitedDecoder uses a window search to find its delimiter. This
is not particularly fast, compared to the more optimized algorithms available in
libc to do this exact thing.

This commit is born from the investigation into #10543. I've managed to
determine that calling `decode_eof` is a serialization point -- hardwiring
`SimpleHttpSource::build_events` to create a single Event with no parse body has
above-the-threshold throughput -- but I'm not totally sure in what area. On my
system this was worth +4Mb/s but I'm curious if this result is statistically
relevant, hence the PR.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>