### PR TITLE
fix(vrl): multiplying negative numbers by string returns an empty string

### DIFF
--- a/lib/vrl/compiler/src/value/arithmetic.rs
+++ b/lib/vrl/compiler/src/value/arithmetic.rs
@@ -8,12 +8,18 @@ impl Value {
     pub fn try_mul(self, rhs: Self) -> Result<Self, Error> {
         let err = || Error::Mul(self.kind(), rhs.kind());
 
+        // When multiplying a string by an integer, if the number is negative we set it to zero to
+        // return an empty string.
+        let as_usize = |num| if num < 0 { 0 } else { num as usize };
+
         let value = match self {
-            Value::Integer(lhv) if rhs.is_bytes() => rhs.try_bytes()?.repeat(lhv as usize).into(),
+            Value::Integer(lhv) if rhs.is_bytes() => rhs.try_bytes()?.repeat(as_usize(lhv)).into(),
             Value::Integer(lhv) if rhs.is_float() => (lhv as f64 * rhs.try_float()?).into(),
             Value::Integer(lhv) => (lhv * i64::try_from(&rhs).map_err(|_| err())?).into(),
             Value::Float(lhv) => (lhv * f64::try_from(&rhs).map_err(|_| err())?).into(),
-            Value::Bytes(lhv) if rhs.is_integer() => lhv.repeat(rhs.try_integer()? as usize).into(),
+            Value::Bytes(lhv) if rhs.is_integer() => {
+                lhv.repeat(as_usize(rhs.try_integer()?)).into()
+            }
             _ => return Err(err()),
         };
 

--- a/lib/vrl/tests/tests/expressions/arithmetic/multiplication/string_integer.vrl
+++ b/lib/vrl/tests/tests/expressions/arithmetic/multiplication/string_integer.vrl
@@ -1,3 +1,8 @@
-# result: "foofoo"
+# result: [ "foofoo", "", "", "" ]
 
-"foo" * 2
+[
+  "foo" * 2,
+  "foo" * 0,
+  "foo" * -42,
+  -42 * "foo",
+]


### PR DESCRIPTION
Closes #11105 

This fixes VRL so it no longer panics when you multiply a string by a negative number. Now it defaults to multiplying that number by 0 (ie returns an empty string).

I haven't updated the documentation as it seems multiplying strings is undocumented anyway (https://vector.dev/docs/reference/vrl/expressions/#arithmetic-example-multiplication-int).

I need this fix because the fuzz testing I am doing for the VM keeps bumping up against it.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
