### PR TITLE
fix(ci): Remove clean step from Windows nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -200,7 +200,6 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings -Ctarget-feature=+crt-static"
     steps:
-      - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v2.4.0
       - name: "Add Vector version"
         run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV


### PR DESCRIPTION
This action only supports Linux. We'll need to handle Windows
differently though, at least so far, we haven't run into disk space
issues there.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
