### PR TITLE
fix(external docs): Remove documented elasticsearch sink options that were removed from code

### DIFF
--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -65,7 +65,7 @@ components: sinks: elasticsearch: {
 	support: {
 		requirements: [
 			#"""
-				Elasticsearch's Data streams feature requires Vector to be configured with the `create` `bulk_action`.
+				Elasticsearch's Data streams feature requires Vector to be configured with the `create` `bulk.action`.
 				This is *not* enabled by default.
 				"""#,
 		]
@@ -125,20 +125,6 @@ components: sinks: elasticsearch: {
 						}
 					}
 				}
-			}
-		}
-		bulk_action: {
-			common:      false
-			description: """
-				Action to use when making requests to the [Elasticsearch Bulk API](\(urls.elasticsearch_bulk)).
-				Currently, Vector only supports `index` and `create`. `update` and `delete` actions are not supported.
-				"""
-			required:    false
-			warnings: ["This option has been deprecated, the `bulk.action` option should be used."]
-			type: string: {
-				default: "index"
-				examples: ["index", "create", "{{ action }}"]
-				syntax: "template"
 			}
 		}
 		bulk: {
@@ -254,17 +240,6 @@ components: sinks: elasticsearch: {
 				examples: ["id", "_id"]
 			}
 		}
-		index: {
-			common:      true
-			description: "Index name to write events to."
-			required:    false
-			warnings: ["This option has been deprecated, the `bulk.index` option should be used."]
-			type: string: {
-				default: "vector-%F"
-				examples: ["application-{{ application_id }}-%Y-%m-%d", "vector-%Y-%m-%d"]
-				syntax: "template"
-			}
-		}
 		metrics: {
 			common:      false
 			description: "Options for metrics."
@@ -337,7 +312,7 @@ components: sinks: elasticsearch: {
 				Vector [batches](#buffers-and-batches) data and flushes it to Elasticsearch's
 				[`_bulk` API endpoint](\(urls.elasticsearch_bulk)). By default, all events are
 				inserted via the `index` action, which replaces documents if an existing
-				one has the same `id`. If `bulk_action` is configured with `create`, Elasticsearch
+				one has the same `id`. If `bulk.action` is configured with `create`, Elasticsearch
 				does _not_ replace an existing document and instead returns a conflict error.
 				"""
 		}


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

This won't stop the site from rendering things like `bulk: null` but removes options that are no longer valid

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
