### PR TITLE
chore(transforms): Set up task transforms to accept event arrays

### DIFF
--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -30,7 +30,7 @@ fn bench_add_fields(c: &mut Criterion) {
         ("v1", {
             let source = format!("event['{}'] = '{}'", key, value);
 
-            Transform::task(transforms::lua::v1::Lua::new(source, vec![]).unwrap())
+            Transform::event_task(transforms::lua::v1::Lua::new(source, vec![]).unwrap())
         }),
         ("v2", {
             let config = format!(
@@ -45,7 +45,7 @@ fn bench_add_fields(c: &mut Criterion) {
                 "#},
                 key, value
             );
-            Transform::task(
+            Transform::event_task(
                 transforms::lua::v2::Lua::new(&toml::from_str::<LuaConfig>(&config).unwrap())
                     .unwrap(),
             )
@@ -67,7 +67,7 @@ fn bench_add_fields(c: &mut Criterion) {
             Transform::Synchronous(_t) => {
                 unreachable!("no sync transform used in these benches");
             }
-            Transform::Task(t) => t.transform(Box::pin(rx)),
+            Transform::Task(t) => t.transform_events(Box::pin(rx)),
         };
 
         group.bench_function(name.to_owned(), |b| {
@@ -121,7 +121,7 @@ fn bench_field_filter(c: &mut Criterion) {
                     event = nil
                 end
             "#});
-            Transform::task(transforms::lua::v1::Lua::new(source, vec![]).unwrap())
+            Transform::event_task(transforms::lua::v1::Lua::new(source, vec![]).unwrap())
         }),
         ("v2", {
             let config = indoc! {r#"
@@ -134,7 +134,7 @@ fn bench_field_filter(c: &mut Criterion) {
                 end
                 """
             "#};
-            Transform::task(
+            Transform::event_task(
                 transforms::lua::v2::Lua::new(&toml::from_str(config).unwrap()).unwrap(),
             )
         }),
@@ -155,7 +155,7 @@ fn bench_field_filter(c: &mut Criterion) {
             Transform::Synchronous(_t) => {
                 unreachable!("no sync transform used in these benches");
             }
-            Transform::Task(t) => t.transform(Box::pin(rx)),
+            Transform::Task(t) => t.transform_events(Box::pin(rx)),
         };
 
         group.bench_function(name.to_owned(), |b| {

--- a/benches/transform/dedupe.rs
+++ b/benches/transform/dedupe.rs
@@ -91,7 +91,7 @@ fn dedupe(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let dedupe =
-                        Transform::task(Dedupe::new(param.dedupe_config.clone())).into_task();
+                        Transform::event_task(Dedupe::new(param.dedupe_config.clone())).into_task();
                     (Box::new(dedupe), Box::pin(param.input.clone()))
                 },
                 |(dedupe, input)| {

--- a/benches/transform/reduce.rs
+++ b/benches/transform/reduce.rs
@@ -57,7 +57,7 @@ fn reduce(c: &mut Criterion) {
             b.to_async(tokio::runtime::Runtime::new().unwrap())
                 .iter_batched(
                     || {
-                        let reduce = Transform::task(
+                        let reduce = Transform::event_task(
                             Reduce::new(&param.reduce_config, &Default::default()).unwrap(),
                         )
                         .into_task();

--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -106,7 +106,7 @@ impl EventContainer for MetricArray {
 }
 
 /// An array of one of the `Event` variants exclusively.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum EventArray {
     /// An array of type `LogEvent`
     Logs(LogArray),

--- a/lib/vector-core/src/transform/runtime_transform/mod.rs
+++ b/lib/vector-core/src/transform/runtime_transform/mod.rs
@@ -68,9 +68,9 @@ enum Message {
     Timer(Timer),
 }
 
-impl<T> TaskTransform for T
+impl<T> TaskTransform<Event> for T
 where
-    T: RuntimeTransform + Send,
+    T: RuntimeTransform + Send + 'static,
 {
     fn transform(
         mut self: Box<Self>,

--- a/src/sources/kubernetes_logs/transform_utils/optional.rs
+++ b/src/sources/kubernetes_logs/transform_utils/optional.rs
@@ -6,20 +6,21 @@ use std::pin::Pin;
 
 use futures::Stream;
 
-use crate::{event::Event, transforms::TaskTransform};
+use crate::event::EventContainer;
+use crate::transforms::TaskTransform;
 
 /// Optional transform.
 /// Passes events through the specified transform is any, otherwise passes them,
 /// as-is.
 /// Useful to avoid boxing the transforms.
 #[derive(Clone, Debug)]
-pub struct Optional<T: TaskTransform>(pub Option<T>);
+pub struct Optional<T>(pub Option<T>);
 
-impl<T: TaskTransform> TaskTransform for Optional<T> {
+impl<T: TaskTransform<E>, E: EventContainer + 'static> TaskTransform<E> for Optional<T> {
     fn transform(
         self: Box<Self>,
-        task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+        task: Pin<Box<dyn Stream<Item = E> + Send>>,
+    ) -> Pin<Box<dyn Stream<Item = E> + Send>>
     where
         Self: 'static,
     {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -347,14 +347,14 @@ pub async fn build_pieces(
 
             sink.run(
                 rx.by_ref()
-                    .filter(|event| ready(filter_event_type(event, input_type)))
-                    .inspect(|event| {
+                    .map(EventArray::from) // Convert the `Event` into an `EventArray`
+                    .filter(|events| ready(filter_events_type(events, input_type)))
+                    .inspect(|events| {
                         emit!(&EventsReceived {
-                            count: 1,
-                            byte_size: event.size_of(),
+                            count: events.len(),
+                            byte_size: events.size_of(),
                         })
                     })
-                    .map(Into::into) // Convert the `Event` into an `EventArray`
                     .take_until_if(tripwire),
             )
             .await
@@ -450,6 +450,14 @@ const fn filter_event_type(event: &Event, data_type: DataType) -> bool {
         DataType::Any => true,
         DataType::Log => matches!(event, Event::Log(_)),
         DataType::Metric => matches!(event, Event::Metric(_)),
+    }
+}
+
+const fn filter_events_type(events: &EventArray, data_type: DataType) -> bool {
+    match data_type {
+        DataType::Any => true,
+        DataType::Log => matches!(events, EventArray::Logs(_)),
+        DataType::Metric => matches!(events, EventArray::Metrics(_)),
     }
 }
 
@@ -655,14 +663,14 @@ fn build_task_transform(
     let input_rx = crate::utilization::wrap(input_rx);
 
     let filtered = input_rx
-        .filter(move |event: &Event| ready(filter_event_type(event, input_type)))
-        .inspect(|event: &Event| {
+        .map(EventArray::from)
+        .filter(move |events| ready(filter_events_type(events, input_type)))
+        .inspect(|events| {
             emit!(&EventsReceived {
-                count: 1,
-                byte_size: event.size_of(),
+                count: events.len(),
+                byte_size: events.size_of(),
             })
-        })
-        .map(EventArray::from);
+        });
     let transform = t
         .transform(Box::pin(filtered))
         .flat_map(|events| futures::stream::iter(events.into_events()))

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -169,7 +169,7 @@ impl TransformConfig for Ec2Metadata {
             .instrument(info_span!("aws_ec2_metadata: worker")),
         );
 
-        Ok(Transform::task(Ec2MetadataTransform { state }))
+        Ok(Transform::event_task(Ec2MetadataTransform { state }))
     }
 
     fn input_type(&self) -> DataType {
@@ -185,7 +185,7 @@ impl TransformConfig for Ec2Metadata {
     }
 }
 
-impl TaskTransform for Ec2MetadataTransform {
+impl TaskTransform<Event> for Ec2MetadataTransform {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
@@ -551,9 +551,8 @@ mod integration_tests {
 
     use super::*;
     use crate::{
-        event::{metric, LogEvent, Metric},
+        event::{metric, EventArray, LogEvent, Metric},
         test_util::trace_init,
-        transforms::TaskTransform,
     };
 
     fn ec2_metadata_address() -> String {
@@ -583,7 +582,7 @@ mod integration_tests {
         )
     }
 
-    async fn make_transform(config: Ec2Metadata) -> Box<dyn TaskTransform> {
+    async fn make_transform(config: Ec2Metadata) -> Box<dyn TaskTransform<EventArray>> {
         config
             .build(&TransformContext::default())
             .await
@@ -607,7 +606,7 @@ mod integration_tests {
         .await;
 
         let (mut tx, rx) = futures::channel::mpsc::channel(100);
-        let mut stream = transform.transform(Box::pin(rx));
+        let mut stream = transform.transform_events(Box::pin(rx));
 
         // We need to sleep to let the background task fetch the data.
         sleep(Duration::from_secs(1)).await;
@@ -635,7 +634,7 @@ mod integration_tests {
         .await;
 
         let (mut tx, rx) = futures::channel::mpsc::channel(100);
-        let mut stream = transform.transform(Box::pin(rx));
+        let mut stream = transform.transform_events(Box::pin(rx));
 
         // We need to sleep to let the background task fetch the data.
         sleep(Duration::from_secs(1)).await;
@@ -662,7 +661,7 @@ mod integration_tests {
         .await;
 
         let (mut tx, rx) = futures::channel::mpsc::channel(100);
-        let mut stream = transform.transform(Box::pin(rx));
+        let mut stream = transform.transform_events(Box::pin(rx));
 
         // We need to sleep to let the background task fetch the data.
         sleep(Duration::from_secs(1)).await;
@@ -688,7 +687,7 @@ mod integration_tests {
         .await;
 
         let (mut tx, rx) = futures::channel::mpsc::channel(100);
-        let mut stream = transform.transform(Box::pin(rx));
+        let mut stream = transform.transform_events(Box::pin(rx));
 
         // We need to sleep to let the background task fetch the data.
         sleep(Duration::from_secs(1)).await;
@@ -715,7 +714,7 @@ mod integration_tests {
             .await;
 
             let (mut tx, rx) = futures::channel::mpsc::channel(100);
-            let mut stream = transform.transform(Box::pin(rx));
+            let mut stream = transform.transform_events(Box::pin(rx));
 
             // We need to sleep to let the background task fetch the data.
             sleep(Duration::from_secs(1)).await;
@@ -741,7 +740,7 @@ mod integration_tests {
             .await;
 
             let (mut tx, rx) = futures::channel::mpsc::channel(100);
-            let mut stream = transform.transform(Box::pin(rx));
+            let mut stream = transform.transform_events(Box::pin(rx));
 
             // We need to sleep to let the background task fetch the data.
             sleep(Duration::from_secs(1)).await;
@@ -769,7 +768,7 @@ mod integration_tests {
             .await;
 
             let (mut tx, rx) = futures::channel::mpsc::channel(100);
-            let mut stream = transform.transform(Box::pin(rx));
+            let mut stream = transform.transform_events(Box::pin(rx));
 
             // We need to sleep to let the background task fetch the data.
             sleep(Duration::from_secs(1)).await;
@@ -797,7 +796,7 @@ mod integration_tests {
             .await;
 
             let (mut tx, rx) = futures::channel::mpsc::channel(100);
-            let mut stream = transform.transform(Box::pin(rx));
+            let mut stream = transform.transform_events(Box::pin(rx));
 
             // We need to sleep to let the background task fetch the data.
             sleep(Duration::from_secs(1)).await;

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -83,7 +83,7 @@ impl GenerateConfig for DedupeConfig {
 #[typetag::serde(name = "dedupe")]
 impl TransformConfig for DedupeConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::task(Dedupe::new(self.clone())))
+        Ok(Transform::event_task(Dedupe::new(self.clone())))
     }
 
     fn input_type(&self) -> DataType {
@@ -195,7 +195,7 @@ fn build_cache_entry(event: &Event, fields: &FieldMatchConfig) -> CacheEntry {
     }
 }
 
-impl TaskTransform for Dedupe {
+impl TaskTransform<Event> for Dedupe {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -33,7 +33,7 @@ pub struct LuaConfig {
 // be exposed to users.
 impl LuaConfig {
     pub fn build(&self) -> crate::Result<Transform> {
-        Lua::new(self.source.clone(), self.search_dirs.clone()).map(Transform::task)
+        Lua::new(self.source.clone(), self.search_dirs.clone()).map(Transform::event_task)
     }
 
     pub const fn input_type(&self) -> DataType {
@@ -158,7 +158,7 @@ impl Lua {
     }
 }
 
-impl TaskTransform for Lua {
+impl TaskTransform<Event> for Lua {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -90,7 +90,7 @@ struct TimerConfig {
 // be exposed to users.
 impl LuaConfig {
     pub fn build(&self) -> crate::Result<Transform> {
-        Lua::new(self).map(Transform::task)
+        Lua::new(self).map(Transform::event_task)
     }
 
     pub const fn input_type(&self) -> DataType {

--- a/src/transforms/merge.rs
+++ b/src/transforms/merge.rs
@@ -56,7 +56,7 @@ impl Default for MergeConfig {
 #[typetag::serde(name = "merge")]
 impl TransformConfig for MergeConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::task(Merge::from(self.clone())))
+        Ok(Transform::event_task(Merge::from(self.clone())))
     }
 
     fn input_type(&self) -> DataType {
@@ -145,7 +145,7 @@ impl From<MergeConfig> for Merge {
     }
 }
 
-impl TaskTransform for Merge {
+impl TaskTransform<Event> for Merge {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -93,7 +93,9 @@ impl GenerateConfig for TagCardinalityLimitConfig {
 #[typetag::serde(name = "tag_cardinality_limit")]
 impl TransformConfig for TagCardinalityLimitConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::task(TagCardinalityLimit::new(self.clone())))
+        Ok(Transform::event_task(TagCardinalityLimit::new(
+            self.clone(),
+        )))
     }
 
     fn input_type(&self) -> DataType {
@@ -256,7 +258,7 @@ impl TagCardinalityLimit {
     }
 }
 
-impl TaskTransform for TagCardinalityLimit {
+impl TaskTransform<Event> for TagCardinalityLimit {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,


### PR DESCRIPTION
This is just surfacing the initial dumb code that converts events into single-element arrays and back for task transforms. More work on this path is coming but touches a lot more components so I wanted to get an idea of the impact of this minimal step forward.

Closes #10864