### PR TITLE
chore: Convert delimiter to byte

### DIFF
--- a/benches/codecs/character_delimited_bytes.rs
+++ b/benches/codecs/character_delimited_bytes.rs
@@ -47,8 +47,8 @@ fn decoding(c: &mut Criterion) {
                         let framer = Box::new(
                             param
                                 .max_length
-                                .map(|ml| CharacterDelimitedDecoder::new_with_max_length('a', ml))
-                                .unwrap_or(CharacterDelimitedDecoder::new('a')),
+                                .map(|ml| CharacterDelimitedDecoder::new_with_max_length(b'a', ml))
+                                .unwrap_or(CharacterDelimitedDecoder::new(b'a')),
                         );
                         let deserializer = Box::new(BytesDeserializer::new());
                         let decoder = codecs::Decoder::new(framer, deserializer);

--- a/benches/languages.rs
+++ b/benches/languages.rs
@@ -331,7 +331,7 @@ fn benchmark_configs(
                     config.push_str(&transform_config);
                     config.push_str(&sink_config);
 
-                    let config = config::load_from_str(&config, Some(config::Format::Toml))
+                    let config = config::load_from_str(&config, config::Format::Toml)
                         .expect(&format!("invalid TOML configuration: {}", &config));
                     let rt = runtime();
                     let (output_lines, topology) = rt.block_on(async move {

--- a/src/codecs/framing/newline_delimited.rs
+++ b/src/codecs/framing/newline_delimited.rs
@@ -71,7 +71,7 @@ pub struct NewlineDelimitedDecoder(CharacterDelimitedDecoder);
 impl NewlineDelimitedDecoder {
     /// Creates a new `NewlineDelimitedDecoder`.
     pub const fn new() -> Self {
-        Self(CharacterDelimitedDecoder::new('\n'))
+        Self(CharacterDelimitedDecoder::new(b'\n'))
     }
 
     /// Creates a `NewlineDelimitedDecoder` with a maximum frame length limit.
@@ -79,7 +79,7 @@ impl NewlineDelimitedDecoder {
     /// Any frames longer than `max_length` bytes will be discarded entirely.
     pub const fn new_with_max_length(max_length: usize) -> Self {
         Self(CharacterDelimitedDecoder::new_with_max_length(
-            '\n', max_length,
+            b'\n', max_length,
         ))
     }
 }

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -429,7 +429,7 @@ impl IngestorProcess {
                 // the case that the same vector instance processes the same message.
                 let mut read_error = None;
                 let lines: Box<dyn Stream<Item = Bytes> + Send + Unpin> = Box::new(
-                    FramedRead::new(object_reader, CharacterDelimitedDecoder::new('\n'))
+                    FramedRead::new(object_reader, CharacterDelimitedDecoder::new(b'\n'))
                         .map(|res| {
                             res.map_err(|err| {
                                 read_error = Some(err);

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -426,7 +426,7 @@ fn start_journalctl(
 
     let stream = FramedRead::new(
         child.stdout.take().unwrap(),
-        CharacterDelimitedDecoder::new('\n'),
+        CharacterDelimitedDecoder::new(b'\n'),
     )
     .boxed();
 


### PR DESCRIPTION
This commit converts the delimiter to byte from char. In some instances a char
can be multi-bytes wide, meaning that it's possible for the current algorithm to
split a delimiter as it forwards in the underlying buffer. The implementation
assumes that we want single-byte delimiters, which is now the case.

Resolves #10569

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
