### PR TITLE
chore(deps): Upgrade tokio to 1.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7359,9 +7359,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "95e99d373042c30406d317cfc5bfad7b5d604bdd31dab72cf8739abebaa64aee"
 dependencies = [
  "bytes 1.1.0",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ vector-vrl-functions = { path = "lib/vector-vrl-functions" }
 async-stream = "0.3.2"
 async-trait = "0.1.52"
 futures = { version = "0.3.19", default-features = false, features = ["compat", "io-compat"], package = "futures" }
-tokio = { version = "1.15.0", default-features = false, features = ["full"] }
+tokio = { version = "1.16.0", default-features = false, features = ["full"] }
 tokio-openssl = { version = "0.6.3", default-features = false }
 tokio-stream = { version = "0.1.8", default-features = false, features = ["net", "sync", "time"] }
 tokio-util = { version = "0.6", default-features = false, features = ["time"] }
@@ -332,7 +332,7 @@ pretty_assertions = "1.0.0"
 reqwest = { version = "0.11.9", features = ["json"] }
 proptest = "1.0"
 tempfile = "3.2.0"
-tokio = { version = "1.15.0", features = ["test-util"] }
+tokio = { version = "1.16.0", features = ["test-util"] }
 tokio-test = "0.4.2"
 tower-test = "0.4.0"
 vector_core = { path = "lib/vector-core", default-features = false, features = ["vrl", "test"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ vector-vrl-functions = { path = "lib/vector-vrl-functions" }
 async-stream = "0.3.2"
 async-trait = "0.1.52"
 futures = { version = "0.3.19", default-features = false, features = ["compat", "io-compat"], package = "futures" }
-tokio = { version = "1.16.0", default-features = false, features = ["full"] }
+tokio = { version = "1.16.1", default-features = false, features = ["full"] }
 tokio-openssl = { version = "0.6.3", default-features = false }
 tokio-stream = { version = "0.1.8", default-features = false, features = ["net", "sync", "time"] }
 tokio-util = { version = "0.6", default-features = false, features = ["time"] }

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -66,7 +66,7 @@ default-features = false
 features = []
 
 [dependencies.tokio]
-version = "1.15.0"
+version = "1.16.0"
 default-features = false
 features = ["full"]
 

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -14,7 +14,7 @@ k8s-test-framework = { version = "0.1", path = "../k8s-test-framework" }
 regex = "1"
 reqwest = { version = "0.11.9", features = ["json"] }
 serde_json = "1"
-tokio = { version = "1.15.0", features = ["full"] }
+tokio = { version = "1.16.0", features = ["full"] }
 indoc = "1.0.3"
 env_logger = "0.9"
 tracing = { version = "0.1", features = ["log"] }

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -14,7 +14,7 @@ k8s-test-framework = { version = "0.1", path = "../k8s-test-framework" }
 regex = "1"
 reqwest = { version = "0.11.9", features = ["json"] }
 serde_json = "1"
-tokio = { version = "1.16.0", features = ["full"] }
+tokio = { version = "1.16.1", features = ["full"] }
 indoc = "1.0.3"
 env_logger = "0.9"
 tracing = { version = "0.1", features = ["log"] }

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -12,5 +12,5 @@ k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_16
 once_cell = "1"
 serde_json = "1"
 tempfile = "3"
-tokio = { version = "1.16.0", features = ["full"] }
+tokio = { version = "1.16.1", features = ["full"] }
 log = "0.4"

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -12,5 +12,5 @@ k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_16
 once_cell = "1"
 serde_json = "1"
 tempfile = "3"
-tokio = { version = "1.15.0", features = ["full"] }
+tokio = { version = "1.16.0", features = ["full"] }
 log = "0.4"

--- a/lib/soak/Cargo.toml
+++ b/lib/soak/Cargo.toml
@@ -28,7 +28,7 @@ default-features = false
 features = []
 
 [dependencies.tokio]
-version = "1.15"
+version = "1.16"
 default-features = false
 features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "io-std", "signal"]
 

--- a/lib/vector-api-client/Cargo.toml
+++ b/lib/vector-api-client/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.53"
 async-stream = "0.3.2"
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["compat", "io-compat"] }
-tokio = { version = "1.16.0", features = ["full"] }
+tokio = { version = "1.16.1", features = ["full"] }
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 
 # GraphQL

--- a/lib/vector-api-client/Cargo.toml
+++ b/lib/vector-api-client/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.53"
 async-stream = "0.3.2"
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["compat", "io-compat"] }
-tokio = { version = "1.15.0", features = ["full"] }
+tokio = { version = "1.16.0", features = ["full"] }
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 
 # GraphQL

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.136", default-features = false, features = ["derive"] }
 snafu = { version = "0.7.0", default-features = false, features = ["std"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
 tokio-util = { version = "0.6", default-features = false }
-tokio = { version = "1.16.0", default-features = false, features = ["rt", "macros", "rt-multi-thread", "sync", "fs", "io-util", "time"] }
+tokio = { version = "1.16.1", default-features = false, features = ["rt", "macros", "rt-multi-thread", "sync", "fs", "io-util", "time"] }
 tracing = { version = "0.1.29", default-features = false, features = ["attributes"] }
 vector_common = { path = "../vector-common", default-features = false }
 

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.136", default-features = false, features = ["derive"] }
 snafu = { version = "0.7.0", default-features = false, features = ["std"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
 tokio-util = { version = "0.6", default-features = false }
-tokio = { version = "1.15.0", default-features = false, features = ["rt", "macros", "rt-multi-thread", "sync", "fs", "io-util", "time"] }
+tokio = { version = "1.16.0", default-features = false, features = ["rt", "macros", "rt-multi-thread", "sync", "fs", "io-util", "time"] }
 tracing = { version = "0.1.29", default-features = false, features = ["attributes"] }
 vector_common = { path = "../vector-common", default-features = false }
 

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = { version = "1.0.78", default-features = false }
 shared = { path = "../shared" }
 snafu = { version = "0.7.0", default-features = false }
 substring = { version = "1.4", default-features = false }
-tokio = { version = "1.16.0", default-features = false }
+tokio = { version = "1.16.1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false, optional = true }
 tokio-util = { version = "0.6", default-features = false, features = ["time"] }
 toml = { version = "0.5.8", default-features = false }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = { version = "1.0.78", default-features = false }
 shared = { path = "../shared" }
 snafu = { version = "0.7.0", default-features = false }
 substring = { version = "1.4", default-features = false }
-tokio = { version = "1.15.0", default-features = false }
+tokio = { version = "1.16.0", default-features = false }
 tokio-stream = { version = "0.1", default-features = false, optional = true }
 tokio-util = { version = "0.6", default-features = false, features = ["time"] }
 toml = { version = "0.5.8", default-features = false }


### PR DESCRIPTION
Opening as a separate PR from https://github.com/vectordotdev/vector/pull/11075 because I'm curious to see the soaks which dependabot PRs do not run.