### PR TITLE
chore(transforms): Introduce transform output buffer abstraction

### DIFF
--- a/benches/event.rs
+++ b/benches/event.rs
@@ -6,7 +6,7 @@ use vector::{
     event::{Event, LogEvent},
     transforms::{
         json_parser::{JsonParser, JsonParserConfig},
-        FunctionTransform,
+        FunctionTransform, OutputBuffer,
     },
 };
 
@@ -98,9 +98,9 @@ fn create_event(json: Value) -> LogEvent {
     event.as_mut_log().insert(log_schema().message_key(), s);
 
     let mut parser = JsonParser::from(JsonParserConfig::default());
-    let mut output = Vec::with_capacity(1);
+    let mut output = OutputBuffer::with_capacity(1);
     parser.transform(&mut output, event);
-    output.into_iter().next().unwrap().into_log()
+    output.into_events().next().unwrap().into_log()
 }
 
 criterion_group!(

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -9,7 +9,7 @@ use vector::{
     config::{TransformConfig, TransformContext},
     event::Event,
     test_util::{collect_ready, runtime},
-    transforms::{self, Transform},
+    transforms::{self, OutputBuffer, Transform},
 };
 
 fn bench_add_fields(c: &mut Criterion) {
@@ -59,9 +59,9 @@ fn bench_add_fields(c: &mut Criterion) {
             Transform::Function(t) => {
                 let mut t = t.clone();
                 Box::pin(rx.flat_map(move |v| {
-                    let mut buf = Vec::with_capacity(1);
+                    let mut buf = OutputBuffer::with_capacity(1);
                     t.transform(&mut buf, v);
-                    stream::iter(buf.into_iter())
+                    stream::iter(buf.into_events())
                 }))
             }
             Transform::Synchronous(_t) => {
@@ -147,9 +147,9 @@ fn bench_field_filter(c: &mut Criterion) {
             Transform::Function(t) => {
                 let mut t = t.clone();
                 Box::pin(rx.flat_map(move |v| {
-                    let mut buf = Vec::with_capacity(1);
+                    let mut buf = OutputBuffer::with_capacity(1);
                     t.transform(&mut buf, v);
-                    stream::iter(buf.into_iter())
+                    stream::iter(buf.into_events())
                 }))
             }
             Transform::Synchronous(_t) => {

--- a/benches/regex.rs
+++ b/benches/regex.rs
@@ -36,7 +36,7 @@ fn benchmark_regex(c: &mut Criterion) {
 
         b.iter_batched(
             || {
-                (input.clone(), Vec::with_capacity(input.len()))
+                (input.clone(), transforms::OutputBuffer::with_capacity(input.len()))
             },
             |(events, mut output)| {
                 let event_count = events.len();

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -34,7 +34,7 @@ fn benchmark_remap(c: &mut Criterion) {
             TransformOutputsBuf::new_with_capacity(vec![Output::default(DataType::Any)], 1);
         tform.transform(event, &mut outputs);
         let result = outputs.take_primary();
-        let output_1 = result[0].as_log();
+        let output_1 = result.first().unwrap().as_log();
 
         debug_assert_eq!(output_1.get("foo").unwrap().to_string_lossy(), "bar");
         debug_assert_eq!(output_1.get("bar").unwrap().to_string_lossy(), "baz");
@@ -104,7 +104,7 @@ fn benchmark_remap(c: &mut Criterion) {
             TransformOutputsBuf::new_with_capacity(vec![Output::default(DataType::Any)], 1);
         tform.transform(event, &mut outputs);
         let result = outputs.take_primary();
-        let output_1 = result[0].as_log();
+        let output_1 = result.first().unwrap().as_log();
 
         debug_assert_eq!(
             output_1.get("foo").unwrap().to_string_lossy(),
@@ -179,7 +179,7 @@ fn benchmark_remap(c: &mut Criterion) {
                 TransformOutputsBuf::new_with_capacity(vec![Output::default(DataType::Any)], 1);
             tform.transform(event, &mut outputs);
             let result = outputs.take_primary();
-            let output_1 = result[0].as_log();
+            let output_1 = result.first().unwrap().as_log();
 
             debug_assert_eq!(output_1.get("number").unwrap(), &Value::Integer(1234));
             debug_assert_eq!(output_1.get("bool").unwrap(), &Value::Boolean(true));

--- a/lib/vector-core/src/transform/runtime_transform/mod.rs
+++ b/lib/vector-core/src/transform/runtime_transform/mod.rs
@@ -10,7 +10,8 @@ use tokio::time;
 use tokio_stream::wrappers::IntervalStream;
 use vec_stream::VecStreamExt;
 
-use crate::{event::Event, transform::TaskTransform};
+use super::{OutputBuffer, TaskTransform};
+use crate::event::Event;
 
 /// A structure representing user-defined timer.
 #[derive(Clone, Copy, Debug)]
@@ -52,7 +53,7 @@ pub trait RuntimeTransform {
         Vec::new()
     }
 
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         let mut maybe = None;
         self.hook_process(event, |event| maybe = Some(event));
         output.extend(maybe.into_iter());

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     kubernetes::hash_value::HashKey,
     shutdown::ShutdownSignal,
     sources,
-    transforms::{FunctionTransform, TaskTransform},
+    transforms::{FunctionTransform, OutputBuffer, TaskTransform},
     SourceSender,
 };
 
@@ -431,9 +431,9 @@ impl Source {
             event
         });
         let events = events.flat_map(move |event| {
-            let mut buf = Vec::with_capacity(1);
+            let mut buf = OutputBuffer::with_capacity(1);
             parser.transform(&mut buf, event);
-            futures::stream::iter(buf)
+            futures::stream::iter(buf.into_events())
         });
 
         let mut stream = partial_events_merger.transform(Box::pin(events));

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -6,7 +6,7 @@ use crate::{
     event::{self, Event, LogEvent, Value},
     transforms::{
         regex_parser::{RegexParser, RegexParserConfig},
-        FunctionTransform,
+        FunctionTransform, OutputBuffer,
     },
 };
 
@@ -54,10 +54,10 @@ impl Cri {
 }
 
 impl FunctionTransform for Cri {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
-        let mut buf = Vec::with_capacity(1);
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
+        let mut buf = OutputBuffer::with_capacity(1);
         self.regex_parser.transform(&mut buf, event);
-        if let Some(mut event) = buf.into_iter().next() {
+        if let Some(mut event) = buf.into_events().next() {
             if normalize_event(event.as_mut_log()).ok().is_some() {
                 output.push(event);
             }

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -7,7 +7,7 @@ use crate::{
     config::log_schema,
     event::{self, Event, LogEvent, Value},
     internal_events::KubernetesLogsDockerFormatParseFailed,
-    transforms::FunctionTransform,
+    transforms::{FunctionTransform, OutputBuffer},
 };
 
 pub const TIME: &str = "time";
@@ -23,7 +23,7 @@ pub const LOG: &str = "log";
 pub struct Docker;
 
 impl FunctionTransform for Docker {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let log = event.as_mut_log();
         if let Err(err) = parse_json(log) {
             emit!(&KubernetesLogsDockerFormatParseFailed { error: &err });
@@ -239,7 +239,7 @@ pub mod tests {
 
         for message in cases {
             let input = Event::from(message);
-            let mut output = Vec::new();
+            let mut output = OutputBuffer::default();
             Docker.transform(&mut output, input);
             assert!(output.is_empty(), "Expected no events: {:?}", output);
         }

--- a/src/sources/kubernetes_logs/parser/picker.rs
+++ b/src/sources/kubernetes_logs/parser/picker.rs
@@ -4,7 +4,7 @@ use super::{cri::Cri, docker::Docker};
 use crate::{
     event::{Event, Value},
     internal_events::KubernetesLogsFormatPickerEdgeCase,
-    transforms::FunctionTransform,
+    transforms::{FunctionTransform, OutputBuffer},
 };
 
 #[derive(Clone, Debug)]
@@ -28,7 +28,7 @@ impl Picker {
 }
 
 impl FunctionTransform for Picker {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         match &mut self.state {
             PickerState::Init => {
                 let message = match event
@@ -106,7 +106,7 @@ mod tests {
         for message in cases {
             let input = Event::from(message);
             let mut picker = Picker::new(TimeZone::Local);
-            let mut output = Vec::new();
+            let mut output = OutputBuffer::default();
             picker.transform(&mut output, input);
             assert!(output.is_empty(), "Expected no events: {:?}", output);
         }
@@ -129,7 +129,7 @@ mod tests {
 
         for input in cases {
             let mut picker = Picker::new(TimeZone::Local);
-            let mut output = Vec::new();
+            let mut output = OutputBuffer::default();
             picker.transform(&mut output, input);
             assert!(output.is_empty(), "Expected no events: {:?}", output);
         }

--- a/src/sources/kubernetes_logs/parser/test_util.rs
+++ b/src/sources/kubernetes_logs/parser/test_util.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 
 use crate::{
     event::{Event, LogEvent},
-    transforms::Transform,
+    transforms::{OutputBuffer, Transform},
 };
 
 /// Build a log event for test purposes.
@@ -71,11 +71,11 @@ where
         let mut parser = (builder)();
         let parser = parser.as_function();
 
-        let mut output = Vec::new();
+        let mut output = OutputBuffer::default();
         parser.transform(&mut output, input);
 
         let expected = expected.into_iter().map(Event::Log).collect::<Vec<_>>();
 
-        shared::assert_event_data_eq!(expected, output, "expected left, actual right");
+        shared::assert_event_data_eq!(output, expected, "expected left, actual right");
     }
 }

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     serde::Fields,
     template::Template,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -106,7 +106,7 @@ impl AddFields {
 }
 
 impl FunctionTransform for AddFields {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         for (key, value_or_template) in self.fields.clone() {
             let key_string = key.to_string(); // TODO: Step 6 of https://github.com/timberio/vector/blob/c4707947bd876a0ff7d7aa36717ae2b32b731593/rfcs/2020-05-25-more-usable-logevents.md#sales-pitch.
             let value = match value_or_template {

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     event::Event,
     internal_events::{AddTagsTagNotOverwritten, AddTagsTagOverwritten},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -70,7 +70,7 @@ impl AddTags {
 }
 
 impl FunctionTransform for AddTags {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         if !self.tags.is_empty() {
             let metric = event.as_mut_metric();
 

--- a/src/transforms/ansi_stripper.rs
+++ b/src/transforms/ansi_stripper.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     event::{Event, Value},
     internal_events::{AnsiStripperFailed, AnsiStripperFieldInvalid, AnsiStripperFieldMissing},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     Result,
 };
 
@@ -57,7 +57,7 @@ pub struct AnsiStripper {
 }
 
 impl FunctionTransform for AnsiStripper {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let log = event.as_mut_log();
 
         match log.get_mut(&self.field) {

--- a/src/transforms/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/transforms/aws_cloudwatch_logs_subscription_parser.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     event::Event,
     internal_events::AwsCloudwatchLogsSubscriptionParserFailedParse,
-    transforms::FunctionTransform,
+    transforms::{FunctionTransform, OutputBuffer},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone, Derivative)]
@@ -77,7 +77,7 @@ impl From<AwsCloudwatchLogsSubscriptionParserConfig> for AwsCloudwatchLogsSubscr
 }
 
 impl FunctionTransform for AwsCloudwatchLogsSubscriptionParser {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         let log = event.as_log();
 
         let message = log
@@ -180,7 +180,7 @@ mod test {
         log.insert("keep", "field");
         let orig_metadata = event.metadata().clone();
 
-        let mut output: Vec<Event> = Vec::new();
+        let mut output = OutputBuffer::default();
 
         parser.transform(&mut output, event);
 
@@ -209,8 +209,9 @@ mod test {
                 },
             ]
         );
-        assert_eq!(output[0].metadata(), &orig_metadata);
-        assert_eq!(output[1].metadata(), &orig_metadata);
+        let mut output = output.into_events();
+        assert_eq!(output.next().unwrap().metadata(), &orig_metadata);
+        assert_eq!(output.next().unwrap().metadata(), &orig_metadata);
     }
 
     #[test]
@@ -239,10 +240,10 @@ mod test {
 "#,
         );
 
-        let mut output: Vec<Event> = Vec::new();
+        let mut output = OutputBuffer::default();
 
         parser.transform(&mut output, event);
 
-        assert_eq!(output, vec![]);
+        assert!(output.is_empty());
     }
 }

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -7,7 +7,7 @@ use crate::{
     config::{DataType, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, LogEvent, Value},
     internal_events::CoercerConversionFailed,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
 
@@ -66,7 +66,7 @@ impl Coercer {
 }
 
 impl FunctionTransform for Coercer {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         let mut log = event.into_log();
 
         if self.drop_unspecified {
@@ -111,6 +111,7 @@ mod tests {
     use crate::{
         config::{TransformConfig, TransformContext},
         event::{Event, LogEvent, Value},
+        transforms::OutputBuffer,
     };
 
     #[test]
@@ -144,7 +145,7 @@ mod tests {
         .await
         .unwrap();
         let coercer = coercer.as_function();
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         coercer.transform(&mut buf, event);
         let result = buf.pop().unwrap().into_log();
         assert_eq!(&metadata, result.metadata());

--- a/src/transforms/concat.rs
+++ b/src/transforms/concat.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     event::{Event, Value},
     internal_events::{ConcatSubstringError, ConcatSubstringSourceMissing},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -136,7 +136,7 @@ impl Concat {
 }
 
 impl FunctionTransform for Concat {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let mut content_vec: Vec<bytes::Bytes> = Vec::new();
 
         for substring in self.items.iter() {

--- a/src/transforms/field_filter.rs
+++ b/src/transforms/field_filter.rs
@@ -5,7 +5,7 @@ use crate::{
         DataType, GenerateConfig, Output, TransformConfig, TransformContext, TransformDescription,
     },
     event::Event,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -69,7 +69,7 @@ impl FieldFilter {
 }
 
 impl FunctionTransform for FieldFilter {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         if event
             .as_log()
             .get(&self.field_name)

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     event::Event,
     internal_events::FilterEventDiscarded,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -76,7 +76,7 @@ impl Filter {
 }
 
 impl FunctionTransform for Filter {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         if self.condition.check(&event) {
             output.push(event);
         } else {

--- a/src/transforms/geoip.rs
+++ b/src/transforms/geoip.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     event::Event,
     internal_events::{GeoipFieldDoesNotExist, GeoipIpAddressParseError},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     Result,
 };
 
@@ -128,7 +128,7 @@ struct City<'a> {
 }
 
 impl FunctionTransform for Geoip {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let mut isp: Isp = Default::default();
         let mut city: City = Default::default();
         let target_field = self.target.clone();

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     event::{Event, PathComponent, PathIter, Value},
     internal_events::{GrokParserConversionFailed, GrokParserFailedMatch, GrokParserMissingField},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
 
@@ -112,7 +112,7 @@ impl Clone for GrokParser {
 }
 
 impl FunctionTransform for GrokParser {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         let mut event = event.into_log();
         let value = event.get(&self.field).map(|s| s.to_string_lossy());
 
@@ -164,6 +164,7 @@ mod tests {
     use crate::{
         config::{log_schema, TransformConfig, TransformContext},
         event::{self, Event, LogEvent},
+        transforms::OutputBuffer,
     };
 
     #[test]
@@ -192,7 +193,7 @@ mod tests {
         .unwrap();
         let parser = parser.as_function();
 
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         parser.transform(&mut buf, event);
         let result = buf.pop().unwrap().into_log();
         assert_eq!(result.metadata(), &metadata);

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     event::Event,
     internal_events::{JsonParserFailedParse, JsonParserTargetExists},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone, Derivative)]
@@ -78,7 +78,7 @@ impl From<JsonParserConfig> for JsonParser {
 }
 
 impl FunctionTransform for JsonParser {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let log = event.as_mut_log();
         let value = log.get(&self.field);
 

--- a/src/transforms/key_value_parser.rs
+++ b/src/transforms/key_value_parser.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     event::{Event, Value},
     internal_events::{KeyValueFieldDoesNotExist, KeyValueParseFailed, KeyValueTargetExists},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
 
@@ -137,7 +137,7 @@ impl KeyValue {
 }
 
 impl FunctionTransform for KeyValue {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let log = event.as_mut_log();
         let value = log.get(&self.field).map(|s| s.to_string_lossy());
 
@@ -195,6 +195,7 @@ mod tests {
     use crate::{
         config::{TransformConfig, TransformContext},
         event::{Event, LogEvent, Value},
+        transforms::OutputBuffer,
     };
 
     async fn parse_log(
@@ -228,7 +229,7 @@ mod tests {
 
         let parser = parser.as_function();
 
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         parser.transform(&mut buf, event);
         let result = buf.pop().unwrap().into_log();
         assert_eq!(result.metadata(), &metadata);

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -17,7 +17,7 @@ use crate::{
         LogToMetricTemplateParseError, TemplateRenderingFailed,
     },
     template::{Template, TemplateParseError, TemplateRenderingError},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -382,7 +382,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
 }
 
 impl FunctionTransform for LogToMetric {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         for config in self.config.metrics.iter() {
             match to_metric(config, &event) {
                 Ok(metric) => {
@@ -728,7 +728,7 @@ mod tests {
 
         let mut transform = LogToMetric::new(config);
 
-        let mut output = Vec::new();
+        let mut output = OutputBuffer::default();
         transform.transform(&mut output, event);
         assert_eq!(2, output.len());
         assert_eq!(
@@ -783,7 +783,7 @@ mod tests {
 
         let mut transform = LogToMetric::new(config);
 
-        let mut output = Vec::new();
+        let mut output = OutputBuffer::default();
         transform.transform(&mut output, event);
         assert_eq!(2, output.len());
         assert_eq!(

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -7,7 +7,7 @@ use crate::{
     config::{DataType, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, Value},
     internal_events::{LogfmtParserConversionFailed, LogfmtParserMissingField},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
 
@@ -69,7 +69,7 @@ pub struct Logfmt {
 }
 
 impl FunctionTransform for Logfmt {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let value = event.as_log().get(&self.field).map(|s| s.to_string_lossy());
 
         let mut drop_field = self.drop_field;
@@ -118,6 +118,7 @@ mod tests {
     use crate::{
         config::{TransformConfig, TransformContext},
         event::{Event, LogEvent, Value},
+        transforms::OutputBuffer,
     };
 
     #[test]
@@ -140,7 +141,7 @@ mod tests {
         .unwrap();
         let parser = parser.as_function();
 
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         parser.transform(&mut buf, event);
         let result = buf.pop().unwrap().into_log();
         assert_eq!(result.metadata(), &metadata);

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     event::{self, Event, LogEvent, Metric},
     internal_events::MetricToLogFailedSerialize,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::Conversion,
 };
 
@@ -116,7 +116,7 @@ impl MetricToLog {
 }
 
 impl FunctionTransform for MetricToLog {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         let retval: Option<Event> = self
             .transform_one(event.into_metric())
             .map(|log| log.into());

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -71,7 +71,7 @@ pub mod throttle;
 pub mod tokenizer;
 
 pub use vector_core::transform::{
-    FunctionTransform, SyncTransform, TaskTransform, Transform, TransformOutputs,
+    FunctionTransform, OutputBuffer, SyncTransform, TaskTransform, Transform, TransformOutputs,
     TransformOutputsBuf,
 };
 
@@ -88,7 +88,7 @@ enum BuildError {
 mod test {
     use vector_core::transform::FunctionTransform;
 
-    use crate::event::Event;
+    use crate::{event::Event, transforms::OutputBuffer};
 
     /// Transform a single `Event` through the `FunctionTransform`
     ///
@@ -102,9 +102,9 @@ mod test {
     // issue a unused warnings about the import above.
     #[allow(dead_code)]
     pub fn transform_one(ft: &mut dyn FunctionTransform, event: Event) -> Option<Event> {
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         ft.transform(&mut buf, event);
         assert!(buf.len() < 2);
-        buf.into_iter().next()
+        buf.first().cloned()
     }
 }

--- a/src/transforms/noop.rs
+++ b/src/transforms/noop.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{DataType, Output, TransformConfig, TransformContext},
     event::Event,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -30,7 +30,7 @@ impl TransformConfig for Noop {
 }
 
 impl FunctionTransform for Noop {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         output.push(event);
     }
 }

--- a/src/transforms/pipelines/router.rs
+++ b/src/transforms/pipelines/router.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{DataType, ExpandType, Output, TransformConfig, TransformContext},
     event::Event,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -128,7 +128,7 @@ impl TransformConfig for EventFilterConfig {
 }
 
 impl FunctionTransform for EventFilterConfig {
-    fn transform(&mut self, output: &mut Vec<Event>, event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         if self.inner.validate(&event) {
             output.push(event);
         }

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -13,7 +13,7 @@ use crate::{
         RegexParserConversionFailed, RegexParserFailedMatch, RegexParserMissingField,
         RegexParserTargetExists,
     },
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_check_conversion_map, Conversion},
 };
 
@@ -245,7 +245,7 @@ impl RegexParser {
 }
 
 impl FunctionTransform for RegexParser {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let log = event.as_mut_log();
         let value = log.get(&self.field).map(|s| s.as_bytes());
 
@@ -311,6 +311,7 @@ mod tests {
     use crate::{
         config::{TransformConfig, TransformContext},
         event::{Event, LogEvent, Value},
+        transforms::OutputBuffer,
     };
 
     #[test]
@@ -334,7 +335,7 @@ mod tests {
         .unwrap();
         let parser = parser.as_function();
 
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         parser.transform(&mut buf, event);
         let result = buf.pop().map(|event| event.into_log());
         if let Some(event) = &result {

--- a/src/transforms/remove_fields.rs
+++ b/src/transforms/remove_fields.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     event::Event,
     internal_events::RemoveFieldsFieldMissing,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -64,7 +64,7 @@ impl RemoveFields {
 }
 
 impl FunctionTransform for RemoveFields {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let log = event.as_mut_log();
         for field in &self.fields {
             let field_string = field.to_string();

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -5,7 +5,7 @@ use crate::{
         DataType, GenerateConfig, Output, TransformConfig, TransformContext, TransformDescription,
     },
     event::Event,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -56,7 +56,7 @@ impl RemoveTags {
 }
 
 impl FunctionTransform for RemoveTags {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let metric = event.as_mut_metric();
 
         for tag in &self.tags {

--- a/src/transforms/rename_fields.rs
+++ b/src/transforms/rename_fields.rs
@@ -8,7 +8,7 @@ use crate::{
     event::Event,
     internal_events::{RenameFieldsFieldDoesNotExist, RenameFieldsFieldOverwritten},
     serde::Fields,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -68,7 +68,7 @@ impl RenameFields {
 }
 
 impl FunctionTransform for RenameFields {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         for (old_key, new_key) in &self.fields {
             let log = event.as_mut_log();
             match log.remove_prune(&old_key, self.drop_empty) {

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     event::Event,
     internal_events::SampleEventDiscarded,
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -108,7 +108,7 @@ impl Sample {
 }
 
 impl FunctionTransform for Sample {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         if let Some(condition) = self.exclude.as_ref() {
             if condition.check(&event) {
                 output.push(event);
@@ -180,7 +180,7 @@ mod tests {
         let total_passed = events
             .into_iter()
             .filter_map(|event| {
-                let mut buf = Vec::with_capacity(1);
+                let mut buf = OutputBuffer::with_capacity(1);
                 sampler.transform(&mut buf, event);
                 buf.pop()
             })
@@ -198,7 +198,7 @@ mod tests {
         let total_passed = events
             .into_iter()
             .filter_map(|event| {
-                let mut buf = Vec::with_capacity(1);
+                let mut buf = OutputBuffer::with_capacity(1);
                 sampler.transform(&mut buf, event);
                 buf.pop()
             })
@@ -221,7 +221,7 @@ mod tests {
             .clone()
             .into_iter()
             .filter_map(|event| {
-                let mut buf = Vec::with_capacity(1);
+                let mut buf = OutputBuffer::with_capacity(1);
                 sampler.transform(&mut buf, event);
                 buf.pop()
             })
@@ -229,7 +229,7 @@ mod tests {
         let second_run = events
             .into_iter()
             .filter_map(|event| {
-                let mut buf = Vec::with_capacity(1);
+                let mut buf = OutputBuffer::with_capacity(1);
                 sampler.transform(&mut buf, event);
                 buf.pop()
             })

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -8,7 +8,7 @@ use crate::{
     config::{DataType, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, Value},
     internal_events::{SplitConvertFailed, SplitFieldMissing},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_check_conversion_map, Conversion},
 };
 
@@ -101,7 +101,7 @@ impl Split {
 }
 
 impl FunctionTransform for Split {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let value = event.as_log().get(&self.field).map(|s| s.to_string_lossy());
 
         if let Some(value) = &value {
@@ -198,7 +198,7 @@ mod tests {
         let parser = parser.as_function();
 
         let metadata = event.metadata().clone();
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         parser.transform(&mut buf, event);
         let result = buf.pop().unwrap().into_log();
         assert_eq!(result.metadata(), &metadata);

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -8,7 +8,7 @@ use crate::{
     config::{DataType, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, PathComponent, PathIter, Value},
     internal_events::{TokenizerConvertFailed, TokenizerFieldMissing},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_check_conversion_map, Conversion},
 };
 
@@ -102,7 +102,7 @@ impl Tokenizer {
 }
 
 impl FunctionTransform for Tokenizer {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         let value = event.as_log().get(&self.field).map(|s| s.to_string_lossy());
 
         if let Some(value) = &value {
@@ -135,6 +135,7 @@ mod tests {
     use crate::{
         config::{TransformConfig, TransformContext},
         event::{Event, LogEvent, Value},
+        transforms::OutputBuffer,
     };
 
     #[test]
@@ -165,7 +166,7 @@ mod tests {
         let parser = parser.as_function();
 
         let metadata = event.metadata().clone();
-        let mut buf = Vec::with_capacity(1);
+        let mut buf = OutputBuffer::with_capacity(1);
         parser.transform(&mut buf, event);
         let result = buf.pop().unwrap().into_log();
         assert_eq!(result.metadata(), &metadata);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -38,7 +38,7 @@ use vector::{
     source_sender::{ReceiverStream, SourceSender},
     sources::Source,
     test_util::{temp_dir, temp_file},
-    transforms::{FunctionTransform, Transform},
+    transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 use vector_buffers::Acker;
 
@@ -227,7 +227,7 @@ pub struct MockTransform {
 }
 
 impl FunctionTransform for MockTransform {
-    fn transform(&mut self, output: &mut Vec<Event>, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
         match &mut event {
             Event::Log(log) => {
                 let mut v = log


### PR DESCRIPTION
Does what it says, pretty much just a wrapper for `Vec<Event>` that will simplify changing the internal type to an array type.