### PR TITLE
fix(vrl): convert floats to integers when possible in `parse_groks`

### DIFF
--- a/lib/datadog/grok/src/grok_filter.rs
+++ b/lib/datadog/grok/src/grok_filter.rs
@@ -108,35 +108,51 @@ pub fn apply_filter(value: &Value, filter: &GrokFilter) -> Result<Value, GrokRun
             )),
         },
         GrokFilter::Number | GrokFilter::NumberExt => match value {
-            Value::Bytes(v) => Ok(String::from_utf8_lossy(v)
-                .parse::<f64>()
-                .map_err(|_e| {
-                    GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
-                })?
-                .into()),
-            _ => Err(GrokRuntimeError::FailedToApplyFilter(
-                filter.to_string(),
-                value.to_string(),
-            )),
-        },
-        GrokFilter::Scale(scale_factor) => match value {
-            Value::Integer(v) => Ok(Value::Float(
-                NotNan::new((*v as f64) * scale_factor).expect("NaN"),
-            )),
-            Value::Float(v) => Ok(Value::Float(
-                NotNan::new(v.into_inner() * scale_factor).expect("NaN"),
-            )),
             Value::Bytes(v) => {
-                let v = String::from_utf8_lossy(v).parse::<f64>().map_err(|_e| {
-                    GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
-                })?;
-                Ok(Value::Float(NotNan::new(v * scale_factor).expect("NaN")))
+                let v = Ok(String::from_utf8_lossy(v)
+                    .parse::<f64>()
+                    .map_err(|_e| {
+                        GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                    })?
+                    .into());
+                match v {
+                    Ok(Value::Float(v)) if (v.into_inner() as i64) as f64 == v.into_inner() => {
+                        Ok(Value::Integer(v.into_inner() as i64))
+                    }
+                    _ => v,
+                }
             }
             _ => Err(GrokRuntimeError::FailedToApplyFilter(
                 filter.to_string(),
                 value.to_string(),
             )),
         },
+        GrokFilter::Scale(scale_factor) => {
+            let v = match value {
+                Value::Integer(v) => Ok(Value::Float(
+                    NotNan::new((*v as f64) * scale_factor).expect("NaN"),
+                )),
+                Value::Float(v) => Ok(Value::Float(
+                    NotNan::new(v.into_inner() * scale_factor).expect("NaN"),
+                )),
+                Value::Bytes(v) => {
+                    let v = String::from_utf8_lossy(v).parse::<f64>().map_err(|_e| {
+                        GrokRuntimeError::FailedToApplyFilter(filter.to_string(), value.to_string())
+                    })?;
+                    Ok(Value::Float(NotNan::new(v * scale_factor).expect("NaN")))
+                }
+                _ => Err(GrokRuntimeError::FailedToApplyFilter(
+                    filter.to_string(),
+                    value.to_string(),
+                )),
+            };
+            match v {
+                Ok(Value::Float(v)) if (v.into_inner() as i64) as f64 == v.into_inner() => {
+                    Ok(Value::Integer(v.into_inner() as i64))
+                }
+                _ => v,
+            }
+        }
         GrokFilter::Lowercase => match value {
             Value::Bytes(bytes) => Ok(String::from_utf8_lossy(bytes).to_lowercase().into()),
             _ => Err(GrokRuntimeError::FailedToApplyFilter(

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -164,7 +164,7 @@ mod tests {
             parsed,
             Value::from(btreemap! {
                 "date_access" => "13/Jul/2016:10:55:36",
-                "duration" => 202000000.0,
+                "duration" => 202000000,
                 "http" => btreemap! {
                     "auth" => "frank",
                     "ident" => "-",
@@ -190,13 +190,9 @@ mod tests {
     fn supports_matchers() {
         test_grok_pattern(vec![
             ("%{number:field}", "-1.2", Ok(Value::from(-1.2_f64))),
-            ("%{number:field}", "-1", Ok(Value::from(-1_f64))),
-            (
-                "%{numberExt:field}",
-                "-1234e+3",
-                Ok(Value::from(-1234e+3_f64)),
-            ),
-            ("%{numberExt:field}", ".1e+3", Ok(Value::from(0.1e+3_f64))),
+            ("%{number:field}", "-1", Ok(Value::from(-1))),
+            ("%{numberExt:field}", "-1234e+3", Ok(Value::from(-1234000))),
+            ("%{numberExt:field}", ".1e+3", Ok(Value::from(100))),
             ("%{integer:field}", "-2", Ok(Value::from(-2))),
             ("%{integerExt:field}", "+2", Ok(Value::from(2))),
             ("%{integerExt:field}", "-2", Ok(Value::from(-2))),
@@ -208,7 +204,7 @@ mod tests {
     #[test]
     fn supports_filters() {
         test_grok_pattern(vec![
-            ("%{data:field:number}", "1.0", Ok(Value::from(1.0_f64))),
+            ("%{data:field:number}", "1.0", Ok(Value::from(1))),
             ("%{data:field:integer}", "1", Ok(Value::from(1))),
             (
                 "%{data:field:lowercase}",
@@ -220,8 +216,8 @@ mod tests {
                 "Abc",
                 Ok(Value::Bytes("ABC".into())),
             ),
-            ("%{integer:field:scale(10)}", "1", Ok(Value::from(10.0))),
-            ("%{number:field:scale(0.5)}", "10.0", Ok(Value::from(5.0))),
+            ("%{integer:field:scale(10)}", "1", Ok(Value::from(10))),
+            ("%{number:field:scale(0.5)}", "10.0", Ok(Value::from(5))),
         ]);
     }
 
@@ -576,7 +572,7 @@ mod tests {
             (
                 "%{data:field:array(number)}",
                 "[1,2]",
-                Ok(Value::Array(vec![1.0.into(), 2.0.into()])),
+                Ok(Value::Array(vec![1.into(), 2.into()])),
             ),
             (
                 "%{data:field:array(integer)}",
@@ -586,17 +582,17 @@ mod tests {
             (
                 "%{data:field:array(scale(10))}",
                 "[1,2.1]",
-                Ok(Value::Array(vec![10.0.into(), 21.0.into()])),
+                Ok(Value::Array(vec![10.into(), 21.into()])),
             ),
             (
                 r#"%{data:field:array(";", scale(10))}"#,
                 "[1;2.1]",
-                Ok(Value::Array(vec![10.0.into(), 21.0.into()])),
+                Ok(Value::Array(vec![10.into(), 21.into()])),
             ),
             (
                 r#"%{data:field:array("{}",";", scale(10))}"#,
                 "{1;2.1}",
-                Ok(Value::Array(vec![10.0.into(), 21.0.into()])),
+                Ok(Value::Array(vec![10.into(), 21.into()])),
             ),
         ]);
 

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -339,7 +339,7 @@ mod test {
             ],
             want: Ok(Value::Object(btreemap! {
                 "date_access" => "13/Jul/2016:10:55:36",
-                "duration" => 202000000.0,
+                "duration" => 202000000,
                 "http" => btreemap! {
                     "auth" => "frank",
                     "ident" => "-",


### PR DESCRIPTION
`parse_groks` should return integers instead of floats whenever lossless conversion is possible.