### PR TITLE
fix(vrl): support nested paths in `keyvalue` filter for `parse_groks`

### DIFF
--- a/lib/datadog/grok/src/filters/keyvalue.rs
+++ b/lib/datadog/grok/src/filters/keyvalue.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeMap;
 use std::fmt::Formatter;
 
 use bytes::Bytes;
+use lookup::{Lookup, LookupBuf};
 use nom::{
     self,
     branch::alt,
@@ -15,7 +17,7 @@ use nom::{
 use nom_regex::str::re_find;
 use ordered_float::NotNan;
 use regex::Regex;
-use vrl_compiler::Value;
+use vrl_compiler::{Target, Value};
 
 use crate::{
     ast::{Function, FunctionArgument},
@@ -120,7 +122,8 @@ impl std::fmt::Display for KeyValueFilter {
 
 pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, GrokRuntimeError> {
     match value {
-        Value::Bytes(bytes) => Ok(Value::from_iter::<Vec<(String, Value)>>(
+        Value::Bytes(bytes) => {
+            let mut result = Value::Object(BTreeMap::default());
             parse(
                 String::from_utf8_lossy(bytes).as_ref(),
                 &filter.key_value_delimiter,
@@ -132,18 +135,23 @@ pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, Gro
                 &filter.quotes,
                 &filter.value_re,
             )
-            .map_err(|_e| {
-                GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
-            })?
-            .iter()
-            .filter(|(k, v)| {
-                !(v.is_null()
-                    || matches!(v, Value::Bytes(b) if b.is_empty())
+            .unwrap_or_default()
+            .into_iter()
+            .for_each(|(k, v)| {
+                if !(v.is_null()
+                    || matches!(&v, Value::Bytes(b) if b.is_empty())
                     || k.trim().is_empty())
-            })
-            .map(|(k, v)| (k.to_owned(), v.to_owned()))
-            .collect(),
-        )),
+                {
+                    let lookup: LookupBuf = Lookup::from_str(&k)
+                        .unwrap_or_else(|_| Lookup::from(&k))
+                        .into();
+                    result.insert(&lookup, v).unwrap_or_else(
+                        |error| warn!(message = "Error updating field value", field = %lookup, %error)
+                    );
+                }
+            });
+            Ok(result)
+        }
         _ => Err(GrokRuntimeError::FailedToApplyFilter(
             filter.to_string(),
             value.to_string(),

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -784,6 +784,16 @@ mod tests {
                 "key =valueStr",
                 Ok(Value::from(btreemap! {})),
             ),
+            (
+                "%{data::keyvalue}",
+                "db.name=my_db,db.operation=insert",
+                Ok(Value::from(btreemap! {
+                    "db" => btreemap! {
+                        "name" => "my_db",
+                        "operation" => "insert",
+                    }
+                })),
+            ),
         ]);
     }
 }


### PR DESCRIPTION
`keyvalue` filter in `parse_groks` function should support nested paths as keys.
 For example,
  ```
  parse_groks("db.name=my_db,db.operation=insert", 
    patterns: ["%{data::keyvalue}"] 
  )
  ```
   => 
```
{
    "db" : {
        "name" : "my_db",
        "operation" : "insert",
    }
}
```