### PR TITLE
fix(codecs): continue on error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8111,17 +8111,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "value"
 version = "0.1.0"
 dependencies = [
  "lookup",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7501,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",

--- a/deny.toml
+++ b/deny.toml
@@ -48,3 +48,9 @@ ignore = [
     # https://github.com/vectordotdev/vector/issues/9679
     "RUSTSEC-2020-0159",
 ]
+
+[bans]
+deny = [
+    # https://github.com/vectordotdev/vector/issues/11257
+    { name = "tokio-util", version = ">=0.6.9" },
+]

--- a/src/expiring_hash_map.rs
+++ b/src/expiring_hash_map.rs
@@ -244,6 +244,7 @@ mod tests {
         let mut map = ExpiringHashMap::<String, String>::default();
 
         map.insert("key".to_owned(), "val".to_owned(), Duration::from_secs(1));
+        map.remove("key");
 
         let mut fut = task::spawn(map.next_expired());
         assert_pending!(fut.poll());


### PR DESCRIPTION
This reverts a commit to bump tokio-util from 0.6.8 to 0.6.9 (#9938)
since this introduced behavior where Vector would stop processing if the
incoming data couldn't be parsed by the codec.

This reverts commit d6ace26a214f61f33b5063f45333e9765befd2f3.

Closes: #11245
