### PR TITLE
chore(codecs): Use `enum` delegation when decoding rather than dynamic dispatch

### DIFF
--- a/src/codecs/decoding/format/bytes.rs
+++ b/src/codecs/decoding/format/bytes.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 
-use super::{BoxedDeserializer, Deserializer, DeserializerConfig};
+use super::Deserializer;
 use crate::{
     config::log_schema,
     event::{Event, LogEvent},
@@ -17,12 +17,10 @@ impl BytesDeserializerConfig {
     pub const fn new() -> Self {
         Self
     }
-}
 
-#[typetag::serde(name = "bytes")]
-impl DeserializerConfig for BytesDeserializerConfig {
-    fn build(&self) -> crate::Result<BoxedDeserializer> {
-        Ok(Box::new(BytesDeserializer::new()))
+    /// Build the `BytesDeserializer` from this configuration.
+    pub fn build(&self) -> BytesDeserializer {
+        BytesDeserializer::new()
     }
 }
 

--- a/src/codecs/decoding/format/json.rs
+++ b/src/codecs/decoding/format/json.rs
@@ -5,17 +5,17 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 
-use super::{BoxedDeserializer, Deserializer, DeserializerConfig};
+use super::Deserializer;
 use crate::{config::log_schema, event::Event};
 
 /// Config used to build a `JsonDeserializer`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct JsonDeserializerConfig;
 
-#[typetag::serde(name = "json")]
-impl DeserializerConfig for JsonDeserializerConfig {
-    fn build(&self) -> crate::Result<BoxedDeserializer> {
-        Ok(Box::new(Into::<JsonDeserializer>::into(self)))
+impl JsonDeserializerConfig {
+    /// Build the `JsonDeserializer` from this configuration.
+    pub fn build(&self) -> JsonDeserializer {
+        Into::<JsonDeserializer>::into(self)
     }
 }
 

--- a/src/codecs/decoding/format/syslog.rs
+++ b/src/codecs/decoding/format/syslog.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use syslog_loose::{IncompleteDate, Message, ProcId, Protocol};
 
-use super::{BoxedDeserializer, Deserializer, DeserializerConfig};
+use super::Deserializer;
 use crate::{
     config::log_schema,
     event::{Event, Value},
@@ -15,10 +15,10 @@ use crate::{
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct SyslogDeserializerConfig;
 
-#[typetag::serde(name = "syslog")]
-impl DeserializerConfig for SyslogDeserializerConfig {
-    fn build(&self) -> crate::Result<BoxedDeserializer> {
-        Ok(Box::new(SyslogDeserializer))
+impl SyslogDeserializerConfig {
+    /// Build the `SyslogDeserializer` from this configuration.
+    pub const fn build(&self) -> SyslogDeserializer {
+        SyslogDeserializer
     }
 }
 

--- a/src/codecs/decoding/framing/bytes.rs
+++ b/src/codecs/decoding/framing/bytes.rs
@@ -2,7 +2,7 @@ use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Decoder;
 
-use super::{BoxedFramer, BoxedFramingError, FramingConfig};
+use super::BoxedFramingError;
 
 /// Config used to build a `BytesDecoderConfig`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -13,12 +13,10 @@ impl BytesDecoderConfig {
     pub const fn new() -> Self {
         Self
     }
-}
 
-#[typetag::serde(name = "bytes")]
-impl FramingConfig for BytesDecoderConfig {
-    fn build(&self) -> crate::Result<BoxedFramer> {
-        Ok(Box::new(BytesDecoder::new()))
+    /// Build the `ByteDecoder` from this configuration.
+    pub const fn build(&self) -> BytesDecoder {
+        BytesDecoder::new()
     }
 }
 

--- a/src/codecs/decoding/framing/character_delimited.rs
+++ b/src/codecs/decoding/framing/character_delimited.rs
@@ -3,12 +3,26 @@ use memchr::memchr;
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Decoder;
 
-use super::{BoxedFramer, BoxedFramingError, FramingConfig};
+use super::BoxedFramingError;
 
 /// Config used to build a `CharacterDelimitedDecoder`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CharacterDelimitedDecoderConfig {
     character_delimited: CharacterDelimitedDecoderOptions,
+}
+
+impl CharacterDelimitedDecoderConfig {
+    /// Build the `CharacterDelimitedDecoder` from this configuration.
+    pub const fn build(&self) -> CharacterDelimitedDecoder {
+        if let Some(max_length) = self.character_delimited.max_length {
+            CharacterDelimitedDecoder::new_with_max_length(
+                self.character_delimited.delimiter,
+                max_length,
+            )
+        } else {
+            CharacterDelimitedDecoder::new(self.character_delimited.delimiter)
+        }
+    }
 }
 
 /// Options for building a `CharacterDelimitedDecoder`.
@@ -22,22 +36,6 @@ pub struct CharacterDelimitedDecoderOptions {
     /// This length does *not* include the trailing delimiter.
     #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
     max_length: Option<usize>,
-}
-
-#[typetag::serde(name = "character_delimited")]
-impl FramingConfig for CharacterDelimitedDecoderConfig {
-    fn build(&self) -> crate::Result<BoxedFramer> {
-        if let Some(max_length) = self.character_delimited.max_length {
-            Ok(Box::new(CharacterDelimitedDecoder::new_with_max_length(
-                self.character_delimited.delimiter,
-                max_length,
-            )))
-        } else {
-            Ok(Box::new(CharacterDelimitedDecoder::new(
-                self.character_delimited.delimiter,
-            )))
-        }
-    }
 }
 
 /// A decoder for handling bytes that are delimited by (a) chosen character(s).

--- a/src/codecs/decoding/framing/character_delimited.rs
+++ b/src/codecs/decoding/framing/character_delimited.rs
@@ -8,7 +8,8 @@ use super::BoxedFramingError;
 /// Config used to build a `CharacterDelimitedDecoder`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CharacterDelimitedDecoderConfig {
-    character_delimited: CharacterDelimitedDecoderOptions,
+    /// Options for the character delimited decoder.
+    pub character_delimited: CharacterDelimitedDecoderOptions,
 }
 
 impl CharacterDelimitedDecoderConfig {

--- a/src/codecs/decoding/framing/length_delimited.rs
+++ b/src/codecs/decoding/framing/length_delimited.rs
@@ -2,16 +2,16 @@ use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Decoder;
 
-use super::{BoxedFramer, BoxedFramingError, FramingConfig};
+use super::BoxedFramingError;
 
 /// Config used to build a `LengthDelimitedDecoder`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct LengthDelimitedDecoderConfig;
 
-#[typetag::serde(name = "length_delimited")]
-impl FramingConfig for LengthDelimitedDecoderConfig {
-    fn build(&self) -> crate::Result<BoxedFramer> {
-        Ok(Box::new(LengthDelimitedDecoder::new()))
+impl LengthDelimitedDecoderConfig {
+    /// Build the `LengthDelimitedDecoder` from this configuration.
+    pub fn build(&self) -> LengthDelimitedDecoder {
+        LengthDelimitedDecoder::new()
     }
 }
 

--- a/src/codecs/decoding/framing/mod.rs
+++ b/src/codecs/decoding/framing/mod.rs
@@ -10,10 +10,16 @@ mod newline_delimited;
 mod octet_counting;
 
 pub use self::bytes::{BytesDecoder, BytesDecoderConfig};
-pub use character_delimited::{CharacterDelimitedDecoder, CharacterDelimitedDecoderConfig};
+pub use character_delimited::{
+    CharacterDelimitedDecoder, CharacterDelimitedDecoderConfig, CharacterDelimitedDecoderOptions,
+};
 pub use length_delimited::{LengthDelimitedDecoder, LengthDelimitedDecoderConfig};
-pub use newline_delimited::{NewlineDelimitedDecoder, NewlineDelimitedDecoderConfig};
-pub use octet_counting::{OctetCountingDecoder, OctetCountingDecoderConfig};
+pub use newline_delimited::{
+    NewlineDelimitedDecoder, NewlineDelimitedDecoderConfig, NewlineDelimitedDecoderOptions,
+};
+pub use octet_counting::{
+    OctetCountingDecoder, OctetCountingDecoderConfig, OctetCountingDecoderOptions,
+};
 
 use super::StreamDecodingError;
 use ::bytes::Bytes;

--- a/src/codecs/decoding/framing/newline_delimited.rs
+++ b/src/codecs/decoding/framing/newline_delimited.rs
@@ -2,7 +2,7 @@ use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Decoder;
 
-use super::{BoxedFramer, BoxedFramingError, CharacterDelimitedDecoder, FramingConfig};
+use super::{BoxedFramingError, CharacterDelimitedDecoder};
 
 /// Config used to build a `NewlineDelimitedDecoder`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
@@ -46,17 +46,13 @@ impl NewlineDelimitedDecoderConfig {
             newline_delimited: { NewlineDelimitedDecoderOptions::new_with_max_length(max_length) },
         }
     }
-}
 
-#[typetag::serde(name = "newline_delimited")]
-impl FramingConfig for NewlineDelimitedDecoderConfig {
-    fn build(&self) -> crate::Result<BoxedFramer> {
+    /// Build the `NewlineDelimitedDecoder` from this configuration.
+    pub const fn build(&self) -> NewlineDelimitedDecoder {
         if let Some(max_length) = self.newline_delimited.max_length {
-            Ok(Box::new(NewlineDelimitedDecoder::new_with_max_length(
-                max_length,
-            )))
+            NewlineDelimitedDecoder::new_with_max_length(max_length)
         } else {
-            Ok(Box::new(NewlineDelimitedDecoder::new()))
+            NewlineDelimitedDecoder::new()
         }
     }
 }

--- a/src/codecs/decoding/framing/newline_delimited.rs
+++ b/src/codecs/decoding/framing/newline_delimited.rs
@@ -11,7 +11,8 @@ pub struct NewlineDelimitedDecoderConfig {
         default,
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
-    newline_delimited: NewlineDelimitedDecoderOptions,
+    /// Options for the newline delimited decoder.
+    pub newline_delimited: NewlineDelimitedDecoderOptions,
 }
 
 /// Options for building a `NewlineDelimitedDecoder`.

--- a/src/codecs/decoding/framing/octet_counting.rs
+++ b/src/codecs/decoding/framing/octet_counting.rs
@@ -13,7 +13,8 @@ pub struct OctetCountingDecoderConfig {
         default,
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
-    octet_counting: OctetCountingDecoderOptions,
+    /// Options for the octet counting decoder.
+    pub octet_counting: OctetCountingDecoderOptions,
 }
 
 impl OctetCountingDecoderConfig {

--- a/src/codecs/decoding/framing/octet_counting.rs
+++ b/src/codecs/decoding/framing/octet_counting.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::{LinesCodec, LinesCodecError};
 
-use super::{BoxedFramer, BoxedFramingError, FramingConfig};
+use super::BoxedFramingError;
 
 /// Config used to build a `OctetCountingDecoder`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -16,25 +16,23 @@ pub struct OctetCountingDecoderConfig {
     octet_counting: OctetCountingDecoderOptions,
 }
 
+impl OctetCountingDecoderConfig {
+    /// Build the `OctetCountingDecoder` from this configuration.
+    pub fn build(&self) -> OctetCountingDecoder {
+        if let Some(max_length) = self.octet_counting.max_length {
+            OctetCountingDecoder::new_with_max_length(max_length)
+        } else {
+            OctetCountingDecoder::new()
+        }
+    }
+}
+
 /// Options for building a `OctetCountingDecoder`.
 #[derive(Debug, Clone, Derivative, Deserialize, Serialize, PartialEq)]
 #[derivative(Default)]
 pub struct OctetCountingDecoderOptions {
     #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
     max_length: Option<usize>,
-}
-
-#[typetag::serde(name = "octet_counting")]
-impl FramingConfig for OctetCountingDecoderConfig {
-    fn build(&self) -> crate::Result<BoxedFramer> {
-        if let Some(max_length) = self.octet_counting.max_length {
-            Ok(Box::new(OctetCountingDecoder::new_with_max_length(
-                max_length,
-            )))
-        } else {
-            Ok(Box::new(OctetCountingDecoder::new()))
-        }
-    }
 }
 
 /// Codec using the `Octet Counting` format as specified in

--- a/src/codecs/decoding/mod.rs
+++ b/src/codecs/decoding/mod.rs
@@ -371,13 +371,13 @@ impl DecodingConfig {
     }
 
     /// Builds a `Decoder` from the provided configuration.
-    pub fn build(self) -> crate::Result<Decoder> {
+    pub fn build(self) -> Decoder {
         // Build the framer.
         let framer = self.framing.build();
 
         // Build the deserializer.
         let deserializer = self.decoding.build();
 
-        Ok(Decoder::new(framer, deserializer))
+        Decoder::new(framer, deserializer)
     }
 }

--- a/src/codecs/decoding/mod.rs
+++ b/src/codecs/decoding/mod.rs
@@ -68,6 +68,7 @@ impl StreamDecodingError for Error {
 
 /// Configuration for building a `Framer`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "method", rename_all = "snake_case")]
 pub enum FramingConfig {
     /// Configures the `BytesDecoder`.
     Bytes(BytesDecoderConfig),
@@ -139,6 +140,7 @@ impl tokio_util::codec::Decoder for Framer {
 
 /// Configuration for building a `Deserializer`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "codec", rename_all = "snake_case")]
 pub enum DeserializerConfig {
     /// Configures the `BytesDeserializer`.
     Bytes(BytesDeserializerConfig),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -24,18 +24,18 @@ pub fn default_max_length() -> usize {
 }
 
 #[cfg(feature = "codecs")]
-pub fn default_framing_message_based() -> Box<dyn FramingConfig> {
-    Box::new(BytesDecoderConfig::new())
+pub const fn default_framing_message_based() -> FramingConfig {
+    FramingConfig::Bytes(BytesDecoderConfig::new())
 }
 
 #[cfg(feature = "codecs")]
-pub fn default_framing_stream_based() -> Box<dyn FramingConfig> {
-    Box::new(NewlineDelimitedDecoderConfig::new())
+pub fn default_framing_stream_based() -> FramingConfig {
+    FramingConfig::NewlineDelimited(NewlineDelimitedDecoderConfig::new())
 }
 
 #[cfg(feature = "codecs")]
-pub fn default_decoding() -> Box<dyn DeserializerConfig> {
-    Box::new(BytesDeserializerConfig::new())
+pub const fn default_decoding() -> DeserializerConfig {
+    DeserializerConfig::Bytes(BytesDeserializerConfig::new())
 }
 
 pub fn to_string(value: impl serde::Serialize) -> String {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -24,18 +24,18 @@ pub fn default_max_length() -> usize {
 }
 
 #[cfg(feature = "codecs")]
-pub const fn default_framing_message_based() -> FramingConfig {
-    FramingConfig::Bytes(BytesDecoderConfig::new())
+pub fn default_framing_message_based() -> FramingConfig {
+    BytesDecoderConfig::new().into()
 }
 
 #[cfg(feature = "codecs")]
 pub fn default_framing_stream_based() -> FramingConfig {
-    FramingConfig::NewlineDelimited(NewlineDelimitedDecoderConfig::new())
+    NewlineDelimitedDecoderConfig::new().into()
 }
 
 #[cfg(feature = "codecs")]
-pub const fn default_decoding() -> DeserializerConfig {
-    DeserializerConfig::Bytes(BytesDeserializerConfig::new())
+pub fn default_decoding() -> DeserializerConfig {
+    BytesDeserializerConfig::new().into()
 }
 
 pub fn to_string(value: impl serde::Serialize) -> String {

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -26,9 +26,9 @@ pub struct AwsKinesisFirehoseConfig {
     tls: Option<TlsConfig>,
     record_compression: Option<Compression>,
     #[serde(default = "default_framing_message_based")]
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     #[serde(default = "default_decoding")]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Compression {
 #[typetag::serde(name = "aws_kinesis_firehose")]
 impl SourceConfig for AwsKinesisFirehoseConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
         let acknowledgements = cx.globals.acknowledgements.merge(&self.acknowledgements);
 
         let svc = filters::firehose(

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -32,10 +32,10 @@ pub struct AwsSqsConfig {
 
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
-    pub framing: Box<dyn FramingConfig>,
+    pub framing: FramingConfig,
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
-    pub decoding: Box<dyn DeserializerConfig>,
+    pub decoding: DeserializerConfig,
     #[serde(default, deserialize_with = "bool_or_struct")]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -45,7 +45,7 @@ pub struct AwsSqsConfig {
 impl SourceConfig for AwsSqsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<crate::sources::Source> {
         let client = self.build_client(&cx).await?;
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
         let acknowledgements = cx.globals.acknowledgements.merge(&self.acknowledgements);
 
         Ok(Box::pin(

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -105,7 +105,7 @@ impl GenerateConfig for DatadogAgentConfig {
 #[typetag::serde(name = "datadog_agent")]
 impl SourceConfig for DatadogAgentConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<sources::Source> {
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
         let tls = MaybeTlsSettings::from_config(&self.tls, true)?;
         let source = DatadogAgentSource::new(self.store_api_key, decoder, tls.http_protocol_name());
         let listener = tls.bind(&self.address).await?;

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -67,9 +67,9 @@ pub struct DatadogAgentConfig {
     #[serde(default = "crate::serde::default_true")]
     store_api_key: bool,
     #[serde(default = "default_framing_message_based")]
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     #[serde(default = "default_decoding")]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
     #[serde(default = "crate::serde::default_false")]

--- a/src/sources/datadog/agent/tests.rs
+++ b/src/sources/datadog/agent/tests.rs
@@ -1,6 +1,10 @@
 use super::{DatadogAgentConfig, DatadogAgentSource, DatadogSeriesRequest, LogMsg};
 use crate::{
-    codecs::{self, BytesDecoder, BytesDeserializer},
+    codecs::{
+        self,
+        decoding::{Deserializer, Framer},
+        BytesDecoder, BytesDeserializer,
+    },
     common::datadog::{DatadogMetricType, DatadogPoint, DatadogSeriesMetric},
     config::{log_schema, SourceConfig, SourceContext},
     event::{
@@ -53,8 +57,8 @@ fn test_decode_log_body() {
         let api_key = None;
 
         let decoder = codecs::Decoder::new(
-            Box::new(BytesDecoder::new()),
-            Box::new(BytesDeserializer::new()),
+            Framer::Bytes(BytesDecoder::new()),
+            Deserializer::Bytes(BytesDeserializer::new()),
         );
         let source = DatadogAgentSource::new(true, decoder, "http");
         let events = source.decode_log_body(body, api_key).unwrap();

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -216,7 +216,7 @@ impl_generate_config_from_default!(DemoLogsConfig);
 impl SourceConfig for DemoLogsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         self.format.validate()?;
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
         Ok(Box::pin(demo_logs_source(
             self.interval,
             self.count,
@@ -276,9 +276,8 @@ mod tests {
     async fn runit(config: &str) -> ReceiverStream<Event> {
         let (tx, rx) = SourceSender::new_test();
         let config: DemoLogsConfig = toml::from_str(config).unwrap();
-        let decoder = DecodingConfig::new(default_framing_message_based(), default_decoding())
-            .build()
-            .unwrap();
+        let decoder =
+            DecodingConfig::new(default_framing_message_based(), default_decoding()).build();
         demo_logs_source(
             config.interval,
             config.count,

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -36,9 +36,9 @@ pub struct DemoLogsConfig {
     #[serde(flatten)]
     pub format: OutputFormat,
     #[derivative(Default(value = "default_framing_message_based()"))]
-    pub framing: Box<dyn FramingConfig>,
+    pub framing: FramingConfig,
     #[derivative(Default(value = "default_decoding()"))]
-    pub decoding: Box<dyn DeserializerConfig>,
+    pub decoding: DeserializerConfig,
 }
 
 const fn default_interval() -> f64 {

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -190,7 +190,7 @@ impl SourceConfig for ExecConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         self.validate()?;
         let hostname = get_hostname();
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
         match &self.mode {
             Mode::Scheduled => {
                 let exec_interval_secs = self.exec_interval_secs_or_default();

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -53,9 +53,9 @@ pub struct ExecConfig {
     #[serde(default = "default_maximum_buffer_size")]
     pub maximum_buffer_size_bytes: usize,
     #[serde(default = "default_framing_stream_based")]
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     #[serde(default = "default_decoding")]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
 }
 
 // TODO: Would be nice to combine the scheduled and streaming config with the mode enum once

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -92,7 +92,7 @@ impl HttpSource for LogplexSource {
 #[typetag::serde(name = "heroku_logs")]
 impl SourceConfig for LogplexConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
         let source = LogplexSource {
             query_parameters: self.query_parameters.clone(),
             decoder,

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -38,9 +38,9 @@ pub struct LogplexConfig {
     tls: Option<TlsConfig>,
     auth: Option<HttpSourceAuthConfig>,
     #[serde(default = "default_framing_message_based")]
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     #[serde(default = "default_decoding")]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -144,20 +144,20 @@ impl SourceConfig for SimpleHttpConfig {
         let (framing, decoding) = if let Some(encoding) = self.encoding {
             match encoding {
                 Encoding::Text => (
-                    FramingConfig::NewlineDelimited(NewlineDelimitedDecoderConfig::new()),
-                    DeserializerConfig::Bytes(BytesDeserializerConfig::new()),
+                    NewlineDelimitedDecoderConfig::new().into(),
+                    BytesDeserializerConfig::new().into(),
                 ),
                 Encoding::Json => (
-                    FramingConfig::Bytes(BytesDecoderConfig::new()),
-                    DeserializerConfig::Json(JsonDeserializerConfig::new()),
+                    BytesDecoderConfig::new().into(),
+                    JsonDeserializerConfig::new().into(),
                 ),
                 Encoding::Ndjson => (
-                    FramingConfig::NewlineDelimited(NewlineDelimitedDecoderConfig::new()),
-                    DeserializerConfig::Json(JsonDeserializerConfig::new()),
+                    NewlineDelimitedDecoderConfig::new().into(),
+                    JsonDeserializerConfig::new().into(),
                 ),
                 Encoding::Binary => (
-                    FramingConfig::Bytes(BytesDecoderConfig::new()),
-                    DeserializerConfig::Bytes(BytesDeserializerConfig::new()),
+                    BytesDecoderConfig::new().into(),
+                    BytesDeserializerConfig::new().into(),
                 ),
             }
         } else {
@@ -452,7 +452,7 @@ mod tests {
             true,
             EventStatus::Delivered,
             true,
-            Some(FramingConfig::Bytes(BytesDecoderConfig::new())),
+            Some(BytesDecoderConfig::new().into()),
             None,
         )
         .await;
@@ -482,7 +482,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -523,7 +523,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -567,7 +567,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -610,7 +610,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -685,7 +685,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -724,7 +724,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -799,7 +799,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -831,7 +831,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 
@@ -881,7 +881,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
+            Some(JsonDeserializerConfig::new().into()),
         )
         .await;
 

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -173,7 +173,7 @@ impl SourceConfig for SimpleHttpConfig {
             )
         };
 
-        let decoder = DecodingConfig::new(framing, decoding).build()?;
+        let decoder = DecodingConfig::new(framing, decoding).build();
         let source = SimpleHttpSource {
             headers: self.headers.clone(),
             query_parameters: self.query_parameters.clone(),

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -43,8 +43,8 @@ pub struct SimpleHttpConfig {
     path: String,
     #[serde(default = "default_path_key")]
     path_key: String,
-    framing: Option<Box<dyn FramingConfig>>,
-    decoding: Option<Box<dyn DeserializerConfig>>,
+    framing: Option<FramingConfig>,
+    decoding: Option<DeserializerConfig>,
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
 }
@@ -144,20 +144,20 @@ impl SourceConfig for SimpleHttpConfig {
         let (framing, decoding) = if let Some(encoding) = self.encoding {
             match encoding {
                 Encoding::Text => (
-                    Box::new(NewlineDelimitedDecoderConfig::new()) as Box<dyn FramingConfig>,
-                    Box::new(BytesDeserializerConfig::new()) as Box<dyn DeserializerConfig>,
+                    FramingConfig::NewlineDelimited(NewlineDelimitedDecoderConfig::new()),
+                    DeserializerConfig::Bytes(BytesDeserializerConfig::new()),
                 ),
                 Encoding::Json => (
-                    Box::new(BytesDecoderConfig::new()) as Box<dyn FramingConfig>,
-                    Box::new(JsonDeserializerConfig::new()) as Box<dyn DeserializerConfig>,
+                    FramingConfig::Bytes(BytesDecoderConfig::new()),
+                    DeserializerConfig::Json(JsonDeserializerConfig::new()),
                 ),
                 Encoding::Ndjson => (
-                    Box::new(NewlineDelimitedDecoderConfig::new()) as Box<dyn FramingConfig>,
-                    Box::new(JsonDeserializerConfig::new()) as Box<dyn DeserializerConfig>,
+                    FramingConfig::NewlineDelimited(NewlineDelimitedDecoderConfig::new()),
+                    DeserializerConfig::Json(JsonDeserializerConfig::new()),
                 ),
                 Encoding::Binary => (
-                    Box::new(BytesDecoderConfig::new()) as Box<dyn FramingConfig>,
-                    Box::new(BytesDeserializerConfig::new()) as Box<dyn DeserializerConfig>,
+                    FramingConfig::Bytes(BytesDecoderConfig::new()),
+                    DeserializerConfig::Bytes(BytesDeserializerConfig::new()),
                 ),
             }
         } else {
@@ -165,11 +165,11 @@ impl SourceConfig for SimpleHttpConfig {
                 match self.framing.as_ref() {
                     Some(framing) => framing.clone(),
                     None => default_framing_stream_based(),
-                } as Box<dyn FramingConfig>,
+                },
                 match self.decoding.as_ref() {
                     Some(decoding) => decoding.clone(),
                     None => default_decoding(),
-                } as Box<dyn DeserializerConfig>,
+                },
             )
         };
 
@@ -262,8 +262,8 @@ mod tests {
         strict_path: bool,
         status: EventStatus,
         acknowledgements: bool,
-        framing: Option<Box<dyn FramingConfig>>,
-        decoding: Option<Box<dyn DeserializerConfig>>,
+        framing: Option<FramingConfig>,
+        decoding: Option<DeserializerConfig>,
     ) -> (impl Stream<Item = Event> + 'a, SocketAddr) {
         components::init_test();
         let (sender, recv) = SourceSender::new_test_finalize(status);
@@ -452,7 +452,7 @@ mod tests {
             true,
             EventStatus::Delivered,
             true,
-            Some(Box::new(BytesDecoderConfig::new())),
+            Some(FramingConfig::Bytes(BytesDecoderConfig::new())),
             None,
         )
         .await;
@@ -482,7 +482,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -523,7 +523,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -567,7 +567,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -610,7 +610,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -685,7 +685,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -724,7 +724,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -799,7 +799,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -831,7 +831,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 
@@ -881,7 +881,7 @@ mod tests {
             EventStatus::Delivered,
             true,
             None,
-            Some(Box::new(JsonDeserializerConfig::new())),
+            Some(DeserializerConfig::Json(JsonDeserializerConfig::new())),
         )
         .await;
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -80,10 +80,10 @@ pub struct KafkaSourceConfig {
     auth: KafkaAuthConfig,
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -139,7 +139,7 @@ impl_generate_config_from_default!(KafkaSourceConfig);
 impl SourceConfig for KafkaSourceConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         let consumer = create_consumer(self)?;
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
         let acknowledgements = cx.globals.acknowledgements.merge(&self.acknowledgements);
 
         Ok(Box::pin(kafka_source(

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -42,10 +42,10 @@ pub struct NatsSourceConfig {
     queue: Option<String>,
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
 }
 
 inventory::submit! {

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -69,7 +69,7 @@ impl GenerateConfig for NatsSourceConfig {
 impl SourceConfig for NatsSourceConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         let (connection, subscription) = create_subscription(self).await?;
-        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build()?;
+        let decoder = DecodingConfig::new(self.framing.clone(), self.decoding.clone()).build();
 
         Ok(Box::pin(nats_source(
             connection,
@@ -226,9 +226,7 @@ mod integration_tests {
         let nc_pub = nc.clone();
 
         let (tx, rx) = SourceSender::new_test();
-        let decoder = DecodingConfig::new(conf.framing.clone(), conf.decoding.clone())
-            .build()
-            .unwrap();
+        let decoder = DecodingConfig::new(conf.framing.clone(), conf.decoding.clone()).build();
         tokio::spawn(nats_source(nc, sub, decoder, ShutdownSignal::noop(), tx));
         let msg = "my message";
         nc_pub.publish(&subject, msg).await.unwrap();

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -98,7 +98,7 @@ impl SourceConfig for SocketConfig {
                     None => NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into(),
                 };
 
-                let decoder = DecodingConfig::new(framing, config.decoding().clone()).build()?;
+                let decoder = DecodingConfig::new(framing, config.decoding().clone()).build();
 
                 let tcp = tcp::RawTcpSource::new(config.clone(), decoder);
                 let tls = MaybeTlsSettings::from_config(config.tls(), true)?;
@@ -120,7 +120,7 @@ impl SourceConfig for SocketConfig {
                     .unwrap_or_else(|| log_schema().host_key().to_string());
                 let decoder =
                     DecodingConfig::new(config.framing().clone(), config.decoding().clone())
-                        .build()?;
+                        .build();
                 Ok(udp::udp(
                     config.address(),
                     config.max_length(),
@@ -140,7 +140,7 @@ impl SourceConfig for SocketConfig {
                     config.framing.unwrap_or_else(default_framing_message_based),
                     config.decoding.clone(),
                 )
-                .build()?;
+                .build();
                 Ok(unix::unix_datagram(
                     config.path,
                     config
@@ -167,7 +167,7 @@ impl SourceConfig for SocketConfig {
                     None => NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into(),
                 };
 
-                let decoder = DecodingConfig::new(framing, config.decoding.clone()).build()?;
+                let decoder = DecodingConfig::new(framing, config.decoding.clone()).build();
 
                 let host_key = config
                     .host_key

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -10,10 +10,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use crate::serde::default_framing_message_based;
 use crate::{
-    codecs::{
-        decoding::{DecodingConfig, FramingConfig},
-        NewlineDelimitedDecoderConfig,
-    },
+    codecs::{decoding::DecodingConfig, NewlineDelimitedDecoderConfig},
     config::{
         log_schema, DataType, GenerateConfig, Output, Resource, SourceConfig, SourceContext,
         SourceDescription,
@@ -98,9 +95,7 @@ impl SourceConfig for SocketConfig {
 
                 let framing = match config.framing().as_ref() {
                     Some(framing) => framing.clone(),
-                    None => FramingConfig::NewlineDelimited(
-                        NewlineDelimitedDecoderConfig::new_with_max_length(max_length),
-                    ),
+                    None => NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into(),
                 };
 
                 let decoder = DecodingConfig::new(framing, config.decoding().clone()).build()?;
@@ -169,9 +164,7 @@ impl SourceConfig for SocketConfig {
 
                 let framing = match config.framing.as_ref() {
                     Some(framing) => framing.clone(),
-                    None => FramingConfig::NewlineDelimited(
-                        NewlineDelimitedDecoderConfig::new_with_max_length(max_length),
-                    ),
+                    None => NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into(),
                 };
 
                 let decoder = DecodingConfig::new(framing, config.decoding.clone()).build()?;
@@ -244,7 +237,7 @@ mod test {
     #[cfg(unix)]
     use crate::source_sender::ReceiverStream;
     use crate::{
-        codecs::{decoding::FramingConfig, NewlineDelimitedDecoderConfig},
+        codecs::NewlineDelimitedDecoderConfig,
         config::{
             log_schema, ComponentKey, GlobalOptions, SinkContext, SourceConfig, SourceContext,
         },
@@ -346,9 +339,9 @@ mod test {
 
         let mut config = TcpConfig::from_address(addr.into());
         config.set_max_length(None);
-        config.set_framing(Some(FramingConfig::NewlineDelimited(
-            NewlineDelimitedDecoderConfig::new_with_max_length(10),
-        )));
+        config.set_framing(Some(
+            NewlineDelimitedDecoderConfig::new_with_max_length(10).into(),
+        ));
 
         let server = SocketConfig::from(config)
             .build(SourceContext::new_test(tx))

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use crate::serde::default_framing_message_based;
 use crate::{
-    codecs::{decoding::DecodingConfig, NewlineDelimitedDecoderConfig},
+    codecs::{
+        decoding::{DecodingConfig, FramingConfig},
+        NewlineDelimitedDecoderConfig,
+    },
     config::{
         log_schema, DataType, GenerateConfig, Output, Resource, SourceConfig, SourceContext,
         SourceDescription,
@@ -95,9 +98,9 @@ impl SourceConfig for SocketConfig {
 
                 let framing = match config.framing().as_ref() {
                     Some(framing) => framing.clone(),
-                    None => Box::new(NewlineDelimitedDecoderConfig::new_with_max_length(
-                        max_length,
-                    )),
+                    None => FramingConfig::NewlineDelimited(
+                        NewlineDelimitedDecoderConfig::new_with_max_length(max_length),
+                    ),
                 };
 
                 let decoder = DecodingConfig::new(framing, config.decoding().clone()).build()?;
@@ -166,9 +169,9 @@ impl SourceConfig for SocketConfig {
 
                 let framing = match config.framing.as_ref() {
                     Some(framing) => framing.clone(),
-                    None => Box::new(NewlineDelimitedDecoderConfig::new_with_max_length(
-                        max_length,
-                    )),
+                    None => FramingConfig::NewlineDelimited(
+                        NewlineDelimitedDecoderConfig::new_with_max_length(max_length),
+                    ),
                 };
 
                 let decoder = DecodingConfig::new(framing, config.decoding.clone()).build()?;
@@ -241,7 +244,7 @@ mod test {
     #[cfg(unix)]
     use crate::source_sender::ReceiverStream;
     use crate::{
-        codecs::NewlineDelimitedDecoderConfig,
+        codecs::{decoding::FramingConfig, NewlineDelimitedDecoderConfig},
         config::{
             log_schema, ComponentKey, GlobalOptions, SinkContext, SourceConfig, SourceContext,
         },
@@ -343,7 +346,7 @@ mod test {
 
         let mut config = TcpConfig::from_address(addr.into());
         config.set_max_length(None);
-        config.set_framing(Some(Box::new(
+        config.set_framing(Some(FramingConfig::NewlineDelimited(
             NewlineDelimitedDecoderConfig::new_with_max_length(10),
         )));
 

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -36,10 +36,10 @@ pub struct TcpConfig {
     #[get_copy = "pub"]
     receive_buffer_bytes: Option<usize>,
     #[getset(get = "pub", set = "pub")]
-    framing: Option<Box<dyn FramingConfig>>,
+    framing: Option<FramingConfig>,
     #[serde(default = "default_decoding")]
     #[getset(get = "pub", set = "pub")]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
     pub connection_limit: Option<u32>,
 }
 
@@ -48,7 +48,7 @@ const fn default_shutdown_timeout_secs() -> u64 {
 }
 
 impl TcpConfig {
-    pub fn new(
+    pub const fn new(
         address: SocketListenAddr,
         keepalive: Option<TcpKeepaliveConfig>,
         max_length: Option<usize>,
@@ -56,8 +56,8 @@ impl TcpConfig {
         host_key: Option<String>,
         tls: Option<TlsConfig>,
         receive_buffer_bytes: Option<usize>,
-        framing: Option<Box<dyn FramingConfig>>,
-        decoding: Box<dyn DeserializerConfig>,
+        framing: Option<FramingConfig>,
+        decoding: DeserializerConfig,
         connection_limit: Option<u32>,
     ) -> Self {
         Self {

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -38,10 +38,10 @@ pub struct UdpConfig {
     receive_buffer_bytes: Option<usize>,
     #[serde(default = "default_framing_message_based")]
     #[get = "pub"]
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     #[serde(default = "default_decoding")]
     #[get = "pub"]
-    decoding: Box<dyn DeserializerConfig>,
+    decoding: DeserializerConfig,
 }
 
 impl UdpConfig {

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -28,9 +28,9 @@ pub struct UnixConfig {
     pub max_length: Option<usize>,
     pub host_key: Option<String>,
     #[serde(default)]
-    pub framing: Option<Box<dyn FramingConfig>>,
+    pub framing: Option<FramingConfig>,
     #[serde(default = "default_decoding")]
-    pub decoding: Box<dyn DeserializerConfig>,
+    pub decoding: DeserializerConfig,
 }
 
 impl UnixConfig {

--- a/src/sources/statsd/unix.rs
+++ b/src/sources/statsd/unix.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use super::StatsdDeserializer;
 use crate::{
-    codecs::{Decoder, NewlineDelimitedDecoder},
+    codecs::{
+        decoding::{Deserializer, Framer},
+        Decoder, NewlineDelimitedDecoder,
+    },
     shutdown::ShutdownSignal,
     sources::{util::build_unix_stream_source, Source},
     SourceSender,
@@ -17,8 +20,8 @@ pub struct UnixConfig {
 
 pub fn statsd_unix(config: UnixConfig, shutdown: ShutdownSignal, out: SourceSender) -> Source {
     let decoder = Decoder::new(
-        Box::new(NewlineDelimitedDecoder::new()),
-        Box::new(StatsdDeserializer),
+        Framer::NewlineDelimited(NewlineDelimitedDecoder::new()),
+        Deserializer::Boxed(Box::new(StatsdDeserializer)),
     );
 
     build_unix_stream_source(

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -27,9 +27,9 @@ pub struct StdinConfig {
     pub max_length: usize,
     pub host_key: Option<String>,
     #[serde(default = "default_framing_stream_based")]
-    pub framing: Box<dyn FramingConfig>,
+    pub framing: FramingConfig,
     #[serde(default = "default_decoding")]
-    pub decoding: Box<dyn DeserializerConfig>,
+    pub decoding: DeserializerConfig,
 }
 
 impl Default for StdinConfig {
@@ -87,7 +87,7 @@ where
         .host_key
         .unwrap_or_else(|| log_schema().host_key().to_string());
     let hostname = crate::get_hostname().ok();
-    let decoder = DecodingConfig::new(config.framing.clone(), config.decoding.clone()).build()?;
+    let decoder = DecodingConfig::new(config.framing.clone(), config.decoding).build()?;
 
     let (mut sender, receiver) = mpsc::channel(1024);
 

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -87,7 +87,7 @@ where
         .host_key
         .unwrap_or_else(|| log_schema().host_key().to_string());
     let hostname = crate::get_hostname().ok();
-    let decoder = DecodingConfig::new(config.framing.clone(), config.decoding).build()?;
+    let decoder = DecodingConfig::new(config.framing.clone(), config.decoding).build();
 
     let (mut sender, receiver) = mpsc::channel(1024);
 


### PR DESCRIPTION
We'll be doing the same for the encoding side, which is necessary to eventually infer the HTTP content type from the encoding configuration.