### PR TITLE
chore: Correct detect_regressions drift filter bug

### DIFF
--- a/soaks/bin/detect_regressions
+++ b/soaks/bin/detect_regressions
@@ -79,7 +79,7 @@ print("")
 print(results.to_markdown(index=False, tablefmt='github'))
 
 p_value_violation = results['p-value'] < args.p_value
-drift_filter = results['Δ mean %'] > args.mean_drift_percentage
+drift_filter = results['Δ mean %'] < -args.mean_drift_percentage
 declared_erratic = results.experiment.isin(known_erratic_soaks)
 
 changes = results[p_value_violation & drift_filter & ~declared_erratic]


### PR DESCRIPTION
In the analysis script we are interested in the absolute magnitude of any mean
swing. That is not the case in detect_regressions, where we only care for
negative movements. The logic was inappropriately moved from the one script to
the other, now fixed. Regressions will no longer be flagged for _positive_
changes, only negative.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
