### PR TITLE
fix(core,topology): Replace feed with send to fix flushing behaviour on disk buffers

### DIFF
--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -239,7 +239,7 @@ impl TransformOutputs {
 
 async fn send_inner(buf: &mut Vec<Event>, output: &mut Fanout) {
     for event in buf.drain(..) {
-        output.feed(event).await.expect("unit error");
+        output.send(event).await.expect("unit error");
     }
 }
 

--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -239,8 +239,9 @@ impl TransformOutputs {
 
 async fn send_inner(buf: &mut Vec<Event>, output: &mut Fanout) {
     for event in buf.drain(..) {
-        output.send(event).await.expect("unit error");
+        output.feed(event).await.expect("unit error");
     }
+    output.flush().await.expect("unit error");
 }
 
 pub struct TransformOutputsBuf {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -159,7 +159,7 @@ pub async fn build_pieces(
             let (mut fanout, control) = Fanout::new();
             let pump = async move {
                 while let Some(event) = rx.next().await {
-                    fanout.send(event).await?;
+                    fanout.feed(event).await?;
                 }
                 fanout.flush().await?;
                 Ok(TaskOutput::Source)

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -159,7 +159,7 @@ pub async fn build_pieces(
             let (mut fanout, control) = Fanout::new();
             let pump = async move {
                 while let Some(event) = rx.next().await {
-                    fanout.feed(event).await?;
+                    fanout.send(event).await?;
                 }
                 fanout.flush().await?;
                 Ok(TaskOutput::Source)

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use futures::{stream::FuturesOrdered, FutureExt, SinkExt, StreamExt, TryFutureExt};
+use futures_util::stream;
 use lazy_static::lazy_static;
 use once_cell::sync::Lazy;
 use stream_cancel::{StreamExt as StreamCancelExt, Trigger, Tripwire};
@@ -154,14 +155,15 @@ pub async fn build_pieces(
         let mut pumps = Vec::new();
         let mut controls = HashMap::new();
         for output in source_outputs {
-            let mut rx = builder.add_output(output.clone());
+            let rx = builder.add_output(output.clone());
 
             let (mut fanout, control) = Fanout::new();
             let pump = async move {
-                while let Some(event) = rx.next().await {
-                    fanout.feed(event).await?;
+                let mut rx = rx.ready_chunks(128);
+                while let Some(events) = rx.next().await {
+                    let mut events = stream::iter(events).map(Ok);
+                    fanout.send_all(&mut events).await?;
                 }
-                fanout.flush().await?;
                 Ok(TaskOutput::Source)
             };
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #10806

Our transform concurrency work replaced a `SinkExt::send_all` call -- which will generate a `poll_flush call` -- with a `SinkExt::feed` call, which explicitly does not flush.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
