### PR TITLE
chore: Add 'perf' feature flag on regex crate

### DIFF
--- a/lib/datadog/grok/Cargo.toml
+++ b/lib/datadog/grok/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = { version = "1.9", default-features = false, features = ["std", "par
 onig = { version = "6.3", default-features = false }
 ordered-float = { version = "2", default-features = false }
 peeking_take_while = { version = "1.0.0", default-features = false }
-regex = { version = "1", default-features = false }
+regex = { version = "1.5", default-features = false, features = ["perf"] }
 serde = { version = "1.0.136", default-features = false  }
 serde_json = { version = "1.0.78", default-features = false }
 strum_macros = { version = "0.23", default-features = false }

--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -16,7 +16,7 @@ exitcode = "1"
 indoc = "1.0.3"
 lazy_static = { version = "1", optional = true }
 prettytable-rs = { version = "0.8", default-features = false, optional = true }
-regex = { version = "1", default-features = false, optional = true }
+regex = { version = "1", default-features = false, optional = true, features = ["perf"] }
 rustyline = { version = "9", default-features = false, optional = true }
 serde_json = "1"
 structopt = { version = "0.3", default-features = false }


### PR DESCRIPTION
Our grok crate is unusual. We use regex in certain places like date parsing and
onig when dealing with the grok patterns themselves. Work on #11206 strongly
suggests that if sinks are allowed to run less subject to slow receiver issue
then `apply_date_filter` is a CPU hotspot. As suggested by @tobz we enable the
'perf' flags to the regex crate, which features heavily in the implementation of
that function.

REF #10144

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
