### PR TITLE
chore(api): Fix flakey vector tap integration test

### DIFF
--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -626,13 +626,10 @@ mod tests {
                             .any(|log| log.get_message().unwrap_or_default() == "test2");
                     }
                 }
-                None => {
-                    panic!("Failed to tap multiple outputs, not all expected events were found")
-                }
+                None => break,
             }
         }
 
-        assert!(default_output_found);
-        assert!(dropped_output_found);
+        assert!(default_output_found && dropped_output_found);
     }
 }

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -595,22 +595,44 @@ mod tests {
 
         let (topology, _crash) = start_topology(config.build().unwrap(), false).await;
 
-        let transform_tap_all_outputs_stream =
+        let mut transform_tap_all_outputs_stream =
             create_events_stream(topology.watch(), vec!["transform*".to_string()], 500, 100);
 
-        let transform_tap_events: Vec<_> = transform_tap_all_outputs_stream.take(2).collect().await;
+        let transform_tap_notifications = transform_tap_all_outputs_stream.next().await.unwrap();
         assert_eq!(
-            assert_notification(transform_tap_events[0][0].clone()),
+            assert_notification(transform_tap_notifications[0].clone()),
             EventNotification::new("transform*".to_string(), EventNotificationType::Matched)
         );
 
-        assert!(transform_tap_events[1]
-            .iter()
-            .map(|payload| assert_log(payload.clone()))
-            .any(|log| log.get_message().unwrap_or_default() == "test1"));
-        assert!(transform_tap_events[1]
-            .iter()
-            .map(|payload| assert_log(payload.clone()))
-            .any(|log| log.get_message().unwrap_or_default() == "test2"));
+        let mut default_output_found = false;
+        let mut dropped_output_found = false;
+        for _ in 0..2 {
+            if default_output_found && dropped_output_found {
+                break;
+            }
+
+            match transform_tap_all_outputs_stream.next().await {
+                Some(tap_events) => {
+                    if !default_output_found {
+                        default_output_found = tap_events
+                            .iter()
+                            .map(|payload| assert_log(payload.clone()))
+                            .any(|log| log.get_message().unwrap_or_default() == "test1");
+                    }
+                    if !dropped_output_found {
+                        dropped_output_found = tap_events
+                            .iter()
+                            .map(|payload| assert_log(payload.clone()))
+                            .any(|log| log.get_message().unwrap_or_default() == "test2");
+                    }
+                }
+                None => {
+                    panic!("Failed to tap multiple outputs, not all expected events were found")
+                }
+            }
+        }
+
+        assert!(default_output_found);
+        assert!(dropped_output_found);
     }
 }


### PR DESCRIPTION
This PR fixes a still-flakey `vector tap` integration test for multiple outputs which I'd seen fail in unrelated PRs (e.g. [here](https://github.com/vectordotdev/vector/runs/5008576376?check_suite_focus=true#step:8:3181)). 

Based on the error message in those failures, I think this test currently fails because of the following scenario and is a timing issue.
- One of the `demo_log` sources, but not both, sends an event which makes its way to the task in `create_events_stream`. It's stored away.
- Before the other event can arrive, the `interval` in the `create_events_stream` task ticks and the single stored event is sent into the stream.
- We expect this next payload to include both events, so our assertion fails.

This change accounts for the fact that we might see a third tap payload come through with the remaining event. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
