### PR TITLE
docs: Add component outputs as structured cue data

### DIFF
--- a/website/content/en/blog/kubernetes-integration.md
+++ b/website/content/en/blog/kubernetes-integration.md
@@ -108,7 +108,7 @@ We want Vector to become the backbone of observability in Kubernetes. If you sha
 [arc]: /blog/adaptive-request-concurrency
 [chat]: https://chat.vector.dev
 [clickhouse]: /docs/reference/configuration/sinks/clickhouse
-[enriching]: /docs/reference/configuration/sources/kubernetes_logs/#output
+[enriching]: /docs/reference/configuration/sources/kubernetes_logs/#output-data
 [elasticsearch]: /docs/reference/configuration/sinks/elasticsearch
 [helm]: https://helm.sh
 [install]: /docs/setup/installation/platforms/kubernetes/#install

--- a/website/content/en/docs/administration/monitoring.md
+++ b/website/content/en/docs/administration/monitoring.md
@@ -121,7 +121,7 @@ IO and disrupting the service. The trade-off is that repetitive logs aren't logg
 [internal_metrics]: /docs/reference/configuration/sources/internal_metrics
 [journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 [journald_source]: /docs/reference/configuration/sources/journald
-[output]: /docs/reference/configuration/sources/internal_metrics/#output
+[output]: /docs/reference/configuration/sources/internal_metrics/#output-data
 [remap]: /docs/reference/configuration/transforms/remap
 [rfc_2064]: https://github.com/vectordotdev/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
 [sinks]: /sinks

--- a/website/content/en/docs/setup/installation/platforms/kubernetes.md
+++ b/website/content/en/docs/setup/installation/platforms/kubernetes.md
@@ -322,7 +322,7 @@ Vector is tested extensively against Kubernetes. In addition to Kubernetes being
 [kubernetes]: https://kubernetes.io
 [kubernetes_logs]: /docs/reference/configuration/sources/kubernetes_logs
 [kubernetes_logs_config]: /docs/reference/configuration/sources/kubernetes_logs/#configuration
-[kubernetes_logs_output]: /docs/reference/configuration/sources/kubernetes_logs#output
+[kubernetes_logs_output]: /docs/reference/configuration/sources/kubernetes_logs#output-data
 [kustomize]: https://kustomize.io
 [node]: https://kubernetes.io/docs/concepts/architecture/nodes
 [reduce]: /docs/reference/configuration/transforms/reduce

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -119,7 +119,7 @@ components: {
 		if Kind != "sink" {
 			// `output` documents output of the component. This is very important
 			// as it communicate which events and fields are emitted.
-			output: #Output
+			output: #OutputData
 		}
 
 		// `support` communicates the varying levels of support of the component.
@@ -439,7 +439,7 @@ components: {
 		default_namespace: string
 	}
 
-	#Output: {
+	#OutputData: {
 		logs?:    #LogOutput
 		metrics?: #MetricOutput
 	}

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -122,6 +122,10 @@ components: {
 			output: #OutputData
 		}
 
+		if Kind == "transform" {
+			outputs: #Outputs
+		}
+
 		// `support` communicates the varying levels of support of the component.
 		support: #Support & {_args: kind: Kind}
 
@@ -442,6 +446,21 @@ components: {
 	#OutputData: {
 		logs?:    #LogOutput
 		metrics?: #MetricOutput
+	}
+
+	#Output: {
+		name:        string
+		description: string
+	}
+
+	#Outputs: {
+		_default_output: #Output & {
+			name:        ""
+			description: "This component has a default output. You can use this component's ID as an input to downstream transforms and sinks."
+		}
+
+		default_output: *_default_output | #Output | null
+		named_outputs: [...#Output]
 	}
 
 	#IAM: {

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -456,7 +456,7 @@ components: {
 	#Outputs: {
 		_default_output: #Output & {
 			name:        ""
-			description: "This component has a default output. You can use this component's ID as an input to downstream transforms and sinks."
+			description: "Use this component's ID as an input to downstream transforms and sinks."
 		}
 
 		default_output: *_default_output | #Output | null

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -456,7 +456,7 @@ components: {
 	#Outputs: {
 		_default_output: #Output & {
 			name:        ""
-			description: "Use this component's ID as an input to downstream transforms and sinks."
+			description: "Default output stream of the component. Use this component's ID as an input to downstream transforms and sinks."
 		}
 
 		default_output: *_default_output | #Output | null

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -122,7 +122,7 @@ components: {
 			output: #OutputData
 		}
 
