### PR TITLE
docs(vector source, vector sink): Document unsupported version 2 options

### DIFF
--- a/website/content/en/highlights/2021-08-24-vector-source-sink.md
+++ b/website/content/en/highlights/2021-08-24-vector-source-sink.md
@@ -49,8 +49,8 @@ There are a couple of things to be aware of:
 There are some configuration options that are no longer valid with version 2 of
 the source and sink:
 
-* `vector` source: `keepalive` and `receive_buffer_bytes`
-* `vector` sink: `keepalive` and `send_buffer_bytes`
+- `vector` source: `keepalive` and `receive_buffer_bytes`
+- `vector` sink: `keepalive` and `send_buffer_bytes`
 
 As these were specific to the TCP-based version 1 of the protocol.
 

--- a/website/content/en/highlights/2021-08-24-vector-source-sink.md
+++ b/website/content/en/highlights/2021-08-24-vector-source-sink.md
@@ -44,6 +44,16 @@ follows:
 
 There are a couple of things to be aware of:
 
+#### Removed options
+
+There are some configuration options that are no longer valid with version 2 of
+the source and sink:
+
+* `vector` source: `keepalive` and `receive_buffer_bytes`
+* `vector` sink: `keepalive` and `send_buffer_bytes`
+
+As these were specific to the TCP-based version 1 of the protocol.
+
 #### Upgrade both the source _and_ sink
 
 You **have** to upgrade **both** the source and sink to `v2`, or none at all,

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -111,8 +111,8 @@ However, we recommend that you transition to the `v2` protocol by setting `versi
 There are some configuration options that are no longer valid with version 2 of
 the source and sink:
 
-* `vector` source: `keepalive` and `receive_buffer_bytes`
-* `vector` sink: `keepalive` and `send_buffer_bytes`
+- `vector` source: `keepalive` and `receive_buffer_bytes`
+- `vector` sink: `keepalive` and `send_buffer_bytes`
 
 As these were specific to the TCP-based version 1 of the protocol.
 

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -108,10 +108,19 @@ However, we recommend that you transition to the `v2` protocol by setting `versi
 + version = "2"
 ```
 
+There are some configuration options that are no longer valid with version 2 of
+the source and sink:
+
+* `vector` source: `keepalive` and `receive_buffer_bytes`
+* `vector` sink: `keepalive` and `send_buffer_bytes`
+
+As these were specific to the TCP-based version 1 of the protocol.
+
 See the [announcement post][vector-v2-announcement] for a guide on how to transition without downtime.
 
 In a subsequent release we will begin defaulting to the `v2` protocol and eventually remove support for the `v1`
 protocol.
+
 
 [vector-v2-announcement]: /highlights/2021-08-24-vector-source-sink
 


### PR DESCRIPTION
These options are not supported by version 2.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
