### PR TITLE
chore(performance): Assess performance of `wildmatch` for `datadog_search` condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
  "url",
  "webpki 0.21.4",
  "webpki-roots 0.19.0",
- "wildmatch",
+ "wildmatch 1.1.0",
 ]
 
 [[package]]
@@ -1830,6 +1830,7 @@ dependencies = [
  "datadog-search-syntax",
  "dyn-clone",
  "regex",
+ "wildmatch 2.1.0",
 ]
 
 [[package]]
@@ -8984,6 +8985,12 @@ name = "wildmatch"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
+
+[[package]]
+name = "wildmatch"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c48bd20df7e4ced539c12f570f937c6b4884928a87fee70a479d72f031d4e0"
 
 [[package]]
 name = "winapi"

--- a/lib/datadog/filter/Cargo.toml
+++ b/lib/datadog/filter/Cargo.toml
@@ -9,4 +9,5 @@ publish = false
 datadog-search-syntax = { path = "../search-syntax" }
 
 regex = "1"
+wildmatch = "2.1.0"
 dyn-clone = { version = "1.0.4", default-features = false }

--- a/lib/datadog/filter/src/regex.rs
+++ b/lib/datadog/filter/src/regex.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use wildmatch::WildMatch;
 
 /// Returns compiled word boundary regex.
 pub fn word_regex(to_match: &str) -> Regex {
@@ -10,10 +11,6 @@ pub fn word_regex(to_match: &str) -> Regex {
 }
 
 /// Returns compiled wildcard regex.
-pub fn wildcard_regex(to_match: &str) -> Regex {
-    Regex::new(&format!(
-        "^{}$",
-        regex::escape(to_match).replace("\\*", ".*")
-    ))
-    .expect("invalid wildcard regex")
+pub fn wildcard(to_match: &str) -> WildMatch {
+    WildMatch::new(to_match)
 }

--- a/lib/vector-datadog-filter/src/filter.rs
+++ b/lib/vector-datadog-filter/src/filter.rs
@@ -1,10 +1,7 @@
 use std::borrow::Cow;
 
 use bytes::Bytes;
-use datadog_filter::{
-    regex::{wildcard_regex, word_regex},
-    Filter, Matcher, Resolver, Run,
-};
+use datadog_filter::{regex, Filter, Matcher, Resolver, Run};
 use datadog_search_syntax::{Comparison, ComparisonValue, Field};
 use vector_core::event::{LogEvent, Value};
 
@@ -38,7 +35,7 @@ impl Filter<LogEvent> for EventFilter {
         match field {
             // Default fields are compared by word boundary.
             Field::Default(field) => {
-                let re = word_regex(to_match);
+                let re = regex::word_regex(to_match);
 
                 string_match(&field, move |value| re.is_match(&value))
             }
@@ -69,7 +66,7 @@ impl Filter<LogEvent> for EventFilter {
         match field {
             // Default fields are matched by word boundary.
             Field::Default(field) => {
-                let re = word_regex(&format!("{}*", prefix));
+                let re = regex::word_regex(&format!("{}*", prefix));
 
                 string_match(field, move |value| re.is_match(&value))
             }
@@ -91,19 +88,19 @@ impl Filter<LogEvent> for EventFilter {
     fn wildcard(&self, field: Field, wildcard: &str) -> Box<dyn Matcher<LogEvent>> {
         match field {
             Field::Default(field) => {
-                let re = word_regex(wildcard);
+                let re = regex::word_regex(wildcard);
 
                 string_match(field, move |value| re.is_match(&value))
             }
             Field::Tag(tag) => {
-                let re = wildcard_regex(&format!("{}:{}", tag, wildcard));
+                let re = regex::wildcard(&format!("{}:{}", tag, wildcard));
 
-                any_string_match("tags", move |value| re.is_match(&value))
+                any_string_match("tags", move |value| re.matches(&value))
             }
             Field::Reserved(field) | Field::Facet(field) => {
-                let re = wildcard_regex(wildcard);
+                let re = regex::wildcard(wildcard);
 
-                string_match(field, move |value| re.is_match(&value))
+                string_match(field, move |value| re.matches(&value))
             }
         }
     }

--- a/lib/vrl/stdlib/src/match_datadog_query.rs
+++ b/lib/vrl/stdlib/src/match_datadog_query.rs
@@ -1,10 +1,6 @@
 use std::borrow::Cow;
 
-use datadog_filter::{
-    build_matcher,
-    regex::{wildcard_regex, word_regex},
-    Filter, Matcher, Resolver, Run,
-};
+use datadog_filter::{build_matcher, regex, Filter, Matcher, Resolver, Run};
 use datadog_search_syntax::{parse, Comparison, ComparisonValue, Field};
 use lookup_lib::{parser::parse_lookup, LookupBuf};
 use vrl::prelude::*;
@@ -159,7 +155,7 @@ impl Filter<Value> for VrlFilter {
         match field {
             // Default fields are compared by word boundary.
             Field::Default(_) => {
-                let re = word_regex(to_match);
+                let re = regex::word_regex(to_match);
 
                 resolve_value(
                     buf,
@@ -213,7 +209,7 @@ impl Filter<Value> for VrlFilter {
         match field {
             // Default fields are matched by word boundary.
             Field::Default(_) => {
-                let re = word_regex(&format!("{}*", prefix));
+                let re = regex::word_regex(&format!("{}*", prefix));
 
                 resolve_value(
                     buf,
@@ -251,7 +247,7 @@ impl Filter<Value> for VrlFilter {
 
         match field {
             Field::Default(_) => {
-                let re = word_regex(wildcard);
+                let re = regex::word_regex(wildcard);
 
                 resolve_value(
                     buf,
@@ -259,22 +255,22 @@ impl Filter<Value> for VrlFilter {
                 )
             }
             Field::Tag(tag) => {
-                let re = wildcard_regex(&format!("{}:{}", tag, wildcard));
+                let re = regex::wildcard(&format!("{}:{}", tag, wildcard));
 
                 resolve_value(
                     buf,
                     Run::boxed(move |value| match value {
-                        Value::Array(v) => v.iter().any(|v| re.is_match(&string_value(v))),
+                        Value::Array(v) => v.iter().any(|v| re.matches(&string_value(v))),
                         _ => false,
                     }),
                 )
             }
             _ => {
-                let re = wildcard_regex(wildcard);
+                let re = regex::wildcard(wildcard);
 
                 resolve_value(
                     buf,
-                    Run::boxed(move |value| re.is_match(&string_value(value))),
+                    Run::boxed(move |value| re.matches(&string_value(value))),
                 )
             }
         }


### PR DESCRIPTION
**⚠️ Experimental.**

Trying out the [wildmatch](https://docs.rs/wildmatch/latest/wildmatch/) lib in place of regex building.

Just here for the soak numbers.

Signed-off-by: Lee Benson <lee@leebenson.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
