### PR TITLE
fix(setup): Fix get_gnu_musl_glibc function

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -171,7 +171,6 @@ install_from_archive() {
       local _path="export PATH=\"\$HOME/.vector/bin:\$PATH\""
       add_to_path "${HOME}/.zprofile" "${_path}"
       add_to_path "${HOME}/.profile" "${_path}"
-      printf " ✓\n"
     fi
 
     printf "%s Install succeeded! 🚀\n" "$_prompt"
@@ -200,6 +199,8 @@ add_to_path() {
   else
     grep -qxF "${new_path}" "${file}" || echo "${new_path}" >> "${file}"
   fi
+
+  printf " ✓\n"
 }
 
 # ------------------------------------------------------------------------------
@@ -209,26 +210,18 @@ add_to_path() {
 
 get_gnu_musl_glibc() {
   need_cmd ldd
-  need_cmd bc
   need_cmd awk
   # Detect both gnu and musl
-  # Also detect glibc versions older than 2.18 and return musl for these
-  # Required until we address https://github.com/timberio/vector/issues/5412.
   local _ldd_version
   local _glibc_version
-  _ldd_version=$(ldd --version)
-  if [[ $_ldd_version =~ "GNU" ]]; then
-    _glibc_version=$(echo "$_ldd_version" | awk '/ldd/{print $NF}')
-    if [ 1 -eq "$(echo "${_glibc_version} < 2.18" | bc)" ]; then
-      echo "musl"
-    else
-      echo "gnu"
-    fi
-elif [[ $_ldd_version =~ "musl" ]]; then
-  echo "musl"
-else
-  err "Unknown architecture from ldd: ${_ldd_version}"
-fi
+  _ldd_version=$(ldd --version 2>&1)
+  if [[ $_ldd_version =~ "GNU" ]] || [[ $_ldd_version =~ "GLIBC" ]]; then
+    echo "gnu"
+  elif [[ $_ldd_version =~ "musl" ]]; then
+    echo "musl"
+  else
+    err "Unknown architecture from ldd: ${_ldd_version}"
+  fi
 }
 
 get_bitness() {


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #10740

This fixes the case on Alpine where the `ldd --version` output is on STDERR, as well as Ubuntu where "GNU" is not included in the `ldd --version` output.
Also included is a minor change to fix linebreaks when adding Vector to the user's path.

Before:

```bash
>>> Unpacking archive to /root/.vector ... ✓
>>> Adding Vector path to /root/.zprofile>>> Adding Vector path to /root/.profile ✓
>>> Install succeeded! 🚀
```

After:

```bash
>>> Unpacking archive to /root/.vector ... ✓
>>> Adding Vector path to /root/.zprofile  ✓
>>> Adding Vector path to /root/.profile  ✓
>>> Install succeeded! 🚀
```

Ubuntu 20.04.3

```bash
ldd --version
ldd (Ubuntu GLIBC 2.31-0ubuntu9.2) 2.31
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
