### PR TITLE
fix: Tabs Wrap, Not Overflow (website)

### DIFF
--- a/website/layouts/shortcodes/tabs.html
+++ b/website/layouts/shortcodes/tabs.html
@@ -4,7 +4,7 @@
 
 {{ $default := .Params.default | urlize }}
 <div x-data="{ selected: '{{ $default }}' }" class="tabs no-prose border rounded-md py-3 px-4 shadow dark:border-gray-700">
-  <div class="flex space-x-2.5">
+  <div class="flex flex-wrap gap-2.5">
     {{ .Inner }}
   </div>
 


### PR DESCRIPTION
## What does this PR do?
- Fixes long list of tabs overflowing the container

Updated HTML
- tabs shortcode flex container now raps, tweaking spacing logic

## Link to preview site and any special testing guidelines
Tabs container with a long list of tabs should wrap to the next line. 

- https://deploy-preview-11259--vector-project.netlify.app/docs/reference/configuration/#automatic-namespacing
