### PR TITLE
chore(ci): Add a workflow for opening issues for security vulnerabilities

### DIFF
--- a/.github/audit.yml
+++ b/.github/audit.yml
@@ -1,0 +1,17 @@
+name: Security audit
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  push:
+    branches:
+      - master
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This opens an issue like: https://github.com/tokio-rs/tracing/issues/1834 . We currently open these sorts of issues manually (like #10862).

We could consider dropping the `cargo deny` check that happens in, and
blocks, PRs as part of this. It's currently a bit of a nuisance when
a new vulnerability shows up because this causes all new PRs to fail
even though they if they aren't changing anything about dependencies
until it is fixed in master. The risk is that PRs that do change
dependencies introduce a security vulnerability which would be nice to
catch on the PR itself.

We can start with this new workflow and evaluating the removal, or
softening, of the `cargo deny` check on PRs.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
