### PR TITLE
fix(prometheus_exporter sink): lint/fmt/clippy issues due to a bad merge

### DIFF
--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -237,7 +237,7 @@ impl MetricValue {
     pub fn distribution_to_agg_histogram(&self, buckets: &[f64]) -> Option<MetricValue> {
         match self {
             MetricValue::Distribution { samples, .. } => {
-                let (buckets, count, sum) = samples_to_buckets(&samples, buckets);
+                let (buckets, count, sum) = samples_to_buckets(samples, buckets);
 
                 Some(MetricValue::AggregatedHistogram {
                     buckets,


### PR DESCRIPTION
#10741 was accidentally merged before CI checks completed, which lead to some issues being merged into `master`.  This PR fixes those issues.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>