-		if Kind == "transform" {
+		if Kind != "sink" {
 			outputs: #Outputs
 		}
 
@@ -451,6 +451,7 @@ components: {
 	#Output: {
 		name:        string
 		description: string
+		data?:       #OutputData
 	}
 
 	_default_output: #Output & {

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -451,7 +451,6 @@ components: {
 	#Output: {
 		name:        string
 		description: string
-		data?:       #OutputData
 	}
 
 	_default_output: #Output & {

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -453,15 +453,12 @@ components: {
 		description: string
 	}
 
-	#Outputs: {
-		_default_output: #Output & {
-			name:        ""
-			description: "Default output stream of the component. Use this component's ID as an input to downstream transforms and sinks."
-		}
-
-		default_output: *_default_output | #Output | null
-		named_outputs: [...#Output]
+	_default_output: #Output & {
+		name:        "<component_id>"
+		description: "Default output stream of the component. Use this component's ID as an input to downstream transforms and sinks."
 	}
+
+	#Outputs: *[_default_output] | [#Output, ...#Output]
 
 	#IAM: {
 		#Policy: {

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -472,7 +472,7 @@ components: sources: kubernetes_logs: {
 			body:  """
 					Vector will enrich data with Kubernetes context. A comprehensive
 					list of fields can be found in the
-					[`kubernetes_logs` source output docs](\(urls.vector_kubernetes_logs_source)#output).
+					[`kubernetes_logs` source output docs](\(urls.vector_kubernetes_logs_source)#output-data).
 					"""
 		}
 

