### PR TITLE
fix(buffers): detect partially written data file + wait on writer/reader file lap

### DIFF
--- a/lib/vector-core/buffers/Cargo.toml
+++ b/lib/vector-core/buffers/Cargo.toml
@@ -46,7 +46,7 @@ metrics-tracing-context = { version = "0.9.0", default-features = false }
 serde_yaml = { version = "0.8", default-features = false }
 # https://github.com/tobz/tracing-fluent-assertions/pull/1
 tracing-fluent-assertions = { git = "https://github.com/vectordotdev/tracing-fluent-assertions", branch = "bump-tracing-subscriber" }
-tracing-subscriber = { version = "0.3.5", default-features = false, features = ["env-filter", "fmt", "registry", "std"] }
+tracing-subscriber = { version = "0.3.5", default-features = false, features = ["env-filter", "fmt", "registry", "std", "ansi"] }
 human_bytes = "0.3.0"
 
 [[bench]]

--- a/lib/vector-core/buffers/src/disk_v2/mod.rs
+++ b/lib/vector-core/buffers/src/disk_v2/mod.rs
@@ -141,7 +141,7 @@ impl<T> Buffer<T>
 where
     T: Bufferable,
 {
-    #[cfg_attr(test, instrument(level = "trace"))]
+    #[cfg_attr(test, instrument(skip(config, usage_handle), level = "trace"))]
     pub(crate) async fn from_config_inner(
         config: DiskBufferConfig,
         usage_handle: BufferUsageHandle,
@@ -181,7 +181,7 @@ where
     ///
     /// If an error occurred during the creation or loading of the disk buffer, an error variant
     /// will be returned describing the error.
-    #[cfg_attr(test, instrument(level = "trace"))]
+    #[cfg_attr(test, instrument(skip(config, usage_handle), level = "trace"))]
     pub async fn from_config(
         config: DiskBufferConfig,
         usage_handle: BufferUsageHandle,

--- a/lib/vector-core/buffers/src/disk_v2/reader.rs
+++ b/lib/vector-core/buffers/src/disk_v2/reader.rs
@@ -430,7 +430,7 @@ where
                     // the number of acknowledged records exceeds the difference between "last acked" and
                     // "highest record ID", which handles the wrapping-to-zero case.
                     self.last_acked_record_id >= pending.highest_record_id
-                        || (self.last_acked_record_id < pending.last_acked_record_id
+                        || (self.last_acked_record_id <= pending.last_acked_record_id
                             && pending.highest_record_id > pending.last_acked_record_id)
                 })
                 .count();

--- a/lib/vector-core/buffers/src/disk_v2/reader.rs
+++ b/lib/vector-core/buffers/src/disk_v2/reader.rs
@@ -30,6 +30,12 @@ struct DeletionMarker {
     bytes_read: u64,
 }
 
+#[derive(Debug)]
+struct DelayedAck {
+    record_id_threshold: u64,
+    amount: u64,
+}
+
 pub(super) struct ReadToken(usize, u64);
 
 impl ReadToken {
@@ -68,7 +74,7 @@ where
     /// records in a way that is not easily detectable and could lead to records which
     /// deserialize/decode but contain invalid data.
     #[snafu(display("failed to deserialize encoded record from buffer: {}", reason))]
-    FailedToDeserialize { reason: String },
+    Deserialization { reason: String },
 
     /// The record's checksum did not match.
     ///
@@ -82,16 +88,25 @@ where
         calculated,
         actual
     ))]
-    InvalidChecksum { calculated: u32, actual: u32 },
+    Checksum { calculated: u32, actual: u32 },
 
     /// The decoder encountered an issue during decoding.
     ///
     /// At this stage, the record can be assumed to have been written correctly, and read correctly
     /// from disk, as the checksum was also validated.
     #[snafu(display("failed to decoded record: {:?}", source))]
-    FailedToDecode {
+    Decode {
         source: <T as DecodeBytes<T>>::Error,
     },
+
+    /// The reader detected that a data file contains a partially-written record.
+    ///
+    /// Records should never be partially written to a data file (we don't split records across data
+    /// files) so this would be indicative of a write that was never properly written/flushed, or
+    /// some issue with the write where it was acknowledged but the data/file was corrupted in same way.
+    ///
+    /// This is effectively the same class of error as an invalid checksum/failed deserialization.
+    PartialWrite,
 }
 
 impl<T> ReaderError<T>
@@ -101,7 +116,9 @@ where
     fn is_bad_read(&self) -> bool {
         matches!(
             self,
-            ReaderError::InvalidChecksum { .. } | ReaderError::FailedToDeserialize { .. }
+            ReaderError::Checksum { .. }
+                | ReaderError::Deserialization { .. }
+                | ReaderError::PartialWrite
         )
     }
 }
@@ -136,9 +153,13 @@ where
     }
 
     #[cfg_attr(test, instrument(skip(self), level = "trace"))]
