### PR TITLE
chore(ci): Disable ASLR when running Vector in soaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@
 !Cargo.toml
 !rust-toolchain.toml
 !scripts
+!soaks/entrypoint.sh

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -177,7 +177,7 @@ jobs:
         uses: docker/build-push-action@v2.8.0
         with:
           context: baseline-vector/
-          file: soaks/Dockerfile
+          file: baseline-vector/soaks/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -224,7 +224,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: comparison-vector/
-          file: soaks/Dockerfile
+          file: comparison-vector/soaks/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -17,8 +17,10 @@ FROM docker.io/debian:bullseye-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dede
 RUN apt-get update && apt-get -y install zlib1g
 COPY --from=builder /vector/vector /usr/bin/vector
 VOLUME /var/lib/vector/
+COPY soaks/entrypoint.sh /entrypoint.sh
 
 # Smoke test
 RUN ["vector", "--version"]
 
-ENTRYPOINT ["/usr/bin/vector"]
+# use setarch to disable ASLR to reduce noise
+ENTRYPOINT ["/entrypoint.sh"]

--- a/soaks/bin/build_container.sh
+++ b/soaks/bin/build_container.sh
@@ -33,7 +33,7 @@ build_vector() {
         popd
     fi
 
-    docker build --file "${BUILD_DIR}/Dockerfile" --tag "${IMAGE}" "${BUILD_DIR}"
+    docker build --file "${BUILD_DIR}/soaks/Dockerfile" --tag "${IMAGE}" "${BUILD_DIR}"
     rm -rf "${BUILD_DIR}"
 }
 

--- a/soaks/bin/build_container.sh
+++ b/soaks/bin/build_container.sh
@@ -7,7 +7,6 @@ set -o nounset
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="${__dir}/../../"
-SOAK_ROOT="${__dir}/../"
 
 display_usage() {
     echo ""

--- a/soaks/bin/build_container.sh
+++ b/soaks/bin/build_container.sh
@@ -33,7 +33,7 @@ build_vector() {
         popd
     fi
 
-    docker build --file "${SOAK_ROOT}/Dockerfile" --tag "${IMAGE}" "${BUILD_DIR}"
+    docker build --file "${BUILD_DIR}/Dockerfile" --tag "${IMAGE}" "${BUILD_DIR}"
     rm -rf "${BUILD_DIR}"
 }
 

--- a/soaks/entrypoint.sh
+++ b/soaks/entrypoint.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+setarch $(uname --machine) --addr-no-randomize /usr/bin/vector $@

--- a/soaks/entrypoint.sh
+++ b/soaks/entrypoint.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-setarch $(uname --machine) --addr-no-randomize /usr/bin/vector $@
+setarch "$(uname --machine)" --addr-no-randomize /usr/bin/vector $@

--- a/soaks/entrypoint.sh
+++ b/soaks/entrypoint.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-setarch "$(uname --machine)" --addr-no-randomize /usr/bin/vector $@
+setarch "$(uname --machine)" --addr-no-randomize /usr/bin/vector "$@"


### PR DESCRIPTION
This should hypothetically result in less random noise between runs.

This takes the soaks further away from how Vector will typically be run
in the wild, but for the soaks, which are used to control regressions,
the goal is to reduce noise rather than mimic the end-user environment
which has resulted in other changes like disabling hyper-threading.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
