### PR TITLE
chore(ci): Bump the k8s versions we test against

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -101,12 +101,17 @@ jobs:
             const minikube_version = [
               "v1.24.0",
             ]
+
+            // Aim to test against oldest supported k8s cloud-provider versions
+            // https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+            // https://cloud.google.com/kubernetes-engine/docs/release-notes
+            // https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
             const kubernetes_version = [
-              { version: "v1.19.2", is_essential: true },
-              { version: "v1.18.9" },
-              { version: "v1.17.12" },
-              { version: "v1.16.15" },
-              { version: "v1.15.12" },
+              { version: "v1.23.3", is_essential: true },
+              { version: "v1.22.5", is_essential: true },
+              { version: "v1.21.8", is_essential: true },
+              { version: "v1.20.14", is_essential: true },
+              { version: "v1.19.8" },
             ]
             const container_runtime = [
               "docker",

--- a/website/content/en/docs/setup/installation/platforms/kubernetes.md
+++ b/website/content/en/docs/setup/installation/platforms/kubernetes.md
@@ -5,7 +5,8 @@ weight: 2
 ---
 
 {{< requirement title="Minimum Kubernetes version" >}}
-Vector must be installed on Kubernetes version **1.15** or higher.
+Vector must be installed on Kubernetes version **1.15** or higher. Vector is
+tested with Kubernetes versions **1.19** or higher.
 {{< /requirement >}}
 
 [Kubernetes], also known as **k8s**, is an open source container orchestration system for automating application deployment, scaling, and management. This page covers installing and managing Vector on the Kubernetes platform.

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -624,7 +624,7 @@ components: sources: kubernetes_logs: {
 				Vector is tested extensively against Kubernetes. In addition to Kubernetes
 				being Vector's most popular installation method, Vector implements a
 				comprehensive end-to-end test suite for all minor Kubernetes versions starting
-				with `1.15`.
+				with `1.19`.
 				"""
 		}
 

--- a/website/cue/reference/services/kubernetes.cue
+++ b/website/cue/reference/services/kubernetes.cue
@@ -4,5 +4,5 @@ services: kubernetes: {
 	name:     "Kubernetes"
 	thing:    "a \(name) cluster"
 	url:      urls.kubernetes
-	versions: ">= 1.15"
+	versions: ">= 1.19"
 }


### PR DESCRIPTION
To include newer versions. I dropped the versions no longer supported by
GCP, AWS, and Azure as a proxy for general cloud k8s support.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
