### PR TITLE
chore(buffers): harden buffer directory name generation for disk buffer v1

### DIFF
--- a/testing/github-10895/config.toml
+++ b/testing/github-10895/config.toml
@@ -1,0 +1,19 @@
+data_dir = "/tmp/vector/github-10895"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7777/foo"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.encoding]
+codec = "ndjson"
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/testing/github-10895/create-clean-data-directories.sh
+++ b/testing/github-10895/create-clean-data-directories.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/vector/github-10895
+mkdir -p /tmp/vector/github-10895

--- a/testing/github-10895/get-and-build-vector-binaries.sh
+++ b/testing/github-10895/get-and-build-vector-binaries.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+curl -q -o vector-v0.18.1.tar.gz -L https://github.com/vectordotdev/vector/releases/download/v0.18.1/vector-0.18.1-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf vector-v0.18.1.tar.gz
+mv vector-x86_64-unknown-linux-gnu/bin/vector vector-v0.18.1
+rm -rf vector-x86_64-unknown-linux-gnu
+rm -f vector-v0.18.1.tar.gz
+
+curl -q -o vector-v0.19.1.tar.gz -L https://github.com/vectordotdev/vector/releases/download/v0.19.1/vector-0.19.1-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf vector-v0.19.1.tar.gz
+mv vector-x86_64-unknown-linux-gnu/bin/vector vector-v0.19.1
+rm -rf vector-x86_64-unknown-linux-gnu
+rm -f vector-v0.19.1.tar.gz
+
+pushd ../..
+cargo clean && cargo build --release --no-default-features --features sources-stdin,sinks-http
+popd || exit
+cp ../../target/release/vector vector-pr

--- a/testing/github-10895/steps.md
+++ b/testing/github-10895/steps.md
@@ -1,0 +1,38 @@
+## Enhancement
+
+As part of the fallout of #10379, we wanted to further shore up our testing around buffers to
+ideally prevent us (me) for inadvertantly changing things and not noticing... like the buffer data
+directory.
+
+To that end, the PR to address #10895 is simple, but we're doing our due diligence here by
+re-running tests that are more or less identical to what we did for #10430, so that we can feel
+confident that our changes here haven't yet again introduced a regression.
+
+## Testing Plan
+
+Start by grabbing Vector binaries for 0.18.1 and 0.19.1, and build one from the PR branch.  We'll
+use the same configuration as the testing for #10430, which is a stdin source and HTTP sink,
+although we won't actually _use_ them.  In this case, we just need a valid configuration that will
+also create a buffer.
+
+## Test Case(s)
+
+1. Establish a baseline of ther "old to new" migration behavior from 0.18.1 to 0.19.1:
+  - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+    data directory, but don't send any data through.
+  - Run the PR binary and ensure that it renames the old-style buffer data directory to the
+    new-style buffer data directory.  Again, send no data through.
+  - No other data directories for the buffer should exist.
+2. Ensure that the "old to new" migration logic still works from 0.18.1 (old) to the PR (new) version:
+  - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+    data directory, but don't send any data through.
+  - Run the PR binary and ensure that it renames the old-style buffer data directory to the
+    new-style buffer data directory.  Again, send no data through.
+  - No other data directories for the buffer should exist.
+  - Crucially, each step should appear identical to the output in test case #1.
+3. Ensure that the "new" style name still holds through from 0.19.1 to the PR version:
+  - Run the 0.19.1 binary with a clean data directory and ensure it creates the new-style buffer
+    data directory, but don't send any data through.
+  - Run the PR binary and ensure that it leaves the data directory, as created by the 0.19.1 binary,
+    as is, in terms of naming.
+  - No other data directories for the buffer should exist.

--- a/testing/github-10895/steps.md
+++ b/testing/github-10895/steps.md
@@ -18,21 +18,21 @@ also create a buffer.
 ## Test Case(s)
 
 1. Establish a baseline of ther "old to new" migration behavior from 0.18.1 to 0.19.1:
-  - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+    - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
     data directory, but don't send any data through.
-  - Run the PR binary and ensure that it renames the old-style buffer data directory to the
+    - Run the PR binary and ensure that it renames the old-style buffer data directory to the
     new-style buffer data directory.  Again, send no data through.
-  - No other data directories for the buffer should exist.
+    - No other data directories for the buffer should exist.
 2. Ensure that the "old to new" migration logic still works from 0.18.1 (old) to the PR (new) version:
-  - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+    - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
     data directory, but don't send any data through.
-  - Run the PR binary and ensure that it renames the old-style buffer data directory to the
+    - Run the PR binary and ensure that it renames the old-style buffer data directory to the
     new-style buffer data directory.  Again, send no data through.
-  - No other data directories for the buffer should exist.
-  - Crucially, each step should appear identical to the output in test case #1.
+    - No other data directories for the buffer should exist.
+    - Crucially, each step should appear identical to the output in test case #1.
 3. Ensure that the "new" style name still holds through from 0.19.1 to the PR version:
