### PR TITLE
docs(external docs): fixed aggragator spelling

### DIFF
--- a/website/content/en/docs/setup/installation/package-managers/helm.md
+++ b/website/content/en/docs/setup/installation/package-managers/helm.md
@@ -69,7 +69,7 @@ To check available Helm chart configuration options:
 helm show values vector/vector
 ```
 
-The chart deploys an Aggragator by default, the full configuration can be found [here](https://github.com/vectordotdev/helm-charts/blob/develop/charts/vector/templates/configmap.yaml). For more information about configuration options, see the [Configuration] docs page.
+The chart deploys an Aggregator by default, the full configuration can be found [here](https://github.com/vectordotdev/helm-charts/blob/develop/charts/vector/templates/configmap.yaml). For more information about configuration options, see the [Configuration] docs page.
 
 ### Installing
 

--- a/website/content/en/docs/setup/installation/platforms/kubernetes.md
+++ b/website/content/en/docs/setup/installation/platforms/kubernetes.md
@@ -98,7 +98,7 @@ kubectl create namespace --dry-run=client -o yaml vector > namespace.yaml
 
 ##### Prepare your kustomization file
 
-This example configuration deploys Vector as an Aggragator, the full configuration can be found [here](https://github.com/vectordotdev/helm-charts/blob/develop/charts/vector/templates/configmap.yaml). For more information about configuration options, see the [Configuration] docs page.
+This example configuration deploys Vector as an Aggregator, the full configuration can be found [here](https://github.com/vectordotdev/helm-charts/blob/develop/charts/vector/templates/configmap.yaml). For more information about configuration options, see the [Configuration] docs page.
 
 ```shell
 cat <<-'KUSTOMIZATION' > kustomization.yaml


### PR DESCRIPTION
Aggregator was misspelled as aggragator in a couple of places.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

