### PR TITLE
fix(vrl): support `d` and `y` shorthands in `date` matcher of `parse_groks` function

### DIFF
--- a/lib/datadog/grok/src/matchers/date.rs
+++ b/lib/datadog/grok/src/matchers/date.rs
@@ -140,8 +140,15 @@ pub fn time_format_to_regex(
         if ('A'..='Z').contains(&c) || ('a'..='z').contains(&c) {
             let token: String = chars.by_ref().peeking_take_while(|&cn| cn == c).collect();
             match token.chars().next().unwrap() {
-                'h' | 'H' | 'm' | 's' | 'S' | 'y' | 'Y' | 'x' | 'c' | 'C' | 'd' | 'e' | 'D'
-                | 'w' => regex.push_str(format!("[\\d]{{{}}}", token.len()).as_str()),
+                'h' | 'H' | 'm' | 's' | 'S' | 'Y' | 'x' | 'c' | 'C' | 'e' | 'D' | 'w' => {
+                    regex.push_str(format!("[\\d]{{{}}}", token.len()).as_str())
+                }
+                // days
+                'd' if token.len() == 1 => regex.push_str("[\\d]{2}"), // expand d to dd
+                'd' => regex.push_str(format!("[\\d]{{{}}}", token.len()).as_str()),
+                // years
+                'y' if token.len() == 1 => regex.push_str("[\\d]{4}"), // expand y to yyyy
+                'y' => regex.push_str(format!("[\\d]{{{}}}", token.len()).as_str()),
                 'M' if token.len() == 2 =>
                 // Month number
                 {

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -520,6 +520,11 @@ mod tests {
                 "Thu Jun 16 08:29:03 2016",
                 Ok(Value::Integer(1466076543000)),
             ),
+            (
+                r#"%{date("MMM d y HH:mm:ss z"):field}"#,
+                "Nov 16 2020 13:41:29 GMT",
+                Ok(Value::Integer(1605534089000)),
+            ),
         ]);
 
         // check error handling


### PR DESCRIPTION
We need to support `d` and `y` shorthands in `date` matcher of `parse_groks` function:
```
  parse_groks("Nov 16 2020 13:41:29 GMT", 
    patterns: ["%{date("MMM d y HH:mm:ss z"):field}"] 
  )
```
   => 1605534089000