### PR TITLE
chore(codecs): Have encode_logfmt take the `BTreeMap` by reference

### DIFF
--- a/lib/vector-common/src/encode_logfmt.rs
+++ b/lib/vector-common/src/encode_logfmt.rs
@@ -9,6 +9,6 @@ use crate::encode_key_value::{to_string as encode_key_value, EncodingError};
 /// # Errors
 ///
 /// Returns an `EncodingError` if any of the keys are not strings.
-pub fn to_string<V: Serialize>(input: BTreeMap<String, V>) -> Result<String, EncodingError> {
+pub fn to_string<V: Serialize>(input: &BTreeMap<String, V>) -> Result<String, EncodingError> {
     encode_key_value(input, &[], "=", " ", true)
 }

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -134,7 +134,7 @@ impl Expression for EncodeKeyValueFn {
         let flatten_boolean = self.flatten_boolean.resolve(ctx)?.try_boolean()?;
 
         Ok(encode_key_value::to_string(
-            object,
+            &object,
             &fields[..],
             &key_value_delimiter,
             &field_delimiter,

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -132,7 +132,7 @@ async fn logfmt() {
     let (_, outputs) = fetch_stream(stream.to_string(), "default").await;
     assert_eq!(lines.len(), outputs.len());
     for (i, output) in outputs.iter().enumerate() {
-        let expected_logfmt = encode_logfmt::to_string(lines[i].as_map()).unwrap();
+        let expected_logfmt = encode_logfmt::to_string(lines[i].as_log().as_map()).unwrap();
         assert_eq!(output, &expected_logfmt);
     }
 }

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -132,8 +132,7 @@ async fn logfmt() {
     let (_, outputs) = fetch_stream(stream.to_string(), "default").await;
     assert_eq!(lines.len(), outputs.len());
     for (i, output) in outputs.iter().enumerate() {
-        let expected_logfmt =
-            encode_logfmt::to_string(lines[i].clone().into_log().into_parts().0).unwrap();
+        let expected_logfmt = encode_logfmt::to_string(lines[i].as_map()).unwrap();
         assert_eq!(output, &expected_logfmt);
     }
 }

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -213,8 +213,9 @@ impl EventEncoder {
                 .map(Value::to_string_lossy)
                 .unwrap_or_default(),
 
-            Encoding::Logfmt => encode_logfmt::to_string(log.into_parts().0)
-                .expect("Logfmt encoding should never fail."),
+            Encoding::Logfmt => {
+                encode_logfmt::to_string(log.as_map()).expect("Logfmt encoding should never fail.")
+            }
         };
 
         // If no labels are provided we set our own default


### PR DESCRIPTION
There doesn't seem to be a real reason it needs an owned version. Cloning the keys as needed, to flatten the map, should result in less copying. I think we could probably even remove that clone if we used a different data structure to store the keys.

Removes a clone that would be needed in https://github.com/vectordotdev/vector/pull/11234

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
