### PR TITLE
fix(ci): Enable std feature for tracing-subscriber

### DIFF
--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -51,7 +51,7 @@ tower = { version = "0.4", default-features = false, features = ["util"] }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.21", default-features = false }
 tracing-log = { version = "0.1.2", default-features = false }
-tracing-subscriber = { version = "0.3.4", default-features = false }
+tracing-subscriber = { version = "0.3.4", default-features = false, features = ["std"] }
 typetag = { version = "0.1.8", default-features = false }
 twox-hash = { version = "1.6.1", default-features = false }
 vrl-core = { package = "vrl", path = "../vrl/core", optional = true }


### PR DESCRIPTION
Required for `extensions` method on `SpanRef`

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
