### PR TITLE
fix(topology): ensure fanout is flushed on idle

### DIFF
--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -241,6 +241,7 @@ async fn send_inner(buf: &mut Vec<Event>, output: &mut Fanout) {
     for event in buf.drain(..) {
         output.feed(event).await.expect("unit error");
     }
+    output.flush().await.expect("unit error");
 }
 
 pub struct TransformOutputsBuf {

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "datadog-pipelines")]
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -180,6 +181,10 @@ impl ConfigBuilder {
 
         self.transforms
             .insert(ComponentKey::from(id.into()), transform);
+    }
+
+    pub fn set_data_dir(&mut self, path: &Path) {
+        self.global.data_dir = Some(path.to_owned());
     }
 
     pub fn append(&mut self, with: Self) -> Result<(), Vec<String>> {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -154,14 +154,11 @@ pub async fn build_pieces(
         let mut pumps = Vec::new();
         let mut controls = HashMap::new();
         for output in source_outputs {
-            let mut rx = builder.add_output(output.clone());
+            let rx = builder.add_output(output.clone());
 
-            let (mut fanout, control) = Fanout::new();
+            let (fanout, control) = Fanout::new();
             let pump = async move {
-                while let Some(event) = rx.next().await {
-                    fanout.feed(event).await?;
-                }
-                fanout.flush().await?;
+                rx.map(Ok).forward(fanout).await?;
                 Ok(TaskOutput::Source)
             };
 

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -11,7 +11,13 @@ use std::{
 
 use futures::{future, stream, StreamExt};
 use tokio::time::{sleep, Duration};
-use vector::{config::Config, event::Event, test_util::start_topology, topology};
+use vector::{
+    config::{Config, SinkOuter},
+    event::Event,
+    test_util::start_topology,
+    topology,
+};
+use vector_buffers::{BufferConfig, BufferType, WhenFull};
 
 use crate::support::{
     sink, sink_failing_healthcheck, sink_with_data, source, source_with_data, transform,
@@ -579,4 +585,53 @@ async fn topology_healthcheck_run_for_changes_on_reload() {
     let mut config = config.build().unwrap();
     config.healthchecks.require_healthy = true;
     assert!(!topology.reload_config_and_respawn(config).await.unwrap());
+}
+
+#[tokio::test]
+async fn topology_disk_buffer_flushes_on_idle() {
+    let tmpdir = tempfile::tempdir().expect("no tmpdir");
+    let event = Event::from("foo");
+
+    let (mut in1, source1) = source();
+    let transform1 = transform("", 0.0);
+    let (mut out1, sink1) = sink(10);
+
+    let mut config = Config::builder();
+    config.set_data_dir(tmpdir.path());
+    config.add_source("in1", source1);
+    config.add_transform("t1", &["in1"], transform1);
+    let mut sink1_outer = SinkOuter::new(
+        vec![String::from("in1"), String::from("t1")],
+        Box::new(sink1),
+    );
+    sink1_outer.buffer = BufferConfig {
+        stages: vec![BufferType::DiskV1 {
+            max_size: 1024,
+            when_full: WhenFull::DropNewest,
+        }],
+    };
+    config.add_sink_outer("out1", sink1_outer);
+
+    let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
+
+    in1.send(event).await.unwrap();
+
+    let res = tokio::time::timeout(Duration::from_secs(1), out1.next())
+        .await
+        .expect("timeout 1")
+        .map(into_message)
+        .expect("no output");
+    assert_eq!("foo", res);
+
+    let res = tokio::time::timeout(Duration::from_secs(1), out1.next())
+        .await
+        .expect("timeout 2")
+        .map(into_message)
+        .expect("no output");
+    assert_eq!("foo", res);
+
+    topology.stop().await;
+
+    let rest = out1.collect::<Vec<_>>().await;
+    assert_eq!(rest, vec![]);
 }


### PR DESCRIPTION
Fixes #10806

This is a fresh and clean version of #10899, which should hopefully give cleaner soak results. Also included is a new topology test that fails if either the source-side fix or the transform-side fix are removed.

The transform fix is a simple `flush` call after draining the whole buffer, which _shouldn't_ have a large performance impact because:

1. Flushing is a no-op for in-memory buffers, which all the soaks use
2. The buffer that's drained before flushing contains the results from a whole batch of events (up to 1024 for concurrent execution, 128 for inline), so when we're under load the call should be pretty effectively amortized.

The source fix is to switch from a feed loop to the `forward` method, which also _shouldn't_ have a large perf impact because:

1. Again, flushing is a no-op in every soak config
2. The `forward` future only flushes the sink when the input is idle, so again when we're under load it shouldn't need to come into play at all.
3. There's no additional copying or allocations as there would need to be if we broke up the input via `ready_chunks` or similar.