### PR TITLE
chore: Ensure we collect at least 200 `bytes_written` samples

### DIFF
--- a/.github/workflows/soak_infra.yml
+++ b/.github/workflows/soak_infra.yml
@@ -6,8 +6,8 @@ name: Soak Infra
 
 on:
   pull_request:
-    # paths:
-    #   - 'lib/soak'
+    paths:
+      - 'lib/soak'
   push:
     branches:
       - master

--- a/.github/workflows/soak_infra.yml
+++ b/.github/workflows/soak_infra.yml
@@ -6,8 +6,8 @@ name: Soak Infra
 
 on:
   pull_request:
-    paths:
-      - 'lib/soak'
+    # paths:
+    #   - 'lib/soak'
   push:
     branches:
       - master

--- a/lib/soak/src/bin/observer.rs
+++ b/lib/soak/src/bin/observer.rs
@@ -294,7 +294,7 @@ impl TargetWorker {
                     }
                 }
                 Err(e) => {
-                    debug!(
+                    error!(
                         "Did not receive a response from {} with error: {}",
                         self.target_id, e
                     );

--- a/lib/soak/src/bin/observer.rs
+++ b/lib/soak/src/bin/observer.rs
@@ -25,7 +25,7 @@ use tokio::{
     sync::mpsc::{channel, Receiver, Sender},
     time::{interval_at, Instant},
 };
-use tracing::{debug, info, instrument};
+use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 fn default_config_path() -> String {

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-#set -o xtrace
+set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOAK_ROOT="${__dir}/.."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit
-set -o pipefail
+#set -o pipefail # grep will exit 1 without a match, even with --count
 set -o nounset
 #set -o xtrace
 
@@ -114,9 +114,10 @@ periods=0
 (( target_samples = TOTAL_SAMPLES + WARMUP_SECONDS ))
 while [ $recorded_samples -le $target_samples ]
 do
+    observed_samples=$(grep --count "bytes_written" "${SOAK_CAPTURE_FILE}")
+
     # Check that the capture file grows monotonically. If it shrinks this
     # indicates a serious problem.
-    observed_samples=$(grep --count "bytes_written" "${SOAK_CAPTURE_FILE}")
     # shellcheck disable=SC2086
     if [ $recorded_samples -gt $observed_samples ]; then
         echo "SAMPLES LOST. THIS IS A CATASTROPHIC, UNRECOVERABLE FAILURE."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -o errexit
-#set -o pipefail # grep will exit 1 without a match, even with --count
+#set -o errexit # grep will exit 1 without a match, even with --count
+set -o pipefail # grep will exit 1 without a match, even with --count
 set -o nounset
 set -o xtrace
 

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -114,7 +114,6 @@ periods=0
 (( target_samples = TOTAL_SAMPLES + WARMUP_SECONDS ))
 while [ $recorded_samples -le $target_samples ]
 do
-    kubectl get pods -owide -A
     # Check that the capture file grows monotonically. If it shrinks this
     # indicates a serious problem.
     observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" | wc -l)

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -116,7 +116,7 @@ while [ $recorded_samples -le $target_samples ]
 do
     # Check that the capture file grows monotonically. If it shrinks this
     # indicates a serious problem.
-    observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" | wc -l)
+    observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" || true | wc -l)
     # shellcheck disable=SC2086
     if [ $recorded_samples -gt $observed_samples ]; then
         echo "SAMPLES LOST. THIS IS A CATASTROPHIC, UNRECOVERABLE FAILURE."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #set -o errexit # grep will exit 1 without a match, even with --count
-set -o pipefail # grep will exit 1 without a match, even with --count
+set -o pipefail
 set -o nounset
 set -o xtrace
 

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit
-set -o pipefail
+#set -o pipefail # grep will exit 1 without a match
 set -o nounset
 set -o xtrace
 
@@ -116,7 +116,7 @@ while [ $recorded_samples -le $target_samples ]
 do
     # Check that the capture file grows monotonically. If it shrinks this
     # indicates a serious problem.
-    observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" || echo "" | wc -l)
+    observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" | wc -l)
     # shellcheck disable=SC2086
     if [ $recorded_samples -gt $observed_samples ]; then
         echo "SAMPLES LOST. THIS IS A CATASTROPHIC, UNRECOVERABLE FAILURE."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -116,7 +116,7 @@ while [ $recorded_samples -le $target_samples ]
 do
     # Check that the capture file grows monotonically. If it shrinks this
     # indicates a serious problem.
-    observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" || true | wc -l)
+    observed_samples=$((grep "bytes_written" "${SOAK_CAPTURE_FILE}" || echo "") | wc -l)
     # shellcheck disable=SC2086
     if [ $recorded_samples -gt $observed_samples ]; then
         echo "SAMPLES LOST. THIS IS A CATASTROPHIC, UNRECOVERABLE FAILURE."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -3,7 +3,7 @@
 set -o errexit
 #set -o pipefail # grep will exit 1 without a match
 set -o nounset
-set -o xtrace
+#set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOAK_ROOT="${__dir}/.."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit
-#set -o pipefail # grep will exit 1 without a match
+set -o pipefail
 set -o nounset
 #set -o xtrace
 
@@ -116,7 +116,7 @@ while [ $recorded_samples -le $target_samples ]
 do
     # Check that the capture file grows monotonically. If it shrinks this
     # indicates a serious problem.
-    observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" | wc -l)
+    observed_samples=$(grep --count "bytes_written" "${SOAK_CAPTURE_FILE}")
     # shellcheck disable=SC2086
     if [ $recorded_samples -gt $observed_samples ]; then
         echo "SAMPLES LOST. THIS IS A CATASTROPHIC, UNRECOVERABLE FAILURE."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -3,7 +3,7 @@
 set -o errexit
 #set -o pipefail # grep will exit 1 without a match, even with --count
 set -o nounset
-#set -o xtrace
+set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOAK_ROOT="${__dir}/.."

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -86,7 +86,7 @@ TOTAL_SAMPLES=200
 SOAK_CAPTURE_DIR="${CAPTURE_DIR}/${SOAK_NAME}"
 SOAK_CAPTURE_FILE="${SOAK_CAPTURE_DIR}/${VARIANT}.captures"
 
-pushd "${__dir}"
+pushd "${__dir}" || exit
 ./boot_minikube.sh --cpus "${SOAK_CPUS}" --memory "${SOAK_MEMORY}"
 mkdir --parents "${SOAK_CAPTURE_DIR}"
 minikube image load "${IMAGE}"
@@ -94,9 +94,9 @@ minikube image load "${IMAGE}"
 # the minikube will be placed on the host.
 minikube mount "${SOAK_CAPTURE_DIR}:/captures" &
 CAPTURE_MOUNT_PID=$!
-popd
+popd || exit
 
-pushd "${SOAK_ROOT}/tests/${SOAK_NAME}/terraform"
+pushd "${SOAK_ROOT}/tests/${SOAK_NAME}/terraform" || exit
 terraform init
 terraform apply -var "experiment_name=${SOAK_NAME}" -var "type=${VARIANT}" \
           -var "vector_image=${IMAGE}" -var "vector_cpus=${VECTOR_CPUS}" \
@@ -129,8 +129,8 @@ do
 done
 echo "[${VARIANT}] Recording captures to ${SOAK_CAPTURE_DIR} complete in ${periods} seconds. At least ${recorded_samples} collected."
 kill "${CAPTURE_MOUNT_PID}"
-popd
+popd || exit
 
-pushd "${__dir}"
+pushd "${__dir}" || exit
 ./shutdown_minikube.sh
-popd
+popd || exit

--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -116,7 +116,7 @@ while [ $recorded_samples -le $target_samples ]
 do
     # Check that the capture file grows monotonically. If it shrinks this
     # indicates a serious problem.
-    observed_samples=$((grep "bytes_written" "${SOAK_CAPTURE_FILE}" || echo "") | wc -l)
+    observed_samples=$(grep "bytes_written" "${SOAK_CAPTURE_FILE}" || echo "" | wc -l)
     # shellcheck disable=SC2086
     if [ $recorded_samples -gt $observed_samples ]; then
         echo "SAMPLES LOST. THIS IS A CATASTROPHIC, UNRECOVERABLE FAILURE."

--- a/soaks/common/terraform/modules/monitoring/observer.tf
+++ b/soaks/common/terraform/modules/monitoring/observer.tf
@@ -42,7 +42,7 @@ resource "kubernetes_deployment" "observer" {
         automount_service_account_token = false
         container {
           image_pull_policy = "IfNotPresent"
-          image             = "ghcr.io/vectordotdev/vector/soak-observer:sha-7b2b0d0d6bcaafcd83b3fe636d92d5242d7b550b"
+          image             = "ghcr.io/vectordotdev/vector/soak-observer:sha-3cb06fedb1863956cd2d423c87f6fee13a1f8f40"
           name              = "observer"
           args              = ["--config-path", "/etc/vector/soak/observer.yaml"]
 


### PR DESCRIPTION
This commit ensures that we collect a sufficient number of `bytes_written` samples
from the underlying experiment. In some cases -- such as when minikube restarts
pods -- we can see collection blink out for a time. Previously we collected for a fixed time, 
meaning that we would lose sample opportunities. With this change we expose ourselves
to unbounded time runs if a soak test is buggy. The `observer` now logs somewhat
differently.

I have also bumped the total samples collected back to 200 from 60. This was an accidental
change. 

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
