### PR TITLE
feat(api): Allow health endpoint to return 503s when Vector is shutting down

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -790,7 +790,7 @@ splunk-integration-tests = ["sinks-splunk_hec", "warp"]
 dnstap-integration-tests = ["sources-dnstap", "bollard"]
 
 disable-resolv-conf = []
-shutdown-tests = ["rdkafka", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-log_to_metric", "transforms-lua", "unix"]
+shutdown-tests = ["api", "rdkafka", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-log_to_metric", "transforms-lua", "unix"]
 cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file"]
 
 # grouping together features for benchmarks

--- a/src/api/handler.rs
+++ b/src/api/handler.rs
@@ -1,7 +1,19 @@
+use std::sync::{atomic::AtomicBool, Arc};
+
 use serde_json::json;
 use warp::{reply::json, Rejection, Reply};
 
 // Health handler, responds with { ok: true }
-pub async fn health() -> Result<impl Reply, Rejection> {
-    Ok(json(&json!({"ok": true})))
+pub async fn health(running: Arc<AtomicBool>) -> Result<impl Reply, Rejection> {
+    if running.load(std::sync::atomic::Ordering::Relaxed) {
+        Ok(warp::reply::with_status(
+            json(&json!({"ok": true})),
+            warp::http::StatusCode::OK,
+        ))
+    } else {
+        Ok(warp::reply::with_status(
+            json(&json!({"ok": false})),
+            warp::http::StatusCode::SERVICE_UNAVAILABLE,
+        ))
+    }
 }

--- a/src/api/handler.rs
+++ b/src/api/handler.rs
@@ -1,11 +1,15 @@
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{
+    atomic::{self, AtomicBool},
+    Arc,
+};
 
 use serde_json::json;
 use warp::{reply::json, Rejection, Reply};
 
-// Health handler, responds with { ok: true }
+// Health handler, responds with '{ ok: true }' when running and '{ ok: false}'
+// when shutting down
 pub async fn health(running: Arc<AtomicBool>) -> Result<impl Reply, Rejection> {
-    if running.load(std::sync::atomic::Ordering::Relaxed) {
+    if running.load(atomic::Ordering::Relaxed) {
         Ok(warp::reply::with_status(
             json(&json!({"ok": true})),
             warp::http::StatusCode::OK,

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,4 +1,8 @@
-use std::{convert::Infallible, net::SocketAddr};
+use std::{
+    convert::Infallible,
+    net::SocketAddr,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 use async_graphql::{
     http::{playground_source, GraphQLPlaygroundConfig, WebSocketProtocols},
@@ -19,8 +23,12 @@ pub struct Server {
 impl Server {
     /// Start the API server. This creates the routes and spawns a Warp server. The server is
     /// gracefully shut down when Self falls out of scope by way of the oneshot sender closing.
-    pub fn start(config: &config::Config, watch_rx: topology::WatchRx) -> Self {
-        let routes = make_routes(config.api.playground, watch_rx);
+    pub fn start(
+        config: &config::Config,
+        watch_rx: topology::WatchRx,
+        running: Arc<AtomicBool>,
+    ) -> Self {
+        let routes = make_routes(config.api.playground, watch_rx, running);
 
         let (_shutdown, rx) = oneshot::channel();
         let (addr, server) = warp::serve(routes).bind_with_graceful_shutdown(
@@ -52,11 +60,17 @@ impl Server {
     }
 }
 
-fn make_routes(playground: bool, watch_tx: topology::WatchRx) -> BoxedFilter<(impl Reply,)> {
+fn make_routes(
+    playground: bool,
+    watch_tx: topology::WatchRx,
+    running: Arc<AtomicBool>,
+) -> BoxedFilter<(impl Reply,)> {
     // Routes...
 
     // Health.
-    let health = warp::path("health").and_then(handler::health);
+    let health = warp::path("health")
+        .and(with_shared(running.clone()))
+        .and_then(handler::health);
 
     // 404.
     let not_found = warp::any().and_then(|| async { Err(warp::reject::not_found()) });
@@ -141,4 +155,10 @@ fn make_routes(playground: bool, watch_tx: topology::WatchRx) -> BoxedFilter<(im
                 .allow_methods(vec!["POST", "GET"]),
         )
         .boxed()
+}
+
+fn with_shared(
+    shared: Arc<AtomicBool>,
+) -> impl Filter<Extract = (Arc<AtomicBool>,), Error = Infallible> + Clone {
+    warp::any().map(move || shared.clone())
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -69,7 +69,7 @@ fn make_routes(
 
     // Health.
     let health = warp::path("health")
-        .and(with_shared(running.clone()))
+        .and(with_shared(running))
         .and_then(handler::health);
 
     // 404.
@@ -160,5 +160,5 @@ fn make_routes(
 fn with_shared(
     shared: Arc<AtomicBool>,
 ) -> impl Filter<Extract = (Arc<AtomicBool>,), Error = Infallible> + Clone {
-    warp::any().map(move || shared.clone())
+    warp::any().map(move || Arc::<AtomicBool>::clone(&shared))
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    num::NonZeroUsize,
-    path::PathBuf,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::{collections::HashMap, num::NonZeroUsize, path::PathBuf};
 
 use futures::StreamExt;
 use once_cell::race::OnceNonZeroUsize;
@@ -253,6 +248,7 @@ impl Application {
             #[cfg(feature = "api")]
             // Assigned to prevent the API terminating when falling out of scope.
             let api_server = if api_config.enabled {
+                use std::sync::{Arc, atomic::AtomicBool};
                 emit!(&ApiStarted {
                     addr: api_config.address.unwrap(),
                     playground: api_config.playground

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, num::NonZeroUsize, path::PathBuf};
+use std::{
+    collections::HashMap,
+    num::NonZeroUsize,
+    path::PathBuf,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 use futures::StreamExt;
 use once_cell::race::OnceNonZeroUsize;
@@ -253,7 +258,7 @@ impl Application {
                     playground: api_config.playground
                 });
 
-                Some(api::Server::start(topology.config(), topology.watch(), topology.running.clone()))
+                Some(api::Server::start(topology.config(), topology.watch(), Arc::<AtomicBool>::clone(&topology.running)))
             } else {
                 info!(message="API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.");
                 None

--- a/src/app.rs
+++ b/src/app.rs
@@ -253,7 +253,7 @@ impl Application {
                     playground: api_config.playground
                 });
 
-                Some(api::Server::start(topology.config(), topology.watch()))
+                Some(api::Server::start(topology.config(), topology.watch(), topology.running.clone()))
             } else {
                 info!(message="API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.");
                 None

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 
 use futures::{future, Future, FutureExt};
@@ -37,6 +40,7 @@ pub struct RunningTopology {
     pub(crate) config: Config,
     abort_tx: mpsc::UnboundedSender<()>,
     watch: (WatchTx, WatchRx),
+    pub(crate) running: Arc<AtomicBool>,
 }
 
 impl RunningTopology {
@@ -51,6 +55,7 @@ impl RunningTopology {
             tasks: HashMap::new(),
             abort_tx,
             watch: watch::channel(HashMap::new()),
+            running: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -79,6 +84,8 @@ impl RunningTopology {
     /// dropped then everything from this RunningTopology instance is fully
     /// dropped.
     pub fn stop(self) -> impl Future<Output = ()> {
+        // Update the API's health endpoint to signal shutdown
+        self.running.store(false, Ordering::Relaxed);
         // Create handy handles collections of all tasks for the subsequent
         // operations.
         let mut wait_handles = Vec::new();

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -594,12 +594,12 @@ async fn health_503_during_shutdown() {
             [api]
               enabled = true
               address = "127.0.0.1:8686"
-                    
+
             [sources.source]
               type = "demo_logs"
               format = "json"
               interval = 0
-            
+
             [sinks.sink]
               type = "blackhole"
               inputs = ["source"]

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -15,6 +15,7 @@ use nix::{
     sys::signal::{kill, Signal},
     unistd::Pid,
 };
+use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
 use vector::test_util::{next_addr, temp_file};
 
@@ -578,4 +579,56 @@ fn timely_reload_shutdown() {
             "Vector exited too early on reload."
         );
     });
+}
+
+#[tokio::test]
+async fn health_503_during_shutdown() {
+    use std::process::Command;
+
+    let mut cmd = Command::cargo_bin("vector").unwrap();
+
+    cmd.arg("--quiet")
+        .arg("-c")
+        .arg(create_file(
+            r#"
+            [api]
+              enabled = true
+              address = "127.0.0.1:8686"
+                    
+            [sources.source]
+              type = "demo_logs"
+              format = "json"
+              interval = 0
+            
+            [sinks.sink]
+              type = "blackhole"
+              inputs = ["source"]
+              rate = 1
+            "#,
+        ))
+        .env("VECTOR_DATA_DIR", create_directory());
+
+    let mut vector = cmd
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Give vector time to start.
+    sleep(STARTUP_TIME);
+
+    // Check if vector is still running
+    assert_eq!(None, vector.try_wait().unwrap(), "Vector exited too early.");
+
+    // Signal shutdown
+    kill(Pid::from_raw(vector.id() as i32), Signal::SIGTERM).unwrap();
+
+    // Give vector time to begin shutting down.
+    sleep(Duration::from_secs(1));
+
+    let response = reqwest::get("http://127.0.0.1:8686/health").await.unwrap();
+
+    assert_eq!(response.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+
+    kill(Pid::from_raw(vector.id() as i32), Signal::SIGKILL).unwrap();
 }


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Adds an Arc wrapped AtomicBool for the `stop` function from `RunningTopology` to use. The health handler references this new field to determine if a response is 200 or 503.

Initial work from health check RFC before larger task described in https://github.com/vectordotdev/vector/issues/10555

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
