### PR TITLE
chore(route transform): Use multiple outputs for route

### DIFF
--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -374,11 +374,17 @@ async fn build_unit_test(
         .collect();
 
     // Sanitize the inputs of all relevant transforms
+    let graph = Graph::new_unchecked(
+        &config_builder.sources,
+        &config_builder.transforms,
+        &config_builder.sinks,
+    );
+    let valid_inputs = graph.input_map()?;
     for (_, transform) in config_builder.transforms.iter_mut() {
         let inputs = std::mem::take(&mut transform.inputs);
         transform.inputs = inputs
             .into_iter()
-            .filter(|input| valid_components.contains(input))
+            .filter(|input| valid_inputs.contains_key(input))
             .collect::<Vec<_>>();
     }
 

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use vector_core::transform::SyncTransform;
 
 use crate::{
     conditions::{AnyCondition, Condition},
@@ -67,6 +68,23 @@ impl FunctionTransform for Lane {
 
 //------------------------------------------------------------------------------
 
+#[derive(Clone)]
+pub struct Route;
+
+impl Route {
+    pub fn new(config: &RouteConfig, context: &TransformContext) -> Self {
+        Self
+    }
+}
+
+impl SyncTransform for Route {
+    fn transform(&mut self, event: Event, output: &mut vector_core::transform::TransformOutputsBuf) {
+        todo!()
+    }
+}
+
+//------------------------------------------------------------------------------
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct RouteConfig {
@@ -95,8 +113,9 @@ impl GenerateConfig for RouteConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "route")]
 impl TransformConfig for RouteConfig {
-    async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Err("this transform must be expanded".into())
+    async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
+        let route = Route::new(self, context);
+        Ok(Transform::synchronous(route))
     }
 
     fn input_type(&self) -> DataType {

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -5,8 +5,7 @@ use vector_core::transform::SyncTransform;
 use crate::{
     conditions::{AnyCondition, Condition},
     config::{
-        DataType, ExpandType, GenerateConfig, Output, TransformConfig, TransformContext,
-        TransformDescription,
+        DataType, GenerateConfig, Output, TransformConfig, TransformContext, TransformDescription,
     },
     event::Event,
     internal_events::RouteEventDiscarded,

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -109,12 +109,6 @@ impl TransformConfig for RouteCompatConfig {
         self.0.build(context).await
     }
 
-    fn expand(
-        &mut self,
-    ) -> crate::Result<Option<(IndexMap<String, Box<dyn TransformConfig>>, ExpandType)>> {
-        self.0.expand()
-    }
-
     fn input_type(&self) -> DataType {
         self.0.input_type()
     }

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -99,33 +99,15 @@ impl TransformConfig for RouteConfig {
         Err("this transform must be expanded".into())
     }
 
-    fn expand(
-        &mut self,
-    ) -> crate::Result<Option<(IndexMap<String, Box<dyn TransformConfig>>, ExpandType)>> {
-        let mut map: IndexMap<String, Box<dyn TransformConfig>> = IndexMap::new();
-
-        while let Some((k, v)) = self.route.pop() {
-            if map
-                .insert(k.clone(), Box::new(LaneConfig { condition: v }))
-                .is_some()
-            {
-                return Err("duplicate route id".into());
-            }
-        }
-
-        if !map.is_empty() {
-            Ok(Some((map, ExpandType::Parallel { aggregates: false })))
-        } else {
-            Err("must specify at least one lane".into())
-        }
-    }
-
     fn input_type(&self) -> DataType {
         DataType::Any
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Any)]
+        self.route
+            .keys()
+            .map(|output_name| Output::from((output_name, DataType::Any)))
+            .collect()
     }
 
     fn transform_type(&self) -> &'static str {


### PR DESCRIPTION
This PR refactors `route` to use the new system of multiple outputs rather than macro expansion.

Based off #10640 