### PR TITLE
chore(ci): Bump minikube version for k8s e2e tests

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -99,7 +99,7 @@ jobs:
           script: |
             // Parameters.
             const minikube_version = [
-              "v1.21.0",
+              "v1.24.0",
             ]
             const kubernetes_version = [
               { version: "v1.19.2", is_essential: true },


### PR DESCRIPTION
Isolating from https://github.com/vectordotdev/vector/pull/10567

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
