### PR TITLE
chore(tests): migrate fluent integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -58,7 +58,6 @@ jobs:
         include:
           - test: 'datadog-metrics'
           - test: 'eventstoredb_metrics'
-          - test: 'fluent'
           - test: 'gcp'
           - test: 'humio'
           - test: 'influxdb'
@@ -102,6 +101,7 @@ jobs:
           - test: 'datadog-logs'
           - test: 'docker'
           - test: 'elasticsearch'
+          - test: 'fluent'
           - test: 'logstash'
           - test: 'loki'
           - test: 'mongo'

--- a/Makefile
+++ b/Makefile
@@ -339,10 +339,6 @@ ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh eventstoredb_metrics stop
 endif
 
-.PHONY: test-integration-fluent
-test-integration-fluent: ## Runs Fluent integration tests
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features fluent-integration-tests --lib ::fluent::
-
 .PHONY: test-integration-gcp
 test-integration-gcp: ## Runs GCP integration tests
 ifeq ($(AUTOSPAWN), true)

--- a/scripts/integration/docker-compose.fluent.yml
+++ b/scripts/integration/docker-compose.fluent.yml
@@ -1,0 +1,32 @@
+services:
+  runner:
+    build:
+      context: ${PWD}
+      dockerfile: scripts/integration/Dockerfile
+      args:
+        - RUST_VERSION=${RUST_VERSION}
+    working_dir: /code
+    network_mode: host
+    command:
+      - "cargo"
+      - "test"
+      - "--no-fail-fast"
+      - "--no-default-features"
+      - "--features"
+      - "fluent-integration-tests"
+      - "--lib"
+      - "::fluent::"
+      - "--"
+      - "--nocapture"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
+      - ${PWD}:/code
+
+# this is made to improve the build when running locally
+volumes:
+  cargogit: {}
+  cargoregistry: {}
+


### PR DESCRIPTION
Following #10466, this PR moves the fluent tests to use docker-compose on the CI

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
