### PR TITLE
chore: Automatically detect erratic tests, un-erratic

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -46,6 +46,8 @@ jobs:
       vector-cpus: ${{ steps.system.outputs.VECTOR_CPUS }}
       soak-cpus: ${{ steps.system.outputs.SOAK_CPUS }}
       soak-memory: ${{ steps.system.outputs.SOAK_MEMORY }}
+      coefficient-of-variation: ${{ steps.system.outputs.COEFFICIENT_OF_VARIATION }}
+      erratic-soaks: ${{ steps.system.outputs.ERRATIC_SOAKS }}
     steps:
       - uses: actions/checkout@v2.3.5
         with:
@@ -91,14 +93,20 @@ jobs:
           export SOAK_CPUS="7"
           export SOAK_MEMORY="30g"
           export VECTOR_CPUS="4"
+          export COEFFICIENT_OF_VARIATION="0.3"
+          export ERRATIC_SOAKS="http_pipelines_blackhole,http_pipelines_blackhole_acks,http_to_http_acks,http_datadog_filter_blackhole"
 
           echo "soak cpus total: ${SOAK_CPUS}"
           echo "soak memory total: ${SOAK_MEMORY}"
           echo "vector cpus: ${VECTOR_CPUS}"
+          echo "coefficient of variation limit: ${COEFFICIENT_OF_VARIATION}"
+          echo "list of erratic soaks: ${ERRATIC_SOAKS}"
 
           echo "::set-output name=SOAK_CPUS::${SOAK_CPUS}"
+          echo "::set-output name=COEFFICIENT_OF_VARIATION::${COEFFICIENT_OF_VARIATION}"
           echo "::set-output name=SOAK_MEMORY::${SOAK_MEMORY}"
           echo "::set-output name=VECTOR_CPUS::${VECTOR_CPUS}"
+          echo "::set-output name=ERRATIC_SOAKS::${ERRATIC_SOAKS}"
 
   compute-test-plan:
     name: Compute soak test plan
@@ -268,6 +276,46 @@ jobs:
           minikube delete --all --purge
           docker system prune --all --volumes --force
 
+  detect-erratic-baseline:
+    name: Erratic detection - baseline
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-20.04
+    needs:
+      - compute-soak-meta
+      - soak-baseline
+
+    steps:
+      - name: Set up Python3
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10.1"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install scipy==1.7.* pandas==1.3.* tabulate==0.8.*
+
+      - name: Check out the repo
+        uses: actions/checkout@v2.4.0
+
+      - name: Download captures artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ github.event.number }}-${{ github.run_attempt }}-captures/
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ github.event.number }}-${{ github.run_attempt }}-captures/
+
+      - name: Detect erratic
+        run: |
+          ./soaks/bin/detect_erratic --capture-dir ${{ github.event.number }}-${{ github.run_attempt }}-captures/ \
+                                     --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
+                                     --warmup-seconds 30 \
+                                     --variant baseline \
+                                     --coefficient-of-variation-limit ${{ needs.compute-soak-meta.outputs.coefficient-of-variation }} \
+                                     --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }}
+
   soak-comparison:
     name: Soak (${{ matrix.target }}) - comparison - replica ${{ matrix.replica }}
     if: ${{ github.actor != 'dependabot[bot]' }}
@@ -305,6 +353,46 @@ jobs:
         run: |
           minikube delete --all --purge
           docker system prune --all --volumes --force
+
+  detect-erratic-comparison:
+    name: Erratic detection - comparison
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-20.04
+    needs:
+      - compute-soak-meta
+      - soak-comparison
+
+    steps:
+      - name: Set up Python3
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10.1"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install scipy==1.7.* pandas==1.3.* tabulate==0.8.*
+
+      - name: Check out the repo
+        uses: actions/checkout@v2.4.0
+
+      - name: Download captures artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ github.event.number }}-${{ github.run_attempt }}-captures/
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ github.event.number }}-${{ github.run_attempt }}-captures/
+
+      - name: Detect erratic
+        run: |
+          ./soaks/bin/detect_erratic --capture-dir ${{ github.event.number }}-${{ github.run_attempt }}-captures/ \
+                                     --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
+                                     --warmup-seconds 30 \
+                                     --variant comparison \
+                                     --coefficient-of-variation-limit ${{ needs.compute-soak-meta.outputs.coefficient-of-variation }} \
+                                     --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }}
 
   analyze-results:
     name: Soak analysis
