### PR TITLE
chore(releasing): Prepare v0.19.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7619,9 +7619,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8234,7 +8234,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "approx",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Vector Contributors <vector@timber.io>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"

--- a/deny.toml
+++ b/deny.toml
@@ -52,3 +52,9 @@ ignore = [
     # https://github.com/vectordotdev/vector/issues/10862
     "RUSTSEC-2022-0002"
 ]
+
+[bans]
+deny = [
+    # https://github.com/vectordotdev/vector/issues/11257
+    { name = "tokio-util", version = ">=0.6.9" },
+]

--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -12,7 +12,7 @@ set -u
 
 # If PACKAGE_ROOT is unset or empty, default it.
 PACKAGE_ROOT="${PACKAGE_ROOT:-"https://packages.timber.io/vector"}"
-VECTOR_VERSION="0.19.1"
+VECTOR_VERSION="0.19.2"
 _divider="--------------------------------------------------------------------------------"
 _prompt=">>>"
 _indent="   "

--- a/lib/shared/Cargo.toml
+++ b/lib/shared/Cargo.toml
@@ -14,8 +14,8 @@ derivative = "2.1.3"
 nom = { version = "7", optional = true }
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
 snafu = { version = "0.6", optional = true }
-tracing = { version = "0.1", optional = true }
 serde_json = { version = "1.0.73", optional = true }