-    async fn read_length_delimiter(&mut self) -> Result<Option<usize>, ReaderError<T>> {
+    async fn read_length_delimiter(
+        &mut self,
+        is_finalized: bool,
+    ) -> Result<Option<usize>, ReaderError<T>> {
         loop {
-            if self.reader.buffer().len() >= 8 {
+            let available = self.reader.buffer().len();
+            if available >= 8 {
                 let length_buf = &self.reader.buffer()[..8];
                 let length = length_buf
                     .try_into()
@@ -160,22 +181,32 @@ where
                 return Ok(Some(record_len));
             }
 
+            // We don't have enough bytes, so we need to fill our buffer again.
             let buf = self.reader.fill_buf().await.context(IoSnafu)?;
             if buf.is_empty() {
                 return Ok(None);
+            }
+
+            // If we tried to read more bytes, and we still don't have enough for the record
+            // delimiter, and the data file has been finalized already: we've got a partial
+            // write situation on our hands.
+            if buf.len() < 8 && is_finalized {
+                return Err(ReaderError::PartialWrite);
             }
         }
     }
 
     /// Attempts to read a record.
     ///
-    /// In order to facilitate driving other logic within the reader when there is no data to
-    /// currently read, this method returns early when there is no available data at all, rather
-    /// than waiting for enough data to start readiong a normal record.  In cases where there is not
-    /// enough data to begin reading a record, `None` is returned.
+    /// Records are prececded by a length delimiter, a fixed-size integer (currently 8 bytes) that
+    /// tells the reader how many more bytes to read in order to completely read the next record.
     ///
-    /// If there is any available data, even if it's not _enough_ data, then this method will
-    /// continue awaiting until it can read an entire record.
+    /// If there are no more bytes to read, we return early in order to allow the caller to wait
+    /// until such a time where there should be more data, as no wake-ups can be generated when
+    /// reading a file after reaching EOF.
+    ///
+    /// If there is any data available, we attempt to continue reading until both a length
+    /// delimiter, and the accompanying record, can be read in their entirety.
     ///
     /// If a record is able to be read in its entirety, a token is returned to caller that can be
     /// used with [`read_record`] in order to get an owned `T`.  This is due to a quirk with the
@@ -183,13 +214,30 @@ where
     /// which is handled by splitting the "do we have a valid record in our buffer?" logic from the
     /// "read that record and decode it" logic.
     ///
+    /// # Finalized reads
+    ///
+    /// All of the above logic applies when `is_finalized` is `false`, which signals that a data
+    /// file is still currently being written to.  If `is_finalized` is `true`, most of the above
+    /// logic applies but in cases where we detect a partial write, we explicitly return an error
+    /// for a partial read.
+    ///
+    /// In practice, what this means is that when we believe a file should be "finalized" -- the
+    /// writer flushed the file to disk, the ledger has been flushed, etc -- then we also expect to
+    /// be able to read all bytes with no leftover.  A partially-written length delimiter, or
+    /// record, would be indicative of a bug with the writer or OS/disks, essentially telling us
+    /// that the current data file is not valid for reads anymore.  We don't know _why_ it's in this
+    /// state, only that something is not right and that we must skip the file.
+    ///
     /// # Errors
     ///
     /// Errors can occur during the I/O or deserialization stage.  If an error occurs during any of
     /// these stages, an appropriate error variant will be returned describing the error.
     #[cfg_attr(test, instrument(skip(self), level = "trace"))]
-    pub async fn try_next_record(&mut self) -> Result<Option<ReadToken>, ReaderError<T>> {
-        let record_len = if let Some(len) = self.read_length_delimiter().await? {
+    pub async fn try_next_record(
+        &mut self,
+        is_finalized: bool,
+    ) -> Result<Option<ReadToken>, ReaderError<T>> {
+        let record_len = if let Some(len) = self.read_length_delimiter(is_finalized).await? {
             len
         } else {
             trace!("read_length_delimiter returned None");
@@ -197,7 +245,7 @@ where
         };
 
         if record_len == 0 {
-            return Err(ReaderError::FailedToDeserialize {
+            return Err(ReaderError::Deserialization {
                 reason: "record length was zero".to_string(),
             });
         }
@@ -207,6 +255,11 @@ where
         while self.aligned_buf.len() < record_len {
             let needed = record_len - self.aligned_buf.len();
             let buf = self.reader.fill_buf().await.context(IoSnafu)?;
+            if buf.is_empty() && is_finalized {
+                // If we needed more data, but there was none available, and we're finalized: we've
+                // got ourselves a partial write situation.
+                return Err(ReaderError::PartialWrite);
+            }
 
             let available = cmp::min(buf.len(), needed);
             self.aligned_buf.extend_from_slice(&buf[..available]);
@@ -216,11 +269,11 @@ where
         // Now see if we can deserialize our archived record from this.
         let buf = self.aligned_buf.as_slice();
         match try_as_record_archive(buf, &self.checksummer) {
-            RecordStatus::FailedDeserialization(de) => Err(ReaderError::FailedToDeserialize {
+            RecordStatus::FailedDeserialization(de) => Err(ReaderError::Deserialization {
                 reason: de.into_inner(),
             }),
             RecordStatus::Corrupted { calculated, actual } => {
-                Err(ReaderError::InvalidChecksum { calculated, actual })
+                Err(ReaderError::Checksum { calculated, actual })
             }
             RecordStatus::Valid(id) => {
                 self.current_record_id = id;
@@ -253,7 +306,7 @@ where
         // - `try_next_record` does all the archive checks, checksum validation, etc
         let archived_record = unsafe { archived_root::<Record<'_>>(&self.aligned_buf) };
 
-        T::decode(archived_record.payload()).context(FailedToDecodeSnafu)
+        T::decode(archived_record.payload()).context(DecodeSnafu)
     }
 }
 
@@ -268,6 +321,7 @@ pub struct Reader<T> {
     ready_to_read: bool,
     check_pending_deletions: bool,
     pending_deletions: Vec<DeletionMarker>,
+    delayed_acks: Vec<DelayedAck>,
     pending_read_sizes: Vec<u64>,
     _t: PhantomData<T>,
 }
@@ -287,6 +341,7 @@ where
             ready_to_read: false,
             check_pending_deletions: false,
             pending_deletions: Vec::new(),
+            delayed_acks: Vec::new(),
             pending_read_sizes: Vec::new(),
             _t: PhantomData,
         }
@@ -358,18 +413,24 @@ where
 
     #[cfg_attr(test, instrument(skip(self), level = "debug"))]
     async fn delete_completed_data_files(&mut self) -> io::Result<()> {
+        trace!(
+            message = "scanning for pending data files now eligible for deletion",
+            self.last_acked_record_id
+        );
+
         // Figure out if any of the pending deletions we have are now ready.
         let ready_deletions = {
             let ready_deletions_len = self
                 .pending_deletions
                 .iter()
                 .take_while(|pending| {
+                    trace!(message = "examining pending deletion", marker = ?pending);
                     // If we haven't wrapped around past zero, then we simply check if our new "last acked"
                     // value is highest than the highest record ID for the deletion, otherwise we check if
                     // the number of acknowledged records exceeds the difference between "last acked" and
                     // "highest record ID", which handles the wrapping-to-zero case.
                     self.last_acked_record_id >= pending.highest_record_id
-                        || (self.last_acked_record_id <= pending.last_acked_record_id
+                        || (self.last_acked_record_id < pending.last_acked_record_id
                             && pending.highest_record_id > pending.last_acked_record_id)
                 })
                 .count();
@@ -388,12 +449,54 @@ where
 
     #[cfg_attr(test, instrument(skip(self), level = "debug"))]
     async fn adjust_acknowledgement_state(&mut self, ack_offset: u64) -> io::Result<()> {
-        // Track our new highest acknowledged record ID, and handle any pending deletions that now qualify.
-        self.last_acked_record_id = self.last_acked_record_id.wrapping_add(ack_offset);
+        // Calculate our new `last_acked_record_id`, and then proactively drain any delayed
+        // acknowledgements that would become eligible by either adding `ack_offset`, or any
+        // knock-on acknowledgement changes from an eligible delayed acknowledgement.
+        //
+        // For example, if we had last_acked_record_id=2, and two delayed acknowledgements -- one
+        // with a threshold of 4 and one with a threshold of 6, both with an amount of 2, then our
+        // outstanding expected acknowledgement timeline would look like:
+        //
+        //                           [ delayed ack region 4/2 ][ delayed ack region 6/2 ]
+        // [record ID 3][record ID 4][record ID 5][record ID 6][record ID 7][record ID 8]
+        //
+        // This means that if we acknowledge record IDs 3 and 4 (ack_offset=2), we would make the
+        // first delayed acknowledgement eligible, because `last_acked_record_id` would now be 4.
+        // However, once we also incorporated the acknowledgements from the first delayed ack, then
+        // the _second_ delayed acknowledgement would become eligible, since `last_acked_record_id`
+        // would now be at 6.
+        //
+        // Thus, we track the estimated `last_acked_record_id` for every delayed acknowledgement
+        // that becomes eligible so that we can maximally consume them in this one call.
+        let mut new_last_acked_record_id = self.last_acked_record_id.wrapping_add(ack_offset);
+        while !self.delayed_acks.is_empty() {
+            let delayed_ack = self
+                .delayed_acks
+                .first()
+                .expect("delayed_acks cannot be empty");
+            if new_last_acked_record_id >= delayed_ack.record_id_threshold {
+                let delayed_ack = self.delayed_acks.remove(0);
+                new_last_acked_record_id =
+                    new_last_acked_record_id.wrapping_add(delayed_ack.amount);
+            }
+        }
+
+        // Now calculate the actual delta to apply to `last_acked_record_id` and make it so.
+        let last_acked_delta = new_last_acked_record_id.wrapping_sub(self.last_acked_record_id);
+        self.last_acked_record_id = self.last_acked_record_id.wrapping_add(last_acked_delta);
         self.ledger
             .state()
-            .increment_last_reader_record_id(ack_offset);
+            .increment_last_reader_record_id(last_acked_delta);
+
+        // Pending data file deletions may be eligible now, so check.
         self.delete_completed_data_files().await
+    }
+
+    fn add_delayed_ack_range(&mut self, record_id_threshold: u64, amount: u64) {
+        self.delayed_acks.push(DelayedAck {
+            record_id_threshold,
+            amount,
+        });
     }
 
     #[cfg_attr(test, instrument(skip(self), level = "debug"))]
@@ -423,12 +526,17 @@ where
 
             self.ledger.track_reads(ack_count, total_bytes_read);
 
+            // Adjust our acknowledgement state, which may also trigger delayed acknowledgements
+            // to fire depending on how much acknowledgement progress we make from "real"
+            // acknowledgements.  We do this before notifying the writer because if we do end up
+            // allowing a delayed acknowledgement to proceed, we may free up even more bytes in the
+            // buffer.
+            self.adjust_acknowledgement_state(pending_acks as u64)
+                .await?;
+
             // Notify any waiting writers that we've consumed a bunch of records/bytes, since they
             // might be waiting for the total buffer size to go down below the configured limit.
             self.ledger.notify_reader_waiters();
-
-            self.adjust_acknowledgement_state(pending_acks as u64)
-                .await?;
         }
 
         // Due to the structure of `next`, we handle pending acknowledgements before we generate
@@ -516,6 +624,8 @@ where
                 },
             };
 
+            debug!("reader opened data file '{:?}'", data_file_path);
+
             self.reader = Some(RecordReader::new(data_file));
             return Ok(());
         }
@@ -565,18 +675,16 @@ where
                 count: corrupted_records,
             });
 
-            // We call this here, instead of incrementing `pending_acks` in the ledger
-            // directly, or waiting for the next call to `next`, for two reasons:
-            // - we can delete data files faster, potentially, by doing it right before
-            //   `next` successfully returns a record
-            // - since we're skipping records, there's no pending read sizes for the records
-            //   we're skipping, so we just need to update the acknowledgement state
-            //   directly, without going through the normal path
+            // Track the range of record IDs for the corrupted region, which ensures that we won't
+            // acknowledge them until all record IDs before the start of the range have also been
+            // acknowledged.  This avoids potentially acknowledging not-yet-acknowledged records
+            // which are part of a corrupted data file, since it could cause the data file to be
+            // deleted before those not-yet-acknowledged records were _actually_ acknowledged.
             //
-            // We maintain ledger consistency, even without going through
-            // `handle_pending_acknowledgements`, by updating the record count above, and
-            // the data file deletion logic handles fixing up the buffer size.
-            self.adjust_acknowledgement_state(corrupted_records).await?;
+            // Essentially, we need to wait until the last valid record ID that we read has been
+            // acknowledged, and then we can fast-forward acknowledge the record ID range for the
+            // corrupted records we just discovered.
+            self.add_delayed_ack_range(previous_id, corrupted_records);
         }
 
         Ok(())
@@ -670,8 +778,21 @@ where
             // corrupted records, but hadn't yet had a "good" record that we could read, since the
             // "we skipped records due to corruption" logic requires performing valid read to
             // detect, and calculate a valid delta from.
-            if self.ledger.is_writer_done() && self.ledger.get_total_buffer_size() == 0 {
-                return Ok(None);
+            //
+            // TODO: Validate this with a test that messes with a data file without having to reload
+            // the buffer, since reloading the buffer will recalculate our buffer size.
+            if self.ledger.is_writer_done() {
+                let total_buffer_size = self.ledger.get_total_buffer_size();
+                let total_records = self.ledger.get_total_records();
+                trace!(
+                    "writer done, buffer_size={}, total_records={}",
+                    total_buffer_size,
+                    total_records
+                );
+
+                if total_buffer_size == 0 || total_records == 0 {
+                    return Ok(None);
+                }
             }
 
             self.ensure_ready_for_read().await.context(IoSnafu)?;
@@ -683,10 +804,16 @@ where
 
             let (reader_file_id, writer_file_id) = self.ledger.get_current_reader_writer_file_id();
 
+            // Essentially: is the writer still writing to this data file or not?
+            //
+            // A necessary invariant to have to understand if the record reader should actually keep
+            // waiting for data, or if a data file had a partial write/missing data and should be skipped.
+            let is_finalized = reader_file_id != writer_file_id;
+
             // Try reading a record, which if successful, gives us a token to actually read/get a
             // reference to the record.  This is a slightly-tricky song-and-dance due to rustc not
             // yet fully understanding mutable borrows when conditional control flow is involved.
-            match reader.try_next_record().await {
+            match reader.try_next_record(is_finalized).await {
                 // Not even enough data to read a length delimiter, so we need to wait for the
                 // writer to signal us that there's some actual data to read.
                 Ok(None) => {}
@@ -751,13 +878,6 @@ where
             // loop, because otherwise we could get stuck waiting for the writer after an empty
             // `try_read_record` attempt when the writer is done and we're at the end of the file,
             // etc.
-            //
-            // TODO: We may want to explore adding logic to the reader that returns a sentinel value
-            // when we're trying to read a length delimiter from a position that is past the maximum
-            // file size, since that is theoretically not possible.  We could _start_ a read that is
-            // below the limit, and continue it past the limit, but we should never be able to read
-            // a length delimiter past the limit, because we can't write a length delimiter that
-            // _starts_ past the limit.
             if self.ready_to_read {
                 self.ledger.wait_for_writer().await;
             } else {

--- a/lib/vector-core/buffers/src/disk_v2/tests/invariants.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/invariants.rs
@@ -1,3 +1,4 @@
+use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 use tokio_test::{assert_pending, task::spawn};
 use tracing::Instrument;
 
@@ -6,8 +7,9 @@ use super::{
 };
 use crate::{
     assert_buffer_is_empty, assert_buffer_records, assert_buffer_size, assert_enough_bytes_written,
-    assert_reader_writer_file_positions,
+    assert_reader_writer_file_positions, await_timeout,
     disk_v2::{common::MAX_FILE_ID, tests::create_default_buffer},
+    set_data_file_length,
 };
 
 #[tokio::test]
@@ -18,13 +20,13 @@ async fn last_record_is_valid_during_load_when_buffer_correctly_flushed_and_stop
         let data_dir = dir.to_path_buf();
 
         async move {
-            let reset_called = assertion_registry
+            let writer_did_not_call_reset = assertion_registry
                 .build()
                 .with_name("reset")
                 .with_parent_name(
                     "last_record_is_valid_during_load_when_buffer_correctly_flushed_and_stopped",
                 )
-                .was_entered()
+                .was_not_entered()
                 .finalize();
 
             // Create a normal buffer.
@@ -44,10 +46,7 @@ async fn last_record_is_valid_during_load_when_buffer_correctly_flushed_and_stop
             // Make sure we can open the buffer again without any errors.
             let (_, _, _, ledger) = create_default_buffer::<_, SizedRecord>(data_dir).await;
             assert_eq!(ledger.get_total_records(), 1);
-
-            // TODO: Rewrite this as a negative assertion (i.e. `was_not_entered`) once
-            // `tracing-fluent-assertions` adds support for them.
-            assert!(!reset_called.try_assert());
+            writer_did_not_call_reset.assert();
         }
     });
 
@@ -263,7 +262,6 @@ async fn reader_still_works_when_record_id_wraps_around() {
         async move {
             // Create a simple buffer.
             let (_, _, _, ledger) = create_default_buffer::<_, SizedRecord>(data_dir.clone()).await;
-
             assert_buffer_is_empty!(ledger);
             assert_reader_writer_file_positions!(ledger, 0, 0);
 
@@ -490,5 +488,167 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
     });
 
     let parent = trace_span!("reader_deletes_data_file_around_record_id_wraparound");
+    fut.instrument(parent).await;
+}
+
+#[tokio::test]
+async fn writer_waits_for_reader_after_validate_last_write_fails_and_data_file_skip_triggered() {
+    // The title is long and probably hard to grok, so here's a more straightforward explanation:
+    //
+    // When we initialize a buffer, if the writer previously left off on a partially-filled data
+    // file, we load that dataa file and do a simple check to make sure the last record in the file
+    // is valid.  If it's not valid, we consider that data file corrupted and skip to the next data
+    // file.  This is intended to limit us writing records to a data file that the reader is going
+    // skip the rest of when it detects a bad/corrupted record.
+    //
+    // The problem is that we might be skipping to a data file that we previously finished writing
+    // to, but has not yet been fully processed (and thus deleted) by the reader.
+    //
+    // Assume our maximum data file count is 10, and the writer is on #9, and the reader is on #0.
+    // We open data file #9 as the writer, and detect that it's not valid, so we want to skip to the
+    // next data file, which is #0.  When we go to open that data file, we do detect that it already
+    // exists, so we examine the size of the file.  That file could actually be less than the
+    // maximum data file size: maybe we also skipped that one previously due to corruption and it
+    // wasn't yet full.
+    //
+    // Thus, we are _only_ willing to open and use a partially-filled data file when it's the file
+    // we left off on according to the ledger.  If we have to skip to the next data file, so be it,
+    // but if it already exists, regardless of size, we need to wait for the reader to clear it out.
+    //
+    // TODO: Encode the "max data file size" in the ledger when creating a buffer for the first
+    // time, so that we can refuse to open a buffer when the max data file size does not match.
+    // This would provide the invariant that a data file, once full, can never become writable again
+    // by reopening the buffer with a higher max data file size.
+    let assertion_registry = install_tracing_helpers();
+    let fut = with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let record_size: u32 = 100;
+
+            // Create our buffer with an arbitrarily low max data file size, which will let us
+            // quickly run through the file ID range.  We want to be able to writw at least two
+            // records to each data file, though.
+            let (mut writer, _, _, ledger) =
+                create_buffer_with_max_data_file_size(data_dir.clone(), u64::from(record_size * 2))
+                    .await;
+
+            assert_buffer_is_empty!(ledger);
+            assert_reader_writer_file_positions!(ledger, 0, 0);
+
+            // We want to write enough records so that our writer writes its last record on the last
+            // file ID before file ID rollover occurs.
+            let target_writer_file_id = MAX_FILE_ID - 1;
+
+            let mut records_written = 0;
+            let mut bytes_written = 0;
+            let mut total_bytes_written = 0;
+            let mut writer_file_id = 0;
+            while writer_file_id != target_writer_file_id {
+                for _ in 0..2 {
+                    let record = SizedRecord(record_size);
+                    bytes_written = writer
+                        .write_record(record.clone())
+                        .await
+                        .expect("write should not fail");
+                    assert_enough_bytes_written!(bytes_written, SizedRecord, record_size);
+                }
+                writer.flush().await.expect("flush should not fail");
+
+                total_bytes_written += bytes_written * 2;
+                records_written += 2;
+                writer_file_id = ledger.get_current_writer_file_id();
+
+                assert_buffer_size!(ledger, records_written, total_bytes_written);
+            }
+
+            writer.close();
+            let current_data_file_path = ledger.get_current_writer_data_file_path();
+            let next_data_file_path = ledger.get_next_writer_data_file_path();
+            let next_data_file_id = ledger.get_next_writer_file_id();
+            drop(writer);
+            drop(ledger);
+
+            // Now, we need to load the data file we just left off on and modify it so that it
+            // appears corrupted and triggers the writer to skip it during initiailization, thus
+            // pushing the writer to skip to next data file.  We do this by simply truncating it in
+            // the middle of record, which _also_ has the effect that the data file is technically
+            // not full anymore.
+            //
+            // Additionally, we'll remove one record from the _next_ data file, where the goal is
+            // that we leave the data file in a valid state but smaller than the limit, so that we
+            // can ensure that the writer doesn't mistakenly think it's fine to use simply because
+            // the file is not yet full.
+            set_data_file_length!(
+                current_data_file_path,
+                bytes_written * 2,
+                (bytes_written * 2) - 4
+            );
+            set_data_file_length!(next_data_file_path, bytes_written * 2, bytes_written);
+
+            // Now our last data file has been corrupted, and the next data file is below the
+            // maximum data file size, let's open the writer and make sure that it first skips the
+            // current data file since it's corrupted.
+            let mark_to_skip_called = assertion_registry.build()
+                .with_name("mark_for_skip")
+                .with_parent_name("writer_waits_for_reader_after_validate_last_write_fails_and_data_file_skip_triggered")
+                .was_closed()
+                .finalize();
+            let waiting_on_reader = assertion_registry.build()
+                .with_name("wait_for_reader")
+                .with_parent_name("writer_waits_for_reader_after_validate_last_write_fails_and_data_file_skip_triggered")
+                .was_entered()
+                .finalize();
+
+            let (mut writer, mut reader, acker, ledger) =
+                create_buffer_with_max_data_file_size(data_dir, u64::from(record_size * 2)).await;
+            assert!(mark_to_skip_called.try_assert());
+            assert_eq!(next_data_file_id, ledger.get_next_writer_file_id());
+            assert!(!waiting_on_reader.try_assert());
+
+            let total_records = ledger.get_total_records();
+
+            // The writer correctly reset/marked itself as needing to skip the current data file,
+            // but we need to actually attempt a write to drive the logic where it tries to open up
+            // the next data file, so we do that here, expecting it to end up blocked on the reader.
+            let mut blocked_write =
+                spawn(async move { writer.write_record(SizedRecord(record_size)).await });
+
+            while !waiting_on_reader.try_assert() {
+                assert_pending!(blocked_write.poll());
+            }
+            assert_eq!(next_data_file_id, ledger.get_next_writer_file_id());
+            assert_eq!(total_records, ledger.get_total_records());
+
+            // Now, let's actually read some records!  We'll read our way through the first data
+            // file, which should yield a good read.  Remember, we removed a record from the "next"
+            // data file, which is the data file the reader is currently on.  Thus, our second read
+            // will move forward, which should allow deleting the first data file, aka "next", which
+            // is what the writer is waiting on.
+            let first_good_read = reader.next().await.expect("read should not fail");
+            assert_eq!(first_good_read, Some(SizedRecord(record_size)));
+            acker.ack(1);
+            assert_pending!(blocked_write.poll());
+            assert_reader_writer_file_positions!(ledger, next_data_file_id, writer_file_id);
+
+            let second_good_read = reader.next().await.expect("read should not fail");
+            assert_eq!(second_good_read, Some(SizedRecord(record_size)));
+            acker.ack(1);
+            assert_reader_writer_file_positions!(ledger, next_data_file_id + 1, writer_file_id);
+
+            // Now the "next" data file should be acknowledged and deleted, and so the writer should
+            // be unblocked.  We drive it as a normal future here because this is going to have to
+            // do file I/O, which may yield a few times so a single poll isn't enough.  This should
+            // open the next data file, the one the reader just deleted, and make it the current
+            // data file for the writer.
+            let blocked_write_result = await_timeout!(blocked_write, 2);
+            let _bytes_written = blocked_write_result.expect("write should not fail");
+            assert_eq!(next_data_file_id, ledger.get_current_writer_file_id());
+        }
+    });
+
+    let parent = trace_span!(
+        "writer_waits_for_reader_after_validate_last_write_fails_and_data_file_skip_triggered"
+    );
     fut.instrument(parent).await;
 }

--- a/lib/vector-core/buffers/src/disk_v2/tests/known_errors.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/known_errors.rs
@@ -535,7 +535,7 @@ async fn writer_detects_when_last_record_wasnt_flushed() {
             let marked_for_skip = assertion_registry
                 .build()
                 .with_name("mark_for_skip")
-                .with_parent_name("writer_detects_when_last_record_has_invalid_checksum")
+                .with_parent_name("writer_detects_when_last_record_wasnt_flushed")
                 .was_entered()
                 .finalize();
 

--- a/lib/vector-core/buffers/src/disk_v2/tests/known_errors.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/known_errors.rs
@@ -9,9 +9,14 @@ use tracing::Instrument;
 
 use super::{create_default_buffer, install_tracing_helpers, with_temp_dir, UndecodableRecord};
 use crate::{
-    assert_enough_bytes_written, assert_file_does_not_exist_async, assert_file_exists_async,
-    assert_reader_writer_file_positions,
-    disk_v2::{backed_archive::BackedArchive, record::Record, tests::SizedRecord, ReaderError},
+    assert_buffer_size, assert_enough_bytes_written, assert_file_does_not_exist_async,
+    assert_file_exists_async, assert_reader_writer_file_positions, await_timeout,
+    disk_v2::{
+        backed_archive::BackedArchive,
+        record::Record,
+        tests::{create_buffer_with_max_data_file_size, SizedRecord},
+        ReaderError,
+    },
 };
 
 #[tokio::test]
@@ -70,7 +75,7 @@ async fn reader_throws_error_when_record_length_delimiter_is_zero() {
             // deserialization failure, but specifically that the record length was zero.
             let (_, mut reader, _, _) = create_default_buffer::<_, SizedRecord>(data_dir).await;
             match reader.next().await {
-                Err(ReaderError::FailedToDeserialize { reason }) => {
+                Err(ReaderError::Deserialization { reason }) => {
                     assert!(reason.ends_with("record length was zero"));
                 }
                 _ => panic!("read_result should be deserialization error"),
@@ -82,17 +87,131 @@ async fn reader_throws_error_when_record_length_delimiter_is_zero() {
 
 #[tokio::test]
 async fn reader_throws_error_when_finished_file_has_truncated_record_data() {
-    // TODO: We really do want this test, which is the equivalent of saying:
-    // "do we correctly detect when a file has, say, the u64 'record length' delimiter but either no
-    // more data after that, or not enough data, and we know for sure the writer has moved on?"
-    //
     // Right now, we _always_ assume the data is coming if we can at least read 8 bytes for the
     // length delimiter... but the point in the code where that happens is oblivious to the
-    // higher-level reader/writer state, so making it possible to detect this condition will take a
-    // small chunk of redesign work, but is definitely one of the last major possible issues that
-    // the buffer reasonably has to handle.
-    let worked = true;
-    assert!(worked);
+    // higher-level reader/writer state, so if there was an error that lead to a data file ending
+    // prematurely, the underlying reader would not be aware of this and would wait forever for
+    // however many bytes.
+    //
+    // This is actually a higher-level problem insofar as we'll willingly continue trying to read
+    // out a record even if there's only one byte left, because the contract is that when a data
+    // file is done, and we've read all the records, there should be no bytes left over... which is
+    // a reasonable invariant!
+    //
+    // If there's at least one more byte, though, or if there was a record that took up, say, 1000
+    // bytes in theory but only 999 bytes got written and the writer has moved on, we'll sit there
+    // forever waiting for that last byte before we move on to the next data file.
+    //
+    // Thus, what we want to test for is to ensure that when the writer _has_ moved on, and there's
+    // not enough data to possibly continue, we correctly detect this situation and move on.  All of
+    // our existing logic -- checking bytes read vs file size when deleting, checking record ID gap
+    // when updating last read record ID -- should handle keeping the buffer size accurate as well
+    // as detecting corrupted records, so there should be no issue there.
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            // Create a buffer with a smaller-than-normal data file size limit, just so that we can
+            // force the writer to roll to another data file and then easily mess with the previous
+            // data file.
+            let (mut writer, _, _, ledger) =
+                create_buffer_with_max_data_file_size(data_dir.clone(), 128).await;
+
+            // Write two smaller records, such that the first one fits entirelyh, and the second one
+            // starts within the 128-byte zone but finishes over the limit, thus triggering data
+            // file rollover.
+            let first_bytes_written = writer
+                .write_record(SizedRecord(62))
+                .await
+                .expect("write should not fail");
+            let second_bytes_written = writer
+                .write_record(SizedRecord(63))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
+
+            let expected_first_data_file_len = first_bytes_written + second_bytes_written;
+            let first_data_file_path = ledger.get_current_writer_data_file_path();
+
+            // Make sure we're in the right state before doing a third write, which should land in
+            // another data file.
+            assert_buffer_size!(ledger, 2, expected_first_data_file_len);
+            assert_reader_writer_file_positions!(ledger, 0, 0);
+
+            // Do our third write, which should land in a new data file.
+            let third_bytes_written = writer
+                .write_record(SizedRecord(64))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
+
+            assert_buffer_size!(
+                ledger,
+                3,
+                expected_first_data_file_len + third_bytes_written
+            );
+            assert_reader_writer_file_positions!(ledger, 0, 1);
+
+            // Now drop the writer/ledger to close the buffer, so we can do some hackin' and
+            // slashin' to the first data file. >:D
+            drop(writer);
+            drop(ledger);
+
+            // Open the file and truncate it so that we can read the length delimiter of the second
+            // record, but only part of the second record itself.
+            let mut data_file = OpenOptions::new()
+                .write(true)
+                .open(&first_data_file_path)
+                .await
+                .expect("open should not fail");
+
+            // Just to make sure the data file matches our expected state before futzing with it.
+            let metadata = data_file
+                .metadata()
+                .await
+                .expect("metadata should not fail");
+            assert_eq!(expected_first_data_file_len as u64, metadata.len());
+
+            // Middle of the second record seems good.
+            data_file
+                .set_len((first_bytes_written + (second_bytes_written / 2)) as u64)
+                .await
+                .expect("truncating should not fail");
+            data_file.flush().await.expect("flush should not fail");
+            data_file.sync_all().await.expect("sync should not fail");
+            drop(data_file);
+
+            // Now reopen the buffer.  We should get a good read, a failed read, and then a final
+            // good read:
+            // - first read is the first record, nothing special
+            // - second read is an error because we detect a partial record write which can't be
+            //   read as a valid record, forcing us to skip to the second data file
+            // - third read is the third record that we successfully wrote to the second data file
+            let (mut writer, mut reader, acker, ledger) =
+                create_default_buffer::<_, SizedRecord>(data_dir).await;
+            writer.close();
+            assert_reader_writer_file_positions!(ledger, 0, 1);
+
+            let first_read = await_timeout!(reader.next(), 2).expect("read should not fail");
+            assert_eq!(first_read, Some(SizedRecord(62)));
+            assert_reader_writer_file_positions!(ledger, 0, 1);
+            acker.ack(1);
+
+            let second_read = await_timeout!(reader.next(), 2).expect_err("read should fail");
+            assert!(matches!(second_read, ReaderError::PartialWrite));
+            assert_reader_writer_file_positions!(ledger, 1, 1);
+
+            let third_read = await_timeout!(reader.next(), 2).expect("read should not fail");
+            assert_eq!(third_read, Some(SizedRecord(64)));
+            assert_reader_writer_file_positions!(ledger, 1, 1);
+            acker.ack(1);
+
+            let final_read = await_timeout!(reader.next(), 2).expect("read should not fail");
+            assert_eq!(final_read, None);
+            assert_reader_writer_file_positions!(ledger, 1, 1);
+        }
+    })
+    .await;
 }
 
 #[tokio::test]
@@ -166,7 +285,7 @@ async fn reader_throws_error_when_record_has_scrambled_archive_data() {
             let read_result = reader.next().await;
             assert!(matches!(
                 read_result,
-                Err(ReaderError::FailedToDeserialize { .. })
+                Err(ReaderError::Deserialization { .. })
             ));
         }
     })
@@ -192,10 +311,7 @@ async fn reader_throws_error_when_record_has_decoding_error() {
 
             // Now try to read it back, which should return an error.
             let read_result = reader.next().await;
-            assert!(matches!(
-                read_result,
-                Err(ReaderError::FailedToDecode { .. })
-            ));
+            assert!(matches!(read_result, Err(ReaderError::Decode { .. })));
         }
     })
     .await;
@@ -208,15 +324,16 @@ async fn writer_detects_when_last_record_has_scrambled_archive_data() {
         let data_dir = dir.to_path_buf();
 
         async move {
-            let writer_called_reset = assertion_registry
+            let marked_for_skip = assertion_registry
                 .build()
-                .with_name("reset")
+                .with_name("mark_for_skip")
                 .with_parent_name("writer_detects_when_last_record_has_scrambled_archive_data")
                 .was_entered()
                 .finalize();
 
             // Create a regular buffer, no customizations required.
             let (mut writer, _, _, ledger) = create_default_buffer(data_dir.clone()).await;
+            let starting_writer_file_id = ledger.get_current_writer_file_id();
             let expected_final_writer_file_id = ledger.get_next_writer_file_id();
             let expected_final_write_data_file = ledger.get_next_writer_data_file_path();
             assert_file_does_not_exist_async!(&expected_final_write_data_file);
@@ -241,8 +358,8 @@ async fn writer_detects_when_last_record_has_scrambled_archive_data() {
             drop(writer);
             drop(ledger);
 
-            // We should not have seen a call to `reset` yet.
-            assert!(!writer_called_reset.try_assert());
+            // We should not have seen a call to `mark_for_skip` yet.
+            assert!(!marked_for_skip.try_assert());
 
             // Open the file and set the last eight bytes of the record to something clearly
             // wrong/invalid, which should end up messing with the relative pointer stuff in the
@@ -274,10 +391,21 @@ async fn writer_detects_when_last_record_has_scrambled_archive_data() {
             data_file.sync_all().await.expect("sync should not fail");
             drop(data_file);
 
-            // Now reopen the buffer, which should trigger a `Writer::reset` call and additionally,
-            // we should be rolled over to a new data file now on the writer side.
-            let (_, _, _, ledger) = create_default_buffer::<_, SizedRecord>(data_dir).await;
-            writer_called_reset.assert();
+            // Now reopen the buffer, which should trigger a `Writer::mark_for_skip` call which
+            // instructs the writer to skip to the next data file, although this doesn't happen
+            // until the first write is attempted.
+            let (mut writer, _, _, ledger) =
+                create_default_buffer::<_, SizedRecord>(data_dir).await;
+            marked_for_skip.assert();
+            assert_reader_writer_file_positions!(ledger, 0, starting_writer_file_id);
+            assert_file_does_not_exist_async!(&expected_final_write_data_file);
+
+            // Do a simple write to ensure it opens the next data file.
+            let _bytes_written = writer
+                .write_record(SizedRecord(64))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
             assert_reader_writer_file_positions!(ledger, 0, expected_final_writer_file_id);
             assert_file_exists_async!(&expected_final_write_data_file);
         }
@@ -294,15 +422,16 @@ async fn writer_detects_when_last_record_has_invalid_checksum() {
         let data_dir = dir.to_path_buf();
 
         async move {
-            let writer_called_reset = assertion_registry
+            let marked_for_skip = assertion_registry
                 .build()
-                .with_name("reset")
+                .with_name("mark_for_skip")
                 .with_parent_name("writer_detects_when_last_record_has_invalid_checksum")
                 .was_entered()
                 .finalize();
 
             // Create a regular buffer, no customizations required.
             let (mut writer, _, _, ledger) = create_default_buffer(data_dir.clone()).await;
+            let starting_writer_file_id = ledger.get_current_writer_file_id();
             let expected_final_writer_file_id = ledger.get_next_writer_file_id();
             let expected_final_write_data_file = ledger.get_next_writer_data_file_path();
             assert_file_does_not_exist_async!(&expected_final_write_data_file);
@@ -329,8 +458,8 @@ async fn writer_detects_when_last_record_has_invalid_checksum() {
             drop(writer);
             drop(ledger);
 
-            // We should not have seen a call to `reset` yet.
-            assert!(!writer_called_reset.try_assert());
+            // We should not have seen a call to `mark_for_skip` yet.
+            assert!(!marked_for_skip.try_assert());
 
             // Open the file, mutably deserialize the record, and flip a bit in the checksum.
             let data_file = OpenOptions::new()
@@ -372,10 +501,21 @@ async fn writer_detects_when_last_record_has_invalid_checksum() {
                 .expect("flush should not fail");
             drop(backed_record);
 
-            // Now reopen the buffer, which should trigger a `Writer::reset` call and additionally,
-            // we should be rolled over to a new data file now on the writer side.
-            let (_, _, _, ledger) = create_default_buffer::<_, SizedRecord>(data_dir).await;
-            writer_called_reset.assert();
+            // Now reopen the buffer, which should trigger a `Writer::mark_for_skip` call which
+            // instructs the writer to skip to the next data file, although this doesn't happen
+            // until the first write is attempted.
+            let (mut writer, _, _, ledger) =
+                create_default_buffer::<_, SizedRecord>(data_dir).await;
+            marked_for_skip.assert();
+            assert_reader_writer_file_positions!(ledger, 0, starting_writer_file_id);
+            assert_file_does_not_exist_async!(&expected_final_write_data_file);
+
+            // Do a simple write to ensure it opens the next data file.
+            let _bytes_written = writer
+                .write_record(SizedRecord(64))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
             assert_reader_writer_file_positions!(ledger, 0, expected_final_writer_file_id);
             assert_file_exists_async!(&expected_final_write_data_file);
         }
@@ -392,15 +532,16 @@ async fn writer_detects_when_last_record_wasnt_flushed() {
         let data_dir = dir.to_path_buf();
 
         async move {
-            let writer_called_reset = assertion_registry
+            let marked_for_skip = assertion_registry
                 .build()
-                .with_name("reset")
-                .with_parent_name("writer_detects_when_last_record_wasnt_flushed")
+                .with_name("mark_for_skip")
+                .with_parent_name("writer_detects_when_last_record_has_invalid_checksum")
                 .was_entered()
                 .finalize();
 
             // Create a regular buffer, no customizations required.
             let (mut writer, _, _, ledger) = create_default_buffer(data_dir.clone()).await;
+            let starting_writer_file_id = ledger.get_current_writer_file_id();
             let expected_final_writer_file_id = ledger.get_next_writer_file_id();
             let expected_final_write_data_file = ledger.get_next_writer_data_file_path();
             assert_file_does_not_exist_async!(&expected_final_write_data_file);
@@ -430,13 +571,24 @@ async fn writer_detects_when_last_record_wasnt_flushed() {
             drop(writer);
             drop(ledger);
 
-            // We should not have seen a call to `reset` yet.
-            assert!(!writer_called_reset.try_assert());
+            // We should not have seen a call to `mark_for_skip` yet.
+            assert!(!marked_for_skip.try_assert());
 
-            // Now reopen the buffer, which should trigger a `Writer::reset` call and additionally,
-            // we should be rolled over to a new data file now on the writer side.
-            let (_, _, _, ledger) = create_default_buffer::<_, SizedRecord>(data_dir).await;
-            writer_called_reset.assert();
+            // Now reopen the buffer, which should trigger a `Writer::mark_for_skip` call which
+            // instructs the writer to skip to the next data file, although this doesn't happen
+            // until the first write is attempted.
+            let (mut writer, _, _, ledger) =
+                create_default_buffer::<_, SizedRecord>(data_dir).await;
+            marked_for_skip.assert();
+            assert_reader_writer_file_positions!(ledger, 0, starting_writer_file_id);
+            assert_file_does_not_exist_async!(&expected_final_write_data_file);
+
+            // Do a simple write to ensure it opens the next data file.
+            let _bytes_written = writer
+                .write_record(SizedRecord(64))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
             assert_reader_writer_file_positions!(ledger, 0, expected_final_writer_file_id);
             assert_file_exists_async!(&expected_final_write_data_file);
         }
@@ -453,13 +605,13 @@ async fn writer_detects_when_last_record_was_flushed_but_id_wasnt_incremented() 
         let data_dir = dir.to_path_buf();
 
         async move {
-            let writer_called_reset = assertion_registry
+            let writer_did_not_call_reset = assertion_registry
                 .build()
                 .with_name("reset")
                 .with_parent_name(
                     "writer_detects_when_last_record_was_flushed_but_id_wasnt_incremented",
                 )
-                .was_entered()
+                .was_not_entered()
                 .finalize();
 
             // Create a regular buffer, no customizations required.
@@ -493,18 +645,14 @@ async fn writer_detects_when_last_record_was_flushed_but_id_wasnt_incremented() 
             drop(writer);
             drop(ledger);
 
-            // We should not have seen a call to `reset` yet.
-            assert!(!writer_called_reset.try_assert());
+            writer_did_not_call_reset.assert();
 
             // Now reopen the buffer, which should trigger the skip ahead logic where we move our
             // writer next record ID to be ahead of the actual last record ID, but on whatever we
             // pulled out of the data file.  This is required to maintain our monotonicity invariant
             // for all records written into the buffer.
             let (_, _, _, ledger) = create_default_buffer::<_, SizedRecord>(data_dir).await;
-
-            // TODO: Rewrite this as a negative assertion (i.e. `was_not_entered`) once
-            // `tracing-fluent-assertions` adds support for them.
-            assert!(!writer_called_reset.try_assert());
+            writer_did_not_call_reset.assert();
             assert_reader_writer_file_positions!(ledger, 0, expected_final_writer_file_id);
             assert_file_does_not_exist_async!(&expected_final_write_data_file);
             assert_eq!(

--- a/lib/vector-core/buffers/src/disk_v2/tests/mod.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/mod.rs
@@ -338,7 +338,16 @@ pub fn install_tracing_helpers() -> AssertionRegistry {
     // with a unique span that can be matched on specifically with
     // `AssertionBuilder::with_parent_name`.
     //
-    // At some point, we might be able to write a simple derive macro that does this for us, and
+    // TODO: We also need a better way of wrapping our test functions in their own parent spans, for
+    // the purpose of isolating their assertions.  Right now, we do it with a unique string that we
+    // have set to the test function name, but this is susceptible to being copypasta'd
+    // unintentionally, thus letting assertions bleed into other tests.
+    //
+    // Maybe we should add a helper method to `tracing-fluent-assertions` for generating a
+    // uniquely-named span that can be passed directly to the assertion builder methods, then it's a
+    // much tighter loop.
+    //
+    // TODO: At some point, we might be able to write a simple derive macro that does this for us, and
     // configures the other necessary bits, but for now.... by hand will get the job done.
     static ASSERTION_REGISTRY: Lazy<AssertionRegistry> = Lazy::new(|| {
         let assertion_registry = AssertionRegistry::default();

--- a/lib/vector-core/buffers/src/disk_v2/tests/record.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/record.rs
@@ -20,7 +20,7 @@ async fn roundtrip_through_record_writer_and_record_reader() {
     record_writer.flush().await.expect("flush should not fail");
 
     let read_token = record_reader
-        .try_next_record()
+        .try_next_record(false)
         .await
         .expect("read should not fail");
     assert!(read_token.is_some());
@@ -41,7 +41,7 @@ async fn record_reader_always_returns_none_when_no_data() {
 
     let mut record_reader = RecordReader::<_, SizedRecord>::new(reader_io);
     let read_token = record_reader
-        .try_next_record()
+        .try_next_record(false)
         .await
         .expect("read should not fail");
     assert!(read_token.is_none());


### PR DESCRIPTION
Back again with more inscrutable code changes!  Just kidding... I think.

This PR addresses two specific corner cases with the disk buffer v2:
- when a reader encounters a data file with a partially-written record at the end
- when a writer tries to skip an invalid data file and the next data file already exists

It also improves our acknowledgement logic by fixing an issue with acknowledging records that were part of a corrupted data file.

### Partially written records

The first scenario is pretty straight-forward: for whatever reason, either due to a bug in the code or maybe a legitimate issue with the OS/filesystem/disk, we could potentially do a partial write for a record.  The reader currently expects that if there's even a single byte that it can read, the rest of it must be coming, and so it dutifully awaits, including sometimes waiting for the writer to signal that progress has been made, and to try again.

This corner case is pertinent because a writer may not always _make_ progress, which could leave the reader sitting there, thinking that because it saw a single byte, there's more coming.  The writer also _could_ make more progress, which would wake up the reader, but it might be progress on the next data file, while the reader is stuck back on one that had a partial write.

We handle this by tracking the reader/writer file ID deltas, essentially: am I reading from the same file the writer is currently writing to?  If we're reading from a different file, we depend on the invariant that in order for a writer to increment its file ID and move on, it first has to flush and `fsync` the data file to disk, which should ensure all bytes have made it to the data file.  With that in mind, it should not be possible for a file to legitimately not have all the data available to read if it has in fact moved on to the next data file, and a reader that encounters a partial read (not enough bytes for the length delimiter, or not enough bytes according to the length delimiter) now correctly detects this error and bubbles it up, letting us do all the necessary stuff such as skipping to the next file, adjusting buffer size, figuring out how many records we have lost, etc.


### Writer skipping invalid data files

When a buffer is initialized, the writer attempts to open its current data file.  For new buffers, this is basically file ID 0, and it shouldn't yet exist, so there's nothing to check.  If it had previously left off on a non-empty file, though, we do a lightweight verification of the last record written to the file.  This doesn't necessarily capture all possible corruption in the file, but it's useful because we can detect if the last record written to the data file is corrupt _or_ if there was a failed/missing writer flush, where the buffer thinks it should have written up to, say, record ID 10, but the last record in the data file is actually record ID 7, indicating we somehow lost record IDs 8 and 9.

So, when this initialization occurs and we do the aforementioned validation, if we do detect an issue, we want to move to the next data file, because while the current data file might not yet be full, it's in an inconsistent state, and writing more records to it would mean those records would 100% be lost because the reader would then skip the data file when it detected the same issue that the writer just did.

We already have existing logic to ensure that the writer and reader don't lap each other -- file IDs wrapping around at 2^16 -- but in the case of the writer, we were incorrectly running some of the logic that would normally occur in the methods that provide the aforementioned logic.  This lead to an invalid state where the writer might open a data file that the reader was still on, when it should have been waiting for the data file to be finished and deleted by the reader.

We've fixed this by adding a very small amount of logic to the initialization routine, and the "open my current/next data file" routine so that we can flag ourselves when we specifically want to skip to the next data file due to an error during initialization.

### Corrupted record acknowledgement ordering

As mentioned above, we additionally fixed a bug with bad ordering around the acknowledgement of corrupted records.

Essentially, when we detect corruption in a data file, we track just enough information so that we can know when the file is safe to delete.  We may have read valid records out of a file before detecting the corruption, so we can't realistically delete it until all of those valid records have been acknowledged.

The logic to do this was almost correct, but we had an issue where we would forcefully acknowledge those corrupted records -- after all, we still need to account for them for the overall acknowledgement state to be valid -- as soon as we detected the corruption, but this was incorrect because we were effectively updating the acknowledgement position in a way that may have made it look like records that came _before_ the corrupted records were now acknowledged.  This introduced the possibility of deleting a data file before all records were acknowledged from it

We've fixed this by introducing "delayed acks", which are simply an acknowledgement marker that can become eligible during the acknowledgement handling routine.  What this looks like is that if we read 7 records from a file, but then we detect corruption, and detect that there are 3 corrupted records we're dropping, we naturally can't acknowledge those 3 corrupted records until we've acknowledged the 7 records before it.  We now track these delayed acks as an acknowledged record ID threshold/amount.

When we run acknowledgement, we now know that we have a delayed ack region that has a record ID threshold at 7 (7th record) and has an amount of 3.  So we handle normal acks, and as soon as those normal acks would push the "highest acknowledged record ID" to greater than or equal to the record ID threshold, that delayed ack region is now "eligible" and we immediately drain it and update our acknowledgement position to include the amount in that delayed ack region.  We continue trying to drain any other delayed acks we have, since one delayed ack becoming eligible and contributing to the highest acknowledged record ID might also make other delayed ack regions eligible as way.