### PR TITLE
enhancement(vrl): Support optional user-provided message with abort expression

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -394,7 +394,9 @@ impl<'a> Compiler<'a> {
     fn compile_abort(&mut self, node: Node<ast::Abort>) -> Abort {
         self.abortable = true;
         let (span, abort) = node.take();
-        let message = abort.message.map(|expr| self.compile_expr(*expr));
+        let message = abort
+            .message
+            .map(|expr| Node::new(expr.span(), self.compile_expr(*expr)));
 
         Abort::new(span, message, self.state).unwrap_or_else(|err| {
             self.errors.push(Box::new(err));

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -399,7 +399,7 @@ impl<'a> Compiler<'a> {
             .map(|expr| Node::new(expr.span(), self.compile_expr(*expr)));
 
         Abort::new(span, message, self.state).unwrap_or_else(|err| {
-            self.errors.push(err);
+            self.errors.push(Box::new(err));
             Abort::noop(span)
         })
     }

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -391,9 +391,10 @@ impl<'a> Compiler<'a> {
         })
     }
 
-    fn compile_abort(&mut self, node: Node<()>) -> Abort {
+    fn compile_abort(&mut self, node: Node<ast::Abort>) -> Abort {
         self.abortable = true;
-        Abort::new(node.span())
+        let (span, abort) = node.take();
+        Abort::new(span, abort.message)
     }
 
     fn handle_parser_error(&mut self, error: parser::Error) {

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -399,7 +399,7 @@ impl<'a> Compiler<'a> {
             .map(|expr| Node::new(expr.span(), self.compile_expr(*expr)));
 
         Abort::new(span, message, self.state).unwrap_or_else(|err| {
-            self.errors.push(Box::new(err));
+            self.errors.push(err);
             Abort::noop(span)
         })
     }

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -313,6 +313,7 @@ impl DiagnosticError for Error {
 pub enum ExpressionError {
     Abort {
         span: Span,
+        message: Option<String>,
     },
     Error {
         message: String,
@@ -342,7 +343,7 @@ impl DiagnosticError for ExpressionError {
         use ExpressionError::*;
 
         match self {
-            Abort { .. } => "aborted".to_owned(),
+            Abort { message, .. } => message.clone().unwrap_or_else(|| "aborted".to_owned()),
             Error { message, .. } => message.clone(),
         }
     }
@@ -351,7 +352,7 @@ impl DiagnosticError for ExpressionError {
         use ExpressionError::*;
 
         match self {
-            Abort { span } => {
+            Abort { span, .. } => {
                 vec![Label::primary("aborted", span)]
             }
             Error { labels, .. } => labels.clone(),

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -5,20 +5,24 @@ use crate::{
     Context, Expression, Span, State, TypeDef,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Abort {
     span: Span,
+    message: Option<String>,
 }
 
 impl Abort {
-    pub fn new(span: Span) -> Abort {
-        Abort { span }
+    pub fn new(span: Span, message: Option<String>) -> Abort {
+        Abort { span, message }
     }
 }
 
 impl Expression for Abort {
     fn resolve(&self, _: &mut Context) -> Resolved {
-        Err(ExpressionError::Abort { span: self.span })
+        Err(ExpressionError::Abort {
+            span: self.span,
+            message: self.message.clone(),
+        })
     }
 
     fn type_def(&self, _: &State) -> TypeDef {

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -1,27 +1,65 @@
 use std::fmt;
 
+use diagnostic::DiagnosticError;
+
 use crate::{
     expression::{ExpressionError, Resolved},
     Context, Expression, Span, State, TypeDef,
 };
 
+use super::Expr;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Abort {
     span: Span,
-    message: Option<String>,
+    message: Option<Box<Expr>>,
 }
 
 impl Abort {
-    pub fn new(span: Span, message: Option<String>) -> Abort {
-        Abort { span, message }
+    pub fn new(span: Span, message: Option<Expr>, state: &State) -> Result<Self, Error> {
+        if let Some(expr) = message {
+            let type_def = expr.type_def(state);
+            if type_def.is_fallible() {
+                Err(Error {
+                    variant: ErrorVariant::FallibleExpr,
+                })
+            } else if !type_def.is_bytes() {
+                Err(Error {
+                    variant: ErrorVariant::NonString,
+                })
+            } else {
+                Ok(Self {
+                    span,
+                    message: Some(Box::new(expr)),
+                })
+            }
+        } else {
+            Ok(Self {
+                span,
+                message: None,
+            })
+        }
+    }
+
+    pub fn noop(span: Span) -> Self {
+        Self {
+            span,
+            message: None,
+        }
     }
 }
 
 impl Expression for Abort {
-    fn resolve(&self, _: &mut Context) -> Resolved {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let message = if let Some(expr) = &self.message {
+            Some(expr.resolve(ctx)?.try_bytes_utf8_lossy()?.to_string())
+        } else {
+            None
+        };
+
         Err(ExpressionError::Abort {
             span: self.span,
-            message: self.message.clone(),
+            message,
         })
     }
 
@@ -33,5 +71,43 @@ impl Expression for Abort {
 impl fmt::Display for Abort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "abort")
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct Error {
+    variant: ErrorVariant,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ErrorVariant {
+    #[error("non-string message")]
+    NonString,
+    #[error("unhandled fallible expression")]
+    FallibleExpr,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#}", self.variant)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.variant)
+    }
+}
+
+impl DiagnosticError for Error {
+    fn code(&self) -> usize {
+        use ErrorVariant::*;
+
+        match self.variant {
+            NonString => 300,
+            FallibleExpr => 630,
+        }
     }
 }

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -57,11 +57,10 @@ impl Abort {
 
 impl Expression for Abort {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let message = if let Some(expr) = &self.message {
-            Some(expr.resolve(ctx)?.try_bytes_utf8_lossy()?.to_string())
-        } else {
-            None
-        };
+        let message = self
+            .message
+            .map(|expr| Ok(expr.resolve(ctx)?.try_bytes_utf8_lossy()?.to_string())
+            .transpose()?;
 
         Err(ExpressionError::Abort {
             span: self.span,

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -111,7 +111,7 @@ impl DiagnosticError for Error {
         use ErrorVariant::*;
 
         match self.variant {
-            FallibleExpr => 630,
+            FallibleExpr => 631,
             NonString(_) => 300,
         }
     }

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -1088,11 +1088,9 @@ pub struct Abort {
 
 impl fmt::Display for Abort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(message) = self.message.as_ref() {
-            write!(f, "abort: {}", message)
-        } else {
-            write!(f, "abort")
-        }
+        f.write_str(self.message.as_ref()
+            .map(|m| format!("abort: {}", m))
+            .unwrap_or_else(|| "abort".to_owned()))
     }
 }
 

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -1083,7 +1083,7 @@ impl fmt::Debug for Not {
 
 #[derive(Clone, PartialEq)]
 pub struct Abort {
-    pub message: Option<String>,
+    pub message: Option<Box<Node<Expr>>>,
 }
 
 impl fmt::Display for Abort {

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -1088,9 +1088,13 @@ pub struct Abort {
 
 impl fmt::Display for Abort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.message.as_ref()
-            .map(|m| format!("abort: {}", m))
-            .unwrap_or_else(|| "abort".to_owned()))
+        f.write_str(
+            &self
+                .message
+                .as_ref()
+                .map(|m| format!("abort: {}", m))
+                .unwrap_or_else(|| "abort".to_owned()),
+        )
     }
 }
 

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -215,7 +215,7 @@ pub enum Expr {
     FunctionCall(Node<FunctionCall>),
     Variable(Node<Ident>),
     Unary(Node<Unary>),
-    Abort(Node<()>),
+    Abort(Node<Abort>),
 }
 
 impl fmt::Debug for Expr {
@@ -232,7 +232,7 @@ impl fmt::Debug for Expr {
             FunctionCall(v) => format!("{:?}", v),
             Variable(v) => format!("{:?}", v),
             Unary(v) => format!("{:?}", v),
-            Abort(_) => "abort".to_owned(),
+            Abort(v) => format!("{:?}", v),
         };
 
         write!(f, "Expr({})", value)
@@ -253,7 +253,7 @@ impl fmt::Display for Expr {
             FunctionCall(v) => v.fmt(f),
             Variable(v) => v.fmt(f),
             Unary(v) => v.fmt(f),
-            Abort(_) => f.write_str("abort"),
+            Abort(v) => v.fmt(f),
         }
     }
 }
@@ -1074,6 +1074,31 @@ impl fmt::Display for Not {
 impl fmt::Debug for Not {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Not({:?})", self.1)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// abort
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, PartialEq)]
+pub struct Abort {
+    pub message: Option<String>,
+}
+
+impl fmt::Display for Abort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(message) = self.message.as_ref() {
+            write!(f, "abort: {}", message)
+        } else {
+            write!(f, "abort")
+        }
+    }
+}
+
+impl fmt::Debug for Abort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Abort({:?})", self.message)
     }
 }
 

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -225,7 +225,10 @@ Ident: Ident = "identifier" => Ident(<>.to_owned());
 
 PathField: Ident = "path field" => Ident(<>.to_owned());
 
-AbortExpr: Expr = Sp<"abort"> => Expr::Abort(<>.map(|_| ()));
+AbortExpr: Expr = {
+    Sp<"abort"> => Expr::Abort(<>.map(|_| Abort { message: None })),
+    <n: Sp<"abort">> <message: String> => Expr::Abort(n.map(|_| Abort { message: Some(message.clone()) })),
+}
 
 // An identifier that is allowed to include reserved keywords.
 AnyIdent: Ident = {

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -227,7 +227,7 @@ PathField: Ident = "path field" => Ident(<>.to_owned());
 
 AbortExpr: Expr = {
     Sp<"abort"> => Expr::Abort(<>.map(|_| Abort { message: None })),
-    <n: Sp<"abort">> <message: String> => Expr::Abort(n.map(|_| Abort { message: Some(message.clone()) })),
+    <n: Sp<"abort">> <message: Expr> => Expr::Abort(n.map(|_| Abort { message: Some(Box::new(message.clone())) })),
 }
 
 // An identifier that is allowed to include reserved keywords.

--- a/lib/vrl/tests/tests/diagnostics/abort_with_fallible_message.vrl
+++ b/lib/vrl/tests/tests/diagnostics/abort_with_fallible_message.vrl
@@ -1,6 +1,6 @@
 # result:
 #
-# error[E630]: unhandled fallible expression
+# error[E631]: unhandled fallible expression
 #   ┌─ :2:7
 #   │
 # 2 │ abort to_syslog_level(0)

--- a/lib/vrl/tests/tests/diagnostics/abort_with_fallible_message.vrl
+++ b/lib/vrl/tests/tests/diagnostics/abort_with_fallible_message.vrl
@@ -1,0 +1,15 @@
+# result:
+#
+# error[E630]: unhandled fallible expression
+#   ┌─ :2:7
+#   │
+# 2 │ abort to_syslog_level(0)
+#   │       ^^^^^^^^^^^^^^^^^^
+#   │       │
+#   │       abort only accepts an infallible expression argument
+#   │       handle errors before using the expression as an abort message
+#   │
+#   = see documentation about error handling at https://errors.vrl.dev/#handling
+#   = see language documentation at https://vrl.dev
+
+abort to_syslog_level(0)

--- a/lib/vrl/tests/tests/diagnostics/abort_with_non_string_message.vrl
+++ b/lib/vrl/tests/tests/diagnostics/abort_with_non_string_message.vrl
@@ -1,0 +1,16 @@
+# result:
+#
+# error[E300]: non-string abort message
+#   ┌─ :2:7
+#   │
+# 2 │ abort .
+#   │       ^
+#   │       │
+#   │       abort only accepts an expression argument resolving to a string
+#   │       this expression resolves to "object"
+#   │
+#   = hint: coerce the value to the required type using a coercion function
+#   = see documentation about type coercion at https://functions.vrl.dev/#coerce-functions
+#   = see language documentation at https://vrl.dev
+
+abort .

--- a/lib/vrl/tests/tests/diagnostics/abort_with_non_string_message.vrl
+++ b/lib/vrl/tests/tests/diagnostics/abort_with_non_string_message.vrl
@@ -1,6 +1,16 @@
 # result:
 #
-# error[E300]: expected "string", got "object"
-#  = see language documentation at https://vrl.dev
+# error[E300]: non-string abort message
+#   ┌─ :2:7
+#   │
+# 2 │ abort .
+#   │       ^
+#   │       │
+#   │       abort only accepts an expression argument resolving to a string
+#   │       this expression resolves to "object"
+#   │
+#   = hint: coerce the value to the required type using a coercion function
+#   = see documentation about type coercion at https://functions.vrl.dev/#coerce-functions
+#   = see language documentation at https://vrl.dev
 
 abort .

--- a/lib/vrl/tests/tests/diagnostics/abort_with_non_string_message.vrl
+++ b/lib/vrl/tests/tests/diagnostics/abort_with_non_string_message.vrl
@@ -1,16 +1,6 @@
 # result:
 #
-# error[E300]: non-string abort message
-#   ┌─ :2:7
-#   │
-# 2 │ abort .
-#   │       ^
-#   │       │
-#   │       abort only accepts an expression argument resolving to a string
-#   │       this expression resolves to "object"
-#   │
-#   = hint: coerce the value to the required type using a coercion function
-#   = see documentation about type coercion at https://functions.vrl.dev/#coerce-functions
-#   = see language documentation at https://vrl.dev
+# error[E300]: expected "string", got "object"
+#  = see language documentation at https://vrl.dev
 
 abort .

--- a/lib/vrl/tests/tests/expressions/abort/abort_with_complex_message.vrl
+++ b/lib/vrl/tests/tests/expressions/abort/abort_with_complex_message.vrl
@@ -1,0 +1,12 @@
+# result: { "foo": true, "id": 1 }
+
+.id = 1
+.foo = true
+abort {
+    if !.foo {
+        "aw man " + to_string(.id)
+    } else {
+        "uh oh " + uuid_v4()
+    }
+}
+.bar = false

--- a/lib/vrl/tests/tests/expressions/abort/abort_with_message.vrl
+++ b/lib/vrl/tests/tests/expressions/abort/abort_with_message.vrl
@@ -1,0 +1,5 @@
+# result: { "foo": true }
+
+.foo = true
+abort "a custom abort message"
+.bar = false

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -771,6 +771,44 @@ mod tests {
     }
 
     #[test]
+    fn check_remap_branching_abort_with_message() {
+        let error = Event::try_from(serde_json::json!({"hello": 42})).unwrap();
+        let conf = RemapConfig {
+            source: Some(formatdoc! {r#"
+                abort "custom message here"
+            "#}),
+            drop_on_error: true,
+            drop_on_abort: true,
+            reroute_dropped: true,
+            ..Default::default()
+        };
+        let context = TransformContext {
+            key: Some(ComponentKey::from("remapper")),
+            ..Default::default()
+        };
+        let mut tform = Remap::new(conf, &context).unwrap();
+
+        let output = transform_one_fallible(&mut tform, error).unwrap_err();
+        let log = output.as_log();
+        assert_eq!(log["hello"], 42.into());
+        assert!(!log.contains("foo"));
+        assert_eq!(
+            log["metadata"],
+            serde_json::json!({
+                "dropped": {
+                    "reason": "abort",
+                    "message": "custom message here",
+                    "component_id": "remapper",
+                    "component_type": "remap",
+                    "component_kind": "transform",
+                }
+            })
+            .try_into()
+            .unwrap()
+        );
+    }
+
+    #[test]
     fn check_remap_branching_disabled() {
         let happy = Event::try_from(serde_json::json!({"hello": "world"})).unwrap();
         let abort = Event::try_from(serde_json::json!({"hello": "goodbye"})).unwrap();

--- a/website/cue/reference/remap/errors/631_fallible_abort_message.cue
+++ b/website/cue/reference/remap/errors/631_fallible_abort_message.cue
@@ -1,0 +1,29 @@
+package metadata
+
+remap: errors: "631": {
+	title: "Fallible abort message expression"
+	description: """
+		You've passed a fallible expression as a message to abort.
+		"""
+
+	rationale: """
+		An expression that you pass to abort needs to be infallible. Otherwise, the abort expression could fail at runtime.
+		"""
+
+	resolution: """
+		Make the expression infallible, potentially by handling the error, coalescing the error using `??`, or via some other method.
+		"""
+
+	examples: [
+		{
+			"title": "\(title)"
+			source: #"""
+				abort to_syslog_level(0)
+				"""#
+			diff: #"""
+				- abort to_syslog_level(0)
+				+ abort to_syslog_level(0) ?? "other"
+				"""#
+		},
+	]
+}

--- a/website/cue/reference/remap/expressions/abort.cue
+++ b/website/cue/reference/remap/expressions/abort.cue
@@ -11,7 +11,14 @@ remap: expressions: abort: {
 		"""
 
 	grammar: {
-		source: "abort"
+		source: "abort ~ message?"
+		definitions: {
+			message: {
+				description: """
+					`message` is an optional debug message that can be used for diagnostic purposes and is included in a `remap` transform's dropped event metadata.
+					"""
+			}
+		}
 	}
 
 	examples: [


### PR DESCRIPTION
Closes #10686 

This PR adds the ability to include a user-specified message when using the `abort` expression. The syntax is 
```
abort {some expression resolving to string here}

# example

abort "your message here"
```
The message will appear in diagnostic prints.
- The `remap` transform will attach the abort message (if present) to a dropped event's metadata when relevant

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