--- a/website/cue/reference/components/transforms/geoip.cue
+++ b/website/cue/reference/components/transforms/geoip.cue
@@ -52,7 +52,7 @@ components: transforms: geoip: {
 		}
 		target: {
 			common:      true
-			description: "The default field to insert the resulting GeoIP data into. See [output](#output) for more info."
+			description: "The default field to insert the resulting GeoIP data into. See [output](#output-data) for more info."
 			required:    false
 			type: string: {
 				default: "geoip"

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -8,15 +8,6 @@ components: transforms: "remap": {
 		[Vector Remap Language](\(urls.vrl_reference)) (VRL), an expression-oriented language designed for processing
 		observability data (logs and metrics) in a safe and performant manner.
 
-		This transform also implements an additional `dropped` output. When the
-		`drop_on_error` or `drop_on_abort` configuration values are set to `true`
-		and `reroute_dropped` is also set to `true`, events that result in runtime
-		errors or aborts will be dropped from the default output stream and sent to
-		the `dropped` output instead. For a transform component named `foo`, this
-		output can be accessed by specifying `foo.dropped` as the input to another
-		component. Events sent to this output will be in their original form,
-		omitting any partial modification that took place before the error or abort.
-
 		Please refer to the [VRL reference](\(urls.vrl_reference)) when writing VRL scripts.
 		"""
 
@@ -214,6 +205,24 @@ components: transforms: "remap": {
 				```
 				"""#
 		}
+	}
+
+	outputs: {
+		named_outputs: [
+			{
+				name: "dropped"
+				description: """
+					This transform also implements an additional `dropped` output. When the
+					`drop_on_error` or `drop_on_abort` configuration values are set to `true`
+					and `reroute_dropped` is also set to `true`, events that result in runtime
+					errors or aborts will be dropped from the default output stream and sent to
+					the `dropped` output instead. For a transform component named `foo`, this
+					output can be accessed by specifying `foo.dropped` as the input to another
+					component. Events sent to this output will be in their original form,
+					omitting any partial modification that took place before the error or abort.
+					"""
+			},
+		]
 	}
 
 	telemetry: metrics: {

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -207,23 +207,22 @@ components: transforms: "remap": {
 		}
 	}
 
-	outputs: {
-		named_outputs: [
-			{
-				name: "dropped"
-				description: """
-					This transform also implements an additional `dropped` output. When the
-					`drop_on_error` or `drop_on_abort` configuration values are set to `true`
-					and `reroute_dropped` is also set to `true`, events that result in runtime
-					errors or aborts will be dropped from the default output stream and sent to
-					the `dropped` output instead. For a transform component named `foo`, this
-					output can be accessed by specifying `foo.dropped` as the input to another
-					component. Events sent to this output will be in their original form,
-					omitting any partial modification that took place before the error or abort.
-					"""
-			},
-		]
-	}
+	outputs: [
+		components._default_output,
+		{
+			name: "dropped"
+			description: """
+				This transform also implements an additional `dropped` output. When the
+				`drop_on_error` or `drop_on_abort` configuration values are set to `true`
+				and `reroute_dropped` is also set to `true`, events that result in runtime
+				errors or aborts will be dropped from the default output stream and sent to
+				the `dropped` output instead. For a transform component named `foo`, this
+				output can be accessed by specifying `foo.dropped` as the input to another
+				component. Events sent to this output will be in their original form,
+				omitting any partial modification that took place before the error or abort.
+				"""
+		},
+	]
 
 	telemetry: metrics: {
 		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total

--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -110,6 +110,16 @@ components: transforms: route: {
 		},
 	]
 
+	outputs: {
+		default_output: null
+		named_outputs: [
+			{
+				name:        "<route_id>"
+				description: "Each route can be referenced as an input by other components with the name <transform_name>.<route_id>."
+			},
+		]
+	}
+
 	telemetry: metrics: {
 		events_discarded_total: components.sources.internal_metrics.output.metrics.events_discarded_total
 	}

--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -110,15 +110,12 @@ components: transforms: route: {
 		},
 	]
 
