### PR TITLE
enhancement(datadog_agent source): add an option to route metrics and logs to different outputs

### DIFF
--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -103,6 +103,23 @@ impl SourceSender {
         (pipe, recv)
     }
 
+    #[cfg(test)]
+    pub fn add_outputs(
+        &mut self,
+        status: EventStatus,
+        name: String,
+    ) -> impl Stream<Item = Event> + Unpin {
+        let (inner, recv) = Inner::new_with_buffer(100);
+        let recv = recv.map(move |mut event| {
+            let metadata = event.metadata_mut();
+            metadata.update_status(status);
+            metadata.update_sources();
+            event
+        });
+        self.named_inners.insert(name, inner);
+        recv
+    }
+
     pub async fn send(&mut self, event: Event) -> Result<(), ClosedError> {
         self.inner
             .as_mut()

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -119,6 +119,18 @@ impl SourceSender {
             .await
     }
 
+    pub async fn send_all_named(
+        &mut self,
+        name: &str,
+        events: impl Stream<Item = Event> + Unpin,
+    ) -> Result<(), ClosedError> {
+        self.named_inners
+            .get_mut(name)
+            .expect("unknown output")
+            .send_all(events)
+            .await
+    }
+
     pub async fn send_all(
         &mut self,
         events: impl Stream<Item = Event> + Unpin,

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, io::Read, net::SocketAddr, sync::Arc};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use chrono::{TimeZone, Utc};
 use flate2::read::{MultiGzDecoder, ZlibDecoder};
-use futures::{future, FutureExt, TryFutureExt};
+use futures::{future, FutureExt};
 use http::StatusCode;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -47,6 +47,9 @@ use crate::{
     SourceSender,
 };
 
+const LOGS: &str = "logs";
+const METRICS: &str = "metrics";
+
 #[derive(Clone, Copy, Debug, Snafu)]
 pub(crate) enum ApiError {
     BadRequest,
@@ -68,6 +71,8 @@ pub struct DatadogAgentConfig {
     decoding: Box<dyn DeserializerConfig>,
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
+    #[serde(default = "crate::serde::default_false")]
+    multiple_outputs: bool,
 }
 
 inventory::submit! {
@@ -89,6 +94,7 @@ impl GenerateConfig for DatadogAgentConfig {
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             acknowledgements: Default::default(),
+            multiple_outputs: false,
         })
         .unwrap()
     }
@@ -103,15 +109,21 @@ impl SourceConfig for DatadogAgentConfig {
         let source = DatadogAgentSource::new(self.store_api_key, decoder, tls.http_protocol_name());
         let listener = tls.bind(&self.address).await?;
         let acknowledgements = cx.globals.acknowledgements.merge(&self.acknowledgements);
-        let log_service = source
-            .clone()
-            .event_service(acknowledgements.enabled(), cx.out.clone());
-        let series_v1_service = source
-            .clone()
-            .series_v1_service(acknowledgements.enabled(), cx.out.clone());
-        let sketches_service = source
-            .clone()
-            .sketches_service(acknowledgements.enabled(), cx.out.clone());
+        let log_service = source.clone().event_service(
+            acknowledgements.enabled(),
+            cx.out.clone(),
+            self.multiple_outputs,
+        );
+        let series_v1_service = source.clone().series_v1_service(
+            acknowledgements.enabled(),
+            cx.out.clone(),
+            self.multiple_outputs,
+        );
+        let sketches_service = source.clone().sketches_service(
+            acknowledgements.enabled(),
+            cx.out.clone(),
+            self.multiple_outputs,
+        );
         let series_v2_service = source.series_v2_service();
 
         let shutdown = cx.shutdown;
@@ -146,7 +158,14 @@ impl SourceConfig for DatadogAgentConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Any)]
+        if self.multiple_outputs {
+            vec![
+                Output::from((METRICS, DataType::Metric)),
+                Output::from((LOGS, DataType::Log)),
+            ]
+        } else {
+            vec![Output::default(DataType::Any)]
+        }
     }
 
     fn source_type(&self) -> &'static str {
