### PR TITLE
fix(ci): Revert update k8s-e2e to use new helm chart

### DIFF
--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -30,7 +30,7 @@ pub fn get_namespace() -> String {
         .map(|num| (num as char).to_ascii_lowercase())
         .collect();
 
-    format!("vector-{}", id)
+    format!("test-vector-{}", id)
 }
 
 pub fn get_namespace_appended(namespace: &str, suffix: &str) -> String {
@@ -236,9 +236,9 @@ pub async fn smoke_check_first_line(log_reader: &mut Reader) {
         .read_line()
         .await
         .expect("unable to read first line");
-    let expected_pat = "INFO vector::app: Log level is enabled.";
+    let expected_pat = "INFO vector::app: Log level is enabled. level=\"info\"\n";
     assert!(
-        first_line.contains(expected_pat),
+        first_line.ends_with(expected_pat),
         "Expected a line ending with {:?} but got {:?}; vector might be malfunctioning",
         expected_pat,
         first_line

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -1,61 +1,168 @@
-use indoc::{formatdoc, indoc};
+use indoc::formatdoc;
 use k8s_e2e_tests::*;
 use k8s_test_framework::{
     lock, namespace, test_pod, vector::Config as VectorConfig, wait_for_resource::WaitFor,
 };
 
-fn helm_values_stdout_sink(agent_override_name: &str) -> String {
-    formatdoc!(
-        r#"
-    role: Agent
-    fullnameOverride: "{}"
-    env:
-    - name: VECTOR_REQUIRE_HEALTHY
-      value: true
-    customConfig:
-      data_dir: "/vector-data-dir"
-      api:
-        enabled: true
-        address: 127.0.0.1:8686
-      sources:
-        kubernetes_logs:
-          type: kubernetes_logs
+fn helm_values_stdout_sink(aggregator_override_name: &str, agent_override_name: &str) -> String {
+    if is_multinode() {
+        formatdoc!(
+            r#"
+    global:
+      vector:
+        commonEnvKV:
+          VECTOR_REQUIRE_HEALTHY: true
+
+    vector-agent:
+      fullnameOverride: "{}"
+      kubernetesLogsSource:
+        rawConfig: |
+          glob_minimum_cooldown_ms = 5000
+      vectorSink:
+        host: "{}"
+      dataVolume:
+        hostPath:
+          path: /var/lib/{}-vector/
+
+      extraVolumeMounts:
+        - name: var-lib
+          mountPath: /var/writablelib
+          readOnly: false
+
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - sh
+              - -c
+              - rm -rf /var/writablelib/{}-vector
+
+    vector-aggregator:
+      fullnameOverride: "{}"
+      vectorSource:
+        sourceId: vector
+
       sinks:
-        vector:
-          type: vector
-          inputs: [kubernetes_logs]
-          address: aggregator-vector:6000
-          version: "2"
+        stdout:
+          type: "console"
+          inputs: ["vector"]
+          target: "stdout"
+          encoding: "json"
     "#,
-        agent_override_name,
-    )
+            agent_override_name,
+            aggregator_override_name,
+            agent_override_name,
+            agent_override_name,
+            aggregator_override_name
+        )
+    } else {
+        formatdoc!(
+            r#"
+    global:
+      vector:
+        commonEnvKV:
+          VECTOR_REQUIRE_HEALTHY: true
+
+    vector-agent:
+      fullnameOverride: "{}"
+      kubernetesLogsSource:
+        rawConfig: |
+          glob_minimum_cooldown_ms = 5000
+      vectorSink:
+        host: "{}"
+
+    vector-aggregator:
+      fullnameOverride: "{}"
+      vectorSource:
+        sourceId: vector
+
+      sinks:
+        stdout:
+          type: "console"
+          inputs: ["vector"]
+          target: "stdout"
+          encoding: "json"
+    "#,
+            agent_override_name,
+            aggregator_override_name,
+            aggregator_override_name
+        )
+    }
 }
 
-fn helm_values_haproxy(agent_override_name: &str) -> String {
-    formatdoc!(
-        r#"
-    role: Agent
-    fullnameOverride: "{}"
-    env:
-    - name: VECTOR_REQUIRE_HEALTHY
-      value: true
-    customConfig:
-      data_dir: "/vector-data-dir"
-      api:
-        enabled: true
-        address: 127.0.0.1:8686
-      sources:
-        kubernetes_logs:
-          type: kubernetes_logs
+fn helm_values_haproxy(aggregator_override_name: &str, agent_override_name: &str) -> String {
+    if is_multinode() {
+        formatdoc!(
+            r#"
+    global:
+      vector:
+        commonEnvKV:
+          VECTOR_REQUIRE_HEALTHY: true
+
+    vector-agent:
+      fullnameOverride: "{}"
+      kubernetesLogsSource:
+        rawConfig: |
+          glob_minimum_cooldown_ms = 5000
+      vectorSink:
+        host: "{}-haproxy"
+      dataVolume:
+        hostPath:
+          path: /var/lib/{}-vector/
+
+    vector-aggregator:
+      fullnameOverride: "{}"
+      vectorSource:
+        sourceId: vector
+
       sinks:
-        vector:
-          type: vector
-          inputs: [kubernetes_logs]
-          address: aggregator-vector-haproxy:6000
-          version: "2"
+        stdout:
+          type: "console"
+          inputs: ["vector"]
+          target: "stdout"
+          encoding: "json"
+
+      haproxy:
+        enabled: true
     "#,
-        agent_override_name,
-    )
+            agent_override_name,
+            aggregator_override_name,
+            agent_override_name,
+            aggregator_override_name
+        )
+    } else {
+        formatdoc!(
+            r#"
+    global:
+      vector:
+        commonEnvKV:
+          VECTOR_REQUIRE_HEALTHY: true
+
+    vector-agent:
+      fullnameOverride: "{}"
+      vectorSink:
+        host: "{}-haproxy"
+
+    vector-aggregator:
+      fullnameOverride: "{}"
+      vectorSource:
+        sourceId: vector
+
+      sinks:
+        stdout:
+          type: "console"
+          inputs: ["vector"]
+          target: "stdout"
+          encoding: "json"
+
+      haproxy:
+        enabled: true
+    "#,
+            agent_override_name,
+            aggregator_override_name,
+            aggregator_override_name
+        )
+    }
 }
 
 /// This test validates that vector picks up logs with an agent and
@@ -68,36 +175,19 @@ async fn logs() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
+    let aggregator_override_name = get_override_name(&namespace, "vector-aggregator");
     let agent_override_name = get_override_name(&namespace, "vector-agent");
 
-    let vector_aggregator = framework
+    let vector = framework
         .helm_chart(
             &namespace,
             "vector",
-            "aggregator",
-            "https://helm.vector.dev",
+            "https://packages.timber.io/helm/nightly/",
             VectorConfig {
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    framework
-        .wait_for_rollout(
-            &namespace,
-            &format!("statefulset/aggregator-vector"),
-            vec!["--timeout=60s"],
-        )
-        .await?;
-
-    let vector_agent = framework
-        .helm_chart(
-            &namespace,
-            "vector",
-            "agent",
-            "https://helm.vector.dev",
-            VectorConfig {
-                custom_helm_values: vec![&helm_values_stdout_sink(&agent_override_name)],
+                custom_helm_values: vec![&helm_values_stdout_sink(
+                    &aggregator_override_name,
+                    &agent_override_name,
+                )],
                 ..Default::default()
             },
         )
@@ -107,6 +197,14 @@ async fn logs() -> Result<(), Box<dyn std::error::Error>> {
         .wait_for_rollout(
             &namespace,
             &format!("daemonset/{}", agent_override_name),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("statefulset/{}", aggregator_override_name),
             vec!["--timeout=60s"],
         )
         .await?;
@@ -136,7 +234,10 @@ async fn logs() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, &format!("statefulset/aggregator-vector"))?;
+    let mut log_reader = framework.logs(
+        &namespace,
+        &format!("statefulset/{}", aggregator_override_name),
+    )?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -169,65 +270,33 @@ async fn logs() -> Result<(), Box<dyn std::error::Error>> {
 
     drop(test_pod);
     drop(test_namespace);
-    drop(vector_agent);
-    drop(vector_aggregator);
+    drop(vector);
     Ok(())
 }
 
 /// This test validates that vector picks up logs with an agent and
 /// delivers them to the aggregator through an HAProxy load balancer.
 #[tokio::test]
-async fn haproxy() -> Result<(), Box<dyn std::error::Error>> {
+async fn logs_haproxy() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = lock();
     init();
 
     let namespace = get_namespace();
     let pod_namespace = get_namespace_appended(&namespace, "test-pod");
     let framework = make_framework();
+    let aggregator_override_name = get_override_name(&namespace, "vector-aggregator");
     let agent_override_name = get_override_name(&namespace, "vector-agent");
 
-    const CONFIG: &str = indoc! {r#"
-        haproxy:
-          enabled: true
-    "#};
-
-    let vector_aggregator = framework
+    let vector = framework
         .helm_chart(
             &namespace,
             "vector",
-            "aggregator",
-            "https://helm.vector.dev",
+            "https://packages.timber.io/helm/nightly/",
             VectorConfig {
-                custom_helm_values: vec![CONFIG],
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    framework
-        .wait_for_rollout(
-            &namespace,
-            &format!("statefulset/aggregator-vector"),
-            vec!["--timeout=60s"],
-        )
-        .await?;
-
-    framework
-        .wait_for_rollout(
-            &namespace,
-            &format!("deployment/aggregator-vector-haproxy"),
-            vec!["--timeout=60s"],
-        )
-        .await?;
-
-    let vector_agent = framework
-        .helm_chart(
-            &namespace,
-            "vector",
-            "agent",
-            "https://helm.vector.dev",
-            VectorConfig {
-                custom_helm_values: vec![&helm_values_haproxy(&agent_override_name)],
+                custom_helm_values: vec![&helm_values_haproxy(
+                    &aggregator_override_name,
+                    &agent_override_name,
+                )],
                 ..Default::default()
             },
         )
@@ -237,6 +306,14 @@ async fn haproxy() -> Result<(), Box<dyn std::error::Error>> {
         .wait_for_rollout(
             &namespace,
             &format!("daemonset/{}", agent_override_name),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("statefulset/{}", aggregator_override_name),
             vec!["--timeout=60s"],
         )
         .await?;
@@ -266,7 +343,10 @@ async fn haproxy() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    let mut log_reader = framework.logs(&namespace, &format!("statefulset/aggregator-vector"))?;
+    let mut log_reader = framework.logs(
+        &namespace,
+        &format!("statefulset/{}", aggregator_override_name),
+    )?;
     smoke_check_first_line(&mut log_reader).await;
 
     // Read the rest of the log lines.
@@ -299,7 +379,6 @@ async fn haproxy() -> Result<(), Box<dyn std::error::Error>> {
 
     drop(test_pod);
     drop(test_namespace);
-    drop(vector_agent);
-    drop(vector_aggregator);
+    drop(vector);
     Ok(())
 }

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -24,7 +24,6 @@ impl Framework {
         &self,
         namespace: &str,
         helm_chart: &str,
-        release_name: &str,
         helm_repo: &str,
         config: vector::Config<'_>,
     ) -> Result<up_down::Manager<vector::CommandBuilder>> {
@@ -33,7 +32,6 @@ impl Framework {
             self.interface.deploy_chart_command.as_str(),
             namespace,
             helm_chart,
-            release_name,
             config,
             Some(env),
         )?;

--- a/lib/k8s-test-framework/src/vector.rs
+++ b/lib/k8s-test-framework/src/vector.rs
@@ -11,7 +11,6 @@ pub struct CommandBuilder {
     interface_command: String,
     namespace: String,
     helm_chart: String,
-    release_name: String,
     custom_helm_values_files: Vec<HelmValuesFile>,
     custom_resource_file: Option<ResourceFile>,
     custom_env: Option<Vec<(String, String)>>,
@@ -27,7 +26,6 @@ impl up_down::CommandBuilder for CommandBuilder {
             })
             .arg(&self.namespace)
             .arg(&self.helm_chart)
-            .arg(&self.release_name)
             .stdin(Stdio::null());
 
         command.env(
@@ -70,7 +68,6 @@ pub fn manager(
     interface_command: &str,
     namespace: &str,
     helm_chart: &str,
-    release_name: &str,
     config: Config<'_>,
     custom_env: Option<Vec<(String, String)>>,
 ) -> Result<up_down::Manager<CommandBuilder>> {
@@ -91,7 +88,6 @@ pub fn manager(
         interface_command: interface_command.to_owned(),
         namespace: namespace.to_owned(),
         helm_chart: helm_chart.to_owned(),
-        release_name: release_name.to_owned(),
         custom_helm_values_files,
         custom_resource_file,
         custom_env,

--- a/scripts/deploy-chart-test.sh
+++ b/scripts/deploy-chart-test.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 #
 #   Deploy:
 #
-#   $ CHART_REPO=https://helm.testmaterial.tld scripts/deploy-public-chart-test.sh up test-namespace-qwerty chart release
+#   $ CHART_REPO=https://helm.testmaterial.tld scripts/deploy-public-chart-test.sh up test-namespace-qwerty chart
 #
 #   Teardown:
 #
@@ -32,9 +32,6 @@ NAMESPACE="${2:?"Specify the namespace as the second argument"}"
 
 # The helm chart to manage
 HELM_CHART="${3:?"Specify the helm chart name as the third argument"}"
-
-# Release name for chart install
-RELEASE_NAME="${4:?"Specify the release name as the fourth argument"}"
 
 # Allow overriding kubectl with something like `minikube kubectl --`.
 VECTOR_TEST_KUBECTL="${VECTOR_TEST_KUBECTL:-"kubectl"}"
@@ -64,7 +61,7 @@ up() {
   $VECTOR_TEST_HELM repo add "$CUSTOM_HELM_REPO_LOCAL_NAME" "$CHART_REPO" --force-update || true
   $VECTOR_TEST_HELM repo update
 
-  $VECTOR_TEST_KUBECTL create namespace "$NAMESPACE" --dry-run -o yaml | $VECTOR_TEST_KUBECTL apply -f -
+  $VECTOR_TEST_KUBECTL create namespace "$NAMESPACE"
 
   if [[ -n "$CUSTOM_RESOURCE_CONFIGS_FILE" ]]; then
     $VECTOR_TEST_KUBECTL create --namespace "$NAMESPACE" -f "$CUSTOM_RESOURCE_CONFIGS_FILE"
@@ -83,10 +80,9 @@ up() {
   # overwriting console output.
   split-container-image "$CONTAINER_IMAGE"
   HELM_VALUES+=(
-    --set "env[0].name=VECTOR_LOG"
-    --set "env[0].value=info"
-    --set "image.repository=$CONTAINER_IMAGE_REPOSITORY"
-    --set "image.tag=$CONTAINER_IMAGE_TAG"
+    --set "global.vector.commonEnvKV.LOG=info"
+    --set "global.vector.image.repository=$CONTAINER_IMAGE_REPOSITORY"
+    --set "global.vector.image.tag=$CONTAINER_IMAGE_TAG"
   )
 
   set -x
@@ -94,8 +90,9 @@ up() {
     --atomic \
     --namespace "$NAMESPACE" \
     "${HELM_VALUES[@]}" \
-    "$RELEASE_NAME" \
-    "$CUSTOM_HELM_REPO_LOCAL_NAME/$HELM_CHART"
+    "$HELM_CHART" \
+    "$CUSTOM_HELM_REPO_LOCAL_NAME/$HELM_CHART" \
+    --devel
   { set +x; } &>/dev/null
 }
 
@@ -108,9 +105,7 @@ down() {
     $VECTOR_TEST_HELM delete --namespace "$NAMESPACE" "$HELM_CHART"
   fi
 
-  if $VECTOR_TEST_KUBECTL get namespace "$NAMESPACE" &>/dev/null; then
-    $VECTOR_TEST_KUBECTL delete namespace "$NAMESPACE"
-  fi
+  $VECTOR_TEST_KUBECTL delete namespace "$NAMESPACE"
 }
 
 case "$COMMAND" in


### PR DESCRIPTION
Reverts vectordotdev/vector#10521

Appears to be causing CI failures. Reverting so we can re-open as a PR to investigate.

https://github.com/vectordotdev/vector/actions/runs/1608811257