### PR TITLE
chore: Shuffle sinks before sending in Fanout

### DIFF
--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -36,6 +36,7 @@ pest_derive = { version = "2.1.0", default-features = false }
 pin-project = { version = "1.0.10", default-features = false }
 prost = { version = "0.9", default-features = false, features = ["std"] }
 prost-types = { version = "0.9", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["std"] }
 regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0.136", default-features = false, features = ["derive", "rc"] }
 serde_json = { version = "1.0.78", default-features = false }


### PR DESCRIPTION
Our implementation of Fanout sends to sinks in the same order each time. If we
are unlucky and slow Sinks are stacked toward the front of our list we'll always
pay the cost for that slow sink. Here we shuffle the costs around.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/timberio/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