@@ -209,21 +228,25 @@ impl DatadogAgentSource {
         events: Result<Vec<Event>, ErrorMessage>,
         acknowledgements: bool,
         mut out: SourceSender,
+        output: Option<&str>,
     ) -> Result<Response, Rejection> {
         match events {
             Ok(mut events) => {
                 let receiver = BatchNotifier::maybe_apply_to_events(acknowledgements, &mut events);
 
                 let mut events = futures::stream::iter(events);
-                out.send_all(&mut events)
-                    .map_err(move |error: crate::source_sender::ClosedError| {
-                        // can only fail if receiving end disconnected, so we are shutting down,
-                        // probably not gracefully.
-                        error!(message = "Failed to forward events, downstream is closed.");
-                        error!(message = "Tried to send the following event.", %error);
-                        warp::reject::custom(ApiError::ServerShutdown)
-                    })
-                    .await?;
+                if output.is_none() {
+                    out.send_all(&mut events).await
+                } else {
+                    out.send_all_named(output.unwrap(), &mut events).await
+                }
+                .map_err(move |error: crate::source_sender::ClosedError| {
+                    // can only fail if receiving end disconnected, so we are shutting down,
+                    // probably not gracefully.
+                    error!(message = "Failed to forward events, downstream is closed.");
+                    error!(message = "Tried to send the following event.", %error);
+                    warp::reject::custom(ApiError::ServerShutdown)
+                })?;
                 match receiver {
                     None => Ok(warp::reply().into_response()),
                     Some(receiver) => match receiver.await {
@@ -243,7 +266,12 @@ impl DatadogAgentSource {
         }
     }
 
-    fn event_service(self, acknowledgements: bool, out: SourceSender) -> BoxedFilter<(Response,)> {
+    fn event_service(
+        self,
+        acknowledgements: bool,
+        out: SourceSender,
+        multiple_outputs: bool,
+    ) -> BoxedFilter<(Response,)> {
         warp::post()
             .and(path!("v1" / "input" / ..).or(path!("api" / "v2" / "logs" / ..)))
             .and(warp::path::full())
@@ -269,7 +297,11 @@ impl DatadogAgentSource {
                             self.extract_api_key(path.as_str(), api_token, query_params.dd_api_key),
                         )
                     });
-                    Self::handle_request(events, acknowledgements, out.clone())
+                    if multiple_outputs {
+                        Self::handle_request(events, acknowledgements, out.clone(), Some(LOGS))
+                    } else {
+                        Self::handle_request(events, acknowledgements, out.clone(), None)
+                    }
                 },
             )
             .boxed()
@@ -279,6 +311,7 @@ impl DatadogAgentSource {
         self,
         acknowledgements: bool,
         out: SourceSender,
+        multiple_outputs: bool,
     ) -> BoxedFilter<(Response,)> {
         warp::post()
             .and(path!("api" / "v1" / "series" / ..))
@@ -304,7 +337,11 @@ impl DatadogAgentSource {
                             self.extract_api_key(path.as_str(), api_token, query_params.dd_api_key),
                         )
                     });
-                    Self::handle_request(events, acknowledgements, out.clone())
+                    if multiple_outputs {
+                        Self::handle_request(events, acknowledgements, out.clone(), Some(METRICS))
+                    } else {
+                        Self::handle_request(events, acknowledgements, out.clone(), None)
+                    }
                 },
             )
             .boxed()
@@ -331,6 +368,7 @@ impl DatadogAgentSource {
         self,
         acknowledgements: bool,
         out: SourceSender,
+        multiple_outputs: bool,
     ) -> BoxedFilter<(Response,)> {
         warp::post()
             .and(path!("api" / "beta" / "sketches" / ..))
@@ -356,7 +394,11 @@ impl DatadogAgentSource {
                             self.extract_api_key(path.as_str(), api_token, query_params.dd_api_key),
                         )
                     });
