### PR TITLE
chore: Timebound soak experimental runs

### DIFF
--- a/soaks/bin/run_experiment.sh
+++ b/soaks/bin/run_experiment.sh
@@ -82,6 +82,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+SAMPLE_ATTEMPT_LIMIT=1000
 TOTAL_SAMPLES=200
 SOAK_CAPTURE_DIR="${CAPTURE_DIR}/${SOAK_NAME}"
 SOAK_CAPTURE_FILE="${SOAK_CAPTURE_DIR}/${VARIANT}.captures"
@@ -125,6 +126,10 @@ do
     fi
     recorded_samples=$observed_samples
     (( periods = periods + 1 ))
+    if [ $periods -gt $SAMPLE_ATTEMPT_LIMIT ]; then
+        echo "INSUFFICIENT SAMPLES COlLECTED BEFORE DEADLINE. THIS INDICATES A PROBLEM WITH THE EXPERIMENT."
+        exit 1
+    fi
     sleep 1
 done
 echo "[${VARIANT}] Recording captures to ${SOAK_CAPTURE_DIR} complete in ${periods} seconds. At least ${recorded_samples} collected."


### PR DESCRIPTION
We are seeing in practice that `http_pipelines_blackhole` soak is misbehaving,
queuing up our soak runners. We do not want soak tests to run indefinitely in
the even they've gone sideways. This commit caps sample collection attempts to
1000 periods, no matter how many samples have been collected.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
