### PR TITLE
chore(core): Add a `EventCount` trait to bufferable types

### DIFF
--- a/lib/vector-buffers/benches/common.rs
+++ b/lib/vector-buffers/benches/common.rs
@@ -12,7 +12,7 @@ use vector_buffers::{
         builder::TopologyBuilder,
         channel::{BufferReceiver, BufferSender},
     },
-    BufferType,
+    BufferType, EventCount,
 };
 use vector_common::byte_size_of::ByteSizeOf;
 
@@ -34,6 +34,12 @@ impl<const N: usize> Message<N> {
 impl<const N: usize> ByteSizeOf for Message<N> {
     fn allocated_bytes(&self) -> usize {
         0
+    }
+}
+
+impl<const N: usize> EventCount for Message<N> {
+    fn event_count(&self) -> usize {
+        1
     }
 }
 

--- a/lib/vector-buffers/examples/buffer_perf.rs
+++ b/lib/vector-buffers/examples/buffer_perf.rs
@@ -22,7 +22,7 @@ use vector_buffers::{
         builder::TopologyBuilder,
         channel::{BufferReceiver, BufferSender},
     },
-    Acker, BufferType, Bufferable, WhenFull,
+    Acker, BufferType, Bufferable, EventCount, WhenFull,
 };
 use vector_common::byte_size_of::ByteSizeOf;
 
@@ -45,6 +45,12 @@ impl VariableMessage {
 impl ByteSizeOf for VariableMessage {
     fn allocated_bytes(&self) -> usize {
         self.payload.len()
+    }
+}
+
+impl EventCount for VariableMessage {
+    fn event_count(&self) -> usize {
+        1
     }
 }
 

--- a/lib/vector-buffers/src/disk_v2/tests/known_errors.rs
+++ b/lib/vector-buffers/src/disk_v2/tests/known_errors.rs
@@ -23,6 +23,7 @@ use crate::{
         ReaderError,
     },
     encoding::{AsMetadata, Encodable},
+    EventCount,
 };
 
 #[tokio::test]
@@ -722,6 +723,12 @@ async fn reader_throws_error_when_record_is_undecodable_via_metadata() {
     impl ByteSizeOf for ControllableRecord {
         fn allocated_bytes(&self) -> usize {
             0
+        }
+    }
+
+    impl EventCount for ControllableRecord {
+        fn event_count(&self) -> usize {
+            1
         }
     }
 

--- a/lib/vector-buffers/src/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/disk_v2/tests/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     buffer_usage_data::BufferUsageHandle,
     disk_v2::{Buffer, DiskBufferConfig, Reader, Writer},
     encoding::FixedEncodable,
-    Acker, Bufferable, WhenFull,
+    Acker, Bufferable, EventCount, WhenFull,
 };
 
 mod acknowledgements;
@@ -182,6 +182,12 @@ impl ByteSizeOf for SizedRecord {
     }
 }
 
+impl EventCount for SizedRecord {
+    fn event_count(&self) -> usize {
+        1
+    }
+}
+
 impl FixedEncodable for SizedRecord {
     type EncodeError = io::Error;
     type DecodeError = io::Error;
@@ -218,6 +224,12 @@ pub(crate) struct UndecodableRecord;
 impl ByteSizeOf for UndecodableRecord {
     fn allocated_bytes(&self) -> usize {
         0
+    }
+}
+
+impl EventCount for UndecodableRecord {
+    fn event_count(&self) -> usize {
+        1
     }
 }
 

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -72,12 +72,23 @@ impl Arbitrary for WhenFull {
 ///
 /// This supertrait serves as the base trait for any item that can be pushed into a buffer.
 pub trait Bufferable:
-    ByteSizeOf + Encodable + Debug + Send + Sync + Unpin + Sized + 'static
+    ByteSizeOf + EventCount + Encodable + Debug + Send + Sync + Unpin + Sized + 'static
 {
 }
 
 // Blanket implementation for anything that is already bufferable.
 impl<T> Bufferable for T where
-    T: ByteSizeOf + Encodable + Debug + Send + Sync + Unpin + Sized + 'static
+    T: ByteSizeOf + EventCount + Encodable + Debug + Send + Sync + Unpin + Sized + 'static
 {
+}
+
+pub trait EventCount {
+    fn event_count(&self) -> usize;
+}
+
+#[cfg(test)]
+impl EventCount for u64 {
+    fn event_count(&self) -> usize {
+        1
+    }
 }

--- a/lib/vector-buffers/src/test/common/message.rs
+++ b/lib/vector-buffers/src/test/common/message.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BufMut};
 use quickcheck::{Arbitrary, Gen};
 use vector_common::byte_size_of::ByteSizeOf;
 
-use crate::encoding::FixedEncodable;
+use crate::{encoding::FixedEncodable, EventCount};
 
 #[derive(Debug)]
 pub struct EncodeError;
@@ -42,6 +42,12 @@ impl Message {
 impl ByteSizeOf for Message {
     fn allocated_bytes(&self) -> usize {
         0
+    }
+}
+
+impl EventCount for Message {
+    fn event_count(&self) -> usize {
+        1
     }
 }
 

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use enumflags2::{bitflags, BitFlags, FromBitsError};
 use prost::Message;
 use snafu::Snafu;
-use vector_buffers::encoding::{AsMetadata, Encodable};
+use vector_buffers::{encoding::AsMetadata, encoding::Encodable, EventCount};
 use vector_common::EventDataEq;
 
 use crate::ByteSizeOf;
@@ -61,6 +61,12 @@ impl ByteSizeOf for Event {
             Event::Log(log_event) => log_event.allocated_bytes(),
             Event::Metric(metric_event) => metric_event.allocated_bytes(),
         }
+    }
+}
+
+impl EventCount for Event {
+    fn event_count(&self) -> usize {
+        1
     }
 }
 


### PR DESCRIPTION
This will be used by future changes to the disk buffer to deal with
event arrays, which may have more than one event per record.