-                    Self::handle_request(events, acknowledgements, out.clone())
+                    if multiple_outputs {
+                        Self::handle_request(events, acknowledgements, out.clone(), Some(METRICS))
+                    } else {
+                        Self::handle_request(events, acknowledgements, out.clone(), None)
+                    }
                 },
             )
             .boxed()

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -235,10 +235,10 @@ impl DatadogAgentSource {
                 let receiver = BatchNotifier::maybe_apply_to_events(acknowledgements, &mut events);
 
                 let mut events = futures::stream::iter(events);
-                if output.is_none() {
-                    out.send_all(&mut events).await
+                if let Some(name) = output {
+                    out.send_all_named(name, &mut events).await
                 } else {
-                    out.send_all_named(output.unwrap(), &mut events).await
+                    out.send_all(&mut events).await
                 }
                 .map_err(move |error: crate::source_sender::ClosedError| {
                     // can only fail if receiving end disconnected, so we are shutting down,

--- a/src/sources/datadog/agent/tests.rs
+++ b/src/sources/datadog/agent/tests.rs
@@ -94,6 +94,7 @@ async fn source(
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             acknowledgements: acknowledgements.into(),
+            multiple_outputs: false,
         }
         .build(context)
         .await

--- a/src/sources/datadog/agent/tests.rs
+++ b/src/sources/datadog/agent/tests.rs
@@ -82,8 +82,20 @@ async fn source(
     status: EventStatus,
     acknowledgements: bool,
     store_api_key: bool,
-) -> (impl Stream<Item = Event>, SocketAddr) {
-    let (sender, recv) = SourceSender::new_test_finalize(status);
+    multiple_outputs: bool,
+) -> (
+    impl Stream<Item = Event>,
+    Option<impl Stream<Item = Event>>,
+    Option<impl Stream<Item = Event>>,
+    SocketAddr,
+) {
+    let (mut sender, recv) = SourceSender::new_test_finalize(status);
+    let mut logs_output = None;
+    let mut metrics_output = None;
+    if multiple_outputs {
+        logs_output = Some(sender.add_outputs(status, "logs".to_string()));
+        metrics_output = Some(sender.add_outputs(status, "metrics".to_string()));
+    }
     let address = next_addr();
     let context = SourceContext::new_test(sender);
     tokio::spawn(async move {
@@ -94,7 +106,7 @@ async fn source(
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             acknowledgements: acknowledgements.into(),
-            multiple_outputs: false,
+            multiple_outputs,
         }
         .build(context)
         .await
@@ -103,7 +115,7 @@ async fn source(
         .unwrap();
     });
     wait_for_tcp(address).await;
-    (recv, address)
+    (recv, logs_output, metrics_output, address)
 }
 
 async fn send_with_path(address: SocketAddr, body: &str, headers: HeaderMap, path: &str) -> u16 {
@@ -121,7 +133,7 @@ async fn send_with_path(address: SocketAddr, body: &str, headers: HeaderMap, pat
 #[tokio::test]
 async fn full_payload_v1() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut events = spawn_collect_n(
         async move {
@@ -168,7 +180,7 @@ async fn full_payload_v1() {
 #[tokio::test]
 async fn full_payload_v2() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut events = spawn_collect_n(
         async move {
@@ -215,7 +227,7 @@ async fn full_payload_v2() {
 #[tokio::test]
 async fn no_api_key() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut events = spawn_collect_n(
         async move {
@@ -262,7 +274,7 @@ async fn no_api_key() {
 #[tokio::test]
 async fn api_key_in_url() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut events = spawn_collect_n(
         async move {
@@ -312,7 +324,7 @@ async fn api_key_in_url() {
 #[tokio::test]
 async fn api_key_in_query_params() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut events = spawn_collect_n(
         async move {
@@ -362,7 +374,7 @@ async fn api_key_in_query_params() {
 #[tokio::test]
 async fn api_key_in_header() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -418,7 +430,7 @@ async fn api_key_in_header() {
 #[tokio::test]
 async fn delivery_failure() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Rejected, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Rejected, true, true, false).await;
 
     spawn_collect_n(
         async move {
@@ -451,7 +463,7 @@ async fn delivery_failure() {
 #[tokio::test]
 async fn ignores_disabled_acknowledgements() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Rejected, false, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Rejected, false, true, false).await;
 
     let events = spawn_collect_n(
         async move {
@@ -486,7 +498,7 @@ async fn ignores_disabled_acknowledgements() {
 #[tokio::test]
 async fn ignores_api_key() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, false).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, false, false).await;
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -539,7 +551,7 @@ async fn ignores_api_key() {
 #[tokio::test]
 async fn decode_series_endpoints() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -685,7 +697,7 @@ async fn decode_series_endpoints() {
 #[tokio::test]
 async fn decode_sketches() {
     trace_init();
-    let (rx, addr) = source(EventStatus::Delivered, true, true).await;
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -764,6 +776,119 @@ async fn decode_sketches() {
 
         assert_eq!(
             &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
+            "12345678abcdefgh12345678abcdefgh"
+        );
+    }
+}
+
+#[tokio::test]
+async fn split_outputs() {
+    trace_init();
+    let (_, rx_logs, rx_metrics, addr) = source(EventStatus::Delivered, true, true, true).await;
+
+    let mut headers_for_log = HeaderMap::new();
+    headers_for_log.insert(
+        "dd-api-key",
+        "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
+    );
+
+    let mut log_event = spawn_collect_n(
+        async move {
+            assert_eq!(
+                200,
+                send_with_path(
+                    addr,
+                    &serde_json::to_string(&[LogMsg {
+                        message: Bytes::from("baz"),
+                        timestamp: 789,
+                        hostname: Bytes::from("festeburg"),
+                        status: Bytes::from("notice"),
+                        service: Bytes::from("vector"),
+                        ddsource: Bytes::from("curl"),
+                        ddtags: Bytes::from("one,two,three"),
+                    }])
+                    .unwrap(),
+                    headers_for_log,
+                    "/v1/input/"
+                )
+                .await
+            );
+        },
+        rx_logs.unwrap(),
+        1,
+    )
+    .await;
+
+    let mut headers_for_metric = HeaderMap::new();
+    headers_for_metric.insert(
+        "dd-api-key",
+        "abcdefgh12345678abcdefgh12345678".parse().unwrap(),
+    );
+    let dd_metric_request = DatadogSeriesRequest {
+        series: vec![DatadogSeriesMetric {
+            metric: "dd_gauge".to_string(),
+            r#type: DatadogMetricType::Gauge,
+            interval: None,
+            points: vec![
+                DatadogPoint(1542182950, 3.14),
+                DatadogPoint(1542182951, 3.1415),
+            ],
+            tags: Some(vec!["foo:bar".to_string()]),
+            host: Some("random_host".to_string()),
+            source_type_name: None,
+            device: None,
+        }],
+    };
+    let mut metric_event = spawn_collect_n(
+        async move {
+            assert_eq!(
+                200,
+                send_with_path(
+                    addr,
+                    &serde_json::to_string(&dd_metric_request).unwrap(),
+                    headers_for_metric,
+                    "/api/v1/series"
+                )
+                .await
+            );
+        },
+        rx_metrics.unwrap(),
+        1,
+    )
+    .await;
+
+    {
+        let event = metric_event.remove(0);
+        let metric = event.as_metric();
+        assert_eq!(metric.name(), "dd_gauge");
+        assert_eq!(
+            metric.timestamp(),
+            Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10))
+        );
+        assert_eq!(metric.kind(), MetricKind::Absolute);
+        assert_eq!(*metric.value(), MetricValue::Gauge { value: 3.14 });
+        assert_eq!(metric.tags().unwrap()["host"], "random_host".to_string());
+        assert_eq!(metric.tags().unwrap()["foo"], "bar".to_string());
+
+        assert_eq!(
+            &event.metadata().datadog_api_key().as_ref().unwrap()[..],
+            "abcdefgh12345678abcdefgh12345678"
+        );
+    }
+
+    {
+        let event = log_event.remove(0);
+        let log = event.as_log();
+        assert_eq!(log["message"], "baz".into());
+        assert_eq!(log["timestamp"], 789.into());
+        assert_eq!(log["hostname"], "festeburg".into());
+        assert_eq!(log["status"], "notice".into());
+        assert_eq!(log["service"], "vector".into());
+        assert_eq!(log["ddsource"], "curl".into());
+        assert_eq!(log["ddtags"], "one,two,three".into());
+        assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+        assert_eq!(
+            &event.metadata().datadog_api_key().as_ref().unwrap()[..],
             "12345678abcdefgh12345678abcdefgh"
         );
     }

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -59,6 +59,16 @@ components: sources: datadog_agent: {
 	configuration: {
 		acknowledgements: configuration._acknowledgements
 		address:          sources.http.configuration.address
+		multiple_outputs: {
+			common:      false
+			description: """
+				If this setting is set to `true` metrics and logs will be sent to different ouputs. For a source component
+				named `agent` the received logs and metrics can then be accessed by specifying `agent.logs` and `agent.metrics`,
+				respectively, as the input to another component.
+				"""
+			required:    false
+			type: bool: default: false
+		}
 		store_api_key: {
 			common:      false
 			description: "When incoming events contain a Datadog API key, if this setting is set to `true` the key will kept in the event metadata and will be used if the event is sent to a Datadog sink."

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -60,13 +60,13 @@ components: sources: datadog_agent: {
 		acknowledgements: configuration._acknowledgements
 		address:          sources.http.configuration.address
 		multiple_outputs: {
-			common:      false
+			common: false
 			description: """
 				If this setting is set to `true` metrics and logs will be sent to different ouputs. For a source component
 				named `agent` the received logs and metrics can then be accessed by specifying `agent.logs` and `agent.metrics`,
 				respectively, as the input to another component.
 				"""
-			required:    false
+			required: false
 			type: bool: default: false
 		}
 		store_api_key: {


### PR DESCRIPTION
Small change that leverage named outputs:
With this config
```
sources:
  dd_agent:
    type: datadog_agent
    address: "[::]:8081"
    multiple_outputs: true
```

Metrics & Logs can then respectively be received using `dd_agent.logs` & `dd_agent.metrics`. 