### PR TITLE
fix(remap): fix alias resolution for `parse_groks` function

### DIFF
--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -418,7 +418,7 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             format!("{}", err),
-            "Circular dependency found in the alias 'pattern1'"
+            "Circular dependency found in the alias 'pattern2'"
         );
     }
 
@@ -785,5 +785,26 @@ mod tests {
                 Ok(Value::from(btreemap! {})),
             ),
         ]);
+    }
+
+    #[test]
+    fn alias_and_main_rule_extract_same_fields_to_array() {
+        let rules = parse_grok_rules(
+            // patterns
+            &[r#"%{notSpace:field:number} %{alias}"#.to_string()],
+            // aliases
+            btreemap! {
+                "alias" => r#"%{notSpace:field:integer}"#.to_string()
+            },
+        )
+        .expect("couldn't parse rules");
+        let parsed = parse_grok("1 2", &rules, false).unwrap();
+
+        assert_eq!(
+            parsed,
+            Value::from(btreemap! {
+                 "field" =>  Value::Array(vec![1.0.into(), 2.into()]),
+            })
+        );
     }
 }


### PR DESCRIPTION
Fixing the case when a pattern contains an alias which extracts the same field. An expected output - this field should be an array with all extracted value.
This PR also contains some refactoring around alias resolution to simplify the fix - first we recursively resolve all references in aliases and then use resolved alias definitions to parse patterns.
For example,
```
parse_groks("1 2", 
  patterns: ["%{notSpace:field:number} %{alias}"] 
  aliases: {
   "alias": %{notSpace:field:integer}
  }
)
```
=> { "field": [1.0, 2] }