### PR TITLE
chore(releasing): Bump Cargo.toml version to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8234,7 +8234,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "approx",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"


### PR DESCRIPTION
Now that 0.19.0 is out

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
