### PR TITLE
enhancement(transforms ansi_tripper): updates to comply with component spec

### DIFF
--- a/src/internal_events/ansi_stripper.rs
+++ b/src/internal_events/ansi_stripper.rs
@@ -2,60 +2,89 @@ use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
-pub struct AnsiStripperFieldMissing<'a> {
+pub struct AnsiStripperFieldMissingError<'a> {
     pub field: &'a str,
 }
 
-impl InternalEvent for AnsiStripperFieldMissing<'_> {
+impl InternalEvent for AnsiStripperFieldMissingError<'_> {
     fn emit_logs(&self) {
         debug!(
             message = "Field does not exist.",
             field = %self.field,
+            error = "Field does not exist.",
+            error_type = "field_missing",
+            stage = "processing",
             internal_log_rate_secs = 10
         );
     }
 
     fn emit_metrics(&self) {
+        counter!(
+            "component_errors_total", 1,
+            "error" => "Field does not exist.",
+            "error_type" => "field_missing",
+            "stage" => "processing",
+        );
+        // deprecated
         counter!("processing_errors_total", 1, "error_type" => "field_missing");
     }
 }
 
 #[derive(Debug)]
-pub struct AnsiStripperFieldInvalid<'a> {
+pub struct AnsiStripperFieldInvalidError<'a> {
     pub field: &'a str,
 }
 
-impl InternalEvent for AnsiStripperFieldInvalid<'_> {
+impl InternalEvent for AnsiStripperFieldInvalidError<'_> {
     fn emit_logs(&self) {
-        debug!(
+        error!(
             message = "Field value must be a string.",
             field = %self.field,
-            internal_log_rate_secs = 10
-        );
-    }
-
-    fn emit_metrics(&self) {
-        counter!("processing_errors_total", 1, "error_type" => "value_invalid");
-    }
-}
-
-#[derive(Debug)]
-pub struct AnsiStripperFailed<'a> {
-    pub field: &'a str,
-    pub error: std::io::Error,
-}
-
-impl InternalEvent for AnsiStripperFailed<'_> {
-    fn emit_logs(&self) {
-        debug!(
-            message = "Could not strip ANSI escape sequences.",
-            field = %self.field,
-            error = ?self.error,
+            error = "Field value must be a string.",
+            error_type = "value_invalid",
+            stage = "processing",
             internal_log_rate_secs = 10,
         );
     }
 
     fn emit_metrics(&self) {
+        counter!(
+            "component_errors_total", 1,
+            "error" => "Field value must be a string.",
+            "error_type" => "value_invalid",
+            "stage" => "processing",
+        );
+        // deprecated
+        counter!("processing_errors_total", 1, "error_type" => "value_invalid");
+    }
+}
+
+#[derive(Debug)]
+pub struct AnsiStripperError<'a> {
+    pub field: &'a str,
+    pub error: std::io::Error,
+}
+
+impl InternalEvent for AnsiStripperError<'_> {
+    fn emit_logs(&self) {
+        error!(
+            message = "Could not strip ANSI escape sequences.",
+            field = %self.field,
+            error = ?self.error,
+            error_type = "conversion_failed",
+            stage = "processing",
+            internal_log_rate_secs = 10,
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!(
+            "component_errors_total", 1,
+            "error" => self.error.to_string(),
+            "error_type" => "conversion_failed",
+            "stage" => "processing",
+        );
+        // deprecated
         counter!("processing_errors_total", 1);
     }
 }


### PR DESCRIPTION
Rename all existing errors to end with `Error`

Refers https://github.com/vectordotdev/vector/issues/11217

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
