### PR TITLE
chore(performance): Add column to soaks indicating normality

### DIFF
--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -62,6 +62,10 @@ for exp in bytes_written.experiment.unique():
                                            comparison_stdev,
                                            len(comparison),
                                            equal_var=False)
+
+    baseline_shapiro_res = scipy.stats.shapiro(baseline.throughput.array)
+    comparison_shapiro_res = scipy.stats.shapiro(comparison.throughput.array)
+
     ttest_results.append({'experiment': exp,
                           'Δ mean': diff.mean(),
                           'Δ mean %': percent_change,
@@ -72,6 +76,8 @@ for exp in bytes_written.experiment.unique():
                           'comparison stdev': comparison_stdev,
                           'comparison outlier percentage': (comparison_outliers / len(comparison)) * 100,
                           'p-value': res.pvalue,
+                          'baseline normal?': "{} ({})".format("yes" if baseline_shapiro_res.pvalue < 0.05 else "no", baseline_shapiro_res.pvalue),
+                          'comparison normal?': "{} ({})".format("yes" if comparison_shapiro_res.pvalue < 0.05 else  "no", comparison_shapiro_res.pvalue),
                           'erratic': exp in erratic_soaks
                           })
 


### PR DESCRIPTION
Uses the Shapiro-Wilk test for normality.

https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.shapiro.html

I just chose 0.05 here for the p-value. I considered using the
configured `--p-value` but this felt like it was overloading that flag.
I could add a separate flag for the p-value to use for the normality
test?

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
