### PR TITLE
docs(codecs): Document that character delimited codec only accepts a byte

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -444,6 +444,7 @@ _values: {
 	{"float": #TypeFloat & {_args: required: Args.required}} |
 	{"object": #TypeObject & {_args: required: Args.required}} |
 	{"string": #TypeString & {_args: required: Args.required}} |
+	{"ascii_char": #TypeAsciiChar & {_args: required: Args.required}} |
 	{"timestamp": #TypeTimestamp & {_args: required: Args.required}} |
 	{"uint": #TypeUint & {_args: required: Args.required}}
 }
@@ -531,6 +532,18 @@ _values: {
 	}
 
 	syntax: *"literal" | "file_system_path" | "field_path" | "template" | "regex" | "remap_program" | "strftime"
+}
+
+#TypeAsciiChar: {
+	_args: required: bool
+	let Args = _args
+
+	if !Args.required {
+		// `default` sets the default value.
+		default: string | null
+	}
+
+	examples?: [string, ...string]
 }
 
 #TypeTimestamp: {

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -100,7 +100,7 @@ components: sources: [Name=string]: {
 								delimiter: {
 									description: "The character used to separate frames."
 									required:    true
-									type: string: {
+									type: ascii_char: {
 										examples: ["\n", "\t"]
 									}
 								}


### PR DESCRIPTION
Companion PR to https://github.com/vectordotdev/vector/pull/10570 which
updates the framing implementation to only accept a byte rather than
a, possibly, multi-byte character.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
