### PR TITLE
fix(ci): Test additional bench suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ target/%/vector.tar.gz: target/%/vector CARGO_HANDLES_FRESHNESS
 
 .PHONY: test
 test: ## Run the unit test suite
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE}
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches codecs-benches language-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE}
 
 .PHONY: test-all
 test-all: test test-behavior test-integration ## Runs all tests, unit, behaviorial, and integration.

--- a/benches/languages.rs
+++ b/benches/languages.rs
@@ -140,6 +140,7 @@ fn benchmark_parse_syslog(c: &mut Criterion) {
                   types.level = "string"
                   types.message = "string"
                   types.msgid = "string"
+                  types.version = "int"
                   types.procid = "int"
                   types.timestamp = "timestamp|%Y-%m-%dT%H:%M:%S%.fZ"
             "#},

--- a/benches/languages.rs
+++ b/benches/languages.rs
@@ -157,7 +157,7 @@ fn benchmark_parse_syslog(c: &mut Criterion) {
                     local pattern = "^<(%d+)>(%d+) (%S+) (%S+) (%S+) (%S+) (%S+) (%S+) (.+)$"
                     local priority, version, timestamp, hostname, appname, procid, msgid, sdata, message = string.match(message, pattern)
 
-                    return {priority = priority, version = version, timestamp = timestamp, hostname = hostname, appname = appname, procid = tonumber(procid), msgid = msgid, sdata = sdata, message = message}
+                    return {priority = priority, version = tonumber(version), timestamp = timestamp, hostname = hostname, appname = appname, procid = tonumber(procid), msgid = msgid, sdata = sdata, message = message}
                   end
 
                   function process(event, emit)


### PR DESCRIPTION
Previously `language` was excluded because it required WASM which caused
other tests to fail on OSX, but we dropped WASM support so we can test
the rest. The `codecs` benches are new.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
