### PR TITLE
chore(ci): refactor makefile integration tests command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,10 +375,6 @@ test-integration-datadog-agent: ## Runs Datadog Agent integration tests
 	test $(shell printenv | grep CI_TEST_DATADOG_API_KEY | wc -l) -gt 0 || exit 1 # make sure the environment is available
 	RUST_VERSION=${RUST_VERSION} ${CONTAINER_TOOL}-compose -f scripts/integration/docker-compose.datadog-agent.yml run runner
 
-.PHONY: test-integration-datadog-agent-cleanup
-test-integration-datadog-agent-cleanup:
-	${CONTAINER_TOOL}-compose -f scripts/integration/docker-compose.datadog-agent.yml rm -fsv
-
 .PHONY: test-integration-datadog-metrics
 test-integration-datadog-metrics: ## Runs Datadog metrics integration tests
 	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features datadog-metrics-integration-tests --lib ::datadog::metrics::
@@ -553,14 +549,6 @@ ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh pulsar stop
 endif
 
-.PHONY: test-integration-redis
-test-integration-redis: ## Runs Redis integration tests
-	RUST_VERSION=${RUST_VERSION} ${CONTAINER_TOOL}-compose -f scripts/integration/docker-compose.redis.yml run --rm runner
-
-.PHONY: test-integration-redis-cleanup
-test-integration-redis-cleanup:
-	${CONTAINER_TOOL}-compose -f scripts/integration/docker-compose.redis.yml rm -fsv
-
 .PHONY: test-integration-splunk
 test-integration-splunk: ## Runs Splunk integration tests
 ifeq ($(AUTOSPAWN), true)
@@ -582,6 +570,15 @@ endif
 ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh dnstap stop
 endif
+
+test-integration-%:
+	RUST_VERSION=${RUST_VERSION} ${CONTAINER_TOOL}-compose -f scripts/integration/docker-compose.$*.yml run --rm runner
+ifeq ($(AUTODESPAWN), true)
+	make test-integration-$*-cleanup
+endif
+
+test-integration-%-cleanup:
+	${CONTAINER_TOOL}-compose -f scripts/integration/docker-compose.$*.yml rm -fsv
 
 .PHONY: test-e2e-kubernetes
 test-e2e-kubernetes: ## Runs Kubernetes E2E tests (Sorry, no `ENVIRONMENT=true` support)


### PR DESCRIPTION
Following [this request](https://github.com/vectordotdev/vector/pull/10601#issuecomment-1002662184) from @jszwedko to add `AUTODESPAWN` back and refactoring the makefile to remove duplication for integration tests.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
