### PR TITLE
fix(tests): Use one more thread for merge_and_fork test

### DIFF
--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -161,7 +161,7 @@ async fn fork() {
 // are needed to finish processing all the events before
 // sources are forcefully shutted down.
 // Although that's still not a guarantee.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn merge_and_fork() {
     trace_init();
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -157,7 +157,7 @@ async fn fork() {
     assert_eq!(input_lines, output_lines2);
 }
 
-// In cpu constrained environments at least two threads
+// In cpu constrained environments at least three threads
 // are needed to finish processing all the events before
 // sources are forcefully shutted down.
 // Although that's still not a guarantee.


### PR DESCRIPTION
I'm really not sure why this works, but it appears to fix the issue we
saw with this test starting to fail on Linux after the upgrade to Tokio
1.16.1.

I'm guessing this is due to the multi-threaded scheduler changes mentioned here: https://github.com/tokio-rs/tokio/pull/4383

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