-  - Run the 0.19.1 binary with a clean data directory and ensure it creates the new-style buffer
+    - Run the 0.19.1 binary with a clean data directory and ensure it creates the new-style buffer
     data directory, but don't send any data through.
-  - Run the PR binary and ensure that it leaves the data directory, as created by the 0.19.1 binary,
+    - Run the PR binary and ensure that it leaves the data directory, as created by the 0.19.1 binary,
     as is, in terms of naming.
-  - No other data directories for the buffer should exist.
+    - No other data directories for the buffer should exist.

--- a/testing/github-10895/test-results.md
+++ b/testing/github-10895/test-results.md
@@ -1,0 +1,124 @@
+## Test Results
+
+### Test 1
+
+```shell
+toby@consigliere:~/src/vector/testing/github-10895$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 0
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.18.1 --config config.toml
+2022-01-26T22:20:16.979995Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-26T22:20:16.980039Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:20:16.981919Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:20:17.010091Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:20:17.010121Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:20:17.010157Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:20:17.010155Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:20:17.010203Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-26T22:20:17.010213Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-26T22:20:17.627876Z  INFO vector: Vector has stopped.
+2022-01-26T22:20:17.627922Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:20:17.627952Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="stdin, http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:20 http_tarpit_buffer
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.19.1 --config config.toml
+2022-01-26T22:20:28.399808Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:20:28.399854Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:20:28.400532Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:20:28.400543Z  INFO buffers::disk: Migrated old buffer data directory from '/tmp/vector/github-10895/http_tarpit_buffer' to '/tmp/vector/github-10895/http_tarpit_id' for 'http_tarpit' sink.
+2022-01-26T22:20:28.430796Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:20:28.430824Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:20:28.430847Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:20:28.430849Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:20:28.430879Z  INFO vector: Vector has started. debug="false" version="0.19.1" arch="x86_64" build_id="3cf70cf 2022-01-25"
+2022-01-26T22:20:28.430891Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-26T22:20:29.294516Z  INFO vector: Vector has stopped.
+2022-01-26T22:20:29.294605Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:20:29.295668Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:20 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$
+```
+
+### Test 2
+
+```shell
+toby@consigliere:~/src/vector/testing/github-10895$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 0
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.18.1 --config config.toml
+2022-01-26T22:20:57.412384Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-26T22:20:57.412428Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:20:57.414343Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:20:57.447157Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:20:57.447189Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:20:57.447211Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:20:57.447245Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-26T22:20:57.447255Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-01-26T22:20:57.447245Z  INFO vector::topology::builder: Healthcheck: Passed.
+^C2022-01-26T22:20:58.292801Z  INFO vector: Vector has stopped.
+2022-01-26T22:20:58.292844Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:20:58.293936Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:20 http_tarpit_buffer
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-pr --config config.toml
+2022-01-26T22:21:06.698724Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:21:06.698761Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:21:06.699272Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:21:06.699295Z  INFO vector_buffers::disk: Migrated old buffer data directory from '/tmp/vector/github-10895/http_tarpit_buffer' to '/tmp/vector/github-10895/http_tarpit_id' for 'http_tarpit' sink.
+2022-01-26T22:21:06.728976Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:21:06.728997Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:21:06.729017Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:21:06.729027Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:21:06.729060Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-26T22:21:07.388780Z  INFO vector: Vector has stopped.
+2022-01-26T22:21:07.388822Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:21:07.389894Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:21 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$
+```
+
+### Test 3
+
+```shell
+toby@consigliere:~/src/vector/testing/github-10895$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 0
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.19.1 --config config.toml
+2022-01-26T22:21:41.620286Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:21:41.620331Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:21:41.621069Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:21:41.653647Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:21:41.653675Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:21:41.653688Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:21:41.653697Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:21:41.653726Z  INFO vector: Vector has started. debug="false" version="0.19.1" arch="x86_64" build_id="3cf70cf 2022-01-25"
+2022-01-26T22:21:41.653737Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-26T22:21:42.482989Z  INFO vector: Vector has stopped.
+2022-01-26T22:21:42.483035Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:21:42.484107Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:21 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-pr --config config.toml
+2022-01-26T22:21:53.367043Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:21:53.367080Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:21:53.367588Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:21:53.397431Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:21:53.397453Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:21:53.397473Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:21:53.397480Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:21:53.397517Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-26T22:21:54.469681Z  INFO vector: Vector has stopped.
+2022-01-26T22:21:54.469727Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:21:54.470832Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:21 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$
+```


### PR DESCRIPTION
This PR slightly refactors the buffer directory name generation code for disk buffer v1, and adds a unit test to assert that it meets a particular (fixed) format, in the hopes it will catch us (me) if there's ever an unintentional change that messes with the buffer directory names in the future.

I also ran a modified subset of the tests used for #10430 to validate that the behavior between versions (old to new, new to new, etc) still look the same as a more end-to-end test that the buffer naming is not regressed as a result of this PR.

Closes #10895.