### PR TITLE
chore(ci): fix markdownlint-cli to version 0.30.

### DIFF
--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -10,6 +10,11 @@ cd scripts
 bundle install
 cd ..
 
+# Currently fixing this to version 0.30 since version 0.31 has introduced
+# a change that means it only works with versions of node > 10.
+# https://github.com/igorshubovych/markdownlint-cli/issues/258
+# ubuntu 20.04 gives us version 10.19. We can revert once we update the
+# ci image to install a newer version of node.
 sudo npm -g install markdownlint-cli@0.30
 
 pip3 install jsonschema==3.2.0

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -10,7 +10,7 @@ cd scripts
 bundle install
 cd ..
 
-sudo npm -g install markdownlint-cli
+sudo npm -g install markdownlint-cli@0.30
 
 pip3 install jsonschema==3.2.0
 pip3 install remarshal==0.11.2


### PR DESCRIPTION
It looks like the latest version of `markdownlint` doesn't work with NodeJS version 10.19.0, which is the version provided by apt for ubuntu 20.04. - https://github.com/igorshubovych/markdownlint-cli/issues/258

This fixes the markdownlint-cli version to 0.30, which does work.

This should not be a long term solution!

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

