### PR TITLE
chore(platforms): Pass through jemalloc page size env vars

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -6,6 +6,8 @@ passthrough = [
     "RUST_BACKTRACE",
     "RUST_LOG",
     "VECTOR_BUILD_DESC",
+    "JEMALLOC_SYS_WITH_LG_PAGE",
+    "JEMALLOC_SYS_WITH_LG_HUGEPAGE",
 ]
 
 [target.x86_64-unknown-linux-gnu]


### PR DESCRIPTION
We may or may not end up using these, but it is useful for users that
want to build Vector for another platform with a different page size.

Ref: https://github.com/vectordotdev/vector/issues/4392

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
