### PR TITLE
docs: Document deprecation of `token` for Splunk HEC sinks

### DIFF
--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -17,11 +17,17 @@ Vector's 0.19.0 release includes **breaking changes**:
 1. [Removal of deprecated configuration fields for the Elasticsearch sink: `host`](#elasticsearch-sink-deprecated-fields)
 1. [Removal of default for `version` field for Vector source and sink](#vector-version)
 
+And **deprecations**:
+
+1. [Splunk HEC sinks rename `token` to `default_token`](#splunk-hec-token)
+
 We cover them below to help you upgrade quickly:
 
 ## Upgrade guide
 
-### Removal of deprecated configuration fields for the Splunk HEC Logs sink: `host` {#splunk-hec-logs-sink-deprecated-fields}
+### Breaking changes
+
+#### Removal of deprecated configuration fields for the Splunk HEC Logs sink: `host` {#splunk-hec-logs-sink-deprecated-fields}
 
 We've removed a long deprecated configuration field from the Splunk HEC Logs
 sink: `host`.
@@ -36,7 +42,7 @@ You can migrate your configuration by switching to `endpoint` instead.
    ...
 ```
 
-### Updated internal metrics for the Splunk HEC sinks {#splunk-hec-sinks-metrics-update}
+#### Updated internal metrics for the Splunk HEC sinks {#splunk-hec-sinks-metrics-update}
 
 As part of moving towards more consistent Vector component instrumentation,
 we've updated the following internal metrics in the Splunk HEC sinks. For any
@@ -52,7 +58,7 @@ removed metric, we've added an equivalent alternative.
   - Previously, no metric was emitted when an encoding error occurred and an
     event was dropped.
 
-### Removal of deprecated configuration fields for the Elasticsearch sink {#elasticsearch-sink-deprecated-fields}
+#### Removal of deprecated configuration fields for the Elasticsearch sink {#elasticsearch-sink-deprecated-fields}
 
 | Deprecated Field   | New Field             |
 | -----------        | -----------           |
@@ -62,7 +68,7 @@ removed metric, we've added an equivalent alternative.
 | `index`            | `bulk.index`          |
 | `headers`          | `request.headers`     |
 
-### Removal of default for `version` field for Vector source and sink {#vector-version}
+#### Removal of default for `version` field for Vector source and sink {#vector-version}
 
 In the v0.16.0 release, we have [introduced a new `v2` version of the protocol][vector-v2-announcement] that the
 `vector` source and sink use to communicate. This new protocol offers a number of advantages over our initial `v1`
@@ -108,3 +114,22 @@ In a subsequent release we will begin defaulting to the `v2` protocol and eventu
 protocol.
 
 [vector-v2-announcement]: /highlights/2021-08-24-vector-source-sink
+
+### Deprecations
+
+#### Splunk HEC sinks rename `token` to `default_token` {#splunk-hec-token}
+
+The `token` configuration option on the `splunk_hec_logs` and
+`splunk_hec_metrics` sink has been deprecated in-lieu of the new `default_token`
+option which was added as part of support for Splunk HEC token pass-through.
+
+You can migrate your configuration by renaming `token` to  `default_token`:
+
+```diff
+ [sinks.splunk]
+   type = "splunk_hec_logs"
+   endpoint = "http://splunk-endpoint"
+-  token = "MY-TOKEN"
++  default_token = "MY-TOKEN"
+   ...
+```


### PR DESCRIPTION
This was renamed to `default_token`.

Closes: #10610

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
