### PR TITLE
chore(performance): try tokio mpsc for SourceSender

### DIFF
--- a/src/source_sender/errors.rs
+++ b/src/source_sender/errors.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
-use futures::channel::mpsc;
+use tokio::sync::mpsc;
+
+use crate::event::Event;
 
 #[derive(Debug)]
 pub struct ClosedError;
@@ -13,8 +15,8 @@ impl fmt::Display for ClosedError {
 
 impl std::error::Error for ClosedError {}
 
-impl From<mpsc::SendError> for ClosedError {
-    fn from(_: mpsc::SendError) -> Self {
+impl From<mpsc::error::SendError<Event>> for ClosedError {
+    fn from(_: mpsc::error::SendError<Event>) -> Self {
         Self
     }
 }

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, pin::Pin};
 
 use futures::{
-    channel::mpsc,
     task::{Context, Poll},
-    SinkExt, Stream, StreamExt,
+    Stream, StreamExt,
 };
 use pin_project::pin_project;
+use tokio::sync::mpsc;
 #[cfg(test)]
 use vector_core::event::EventStatus;
 use vector_core::{config::Output, event::Event, internal_event::EventsSent, ByteSizeOf};
@@ -187,6 +187,7 @@ struct Inner {
 impl Inner {
     fn new_with_buffer(n: usize) -> (Self, ReceiverStream<Event>) {
         let (tx, rx) = mpsc::channel(n);
+        let rx = tokio_stream::wrappers::ReceiverStream::new(rx);
         (Self { inner: tx }, ReceiverStream::new(rx))
     }
 
@@ -276,11 +277,11 @@ impl Inner {
 #[derive(Debug)]
 pub struct ReceiverStream<T> {
     #[pin]
-    inner: mpsc::Receiver<T>,
+    inner: tokio_stream::wrappers::ReceiverStream<T>,
 }
 
 impl<T> ReceiverStream<T> {
-    fn new(inner: mpsc::Receiver<T>) -> Self {
+    fn new(inner: tokio_stream::wrappers::ReceiverStream<T>) -> Self {
         Self { inner }
     }
 

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -281,7 +281,7 @@ pub struct ReceiverStream<T> {
 }
 
 impl<T> ReceiverStream<T> {
-    fn new(inner: tokio_stream::wrappers::ReceiverStream<T>) -> Self {
+    const fn new(inner: tokio_stream::wrappers::ReceiverStream<T>) -> Self {
         Self { inner }
     }
 


### PR DESCRIPTION
This started as an experiment to batch the communication between `source_sender::Inner` and the `Fanout` in the matching pump task, but that ran into a few complications (mostly buffer sizing). As part of that issue, I dug into channel implementations a bit more and learned that the `futures` channel uses a linked list implementation that does a heap allocation per item, while `tokio` channels use a linked list of blocks to amortize the cost of allocation. That sounded similar enough to the original goal of batching to try running through the soaks and see how much it gets us.