### PR TITLE
chore(vector source, vector sink): Default to version 2

### DIFF
--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -28,7 +28,7 @@ enum V2 {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfigV2 {
-    version: V2,
+    version: Option<V2>,
     #[serde(flatten)]
     config: v2::VectorConfig,
 }

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -51,7 +51,7 @@ impl GenerateConfig for VectorConfig {
         let config =
             toml::Value::try_into::<v2::VectorConfig>(v2::VectorConfig::generate_config()).unwrap();
         toml::Value::try_from(VectorConfigV2 {
-            version: V2::V2,
+            version: Some(V2::V2),
             config,
         })
         .unwrap()

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -30,7 +30,7 @@ enum V2 {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfigV2 {
-    version: V2,
+    version: Option<V2>,
     #[serde(flatten)]
     config: v2::VectorConfig,
 }

--- a/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
@@ -76,7 +76,7 @@ sink now default the `version` field to `"2"` (in 0.19.0 the default of "v1" was
 removed). Support for version 1 of the protocol will be removed in a future
 release.
 
-See the [announcement post](#vector-v2-announcement) for additional details
+See the [announcement post][vector-v2-announcement] for additional details
 about why we introduced this new gRPC-based protocol.
 
 [vector-v2-announcement]: /highlights/2021-08-24-vector-source-sink

--- a/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
@@ -15,6 +15,10 @@ Vector's 0.20.0 release includes **breaking changes**:
 1. [Change to set expiration behavior in `prometheus_exporter` sink](#prom-exporter-set-expiration)
 1. [New metrics behavior for `route` transform](#metrics-route-transform)
 
+And **deprecations**:
+
+1. [Version 1 of the Vector protocol has been deprecated](#deprecate-v1)
+
 We cover them below to help you upgrade quickly:
 
 ## Upgrade guide
@@ -61,3 +65,18 @@ the `events_discarded_total` metric will now look like the following:
 - {"counter":{"value":10.0},"name":"events_discarded_total"... "tags":{"component_id":"foo.first","component_kind":"transform","component_name":"foo.first","component_type":"route"}}
 + {"counter":{"value":10.0},"name":"events_discarded_total"... "tags":{"component_id":"foo","component_kind":"transform","component_name":"foo","component_type":"route","output":"first"}}
 ```
+
+### Deprecations
+
+#### Version 1 of the Vector protocol has been deprecated {#deprecate-v1}
+
+With this release, we've deprecated version 1 of the Vector protocol used by the
+`vector` sink to write data to a remote `vector` source. The `vector` source and
+sink now default the `version` field to `"2"` (in 0.19.0 the default of "v1" was
+removed). Support for version 1 of the protocol will be removed in a future
+release.
+
+See the [announcement post](#vector-v2-announcement) for additional details
+about why we introduced this new gRPC-based protocol.
+
+[vector-v2-announcement]: /highlights/2021-08-24-vector-source-sink


### PR DESCRIPTION
This takes the next step in the migration to version 2 of the protocol
used by the `vector` source and sink. The final step will be removing
the deprecated version 1 in a future release.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
