### PR TITLE
fix(buffers): fix buffer metrics when using DropNewest

### DIFF
--- a/lib/vector-buffers/src/disk_v2/tests/acknowledgements.rs
+++ b/lib/vector-buffers/src/disk_v2/tests/acknowledgements.rs
@@ -6,6 +6,7 @@ use super::with_temp_dir;
 use crate::{
     buffer_usage_data::BufferUsageHandle,
     disk_v2::{acknowledgements::create_disk_v2_acker, ledger::Ledger, DiskBufferConfig},
+    WhenFull,
 };
 
 #[tokio::test]
@@ -15,7 +16,7 @@ async fn ack_updates_ledger_correctly() {
 
         async move {
             // Create a standalone ledger.
-            let usage_handle = BufferUsageHandle::noop();
+            let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
             let config = DiskBufferConfig::from_path(data_dir).build();
             let ledger = Ledger::load_or_create(config, usage_handle)
                 .await
@@ -43,7 +44,7 @@ async fn ack_wakes_reader() {
 
         async move {
             // Create a standalone ledger.
-            let usage_handle = BufferUsageHandle::noop();
+            let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
             let config = DiskBufferConfig::from_path(data_dir).build();
             let ledger = Ledger::load_or_create(config, usage_handle)
                 .await

--- a/lib/vector-buffers/src/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/disk_v2/tests/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     buffer_usage_data::BufferUsageHandle,
     disk_v2::{Buffer, DiskBufferConfig, Reader, Writer},
     encoding::FixedEncodable,
-    Acker, Bufferable,
+    Acker, Bufferable, WhenFull,
 };
 
 mod acknowledgements;
@@ -256,7 +256,7 @@ where
     R: Bufferable,
 {
     let config = DiskBufferConfig::from_path(data_dir).build();
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
     Buffer::from_config_inner(config, usage_handle)
         .await
         .expect("should not fail to create buffer")
@@ -274,7 +274,7 @@ where
     // ensures it is a minimum size related to the data file size limit, etc.
     let mut config = DiskBufferConfig::from_path(data_dir).build();
     config.max_buffer_size = max_buffer_size;
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
 
     Buffer::from_config_inner(config, usage_handle)
         .await
@@ -292,7 +292,7 @@ where
     let config = DiskBufferConfig::from_path(data_dir)
         .max_record_size(max_record_size)
         .build();
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
 
     Buffer::from_config_inner(config, usage_handle)
         .await
@@ -310,7 +310,7 @@ where
     let config = DiskBufferConfig::from_path(data_dir)
         .max_data_file_size(max_data_file_size)
         .build();
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
 
     Buffer::from_config_inner(config, usage_handle)
         .await

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -25,7 +25,6 @@ conversion = [
   "bytes",
   "chrono",
   "snafu",
-  "tracing",
 ]
 
 encoding = [
@@ -51,4 +50,4 @@ nom = { version = "7", optional = true }
 serde_json = { version = "1.0.78", default-features = false, features = ["std", "raw_value"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 snafu = { version = "0.7", optional = true }
-tracing = { version = "0.1.29", default-features = false, optional = true }
+tracing = { version = "0.1.29", default-features = false }

--- a/lib/vector-common/src/internal_event/bytes_sent.rs
+++ b/lib/vector-common/src/internal_event/bytes_sent.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use tracing::trace;
 
 use crate::internal_event::InternalEvent;
 

--- a/lib/vector-common/src/internal_event/events_received.rs
+++ b/lib/vector-common/src/internal_event/events_received.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use tracing::trace;
 
 use crate::internal_event::InternalEvent;
 

--- a/lib/vector-common/src/internal_event/events_sent.rs
+++ b/lib/vector-common/src/internal_event/events_sent.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use tracing::trace;
 
 use crate::internal_event::InternalEvent;
 

--- a/lib/vector-common/src/lib.rs
+++ b/lib/vector-common/src/lib.rs
@@ -36,6 +36,3 @@ pub mod internal_event;
 
 #[cfg(feature = "tokenize")]
 pub mod tokenize;
-
-#[macro_use]
-extern crate tracing;


### PR DESCRIPTION
As described in the title, this PR fixes an issue where events that were dropped in DropNewest mode were also counted as having been sent to the buffer, which would lead to incorrect buffer metrics over time.

I also tweaked the use of `tracing` in `vector-common` to make it a non-optional crate, as well as skipping the extern import and requiring direct `use tracing::...` statements to bring clarity to what was being used and how it was being imported.  The only reason I touched this code in particular was that the `tracing` dependency was set to optional which meant things broke if you were pulling the crate in without also setting certain feature flags, and `vector-buffers` was not setting those flags... because they're entirely unrelated to what `vector-buffers` needs out of the crate.

Fixes #11151.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>