### PR TITLE
chore(performance): Compare `onig` perf in the `datadog_search` filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,7 +1829,8 @@ version = "0.1.0"
 dependencies = [
  "datadog-search-syntax",
  "dyn-clone",
- "regex",
+ "onig",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/lib/datadog/filter/Cargo.toml
+++ b/lib/datadog/filter/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 [dependencies]
 datadog-search-syntax = { path = "../search-syntax" }
 
-regex = "1"
+onig = "6.3.1"
+regex-syntax = "0.6.25"
 dyn-clone = { version = "1.0.4", default-features = false }

--- a/lib/datadog/filter/src/regex.rs
+++ b/lib/datadog/filter/src/regex.rs
@@ -1,19 +1,14 @@
-use regex::Regex;
+use onig::Regex;
+use regex_syntax::escape;
 
 /// Returns compiled word boundary regex.
 pub fn word_regex(to_match: &str) -> Regex {
-    Regex::new(&format!(
-        r#"\b{}\b"#,
-        regex::escape(to_match).replace("\\*", ".*")
-    ))
-    .expect("invalid wildcard regex")
+    Regex::new(&format!(r#"\b{}\b"#, escape(to_match).replace("\\*", ".*")))
+        .expect("invalid wildcard regex")
 }
 
 /// Returns compiled wildcard regex.
 pub fn wildcard_regex(to_match: &str) -> Regex {
-    Regex::new(&format!(
-        "^{}$",
-        regex::escape(to_match).replace("\\*", ".*")
-    ))
-    .expect("invalid wildcard regex")
+    Regex::new(&format!("^{}$", escape(to_match).replace("\\*", ".*")))
+        .expect("invalid wildcard regex")
 }


### PR DESCRIPTION
**⚠️ Experimental.**

Experiment to see how [onig](https://github.com/rust-onig/rust-onig) compares with the Rust [regex](lihttps://github.com/rust-lang/regex) lib as it relates to `datadog_search` filtering performance.

One difference worth noting is that `onig::Regex` isn't `Clone` (unlike `regex::Regex`). This prevents moving this into the Datadog Search Syntax `Run` matcher, since the closure it takes must be `Send + Sync + Clone`.

To work around that in this experiment, I've wrapped in a `std::sync::Arc`. This clones the wrapper (and increases the ref count) but carries around a common regex pointer. 

This is making me wonder whether the boxed closure is actually being cloned somewhere unexpected. If that _is_ the case, then the current `regex::Regex` would also be cloned, which could be expensive.

There's nothing motivating this thought except that the current implementation allows for it, therefore it _could_ happen. I need to understand better how conditions are compiled and reused to assess whether this is relevant.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