-	outputs: {
-		default_output: null
-		named_outputs: [
-			{
-				name:        "<route_id>"
-				description: "Each route can be referenced as an input by other components with the name <transform_name>.<route_id>."
-			},
-		]
-	}
+	outputs: [
+		{
+			name:        "<route_id>"
+			description: "Each route can be referenced as an input by other components with the name `<transform_name>.<route_id>`."
+		},
+	]
 
 	telemetry: metrics: {
 		events_discarded_total: components.sources.internal_metrics.output.metrics.events_discarded_total

--- a/website/layouts/docs/component.html
+++ b/website/layouts/docs/component.html
@@ -82,7 +82,7 @@
 
           {{/* Component log/metric output */}}
           {{ with $config.output }}
-          {{ partial "heading.html" (dict "text" "Output" "level" 2) }}
+          {{ partial "heading.html" (dict "text" "Output Data" "level" 2) }}
           {{ partial "data.html" (dict "component_output" . ) }}
           {{ end }}
 

--- a/website/layouts/docs/component.html
+++ b/website/layouts/docs/component.html
@@ -80,6 +80,12 @@
           {{ partial "data.html" (dict "component_env_vars" . ) }}
           {{ end }}
 
+          {{/* Component outputs */}}
+          {{ with $config.outputs }}
+          {{ partial "heading.html" (dict "text" "Outputs" "level" 2) }}
+          {{ partial "data.html" (dict "component_outputs" . ) }}
+          {{ end }}
+
           {{/* Component log/metric output */}}
           {{ with $config.output }}
           {{ partial "heading.html" (dict "text" "Output Data" "level" 2) }}

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -300,6 +300,42 @@
   </div>
   {{ end }}
 
+  {{/* Transform outputs */}}
+  {{ with .component_outputs }}
+  <div class="py-4 px-6">
+    {{ with .default_output }}
+      <span>
+        {{ partial "heading.html" (dict "text" "Default Output" "level" 3 "id" "outputs-default-output" "href" "#outputs-default-output") }}
+      </span>
+      <div class="mt-3 border rounded divide-y dark:border-gray-700 dark:divide-gray-700">
+        <div class="py-3 px-5">
+          <div class="my-3 prose dark:prose-dark max-w-none">
+            {{ .description | markdownify }}
+          </div>
+        </div>
+      </div>
+    {{ end }}
+
+    {{ with .named_outputs }}
+      <span>
+        {{ partial "heading.html" (dict "text" "Named Outputs" "level" 3 "id" "outputs-named-outputs" "href" "#outputs-named-outputs") }}
+      </span>
+      <div class="mt-3 border rounded divide-y dark:border-gray-700 dark:divide-gray-700">
+          {{ range . }}
+          <div class="py-3 px-5">
+                <span>
+                  {{ partial "heading.html" (dict "text" .name "level" 4) }}
+                </span>
+                <div class="my-3 prose dark:prose-dark max-w-none">
+                  {{ .description | markdownify }}
+                </div>
+          </div>
+          {{ end }}
+      </div>
+    {{ end }}
+  </div>
+  {{ end }}
+
   {{/* Source/transform/sink examples */}}
   {{ with .component_examples }}
   {{ $formats := slice "toml" "yaml" "json" }}

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -300,40 +300,23 @@
   </div>
   {{ end }}
 
-  {{/* Transform outputs */}}
+  {{/* Source/transform outputs */}}
   {{ with .component_outputs }}
-  <div class="py-4 px-6">
-    {{ with .default_output }}
-      <span>
-        {{ partial "heading.html" (dict "text" "Default Output" "level" 3 "id" "outputs-default-output" "href" "#outputs-default-output") }}
-      </span>
-      <div class="mt-3 border rounded divide-y dark:border-gray-700 dark:divide-gray-700">
-        <div class="py-3 px-5">
-          <div class="my-3 prose dark:prose-dark max-w-none">
-            {{ .description | markdownify }}
-          </div>
+    <div class="flex flex-col divide-y dark:divide-gray-700">
+      {{ range . }}
+      <div class="py-3 px-5">
+        <span class="flex justify-between items-center">
+          <span class="font-mono">
+            {{ partial "heading.html" (dict "text" .name "level" 3 "anchor" true "icon" false) }}
+          </span>
+        </span>
+
+        <div class="my-3 prose dark:prose-dark max-w-none">
+          {{ .description | markdownify }}
         </div>
       </div>
-    {{ end }}
-
-    {{ with .named_outputs }}
-      <span>
-        {{ partial "heading.html" (dict "text" "Named Outputs" "level" 3 "id" "outputs-named-outputs" "href" "#outputs-named-outputs") }}
-      </span>
-      <div class="mt-3 border rounded divide-y dark:border-gray-700 dark:divide-gray-700">
-          {{ range . }}
-          <div class="py-3 px-5">
-                <span>
-                  {{ partial "heading.html" (dict "text" .name "level" 4) }}
-                </span>
-                <div class="my-3 prose dark:prose-dark max-w-none">
-                  {{ .description | markdownify }}
-                </div>
-          </div>
-          {{ end }}
+      {{ end }}
       </div>
-    {{ end }}
-  </div>
   {{ end }}
 
   {{/* Source/transform/sink examples */}}


### PR DESCRIPTION
Closes #10615

This PR adds support for documenting named outputs for transforms in `cue`. Namely, we capture the notion of a `default_output` (for the majority of transforms) and `named_outputs` (for  `remap`, `route`). The `default_output` can be empty for transforms like `route`.
- Renamed `Output` section to `Output Data` for clarity
- Included some minor frontend changes to render this new data but happy to revert these changes and save them for later. I was mainly curious to make sure everything was working end-to-end, so it's not terribly pretty.