### PR TITLE
chore: DO NOT MERGE ME Temporarily remove EventsSent

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -675,14 +675,15 @@ fn build_task_transform(
         .transform(Box::pin(filtered))
         .flat_map(|events| futures::stream::iter(events.into_events()))
         .map(Ok)
-        .forward(output.with(|event: Event| async {
-            emit!(&EventsSent {
-                count: 1,
-                byte_size: event.size_of(),
-                output: None,
-            });
-            Ok(event)
-        }))
+        .forward(output)
+        // .forward(output.with(|event: Event| async {
+        //     emit!(&EventsSent {
+        //         count: 1,
+        //         byte_size: event.size_of(),
+        //         output: None,
+        //     });
+        //     Ok(event)
+        // }))
         .boxed()
         .map_ok(|_| {
             debug!("Finished.");


### PR DESCRIPTION
With regard to #10144 one thing we see very prominately in CPU time is the
recursive call to determine the size of Event instances. This is something we
could potentially keep updated but it's not clear how valuable that would be in
practice. This commit -- by removing one prominate example -- is intended to
figure that out.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
