### PR TITLE
chore(core): Move the conversion to EventArray out of VectorSink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -704,6 +704,7 @@ nightly = []
 # Testing-related features
 all-integration-tests = [
   "aws-integration-tests",
+  "azure-integration-tests",
   "clickhouse-integration-tests",
   "datadog-agent-integration-tests",
   "datadog-logs-integration-tests",

--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -90,6 +90,7 @@ impl EventContainer for MetricArray {
 }
 
 /// An array of one of the `Event` variants exclusively.
+#[derive(Debug)]
 pub enum EventArray {
     /// An array of type `LogEvent`
     Logs(LogArray),
@@ -146,6 +147,7 @@ impl EventContainer for EventArray {
 }
 
 /// The iterator type for `EventArray`.
+#[derive(Debug)]
 pub enum EventArrayIntoIter {
     /// An iterator over type `LogEvent`.
     Logs(vec::IntoIter<LogEvent>),

--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -98,6 +98,22 @@ pub enum EventArray {
     Metrics(MetricArray),
 }
 
+impl EventArray {
+    /// Run the given update function over each `LogEvent` in this array.
+    pub fn for_each_log(&mut self, update: impl FnMut(&mut LogEvent)) {
+        if let Self::Logs(logs) = self {
+            logs.iter_mut().for_each(update);
+        }
+    }
+
+    /// Run the given update function over each `Metric` in this array.
+    pub fn for_each_metric(&mut self, update: impl FnMut(&mut Metric)) {
+        if let Self::Metrics(metrics) = self {
+            metrics.iter_mut().for_each(update);
+        }
+    }
+}
+
 impl From<Event> for EventArray {
     fn from(event: Event) -> Self {
         match event {

--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -11,13 +11,17 @@ use crate::ByteSizeOf;
 /// of events. This is effectively the same as the standard
 /// `IntoIterator<Item = Event>` implementations, but that would
 /// conflict with the base implementation for the type aliases below.
-#[allow(clippy::len_without_is_empty)]
 pub trait EventContainer: ByteSizeOf {
     /// The type of `Iterator` used to turn this container into events.
     type IntoIter: Iterator<Item = Event>;
 
     /// The number of events in this container.
     fn len(&self) -> usize;
+
+    /// Is this container empty?
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Turn this container into an iterator of events.
     fn into_events(self) -> Self::IntoIter;
@@ -28,6 +32,10 @@ impl EventContainer for Event {
 
     fn len(&self) -> usize {
         1
+    }
+
+    fn is_empty(&self) -> bool {
+        false
     }
 
     fn into_events(self) -> Self::IntoIter {
@@ -42,6 +50,10 @@ impl EventContainer for LogEvent {
         1
     }
 
+    fn is_empty(&self) -> bool {
+        false
+    }
+
     fn into_events(self) -> Self::IntoIter {
         iter::once(self.into())
     }
@@ -52,6 +64,10 @@ impl EventContainer for Metric {
 
     fn len(&self) -> usize {
         1
+    }
+
+    fn is_empty(&self) -> bool {
+        false
     }
 
     fn into_events(self) -> Self::IntoIter {

--- a/lib/vector-core/src/sink.rs
+++ b/lib/vector-core/src/sink.rs
@@ -1,4 +1,4 @@
-use std::{fmt, pin::Pin};
+use std::{fmt, iter::IntoIterator, pin::Pin};
 
 use async_trait::async_trait;
 use futures::{stream, task::Context, task::Poll, Sink, SinkExt, Stream, StreamExt};
@@ -16,15 +16,33 @@ impl VectorSink {
     /// # Errors
     ///
     /// It is unclear under what conditions this function will error.
-    pub async fn run<S>(self, input: S) -> Result<(), ()>
-    where
-        S: Stream<Item = Event> + Send,
-    {
-        let input = input.map(Into::into);
+    pub async fn run(self, input: impl Stream<Item = EventArray> + Send) -> Result<(), ()> {
         match self {
             Self::Sink(sink) => input.map(Ok).forward(sink).await,
             Self::Stream(s) => s.run(Box::pin(input)).await,
         }
+    }
+
+    /// Run the `VectorSink` with a one-time `Vec` of `Event`s, for use in tests
+    ///
+    /// # Errors
+    ///
+    /// See `VectorSink::run` for errors.
+    pub async fn run_event_stream(self, input: impl Stream<Item = Event> + Send) -> Result<(), ()> {
+        self.run(input.map(Into::into)).await
+    }
+
+    /// Run the `VectorSink` with a one-time `Vec` of `Event`s, for use in tests
+    ///
+    /// # Errors
+    ///
+    /// See `VectorSink::run` for errors.
+    pub async fn run_events<I>(self, input: I) -> Result<(), ()>
+    where
+        I: IntoIterator<Item = Event> + Send,
+        I::IntoIter: Send,
+    {
+        self.run_event_stream(stream::iter(input)).await
     }
 
     /// Converts `VectorSink` into a `futures::Sink`

--- a/lib/vector-core/src/sink.rs
+++ b/lib/vector-core/src/sink.rs
@@ -28,21 +28,12 @@ impl VectorSink {
     /// # Errors
     ///
     /// See `VectorSink::run` for errors.
-    pub async fn run_event_stream(self, input: impl Stream<Item = Event> + Send) -> Result<(), ()> {
-        self.run(input.map(Into::into)).await
-    }
-
-    /// Run the `VectorSink` with a one-time `Vec` of `Event`s, for use in tests
-    ///
-    /// # Errors
-    ///
-    /// See `VectorSink::run` for errors.
     pub async fn run_events<I>(self, input: I) -> Result<(), ()>
     where
         I: IntoIterator<Item = Event> + Send,
         I::IntoIter: Send,
     {
-        self.run_event_stream(stream::iter(input)).await
+        self.run(stream::iter(input).map(Into::into)).await
     }
 
     /// Converts `VectorSink` into a `futures::Sink`

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -4,7 +4,7 @@
 use std::convert::TryFrom;
 
 use chrono::Duration;
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use pretty_assertions::assert_eq;
 use rusoto_core::Region;
 use rusoto_logs::{
@@ -53,7 +53,7 @@ async fn cloudwatch_insert_log_event() {
     let timestamp = chrono::Utc::now();
 
     let (input_lines, events) = random_lines_with_stream(100, 11, None);
-    sink.run(events).await.unwrap();
+    sink.run_event_stream(events).await.unwrap();
 
     let request = GetLogEventsRequest {
         log_stream_name: stream_name,
@@ -114,7 +114,7 @@ async fn cloudwatch_insert_log_events_sorted() {
         }
         doit = true;
 
-        event
+        event.into()
     });
     let _ = sink.run(events).await.unwrap();
 
@@ -191,7 +191,7 @@ async fn cloudwatch_insert_out_of_range_timestamp() {
     lines.push(add_event(Duration::days(-1)));
     lines.push(add_event(Duration::days(-13)));
 
-    sink.run(stream::iter(events)).await.unwrap();
+    sink.run_events(events).await.unwrap();
 
     let request = GetLogEventsRequest {
         log_stream_name: stream_name,
@@ -238,7 +238,7 @@ async fn cloudwatch_dynamic_group_and_stream_creation() {
     let timestamp = chrono::Utc::now();
 
     let (input_lines, events) = random_lines_with_stream(100, 11, None);
-    sink.run(events).await.unwrap();
+    sink.run_event_stream(events).await.unwrap();
 
     let request = GetLogEventsRequest {
         log_stream_name: stream_name,
@@ -350,7 +350,7 @@ async fn cloudwatch_insert_log_event_partitioned() {
             event
         })
         .collect::<Vec<_>>();
-    sink.run(stream::iter(events)).await.unwrap();
+    sink.run_events(events).await.unwrap();
 
     let request = GetLogEventsRequest {
         log_stream_name: format!("{}-0", stream_name),

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -444,6 +444,7 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use chrono::offset::TimeZone;
+    use futures::StreamExt;
     use rand::seq::SliceRandom;
 
     use super::*;
@@ -528,7 +529,7 @@ mod integration_tests {
             events.push(event);
         }
 
-        let stream = stream::iter(events);
+        let stream = stream::iter(events).map(Into::into);
         sink.run(stream).await.unwrap();
     }
 
@@ -557,7 +558,7 @@ mod integration_tests {
 
         events.shuffle(&mut rand::thread_rng());
 
-        let stream = stream::iter(events);
+        let stream = stream::iter(events).map(Into::into);
         sink.run(stream).await.unwrap();
     }
 }

--- a/src/sinks/aws_kinesis_firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis_firehose/integration_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "aws-kinesis-firehose-integration-tests")]
 #![cfg(test)]
 
-use futures::TryFutureExt;
+use futures::{StreamExt, TryFutureExt};
 use rusoto_core::Region;
 use rusoto_es::{CreateElasticsearchDomainRequest, Es, EsClient};
 use rusoto_firehose::{
@@ -75,7 +75,7 @@ async fn firehose_put_records() {
     let (input, events) = random_events_with_stream(100, 100, None);
 
     components::init_test();
-    sink.0.run(events).await.unwrap();
+    sink.0.run(events.map(Into::into)).await.unwrap();
 
     sleep(Duration::from_secs(5)).await;
     components::SINK_TESTS.assert(&AWS_SINK_TAGS);

--- a/src/sinks/aws_kinesis_streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis_streams/integration_tests.rs
@@ -54,7 +54,7 @@ async fn kinesis_put_records() {
     let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
 
     components::init_test();
-    let _ = sink.run(events).await.unwrap();
+    let _ = sink.run_event_stream(events).await.unwrap();
     sleep(Duration::from_secs(1)).await;
     components::SINK_TESTS.assert(&["region"]);
 

--- a/src/sinks/aws_kinesis_streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis_streams/integration_tests.rs
@@ -54,7 +54,7 @@ async fn kinesis_put_records() {
     let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
 
     components::init_test();
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     sleep(Duration::from_secs(1)).await;
     components::SINK_TESTS.assert(&["region"]);
 

--- a/src/sinks/aws_sqs.rs
+++ b/src/sinks/aws_sqs.rs
@@ -397,6 +397,7 @@ mod integration_tests {
     use tokio::time::{sleep, Duration};
 
     use super::*;
+    use crate::sinks::VectorSink;
     use crate::test_util::{random_lines_with_stream, random_string};
 
     fn sqs_address() -> String {
@@ -431,10 +432,11 @@ mod integration_tests {
 
         config.clone().healthcheck(client.clone()).await.unwrap();
 
-        let mut sink = SqsSink::new(config, cx, client.clone()).unwrap();
+        let sink = SqsSink::new(config, cx, client.clone()).unwrap();
+        let sink = VectorSink::from_event_sink(sink);
 
         let (mut input_lines, events) = random_lines_with_stream(100, 10, None);
-        sink.send_all(&mut events.map(Ok)).await.unwrap();
+        sink.run(events).await.unwrap();
 
         sleep(Duration::from_secs(1)).await;
 

--- a/src/sinks/azure_blob.rs
+++ b/src/sinks/azure_blob.rs
@@ -410,7 +410,7 @@ mod integration_tests {
 
     use super::*;
     use crate::{
-        event::LogEvent,
+        event::{EventArray, LogEvent},
         test_util::{random_events_with_stream, random_lines, random_lines_with_stream},
     };
 
@@ -462,9 +462,7 @@ mod integration_tests {
         let sink = config.to_sink();
         let (lines, input) = random_lines_with_stream(100, 10, None);
 
-        sink.run_event_stream(input)
-            .await
-            .expect("Failed to run sink");
+        sink.run(input).await.expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -486,9 +484,7 @@ mod integration_tests {
         let sink = config.to_sink();
         let (events, input) = random_events_with_stream(100, 10, None);
 
-        sink.run_event_stream(input)
-            .await
-            .expect("Failed to run sink");
+        sink.run(input).await.expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -517,9 +513,7 @@ mod integration_tests {
         let sink = config.to_sink();
         let (lines, events) = random_lines_with_stream(100, 10, None);
 
-        sink.run_event_stream(events)
-            .await
-            .expect("Failed to run sink");
+        sink.run(events).await.expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -548,9 +542,7 @@ mod integration_tests {
         let sink = config.to_sink();
         let (events, input) = random_events_with_stream(100, 10, None);
 
-        sink.run_event_stream(input)
-            .await
-            .expect("Failed to run sink");
+        sink.run(input).await.expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -585,9 +577,7 @@ mod integration_tests {
         };
 
         let sink = config.to_sink();
-        sink.run_event_stream(input)
-            .await
-            .expect("Failed to run sink");
+        sink.run(input).await.expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 3);
@@ -719,7 +709,7 @@ mod integration_tests {
         len: usize,
         count: usize,
         groups: usize,
-    ) -> (Vec<String>, usize, impl Stream<Item = Event>) {
+    ) -> (Vec<String>, usize, impl Stream<Item = EventArray>) {
         let key = count / groups;
         let lines = random_lines(len).take(count).collect::<Vec<_>>();
         let (size, events) = lines
@@ -734,7 +724,7 @@ mod integration_tests {
             })
             .fold((0, Vec::new()), |(mut size, mut events), event| {
                 size += event.size_of();
-                events.push(event);
+                events.push(event.into());
                 (size, events)
             });
 

--- a/src/sinks/azure_blob.rs
+++ b/src/sinks/azure_blob.rs
@@ -697,7 +697,7 @@ mod integration_tests {
                         StatusCode::CONFLICT => Ok(()),
                         status => Err(format!("Unexpected status code {}", status)),
                     },
-                    _ => Err(format!("Unexpected error {}", reason.to_string())),
+                    _ => Err(format!("Unexpected error {}", reason)),
                 },
             };
 

--- a/src/sinks/azure_blob.rs
+++ b/src/sinks/azure_blob.rs
@@ -462,7 +462,9 @@ mod integration_tests {
         let sink = config.to_sink();
         let (lines, input) = random_lines_with_stream(100, 10, None);
 
-        sink.run(input).await.expect("Failed to run sink");
+        sink.run_event_stream(input)
+            .await
+            .expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -484,7 +486,9 @@ mod integration_tests {
         let sink = config.to_sink();
         let (events, input) = random_events_with_stream(100, 10, None);
 
-        sink.run(input).await.expect("Failed to run sink");
+        sink.run_event_stream(input)
+            .await
+            .expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -513,7 +517,9 @@ mod integration_tests {
         let sink = config.to_sink();
         let (lines, events) = random_lines_with_stream(100, 10, None);
 
-        sink.run(events).await.expect("Failed to run sink");
+        sink.run_event_stream(events)
+            .await
+            .expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -542,7 +548,9 @@ mod integration_tests {
         let sink = config.to_sink();
         let (events, input) = random_events_with_stream(100, 10, None);
 
-        sink.run(input).await.expect("Failed to run sink");
+        sink.run_event_stream(input)
+            .await
+            .expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 1);
@@ -577,7 +585,9 @@ mod integration_tests {
         };
 
         let sink = config.to_sink();
-        sink.run(input).await.expect("Failed to run sink");
+        sink.run_event_stream(input)
+            .await
+            .expect("Failed to run sink");
 
         let blobs = config.list_blobs(blob_prefix.as_str()).await;
         assert_eq!(blobs.len(), 3);

--- a/src/sinks/blackhole/mod.rs
+++ b/src/sinks/blackhole/mod.rs
@@ -17,7 +17,7 @@ mod tests {
     use crate::{
         sinks::{
             blackhole::{config::BlackholeConfig, sink::BlackholeSink},
-            util::StreamSink,
+            VectorSink,
         },
         test_util::random_events_with_stream,
     };
@@ -28,9 +28,10 @@ mod tests {
             print_interval_secs: 10,
             rate: None,
         };
-        let sink = Box::new(BlackholeSink::new(config, Acker::passthrough()));
+        let sink = BlackholeSink::new(config, Acker::passthrough());
+        let sink = VectorSink::from_event_streamsink(sink);
 
         let (_input_lines, events) = random_events_with_stream(100, 10, None);
-        let _ = sink.run(Box::pin(events)).await.unwrap();
+        let _ = sink.run(events).await.unwrap();
     }
 }

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -285,7 +285,7 @@ mod integration_tests {
         },
     };
 
-    use futures::{future, stream};
+    use futures::future;
     use serde_json::Value;
     use tokio::time::{timeout, Duration};
     use vector_core::event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent};
@@ -548,13 +548,10 @@ timestamp_format = "unix""#,
 
         // Retries should go on forever, so if we are retrying incorrectly
         // this timeout should trigger.
-        timeout(
-            Duration::from_secs(5),
-            sink.run(stream::once(future::ready(input_event))),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        timeout(Duration::from_secs(5), sink.run_events(vec![input_event]))
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(receiver.try_recv(), Ok(BatchStatus::Rejected));
     }
@@ -593,13 +590,10 @@ timestamp_format = "unix""#,
 
         // Retries should go on forever, so if we are retrying incorrectly
         // this timeout should trigger.
-        timeout(
-            Duration::from_secs(5),
-            sink.run(stream::once(future::ready(input_event))),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        timeout(Duration::from_secs(5), sink.run_events(vec![input_event]))
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(receiver.try_recv(), Ok(BatchStatus::Errored));
     }

--- a/src/sinks/datadog/logs/integration_tests.rs
+++ b/src/sinks/datadog/logs/integration_tests.rs
@@ -1,9 +1,10 @@
+use indoc::indoc;
+use vector_core::event::{BatchNotifier, BatchStatus};
+
 use crate::{
     config::SinkConfig, sinks::datadog::logs::DatadogLogsConfig, sinks::util::test::load_sink,
     test_util::generate_lines_with_stream,
 };
-use indoc::indoc;
-use vector_core::event::{BatchNotifier, BatchStatus};
 
 #[tokio::test]
 async fn to_real_v2_endpoint() {
@@ -21,6 +22,6 @@ async fn to_real_v2_endpoint() {
     let generator = |index| format!("this is a log with index {}", index);
     let (_, events) = generate_lines_with_stream(generator, 10, Some(batch));
 
-    let _ = sink.run(events).await.unwrap();
+    let _ = sink.run_event_stream(events).await.unwrap();
     assert_eq!(receiver.await, BatchStatus::Delivered);
 }

--- a/src/sinks/datadog/logs/integration_tests.rs
+++ b/src/sinks/datadog/logs/integration_tests.rs
@@ -22,6 +22,6 @@ async fn to_real_v2_endpoint() {
     let generator = |index| format!("this is a log with index {}", index);
     let (_, events) = generate_lines_with_stream(generator, 10, Some(batch));
 
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.await, BatchStatus::Delivered);
 }

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -293,7 +293,7 @@ async fn multiple_api_keys_inner(api_status: ApiStatus) {
     let events = vec![
         event_with_api_key("mow", "pkc"),
         event_with_api_key("pnh", "vvo"),
-        Event::from("no API key in metadata").into(),
+        Event::from("no API key in metadata"),
     ];
 
     let _ = sink.run_events(events).await.unwrap();

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -94,7 +94,7 @@ async fn start_test(
     let (batch, receiver) = BatchNotifier::new_with_receiver();
     let (expected, events) = random_lines_with_stream(100, 10, Some(batch));
 
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.await, batch_status);
 
     (expected, rx)
@@ -214,13 +214,14 @@ async fn api_key_in_metadata_inner(api_status: ApiStatus) {
     let api_key = "0xDECAFBAD";
     let events = events.map(|mut e| {
         println!("EVENT: {:?}", e);
-        e.as_mut_log()
-            .metadata_mut()
-            .set_datadog_api_key(Some(Arc::from(api_key)));
+        e.for_each_log(|log| {
+            log.metadata_mut()
+                .set_datadog_api_key(Some(Arc::from(api_key)));
+        });
         e
     });
 
-    let () = sink.run_event_stream(events).await.unwrap();
+    let () = sink.run(events).await.unwrap();
     // The log API takes payloads in units of 1,000 and, as a result, we ship in
     // units of 1,000. There will only be a single response on the stream.
     let output: (Parts, Bytes) = rx.take(1).collect::<Vec<_>>().await.pop().unwrap();
@@ -354,13 +355,14 @@ async fn enterprise_headers_inner(api_status: ApiStatus) {
     let api_key = "0xDECAFBAD";
     let events = events.map(|mut e| {
         println!("EVENT: {:?}", e);
-        e.as_mut_log()
-            .metadata_mut()
-            .set_datadog_api_key(Some(Arc::from(api_key)));
+        e.for_each_log(|log| {
+            log.metadata_mut()
+                .set_datadog_api_key(Some(Arc::from(api_key)));
+        });
         e
     });
 
-    let () = sink.run_event_stream(events).await.unwrap();
+    let () = sink.run(events).await.unwrap();
     let output: (Parts, Bytes) = rx.take(1).collect::<Vec<_>>().await.pop().unwrap();
     let parts = output.0;
 
@@ -418,13 +420,14 @@ async fn no_enterprise_headers_inner(api_status: ApiStatus) {
     let api_key = "0xDECAFBAD";
     let events = events.map(|mut e| {
         println!("EVENT: {:?}", e);
-        e.as_mut_log()
-            .metadata_mut()
-            .set_datadog_api_key(Some(Arc::from(api_key)));
+        e.for_each_log(|log| {
+            log.metadata_mut()
+                .set_datadog_api_key(Some(Arc::from(api_key)));
+        });
         e
     });
 
-    let () = sink.run_event_stream(events).await.unwrap();
+    let () = sink.run(events).await.unwrap();
     let output: (Parts, Bytes) = rx.take(1).collect::<Vec<_>>().await.pop().unwrap();
     let parts = output.0;
 

--- a/src/sinks/datadog/metrics/integration_tests.rs
+++ b/src/sinks/datadog/metrics/integration_tests.rs
@@ -79,7 +79,7 @@ async fn start_test(
         .collect();
     let stream = map_event_batch_stream(stream::iter(events.clone()), Some(batch));
 
-    let _ = sink.run_event_stream(stream).await.unwrap();
+    let _ = sink.run(stream).await.unwrap();
     assert_eq!(receiver.await, batch_status);
 
     (events, rx)
@@ -168,6 +168,6 @@ async fn real_endpoint() {
         .collect();
     let stream = map_event_batch_stream(stream::iter(events.clone()), Some(batch));
 
-    let _ = sink.run_event_stream(stream).await.unwrap();
+    let _ = sink.run(stream).await.unwrap();
     assert_eq!(receiver.await, BatchStatus::Delivered);
 }

--- a/src/sinks/datadog/metrics/integration_tests.rs
+++ b/src/sinks/datadog/metrics/integration_tests.rs
@@ -79,7 +79,7 @@ async fn start_test(
         .collect();
     let stream = map_event_batch_stream(stream::iter(events.clone()), Some(batch));
 
-    let _ = sink.run(stream).await.unwrap();
+    let _ = sink.run_event_stream(stream).await.unwrap();
     assert_eq!(receiver.await, batch_status);
 
     (events, rx)
@@ -168,6 +168,6 @@ async fn real_endpoint() {
         .collect();
     let stream = map_event_batch_stream(stream::iter(events.clone()), Some(batch));
 
-    let _ = sink.run(stream).await.unwrap();
+    let _ = sink.run_event_stream(stream).await.unwrap();
     assert_eq!(receiver.await, BatchStatus::Delivered);
 }

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -376,19 +376,19 @@ async fn run_insert_tests_with_config(
     if break_events {
         // Break all but the first event to simulate some kind of partial failure
         let mut doit = false;
-        sink.run(events.map(move |mut event| {
+        sink.run(events.map(move |mut events| {
             if doit {
-                event.as_mut_log().insert("_type", 1);
+                events.for_each_log(|log| {
+                    log.insert("_type", 1);
+                });
             }
             doit = true;
-            event.into()
+            events
         }))
         .await
         .expect("Sending events failed");
     } else {
-        sink.run_event_stream(events)
-            .await
-            .expect("Sending events failed");
+        sink.run(events).await.expect("Sending events failed");
     }
 
     assert_eq!(receiver.try_recv(), Ok(batch_status));

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -279,7 +279,7 @@ mod integration_tests {
 
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
         let (input, events) = random_events_with_stream(100, 100, Some(batch));
-        components::run_sink_events(sink, events, &HTTP_SINK_TAGS).await;
+        components::run_sink(sink, events, &HTTP_SINK_TAGS).await;
         assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
         let response = pull_messages(&subscription, 1000).await;
@@ -306,9 +306,7 @@ mod integration_tests {
 
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
         let (_input, events) = random_events_with_stream(100, 100, Some(batch));
-        sink.run_event_stream(events)
-            .await
-            .expect("Sending events failed");
+        sink.run(events).await.expect("Sending events failed");
         assert_eq!(receiver.try_recv(), Ok(BatchStatus::Rejected));
     }
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -279,7 +279,7 @@ mod integration_tests {
 
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
         let (input, events) = random_events_with_stream(100, 100, Some(batch));
-        components::run_sink(sink, events, &HTTP_SINK_TAGS).await;
+        components::run_sink_events(sink, events, &HTTP_SINK_TAGS).await;
         assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
         let response = pull_messages(&subscription, 1000).await;
@@ -306,7 +306,9 @@ mod integration_tests {
 
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
         let (_input, events) = random_events_with_stream(100, 100, Some(batch));
-        sink.run(events).await.expect("Sending events failed");
+        sink.run_event_stream(events)
+            .await
+            .expect("Sending events failed");
         assert_eq!(receiver.try_recv(), Ok(BatchStatus::Rejected));
     }
 

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use futures_util::stream::BoxStream;
 use indoc::indoc;
 use serde::{Deserialize, Serialize};
-use vector_core::{event::Event, sink::StreamSink, transform::Transform};
+use vector_core::{sink::StreamSink, transform::Transform};
 
 use super::{host_key, logs::HumioLogsConfig, Encoding};
 use crate::{
@@ -11,6 +11,7 @@ use crate::{
         DataType, GenerateConfig, SinkConfig, SinkContext, SinkDescription, TransformConfig,
         TransformContext,
     },
+    event::{Event, EventArray, EventContainer},
     sinks::{
         splunk_hec::common::SplunkHecDefaultBatchSettings,
         util::{encoding::EncodingConfig, BatchConfig, Compression, TowerRequestConfig},
@@ -103,7 +104,7 @@ impl SinkConfig for HumioMetricsConfig {
             transform,
         };
 
-        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+        Ok((VectorSink::Stream(Box::new(sink)), healthcheck))
     }
 
     fn input_type(&self) -> DataType {
@@ -121,14 +122,18 @@ pub struct HumioMetricsSink {
 }
 
 #[async_trait]
-impl StreamSink<Event> for HumioMetricsSink {
-    async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+impl StreamSink<EventArray> for HumioMetricsSink {
+    async fn run(self: Box<Self>, input: BoxStream<'_, EventArray>) -> Result<(), ()> {
         let mut transform = self.transform;
         self.inner
-            .run(input.flat_map(move |e| {
-                let mut buf = Vec::with_capacity(1);
-                transform.as_function().transform(&mut buf, e);
-                stream::iter(buf.into_iter())
+            .run(input.map(move |events| {
+                let mut buf = Vec::with_capacity(events.len());
+                for event in events.into_events() {
+                    transform.as_function().transform(&mut buf, event);
+                }
+                // Awkward but necessary for the `EventArray` type
+                let events = buf.into_iter().map(Event::into_log).collect::<Vec<_>>();
+                events.into()
             }))
             .await
     }
@@ -137,6 +142,7 @@ impl StreamSink<Event> for HumioMetricsSink {
 #[cfg(test)]
 mod tests {
     use chrono::{offset::TimeZone, Utc};
+    use futures::stream;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -231,7 +237,7 @@ mod tests {
         ];
 
         let len = metrics.len();
-        components::run_sink(sink, stream::iter(metrics), &HTTP_SINK_TAGS).await;
+        components::run_sink_events(sink, stream::iter(metrics), &HTTP_SINK_TAGS).await;
 
         let output = rx.take(len).collect::<Vec<_>>().await;
         assert_eq!(

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -257,7 +257,7 @@ fn to_field(value: &Value) -> Field {
 #[cfg(test)]
 mod tests {
     use chrono::{offset::TimeZone, Utc};
-    use futures::{channel::mpsc, stream, StreamExt};
+    use futures::{channel::mpsc, StreamExt};
     use http::{request::Parts, StatusCode};
     use indoc::indoc;
     use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};
@@ -639,7 +639,7 @@ mod tests {
         drop(batch);
 
         components::init_test();
-        sink.run(stream::iter(events)).await.unwrap();
+        sink.run_events(events).await.unwrap();
         if batch_status == BatchStatus::Delivered {
             components::SINK_TESTS.assert(&HTTP_SINK_TAGS);
         }
@@ -763,7 +763,7 @@ mod integration_tests {
 
         let events = vec![Event::Log(event1), Event::Log(event2)];
 
-        components::run_sink(sink, stream::iter(events), &HTTP_SINK_TAGS).await;
+        components::run_sink_events(sink, stream::iter(events), &HTTP_SINK_TAGS).await;
 
         assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -897,7 +897,6 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use chrono::{SecondsFormat, Utc};
-    use futures::stream;
     use pretty_assertions::assert_eq;
 
     use crate::{
@@ -961,7 +960,7 @@ mod integration_tests {
 
         let events: Vec<_> = (0..10).map(create_event).collect();
         let (sink, _) = config.build(cx).await.expect("error when building config");
-        sink.run(stream::iter(events.clone())).await.unwrap();
+        sink.run_events(events.clone()).await.unwrap();
 
         let res = query_v1_json(url, &format!("show series on {}", database)).await;
 
@@ -1075,7 +1074,7 @@ mod integration_tests {
 
         let client = HttpClient::new(None, cx.proxy()).unwrap();
         let sink = InfluxDbSvc::new(config, cx, client).unwrap();
-        sink.run(stream::iter(events)).await.unwrap();
+        sink.run_events(events).await.unwrap();
 
         let mut body = std::collections::HashMap::new();
         body.insert("query", format!("from(bucket:\"my-bucket\") |> range(start: 0) |> filter(fn: (r) => r._measurement == \"ns.{}\")", metric));

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -404,7 +404,7 @@ mod tests {
         }
         drop(batch);
 
-        sink.run(stream::iter(events)).await.unwrap();
+        sink.run_events(events).await.unwrap();
         if batch_status == BatchStatus::Delivered {
             components::SINK_TESTS.assert(&HTTP_SINK_TAGS);
         }

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -291,7 +291,7 @@ async fn healthcheck(config: LogdnaConfig, client: HttpClient) -> crate::Result<
 
 #[cfg(test)]
 mod tests {
-    use futures::{channel::mpsc, stream, StreamExt};
+    use futures::{channel::mpsc, StreamExt};
     use http::{request::Parts, StatusCode};
     use serde_json::json;
     use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -61,7 +61,7 @@ async fn text() {
 
     let (batch, mut receiver) = BatchNotifier::new_with_receiver();
     let (lines, events) = generate_lines_with_stream(line_generator, 10, Some(batch));
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
@@ -79,7 +79,7 @@ async fn json() {
 
     let (batch, mut receiver) = BatchNotifier::new_with_receiver();
     let (lines, events) = generate_events_with_stream(event_generator, 10, Some(batch));
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
@@ -105,7 +105,7 @@ async fn json_nested_fields() {
         event
     };
     let (lines, events) = generate_events_with_stream(generator, 10, Some(batch));
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
@@ -124,7 +124,7 @@ async fn logfmt() {
 
     let (batch, mut receiver) = BatchNotifier::new_with_receiver();
     let (lines, events) = generate_events_with_stream(event_generator, 10, Some(batch));
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
@@ -168,7 +168,7 @@ async fn many_streams() {
     };
     let (lines, events) = generate_events_with_stream(generator, 10, Some(batch));
 
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
@@ -227,7 +227,7 @@ async fn interpolate_stream_key() {
     };
     let (lines, events) = generate_events_with_stream(generator, 10, Some(batch));
 
-    let _ = sink.run_event_stream(events).await.unwrap();
+    let _ = sink.run(events).await.unwrap();
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -245,6 +245,7 @@ mod integration_tests {
     use std::{thread, time::Duration};
 
     use super::*;
+    use crate::sinks::VectorSink;
     use crate::test_util::{random_lines_with_stream, random_string, trace_init};
 
     #[tokio::test]
@@ -271,11 +272,12 @@ mod integration_tests {
 
         // Publish events.
         let (acker, ack_counter) = Acker::basic();
-        let sink = Box::new(NatsSink::new(cnf.clone(), acker).unwrap());
+        let sink = NatsSink::new(cnf.clone(), acker).unwrap();
+        let sink = VectorSink::from_event_streamsink(sink);
         let num_events = 1_000;
         let (input, events) = random_lines_with_stream(100, num_events, None);
 
-        let _ = sink.run(Box::pin(events)).await.unwrap();
+        let _ = sink.run(events).await.unwrap();
 
         // Unsubscribe from the channel.
         thread::sleep(Duration::from_secs(3));

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -334,7 +334,7 @@ mod tests {
         let input_lines = (0..100).map(|i| format!("msg {}", i)).collect::<Vec<_>>();
         let events = stream::iter(input_lines.clone()).map(Event::from);
 
-        components::run_sink(sink, events, &HTTP_SINK_TAGS).await;
+        components::run_sink_events(sink, events, &HTTP_SINK_TAGS).await;
         drop(trigger);
 
         let output_lines = rx

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -560,7 +560,7 @@ mod tests {
         tokio::spawn(sink.run(Box::pin(UnboundedReceiverStream::new(rx))));
 
         for event in events {
-            tx.send(event).expect("Failed to send event.");
+            tx.send(event.into()).expect("Failed to send event.");
         }
 
         time::sleep(time::Duration::from_millis(100)).await;
@@ -1003,7 +1003,7 @@ mod integration_tests {
         tokio::spawn(sink.run(Box::pin(UnboundedReceiverStream::new(rx))));
 
         let (name, event) = tests::create_metric_gauge(None, 123.4);
-        tx.send(event).expect("Failed to send.");
+        tx.send(event.into()).expect("Failed to send.");
 
         // Wait a bit for the prometheus server to scrape the metrics
         time::sleep(time::Duration::from_secs(2)).await;
@@ -1037,9 +1037,9 @@ mod integration_tests {
 
         // Create two sets with different names but the same size.
         let (name1, event) = tests::create_metric_set(None, vec!["0", "1", "2"]);
-        tx.send(event).expect("Failed to send.");
+        tx.send(event.into()).expect("Failed to send.");
         let (name2, event) = tests::create_metric_set(None, vec!["3", "4", "5"]);
-        tx.send(event).expect("Failed to send.");
+        tx.send(event.into()).expect("Failed to send.");
 
         // Wait for the Prometheus server to scrape them, and then query it to ensure both metrics
         // have their correct set size value.
@@ -1063,7 +1063,7 @@ mod integration_tests {
         time::sleep(time::Duration::from_secs(3)).await;
 
         let (name2, event) = tests::create_metric_set(Some(name2), vec!["8", "9"]);
-        tx.send(event).expect("Failed to send.");
+        tx.send(event.into()).expect("Failed to send.");
 
         // Again, wait for the Prometheus server to scrape the metrics, and then query it again.
         time::sleep(time::Duration::from_secs(2)).await;
@@ -1088,9 +1088,9 @@ mod integration_tests {
 
         // metrics that will not be updated for a full flush period and therefore should expire
         let (name1, event) = tests::create_metric_set(None, vec!["42"]);
-        tx.send(event).expect("Failed to send.");
+        tx.send(event.into()).expect("Failed to send.");
         let (name2, event) = tests::create_metric_gauge(None, 100.0);
-        tx.send(event).expect("Failed to send.");
+        tx.send(event.into()).expect("Failed to send.");
 
         // Wait a bit for the sink to process the events
         time::sleep(time::Duration::from_secs(1)).await;
@@ -1104,7 +1104,7 @@ mod integration_tests {
         for _ in 0..7 {
             // Update the first metric, ensuring it doesn't expire
             let (_, event) = tests::create_metric_set(Some(name1.clone()), vec!["43"]);
-            tx.send(event).expect("Failed to send.");
+            tx.send(event.into()).expect("Failed to send.");
 
             // Wait a bit for time to pass
             time::sleep(time::Duration::from_secs(1)).await;

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -397,7 +397,7 @@ mod tests {
         let cx = SinkContext::new_test();
 
         let (sink, _) = config.build(cx).await.unwrap();
-        sink.run(stream::iter(events)).await.unwrap();
+        sink.run_events(events).await.unwrap();
 
         drop(trigger);
 
@@ -453,7 +453,6 @@ mod tests {
 mod integration_tests {
     use std::{collections::HashMap, ops::Range};
 
-    use futures::stream;
     use serde_json::Value;
 
     use super::{tests::*, *};
@@ -495,7 +494,7 @@ mod integration_tests {
         let events = create_events(0..5, |n| n * 11.0);
 
         let (sink, _) = config.build(cx).await.expect("error building config");
-        sink.run(stream::iter(events.clone())).await.unwrap();
+        sink.run_events(events.clone()).await.unwrap();
 
         let result = query(url, &format!("show series on {}", database)).await;
 

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -400,6 +400,7 @@ mod integration_tests {
     use pulsar::SubType;
 
     use super::*;
+    use crate::sinks::VectorSink;
     use crate::test_util::{random_lines_with_stream, random_string, trace_init};
 
     fn pulsar_address() -> String {
@@ -442,7 +443,8 @@ mod integration_tests {
         let (acker, ack_counter) = Acker::basic();
         let producer = cnf.create_pulsar_producer().await.unwrap();
         let sink = PulsarSink::new(producer, cnf.encoding, acker).unwrap();
-        events.map(Ok).forward(sink).await.unwrap();
+        let sink = VectorSink::from_event_sink(sink);
+        sink.run(events).await.unwrap();
 
         assert_eq!(
             ack_counter.load(std::sync::atomic::Ordering::Relaxed),

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -591,7 +591,7 @@ mod integration_tests {
 
         let sink = cnf.new(conn, cx).unwrap();
         let (_input, events) = random_lines_with_stream(100, num_events, None);
-        sink.run_event_stream(events).await.unwrap();
+        sink.run(events).await.unwrap();
 
         // Receive events.
         let mut received_msg_num = 0;

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -469,8 +469,7 @@ mod integration_tests {
             events.push(e);
         }
 
-        let stream = stream::iter(events.clone());
-        sink.run(stream).await.unwrap();
+        sink.run_events(events.clone()).await.unwrap();
 
         let mut conn = cnf.build_client().await.unwrap();
 
@@ -527,8 +526,7 @@ mod integration_tests {
             events.push(e);
         }
 
-        let stream = stream::iter(events.clone());
-        sink.run(stream).await.unwrap();
+        sink.run_events(events.clone()).await.unwrap();
 
         let mut conn = cnf.build_client().await.unwrap();
 
@@ -593,7 +591,7 @@ mod integration_tests {
 
         let sink = cnf.new(conn, cx).unwrap();
         let (_input, events) = random_lines_with_stream(100, num_events, None);
-        sink.run(events).await.unwrap();
+        sink.run_event_stream(events).await.unwrap();
 
         // Receive events.
         let mut received_msg_num = 0;

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -278,7 +278,7 @@ fn to_fields(label: String, value: f64) -> HashMap<String, Field> {
 #[cfg(test)]
 mod tests {
     use chrono::{offset::TimeZone, Utc};
-    use futures::{stream, StreamExt};
+    use futures::StreamExt;
     use indoc::indoc;
 
     use super::*;

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -406,7 +406,7 @@ mod tests {
             events.push(event);
         }
 
-        let _ = sink.run(stream::iter(events)).await.unwrap();
+        let _ = sink.run_events(events).await.unwrap();
 
         let output = rx.take(metrics.len()).collect::<Vec<_>>().await;
         assert_eq!("os,metric_type=counter,os.host=somehost,token=atoken swap.size=324292 1597784400000000000", output[0].1);

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -85,10 +85,11 @@ impl SinkConfig for SocketSinkConfig {
 mod test {
     use std::{
         future::ready,
+        iter,
         net::{SocketAddr, UdpSocket},
     };
 
-    use futures::stream::{self, StreamExt};
+    use futures::stream::StreamExt;
     use serde_json::Value;
     use tokio::{
         net::TcpListener,
@@ -120,7 +121,7 @@ mod test {
         let (sink, _healthcheck) = config.build(context).await.unwrap();
 
         let event = Event::from("raw log line");
-        sink.run(stream::once(ready(event))).await.unwrap();
+        sink.run_events(iter::once(event)).await.unwrap();
 
         let mut buf = [0; 256];
         let (size, _src_addr) = receiver
@@ -209,6 +210,7 @@ mod test {
         };
         use tokio_stream::wrappers::IntervalStream;
 
+        use crate::event::EventArray;
         use crate::tls::{self, MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsOptions};
 
         trace_init();
@@ -233,7 +235,7 @@ mod test {
         };
         let context = SinkContext::new_test();
         let (sink, _healthcheck) = config.build(context).await.unwrap();
-        let (mut sender, receiver) = mpsc::channel::<Option<Event>>(0);
+        let (mut sender, receiver) = mpsc::channel::<Option<EventArray>>(0);
         let jh1 = tokio::spawn(async move {
             let stream = receiver
                 .take_while(|event| ready(event.is_some()))

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -222,7 +222,7 @@ async fn splunk_insert_many() {
     let (sink, _) = config.build(cx).await.unwrap();
 
     let (messages, events) = random_lines_with_stream(100, 10, None);
-    components::run_sink_events(sink, events, &HTTP_SINK_TAGS).await;
+    components::run_sink(sink, events, &HTTP_SINK_TAGS).await;
 
     assert!(find_entries(messages.as_slice()).await);
 }
@@ -341,7 +341,7 @@ async fn splunk_indexer_acknowledgements() {
     let (tx, mut rx) = BatchNotifier::new_with_receiver();
     let (messages, events) = random_lines_with_stream(100, 10, Some(Arc::clone(&tx)));
     drop(tx);
-    components::run_sink_events(sink, events, &HTTP_SINK_TAGS).await;
+    components::run_sink(sink, events, &HTTP_SINK_TAGS).await;
 
     assert_eq!(rx.try_recv(), Ok(BatchStatus::Delivered));
     assert!(find_entries(messages.as_slice()).await);
@@ -357,7 +357,7 @@ async fn splunk_indexer_acknowledgements_disabled_on_server() {
     let (tx, mut rx) = BatchNotifier::new_with_receiver();
     let (messages, events) = random_lines_with_stream(100, 10, Some(Arc::clone(&tx)));
     drop(tx);
-    components::run_sink_events(sink, events, &HTTP_SINK_TAGS).await;
+    components::run_sink(sink, events, &HTTP_SINK_TAGS).await;
 
     // With indexer acknowledgements disabled on the server, events are still
     // acknowledged based on 200 OK

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use chrono::{TimeZone, Utc};
-use futures_util::{stream, StreamExt};
+use futures_util::StreamExt;
 use serde::Deserialize;
 use vector_core::{
     config::log_schema,
@@ -183,7 +183,7 @@ async fn splunk_passthrough_token() {
         Event::from("default token will be used"),
     ];
 
-    let _ = sink.run(stream::iter(events)).await.unwrap();
+    let _ = sink.run_events(events).await.unwrap();
 
     let mut tokens = rx
         .take(3)

--- a/src/sinks/splunk_hec/metrics/integration_tests.rs
+++ b/src/sinks/splunk_hec/metrics/integration_tests.rs
@@ -128,6 +128,7 @@ async fn splunk_insert_multiple_counter_metrics() {
         events.push(get_counter(Arc::clone(&batch)))
     }
     drop(batch);
+    let events = events.into_iter().map(Into::into);
     components::run_sink(sink, stream::iter(events), &HTTP_SINK_TAGS).await;
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 
@@ -154,6 +155,7 @@ async fn splunk_insert_multiple_gauge_metrics() {
         events.push(get_gauge(Arc::clone(&batch)))
     }
     drop(batch);
+    let events = events.into_iter().map(Into::into);
     components::run_sink(sink, stream::iter(events), &HTTP_SINK_TAGS).await;
     assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
 

--- a/src/sinks/splunk_hec/metrics/tests.rs
+++ b/src/sinks/splunk_hec/metrics/tests.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use chrono::{DateTime, Utc};
-use futures_util::{stream, StreamExt};
+use futures_util::StreamExt;
 use serde_json::{json, Value as JsonValue};
 use shared::btreemap;
 use vector_core::{
@@ -346,7 +346,7 @@ async fn splunk_passthrough_token() {
         Event::from(get_counter()),
     ];
 
-    let _ = sink.run(stream::iter(events)).await.unwrap();
+    let _ = sink.run_events(events).await.unwrap();
 
     let mut tokens = rx
         .take(3)

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -467,7 +467,7 @@ mod test {
             }
         });
 
-        sink.run(stream::iter(events)).await.unwrap();
+        sink.run_events(events).await.unwrap();
 
         let messages = collect_n(rx, 1).await;
         assert_eq!(

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -125,7 +125,6 @@ impl HttpSource for RemoteWriteSource {
 #[cfg(test)]
 mod test {
     use chrono::{SubsecRound as _, Utc};
-    use futures::stream;
     use vector_core::event::{EventStatus, Metric, MetricKind, MetricValue};
 
     use super::*;
@@ -183,7 +182,7 @@ mod test {
         let events_copy = events.clone();
         let mut output = test_util::spawn_collect_ready(
             async move {
-                sink.run(stream::iter(events_copy)).await.unwrap();
+                sink.run_events(events_copy).await.unwrap();
             },
             rx,
             1,

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -532,7 +532,7 @@ mod test {
         // Spawn future that keeps sending lines to the TCP source forever.
         tokio::spawn(async move {
             let input = stream::repeat(())
-                .map(move |_| Event::new_empty_log())
+                .map(move |_| Event::new_empty_log().into())
                 .boxed();
             sink.run(input).await.unwrap();
         });

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -189,7 +189,7 @@ mod test {
             )),
         ];
 
-        sink.run(stream::iter(events.clone())).await.unwrap();
+        sink.run_events(events.clone()).await.unwrap();
 
         sleep(Duration::from_millis(50)).await;
 

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -128,7 +128,6 @@ impl TcpSource for VectorSource {
 mod test {
     use std::net::SocketAddr;
 
-    use futures::stream;
     use shared::assert_event_data_eq;
     use tokio::{
         io::AsyncWriteExt,

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -14,7 +14,7 @@ use lazy_static::lazy_static;
 use vector_core::event_test_util;
 
 use crate::{
-    event::{Event, Metric, MetricValue},
+    event::{Event, EventArray, Metric, MetricValue},
     metrics::{self, Controller},
     sinks::VectorSink,
 };
@@ -161,9 +161,20 @@ impl ComponentTester {
 /// Convenience wrapper for running sink tests
 pub async fn run_sink<S>(sink: VectorSink, events: S, tags: &[&str])
 where
+    S: Stream<Item = EventArray> + Send,
+{
+    init_test();
+    sink.run(events).await.expect("Running sink failed");
+    SINK_TESTS.assert(tags);
+}
+
+/// Convenience wrapper for running sink tests with a stream of `Event`
+pub async fn run_sink_events<S>(sink: VectorSink, events: S, tags: &[&str])
+where
     S: Stream<Item = Event> + Send,
 {
     init_test();
+    let events = events.map(Into::into);
     sink.run(events).await.expect("Running sink failed");
     SINK_TESTS.assert(tags);
 }
@@ -171,7 +182,7 @@ where
 /// Convenience wrapper for running a sink with a single event
 pub async fn run_sink_event(sink: VectorSink, event: Event, tags: &[&str]) {
     init_test();
-    run_sink(sink, stream::once(std::future::ready(event)), tags).await
+    run_sink(sink, stream::once(std::future::ready(event.into())), tags).await
 }
 
 /// Convenience wrapper for running sinks with `send_all`

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -35,7 +35,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 #[cfg(unix)]
 use tokio_stream::wrappers::UnixListenerStream;
 use tokio_util::codec::{Encoder, FramedRead, FramedWrite, LinesCodec};
-use vector_core::event::{BatchNotifier, Event, LogEvent};
+use vector_core::event::{BatchNotifier, Event, EventArray, LogEvent};
 
 use crate::{
     config::{Config, ConfigDiff, GenerateConfig},
@@ -195,23 +195,23 @@ pub fn temp_dir() -> PathBuf {
 pub fn map_event_batch_stream(
     stream: impl Stream<Item = Event>,
     batch: Option<Arc<BatchNotifier>>,
-) -> impl Stream<Item = Event> {
-    stream.map(move |event| event.with_batch_notifier_option(&batch))
+) -> impl Stream<Item = EventArray> {
+    stream.map(move |event| event.with_batch_notifier_option(&batch).into())
 }
 
 // TODO refactor to have a single implementation for `Event`, `LogEvent` and `Metric`.
 fn map_batch_stream(
     stream: impl Stream<Item = LogEvent>,
     batch: Option<Arc<BatchNotifier>>,
-) -> impl Stream<Item = Event> {
-    stream.map(move |log| log.with_batch_notifier_option(&batch).into())
+) -> impl Stream<Item = EventArray> {
+    stream.map(move |log| vec![log.with_batch_notifier_option(&batch)].into())
 }
 
 pub fn generate_lines_with_stream<Gen: FnMut(usize) -> String>(
     generator: Gen,
     count: usize,
     batch: Option<Arc<BatchNotifier>>,
-) -> (Vec<String>, impl Stream<Item = Event>) {
+) -> (Vec<String>, impl Stream<Item = EventArray>) {
     let lines = (0..count).map(generator).collect::<Vec<_>>();
     let stream = map_batch_stream(stream::iter(lines.clone()).map(LogEvent::from), batch);
     (lines, stream)
@@ -221,7 +221,7 @@ pub fn random_lines_with_stream(
     len: usize,
     count: usize,
     batch: Option<Arc<BatchNotifier>>,
-) -> (Vec<String>, impl Stream<Item = Event>) {
+) -> (Vec<String>, impl Stream<Item = EventArray>) {
     let generator = move |_| random_string(len);
     generate_lines_with_stream(generator, count, batch)
 }
@@ -230,7 +230,7 @@ pub fn generate_events_with_stream<Gen: FnMut(usize) -> Event>(
     generator: Gen,
     count: usize,
     batch: Option<Arc<BatchNotifier>>,
-) -> (Vec<Event>, impl Stream<Item = Event>) {
+) -> (Vec<Event>, impl Stream<Item = EventArray>) {
     let events = (0..count).map(generator).collect::<Vec<_>>();
     let stream = map_batch_stream(
         stream::iter(events.clone()).map(|event| event.into_log()),
@@ -243,7 +243,7 @@ pub fn random_events_with_stream(
     len: usize,
     count: usize,
     batch: Option<Arc<BatchNotifier>>,
-) -> (Vec<Event>, impl Stream<Item = Event>) {
+) -> (Vec<Event>, impl Stream<Item = EventArray>) {
     let events = (0..count)
         .map(|_| Event::from(random_string(len)))
         .collect::<Vec<_>>();
@@ -259,7 +259,7 @@ pub fn random_updated_events_with_stream<F>(
     count: usize,
     batch: Option<Arc<BatchNotifier>>,
     update_fn: F,
-) -> (Vec<Event>, impl Stream<Item = Event>)
+) -> (Vec<Event>, impl Stream<Item = EventArray>)
 where
     F: Fn((usize, Event)) -> Event,
 {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -357,6 +357,7 @@ pub async fn build_pieces(
                             byte_size: event.size_of(),
                         })
                     })
+                    .map(Into::into) // Convert the `Event` into an `EventArray`
                     .take_until_if(tripwire),
             )
             .await


### PR DESCRIPTION
This whole patch series is just about moving the `event.into()` out of `VectorSink::run`, which is needed for the next step in the array processing series, but it turned into such a big pain that I wanted to get eyes on it separate from the other work. This has no behavior changes, and almost all of the code changes are in tests.