### PR TITLE
chore(ci): Remove xtrace from soaks/bin/run_experiment

### DIFF
--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -3,7 +3,7 @@
 #set -o errexit # grep will exit 1 without a match, even with --count
 set -o pipefail
 set -o nounset
-set -o xtrace
+#set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOAK_ROOT="${__dir}/.."


### PR DESCRIPTION
It's pretty noisy and I'm curious if we still need it cc/ @blt.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
