### PR TITLE
docs(internal docs): Update component spec for multiple outputs

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -167,6 +167,9 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
 * Properties
   * `count` - The count of Vector events.
   * `byte_size` - The cumulative in-memory byte size of all events sent.
+  * `output` - For components with multiple outputs, the name of the output that
+    events were sent to. For example, the `remap` transform has an additional
+    `dropped` output.
 * Metrics
   * MUST increment the `component_sent_events_total` counter by the defined value with the
     defined properties as metric tags.


### PR DESCRIPTION
Adds an `output` property to the `EventsSent` event for components with multiple possible outputs. Relevant metrics can then be tagged with the appropriate output.