### PR TITLE
chore(unit tests): Update debug output for a disconnected topology

### DIFF
--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -301,17 +301,31 @@ fn get_relevant_test_components(
     graph: &Graph,
 ) -> Result<HashSet<String>, Vec<String>> {
     let _ = graph.check_for_cycles().map_err(|error| vec![error])?;
-    Ok(sources
-        .iter()
-        .flat_map(|source| {
-            let paths = graph.paths_to_sink_from(source);
-            let mut components = HashSet::new();
+    let mut errors = Vec::new();
+    let mut components = HashSet::new();
+    for source in sources {
+        let paths = graph.paths_to_sink_from(source);
+        if paths.is_empty() {
+            errors.push(format!(
+                "Unable to complete topology between input target '{}' and output target(s)",
+                source
+                    .to_string()
+                    .rsplit_once("-source-")
+                    .unwrap_or(("", ""))
+                    .0
+            ));
+        } else {
             for path in paths {
                 components.extend(path.into_iter().map(|key| key.to_string()));
             }
-            components
-        })
-        .collect())
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(components)
+    } else {
+        Err(errors)
+    }
 }
 
 async fn build_unit_test(
@@ -346,14 +360,11 @@ async fn build_unit_test(
         &expanded_config.transforms,
         &expanded_config.sinks,
     );
-    let sources = config_builder.sources.keys().clone().collect::<Vec<_>>();
 
-    let mut valid_components = get_relevant_test_components(sources.as_ref(), &graph)?;
-    if valid_components.is_empty() {
-        return Err(vec![
-            "No path(s) found from inputs to outputs. Topology is disconnected.".to_string(),
-        ]);
-    }
+    let mut valid_components = get_relevant_test_components(
+        config_builder.sources.keys().collect::<Vec<_>>().as_ref(),
+        &graph,
+    )?;
 
     // Preserve the original unexpanded transform(s) which are valid test insertion points
     let unexpanded_transforms = valid_components


### PR DESCRIPTION
It occurred to me while writing #10579 that the disconnected topology debug message for unit tests could be re-aligned more closely with the original. 

The error message was changed for a prior refactoring approach (where it would have been a more general, run-time error) that was decided against. It's now back to being a build-time error and debug output can behave about the same as before -- i.e. it specifies what input(s) is/are disconnected.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
