### PR TITLE
chore: Remove the Sink impl from Fanout

### DIFF
--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -78,9 +78,9 @@ impl Fanout {
 
             {
                 let mut jobs = FuturesUnordered::new();
-                let mut clone_army: Vec<Vec<Event>> =
-                    Vec::with_capacity(self.sinks.iter().filter(|x| x.1.is_some()).count());
-                for _ in 0..(self.sinks.len() - 1) {
+                let count = self.sinks.iter().filter(|x| x.1.is_some()).count();
+                let mut clone_army: Vec<Vec<Event>> = Vec::with_capacity(count);
+                for _ in 0..(count - 1) {
                     clone_army.push(events.clone());
                 }
                 clone_army.push(events);

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -74,11 +74,12 @@ impl Fanout {
                 sink.flush().await?;
             }
         } else {
-            let mut faulty_sinks = Vec::with_capacity(0);
+            let mut faulty_sinks = Vec::new();
 
             {
                 let mut jobs = FuturesUnordered::new();
-                let mut clone_army: Vec<Vec<Event>> = Vec::with_capacity(self.sinks.len());
+                let mut clone_army: Vec<Vec<Event>> =
+                    Vec::with_capacity(self.sinks.iter().filter(|x| x.1.is_some()).count());
                 for _ in 0..(self.sinks.len() - 1) {
                     clone_army.push(events.clone());
                 }

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -299,7 +299,6 @@ mod tests {
     use crate::api::schema::events::{create_events_stream, log, metric};
     use crate::config::Config;
     use crate::transforms::log_to_metric::{GaugeConfig, LogToMetricConfig, MetricConfig};
-    use futures::SinkExt;
     use tokio::sync::watch;
 
     use super::*;
@@ -382,8 +381,10 @@ mod tests {
             MetricValue::Counter { value: 1.0 },
         ));
 
-        let _ = fanout.send(metric_event).await.unwrap();
-        let _ = fanout.send(log_event).await.unwrap();
+        let _ = fanout
+            .send_all(vec![metric_event, log_event])
+            .await
+            .unwrap();
 
         // 3rd payload should be the metric event
         assert!(matches!(

--- a/src/topology/test/backpressure.rs
+++ b/src/topology/test/backpressure.rs
@@ -50,7 +50,9 @@ async fn serial_backpressure() {
 
     let sourced_events = source_counter.load(Ordering::Acquire);
 
-    assert_eq!(sourced_events, expected_sourced_events);
+    assert!(
+        sourced_events >= expected_sourced_events && sourced_events < expected_sourced_events * 2
+    );
 }
 
 /// Connects a single source to two sinks and makes sure that the source is only able
@@ -96,7 +98,9 @@ async fn default_fan_out() {
 
     let sourced_events = source_counter.load(Ordering::Relaxed);
 
-    assert_eq!(sourced_events, expected_sourced_events);
+    assert!(
+        sourced_events >= expected_sourced_events && sourced_events < expected_sourced_events * 2
+    );
 }
 
 /// Connects a single source to two sinks. One of the sinks is configured to drop events that exceed
@@ -149,7 +153,9 @@ async fn buffer_drop_fan_out() {
 
     let sourced_events = source_counter.load(Ordering::Relaxed);
 
-    assert_eq!(sourced_events, expected_sourced_events);
+    assert!(
+        sourced_events >= expected_sourced_events && sourced_events < expected_sourced_events * 2
+    );
 }
 
 /// Connects 2 sources to a single sink, and asserts that the sum of the events produced
@@ -196,7 +202,10 @@ async fn multiple_inputs_backpressure() {
     let sourced_events_2 = source_counter_2.load(Ordering::Relaxed);
     let sourced_events_sum = sourced_events_1 + sourced_events_2;
 
-    assert_eq!(sourced_events_sum, expected_sourced_events);
+    assert!(
+        sourced_events_sum >= expected_sourced_events
+            && sourced_events_sum < expected_sourced_events * 2
+    );
 }
 
 mod test_sink {


### PR DESCRIPTION
This commit is kind of a peer to #11197, in pursuit of #10144. The basic idea
here is we want to get rid of the lock-step behavior that a strict Sink requires
for fanning out, because we know that we have issues with slow receivers. This
commit is not nearly so intrusive as #11197 but does allow for incremental
progress among the cohort of downstream sinks.

I still have some tests commented out. The error propagation story here is yet
to be worked on.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
