### PR TITLE
chore: Ensure we always build grok patterns

### DIFF
--- a/lib/datadog/grok/build.rs
+++ b/lib/datadog/grok/build.rs
@@ -9,14 +9,13 @@ use std::{
 };
 
 fn main() {
+    read_grok_patterns();
+
+    println!("cargo:rerun-if-changed=src/parser.lalrpop");
     lalrpop::Configuration::new()
         .always_use_colors()
         .process_current_dir()
         .unwrap();
-
-    println!("cargo:rerun-if-changed=src/parser.lalrpop");
-
-    read_grok_patterns();
 }
 
 /// Reads grok patterns defined in the `patterns` folder into the static `PATTERNS` variable


### PR DESCRIPTION
This commit juggles where we read in grok patterns above the lalrpop
rerun-if-changed directive. Previously we would only rebuild our patterns file
if src/parser.lalrpop changed, which results in odd build issues for people with
unclean trees.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
