### PR TITLE
chore: Add known issue for 0.19.0 for character delimiter

### DIFF
--- a/website/cue/reference/releases/0.19.0.cue
+++ b/website/cue/reference/releases/0.19.0.cue
@@ -27,6 +27,10 @@ releases: "0.19.0": {
 		},
 	]
 
+	known_issues: [
+		"Using `framing.character_delimited.delimiter` in configs causes Vector to fail to start with `invalid type: string`."
+	]
+
 	description: """
 		The Vector team is pleased to announce version 0.19.0!
 


### PR DESCRIPTION
Following up on https://github.com/vectordotdev/vector/pull/10829

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
