### PR TITLE
chore(codecs): Use `enum` delegation when encoding rather than dynamic dispatch

### DIFF
--- a/src/codecs/encoding/format/json.rs
+++ b/src/codecs/encoding/format/json.rs
@@ -2,7 +2,6 @@ use bytes::{BufMut, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Encoder;
 
-use super::{BoxedSerializer, SerializerConfig};
 use crate::event::Event;
 
 /// Config used to build a `JsonSerializer`.
@@ -14,12 +13,10 @@ impl JsonSerializerConfig {
     pub const fn new() -> Self {
         Self
     }
-}
 
-#[typetag::serde(name = "json")]
-impl SerializerConfig for JsonSerializerConfig {
-    fn build(&self) -> crate::Result<BoxedSerializer> {
-        Ok(Box::new(JsonSerializer))
+    /// Build the `JsonSerializer` from this configuration.
+    pub const fn build(&self) -> JsonSerializer {
+        JsonSerializer
     }
 }
 

--- a/src/codecs/encoding/format/raw_message.rs
+++ b/src/codecs/encoding/format/raw_message.rs
@@ -1,4 +1,3 @@
-use super::{BoxedSerializer, SerializerConfig};
 use crate::{config::log_schema, event::Event};
 
 use bytes::{BufMut, BytesMut};
@@ -14,12 +13,10 @@ impl RawMessageSerializerConfig {
     pub const fn new() -> Self {
         Self
     }
-}
 
-#[typetag::serde(name = "text")]
-impl SerializerConfig for RawMessageSerializerConfig {
-    fn build(&self) -> crate::Result<BoxedSerializer> {
-        Ok(Box::new(RawMessageSerializer))
+    /// Build the `RawMessageSerializer` from this configuration.
+    pub const fn build(&self) -> RawMessageSerializer {
+        RawMessageSerializer
     }
 }
 

--- a/src/codecs/encoding/framing/character_delimited.rs
+++ b/src/codecs/encoding/framing/character_delimited.rs
@@ -2,7 +2,7 @@ use bytes::{BufMut, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Encoder;
 
-use super::{BoxedFramer, BoxedFramingError, FramingConfig};
+use super::BoxedFramingError;
 
 /// Config used to build a `CharacterDelimitedEncoder`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -10,20 +10,18 @@ pub struct CharacterDelimitedEncoderConfig {
     character_delimited: CharacterDelimitedEncoderOptions,
 }
 
+impl CharacterDelimitedEncoderConfig {
+    /// Build the `CharacterDelimitedEncoder` from this configuration.
+    pub const fn build(&self) -> CharacterDelimitedEncoder {
+        CharacterDelimitedEncoder::new(self.character_delimited.delimiter)
+    }
+}
+
 /// Options for building a `CharacterDelimitedEncoder`.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct CharacterDelimitedEncoderOptions {
     /// The character that delimits byte sequences.
     delimiter: u8,
-}
-
-#[typetag::serde(name = "character_delimited")]
-impl FramingConfig for CharacterDelimitedEncoderConfig {
-    fn build(&self) -> crate::Result<BoxedFramer> {
-        Ok(Box::new(CharacterDelimitedEncoder::new(
-            self.character_delimited.delimiter,
-        )))
-    }
 }
 
 /// An encoder for handling bytes that are delimited by (a) chosen character(s).

--- a/src/codecs/encoding/framing/character_delimited.rs
+++ b/src/codecs/encoding/framing/character_delimited.rs
@@ -7,7 +7,8 @@ use super::BoxedFramingError;
 /// Config used to build a `CharacterDelimitedEncoder`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CharacterDelimitedEncoderConfig {
-    character_delimited: CharacterDelimitedEncoderOptions,
+    /// Options for the character delimited encoder.
+    pub character_delimited: CharacterDelimitedEncoderOptions,
 }
 
 impl CharacterDelimitedEncoderConfig {

--- a/src/codecs/encoding/framing/mod.rs
+++ b/src/codecs/encoding/framing/mod.rs
@@ -6,7 +6,9 @@
 mod character_delimited;
 mod newline_delimited;
 
-pub use character_delimited::{CharacterDelimitedEncoder, CharacterDelimitedEncoderConfig};
+pub use character_delimited::{
+    CharacterDelimitedEncoder, CharacterDelimitedEncoderConfig, CharacterDelimitedEncoderOptions,
+};
 pub use newline_delimited::{NewlineDelimitedEncoder, NewlineDelimitedEncoderConfig};
 
 use dyn_clone::DynClone;

--- a/src/codecs/encoding/framing/newline_delimited.rs
+++ b/src/codecs/encoding/framing/newline_delimited.rs
@@ -2,7 +2,7 @@ use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Encoder;
 
-use super::{BoxedFramer, BoxedFramingError, CharacterDelimitedEncoder, FramingConfig};
+use super::{BoxedFramingError, CharacterDelimitedEncoder};
 
 /// Config used to build a `NewlineDelimitedEncoder`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
@@ -13,12 +13,10 @@ impl NewlineDelimitedEncoderConfig {
     pub fn new() -> Self {
         Default::default()
     }
-}
 
-#[typetag::serde(name = "newline_delimited")]
-impl FramingConfig for NewlineDelimitedEncoderConfig {
-    fn build(&self) -> crate::Result<BoxedFramer> {
-        Ok(Box::new(NewlineDelimitedEncoder::new()))
+    /// Build the `NewlineDelimitedEncoder` from this configuration.
+    pub const fn build(&self) -> NewlineDelimitedEncoder {
+        NewlineDelimitedEncoder::new()
     }
 }
 

--- a/src/codecs/encoding/mod.rs
+++ b/src/codecs/encoding/mod.rs
@@ -6,11 +6,11 @@ pub mod framing;
 
 pub use format::{
     BoxedSerializer, JsonSerializer, JsonSerializerConfig, RawMessageSerializer,
-    RawMessageSerializerConfig, Serializer, SerializerConfig,
+    RawMessageSerializerConfig,
 };
 pub use framing::{
     BoxedFramer, BoxedFramingError, CharacterDelimitedEncoder, CharacterDelimitedEncoderConfig,
-    Framer, FramingConfig, NewlineDelimitedEncoder, NewlineDelimitedEncoderConfig,
+    NewlineDelimitedEncoder, NewlineDelimitedEncoderConfig,
 };
 
 use crate::{
@@ -47,18 +47,101 @@ impl From<std::io::Error> for Error {
     }
 }
 
+/// Configuration for building a `Framer`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "method")]
+pub enum FramingConfig {
+    /// Configures the `CharacterDelimitedEncoder`.
+    CharacterDelimited(CharacterDelimitedEncoderConfig),
+    /// Configures the `NewlineDelimitedEncoder`.
+    NewlineDelimited(NewlineDelimitedEncoderConfig),
+}
+
+impl FramingConfig {
+    /// Build the `Framer` from this configuration.
+    pub const fn build(&self) -> Framer {
+        match self {
+            FramingConfig::CharacterDelimited(config) => Framer::CharacterDelimited(config.build()),
+            FramingConfig::NewlineDelimited(config) => Framer::NewlineDelimited(config.build()),
+        }
+    }
+}
+
+/// Produce a byte stream from byte frames.
+#[derive(Debug, Clone)]
+pub enum Framer {
+    /// Uses a `CharacterDelimitedEncoder` for framing.
+    CharacterDelimited(CharacterDelimitedEncoder),
+    /// Uses a `NewlineDelimitedEncoder` for framing.
+    NewlineDelimited(NewlineDelimitedEncoder),
+    /// Uses an opaque `Encoder` implementation for framing.
+    Boxed(BoxedFramer),
+}
+
+impl tokio_util::codec::Encoder<()> for Framer {
+    type Error = BoxedFramingError;
+
+    fn encode(&mut self, _: (), dst: &mut BytesMut) -> Result<(), Self::Error> {
+        match self {
+            Framer::CharacterDelimited(framer) => framer.encode((), dst),
+            Framer::NewlineDelimited(framer) => framer.encode((), dst),
+            Framer::Boxed(framer) => framer.encode((), dst),
+        }
+    }
+}
+
+/// Configuration for building a `Serializer`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "codec")]
+pub enum SerializerConfig {
+    /// Configures the `JsonSerializer`.
+    Json(JsonSerializerConfig),
+    /// Configures the `RawMessageSerializer`.
+    RawMessage(RawMessageSerializerConfig),
+}
+
+impl SerializerConfig {
+    /// Build the `Serializer` from this configuration.
+    pub const fn build(&self) -> Serializer {
+        match self {
+            SerializerConfig::Json(config) => Serializer::Json(config.build()),
+            SerializerConfig::RawMessage(config) => Serializer::RawMessage(config.build()),
+        }
+    }
+}
+
+/// Serialize structured events as bytes.
+#[derive(Debug, Clone)]
+pub enum Serializer {
+    /// Uses a `JsonSerializer` for deserialization.
+    Json(JsonSerializer),
+    /// Uses a `RawMessageSerializer` for deserialization.
+    RawMessage(RawMessageSerializer),
+}
+
+impl tokio_util::codec::Encoder<Event> for Serializer {
+    type Error = crate::Error;
+
+    fn encode(&mut self, item: Event, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        match self {
+            Serializer::Json(serializer) => serializer.encode(item, dst),
+            Serializer::RawMessage(serializer) => serializer.encode(item, dst),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 /// An encoder that can encode structured events into byte frames.
 pub struct Encoder {
-    framer: BoxedFramer,
-    serializer: BoxedSerializer,
+    framer: Framer,
+    serializer: Serializer,
 }
 
 impl Default for Encoder {
     fn default() -> Self {
         Self {
-            framer: Box::new(NewlineDelimitedEncoder::new()),
-            serializer: Box::new(RawMessageSerializer::new()),
+            framer: Framer::NewlineDelimited(NewlineDelimitedEncoder::new()),
+            serializer: Serializer::RawMessage(RawMessageSerializer::new()),
         }
     }
 }
@@ -67,7 +150,7 @@ impl Encoder {
     /// Creates a new `Encoder` with the specified `Serializer` to produce bytes
     /// from a structured event, and the `Framer` to wrap these into a byte
     /// frame.
-    pub fn new(framer: BoxedFramer, serializer: BoxedSerializer) -> Self {
+    pub const fn new(framer: Framer, serializer: Serializer) -> Self {
         Self { framer, serializer }
     }
 }
@@ -104,27 +187,27 @@ impl tokio_util::codec::Encoder<Event> for Encoder {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EncodingConfig {
     /// The framing config.
-    framing: Box<dyn FramingConfig>,
+    framing: FramingConfig,
     /// The encoding config.
-    encoding: Box<dyn SerializerConfig>,
+    encoding: SerializerConfig,
 }
 
 impl EncodingConfig {
     /// Creates a new `EncodingConfig` with the provided `FramingConfig` and
     /// `SerializerConfig`.
-    pub fn new(framing: Box<dyn FramingConfig>, encoding: Box<dyn SerializerConfig>) -> Self {
+    pub const fn new(framing: FramingConfig, encoding: SerializerConfig) -> Self {
         Self { framing, encoding }
     }
 
     /// Builds an `Encoder` from the provided configuration.
-    pub fn build(&self) -> crate::Result<Encoder> {
+    pub const fn build(&self) -> Encoder {
         // Build the framer.
-        let framer: BoxedFramer = self.framing.build()?;
+        let framer = self.framing.build();
 
         // Build the serializer.
-        let serializer: BoxedSerializer = self.encoding.build()?;
+        let serializer = self.encoding.build();
 
-        Ok(Encoder::new(framer, serializer))
+        Encoder::new(framer, serializer)
     }
 }
 
@@ -193,8 +276,8 @@ mod tests {
     #[tokio::test]
     async fn test_encode_events_sink_empty() {
         let encoder = Encoder::new(
-            Box::new(ParenEncoder::new()),
-            Box::new(RawMessageSerializer::new()),
+            Framer::Boxed(Box::new(ParenEncoder::new())),
+            Serializer::RawMessage(RawMessageSerializer::new()),
         );
         let source = futures::stream::iter(vec![
             Event::from("foo"),
@@ -212,8 +295,8 @@ mod tests {
     #[tokio::test]
     async fn test_encode_events_sink_non_empty() {
         let encoder = Encoder::new(
-            Box::new(ParenEncoder::new()),
-            Box::new(RawMessageSerializer::new()),
+            Framer::Boxed(Box::new(ParenEncoder::new())),
+            Serializer::RawMessage(RawMessageSerializer::new()),
         );
         let source = futures::stream::iter(vec![
             Event::from("bar"),
@@ -231,8 +314,8 @@ mod tests {
     #[tokio::test]
     async fn test_encode_events_sink_empty_handle_framing_error() {
         let encoder = Encoder::new(
-            Box::new(ErrorNthEncoder::new(ParenEncoder::new(), 1)),
-            Box::new(RawMessageSerializer::new()),
+            Framer::Boxed(Box::new(ErrorNthEncoder::new(ParenEncoder::new(), 1))),
+            Serializer::RawMessage(RawMessageSerializer::new()),
         );
         let source = futures::stream::iter(vec![
             Event::from("foo"),
@@ -251,8 +334,8 @@ mod tests {
     #[tokio::test]
     async fn test_encode_events_sink_non_empty_handle_framing_error() {
         let encoder = Encoder::new(
-            Box::new(ErrorNthEncoder::new(ParenEncoder::new(), 1)),
-            Box::new(RawMessageSerializer::new()),
+            Framer::Boxed(Box::new(ErrorNthEncoder::new(ParenEncoder::new(), 1))),
+            Serializer::RawMessage(RawMessageSerializer::new()),
         );
         let source = futures::stream::iter(vec![
             Event::from("bar"),

--- a/src/codecs/encoding/mod.rs
+++ b/src/codecs/encoding/mod.rs
@@ -49,7 +49,7 @@ impl From<std::io::Error> for Error {
 
 /// Configuration for building a `Framer`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "method")]
+#[serde(tag = "method", rename_all = "snake_case")]
 pub enum FramingConfig {
     /// Configures the `CharacterDelimitedEncoder`.
     CharacterDelimited(CharacterDelimitedEncoderConfig),
@@ -92,7 +92,7 @@ impl tokio_util::codec::Encoder<()> for Framer {
 
 /// Configuration for building a `Serializer`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "codec")]
+#[serde(tag = "codec", rename_all = "snake_case")]
 pub enum SerializerConfig {
     /// Configures the `JsonSerializer`.
     Json(JsonSerializerConfig),

--- a/src/sinks/util/encoding/adapter.rs
+++ b/src/sinks/util/encoding/adapter.rs
@@ -125,17 +125,17 @@ where
     }
 
     /// Build the framer and serializer for this configuration.
-    pub fn encoding(&self) -> (Option<Framer>, Serializer) {
+    pub fn encoding(self) -> (Option<Framer>, Serializer) {
         let (framer, serializer) = match self {
             Self::Encoding(config) => {
-                let framer = config.framing.as_ref().map(FramingConfig::build);
+                let framer = config.framing.clone().map(FramingConfig::build);
                 let serializer = config.encoding.encoding.build();
 
                 (framer, serializer)
             }
             Self::LegacyEncodingConfig(config) => {
                 let migration = Migrator::migrate(config.encoding.codec());
-                let framer = migration.0.as_ref().map(FramingConfig::build);
+                let framer = migration.0.map(FramingConfig::build);
                 let serializer = migration.1.build();
 
                 (framer, serializer)
@@ -281,7 +281,7 @@ mod tests {
             EncodingConfigAdapter::LegacyEncodingConfig(_) => panic!(),
         };
 
-        assert!(matches!(encoding, SerializerConfig::RawMessage(_)));
+        assert!(matches!(encoding, SerializerConfig::RawMessage));
     }
 
     #[test]

--- a/src/sinks/util/encoding/adapter.rs
+++ b/src/sinks/util/encoding/adapter.rs
@@ -125,7 +125,7 @@ where
     }
 
     /// Build the framer and serializer for this configuration.
-    pub fn encoding(&self) -> crate::Result<(Option<Framer>, Serializer)> {
+    pub fn encoding(&self) -> (Option<Framer>, Serializer) {
         let (framer, serializer) = match self {
             Self::Encoding(config) => {
                 let framer = config.framing.as_ref().map(FramingConfig::build);
@@ -142,7 +142,7 @@ where
             }
         };
 
-        Ok((framer, serializer))
+        (framer, serializer)
     }
 }
 

--- a/src/sinks/util/encoding/adapter.rs
+++ b/src/sinks/util/encoding/adapter.rs
@@ -10,18 +10,18 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 /// Trait used to migrate from a sink-specific `Codec` enum to the new
-/// `Box<dyn FramingConfig>`/`Box<dyn SerializerConfig>` encoding configuration.
+/// `FramingConfig`/`SerializerConfig` encoding configuration.
 pub trait EncodingConfigMigrator {
     /// The sink-specific encoding type to be migrated.
     type Codec;
 
     /// Returns the framing/serializer configuration that is functionally equivalent to the given
     /// legacy codec.
-    fn migrate(codec: &Self::Codec) -> (Option<Box<dyn FramingConfig>>, Box<dyn SerializerConfig>);
+    fn migrate(codec: &Self::Codec) -> (Option<FramingConfig>, SerializerConfig);
 }
 
 /// This adapter serves to migrate sinks from the old sink-specific `EncodingConfig<T>` to the new
-/// `Box<dyn FramingConfig>`/`Box<dyn SerializerConfig>` encoding configuration - while keeping
+/// `FramingConfig`/`SerializerConfig` encoding configuration - while keeping
 /// backwards-compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -46,10 +46,7 @@ where
         + Clone,
 {
     /// Create a new encoding configuration.
-    pub fn new(
-        framing: Option<Box<dyn FramingConfig>>,
-        encoding: Box<dyn SerializerConfig>,
-    ) -> Self {
+    pub fn new(framing: Option<FramingConfig>, encoding: SerializerConfig) -> Self {
         Self::Encoding(EncodingConfig {
             framing,
             encoding: EncodingWithTransformationConfig {
@@ -128,24 +125,18 @@ where
     }
 
     /// Build the framer and serializer for this configuration.
-    pub fn encoding(&self) -> crate::Result<(Option<Box<dyn Framer>>, Box<dyn Serializer>)> {
+    pub fn encoding(&self) -> crate::Result<(Option<Framer>, Serializer)> {
         let (framer, serializer) = match self {
             Self::Encoding(config) => {
-                let framer = match &config.framing {
-                    Some(framing) => Some(framing.build()?),
-                    None => None,
-                };
-                let serializer = config.encoding.encoding.build()?;
+                let framer = config.framing.as_ref().map(FramingConfig::build);
+                let serializer = config.encoding.encoding.build();
 
                 (framer, serializer)
             }
             Self::LegacyEncodingConfig(config) => {
                 let migration = Migrator::migrate(config.encoding.codec());
-                let framer = match migration.0 {
-                    Some(framing) => Some(framing.build()?),
-                    None => None,
-                };
-                let serializer = migration.1.build()?;
+                let framer = migration.0.as_ref().map(FramingConfig::build);
+                let serializer = migration.1.build();
 
                 (framer, serializer)
             }
@@ -164,14 +155,14 @@ pub struct LegacyEncodingConfigWrapper<EncodingConfig, Migrator> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EncodingConfig {
-    framing: Option<Box<dyn FramingConfig>>,
+    framing: Option<FramingConfig>,
     encoding: EncodingWithTransformationConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EncodingWithTransformationConfig {
     #[serde(flatten)]
-    encoding: Box<dyn SerializerConfig>,
+    encoding: SerializerConfig,
     #[serde(flatten)]
     filter: Option<OnlyOrExceptFieldsConfig>,
     timestamp_format: Option<TimestampFormat>,
@@ -239,7 +230,7 @@ mod tests {
         let string = r#"
             {
                 "encoding": {
-                    "codec": "text",
+                    "codec": "raw_message",
                     "timestamp_format": "unix",
                     "except_fields": ["ignore_me"]
                 }
@@ -273,14 +264,12 @@ mod tests {
         impl EncodingConfigMigrator for Migrator {
             type Codec = LegacyEncoding;
 
-            fn migrate(
-                _: &Self::Codec,
-            ) -> (Option<Box<dyn FramingConfig>>, Box<dyn SerializerConfig>) {
+            fn migrate(_: &Self::Codec) -> (Option<FramingConfig>, SerializerConfig) {
                 panic!()
             }
         }
 
-        let string = r#"{ "encoding": { "codec": "text" } }"#;
+        let string = r#"{ "encoding": { "codec": "raw_message" } }"#;
 
         let config = serde_json::from_str::<
             EncodingConfigAdapter<crate::sinks::util::EncodingConfig<LegacyEncoding>, Migrator>,
@@ -292,7 +281,7 @@ mod tests {
             EncodingConfigAdapter::LegacyEncodingConfig(_) => panic!(),
         };
 
-        assert_eq!(encoding.typetag_name(), "text");
+        assert!(matches!(encoding, SerializerConfig::RawMessage(_)));
     }
 
     #[test]
@@ -309,9 +298,7 @@ mod tests {
         impl EncodingConfigMigrator for Migrator {
             type Codec = LegacyEncoding;
 
-            fn migrate(
-                _: &Self::Codec,
-            ) -> (Option<Box<dyn FramingConfig>>, Box<dyn SerializerConfig>) {
+            fn migrate(_: &Self::Codec) -> (Option<FramingConfig>, SerializerConfig) {
                 panic!()
             }
         }


### PR DESCRIPTION
This is a prerequisite for inferring the HTTP content type from the encoding configuration.