### PR TITLE
chore(ci): add tag to skip soak tests

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -34,6 +34,8 @@ jobs:
   compute-soak-meta:
     name: Compute metadata for soaks
     runs-on: ubuntu-20.04
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip soak tests')
     outputs:
       pr-number: ${{ steps.pr-metadata.outputs.PR_NUMBER }}
       comparison-sha: ${{ steps.comparison.outputs.COMPARISON_SHA }}


### PR DESCRIPTION
For PRs like #10464 or #10466, when the vector's source code itself doesn't change, it would be great to avoid using unnecessary computing resources to run the soak tests. This PR introduce a way to skip the soak tests.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>
