### PR TITLE
chore: DO NOT MERGE ME Hack buffering in around Fanout

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -158,7 +158,7 @@ pub async fn build_pieces(
 
             let (fanout, control) = Fanout::new();
             let pump = async move {
-                rx.map(Ok).forward(fanout).await?;
+                rx.map(Ok).forward(fanout.buffer(1024)).await?;
                 Ok(TaskOutput::Source)
             };
 
@@ -659,6 +659,7 @@ fn build_task_transform(
     key: &ComponentKey,
 ) -> (Task, HashMap<OutputId, fanout::ControlChannel>) {
     let (output, control) = Fanout::new();
+    let output = output.buffer(1024);
 
     let input_rx = crate::utilization::wrap(input_rx);
 


### PR DESCRIPTION
The problem with fanout is that it suffers the slowest receiver problem. We wait
for every receiver to be available, then slam input into them. It's possible
that if we buffer up some we can reduce gap time between sends but while this
logic should be done in Fanout for now, to prove out the idea, I'm adding a
Buffer around the relevant fanouts.

REF #10144

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
