### PR TITLE
enhancement(api): Support logfmt formatting option in vector tap

### DIFF
--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -1167,6 +1167,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "LOGFMT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/lib/vector-api-client/src/gql/tap.rs
+++ b/lib/vector-api-client/src/gql/tap.rs
@@ -23,6 +23,7 @@ pub struct OutputEventsByComponentIdPatternsSubscription;
 pub enum TapEncodingFormat {
     Json,
     Yaml,
+    Logfmt,
 }
 
 /// String -> TapEncodingFormat, typically for parsing user input.
@@ -33,6 +34,7 @@ impl std::str::FromStr for TapEncodingFormat {
         match s {
             "json" => Ok(Self::Json),
             "yaml" => Ok(Self::Yaml),
+            "logfmt" => Ok(Self::Logfmt),
             _ => Err("Invalid encoding format".to_string()),
         }
     }
@@ -46,6 +48,7 @@ impl From<TapEncodingFormat>
         match encoding {
             TapEncodingFormat::Json => Self::JSON,
             TapEncodingFormat::Yaml => Self::YAML,
+            TapEncodingFormat::Logfmt => Self::LOGFMT,
         }
     }
 }

--- a/src/api/schema/events/encoding.rs
+++ b/src/api/schema/events/encoding.rs
@@ -5,4 +5,5 @@ use async_graphql::Enum;
 pub enum EventEncodingType {
     Json,
     Yaml,
+    Logfmt,
 }

--- a/src/api/schema/events/log.rs
+++ b/src/api/schema/events/log.rs
@@ -53,10 +53,8 @@ impl Log {
                 .expect("JSON serialization of log event failed. Please report."),
             EventEncodingType::Yaml => serde_yaml::to_string(&self.event)
                 .expect("YAML serialization of log event failed. Please report."),
-            EventEncodingType::Logfmt => {
-                encode_logfmt::to_string(self.event.clone().into_parts().0)
-                    .expect("LOGFMT serialization of log event failed. Please report.")
-            }
+            EventEncodingType::Logfmt => encode_logfmt::to_string(self.event.as_map())
+                .expect("logfmt serialization of log event failed. Please report."),
         }
     }
 

--- a/src/api/schema/events/log.rs
+++ b/src/api/schema/events/log.rs
@@ -52,6 +52,7 @@ impl Log {
                 .expect("JSON serialization of log event failed. Please report."),
             EventEncodingType::Yaml => serde_yaml::to_string(&self.event)
                 .expect("YAML serialization of log event failed. Please report."),
+            EventEncodingType::Logfmt => todo!(),
         }
     }
 

--- a/src/api/schema/events/log.rs
+++ b/src/api/schema/events/log.rs
@@ -1,5 +1,6 @@
 use async_graphql::Object;
 use chrono::{DateTime, Utc};
+use vector_common::encode_logfmt;
 
 use super::EventEncodingType;
 use crate::{
@@ -52,7 +53,10 @@ impl Log {
                 .expect("JSON serialization of log event failed. Please report."),
             EventEncodingType::Yaml => serde_yaml::to_string(&self.event)
                 .expect("YAML serialization of log event failed. Please report."),
-            EventEncodingType::Logfmt => todo!(),
+            EventEncodingType::Logfmt => {
+                encode_logfmt::to_string(self.event.clone().into_parts().0)
+                    .expect("LOGFMT serialization of log event failed. Please report.")
+            }
         }
     }
 

--- a/src/api/schema/events/metric.rs
+++ b/src/api/schema/events/metric.rs
@@ -117,13 +117,13 @@ impl Metric {
                 .expect("YAML serialization of metric event failed. Please report."),
             EventEncodingType::Logfmt => {
                 let json = serde_json::to_value(&self.event)
-                    .expect("LOGFMT serialization of metric event failed. Please report.");
+                    .expect("logfmt serialization of metric event failed. Please report.");
                 match json {
                     Value::Object(map) => encode_logfmt::to_string(
                         map.into_iter().collect::<BTreeMap<String, Value>>(),
                     )
-                    .expect("LOGFMT serialization of metric event failed. Please report."),
-                    _ => panic!("LOGFMT serialization of metric event failed. Please report."),
+                    .expect("logfmt serialization of metric event failed. Please report."),
+                    _ => panic!("logfmt serialization of metric event failed. Please report."),
                 }
             }
         }