+tracing = { version = "0.1.29", default-features = false }
 
 [features]
 default = [
@@ -37,7 +37,6 @@ conversion = [
   "bytes",
   "chrono",
   "snafu",
-  "tracing",
 ]
 
 encoding = [

--- a/lib/vector-core/buffers/src/disk_v2/tests/acknowledgements.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/acknowledgements.rs
@@ -6,6 +6,7 @@ use super::with_temp_dir;
 use crate::{
     buffer_usage_data::BufferUsageHandle,
     disk_v2::{acknowledgements::create_disk_v2_acker, ledger::Ledger, DiskBufferConfig},
+    WhenFull,
 };
 
 #[tokio::test]
@@ -15,7 +16,7 @@ async fn ack_updates_ledger_correctly() {
 
         async move {
             // Create a standalone ledger.
-            let usage_handle = BufferUsageHandle::noop();
+            let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
             let config = DiskBufferConfig::from_path(data_dir).build();
             let ledger = Ledger::load_or_create(config, usage_handle)
                 .await
@@ -43,7 +44,7 @@ async fn ack_wakes_reader() {
 
         async move {
             // Create a standalone ledger.
-            let usage_handle = BufferUsageHandle::noop();
+            let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
             let config = DiskBufferConfig::from_path(data_dir).build();
             let ledger = Ledger::load_or_create(config, usage_handle)
                 .await

--- a/lib/vector-core/buffers/src/disk_v2/tests/mod.rs
+++ b/lib/vector-core/buffers/src/disk_v2/tests/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     buffer_usage_data::BufferUsageHandle,
     disk_v2::{Buffer, DiskBufferConfig, Reader, Writer},
     encoding::{DecodeBytes, EncodeBytes},
-    Acker, Bufferable,
+    Acker, Bufferable, WhenFull,
 };
 
 mod acknowledgements;
@@ -223,7 +223,7 @@ where
     R: Bufferable,
 {
     let config = DiskBufferConfig::from_path(data_dir).build();
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
     Buffer::from_config_inner(config, usage_handle)
         .await
         .expect("should not fail to create buffer")
@@ -241,7 +241,7 @@ where
     // ensures it is a minimum size related to the data file size limit, etc.
     let mut config = DiskBufferConfig::from_path(data_dir).build();
     config.max_buffer_size = max_buffer_size;
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
 
     Buffer::from_config_inner(config, usage_handle)
         .await
@@ -259,7 +259,7 @@ where
     let config = DiskBufferConfig::from_path(data_dir)
         .max_record_size(max_record_size)
         .build();
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
 
     Buffer::from_config_inner(config, usage_handle)
         .await
@@ -277,7 +277,7 @@ where
     let config = DiskBufferConfig::from_path(data_dir)
         .max_data_file_size(max_data_file_size)
         .build();
-    let usage_handle = BufferUsageHandle::noop();
+    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
 
     Buffer::from_config_inner(config, usage_handle)
         .await

--- a/lib/vector-core/buffers/src/topology/test_util.rs
+++ b/lib/vector-core/buffers/src/topology/test_util.rs
@@ -4,6 +4,7 @@ use bytes::{Buf, BufMut};
 
 use super::builder::TopologyBuilder;
 use crate::{
+    buffer_usage_data::BufferUsageHandle,
     encoding::{DecodeBytes, EncodeBytes},
     topology::channel::{BufferReceiver, BufferSender},
     Bufferable, WhenFull,
@@ -58,21 +59,24 @@ pub async fn build_buffer(
     capacity: usize,
     mode: WhenFull,
     overflow_mode: Option<WhenFull>,
-) -> (BufferSender<u64>, BufferReceiver<u64>) {
-    match mode {
+) -> (BufferSender<u64>, BufferReceiver<u64>, BufferUsageHandle) {
+    let handle = BufferUsageHandle::noop(mode);
+    let (tx, rx) = match mode {
         WhenFull::Overflow => {
             let overflow_mode = overflow_mode.expect("overflow mode cannot be empty");
             let (overflow_sender, overflow_receiver) =
-                TopologyBuilder::memory_v2(capacity, overflow_mode).await;
+                TopologyBuilder::memory_v2(capacity, overflow_mode, handle.clone()).await;
             let (mut base_sender, mut base_receiver) =
-                TopologyBuilder::memory_v2(capacity, WhenFull::Overflow).await;
+                TopologyBuilder::memory_v2(capacity, WhenFull::Overflow, handle.clone()).await;
             base_sender.switch_to_overflow(overflow_sender);
             base_receiver.switch_to_overflow(overflow_receiver);
 
             (base_sender, base_receiver)
         }
-        m => TopologyBuilder::memory_v2(capacity, m).await,
-    }
+        m => TopologyBuilder::memory_v2(capacity, m, handle.clone()).await,
+    };
+
+    (tx, rx, handle)
 }
 
 /// Gets the current capacity of the underlying base channel of the given sender.

--- a/lib/vector-core/core-common/src/internal_event/bytes_sent.rs
+++ b/lib/vector-core/core-common/src/internal_event/bytes_sent.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use tracing::trace;
 
 use crate::internal_event::InternalEvent;
 

--- a/lib/vector-core/core-common/src/internal_event/events_received.rs
+++ b/lib/vector-core/core-common/src/internal_event/events_received.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use tracing::trace;
 
 use crate::internal_event::InternalEvent;
 

--- a/lib/vector-core/core-common/src/internal_event/events_sent.rs
+++ b/lib/vector-core/core-common/src/internal_event/events_sent.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use tracing::trace;
 
 use crate::internal_event::InternalEvent;
 

--- a/lib/vector-core/core-common/src/lib.rs
+++ b/lib/vector-core/core-common/src/lib.rs
@@ -9,8 +9,5 @@
 pub mod byte_size_of;
 pub mod internal_event;
 
-#[macro_use]
-extern crate tracing;
-
 #[cfg(any(test, feature = "test"))]
 pub mod event_test_util;

--- a/scripts/check-version.rb
+++ b/scripts/check-version.rb
@@ -23,6 +23,8 @@ class Semantic::Version
   #
   def after_conventional_commit(commit_message)
     case commit_message
+    when /website/
+      self
     when /!:/
       self.increment!(self.major > 0 ? :major : :minor)
     when /^feat/

--- a/src/expiring_hash_map.rs
+++ b/src/expiring_hash_map.rs
@@ -244,6 +244,7 @@ mod tests {
         let mut map = ExpiringHashMap::<String, String>::default();
 
         map.insert("key".to_owned(), "val".to_owned(), Duration::from_secs(1));
+        map.remove("key");
 
         let mut fut = task::spawn(map.next_expired());
         assert_pending!(fut.poll());

--- a/src/sinks/util/encoding/fixed.rs
+++ b/src/sinks/util/encoding/fixed.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     event::PathComponent,
     serde::skip_serializing_if_default,
-    sinks::util::encoding::{EncodingConfiguration, TimestampFormat},
+    sinks::util::encoding::{deserialize_path_components, EncodingConfiguration, TimestampFormat},
 };
 
 /// A structure to wrap sink encodings and enforce field privacy.
@@ -21,8 +21,12 @@ pub struct EncodingConfigFixed<E: Default + PartialEq> {
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) schema: Option<String>,
     /// Keep only the following fields of the message. (Items mutually exclusive with `except_fields`)
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
+    #[serde(
+        default,
+        skip_serializing_if = "skip_serializing_if_default",
+        deserialize_with = "deserialize_path_components"
+    )]
     pub(crate) only_fields: Option<Vec<Vec<PathComponent<'static>>>>,
     /// Remove the following fields of the message. (Items mutually exclusive with `only_fields`)
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -274,6 +274,25 @@ pub enum TimestampFormat {
     Rfc3339,
 }
 
+fn deserialize_path_components<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<Vec<PathComponent<'static>>>>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let fields: Option<Vec<&str>> = serde::de::Deserialize::deserialize(deserializer)?;
+    Ok(fields.map(|fields| {
+        fields
+            .iter()
+            .map(|only| {
+                PathIter::new(only)
+                    .map(|component| component.into_static())
+                    .collect()
+            })
+            .collect()
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use indoc::indoc;

--- a/src/sinks/util/encoding/with_default.rs
+++ b/src/sinks/util/encoding/with_default.rs
@@ -9,9 +9,9 @@ use serde::{
 };
 
 use crate::{
-    event::{PathComponent, PathIter},
+    event::PathComponent,
     serde::skip_serializing_if_default,
-    sinks::util::encoding::{EncodingConfiguration, TimestampFormat},
+    sinks::util::encoding::{deserialize_path_components, EncodingConfiguration, TimestampFormat},
 };
 
 /// A structure to wrap sink encodings and enforce field privacy.
@@ -27,7 +27,6 @@ pub struct EncodingConfigWithDefault<E: Default + PartialEq> {
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) schema: Option<String>,
     /// Keep only the following fields of the message. (Items mutually exclusive with `except_fields`)
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
     pub(crate) only_fields: Option<Vec<Vec<PathComponent<'static>>>>,
     /// Remove the following fields of the message. (Items mutually exclusive with `only_fields`)
@@ -137,17 +136,7 @@ where
         let concrete = Self {
             codec: inner.codec,
             schema: inner.schema,
-            // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-            only_fields: inner.only_fields.map(|fields| {
-                fields
-                    .iter()
-                    .map(|only| {
-                        PathIter::new(only)
-                            .map(|component| component.into_static())
-                            .collect()
-                    })
-                    .collect()
-            }),
+            only_fields: inner.only_fields,
             except_fields: inner.except_fields,
             timestamp_format: inner.timestamp_format,
         };
@@ -163,8 +152,8 @@ pub struct InnerWithDefault<E: Default> {
     codec: E,
     #[serde(default)]
     schema: Option<String>,
-    #[serde(default)]
-    only_fields: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_path_components")]
+    only_fields: Option<Vec<Vec<PathComponent<'static>>>>,
     #[serde(default)]
     except_fields: Option<Vec<String>>,
     #[serde(default)]

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -13,6 +13,7 @@ use tokio::{
     select,
     time::{timeout, Duration},
 };
+use tracing_futures::Instrument;
 use vector_core::{
     buffers::{
         topology::{
@@ -595,7 +596,7 @@ impl Runner {
                                 }
 
                                 outputs_buf
-                            });
+                            }.in_current_span());
                             in_flight.push(task);
                         }
                         None => {

--- a/website/content/en/releases/0.19.2.md
+++ b/website/content/en/releases/0.19.2.md
@@ -1,0 +1,4 @@
+---
+title: Vector v0.19.2 release notes
+weight: 21
+---

--- a/website/cue/reference/releases/0.18.0.cue
+++ b/website/cue/reference/releases/0.18.0.cue
@@ -23,6 +23,21 @@ releases: "0.18.0": {
 		"The new `reroute_dropped` feature of `remap` always creates the `dropped` output even if `reroute_dropped = false`. Fixed in v0.18.1.",
 		"The `headers_key` option for the `kafka` sink was inadvertantly changed to `headers_field`. Fixed in v0.19.0.",
 		"If `--config-dir` is used, Vector incorrectly tries to load files with unknown extensions. Fixed in v0.19.0.",
+		"""
+			`encoding.only_fields` failed to deserialize correctly for sinks that used fixed encodings (i.e. those that don't have `encoding.codec`). Fixed in v0.19.2. As a workaround, you can split the paths up in your configuration like:
+
+			```toml
+			encoding.only_fields = ["message", "foo.bar"]
+			```
+
+			to
+
+			```toml
+			encoding.only_fields = [["message"], ["foo", "bar"]]
+			```
+
+			You will need to convert it back to its original representation when upgrading to >= v0.19.2.
+			""",
 	]
 
 	changelog: [

--- a/website/cue/reference/releases/0.19.0.cue
+++ b/website/cue/reference/releases/0.19.0.cue
@@ -29,7 +29,11 @@ releases: "0.19.0": {
 
 	known_issues: [
 		"A regression was introduced that changed the name of the data directory for sinks using a disk buffer. This means, when upgrading from `v0.18.0`, if there was any data in existing disk buffers, it will not be sent. Vector's starting with clean or empty disk buffers are unaffected. Fixed in v0.19.1. See [#10430](https://github.com/vectordotdev/vector/issues/10430) for more details.",
-		"Presence of `framing.character_delimited.delimiter` in configs causes Vector to fail to start with `invalid type: string`. Fixed in 0.19.1.",
+		"Presence of `framing.character_delimited.delimiter` in configs causes Vector to fail to start with `invalid type: string`. Fixed in v0.19.1.",
+		"When using `decoding.codec` on sources, invalid data will cause the source to cease processing. Fixed in v0.19.2.",
+		"`encoding.only_fields` failed to deserialize correctly for sinks that used fixed encodings (i.e. those that don't have `encoding.codec`). Fixed in v0.19.2.",
+		"Buffers using `when_full` of `block` were incorrectly counting `buffer_events_total` by including discarded events. Fixed in v0.19.2.",
+		"Transforms neglect to tag logs and metrics with their component span tags (like `component_id`). Fixed in v0.19.2.",
 	]
 
 	description: """

--- a/website/cue/reference/releases/0.19.2.cue
+++ b/website/cue/reference/releases/0.19.2.cue
@@ -1,0 +1,67 @@
+package metadata
+
+releases: "0.19.2": {
+	date:     "2022-02-08"
+	codename: ""
+
+	whats_next: []
+
+	description: """
+		The Vector team is pleased to announce version 0.19.2!
+
+		This patch release contains a few bug fixes for regressions in 0.19.0.
+
+		**Note:** Please see the release notes for [`v0.19.0`](/releases/0.19.0/) for additional changes if upgrading from
+		`v0.18.X`. In particular, the upgrade guide for breaking changes.
+		"""
+
+	changelog: [
+		{
+			type: "fix"
+			scopes: ["sources", "codecs"]
+			description: """
+				Continue to process data when decoding fails in a source that is using `decoding.codec`. This was
+				a regression in `v0.19.0`.
+				"""
+			pr_numbers: [11254]
+		},
+		{
+			type: "fix"
+			scopes: ["codecs"]
+			description: """
+				`encoding.only_fields` now correctly deserializes again for sinks that used fixed encodings (i.e. those
+				that don't have `encoding.codec`). This was a regression in `v0.18.0`.
+				"""
+			pr_numbers: [11198]
+		},
+		{
+			type: "fix"
+			scopes: ["buffers"]
+			description: """
+				Report correct `buffer_events_total` metric `drop_newest` is used for buffers. Previously, this was
+				counting discarded events. This was a regression in `v0.19.0`.
+				"""
+			pr_numbers: [11159]
+		},
+		{
+			type: "fix"
+			scopes: ["transforms"]
+			description: """
+				All transforms again correctly publish metrics with their component span tags (like `component_id`).
+				This was a regression in `v0.19.0`.
+				"""
+			pr_numbers: [11241]
+		},
+	]
+
+	commits: [
+		{sha: "134a942144308d83a477771fcc72b2c699bf3250", date: "2022-01-26 06:26:12 UTC", description: "Fix example in CSV enrichment highlight", pr_number:                                       11026, scopes: ["enrichment"], type:    "docs", breaking_change: false, author: "Jesse Szwedko", files_count:   1, insertions_count:  2, deletions_count:   2},
+		{sha: "495b158ea1bcd9831e25d775415fce7389ec3ab7", date: "2022-01-26 09:37:28 UTC", description: "Remove documented elasticsearch sink options that have been removed from code", pr_number: 11028, scopes: ["external docs"], type: "fix", breaking_change:  false, author: "Spencer Gilbert", files_count: 1, insertions_count:  2, deletions_count:   27},
+		{sha: "b4d9bcce6841ad41ee6b7f7584bc8d71bfb8ca6b", date: "2022-02-05 09:26:10 UTC", description: "Signup Functionality (website)", pr_number:                                                10904, scopes: ["website"], type:       "feat", breaking_change: false, author: "David Weid II", files_count:   10, insertions_count: 311, deletions_count: 28},
+		{sha: "f72776059e66c956266c5c2a762519aa24536367", date: "2022-02-08 06:12:10 UTC", description: "Marketo Styles (website)", pr_number:                                                      11228, scopes: ["website"], type:       "fix", breaking_change:  false, author: "David Weid II", files_count:   3, insertions_count:  80, deletions_count:  65},
+		{sha: "c747ddc5df9124b22e03777d968a8d80bb067307", date: "2022-02-09 01:54:02 UTC", description: "continue on error", pr_number:                                                             11254, scopes: ["codecs"], type:        "fix", breaking_change:  false, author: "Jesse Szwedko", files_count:   3, insertions_count:  9, deletions_count:   2},
+		{sha: "78c9bab4e5105a753b74be5bbe0fd32359fa368f", date: "2022-02-08 22:25:46 UTC", description: "Propagate concurrent transform spans", pr_number:                                          11241, scopes: ["observability"], type: "fix", breaking_change:  false, author: "Jesse Szwedko", files_count:   1, insertions_count:  2, deletions_count:   1},
+		{sha: "740d8a11bf7536e5102d14c57ee4afebee70ee0c", date: "2022-02-05 06:35:55 UTC", description: "Fix deserialization of `only_fields` for fixed encodings", pr_number:                      11198, scopes: ["codecs"], type:        "fix", breaking_change:  false, author: "Jesse Szwedko", files_count:   3, insertions_count:  30, deletions_count:  18},
+		{sha: "1382998ee6318a00cc6c572e338ad6ebc03f8792", date: "2022-02-03 08:13:05 UTC", description: "fix buffer metrics when using DropNewest", pr_number:                                      11159, scopes: ["buffers"], type:       "fix", breaking_change:  false, author: "Toby Lawrence", files_count:   12, insertions_count: 135, deletions_count: 47},
+	]
+}

--- a/website/cue/reference/versions.cue
+++ b/website/cue/reference/versions.cue
@@ -2,6 +2,7 @@ package metadata
 
 // This has to be maintained manually because there's currently no way to sort versions programmatically
 versions: [string, ...string] & [
+		"0.19.2",
 		"0.19.1",
 		"0.19.0",
 		"0.18.1",


### PR DESCRIPTION
Backports regression fixes from v0.20.

It's best to review the individual commits, in particular the last one prepping the release; the rest are cherry-picked.