### PR TITLE
chore(internal docs): Clarify `component_discarded_events_total`

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -231,8 +231,14 @@ implement since errors are specific to the component.
 * Metrics
   * MUST increment the `component_errors_total` counter by 1 with the defined properties
     as metric tags.
-  * MUST increment the `component_discarded_events_total` counter by the number of Vector
-    events discarded if the error resulted in discarding (dropping) events.
+  * MUST increment the `component_discarded_events_total` counter by the number
+    of Vector events discarded if the error resulted in discarding (dropping)
+    acknowledged events. For sources, only increment this metric if incoming
+    events were consumed (and acknowledged if applicable) and discarded. The
+    metric MUST not include events that will be re-ingested. For sinks, this
+    means only incrementing this metric if the error resulted in the sink
+    dropping the events, and thus acknowledging them. Retried events MUST not be
+    included in the metric.
 * Logs
   * MUST log a message at the `error` level with the defined properties
     as key-value pairs. It SHOULD be rate limited to 10 seconds.


### PR DESCRIPTION
This metric should not be incremented for events that will be
reprocessed by a source or sink, only if the events were discarded in
a way that they would be lost.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
