### PR TITLE
chore(buffers): fix flaky test in disk buffer v2

### DIFF
--- a/lib/vector-buffers/src/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/disk_v2/reader.rs
@@ -818,19 +818,9 @@ where
             // corrupted records, but hadn't yet had a "good" record that we could read, since the
             // "we skipped records due to corruption" logic requires performing valid read to
             // detect, and calculate a valid delta from.
-            //
-            // TODO: Validate this with a test that messes with a data file without having to reload
-            // the buffer, since reloading the buffer will recalculate our buffer size.
             if self.ledger.is_writer_done() {
                 let total_buffer_size = self.ledger.get_total_buffer_size();
-                let total_records = self.ledger.get_total_records();
-                trace!(
-                    "writer done, buffer_size={}, total_records={}",
-                    total_buffer_size,
-                    total_records
-                );
-
-                if total_buffer_size == 0 || total_records == 0 {
+                if total_buffer_size == 0 {
                     return Ok(None);
                 }
             }

--- a/lib/vector-buffers/src/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/disk_v2/tests/basic.rs
@@ -84,6 +84,8 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
             assert_eq!(first_read, Some(SizedRecord(32)));
             assert_buffer_records!(ledger, 1);
 
+            debug!("MARK MARK MARK");
+
             // Now, we haven't acknowledged that read yet, so our next read should see the writer as
             // done but the total buffer size as >= 0, which means it has to wait for something,
             // which in this case is going to be the wakeup after we acknowledge the read.
@@ -111,7 +113,6 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
             while !waiting_for_writer.try_assert() {
                 assert_pending!(blocked_read.poll());
             }
-            assert!(!blocked_read.is_woken());
 
             // Now acknowledge the first read, which should wake up our blocked read.
             acker.ack(1);


### PR DESCRIPTION
This PR addresses a flaky test related to the disk buffer v2 code.  Simply put, these tests make real file I/O calls that are asynchronous, and so we can sometimes get a number of wakeups that doesn't fully match what we expect when thinking about the code as being otherwise run/driven in a sequential fashion.

We've simply removed a needless check here, because while it would be nice to say definitively that this code is waiting, and only waiting, on some specific primitive... we're already asserting that with `tracing-fluent-assertions`: the wake status isn't _necessary_ to prove that.

We've also cleaned up the logic in the reader that checks if the buffer is actually done and the reader should return.  We had an extra check that was compensating for previously deficient logic, but never removed it when we fixed that deficiency.

Closes #10922.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>