### PR TITLE
fix(observability): Propagate concurrent transform spans

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -13,6 +13,7 @@ use tokio::{
     select,
     time::{timeout, Duration},
 };
+use tracing_futures::Instrument;
 use vector_core::{
     buffers::{
         topology::{
@@ -628,7 +629,7 @@ impl Runner {
                                 }
 
                                 outputs_buf
-                            });
+                            }.in_current_span());
                             in_flight.push(task);
                         }
                         None => {


### PR DESCRIPTION
We were neglecting to propagate the span so any events generated by the
transform were missing tags.

Fixes: #11240

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
