### PR TITLE
fix(tests): increase year in docs

### DIFF
--- a/lib/vrl/stdlib/src/parse_klog.rs
+++ b/lib/vrl/stdlib/src/parse_klog.rs
@@ -40,7 +40,7 @@ impl Function for ParseKlog {
                     "level": "info",
                     "line": 70,
                     "message": "hello from klog",
-                    "timestamp": "2021-05-05T17:59:40.692994Z"
+                    "timestamp": "2022-05-05T17:59:40.692994Z"
                 }"#}),
         }]
     }

--- a/lib/vrl/stdlib/src/parse_linux_authorization.rs
+++ b/lib/vrl/stdlib/src/parse_linux_authorization.rs
@@ -28,7 +28,7 @@ impl Function for ParseLinuxAuthorization {
                 "hostname": "localhost",
                 "message": "Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar",
                 "procid": 1111,
-                "timestamp": "2021-03-23T01:49:58Z"
+                "timestamp": "2022-03-23T01:49:58Z"
             }"#}),
         }]
     }

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -257,7 +257,7 @@ mod tests {
                 "facility" => "local0",
                 "hostname" => "master",
                 "severity" => "err",
-                "timestamp" => chrono::Utc.ymd(2021, 6, 8).and_hms_milli(11, 54, 8, 0),
+                "timestamp" => chrono::Utc.ymd(chrono::Utc::now().year(), 6, 8).and_hms_milli(11, 54, 8, 0),
                 "message" => "[Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message",
             }),
             tdef: TypeDef::new().fallible().object(type_def()),

--- a/website/cue/reference/remap/functions/parse_klog.cue
+++ b/website/cue/reference/remap/functions/parse_klog.cue
@@ -29,7 +29,7 @@ remap: functions: parse_klog: {
 				level:     "info"
 				line:      70
 				message:   "hello from klog"
-				timestamp: "2021-05-05T17:59:40.692994Z"
+				timestamp: "2022-05-05T17:59:40.692994Z"
 			}
 		},
 	]

--- a/website/cue/reference/remap/functions/parse_linux_authorization.cue
+++ b/website/cue/reference/remap/functions/parse_linux_authorization.cue
@@ -39,7 +39,7 @@ remap: functions: parse_linux_authorization: {
 				hostname:  "localhost"
 				message:   "Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar"
 				procid:    1111
-				timestamp: "2021-03-23T01:49:58Z"
+				timestamp: "2022-03-23T01:49:58Z"
 			}
 		},
 	]


### PR DESCRIPTION
This PR fixes the [new year](https://github.com/vectordotdev/vector/runs/4688623472?check_suite_focus=true) bug by increasing the year from 2021 to 2022 in static strings.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>
