### PR TITLE
chore(route transform): Add output tag to route event discarded metric

### DIFF
--- a/src/internal_events/route.rs
+++ b/src/internal_events/route.rs
@@ -2,10 +2,12 @@ use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
-pub struct RouteEventDiscarded;
+pub struct RouteEventDiscarded<'a> {
+    pub output: &'a str,
+}
 
-impl InternalEvent for RouteEventDiscarded {
+impl<'a> InternalEvent for RouteEventDiscarded<'a> {
     fn emit_metrics(&self) {
-        counter!("events_discarded_total", 1);
+        counter!("events_discarded_total", 1, "output" => self.output.to_string());
     }
 }

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -40,7 +40,9 @@ impl SyncTransform for Route {
             if condition.check(&event) {
                 output.push_named(output_name, event.clone());
             } else {
-                emit!(&RouteEventDiscarded);
+                emit!(&RouteEventDiscarded {
+                    output: output_name.as_ref()
+                });
             }
         }
     }

--- a/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
@@ -47,11 +47,15 @@ transform for each defined output. Each of these expanded transforms then
 emitted its own metrics. Now, with improved internal support for components with
 multiple outputs, this expansion mechanism has been removed.
 
-A single `route` transform will now emit one set of metrics. When relevant,
-specific output information will be recorded as a metric tag `output`. For
-example, for a `route` transform `foo` with an output `first` configured, the
-`events_discarded_total` metric will now look like the following:
-<output_name>`.
+A single `route` transform will now emit one set of metrics. For the following
+metrics, specific output information will be recorded as a metric tag `output`.
+
+- `component_sent_events_total`
+- `component_sent_event_bytes_total`
+- `events_discarded_total`
+
+For example, for a `route` transform `foo` with an output `first` configured,
+the `events_discarded_total` metric will now look like the following:
 
 ```diff
 - {"counter":{"value":10.0},"name":"events_discarded_total"... "tags":{"component_id":"foo.first","component_kind":"transform","component_name":"foo.first","component_type":"route"}}

--- a/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
@@ -43,18 +43,18 @@ reporting it.
 #### New metrics behavior for `route` transform {#metrics-route-transform}
 
 Previously, a `route` transform was internally expanded into a separate
-transform for each defined output. Each of these expanded transforms then
+transform for each defined route. Each of these expanded transforms then
 emitted its own metrics. Now, with improved internal support for components with
 multiple outputs, this expansion mechanism has been removed.
 
 A single `route` transform will now emit one set of metrics. For the following
-metrics, specific output information will be recorded as a metric tag `output`.
+metrics, specific route information will be recorded as a metric tag `output`.
 
 - `component_sent_events_total`
 - `component_sent_event_bytes_total`
 - `events_discarded_total`
 
-For example, for a `route` transform `foo` with an output `first` configured,
+For example, for a `route` transform `foo` with a route `first` configured,
 the `events_discarded_total` metric will now look like the following:
 
 ```diff

--- a/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
@@ -13,6 +13,7 @@ badges:
 Vector's 0.20.0 release includes **breaking changes**:
 
 1. [Change to set expiration behavior in `prometheus_exporter` sink](#prom-exporter-set-expiration)
+1. [New metrics behavior for `route` transform](#metrics-route-transform)
 
 We cover them below to help you upgrade quickly:
 
@@ -38,3 +39,21 @@ it.  For sets, however, we would simply clear their values and thus report a set
 behavior was not consistent with how we expired other metric types, and additionally, could still
 lead to a growth of unique series in a scrape, over time, as we would clear the set but not stop
 reporting it.
+
+#### New metrics behavior for `route` transform {#metrics-route-transform}
+
+Previously, a `route` transform was internally expanded into a separate
+transform for each defined output. Each of these expanded transforms then
+emitted its own metrics. Now, with improved internal support for components with
+multiple outputs, this expansion mechanism has been removed.
+
+A single `route` transform will now emit one set of metrics. When relevant,
+specific output information will be recorded as a metric tag `output`. For
+example, for a `route` transform `foo` with an output `first` configured, the
+`events_discarded_total` metric will now look like the following:
+<output_name>`.
+
+```diff
+- {"counter":{"value":10.0},"name":"events_discarded_total"... "tags":{"component_id":"foo.first","component_kind":"transform","component_name":"foo.first","component_type":"route"}}
++ {"counter":{"value":10.0},"name":"events_discarded_total"... "tags":{"component_id":"foo","component_kind":"transform","component_name":"foo","component_type":"route","output":"first"}}
+```

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1199,6 +1199,10 @@ components: sources: internal_metrics: {
 				unix: "Unix domain socket"
 			}
 		}
+		_output: {
+			description: "The specific output of the component."
+			required:    false
+		}
 		_stage: {
 			description: "The stage within the component at which the error occurred."
 			required:    true

--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -118,6 +118,10 @@ components: transforms: route: {
 	]
 
 	telemetry: metrics: {
-		events_discarded_total: components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_discarded_total: components.sources.internal_metrics.output.metrics.events_discarded_total & {
+			tags: {
+				output: components.sources.internal_metrics.output.metrics._output
+			}
+		}
 	}
 }


### PR DESCRIPTION
Following up on #10738, this PR 
- Adds an `output` tag to route's `events_discarded_total` metric to preserve part of the UX of the previous expansion implementation.
- Adds a section to the upgrade guide for route metrics under breaking changes