### PR TITLE
fix(remap): support grok-unsafe field names for `parse_groks`

### DIFF
--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -786,4 +786,34 @@ mod tests {
             ),
         ]);
     }
+
+    #[test]
+    fn parses_unconventional_field_names() {
+        test_full_grok(vec![
+            (
+                r#"%{data:field["quoted name"]}"#,
+                "abc",
+                Ok(Value::from(btreemap! {
+                "field" => btreemap! {
+                    "quoted name" => "abc",
+                    }
+                })),
+            ),
+            (
+                r#"%{data:@field-name-with-symbols$}"#,
+                "abc",
+                Ok(Value::from(btreemap! {
+                "@field-name-with-symbols$" => "abc"})),
+            ),
+            (
+                r#"%{data:@parent.$child}"#,
+                "abc",
+                Ok(Value::from(btreemap! {
+                "@parent" => btreemap! {
+                    "$child" => "abc",
+                    }
+                })),
+            ),
+        ]);
+    }
 }

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -788,7 +788,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_unconventional_field_names() {
+    fn parses_grok_unsafe_field_names() {
         test_full_grok(vec![
             (
                 r#"%{data:field["quoted name"]}"#,


### PR DESCRIPTION
DD field names can have some grok-unsafe symbols(e.g. @,-,$) and support quoted field names(`%{data:field["quoted subfield name"]}`), therefore we need to convert internally field names to grok-compliant names like `grok0`, `grok1` etc.