### PR TITLE
fix(graphql api): Fix GraphQL Playground (and root) route

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -91,16 +91,13 @@ fn make_routes(playground: bool, watch_tx: topology::WatchRx) -> BoxedFilter<(im
     // Handle GraphQL queries. Headers will first be parsed to determine whether the query is
     // a subscription and if so, an attempt will be made to upgrade the connection to WebSockets.
     // All other queries will fall back to the default HTTP handler.
-    let graphql_handler =
-        warp::path("graphql")
-            .and(graphql_subscription_handler)
-            .or(
-                async_graphql_warp::graphql(schema::build_schema().finish()).and_then(
-                    |(schema, request): (Schema<_, _, _>, Request)| async move {
-                        Ok::<_, Infallible>(GraphQLResponse::from(schema.execute(request).await))
-                    },
-                ),
-            );
+    let graphql_handler = warp::path("graphql").and(graphql_subscription_handler.or(
+        async_graphql_warp::graphql(schema::build_schema().finish()).and_then(
+            |(schema, request): (Schema<_, _, _>, Request)| async move {
+                Ok::<_, Infallible>(GraphQLResponse::from(schema.execute(request).await))
+            },
+        ),
+    ));
 
     // Provide a playground for executing GraphQL queries/mutations/subscriptions.
     let graphql_playground = if playground {


### PR DESCRIPTION
Fixes a bug in API routing, where a Warp `.or()` condition intended to distinguish WebSocket from vanilla POST queries was wrongly attached to the outer path, causing it to fall back to GraphQL handling in all cases.

This knocked out the playground, and wrongly made `/` (as well as `/graphql`) an endpoint for GraphQL queries.

I'm posting this as a quick fix to unblock the playground. In a follow-up, I'll add tests to check that all routes are working as intended. Tracking in #10742.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
