### PR TITLE
chore(buffers): Simplify encode/decode traits

### DIFF
--- a/lib/vector-buffers/benches/common.rs
+++ b/lib/vector-buffers/benches/common.rs
@@ -59,7 +59,7 @@ impl fmt::Display for DecodeError {
 
 impl error::Error for DecodeError {}
 
-impl<const N: usize> EncodeBytes<Message<N>> for Message<N> {
+impl<const N: usize> EncodeBytes for Message<N> {
     type Error = EncodeError;
 
     fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
@@ -76,7 +76,7 @@ impl<const N: usize> EncodeBytes<Message<N>> for Message<N> {
     }
 }
 
-impl<const N: usize> DecodeBytes<Message<N>> for Message<N> {
+impl<const N: usize> DecodeBytes for Message<N> {
     type Error = DecodeError;
 
     fn decode<B>(mut buffer: B) -> Result<Self, Self::Error>

--- a/lib/vector-buffers/examples/buffer_perf.rs
+++ b/lib/vector-buffers/examples/buffer_perf.rs
@@ -48,7 +48,7 @@ impl ByteSizeOf for VariableMessage {
     }
 }
 
-impl EncodeBytes<VariableMessage> for VariableMessage {
+impl EncodeBytes for VariableMessage {
     type Error = EncodeError;
 
     fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
@@ -67,7 +67,7 @@ impl EncodeBytes<VariableMessage> for VariableMessage {
     }
 }
 
-impl DecodeBytes<VariableMessage> for VariableMessage {
+impl DecodeBytes for VariableMessage {
     type Error = DecodeError;
 
     fn decode<B>(mut buffer: B) -> Result<Self, Self::Error>

--- a/lib/vector-buffers/src/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/disk_v2/reader.rs
@@ -95,9 +95,7 @@ where
     /// At this stage, the record can be assumed to have been written correctly, and read correctly
     /// from disk, as the checksum was also validated.
     #[snafu(display("failed to decoded record: {:?}", source))]
-    Decode {
-        source: <T as DecodeBytes<T>>::Error,
-    },
+    Decode { source: <T as DecodeBytes>::Error },
 
     /// The reader detected that a data file contains a partially-written record.
     ///

--- a/lib/vector-buffers/src/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/disk_v2/tests/mod.rs
@@ -182,7 +182,7 @@ impl ByteSizeOf for SizedRecord {
     }
 }
 
-impl EncodeBytes<SizedRecord> for SizedRecord {
+impl EncodeBytes for SizedRecord {
     type Error = io::Error;
 
     fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
@@ -202,7 +202,7 @@ impl EncodeBytes<SizedRecord> for SizedRecord {
     }
 }
 
-impl DecodeBytes<SizedRecord> for SizedRecord {
+impl DecodeBytes for SizedRecord {
     type Error = io::Error;
 
     fn decode<B>(mut buffer: B) -> Result<SizedRecord, Self::Error>
@@ -224,7 +224,7 @@ impl ByteSizeOf for UndecodableRecord {
     }
 }
 
-impl EncodeBytes<UndecodableRecord> for UndecodableRecord {
+impl EncodeBytes for UndecodableRecord {
     type Error = io::Error;
 
     fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
@@ -243,7 +243,7 @@ impl EncodeBytes<UndecodableRecord> for UndecodableRecord {
     }
 }
 
-impl DecodeBytes<UndecodableRecord> for UndecodableRecord {
+impl DecodeBytes for UndecodableRecord {
     type Error = io::Error;
 
     fn decode<B>(_buffer: B) -> Result<UndecodableRecord, Self::Error>

--- a/lib/vector-buffers/src/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/disk_v2/writer.rs
@@ -65,9 +65,7 @@ where
     /// For common encoders, failure to write all of the bytes of the input will be the most common
     /// error, and in fact, some some encoders, it's the only possible error that can occur.
     #[snafu(display("failed to encode record: {:?}", source))]
-    FailedToEncode {
-        source: <T as EncodeBytes<T>>::Error,
-    },
+    FailedToEncode { source: <T as EncodeBytes>::Error },
 
     /// The writer failed to serialize the record.
     ///

--- a/lib/vector-buffers/src/encoding.rs
+++ b/lib/vector-buffers/src/encoding.rs
@@ -12,42 +12,36 @@ use std::error;
 
 use bytes::{Buf, BufMut};
 
-/// Encode a `T` into a `bytes` buffer, possibly unsuccessfully
-pub trait EncodeBytes<T> {
+/// Encode a type into a `bytes` buffer, possibly unsuccessfully
+pub trait EncodeBytes: Sized {
     /// The type returned when `encode` fails
     type Error: error::Error + Send + Sync + 'static;
 
-    /// Attempt to encode a `T` into `B` buffer
+    /// Attempt to encode into `B` buffer
     ///
     /// # Errors
     ///
     /// Function will fail when encoding is not possible for the type instance.
-    fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
-    where
-        B: BufMut,
-        Self: Sized;
+    fn encode<B: BufMut>(self, buffer: &mut B) -> Result<(), Self::Error>;
 
-    /// Return the encoded byte size of `T`
+    /// Return the encoded byte size
     ///
-    /// For some `T` it is not clear ahead of time how large the encoded size
+    /// For some types it is not clear ahead of time how large the encoded size
     /// will be. For such types the return will be `None`, otherwise `Some`.
     fn encoded_size(&self) -> Option<usize> {
         None
     }
 }
 
-/// Decode a `T` from a `bytes` buffer, possibly unsuccessfully
-pub trait DecodeBytes<T> {
+/// Decode a type from a `bytes` buffer, possibly unsuccessfully
+pub trait DecodeBytes: Sized {
     /// The type returned when `decode` fails
     type Error: error::Error + Send + Sync + 'static;
 
-    /// Attempt to decode a `T` from `B` buffer
+    /// Attempt to decode from `B` buffer
     ///
     /// # Errors
     ///
     /// Function will fail when decoding is not possible from the passed buffer.
-    fn decode<B>(buffer: B) -> Result<T, Self::Error>
-    where
-        T: Sized,
-        B: Buf;
+    fn decode<B: Buf>(buffer: B) -> Result<Self, Self::Error>;
 }

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -73,12 +73,12 @@ impl Arbitrary for WhenFull {
 ///
 /// This supertrait serves as the base trait for any item that can be pushed into a buffer.
 pub trait Bufferable:
-    ByteSizeOf + EncodeBytes<Self> + DecodeBytes<Self> + Debug + Send + Sync + Unpin + Sized + 'static
+    ByteSizeOf + EncodeBytes + DecodeBytes + Debug + Send + Sync + Unpin + Sized + 'static
 {
 }
 
 // Blanket implementation for anything that is already bufferable.
 impl<T> Bufferable for T where
-    T: ByteSizeOf + EncodeBytes<T> + DecodeBytes<T> + Debug + Send + Sync + Unpin + Sized + 'static
+    T: ByteSizeOf + EncodeBytes + DecodeBytes + Debug + Send + Sync + Unpin + Sized + 'static
 {
 }

--- a/lib/vector-buffers/src/test/common/message.rs
+++ b/lib/vector-buffers/src/test/common/message.rs
@@ -57,7 +57,7 @@ impl Arbitrary for Message {
     }
 }
 
-impl EncodeBytes<Message> for Message {
+impl EncodeBytes for Message {
     type Error = EncodeError;
 
     fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
@@ -74,7 +74,7 @@ impl EncodeBytes<Message> for Message {
     }
 }
 
-impl DecodeBytes<Message> for Message {
+impl DecodeBytes for Message {
     type Error = DecodeError;
 
     fn decode<B>(mut buffer: B) -> Result<Self, Self::Error>

--- a/lib/vector-buffers/src/topology/test_util.rs
+++ b/lib/vector-buffers/src/topology/test_util.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 // Silly implementation of `EncodeBytes`/`DecodeBytes` to fulfill `Bufferable` for our test buffer code.
-impl EncodeBytes<u64> for u64 {
+impl EncodeBytes for u64 {
     type Error = BasicError;
 
     fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
@@ -23,7 +23,7 @@ impl EncodeBytes<u64> for u64 {
     }
 }
 
-impl DecodeBytes<u64> for u64 {
+impl DecodeBytes for u64 {
     type Error = BasicError;
 
     fn decode<B>(mut buffer: B) -> Result<u64, Self::Error>

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -404,7 +404,7 @@ impl<'a> From<&'a Metric> for EventRef<'a> {
     }
 }
 
-impl EncodeBytes<Event> for Event {
+impl EncodeBytes for Event {
     type Error = EncodeError;
 
     fn encode<B>(self, buffer: &mut B) -> Result<(), Self::Error>
@@ -415,7 +415,7 @@ impl EncodeBytes<Event> for Event {
     }
 }
 
-impl DecodeBytes<Event> for Event {
+impl DecodeBytes for Event {
     type Error = DecodeError;
 
     fn decode<B>(buffer: B) -> Result<Event, Self::Error>


### PR DESCRIPTION
The `EncodeBytes` and `DecodeBytes` traits are parameterized over the
type implementing the trait. That type parameter is redundant and
implied by implementing a trait, so it can be removed with no semantic
changes.