### PR TITLE
chore(api): Fix flakey vector tap test

### DIFF
--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -556,7 +556,7 @@ mod tests {
             "in-test1",
             DemoLogsConfig {
                 interval: 0.01,
-                count: 200,
+                count: 1,
                 format: OutputFormat::Shuffle {
                     sequence: false,
                     lines: vec!["test1".to_string()],
@@ -568,7 +568,7 @@ mod tests {
             "in-test2",
             DemoLogsConfig {
                 interval: 0.01,
-                count: 200,
+                count: 1,
                 format: OutputFormat::Shuffle {
                     sequence: false,
                     lines: vec!["test2".to_string()],


### PR DESCRIPTION
This PR fixes a flakey test for `vector tap` on multiple outputs. Kudos to @spencergilbert for pointing this out.
- Previously, we were generating a total of `400` events from the two `demo_logs` sources involved in the test but only collecting a maximum of `100` events to assert on. We need to assert on events originating from both sources, but all `100` events could have come from a single source. This change guarantees that we end up collecting events from both sources.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
