### PR TITLE
chore(performance): emit splunk_hec metrics per request

### DIFF
--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -185,17 +185,6 @@ impl SourceSender {
             .send_batch(events)
             .await
     }
-
-    pub async fn send_result_stream<E>(
-        &mut self,
-        stream: impl Stream<Item = Result<Event, E>> + Unpin,
-    ) -> Result<(), StreamSendError<E>> {
-        self.inner
-            .as_mut()
-            .expect("no default output")
-            .send_result_stream(stream)
-            .await
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -261,43 +250,6 @@ impl Inner {
             output: Some(self.output.as_ref()),
         });
 
-        Ok(())
-    }
-
-    async fn send_result_stream<E>(
-        &mut self,
-        mut stream: impl Stream<Item = Result<Event, E>> + Unpin,
-    ) -> Result<(), StreamSendError<E>> {
-        let mut to_forward = Vec::with_capacity(CHUNK_SIZE);
-        loop {
-            tokio::select! {
-                next = stream.next(), if to_forward.len() <= CHUNK_SIZE => {
-                    match next {
-                        Some(Ok(event)) => {
-                            to_forward.push(event);
-                        }
-                        Some(Err(error)) => {
-                            if !to_forward.is_empty() {
-                                self.send_batch(to_forward).await?;
-                            }
-                            return Err(StreamSendError::Stream(error));
-                        }
-                        None => {
-                            if !to_forward.is_empty() {
-                                self.send_batch(to_forward).await?;
-                            }
-                            break;
-                        }
-                    }
-                }
-                else => {
-                    if !to_forward.is_empty() {
-                        let out = std::mem::replace(&mut to_forward, Vec::with_capacity(CHUNK_SIZE));
-                        self.send_batch(out).await?;
-                    }
-                }
-            }
-        }
         Ok(())
     }
 }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, TimeZone, Utc};
 use flate2::read::MultiGzDecoder;
-use futures::{stream, FutureExt};
+use futures::FutureExt;
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{de::Read as JsonRead, Deserializer, Value as JsonValue};
@@ -33,7 +33,7 @@ use crate::{
         SplunkHecRequestReceived,
     },
     serde::bool_or_struct,
-    source_sender::StreamSendError,
+    source_sender::ClosedError,
     tls::{MaybeTlsSettings, TlsConfig},
     SourceSender,
 };
@@ -267,21 +267,40 @@ impl SplunkSource {
                             }
                             _ => None,
                         };
-                        let mut events = stream::iter(EventIterator::new(
+
+                        let mut error = None;
+                        let events = EventIterator::new(
                             Deserializer::from_str(&body).into_iter::<JsonValue>(),
                             channel,
                             remote,
                             xff,
                             batch,
                             token.filter(|_| store_hec_token).map(Into::into),
-                        ));
-
-                        match out.send_result_stream(&mut events).await {
-                            Ok(()) => Ok(maybe_ack_id),
-                            Err(StreamSendError::Stream(error)) => Err(error),
-                            Err(StreamSendError::Closed(_)) => {
-                                Err(Rejection::from(ApiError::ServerShutdown))
+                        )
+                        .map_while(|result| match result {
+                            Ok(event) => Some(event),
+                            Err(err) => {
+                                error = Some(err);
+                                None
                             }
+                        })
+                        .collect::<Vec<Event>>();
+
+                        if !events.is_empty() {
+                            emit!(&EventsReceived {
+                                count: events.len(),
+                                byte_size: events.size_of(),
+                            });
+
+                            if let Err(ClosedError) = out.send_batch(events).await {
+                                return Err(Rejection::from(ApiError::ServerShutdown));
+                            }
+                        }
+
+                        if let Some(error) = error {
+                            Err(error)
+                        } else {
+                            Ok(maybe_ack_id)
                         }
                     }
                 },
@@ -628,10 +647,6 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
             event.add_batch_notifier(batch);
         }
 
-        emit!(&EventsReceived {
-            count: 1,
-            byte_size: event.size_of(),
-        });
         self.events += 1;
 
         Ok(event)

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -160,7 +160,7 @@ async fn handle_request(
         Ok(mut events) => {
             let receiver = BatchNotifier::maybe_apply_to_events(acknowledgements, &mut events);
 
-            out.send_all(&mut futures::stream::iter(events))
+            out.send_batch(events)
                 .map_err(move |error: crate::source_sender::ClosedError| {
                     // can only fail if receiving end disconnected, so we are shutting down,
                     // probably not gracefully.


### PR DESCRIPTION
Previously this was done in a streaming fashion, where a single internal
event was emitted with each individual event built. Now we build and
collect all the events, and emit one internal event describing the
total. This also lets us remove the awkward `send_result_stream` method
from `SourceSender`, of which this was the only caller.

Signed-off-by: Luke Steensen <luke.steensen@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