@@ -345,6 +433,8 @@ jobs:
                                          --comparison-sha ${{ needs.compute-soak-meta.outputs.comparison-sha }} \
                                          --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
                                          --warmup-seconds 30 \
+                                         --coefficient-of-variation-limit ${{ needs.compute-soak-meta.outputs.coefficient-of-variation }} \
+                                         --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }} \
                                          --p-value 0.1 > /tmp/${{ github.event.number}}-${{ github.run_attempt }}-analysis
 
       - name: Read analysis file
@@ -396,6 +486,7 @@ jobs:
         run: |
           ./soaks/bin/detect_regressions --capture-dir ${{ github.event.number }}-${{ github.run_attempt }}-captures/ \
                                          --warmup-seconds 30 \
+                                         --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }} \
                                          --p-value 0.1
 
   plot-analysis:

--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -16,9 +16,11 @@ parser.add_argument('--mean-drift-percentage', type=float, default=8.87, help='t
 parser.add_argument('--p-value', type=float, default=0.1, help='the p-value for comparing with t-test results, the smaller the more certain')
 parser.add_argument('--vector-cpus', type=int, help='the total number of CPUs given to vector during the experiment')
 parser.add_argument('--warmup-seconds', type=int, default=30, help='the number of seconds to treat as warmup')
+parser.add_argument('--coefficient-of-variation-limit', type=float, default=0.1, help='the acceptable limit +/- for the ratio of stdev to mean, default 0.1')
+parser.add_argument('--report-erratic', type=bool, default=False, help='report on changes in erratic behavior')
 args = parser.parse_args()
 
-erratic_soaks = args.erratic_soaks.split(',')
+known_erratic_soaks = args.erratic_soaks.split(',')
 
 bytes_written = pd.concat(common.compute_throughput(
     common.open_captures(args.capture_dir,
@@ -30,20 +32,27 @@ bytes_written = pd.concat(common.compute_throughput(
 bytes_written = bytes_written[(bytes_written.fetch_index > args.warmup_seconds) &
                               (bytes_written.throughput > 0.0)]
 
-ttest_results = []
+results = []
 for exp in bytes_written.experiment.unique():
     baseline = bytes_written.loc[(bytes_written.experiment == exp) & (bytes_written.variant == 'baseline')]
     comparison = bytes_written.loc[(bytes_written.experiment == exp) & (bytes_written.variant == 'comparison')]
 
     baseline_mean = baseline.throughput.mean()
     baseline_stdev = baseline.throughput.std()
+    baseline_stderr = scipy.stats.sem(baseline.throughput)
     comparison_mean = comparison.throughput.mean()
     comparison_stdev = comparison.throughput.std()
+    comparison_stderr = scipy.stats.sem(comparison.throughput)
     diff =  comparison_mean - baseline_mean
     percent_change = round(((comparison_mean - baseline_mean) / baseline_mean) * 100, 2)
 
     baseline_outliers = common.total_outliers(baseline)
     comparison_outliers = common.total_outliers(comparison)
+
+    baseline_cov = scipy.stats.variation(baseline.throughput)
+    comparison_cov = scipy.stats.variation(comparison.throughput)
+    erratic = ((baseline_cov > args.coefficient_of_variation_limit) or
+               (comparison_cov > args.coefficient_of_variation_limit))
 
     # The t-test here is calculating whether the expected mean of our two
     # distributions is equal, or, put another way, whether the samples we have
@@ -62,20 +71,25 @@ for exp in bytes_written.experiment.unique():
                                            comparison_stdev,
                                            len(comparison),
                                            equal_var=False)
-    ttest_results.append({'experiment': exp,
-                          'Δ mean': diff.mean(),
-                          'Δ mean %': percent_change,
-                          'baseline mean': baseline_mean,
-                          'baseline stdev': baseline_stdev,
-                          'baseline outlier percentage': (baseline_outliers / len(baseline)) * 100,
-                          'comparison mean': comparison_mean,
-                          'comparison stdev': comparison_stdev,
-                          'comparison outlier percentage': (comparison_outliers / len(comparison)) * 100,
-                          'p-value': res.pvalue,
-                          'erratic': exp in erratic_soaks
-                          })
+    results.append({'experiment': exp,
+                    'Δ mean': diff.mean(),
+                    'Δ mean %': percent_change,
+                    'baseline mean': baseline_mean,
+                    'baseline stdev': baseline_stdev,
+                    'baseline stderr': baseline_stderr,
+                    'baseline outlier %': (baseline_outliers / len(baseline)) * 100,
+                    'baseline CoV': scipy.stats.variation(baseline.throughput),
+                    'comparison mean': comparison_mean,
+                    'comparison stdev': comparison_stdev,
+                    'comparison stderr': comparison_stderr,
+                    'comparison outlier %': (comparison_outliers / len(comparison)) * 100,
+                    'comparison CoV': scipy.stats.variation(comparison.throughput),
+                    'p-value': res.pvalue,
+                    'erratic': erratic,
+                    'declared erratic': exp in known_erratic_soaks
+                    })
 
-ttest_results = pd.DataFrame.from_records(ttest_results)
+results = pd.DataFrame.from_records(results)
 
 print(f'''
 # Soak Test Results
@@ -86,52 +100,98 @@ Total Vector CPUs: {args.vector_cpus}
 <details>
 <summary>Explanation</summary>
 <p>
-A soak test is an integrated performance test for vector in a repeatable rig, with varying configuration for vector.
-What follows is a statistical summary of a brief vector run for each configuration across SHAs given above.
-The goal of these tests are to determine, quickly, if vector performance is changed and to what degree by a pull request.
-Test units below are bytes/second/CPU, except for "skewness". The
-further "skewness" is from 0.0 the more indication that vector lacks
-consistency in behavior, making predictions of fitness in the field challenging.
+A soak test is an integrated performance test for vector in a repeatable rig,
+with varying configuration for vector.  What follows is a statistical summary of
+a brief vector run for each configuration across SHAs given above.  The goal of
+these tests are to determine, quickly, if vector performance is changed and to
+what degree by a pull request. Where appropriate units are scaled per-core.
 </p>
 
 <p>
-The abbreviated table below, if present, lists those experiments that have experienced a
+The table below, if present, lists those experiments that have experienced a
 statistically significant change in their throughput performance between
-baseline and comparision SHAs, with {(1.0 - args.p_value) * 100}% confidence. Negative values mean
-that baseline is faster, positive comparison. Results that do not exhibit more than a ±{args.mean_drift_percentage}%
-change in mean throughput are discarded. The abbreviated table will be omitted if no statistically
-interesting changes are observed.
+baseline and comparision SHAs, with {(1.0 - args.p_value) * 100}% confidence OR
+have been detected as newly erratic. Negative values mean that baseline is
+faster, positive comparison. Results that do not exhibit more than a
+±{args.mean_drift_percentage}% change in mean throughput are discarded. An
+experiment is erratic if its coefficient of variation is greater
+than {args.coefficient_of_variation_limit}. The abbreviated table will be
+omitted if no interesting changes are observed.
 </p>
 </details>
 ''')
 
-p_value_violation = ttest_results['p-value'] < args.p_value
-changes = ttest_results[p_value_violation].copy(deep=True)
-changes['confidence'] = changes['p-value'].apply(common.confidence)
+drift_filter = results['Δ mean %'].abs() > args.mean_drift_percentage
+declared_erratic = results.experiment.isin(known_erratic_soaks)
+p_value_violation = results['p-value'] < args.p_value
+erratic_violation = results.erratic == True
+
+changes = results[p_value_violation & drift_filter & ~declared_erratic].copy(deep=True)
+changes['Δ confidence'] = changes['p-value'].apply(common.confidence)
 changes = changes.drop(labels=['p-value', 'baseline mean',
                                'baseline stdev', 'comparison mean',
-                               'baseline outlier percentage',
-                               'comparison outlier percentage',
-                               'comparison stdev', 'erratic'], axis=1)
-changes = changes.loc[~changes['experiment'].isin(erratic_soaks)]
-changes = changes[changes['Δ mean %'].abs() > args.mean_drift_percentage].sort_values('Δ mean %', ascending=False)
+                               'baseline outlier %', 'baseline CoV',
+                               'comparison outlier %', 'comparison CoV', 'erratic',
+                               'comparison stdev', 'declared erratic'], axis=1)
+changes = changes.sort_values('Δ mean %', ascending=False)
 changes['Δ mean'] = changes['Δ mean'].apply(common.human_bytes)
-if len(changes) > 0:
+changes['baseline stderr'] = changes['baseline stderr'].apply(common.human_bytes)
+changes['comparison stderr'] = changes['comparison stderr'].apply(common.human_bytes)
+
+no_longer_erratic = results[~erratic_violation & declared_erratic].copy(deep=True)
+no_longer_erratic = no_longer_erratic.drop(labels=['p-value', 'baseline mean',
+                                                   'baseline stdev', 'comparison mean', 'Δ mean',
+                                                   'baseline outlier %', 'comparison outlier %',
+                                                   'comparison stdev', 'declared erratic'], axis=1)
+no_longer_erratic['baseline stderr'] = no_longer_erratic['baseline stderr'].apply(common.human_bytes)
+no_longer_erratic['comparison stderr'] = no_longer_erratic['comparison stderr'].apply(common.human_bytes)
+
+actually_erratic = results[erratic_violation & ~declared_erratic].copy(deep=True)
+actually_erratic = actually_erratic.drop(labels=['p-value', 'baseline mean',
+                                                 'baseline stdev', 'comparison mean', 'Δ mean',
+                                                 'baseline outlier %', 'comparison outlier %',
+                                                 'comparison stdev', 'declared erratic'], axis=1)
+actually_erratic['baseline stderr'] = actually_erratic['baseline stderr'].apply(common.human_bytes)
+actually_erratic['comparison stderr'] = actually_erratic['comparison stderr'].apply(common.human_bytes)
+
+detected_changes = len(changes) > 0
+detected_not_erratic = len(no_longer_erratic) > 0
+detected_actually_erratic = len(actually_erratic) > 0
+
+if detected_changes:
+    print(f"Changes in throughput with confidence ≥ {common.confidence(args.p_value)}:")
+    print()
     print(changes.to_markdown(index=False, tablefmt='github'))
+    print()
 else:
-    print("No statistically interesting changes with confidence {}.".format(common.confidence(args.p_value)))
+    print(f"No interesting changes with confidence ≥ {common.confidence(args.p_value)}:")
+    print()
+
+if args.report_erratic and detected_not_erratic:
+    print(f"Experiments that were declared erratic but were detected as no longer being so, cutoff {args.coefficient_of_variation_limit}:")
+    print()
+    print(no_longer_erratic.to_markdown(index=False, tablefmt='github'))
+    print()
+
+if args.report_erratic and detected_actually_erratic:
+    print(f"Experiments that were not declared erratic but were detected as being so, cutoff {args.coefficient_of_variation_limit}:")
+    print()
+    print(actually_erratic.to_markdown(index=False, tablefmt='github'))
+    print()
 
 print()
 print("<details>")
 print("<summary>Fine details of change detection per experiment.</summary>")
 print()
-ttest_results = ttest_results.sort_values('Δ mean %', ascending=False)
-ttest_results['Δ mean'] = ttest_results['Δ mean'].apply(common.human_bytes)
-ttest_results['baseline mean'] = ttest_results['baseline mean'].apply(common.human_bytes)
-ttest_results['baseline stdev'] = ttest_results['baseline stdev'].apply(common.human_bytes)
-ttest_results['comparison mean'] = ttest_results['comparison mean'].apply(common.human_bytes)
-ttest_results['comparison stdev'] = ttest_results['comparison stdev'].apply(common.human_bytes)
-print(ttest_results.to_markdown(index=False, tablefmt='github'))
+results = results.sort_values('Δ mean %', ascending=False)
+results['Δ mean'] = results['Δ mean'].apply(common.human_bytes)
+results['baseline mean'] = results['baseline mean'].apply(common.human_bytes)
+results['baseline stdev'] = results['baseline stdev'].apply(common.human_bytes)
+results['baseline stderr'] = results['baseline stderr'].apply(common.human_bytes)
+results['comparison mean'] = results['comparison mean'].apply(common.human_bytes)
+results['comparison stdev'] = results['comparison stdev'].apply(common.human_bytes)
+results['comparison stderr'] = results['comparison stderr'].apply(common.human_bytes)
+print(results.to_markdown(index=False, tablefmt='github'))
 print("</details>")
 
 print("<details>")

--- a/soaks/bin/detect_erratic
+++ b/soaks/bin/detect_erratic
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+import argparse
+import common
+import numpy as np
+import pandas as pd
+import scipy.stats
+import sys
+
+np.seterr(all='raise')
+
+parser = argparse.ArgumentParser(description='determine if we have unknown erratic soak experiments')
+parser.add_argument('--variant', type=str, default='baseline', help='the variant to examine for erratic behavior')
+parser.add_argument('--capture-dir', type=str, help='the directory to search for capture files')
+parser.add_argument('--vector-cpus', type=int, help='the total number of CPUs given to vector during the experiment')
+parser.add_argument('--warmup-seconds', type=int, default=30, help='the number of seconds to treat as warmup')
+parser.add_argument('--coefficient-of-variation-limit', type=float, default=0.1, help='the acceptable limit +/- for the ratio of stdev to mean, default 0.1')
+parser.add_argument('--erratic-soaks', type=str, default='', help='a comma separated list of known-erratic experiments, NOT TO BE USED LIGHTLY')
+parser.add_argument('--fail-if-erratic-shift', type=bool, default=False, help='whether to fail the execution if erratic declarations shifted')
+args = parser.parse_args()
+
+known_erratic_soaks = args.erratic_soaks.split(',')
+
+bytes_written = pd.concat(common.compute_throughput(
+    common.open_captures(args.capture_dir,
+                         'bytes_written',
+                         unwanted_labels=['metric_name', 'metric_kind', 'target']),
+    cpus = args.vector_cpus))
+# Skip past warmup seconds samples, allowing for vector warmup to not factor
+# into judgement.
+bytes_written = bytes_written[(bytes_written.fetch_index > args.warmup_seconds) &
+                              (bytes_written.throughput > 0.0) &
+                              (bytes_written.variant == args.variant)]
+
+results = []
+for exp in bytes_written.experiment.unique():
+    experiment_samples = bytes_written[bytes_written.experiment == exp]
+    for run_id in experiment_samples.run_id.unique():
+        samples = experiment_samples.loc[experiment_samples.run_id == run_id]
+
+        mean = samples.throughput.mean()
+        stdev = samples.throughput.std()
+        cov = scipy.stats.variation(samples.throughput)
+        outliers = common.total_outliers(samples)
+        outlier_ratio = outliers / len(samples)
+        erratic = abs(cov) > args.coefficient_of_variation_limit
+
+        results.append({
+            'experiment': exp,
+            'run_id': run_id,
+            'mean': mean,
+            'stdev': stdev,
+            'coefficient of variation': cov,
+            'erratic': erratic,
+            'outliers': outliers,
+            'outlier ratio': outlier_ratio,
+        })
+
+results = pd.DataFrame.from_records(results)
+results['mean'] = results['mean'].apply(common.human_bytes)
+results['stdev'] = results['stdev'].apply(common.human_bytes)
+
+erratic_violation = results.erratic == True
+declared_erratic = results.experiment.isin(known_erratic_soaks)
+
+actually_erratic = results[erratic_violation & ~declared_erratic].copy(deep=True)
+no_longer_erratic = results[~erratic_violation & declared_erratic].copy(deep=True)
+
+if len(actually_erratic) > 0:
+    print(f"Experiments that were not declared erratic but were detected as being so, cutoff {args.coefficient_of_variation_limit}:")
+    print()
+    print(actually_erratic.to_markdown(index=False, tablefmt='github'))
+    print()
+
+if len(no_longer_erratic) > 0:
+    print(f"Experiments that were declared erratic but were detected as no longer being so, cutoff {args.coefficient_of_variation_limit}:")
+    print()
+    print(no_longer_erratic.to_markdown(index=False, tablefmt='github'))
+    print()
+
+if (len(actually_erratic) > 0) or (len(no_longer_erratic) > 0):
+    print("Incorrectly labeled experiments detected.")
+    # Until we have either a better idea of how to detect erratic soaks _or_ we
+    # have the ability to allow failure -- not just continue -- in Github
+    # Actions we exit here successfully. Eventually we would like to be in a
+    # position where if the variation of a soak goes above limit we fail the PR,
+    # but we aren't there yet. For instance, we see in practice that some
+    # sub-runs will have above CoV but not all, or they dance right around the
+    # limit. Setting CoV to 0.5 _does_ address that but is such a high bar it's
+    # not useful.
+    if args.fail_if_erratic_shift:
+        sys.exit(1)

--- a/soaks/bin/detect_regressions
+++ b/soaks/bin/detect_regressions
@@ -20,7 +20,7 @@ parser.add_argument('--p-value', type=float, default=0.05, help='the p-value for
 parser.add_argument('--warmup-seconds', type=int, default=30, help='the number of seconds to treat as warmup')
 args = parser.parse_args()
 
-erratic_soaks = args.erratic_soaks.split(',')
+known_erratic_soaks = args.erratic_soaks.split(',')
 
 bytes_written = pd.concat(common.compute_throughput(
     common.open_captures(args.capture_dir,
@@ -32,7 +32,7 @@ bytes_written = pd.concat(common.compute_throughput(
 bytes_written = bytes_written[(bytes_written.fetch_index > args.warmup_seconds) &
                               (bytes_written.throughput > 0.0)]
 
-ttest_results = []
+results = []
 for exp in bytes_written.experiment.unique():
     baseline = bytes_written.loc[(bytes_written.experiment == exp) & (bytes_written.variant == 'baseline')]
     comparison = bytes_written.loc[(bytes_written.experiment == exp) & (bytes_written.variant == 'comparison')]
@@ -64,26 +64,27 @@ for exp in bytes_written.experiment.unique():
                                            comparison_stdev,
                                            len(comparison),
                                            equal_var=False)
-    ttest_results.append({'experiment': exp,
-                          'Δ mean': diff.mean(),
-                          'Δ mean %': percent_change,
-                          'baseline mean': baseline_mean,
-                          'comparison mean': comparison_mean,
-                          'p-value': res.pvalue,
-                          'erratic': exp in erratic_soaks
-                          })
-ttest_results = pd.DataFrame.from_records(ttest_results)
+    results.append({'experiment': exp,
+                    'Δ mean': diff.mean(),
+                    'Δ mean %': percent_change,
+                    'baseline mean': baseline_mean,
+                    'comparison mean': comparison_mean,
+                    'p-value': res.pvalue,
+                    'declared erratic': exp in known_erratic_soaks
+                    })
+results = pd.DataFrame.from_records(results)
 print("Table of test results:")
 print("")
 print("")
-print(ttest_results.to_markdown(index=False, tablefmt='github'))
+print(results.to_markdown(index=False, tablefmt='github'))
 
-p_value_violation = ttest_results['p-value'] < args.p_value
-changes = ttest_results[p_value_violation]
-changes = changes.loc[~changes['experiment'].isin(erratic_soaks)]
-changes = changes[changes['Δ mean %'] <  -args.mean_drift_percentage]
+p_value_violation = results['p-value'] < args.p_value
+drift_filter = results['Δ mean %'].abs() > args.mean_drift_percentage
+declared_erratic = results.experiment.isin(known_erratic_soaks)
+
+changes = results[p_value_violation & drift_filter & ~declared_erratic]
 print("")
-print("Table normalized to only show regressions, {} p-value threshold, {} drift threshold:".format(args.p_value, args.mean_drift_percentage))
+print(f"Table normalized to only show regressions, {args.p_value} p-value threshold, {args.mean_drift_percentage} drift threshold:")
 print("")
 print(changes.to_markdown(index=False, tablefmt='github'))
 

--- a/soaks/common/terraform/modules/monitoring/observer.tf
+++ b/soaks/common/terraform/modules/monitoring/observer.tf
@@ -1,12 +1,3 @@
-data "template_file" "soak-observer" {
-  template = file("${path.module}/observer.yaml.tpl")
-  vars = {
-    experiment_name    = var.experiment_name
-    experiment_variant = var.variant
-    vector_id          = var.vector_image
-  }
-}
-
 resource "kubernetes_config_map" "observer" {
   metadata {
     name      = "observer"
@@ -14,7 +5,11 @@ resource "kubernetes_config_map" "observer" {
   }
 
   data = {
-    "observer.yaml" = data.template_file.soak-observer.rendered
+    "observer.yaml" = templatefile("${path.module}/observer.yaml.tpl", {
+      experiment_name    = var.experiment_name
+      experiment_variant = var.variant
+      vector_id          = var.vector_image
+    })
   }
 }
 

--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -76,7 +76,7 @@ resource "kubernetes_deployment" "vector" {
           name              = "vector"
 
           env {
-            name = "VECTOR_THREADS"
+            name  = "VECTOR_THREADS"
             value = var.vector_cpus
           }
 

--- a/soaks/tests/splunk_hec_indexer_ack_blackhole/terraform/main.tf
+++ b/soaks/tests/splunk_hec_indexer_ack_blackhole/terraform/main.tf
@@ -45,10 +45,10 @@ module "vector" {
   vector_cpus  = var.vector_cpus
 }
 module "splunk-hec-gen" {
-  source        = "../../../common/terraform/modules/lading_splunk_hec_gen"
-  type          = var.type
+  source              = "../../../common/terraform/modules/lading_splunk_hec_gen"
+  type                = var.type
   splunk-hec-gen-yaml = file("${path.module}/../../../common/configs/splunk_hec_gen.yaml")
-  namespace     = kubernetes_namespace.soak.metadata[0].name
-  lading_image  = var.lading_image
-  depends_on    = [module.vector]
+  namespace           = kubernetes_namespace.soak.metadata[0].name
+  lading_image        = var.lading_image
+  depends_on          = [module.vector]
 }

--- a/soaks/tests/splunk_hec_to_splunk_hec_logs_acks/terraform/main.tf
+++ b/soaks/tests/splunk_hec_to_splunk_hec_logs_acks/terraform/main.tf
@@ -47,17 +47,17 @@ module "vector" {
   depends_on   = [module.splunk-hec-blackhole]
 }
 module "splunk-hec-blackhole" {
-  source              = "../../../common/terraform/modules/lading_splunk_hec_blackhole"
-  type                = var.type
+  source                    = "../../../common/terraform/modules/lading_splunk_hec_blackhole"
+  type                      = var.type
   splunk-hec-blackhole-yaml = file("${path.module}/../../../common/configs/splunk_hec_blackhole.yaml")
-  namespace           = kubernetes_namespace.soak.metadata[0].name
-  lading_image        = var.lading_image
+  namespace                 = kubernetes_namespace.soak.metadata[0].name
+  lading_image              = var.lading_image
 }
 module "splunk-hec-gen" {
-  source        = "../../../common/terraform/modules/lading_splunk_hec_gen"
-  type          = var.type
+  source              = "../../../common/terraform/modules/lading_splunk_hec_gen"
+  type                = var.type
   splunk-hec-gen-yaml = file("${path.module}/../../../common/configs/splunk_hec_gen.yaml")
-  namespace     = kubernetes_namespace.soak.metadata[0].name
-  lading_image  = var.lading_image
-  depends_on    = [module.vector]
+  namespace           = kubernetes_namespace.soak.metadata[0].name
+  lading_image        = var.lading_image
+  depends_on          = [module.vector]
 }

--- a/soaks/tests/splunk_hec_to_splunk_hec_logs_noack/terraform/main.tf
+++ b/soaks/tests/splunk_hec_to_splunk_hec_logs_noack/terraform/main.tf
@@ -46,17 +46,17 @@ module "vector" {
   depends_on   = [module.splunk-hec-blackhole]
 }
 module "splunk-hec-blackhole" {
-  source              = "../../../common/terraform/modules/lading_splunk_hec_blackhole"
-  type                = var.type
+  source                    = "../../../common/terraform/modules/lading_splunk_hec_blackhole"
+  type                      = var.type
   splunk-hec-blackhole-yaml = file("${path.module}/../../../common/configs/splunk_hec_blackhole.yaml")
-  namespace           = kubernetes_namespace.soak.metadata[0].name
-  lading_image        = var.lading_image
+  namespace                 = kubernetes_namespace.soak.metadata[0].name
+  lading_image              = var.lading_image
 }
 module "splunk-hec-gen" {
-  source        = "../../../common/terraform/modules/lading_splunk_hec_gen"
-  type          = var.type
+  source              = "../../../common/terraform/modules/lading_splunk_hec_gen"
+  type                = var.type
   splunk-hec-gen-yaml = file("${path.module}/splunk_hec_gen_noack.yaml")
-  namespace     = kubernetes_namespace.soak.metadata[0].name
-  lading_image  = var.lading_image
-  depends_on    = [module.vector]
+  namespace           = kubernetes_namespace.soak.metadata[0].name
+  lading_image        = var.lading_image
+  depends_on          = [module.vector]
 }


### PR DESCRIPTION
This commit introduces a mechanism to automatically flag newly erratic
tests and signal when previously erratic tests no longer are. The
basic insight here is that experiments with very high coefficient of
variation are unlikely to produce consistent results. The flakey
results I have examined are all a result of variation within the
standard deviation of these experiments. We now flag a small handful
of soaks as 'erratic' and have a mechanism in place to signal when
they have improved, if other experiments become erratic.

There will need to be a follow-up bit of work to understand why vector
in these configurations displays such a high CoV but that is outside
the scope of this changeset.

Closes #10606 
REF #10626 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>