### PR TITLE
fix(releasing): Update rpm tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -306,7 +306,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        container: ["centos:7","centos:8","amazonlinux:1","amazonlinux:2","fedora:33"]
+        container:
+          - "quay.io/centos/centos:stream8"
+          - "quay.io/centos/centos:stream9"
+          - "amazonlinux:1"
+          - "amazonlinux:2"
+          - "fedora:34"
+          - "fedora:35"
+          - "fedora:36"
     container:
       image: ${{ matrix.container }}
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -318,14 +318,18 @@ jobs:
       image: ${{ matrix.container }}
     steps:
       - run: |
-          yum update -y && \
-          yum install --allowerasing -y \
+          yum update -y
+          yum install -y \
           ca-certificates \
-          curl \
           git \
           systemd \
           tar \
           make
+          # conflicts with curl-minimal on some distros and --allowerased is not
+          # supported on some distros
+          if ! command -v curl &> /dev/null ; then
+            yum install -y curl
+          fi
       - name: checkout
         uses: actions/checkout@v2.4.0
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -319,7 +319,7 @@ jobs:
     steps:
       - run: |
           yum update -y && \
-          yum install -y \
+          yum install --allowerasing -y \
           ca-certificates \
           curl \
           git \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        container: ["centos:7","centos:8","amazonlinux:1","amazonlinux:2","fedora:33"]
+        container:
+          - "quay.io/centos/centos:stream8"
+          - "quay.io/centos/centos:stream9"
+          - "amazonlinux:1"
+          - "amazonlinux:2"
+          - "fedora:34"
+          - "fedora:35"
+          - "fedora:36"
     container:
       image: ${{ matrix.container }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     steps:
       - run: |
           yum update -y && \
-          yum install -y \
+          yum install --allowerasing -y \
           ca-certificates \
           curl \
           git \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,14 +296,18 @@ jobs:
       image: ${{ matrix.container }}
     steps:
       - run: |
-          yum update -y && \
-          yum install --allowerasing -y \
+          yum update -y
+          yum install -y \
           ca-certificates \
-          curl \
           git \
           systemd \
           tar \
           make
+          # conflicts with curl-minimal on some distros and --allowerased is not
+          # supported on some distros
+          if ! command -v curl &> /dev/null ; then
+            yum install -y curl
+          fi
       - name: checkout
         uses: actions/checkout@v2.4.0
       - run: echo VECTOR_VERSION=$(make version) >> $GITHUB_ENV


### PR DESCRIPTION
Drop EOL distributions. This was prompted because the mirrors for Centos
8 no longer exist.

https://www.centos.org/centos-linux-eol/

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
