### PR TITLE
chore(ci): Use variant Dockerfile for soak tests

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -177,7 +177,7 @@ jobs:
         uses: docker/build-push-action@v2.8.0
         with:
           context: baseline-vector/
-          file: soaks/Dockerfile
+          file: baseline-vector/soaks/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -224,7 +224,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: comparison-vector/
-          file: soaks/Dockerfile
+          file: comparison-vector/soaks/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/soaks/bin/build_container.sh
+++ b/soaks/bin/build_container.sh
@@ -7,7 +7,6 @@ set -o nounset
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="${__dir}/../../"
-SOAK_ROOT="${__dir}/../"
 
 display_usage() {
     echo ""
@@ -33,7 +32,7 @@ build_vector() {
         popd
     fi
 
-    docker build --file "${SOAK_ROOT}/Dockerfile" --tag "${IMAGE}" "${BUILD_DIR}"
+    docker build --file "${BUILD_DIR}/soaks/Dockerfile" --tag "${IMAGE}" "${BUILD_DIR}"
     rm -rf "${BUILD_DIR}"
 }
 


### PR DESCRIPTION
Pulled out from https://github.com/vectordotdev/vector/pull/10942 since
I'm not sure if we want the rest of that PR yet.

This updates the soak tests to use the Dockerfile from whatever variant
is being soaked rather than whatever revision the soak test happens to
be ran from. This avoids issues with backwards incompatible changes to
the Dockerfile causing the baseline to fail to build.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
