### PR TITLE
fix(graphql api): Fix `TapSink` not flushing properly

### DIFF
--- a/src/api/schema/events/log.rs
+++ b/src/api/schema/events/log.rs
@@ -7,7 +7,7 @@ use crate::{
     event::{self, Value},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Log {
     output_id: OutputId,
     event: event::LogEvent,

--- a/src/api/schema/events/mod.rs
+++ b/src/api/schema/events/mod.rs
@@ -1,7 +1,7 @@
 mod encoding;
-mod log;
-mod notification;
-mod output;
+pub mod log;
+pub mod notification;
+pub mod output;
 
 use async_graphql::{Context, Subscription};
 use encoding::EventEncodingType;
@@ -37,7 +37,7 @@ impl EventsSubscription {
 /// Creates an events stream based on component ids, and a provided interval. Will emit
 /// control messages that bubble up the application if the sink goes away. The stream contains
 /// all matching events; filtering should be done at the caller level.
-fn create_events_stream(
+pub(crate) fn create_events_stream(
     watch_rx: WatchRx,
     component_id_patterns: Vec<String>,
     interval: u64,

--- a/src/api/schema/events/notification.rs
+++ b/src/api/schema/events/notification.rs
@@ -9,7 +9,7 @@ pub enum EventNotificationType {
     NotMatched,
 }
 
-#[derive(Debug, SimpleObject)]
+#[derive(Debug, SimpleObject, Clone, PartialEq)]
 /// A notification regarding events observation
 pub struct EventNotification {
     /// Pattern that raised the event

--- a/src/api/schema/events/output.rs
+++ b/src/api/schema/events/output.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::api::tap::{TapNotification, TapPayload};
 
-#[derive(Union, Debug)]
+#[derive(Union, Debug, Clone)]
 /// An event or a notification
 pub enum OutputEventsPayload {
     /// Log event

--- a/src/api/schema/mod.rs
+++ b/src/api/schema/mod.rs
@@ -1,5 +1,5 @@
 pub mod components;
-mod events;
+pub mod events;
 pub mod filter;
 mod health;
 mod meta;

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -7,8 +7,11 @@ use std::{
 
 use futures::{future::try_join_all, FutureExt, Sink, SinkExt};
 use itertools::Itertools;
-use tokio::sync::mpsc::error::TrySendError;
-use tokio::sync::{mpsc as tokio_mpsc, mpsc::error::SendError, oneshot};
+use tokio::sync::{
+    mpsc as tokio_mpsc,
+    mpsc::error::{SendError, TrySendError},
+    oneshot,
+};
 use uuid::Uuid;
 
 use super::{ShutdownRx, ShutdownTx};

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -298,7 +298,6 @@ mod tests {
     use crate::api::schema::events::create_events_stream;
     use crate::config::Config;
     use futures::SinkExt;
-    use std::time::Duration;
     use tokio::sync::watch;
 
     use super::*;

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -71,7 +71,7 @@ pub struct TapSink {
 }
 
 impl TapSink {
-    pub fn new(tap_tx: TapSender, output_id: OutputId) -> Self {
+    pub const fn new(tap_tx: TapSender, output_id: OutputId) -> Self {
         Self { tap_tx, output_id }
     }
 }

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, HashSet},
     iter::FromIterator,
     pin::Pin,
     task::{Context, Poll},
@@ -7,6 +7,7 @@ use std::{
 
 use futures::{future::try_join_all, FutureExt, Sink, SinkExt};
 use itertools::Itertools;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc as tokio_mpsc, mpsc::error::SendError, oneshot};
 use uuid::Uuid;
 
@@ -67,71 +68,44 @@ impl TapPayload {
 pub struct TapSink {
     tap_tx: TapSender,
     output_id: OutputId,
-    buffer: VecDeque<LogEvent>,
 }
 
 impl TapSink {
     pub fn new(tap_tx: TapSender, output_id: OutputId) -> Self {
-        Self {
-            tap_tx,
-            output_id,
-            // Pre-allocate space of 100 events, which matches the default `limit` typically
-            // provided to a tap subscription. If there's a higher log volume, this will block
-            // until the upstream event handler has processed the event. Generally, there should
-            // be little upstream pressure in the processing pipeline.
-            buffer: VecDeque::with_capacity(100),
-        }
+        Self { tap_tx, output_id }
     }
 }
 
 impl Sink<Event> for TapSink {
     type Error = ();
 
-    /// The sink is ready to accept events if buffer capacity hasn't been reached.
+    /// This sink is always ready to accept, because TapSink should never cause back-pressure.
+    /// Events will be dropped instead of propagating back-pressure
     fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    /// If the sink is ready, and the event is of type `LogEvent`, add to the buffer.
-    fn start_send(mut self: Pin<&mut Self>, item: Event) -> Result<(), Self::Error> {
-        // If we have a `LogEvent`, and space for it in the buffer, queue it.
-        if let Event::Log(ev) = item {
-            if self.buffer.len() < self.buffer.capacity() {
-                self.buffer.push_back(ev);
+    /// Immediately send the event to the tap_tx, only if it has room. Otherwise just drop it
+    fn start_send(self: Pin<&mut Self>, event: Event) -> Result<(), Self::Error> {
+        if let Event::Log(log) = event {
+            let result = self
+                .tap_tx
+                .try_send(TapPayload::Log(self.output_id.clone(), log));
+
+            if let Err(TrySendError::Closed(payload)) = result {
+                debug!(
+                    message = "Couldn't send log event.",
+                    payload = ?payload,
+                    component_id = ?self.output_id,
+                );
             }
         }
 
         Ok(())
     }
 
-    /// Flushing means FIFO dequeuing. This is an O(1) operation on the `VecDeque` buffer.
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        // Loop over the buffer events, pulling from the front. This will terminate when
-        // the buffer is empty.
-        while let Some(ev) = self.buffer.pop_front() {
-            // Attempt to send upstream. If the channel is closed, log and break. If it's
-            // full, return pending to reattempt later.
-            match self
-                .tap_tx
-                .try_send(TapPayload::Log(self.output_id.clone(), ev))
-            {
-                Err(tokio_mpsc::error::TrySendError::Closed(payload)) => {
-                    debug!(
-                        message = "Couldn't send log event.",
-                        payload = ?payload,
-                        component_id = ?self.output_id,
-                    );
-
-                    break;
-                }
-                Err(tokio_mpsc::error::TrySendError::Full(_)) => return Poll::Ready(Ok(())),
-                _ => continue,
-            }
-        }
-
+    /// Events are immediately flushed, so this doesn't do anything
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
@@ -321,11 +295,22 @@ async fn tap_handler(
 
 #[cfg(test)]
 mod tests {
+    use crate::api::schema::events::create_events_stream;
+    use crate::config::Config;
     use futures::SinkExt;
+    use std::time::Duration;
     use tokio::sync::watch;
 
     use super::*;
+    use crate::api::schema::events::log::Log;
+    use crate::api::schema::events::notification::{EventNotification, EventNotificationType};
+    use crate::api::schema::events::output::OutputEventsPayload;
     use crate::event::{Metric, MetricKind, MetricValue};
+    use crate::sinks::blackhole::BlackholeConfig;
+    use crate::sources::demo_logs::{DemoLogsConfig, OutputFormat};
+    use crate::test_util::start_topology;
+    use crate::transforms::remap::RemapConfig;
+    use futures::StreamExt;
 
     #[test]
     /// Patterns should accept globbing.
@@ -405,5 +390,99 @@ mod tests {
             sink_rx.recv().await,
             Some(TapPayload::Log(returned_id, _)) if returned_id == id
         ));
+    }
+
+    fn assert_notification(payload: OutputEventsPayload) -> EventNotification {
+        if let OutputEventsPayload::Notification(notification) = payload {
+            notification
+        } else {
+            panic!("Expected payload to be a Notification")
+        }
+    }
+
+    fn assert_log(payload: OutputEventsPayload) -> Log {
+        if let OutputEventsPayload::Log(log) = payload {
+            log
+        } else {
+            panic!("Expected payload to be a Log")
+        }
+    }
+
+    #[tokio::test]
+    async fn integration_test_source() {
+        let mut config = Config::builder();
+        config.add_source(
+            "in",
+            DemoLogsConfig {
+                interval: 0.01,
+                count: 200,
+                format: OutputFormat::Json,
+                ..Default::default()
+            },
+        );
+        config.add_sink(
+            "out",
+            &["in"],
+            BlackholeConfig {
+                print_interval_secs: 1,
+                rate: None,
+            },
+        );
+
+        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+
+        let source_tap_stream =
+            create_events_stream(topology.watch(), vec!["in".to_string()], 500, 100);
+
+        let source_tap_events: Vec<_> = source_tap_stream.take(2).collect().await;
+
+        assert_eq!(
+            assert_notification(source_tap_events[0][0].clone()),
+            EventNotification::new("in".to_string(), EventNotificationType::Matched)
+        );
+        let _log = assert_log(source_tap_events[1][0].clone());
+    }
+
+    #[tokio::test]
+    async fn integration_test_transform() {
+        let mut config = Config::builder();
+        config.add_source(
+            "in",
+            DemoLogsConfig {
+                interval: 0.01,
+                count: 200,
+                format: OutputFormat::Json,
+                ..Default::default()
+            },
+        );
+        config.add_transform(
+            "transform",
+            &["in"],
+            RemapConfig {
+                source: Some("".to_string()),
+                ..Default::default()
+            },
+        );
+        config.add_sink(
+            "out",
+            &["transform"],
+            BlackholeConfig {
+                print_interval_secs: 1,
+                rate: None,
+            },
+        );
+
+        let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+
+        let transform_tap_stream =
+            create_events_stream(topology.watch(), vec!["transform".to_string()], 500, 100);
+
+        let transform_tap_events: Vec<_> = transform_tap_stream.take(2).collect().await;
+
+        assert_eq!(
+            assert_notification(transform_tap_events[0][0].clone()),
+            EventNotification::new("transform".to_string(), EventNotificationType::Matched)
+        );
+        let _log = assert_log(transform_tap_events[1][0].clone());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,7 +195,7 @@ pub enum SubCommand {
     #[cfg(feature = "api-client")]
     Top(top::Opts),
 
-    /// Observe log events from topology components
+    /// Observe output log events from source or transform components. Logs are sampled at a specified interval.
     #[cfg(feature = "api-client")]
     Tap(tap::Opts),
 

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -29,15 +29,15 @@ use crate::{
 pub struct DemoLogsConfig {
     #[serde(alias = "batch_interval")]
     #[derivative(Default(value = "default_interval()"))]
-    interval: f64,
+    pub interval: f64,
     #[derivative(Default(value = "default_count()"))]
-    count: usize,
+    pub count: usize,
     #[serde(flatten)]
-    format: OutputFormat,
+    pub format: OutputFormat,
     #[derivative(Default(value = "default_framing_message_based()"))]
-    framing: Box<dyn FramingConfig>,
+    pub framing: Box<dyn FramingConfig>,
     #[derivative(Default(value = "default_decoding()"))]
-    decoding: Box<dyn DeserializerConfig>,
+    pub decoding: Box<dyn DeserializerConfig>,
 }
 
 const fn default_interval() -> f64 {

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -8,7 +8,7 @@ use vector_api_client::gql::TapEncodingFormat;
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(rename_all = "kebab-case")]
 pub struct Opts {
-    /// Interval to sample metrics at, in milliseconds
+    /// Interval to sample logs at, in milliseconds
     #[structopt(default_value = "500", short = "i", long)]
     interval: u32,
 
@@ -16,7 +16,7 @@ pub struct Opts {
     #[structopt(short, long)]
     url: Option<Url>,
 
-    /// Sample log events to the provided limit
+    /// Maximum number of log events to sample each interval
     #[structopt(default_value = "100", short = "l", long)]
     limit: u32,
 

--- a/src/topology/test/backpressure.rs
+++ b/src/topology/test/backpressure.rs
@@ -53,7 +53,7 @@ async fn serial_backpressure() {
     assert_eq!(sourced_events, expected_sourced_events);
 }
 
-/// Connects a single source to two sinks test and makes sure that the source is only able
+/// Connects a single source to two sinks and makes sure that the source is only able
 /// to emit events that the slower sink accepts.
 #[tokio::test]
 async fn default_fan_out() {

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -261,7 +261,8 @@ cli: {
 
 		"tap": {
 			description: """
-				Observe log events from topology components.
+				Observe output log events from source or transform components. Logs are sampled
+				at a specified interval.
 				"""
 
 			flags: _default_flags
@@ -269,7 +270,7 @@ cli: {
 			options: {
 				"interval": {
 					_short:      "i"
-					description: "Interval to sample metrics at, in milliseconds"
+					description: "Interval to sample logs at, in milliseconds"
 					type:        "integer"
 					default:     500
 				}
@@ -280,7 +281,7 @@ cli: {
 				}
 				"limit": {
 					_short:      "l"
-					description: "Sample log events to the provided limit"
+					description: "Number of log events to sample each interval"
 					type:        "integer"
 					default:     100
 				}

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -281,7 +281,7 @@ cli: {
 				}
 				"limit": {
 					_short:      "l"
-					description: "Number of log events to sample each interval"
+					description: "Maximum number of log events to sample each interval"
 					type:        "integer"
 					default:     100
 				}


### PR DESCRIPTION
The `TapSink` had it's own internal buffer that it saved events to. This buffer would only be flushed when `poll_flush` was called on this sink. An unrelated change to the topology / pipelines changed how events were sent to this sink, and it was no longer being flushed correctly.

The buffer inside of `TapSink` was actually unnecessary, and removing that fixes the problem. Instead of saving to a buffer and then flushing the buffer, `TapSink` now just writes directly to the output. The batching is still correctly applied since the channel that `TapSink` writes to has its buffer appropriately set, and all the real timing / batching happens in `create_events_stream`.

Regression tests were also added to make sure this doesn't break in the future.

closes https://github.com/vectordotdev/vector/issues/10833
closes https://github.com/vectordotdev/vector/issues/10847
