### PR TITLE
fix(codecs): Fix framing handling of long frames

### DIFF
--- a/src/codecs/framing/character_delimited.rs
+++ b/src/codecs/framing/character_delimited.rs
@@ -212,7 +212,6 @@ mod tests {
         let mut codec = CharacterDelimitedDecoder::new_with_max_length('\n', MAX_LENGTH);
         let buf = &mut BytesMut::new();
 
-        buf.reserve(200);
         // limit is 6 so it will skip longer lines
         buf.put_slice(b"1234567\n123456\n123412314\n123");
 
@@ -221,12 +220,12 @@ mod tests {
 
         let buf = &mut BytesMut::new();
 
-        buf.reserve(200);
         // limit is 6 so it will skip longer lines
         buf.put_slice(b"1234567\n123456\n123412314\n123");
 
         assert_eq!(codec.decode_eof(buf).unwrap(), Some(Bytes::from("123456")));
         assert_eq!(codec.decode_eof(buf).unwrap(), Some(Bytes::from("123")));
+        assert_eq!(codec.decode_eof(buf).unwrap(), None);
     }
 
     // Regression test for [infinite loop bug](https://github.com/timberio/vector/issues/2564)

--- a/src/codecs/framing/character_delimited.rs
+++ b/src/codecs/framing/character_delimited.rs
@@ -141,7 +141,6 @@ impl Decoder for CharacterDelimitedDecoder {
                         max_length = self.max_length,
                         internal_log_rate_secs = 30
                     );
-                    return Ok(None);
                 }
                 (false, None) => {
                     // We didn't find the delimiter and didn't
@@ -214,13 +213,20 @@ mod tests {
         let buf = &mut BytesMut::new();
 
         buf.reserve(200);
-        // limit is 6 so this should fail
+        // limit is 6 so it will skip longer lines
         buf.put_slice(b"1234567\n123456\n123412314\n123");
 
-        assert!(codec.decode(buf).unwrap().is_none());
-        assert!(codec.decode(buf).unwrap().is_some());
-        assert!(codec.decode_eof(buf).unwrap().is_none());
-        assert!(codec.decode_eof(buf).unwrap().is_some());
+        assert_eq!(codec.decode(buf).unwrap(), Some(Bytes::from("123456")));
+        assert_eq!(codec.decode(buf).unwrap(), None);
+
+        let buf = &mut BytesMut::new();
+
+        buf.reserve(200);
+        // limit is 6 so it will skip longer lines
+        buf.put_slice(b"1234567\n123456\n123412314\n123");
+
+        assert_eq!(codec.decode_eof(buf).unwrap(), Some(Bytes::from("123456")));
+        assert_eq!(codec.decode_eof(buf).unwrap(), Some(Bytes::from("123")));
     }
 
     // Regression test for [infinite loop bug](https://github.com/timberio/vector/issues/2564)

--- a/src/codecs/framing/newline_delimited.rs
+++ b/src/codecs/framing/newline_delimited.rs
@@ -135,6 +135,7 @@ mod tests {
 
         assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "foo");
         assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "baz");
+        assert_eq!(decoder.decode(&mut input).unwrap(), None);
     }
 
     #[test]

--- a/src/codecs/framing/newline_delimited.rs
+++ b/src/codecs/framing/newline_delimited.rs
@@ -134,9 +134,7 @@ mod tests {
         let mut decoder = NewlineDelimitedDecoder::new_with_max_length(3);
 
         assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "foo");
-        assert_eq!(decoder.decode(&mut input).unwrap(), None);
         assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "baz");
-        assert_eq!(decoder.decode(&mut input).unwrap(), None);
     }
 
     #[test]
@@ -166,7 +164,6 @@ mod tests {
         let mut decoder = NewlineDelimitedDecoder::new_with_max_length(3);
 
         assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "foo");
-        assert_eq!(decoder.decode_eof(&mut input).unwrap(), None);
         assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "baz");
         assert_eq!(decoder.decode_eof(&mut input).unwrap(), None);
     }


### PR DESCRIPTION
Previously it would return `Ok(None)` when a frame longer than
`max_length` was encountered, but the `tokio_codec::Decoder#decode` trait method specifies:

> If an entire frame is available, then this instance will remove those bytes from the buffer provided and return them as a decoded frame. Note that removing bytes from the provided buffer doesn't always necessarily copy the bytes, so this should be an efficient operation in most circumstances.
>
> If the bytes look valid, but a frame isn't fully available yet, then Ok(None) is returned. This indicates to the Framed instance that it needs to read some more bytes before calling this method again.
>
> Note that the bytes provided may be empty. If a previous call to decode consumed all the bytes in the buffer then decode will be called again until it returns Ok(None), indicating that more bytes need to be read.

That is, it should only return `Ok(None)` if it hit the end of the
buffer without reading a full frame.

As a reference, consider the implementation of `tokio_codec::LinesCodec`
which, when discarding, discards until it can find the next frame before
returning (granted it behaves slightly differently by returning an
error, first, when it hits a line that is too long where we just warn).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
