### PR TITLE
chore(core): Value unification part 1 - NotNan floats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8423,6 +8423,7 @@ dependencies = [
  "derivative",
  "metrics",
  "nom 7.1.0",
+ "ordered-float",
  "serde",
  "serde_json",
  "smallvec",

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -47,6 +47,7 @@ chrono = { version = "0.4", optional = true }
 derivative = "2.1.3"
 metrics = { version = "0.17.0", default-features = false, features = ["std"] }
 nom = { version = "7", optional = true }
+ordered-float = { version = "2.10.0", default-features = false }
 serde_json = { version = "1.0.78", default-features = false, features = ["std", "raw_value"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false }

--- a/lib/vector-common/src/conversion/tests/mod.rs
+++ b/lib/vector-common/src/conversion/tests/mod.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use ordered_float::NotNan;
 
 use crate::conversion::parse_bool;
 
@@ -30,6 +31,12 @@ impl From<DateTime<Utc>> for StubValue {
 impl From<f64> for StubValue {
     fn from(v: f64) -> Self {
         StubValue::Float(v)
+    }
+}
+
+impl From<NotNan<f64>> for StubValue {
+    fn from(v: NotNan<f64>) -> Self {
+        StubValue::Float(v.into_inner())
     }
 }
 

--- a/lib/vector-common/src/conversion/tests/unix.rs
+++ b/lib/vector-common/src/conversion/tests/unix.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use chrono::{DateTime, NaiveDateTime, TimeZone as _, Utc};
 use chrono_tz::{Australia, Tz};
+use ordered_float::NotNan;
 
 use crate::{
     conversion::{parse_timestamp, tests::StubValue, Conversion, Error},
@@ -56,7 +57,7 @@ fn dateref() -> DateTime<Utc> {
 
 fn convert<T>(fmt: &str, value: &'static str) -> Result<T, Error>
 where
-    T: From<Bytes> + From<i64> + From<f64> + From<bool> + From<DateTime<Utc>>,
+    T: From<Bytes> + From<i64> + From<NotNan<f64>> + From<bool> + From<DateTime<Utc>>,
 {
     std::env::set_var("TZ", TIMEZONE_NAME);
     Conversion::parse(fmt, TimeZone::Local)

--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -58,7 +58,7 @@ fn value_eq(this: &Value, other: &Value) -> bool {
         (Value::Timestamp(this), Value::Timestamp(other)) => this.eq(other),
         (Value::Null, Value::Null) => true,
         // Non-trivial.
-        (Value::Float(this), Value::Float(other)) => f64_eq(*this, *other),
+        (Value::Float(this), Value::Float(other)) => f64_eq(this.into_inner(), other.into_inner()),
         (Value::Array(this), Value::Array(other)) => array_eq(this, other),
         (Value::Map(this), Value::Map(other)) => map_eq(this, other),
         // Type mismatch.
@@ -125,7 +125,7 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &Value) {
         Value::Integer(val) => val.hash(hasher),
         Value::Timestamp(val) => val.hash(hasher),
         // Non-trivial.
-        Value::Float(val) => hash_f64(hasher, *val),
+        Value::Float(val) => hash_f64(hasher, val.into_inner()),
         Value::Array(val) => hash_array(hasher, val),
         Value::Map(val) => hash_map(hasher, val),
         Value::Null => hash_null(hasher),

--- a/lib/vector-core/src/event/legacy_lookup/mod.rs
+++ b/lib/vector-core/src/event/legacy_lookup/mod.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use indexmap::map::IndexMap;
+use ordered_float::NotNan;
 use pest::{iterators::Pair, Parser};
 pub use segment::Segment;
 use serde::{
@@ -118,7 +119,10 @@ impl Lookup {
         match value {
             TomlValue::String(s) => discoveries.insert(lookup, Value::from(s)),
             TomlValue::Integer(i) => discoveries.insert(lookup, Value::from(i)),
-            TomlValue::Float(f) => discoveries.insert(lookup, Value::from(f)),
+            TomlValue::Float(f) => {
+                let value = NotNan::new(f).map_err(|_| "NaN value not supported")?;
+                discoveries.insert(lookup, Value::Float(value))
+            }
             TomlValue::Boolean(b) => discoveries.insert(lookup, Value::from(b)),
             TomlValue::Datetime(dt) => {
                 let dt = dt.to_string();

--- a/lib/vector-core/src/event/lua/value.rs
+++ b/lib/vector-core/src/event/lua/value.rs
@@ -66,13 +66,13 @@ mod test {
                 Value::Bytes("\u{237a}\u{3b2}\u{3b3}".into()),
             ),
             ("123", Value::Integer(123)),
-            ("4.333", Value::Float(4.333)),
+            ("4.333", Value::from(4.333)),
             ("true", Value::Boolean(true)),
             (
                 "{ x = 1, y = '2', nested = { other = 5.678 } }",
                 Value::Map(
                     vec![
-                        ("x".into(), 1.into()),
+                        ("x".into(), 1_i64.into()),
                         ("y".into(), "2".into()),
                         (
                             "nested".into(),
@@ -85,7 +85,7 @@ mod test {
             ),
             (
                 "{1, '2', 0.57721566}",
-                Value::Array(vec![1.into(), "2".into(), 0.577_215_66.into()]),
+                Value::Array(vec![1_i64.into(), "2".into(), 0.577_215_66.into()]),
             ),
             (
                 "os.date('!*t', 1584297428)",
@@ -130,7 +130,7 @@ mod test {
                 "#,
             ),
             (
-                Value::Float(4.333),
+                Value::from(4.333),
                 r#"
                 function (value)
                     return value == 4.333
@@ -148,7 +148,7 @@ mod test {
             (
                 Value::Map(
                     vec![
-                        ("x".into(), 1.into()),
+                        ("x".into(), 1_i64.into()),
                         ("y".into(), "2".into()),
                         (
                             "nested".into(),
@@ -167,7 +167,7 @@ mod test {
                 "#,
             ),
             (
-                Value::Array(vec![1.into(), "2".into(), 0.577_215_66.into()]),
+                Value::Array(vec![1_i64.into(), "2".into(), 0.577_215_66.into()]),
                 r#"
                 function (value)
                     return value[1] == 1 and

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -1,4 +1,5 @@
 use chrono::TimeZone;
+use ordered_float::NotNan;
 
 use crate::{
     event::{self, BTreeMap, WithMetadata},
@@ -325,7 +326,7 @@ fn decode_value(input: Value) -> Option<event::Value> {
             chrono::Utc.timestamp(ts.seconds, ts.nanos as u32),
         )),
         Some(value::Kind::Integer(value)) => Some(event::Value::Integer(value)),
-        Some(value::Kind::Float(value)) => Some(event::Value::Float(value)),
+        Some(value::Kind::Float(value)) => Some(event::Value::Float(NotNan::new(value).unwrap())),
         Some(value::Kind::Boolean(value)) => Some(event::Value::Boolean(value)),
         Some(value::Kind::Map(map)) => decode_map(map.fields),
         Some(value::Kind::Array(array)) => decode_array(array.items),
@@ -370,7 +371,7 @@ fn encode_value(value: event::Value) -> Value {
                 nanos: ts.timestamp_subsec_nanos() as i32,
             })),
             event::Value::Integer(value) => Some(value::Kind::Integer(value)),
-            event::Value::Float(value) => Some(value::Kind::Float(value)),
+            event::Value::Float(value) => Some(value::Kind::Float(value.into_inner())),
             event::Value::Boolean(value) => Some(value::Kind::Boolean(value)),
             event::Value::Map(fields) => Some(value::Kind::Map(encode_map(fields))),
             event::Value::Array(items) => Some(value::Kind::Array(encode_array(items))),

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -562,7 +562,13 @@ impl Arbitrary for Value {
                 Value::Bytes(Bytes::from(bytes))
             }
             1 => Value::Integer(i64::arbitrary(g)),
-            2 => Value::from(f64::arbitrary(g) % MAX_F64_SIZE),
+            2 => {
+                let mut f = f64::arbitrary(g) % MAX_F64_SIZE;
+                if f.is_nan() {
+                    f = 0.0;
+                }
+                Value::from(f)
+            }
             3 => Value::Boolean(bool::arbitrary(g)),
             4 => Value::Timestamp(datetime(g)),
             5 => {

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -562,7 +562,7 @@ impl Arbitrary for Value {
                 Value::Bytes(Bytes::from(bytes))
             }
             1 => Value::Integer(i64::arbitrary(g)),
-            2 => Value::Float(f64::arbitrary(g) % MAX_F64_SIZE),
+            2 => Value::from(f64::arbitrary(g) % MAX_F64_SIZE),
             3 => Value::Boolean(bool::arbitrary(g)),
             4 => Value::Timestamp(datetime(g)),
             5 => {

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -9,7 +9,11 @@ use std::{
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Utc};
 use lookup::{Field, FieldBuf, Lookup, LookupBuf, Segment, SegmentBuf};
+use ordered_float::NotNan;
+use serde::de::{Error as SerdeError, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize, Serializer};
+use std::fmt;
+use std::result::Result as StdResult;
 use toml::value::Value as TomlValue;
 
 use crate::{
@@ -17,11 +21,11 @@ use crate::{
     ByteSizeOf, Result,
 };
 
-#[derive(PartialOrd, Debug, Clone, Deserialize)]
+#[derive(PartialOrd, Debug, Clone)]
 pub enum Value {
     Bytes(Bytes),
     Integer(i64),
-    Float(f64),
+    Float(NotNan<f64>),
     Boolean(bool),
     Timestamp(DateTime<Utc>),
     Map(BTreeMap<String, Value>),
@@ -117,13 +121,13 @@ impl ByteSizeOf for Value {
 }
 
 impl Serialize for Value {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
     where
         S: Serializer,
     {
         match &self {
             Value::Integer(i) => serializer.serialize_i64(*i),
-            Value::Float(f) => serializer.serialize_f64(*f),
+            Value::Float(f) => serializer.serialize_f64(f.into_inner()),
             Value::Boolean(b) => serializer.serialize_bool(*b),
             Value::Bytes(_) | Value::Timestamp(_) => {
                 serializer.serialize_str(&self.to_string_lossy())
@@ -132,6 +136,108 @@ impl Serialize for Value {
             Value::Array(a) => serializer.collect_seq(a),
             Value::Null => serializer.serialize_none(),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for Value {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> StdResult<Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("any valid JSON value")
+            }
+
+            #[inline]
+            fn visit_bool<E>(self, value: bool) -> StdResult<Value, E> {
+                Ok(value.into())
+            }
+
+            #[inline]
+            fn visit_i64<E>(self, value: i64) -> StdResult<Value, E> {
+                Ok(value.into())
+            }
+
+            #[inline]
+            fn visit_u64<E>(self, value: u64) -> StdResult<Value, E> {
+                Ok((value as i64).into())
+            }
+
+            #[inline]
+            fn visit_f64<E>(self, value: f64) -> StdResult<Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let f = NotNan::new(value).map_err(|_| {
+                    SerdeError::invalid_value(serde::de::Unexpected::Float(value), &self)
+                })?;
+                Ok(Value::Float(f))
+            }
+
+            #[inline]
+            fn visit_str<E>(self, value: &str) -> StdResult<Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Bytes(Bytes::copy_from_slice(value.as_bytes())))
+            }
+
+            #[inline]
+            fn visit_string<E>(self, value: String) -> StdResult<Value, E> {
+                Ok(Value::Bytes(value.into()))
+            }
+
+            #[inline]
+            fn visit_none<E>(self) -> StdResult<Value, E> {
+                Ok(Value::Null)
+            }
+
+            #[inline]
+            fn visit_some<D>(self, deserializer: D) -> StdResult<Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> StdResult<Value, E> {
+                Ok(Value::Null)
+            }
+
+            #[inline]
+            fn visit_seq<V>(self, mut visitor: V) -> StdResult<Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+                while let Some(value) = visitor.next_element()? {
+                    vec.push(value);
+                }
+
+                Ok(Value::Array(vec))
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> StdResult<Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut map = BTreeMap::new();
+                while let Some((key, value)) = visitor.next_entry()? {
+                    map.insert(key, value);
+                }
+
+                Ok(Value::Map(map))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
     }
 }
 
@@ -174,7 +280,9 @@ impl TryFrom<TomlValue> for Value {
             ),
             TomlValue::Datetime(dt) => Self::from(dt.to_string().parse::<DateTime<Utc>>()?),
             TomlValue::Boolean(b) => Self::from(b),
-            TomlValue::Float(f) => Self::from(f),
+            TomlValue::Float(f) => {
+                Value::Float(NotNan::new(f).map_err(|_| "NaN value not supported")?)
+            }
         })
     }
 }
@@ -200,14 +308,14 @@ impl<T: Into<Value>> From<Option<T>> for Value {
     }
 }
 
-impl From<f32> for Value {
-    fn from(value: f32) -> Self {
-        Value::Float(f64::from(value))
+impl From<NotNan<f32>> for Value {
+    fn from(value: NotNan<f32>) -> Self {
+        Value::Float(value.into())
     }
 }
 
-impl From<f64> for Value {
-    fn from(value: f64) -> Self {
+impl From<NotNan<f64>> for Value {
+    fn from(value: NotNan<f64>) -> Self {
         Value::Float(value)
     }
 }
@@ -261,8 +369,13 @@ impl From<serde_json::Value> for Value {
             serde_json::Value::Bool(b) => Value::Boolean(b),
             serde_json::Value::Number(n) => {
                 let float_or_byte = || {
-                    n.as_f64()
-                        .map_or_else(|| Value::Bytes(n.to_string().into()), Value::Float)
+                    n.as_f64().map_or_else(
+                        || Value::Bytes(n.to_string().into()),
+                        |f| {
+                            // JSON does not support NaN values
+                            Value::Float(NotNan::new(f).unwrap())
+                        },
+                    )
                 };
                 n.as_i64().map_or_else(float_or_byte, Value::Integer)
             }
@@ -283,11 +396,11 @@ impl From<serde_json::Value> for Value {
 impl TryInto<serde_json::Value> for Value {
     type Error = crate::Error;
 
-    fn try_into(self) -> std::result::Result<serde_json::Value, Self::Error> {
+    fn try_into(self) -> StdResult<serde_json::Value, Self::Error> {
         match self {
             Value::Boolean(v) => Ok(serde_json::Value::from(v)),
             Value::Integer(v) => Ok(serde_json::Value::from(v)),
-            Value::Float(v) => Ok(serde_json::Value::from(v)),
+            Value::Float(v) => Ok(serde_json::Value::from(v.into_inner())),
             Value::Bytes(v) => Ok(serde_json::Value::from(String::from_utf8(v.to_vec())?)),
             Value::Map(v) => Ok(serde_json::to_value(v)?),
             Value::Array(v) => Ok(serde_json::to_value(v)?),
@@ -307,7 +420,7 @@ impl From<vrl_core::Value> for Value {
         match v {
             Bytes(v) => Value::Bytes(v),
             Integer(v) => Value::Integer(v),
-            Float(v) => Value::Float(*v),
+            Float(v) => Value::Float(v),
             Boolean(v) => Value::Boolean(v),
             Object(v) => Value::Map(v.into_iter().map(|(k, v)| (k, v.into())).collect()),
             Array(v) => Value::Array(v.into_iter().map(Into::into).collect()),
@@ -496,7 +609,7 @@ impl Value {
         working_lookup: &LookupBuf,
         sub_value: &mut Value,
         value: Value,
-    ) -> std::result::Result<Option<Value>, EventError> {
+    ) -> StdResult<Option<Value>, EventError> {
         // Creating a needle with a back out of the loop is very important.
         let mut needle = None;
         for sub_segment in sub_segments {
@@ -538,7 +651,7 @@ impl Value {
         mut working_lookup: LookupBuf,
         map: &mut BTreeMap<String, Value>,
         value: Value,
-    ) -> std::result::Result<Option<Value>, EventError> {
+    ) -> StdResult<Option<Value>, EventError> {
         let next_segment = match working_lookup.get(0) {
             Some(segment) => segment,
             None => {
@@ -585,7 +698,7 @@ impl Value {
         mut working_lookup: LookupBuf,
         array: &mut Vec<Value>,
         value: Value,
-    ) -> std::result::Result<Option<Value>, EventError> {
+    ) -> StdResult<Option<Value>, EventError> {
         let index = if i.is_negative() {
             array.len() as isize + i
         } else {
@@ -729,7 +842,7 @@ impl Value {
         &mut self,
         lookup: impl Into<LookupBuf> + Debug,
         value: impl Into<Value> + Debug,
-    ) -> std::result::Result<Option<Value>, EventError> {
+    ) -> StdResult<Option<Value>, EventError> {
         let mut working_lookup: LookupBuf = lookup.into();
         let value = value.into();
         let span = trace_span!("insert", lookup = %working_lookup);
@@ -819,7 +932,7 @@ impl Value {
         &mut self,
         lookup: impl Into<Lookup<'a>> + Debug,
         prune: bool,
-    ) -> std::result::Result<Option<Value>, EventError> {
+    ) -> StdResult<Option<Value>, EventError> {
         let mut working_lookup = lookup.into();
         let span = trace_span!("remove", lookup = %working_lookup, %prune);
         let _guard = span.enter();
@@ -963,7 +1076,7 @@ impl Value {
     pub fn get<'a>(
         &self,
         lookup: impl Into<Lookup<'a>> + Debug,
-    ) -> std::result::Result<Option<&Value>, EventError> {
+    ) -> StdResult<Option<&Value>, EventError> {
         let mut working_lookup = lookup.into();
         let span = trace_span!("get", lookup = %working_lookup);
         let _guard = span.enter();
@@ -1058,7 +1171,7 @@ impl Value {
     pub fn get_mut<'a>(
         &mut self,
         lookup: impl Into<Lookup<'a>> + Debug,
-    ) -> std::result::Result<Option<&mut Value>, EventError> {
+    ) -> StdResult<Option<&mut Value>, EventError> {
         let mut working_lookup = lookup.into();
         let span = trace_span!("get_mut", lookup = %working_lookup);
         let _guard = span.enter();

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -327,13 +327,6 @@ impl From<f64> for Value {
     }
 }
 
-#[cfg(any(test, feature = "test"))]
-impl From<f32> for Value {
-    fn from(f: f32) -> Self {
-        NotNan::new(f as f64).unwrap().into()
-    }
-}
-
 impl From<BTreeMap<String, Value>> for Value {
     fn from(value: BTreeMap<String, Value>) -> Self {
         Value::Map(value)
@@ -1503,10 +1496,10 @@ mod test {
             assert!(Value::Integer(0).eq(&Value::Integer(0)));
             assert!(!Value::Integer(0).eq(&Value::Integer(1)));
             assert!(!Value::Boolean(true).eq(&Value::Integer(2)));
-            assert!(Value::Float(1.2).eq(&Value::Float(1.4)));
-            assert!(!Value::Float(1.2).eq(&Value::Float(-1.2)));
-            assert!(!Value::Float(-0.0).eq(&Value::Float(0.0)));
-            assert!(!Value::Float(f64::NEG_INFINITY).eq(&Value::Float(f64::INFINITY)));
+            assert!(Value::from(1.2).eq(&Value::from(1.4)));
+            assert!(!Value::from(1.2).eq(&Value::from(-1.2)));
+            assert!(!Value::from(-0.0).eq(&Value::from(0.0)));
+            assert!(!Value::from(f64::NEG_INFINITY).eq(&Value::from(f64::INFINITY)));
             assert!(Value::Array(vec![Value::Integer(0), Value::Boolean(true)])
                 .eq(&Value::Array(vec![Value::Integer(0), Value::Boolean(true)])));
             assert!(!Value::Array(vec![Value::Integer(0), Value::Boolean(true)])
@@ -1529,12 +1522,12 @@ mod test {
             assert_eq!(hash(&Value::Integer(0)), hash(&Value::Integer(0)));
             assert_ne!(hash(&Value::Integer(0)), hash(&Value::Integer(1)));
             assert_ne!(hash(&Value::Boolean(true)), hash(&Value::Integer(2)));
-            assert_eq!(hash(&Value::Float(1.2)), hash(&Value::Float(1.4)));
-            assert_ne!(hash(&Value::Float(1.2)), hash(&Value::Float(-1.2)));
-            assert_ne!(hash(&Value::Float(-0.0)), hash(&Value::Float(0.0)));
+            assert_eq!(hash(&Value::from(1.2)), hash(&Value::from(1.4)));
+            assert_ne!(hash(&Value::from(1.2)), hash(&Value::from(-1.2)));
+            assert_ne!(hash(&Value::from(-0.0)), hash(&Value::from(0.0)));
             assert_ne!(
-                hash(&Value::Float(f64::NEG_INFINITY)),
-                hash(&Value::Float(f64::INFINITY))
+                hash(&Value::from(f64::NEG_INFINITY)),
+                hash(&Value::from(f64::INFINITY))
             );
             assert_eq!(
                 hash(&Value::Array(vec![Value::Integer(0), Value::Boolean(true)])),

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -320,6 +320,20 @@ impl From<NotNan<f64>> for Value {
     }
 }
 
+#[cfg(any(test, feature = "test"))]
+impl From<f64> for Value {
+    fn from(f: f64) -> Self {
+        NotNan::new(f).unwrap().into()
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl From<f32> for Value {
+    fn from(f: f32) -> Self {
+        NotNan::new(f as f64).unwrap().into()
+    }
+}
+
 impl From<BTreeMap<String, Value>> for Value {
     fn from(value: BTreeMap<String, Value>) -> Self {
         Value::Map(value)
@@ -486,6 +500,13 @@ impl Value {
     pub fn as_map(&self) -> Option<&BTreeMap<String, Value>> {
         match &self {
             Value::Map(map) => Some(map),
+            _ => None,
+        }
+    }
+
+    pub fn as_float(&self) -> Option<NotNan<f64>> {
+        match self {
+            Value::Float(f) => Some(*f),
             _ => None,
         }
     }

--- a/lib/vector-core/src/mapping/parser/mod.rs
+++ b/lib/vector-core/src/mapping/parser/mod.rs
@@ -1,5 +1,6 @@
 extern crate pest;
 
+use ordered_float::NotNan;
 use std::{convert::TryFrom, str::FromStr};
 
 use pest::{
@@ -413,7 +414,7 @@ fn query_from_pair(pair: Pair<Rule>) -> Result<Box<dyn query::Function>> {
         ))),
         Rule::null => Box::new(Literal::from(Value::Null)),
         Rule::float => Box::new(Literal::from(Value::from(
-            pair.as_str().parse::<f64>().unwrap(),
+            NotNan::new(pair.as_str().parse::<f64>().unwrap()).unwrap(),
         ))),
         Rule::integer => Box::new(Literal::from(Value::from(
             pair.as_str().parse::<i64>().unwrap(),

--- a/lib/vector-core/src/mapping/query/arithmetic.rs
+++ b/lib/vector-core/src/mapping/query/arithmetic.rs
@@ -287,7 +287,7 @@ mod tests {
                     event.as_mut_log().insert("bar", Value::Integer(10));
                     event
                 },
-                Ok(Value::Float(2.0)),
+                Ok(Value::from(2.0)),
                 Arithmetic::new(
                     Box::new(Path::from("bar")),
                     Box::new(Path::from("foo")),
@@ -345,9 +345,9 @@ mod tests {
             ),
             (
                 Event::from(""),
-                Ok(Value::Float(17.0)),
+                Ok(Value::from(17.0)),
                 Arithmetic::new(
-                    Box::new(Literal::from(Value::Float(20.0))),
+                    Box::new(Literal::from(Value::from(20.0))),
                     Box::new(Literal::from(Value::Integer(3))),
                     Operator::Subtract,
                 ),
@@ -356,7 +356,7 @@ mod tests {
                 Event::from(""),
                 Ok(Value::Boolean(true)),
                 Arithmetic::new(
-                    Box::new(Literal::from(Value::Float(20.0))),
+                    Box::new(Literal::from(Value::from(20.0))),
                     Box::new(Literal::from(Value::Integer(20))),
                     Operator::Equal,
                 ),
@@ -374,7 +374,7 @@ mod tests {
                 Event::from(""),
                 Ok(Value::Boolean(true)),
                 Arithmetic::new(
-                    Box::new(Literal::from(Value::Float(21.0))),
+                    Box::new(Literal::from(Value::from(21.0))),
                     Box::new(Literal::from(Value::Integer(18))),
                     Operator::Greater,
                 ),
@@ -383,7 +383,7 @@ mod tests {
                 Event::from(""),
                 Ok(Value::Boolean(false)),
                 Arithmetic::new(
-                    Box::new(Literal::from(Value::Float(18.0))),
+                    Box::new(Literal::from(Value::from(18.0))),
                     Box::new(Literal::from(Value::Integer(18))),
                     Operator::Greater,
                 ),
@@ -393,7 +393,7 @@ mod tests {
                 Ok(Value::Boolean(false)),
                 Arithmetic::new(
                     Box::new(Literal::from(Value::Integer(17))),
-                    Box::new(Literal::from(Value::Float(18.0))),
+                    Box::new(Literal::from(Value::from(18.0))),
                     Operator::GreaterOrEqual,
                 ),
             ),
@@ -402,7 +402,7 @@ mod tests {
                 Ok(Value::Boolean(true)),
                 Arithmetic::new(
                     Box::new(Literal::from(Value::Integer(18))),
-                    Box::new(Literal::from(Value::Float(18.0))),
+                    Box::new(Literal::from(Value::from(18.0))),
                     Operator::GreaterOrEqual,
                 ),
             ),
@@ -411,7 +411,7 @@ mod tests {
                 Ok(Value::Boolean(false)),
                 Arithmetic::new(
                     Box::new(Literal::from(Value::Integer(18))),
-                    Box::new(Literal::from(Value::Float(18.0))),
+                    Box::new(Literal::from(Value::from(18.0))),
                     Operator::Less,
                 ),
             ),
@@ -420,7 +420,7 @@ mod tests {
                 Ok(Value::Boolean(true)),
                 Arithmetic::new(
                     Box::new(Literal::from(Value::Integer(18))),
-                    Box::new(Literal::from(Value::Float(18.0))),
+                    Box::new(Literal::from(Value::from(18.0))),
                     Operator::LessOrEqual,
                 ),
             ),

--- a/lib/vector-datadog-filter/src/filter.rs
+++ b/lib/vector-datadog-filter/src/filter.rs
@@ -142,19 +142,19 @@ impl Filter<LogEvent> for EventFilter {
                         // Floats.
                         (Some(Value::Float(lhs)), ComparisonValue::Float(rhs)) => {
                             match comparator {
-                                Comparison::Lt => lhs < rhs,
-                                Comparison::Lte => lhs <= rhs,
-                                Comparison::Gt => lhs > rhs,
-                                Comparison::Gte => lhs >= rhs,
+                                Comparison::Lt => lhs.into_inner() < *rhs,
+                                Comparison::Lte => lhs.into_inner() <= *rhs,
+                                Comparison::Gt => lhs.into_inner() > *rhs,
+                                Comparison::Gte => lhs.into_inner() >= *rhs,
                             }
                         }
                         // Float value - Integer boundary
                         (Some(Value::Float(lhs)), ComparisonValue::Integer(rhs)) => {
                             match comparator {
-                                Comparison::Lt => *lhs < *rhs as f64,
-                                Comparison::Lte => *lhs <= *rhs as f64,
-                                Comparison::Gt => *lhs > *rhs as f64,
-                                Comparison::Gte => *lhs >= *rhs as f64,
+                                Comparison::Lt => lhs.into_inner() < *rhs as f64,
+                                Comparison::Lte => lhs.into_inner() <= *rhs as f64,
+                                Comparison::Gt => lhs.into_inner() > *rhs as f64,
+                                Comparison::Gte => lhs.into_inner() >= *rhs as f64,
                             }
                         }
                         // Where the rhs is a string ref, the lhs is coerced into a string.

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -62,11 +62,11 @@ impl CheckFieldsPredicate for EqualsPredicate {
                 }
                 CheckFieldsPredicateArg::Integer(i) => match v {
                     Value::Integer(vi) => *i == *vi,
-                    Value::Float(vf) => *i == *vf as i64,
+                    Value::Float(vf) => *i == vf.into_inner() as i64,
                     _ => false,
                 },
                 CheckFieldsPredicateArg::Float(f) => match v {
-                    Value::Float(vf) => *f == *vf,
+                    Value::Float(vf) => *f == vf.into_inner(),
                     Value::Integer(vi) => *f == *vi as f64,
                     _ => false,
                 },

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use indexmap::IndexMap;
+use ordered_float::NotNan;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -503,7 +504,9 @@ fn build_input_event(input: &TestInput) -> Result<Event, String> {
                         TestInputValue::String(s) => Value::from(s.to_owned()),
                         TestInputValue::Boolean(b) => Value::from(*b),
                         TestInputValue::Integer(i) => Value::from(*i),
-                        TestInputValue::Float(f) => Value::from(*f),
+                        TestInputValue::Float(f) => Value::from(
+                            NotNan::new(*f).map_err(|_| "NaN value not supported".to_string())?,
+                        ),
                     };
                     event.as_mut_log().insert(path.to_owned(), value);
                 }

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -248,7 +248,7 @@ impl InfluxDbLogsConfig {
 fn to_field(value: &Value) -> Field {
     match value {
         Value::Integer(num) => Field::Int(*num),
-        Value::Float(num) => Field::Float(*num),
+        Value::Float(num) => Field::Float(num.into_inner()),
         Value::Boolean(b) => Field::Bool(*b),
         _ => Field::String(value.to_string_lossy()),
     }

--- a/src/sinks/new_relic/tests.rs
+++ b/src/sinks/new_relic/tests.rs
@@ -160,7 +160,7 @@ fn generate_metric_api_model() {
         "my_metric".to_owned()
     );
     assert!(metrics[0].get("value").is_some());
-    assert_eq!(metrics[0].get("value").unwrap(), &Value::Float(100.0));
+    assert_eq!(metrics[0].get("value").unwrap(), &Value::from(100.0));
     assert!(metrics[0].get("timestamp").is_some());
 
     // With timestamp
@@ -184,6 +184,6 @@ fn generate_metric_api_model() {
         "my_metric".to_owned()
     );
     assert!(metrics[0].get("value").is_some());
-    assert_eq!(metrics[0].get("value").unwrap(), &Value::Float(100.0));
+    assert_eq!(metrics[0].get("value").unwrap(), &Value::from(100.0));
     assert!(metrics[0].get("timestamp").is_some());
 }

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -151,14 +151,12 @@ impl From<FluentValue> for Value {
             rmpv::Value::F32(f) => {
                 // serde_json converts NaN to Null, so we model that behavior here since this is non-fallible
                 NotNan::new(f as f64)
-                    .map(|f| Value::Float(f))
+                    .map(Value::Float)
                     .unwrap_or(Value::Null)
             }
             rmpv::Value::F64(f) => {
                 // serde_json converts NaN to Null, so we model that behavior here since this is non-fallible
-                NotNan::new(f)
-                    .map(|f| Value::Float(f))
-                    .unwrap_or(Value::Null)
+                NotNan::new(f).map(Value::Float).unwrap_or(Value::Null)
             }
             rmpv::Value::String(s) => Value::Bytes(s.into_bytes().into()),
             rmpv::Value::Binary(bytes) => Value::Bytes(bytes.into()),

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -201,10 +201,13 @@ mod tests {
         let log = LogEvent::from("hello world");
         let mut expected = log.clone();
         expected.insert("float", 4.5);
-        expected.insert("int", 4);
+        expected.insert("int", 4_i64);
         expected.insert("string", "thisisastring");
         expected.insert("bool", true);
-        expected.insert("array", Value::Array(vec![1.into(), 2.into(), 3.into()]));
+        expected.insert(
+            "array",
+            Value::Array(vec![1_i64.into(), 2_i64.into(), 3_i64.into()]),
+        );
         expected.insert(
             "table",
             Value::Map(vec![("key".into(), "value".into())].into_iter().collect()),
@@ -212,7 +215,7 @@ mod tests {
 
         let mut fields = IndexMap::new();
         fields.insert(String::from("float"), Value::from(4.5));
-        fields.insert(String::from("int"), Value::from(4));
+        fields.insert(String::from("int"), Value::from(4_i64));
         fields.insert(String::from("string"), Value::from("thisisastring"));
         fields.insert(String::from("bool"), Value::from(true));
         fields.insert(String::from("array"), Value::from(vec![1_isize, 2, 3]));

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -183,7 +183,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(log["number"], Value::Float(42.3));
+        assert_eq!(log["number"], Value::from(42.3));
         assert_eq!(log["flag"], Value::Boolean(true));
         assert_eq!(log["code"], Value::Integer(1234));
         assert_eq!(log["rest"], Value::Bytes("word".into()));

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -1,6 +1,7 @@
 use std::{future::ready, pin::Pin};
 
 use futures::{stream, Stream, StreamExt};
+use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
@@ -201,8 +202,10 @@ impl mlua::UserData for LuaEvent {
                     Some(mlua::Value::Integer(integer)) => {
                         this.inner.as_mut_log().insert(key, Value::Integer(integer));
                     }
-                    Some(mlua::Value::Number(number)) => {
-                        this.inner.as_mut_log().insert(key, Value::Float(number));
+                    Some(mlua::Value::Number(number)) if !number.is_nan() => {
+                        this.inner
+                            .as_mut_log()
+                            .insert(key, Value::Float(NotNan::new(number).unwrap()));
                     }
                     Some(mlua::Value::Boolean(boolean)) => {
                         this.inner.as_mut_log().insert(key, Value::Boolean(boolean));

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -399,7 +399,7 @@ mod tests {
         .unwrap();
 
         let event = transform.transform_one(Event::new_empty_log()).unwrap();
-        assert_eq!(event.as_log()["number"], Value::Float(3.14159));
+        assert_eq!(event.as_log()["number"], Value::from(3.14159));
     }
 
     #[test]

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -555,7 +555,7 @@ mod tests {
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
 
-        assert_eq!(output.as_log()["number"], Value::Float(3.14159));
+        assert_eq!(output.as_log()["number"], Value::from(3.14159));
         Ok(())
     }
 

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Utc};
+use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
 
 use crate::event::{LogEvent, Value};
@@ -321,7 +322,7 @@ impl ReduceValueMerger for TimestampWindowMerger {
 #[derive(Debug, Clone)]
 enum NumberMergerValue {
     Int(i64),
-    Float(f64),
+    Float(NotNan<f64>),
 }
 
 impl From<i64> for NumberMergerValue {
@@ -330,8 +331,8 @@ impl From<i64> for NumberMergerValue {
     }
 }
 
-impl From<f64> for NumberMergerValue {
-    fn from(v: f64) -> Self {
+impl From<NotNan<f64>> for NumberMergerValue {
+    fn from(v: NotNan<f64>) -> Self {
         NumberMergerValue::Float(v)
     }
 }
@@ -356,7 +357,9 @@ impl ReduceValueMerger for AddNumbersMerger {
         match v {
             Value::Integer(i) => match self.v {
                 NumberMergerValue::Int(j) => self.v = NumberMergerValue::Int(i + j),
-                NumberMergerValue::Float(j) => self.v = NumberMergerValue::Float(i as f64 + j),
+                NumberMergerValue::Float(j) => {
+                    self.v = NumberMergerValue::Float(NotNan::new(i as f64).unwrap() + j)
+                }
             },
             Value::Float(f) => match self.v {
                 NumberMergerValue::Int(j) => self.v = NumberMergerValue::Float(f + j as f64),
@@ -407,7 +410,7 @@ impl ReduceValueMerger for MaxNumberMerger {
                         }
                     }
                     NumberMergerValue::Float(f2) => {
-                        let f = i as f64;
+                        let f = NotNan::new(i as f64).unwrap();
                         if f > f2 {
                             self.v = NumberMergerValue::Float(f);
                         }
@@ -416,7 +419,7 @@ impl ReduceValueMerger for MaxNumberMerger {
             }
             Value::Float(f) => {
                 let f2 = match self.v {
-                    NumberMergerValue::Int(i2) => i2 as f64,
+                    NumberMergerValue::Int(i2) => NotNan::new(i2 as f64).unwrap(),
                     NumberMergerValue::Float(f2) => f2,
                 };
                 if f > f2 {
@@ -468,7 +471,7 @@ impl ReduceValueMerger for MinNumberMerger {
                         }
                     }
                     NumberMergerValue::Float(f2) => {
-                        let f = i as f64;
+                        let f = NotNan::new(i as f64).unwrap();
                         if f < f2 {
                             self.v = NumberMergerValue::Float(f);
                         }
@@ -477,7 +480,7 @@ impl ReduceValueMerger for MinNumberMerger {
             }
             Value::Float(f) => {
                 let f2 = match self.v {
-                    NumberMergerValue::Int(i2) => i2 as f64,
+                    NumberMergerValue::Int(i2) => NotNan::new(i2 as f64).unwrap(),
                     NumberMergerValue::Float(f2) => f2,
                 };
                 if f < f2 {

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -770,32 +770,36 @@ mod test {
         );
 
         assert_eq!(
-            merge(json!([4]).into(), json!([2]).into(), &MergeStrategy::Concat),
-            Ok(json!([4, 2]).into())
+            merge(
+                json!([4_i64]).into(),
+                json!([2_i64]).into(),
+                &MergeStrategy::Concat
+            ),
+            Ok(json!([4_i64, 2_i64]).into())
         );
         assert_eq!(
-            merge(json!([]).into(), 42.into(), &MergeStrategy::Concat),
-            Ok(json!([42]).into())
+            merge(json!([]).into(), 42_i64.into(), &MergeStrategy::Concat),
+            Ok(json!([42_i64]).into())
         );
 
         assert_eq!(
             merge(
-                json!([34]).into(),
-                json!([42, 43]).into(),
+                json!([34_i64]).into(),
+                json!([42_i64, 43_i64]).into(),
                 &MergeStrategy::ShortestArray
             ),
-            Ok(json!([34]).into())
+            Ok(json!([34_i64]).into())
         );
         assert_eq!(
             merge(
-                json!([34]).into(),
-                json!([42, 43]).into(),
+                json!([34_i64]).into(),
+                json!([42_i64, 43_i64]).into(),
                 &MergeStrategy::LongestArray
             ),
-            Ok(json!([42, 43]).into())
+            Ok(json!([42_i64, 43_i64]).into())
         );
 
-        let v = merge(34.into(), 43.into(), &MergeStrategy::FlatUnique).unwrap();
+        let v = merge(34_i64.into(), 43_i64.into(), &MergeStrategy::FlatUnique).unwrap();
         if let Value::Array(v) = v.clone() {
             let v: Vec<_> = v
                 .into_iter()
@@ -812,7 +816,7 @@ mod test {
         } else {
             panic!("Not array");
         }
-        let v = merge(v, 34.into(), &MergeStrategy::FlatUnique).unwrap();
+        let v = merge(v, 34_i32.into(), &MergeStrategy::FlatUnique).unwrap();
         if let Value::Array(v) = v {
             let v: Vec<_> = v
                 .into_iter()

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -313,6 +313,7 @@ mod tests {
         event::{Event, LogEvent, Value},
         transforms::OutputBuffer,
     };
+    use ordered_float::NotNan;
 
     #[test]
     fn generate_config() {
@@ -529,7 +530,7 @@ mod tests {
         .expect("Failed to parse log");
         assert_eq!(log["check"], Value::Boolean(false));
         assert_eq!(log["status"], Value::Integer(1234));
-        assert_eq!(log["time"], Value::Float(6789.01));
+        assert_eq!(log["time"], Value::Float(NotNan::new(6789.01).unwrap()));
     }
 
     #[tokio::test]
@@ -582,7 +583,7 @@ mod tests {
 
         assert_eq!(log.get("id1"), None);
         assert_eq!(log["id2"], Value::Integer(1234));
-        assert_eq!(log["time"], Value::Float(235.42));
+        assert_eq!(log["time"], Value::Float(NotNan::new(235.42).unwrap()));
         assert_eq!(log["check"], Value::Boolean(true));
         assert!(log.get("message").is_some());
     }

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -146,6 +146,7 @@ mod tests {
         config::TransformConfig,
         event::{Event, LogEvent, Value},
     };
+    use ordered_float::NotNan;
 
     #[test]
     fn generate_config() {
@@ -251,7 +252,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(log["number"], Value::Float(42.3));
+        assert_eq!(log["number"], Value::Float(NotNan::new(42.3).unwrap()));
         assert_eq!(log["flag"], Value::Boolean(true));
         assert_eq!(log["code"], Value::Integer(1234));
         assert_eq!(log["rest"], Value::Bytes("word".into()));

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -137,6 +137,7 @@ mod tests {
         event::{Event, LogEvent, Value},
         transforms::OutputBuffer,
     };
+    use ordered_float::NotNan;
 
     #[test]
     fn generate_config() {
@@ -210,9 +211,9 @@ mod tests {
         )
         .await;
 
-        assert_eq!(log["number"], Value::Float(42.3));
+        assert_eq!(log["number"], Value::Float(NotNan::new(42.3).unwrap()));
         assert_eq!(log["flag"], Value::Boolean(true));
-        assert_eq!(log["code"], Value::Integer(1234));
+        assert_eq!(log["code"], Value::Integer(1234_i64));
         assert_eq!(log["rest"], Value::Bytes("word".into()));
     }
 
@@ -226,7 +227,7 @@ mod tests {
             &[("code", "integer"), ("who", "string"), ("why", "string")],
         )
         .await;
-        assert_eq!(log["code"], Value::Integer(1234));
+        assert_eq!(log["code"], Value::Integer(1234_i64));
         assert_eq!(log["who"], Value::Bytes("-".into()));
         assert_eq!(log["why"], Value::Bytes("foo".into()));
     }


### PR DESCRIPTION
This is part 1 in a series of PR's to unify the Vector and VRL Value types.

The VRL Value::Float requires all values to be NotNan. This PR adds that requirement to the Vector Value type.
The From<f64> was kept for testing purposes, but is only included for tests. Everywhere else now handles possible NaN values and converts them to NotNan first.

Note: This PR was cherry-picked from the original one (https://github.com/vectordotdev/vector/pull/11271)