--- a/src/api/schema/events/metric.rs
+++ b/src/api/schema/events/metric.rs
@@ -117,13 +117,13 @@ impl Metric {
                 .expect("YAML serialization of metric event failed. Please report."),
             EventEncodingType::Logfmt => {
                 let json = serde_json::to_value(&self.event)
-                    .expect("logfmt serialization of metric event failed. Please report.");
+                    .expect("logfmt serialization of metric event failed: conversion to serde Value failed. Please report.");
                 match json {
                     Value::Object(map) => encode_logfmt::to_string(
                         &map.into_iter().collect::<BTreeMap<String, Value>>(),
                     )
                     .expect("logfmt serialization of metric event failed. Please report."),
-                    _ => panic!("logfmt serialization of metric event failed. Please report."),
+                    _ => panic!("logfmt serialization of metric event failed: metric converted to unexpected serde Value. Please report."),
                 }
             }
         }

--- a/src/api/schema/events/metric.rs
+++ b/src/api/schema/events/metric.rs
@@ -111,6 +111,7 @@ impl Metric {
                 .expect("JSON serialization of metric event failed. Please report."),
             EventEncodingType::Yaml => serde_yaml::to_string(&self.event)
                 .expect("YAML serialization of metric event failed. Please report."),
+            EventEncodingType::Logfmt => todo!(),
         }
     }
 }

--- a/src/api/schema/events/metric.rs
+++ b/src/api/schema/events/metric.rs
@@ -120,7 +120,7 @@ impl Metric {
                     .expect("logfmt serialization of metric event failed. Please report.");
                 match json {
                     Value::Object(map) => encode_logfmt::to_string(
-                        map.into_iter().collect::<BTreeMap<String, Value>>(),
+                        &map.into_iter().collect::<BTreeMap<String, Value>>(),
                     )
                     .expect("logfmt serialization of metric event failed. Please report."),
                     _ => panic!("logfmt serialization of metric event failed. Please report."),

--- a/src/api/schema/events/metric.rs
+++ b/src/api/schema/events/metric.rs
@@ -1,5 +1,9 @@
 use async_graphql::{Enum, Object};
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
+use serde_json::Value;
+use vector_common::encode_logfmt;
 
 use super::EventEncodingType;
 use crate::{
@@ -111,7 +115,17 @@ impl Metric {
                 .expect("JSON serialization of metric event failed. Please report."),
             EventEncodingType::Yaml => serde_yaml::to_string(&self.event)
                 .expect("YAML serialization of metric event failed. Please report."),
-            EventEncodingType::Logfmt => todo!(),
+            EventEncodingType::Logfmt => {
+                let json = serde_json::to_value(&self.event)
+                    .expect("LOGFMT serialization of metric event failed. Please report.");
+                match json {
+                    Value::Object(map) => encode_logfmt::to_string(
+                        map.into_iter().collect::<BTreeMap<String, Value>>(),
+                    )
+                    .expect("LOGFMT serialization of metric event failed. Please report."),
+                    _ => panic!("LOGFMT serialization of metric event failed. Please report."),
+                }
+            }
         }
     }
 }

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -21,7 +21,7 @@ pub struct Opts {
     limit: u32,
 
     /// Encoding format for events printed to screen
-    #[structopt(default_value = "json", possible_values = &["json", "yaml"], short = "f", long)]
+    #[structopt(default_value = "json", possible_values = &["json", "yaml", "logfmt"], short = "f", long)]
     format: TapEncodingFormat,
 
     /// Components IDs to observe (comma-separated; accepts glob patterns)


### PR DESCRIPTION
~~Opening as draft for now as this is stacked on #11201~~

Closes #6854 

This PR allows specifying `--format logfmt` in `vector tap` to change the event output format.

### Example

For the following config:
```toml
[api]
enabled = true

[sources.in]
type = "demo_logs"
format = "shuffle"
lines = [
  "test1",
  "test2",
]

[sources.internal_metrics]
type = "internal_metrics"

[sinks.out]
type = "blackhole"
inputs = ["in*"]
```
running `vector tap -f logfmt "in" "internal_metrics"` will show log events like
```
message=test1 source_type=demo_logs timestamp=2022-02-07T23:44:56.690520215Z
```
and metric events like
```
counter.value=26 kind=absolute name=events_out_total namespace=vector tags.component_id=in tags.component_kind=source tags.component_name=in tags.component_type=demo_logs tags.output=_default timestamp=2022-02-07T23:44:57.689755837Z
```

Screenshot example:
![Screen Shot 2022-02-07 at 6 46 50 PM](https://user-images.githubusercontent.com/43912346/152891121-36ed0483-e21d-4d3c-bc05-cd68c74248a2.png)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
