### PR TITLE
chore(tests): migrate docker integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,7 +57,6 @@ jobs:
       matrix:
         include:
           - test: 'datadog-metrics'
-          - test: 'docker-logs'
           - test: 'eventstoredb_metrics'
           - test: 'fluent'
           - test: 'gcp'
@@ -103,6 +102,7 @@ jobs:
           - test: 'clickhouse'
           - test: 'datadog-agent'
           - test: 'datadog-logs'
+          - test: 'docker'
           - test: 'elasticsearch'
           - test: 'logstash'
           - test: 'mongo'

--- a/Makefile
+++ b/Makefile
@@ -327,10 +327,6 @@ test-integration-datadog-agent: ## Runs Datadog Agent integration tests
 test-integration-datadog-metrics: ## Runs Datadog metrics integration tests
 	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features datadog-metrics-integration-tests --lib ::datadog::metrics::
 
-.PHONY: test-integration-docker-logs
-test-integration-docker-logs: ## Runs Docker Logs integration tests
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features docker-logs-integration-tests --lib ::docker_logs::
-
 .PHONY: test-integration-eventstoredb_metrics
 test-integration-eventstoredb_metrics: ## Runs EventStoreDB metric integration tests
 ifeq ($(AUTOSPAWN), true)

--- a/scripts/integration/docker-compose.docker.yml
+++ b/scripts/integration/docker-compose.docker.yml
@@ -1,0 +1,30 @@
+services:
+  runner:
+    build:
+      context: ${PWD}
+      dockerfile: scripts/integration/Dockerfile
+      args:
+        - RUST_VERSION=${RUST_VERSION}
+    working_dir: /code
+    command:
+      - "cargo"
+      - "test"
+      - "--no-fail-fast"
+      - "--no-default-features"
+      - "--features"
+      - "docker-logs-integration-tests"
+      - "--lib"
+      - "::docker_::"
+      - "--"
+      - "--nocapture"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${PWD}:/code
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
+
+# this is made to improve the build when running locally
+volumes:
+  cargogit: {}
+  cargoregistry: {}
+


### PR DESCRIPTION
Following #10466, this PR moves the docker tests to use docker-compose
on the CI.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
