### PR TITLE
revert(deps): bump mlua from 0.7.1 to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.7.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b434eeaac97efacd1d7aa067436e5bd668ab46c14ca7e6fe6f2e7315f751c9"
+checksum = "21641904f1bd1cde0951eb16e263b18c3c1655583ee7579875842b58c589d0b0"
 dependencies = [
  "bstr",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,7 @@ maxminddb = { version = "0.21.0", default-features = false, optional = true }
 md-5 = { version = "0.10", optional = true }
 memchr = { version = "2.4", default-features = false, optional = true }
 # make sure to update the external docs when the Lua version changes
-mlua = { version = "0.7.2", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
+mlua = { version = "0.7.1", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
 mongodb = { version = "2.1.0", default-features = false, features = ["tokio-runtime"], optional = true }
 async-nats = { version = "0.10.1", default-features = false, optional = true }
 nom = { version = "7.1.0", default-features = false, optional = true }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -29,7 +29,7 @@ lookup = { path = "../lookup", features = ["arbitrary"] }
 metrics = { version = "0.17.1", default-features = false, features = ["std"]}
 metrics-tracing-context = { version = "0.9.0", default-features = false }
 metrics-util = { version = "0.10.2", default-features = false, features = ["std"] }
-mlua = { version = "0.7.2", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
+mlua = { version = "0.7.1", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
 no-proxy = { version  = "0.3.1", default-features = false, features = ["serialize"] }
 once_cell = { version = "1.9", default-features = false }
 ordered-float = { version = "2.10.0", default-features = false }


### PR DESCRIPTION
Reverts vectordotdev/vector#10896

It seems like the PR checks don't require the cross-builds to pass.

Causing failures on master: https://github.com/vectordotdev/vector/runs/4858991297?check_suite_focus=true