### PR TITLE
docs: Escape \ more in 0.19.0 release changelog

### DIFF
--- a/website/cue/reference/releases/0.19.0.cue
+++ b/website/cue/reference/releases/0.19.0.cue
@@ -67,7 +67,7 @@ releases: "0.19.0": {
 			type: "enhancement"
 			scopes: ["vrl"]
 			description: """
-				VRL now allows for writing multi-line string literals by ending the line with a backslash (\\).
+				VRL now allows for writing multi-line string literals by ending the line with a backslash (\\\\).
 
 				Example:
 


### PR DESCRIPTION
Needs more escaping.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
