### PR TITLE
fix(codecs): Handle `framing.character_delimiter.delimiter` as `char` in config serialization

### DIFF
--- a/src/codecs/framing/character_delimited.rs
+++ b/src/codecs/framing/character_delimited.rs
@@ -15,6 +15,7 @@ pub struct CharacterDelimitedDecoderConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct CharacterDelimitedDecoderOptions {
     /// The character that delimits byte sequences.
+    #[serde(with = "crate::serde::ascii_char")]
     delimiter: u8,
     /// The maximum length of the byte buffer.
     ///


### PR DESCRIPTION
Closes #10814.