### PR TITLE
fix(metrics): Fix conversion of distribution to aggregated histogram

### DIFF
--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -1237,18 +1237,19 @@ fn write_word(fmt: &mut Formatter<'_>, word: &str) -> Result<(), fmt::Error> {
     }
 }
 
-pub fn samples_to_buckets(samples: &[Sample], buckets: &[f64]) -> (Vec<Bucket>, u32, f64) {
+fn samples_to_buckets(samples: &[Sample], buckets: &[f64]) -> (Vec<Bucket>, u32, f64) {
     let mut counts = vec![0; buckets.len()];
     let mut sum = 0.0;
     let mut count = 0;
     for sample in samples {
-        buckets
+        if let Some((i, _)) = buckets
             .iter()
             .enumerate()
             .skip_while(|&(_, b)| *b < sample.value)
-            .for_each(|(i, _)| {
-                counts[i] += sample.rate;
-            });
+            .next()
+        {
+            counts[i] += sample.rate;
+        }
 
         sum += sample.value * f64::from(sample.rate);
         count += sample.rate;
@@ -1649,14 +1650,31 @@ mod test {
         assert_eq!(counter_value.distribution_to_sketch(), None);
 
         let distrib_value = MetricValue::Distribution {
-            samples: samples!(1.0 => 1),
+            samples: samples!(1.0 => 10, 2.0 => 5, 5.0 => 2),
             statistic: StatisticKind::Summary,
         };
-        let converted = distrib_value.distribution_to_agg_histogram(&[1.0]);
-        assert!(matches!(
+        let converted = distrib_value.distribution_to_agg_histogram(&[1.0, 5.0, 10.0]);
+        assert_eq!(
             converted,
-            Some(MetricValue::AggregatedHistogram { .. })
-        ));
+            Some(MetricValue::AggregatedHistogram {
+                buckets: vec![
+                    Bucket {
+                        upper_limit: 1.0,
+                        count: 10,
+                    },
+                    Bucket {
+                        upper_limit: 5.0,
+                        count: 7,
+                    },
+                    Bucket {
+                        upper_limit: 10.0,
+                        count: 0,
+                    },
+                ],
+                sum: 30.0,
+                count: 17,
+            })
+        );
 
         let distrib_value = MetricValue::Distribution {
             samples: samples!(1.0 => 1),

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -1237,7 +1237,7 @@ fn write_word(fmt: &mut Formatter<'_>, word: &str) -> Result<(), fmt::Error> {
     }
 }
 
-fn samples_to_buckets(samples: &[Sample], buckets: &[f64]) -> (Vec<Bucket>, u32, f64) {
+pub fn samples_to_buckets(samples: &[Sample], buckets: &[f64]) -> (Vec<Bucket>, u32, f64) {
     let mut counts = vec![0; buckets.len()];
     let mut sum = 0.0;
     let mut count = 0;

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -1242,12 +1242,7 @@ pub fn samples_to_buckets(samples: &[Sample], buckets: &[f64]) -> (Vec<Bucket>, 
     let mut sum = 0.0;
     let mut count = 0;
     for sample in samples {
-        if let Some((i, _)) = buckets
-            .iter()
-            .enumerate()
-            .skip_while(|&(_, b)| *b < sample.value)
-            .next()
-        {
+        if let Some((i, _)) = buckets.iter().enumerate().find(|&(_, b)| *b < sample.value) {
             counts[i] += sample.rate;
         }
 

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -1242,7 +1242,11 @@ pub fn samples_to_buckets(samples: &[Sample], buckets: &[f64]) -> (Vec<Bucket>, 
     let mut sum = 0.0;
     let mut count = 0;
     for sample in samples {
-        if let Some((i, _)) = buckets.iter().enumerate().find(|&(_, b)| *b < sample.value) {
+        if let Some((i, _)) = buckets
+            .iter()
+            .enumerate()
+            .find(|&(_, b)| *b >= sample.value)
+        {
             counts[i] += sample.rate;
         }
 

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -3,11 +3,11 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use chrono::Utc;
 use indexmap::map::IndexMap;
 use prometheus_parser::{proto, METRIC_NAME_LABEL};
-use vector_core::event::metric::{samples_to_buckets, MetricSketch, Quantile};
+use vector_core::event::metric::{MetricSketch, Quantile};
 
 use crate::{
     event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
-    sinks::util::{encode_namespace, statistic::DistributionStatistic},
+    sinks::util::encode_namespace,
 };
 
 pub(super) trait MetricCollector {


### PR DESCRIPTION
In https://github.com/vectordotdev/vector/pull/10741 we introduced logic
to normalize distributions into aggregated histograms to avoid holding
onto the samples forever. However, the conversion created "cummulative
buckets" which were then accumulated again in the `prometheus_exporter`
sink.

The rest of the code seems to expect that aggregated histograms, in
Vector, have discrete, rather than cummulative, buckets (e.g.
https://github.com/vectordotdev/vector/blob/0ba0d97f5dd116e37b369f3adc755d53ab74d936/lib/vector-core/src/metrics/ddsketch.rs#L596-L601),
so this fixes the conversion to create discrete buckets.

Also removes handling of distributions in the collector since they've
already been normalized.

Closes: #11180

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
