### PR TITLE
chore(codecs): Allow using `encode` on an `Encoder` without `mut`

### DIFF
--- a/src/codecs/framing/newline_delimited.rs
+++ b/src/codecs/framing/newline_delimited.rs
@@ -1,6 +1,6 @@
 use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
-use tokio_util::codec::{Decoder, Encoder};
+use tokio_util::codec::Decoder;
 
 use crate::codecs::{decoding, encoding, CharacterDelimitedDecoder, CharacterDelimitedEncoder};
 
@@ -129,11 +129,9 @@ impl NewlineDelimitedEncoder {
     }
 }
 
-impl Encoder<()> for NewlineDelimitedEncoder {
-    type Error = encoding::BoxedFramingError;
-
-    fn encode(&mut self, _: (), dst: &mut BytesMut) -> Result<(), Self::Error> {
-        self.0.encode((), dst)
+impl encoding::Framer for NewlineDelimitedEncoder {
+    fn frame(&self, buffer: &mut BytesMut) -> Result<(), encoding::BoxedFramingError> {
+        self.0.frame(buffer)
     }
 }
 


### PR DESCRIPTION
That way, the `Encoder` can be reused without needing to `clone` it.

This is accomplished by implementing `tokio::util::Encoder` for our own encoding traits rather than adding `tokio::util::Encoder` as a requirement to our traits.

This is a response to the performance regression reported https://github.com/vectordotdev/vector/pull/10684#issuecomment-1020730289.

Eliding to clone the `Encoder` will hopefully improve performance: https://github.com/vectordotdev/vector/pull/10684/commits/61e4af2beae1bfed1a0b107b92e42d34ba546783.