### PR TITLE
chore(core): Value unification part 2 - Regex

### DIFF
--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -121,6 +121,7 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &Value) {
     match value {
         // Trivial.
         Value::Bytes(val) => val.hash(hasher),
+        Value::Regex(val) => val.as_bytes_slice().hash(hasher),
         Value::Boolean(val) => val.hash(hasher),
         Value::Integer(val) => val.hash(hasher),
         Value::Timestamp(val) => val.hash(hasher),

--- a/lib/vector-core/src/event/lua/value.rs
+++ b/lib/vector-core/src/event/lua/value.rs
@@ -9,6 +9,9 @@ impl<'a> ToLua<'a> for Value {
     fn to_lua(self, lua: &'a Lua) -> LuaResult<LuaValue> {
         match self {
             Value::Bytes(b) => lua.create_string(b.as_ref()).map(LuaValue::String),
+            Value::Regex(regex) => lua
+                .create_string(regex.as_bytes_slice())
+                .map(LuaValue::String),
             Value::Integer(i) => Ok(LuaValue::Integer(i)),
             Value::Float(f) => Ok(LuaValue::Number(f.into_inner())),
             Value::Boolean(b) => Ok(LuaValue::Boolean(b)),

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -44,6 +44,7 @@ pub mod proto;
 mod test;
 pub mod util;
 mod value;
+mod value_regex;
 #[cfg(feature = "vrl")]
 mod vrl_target;
 

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -366,6 +366,7 @@ fn encode_value(value: event::Value) -> Value {
     Value {
         kind: match value {
             event::Value::Bytes(b) => Some(value::Kind::RawBytes(b)),
+            event::Value::Regex(regex) => Some(value::Kind::RawBytes(regex.as_bytes())),
             event::Value::Timestamp(ts) => Some(value::Kind::Timestamp(prost_types::Timestamp {
                 seconds: ts.timestamp(),
                 nanos: ts.timestamp_subsec_nanos() as i32,

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -570,8 +570,7 @@ impl Value {
 
     pub fn kind(&self) -> &str {
         match self {
-            Value::Bytes(_) => "string",
-            Value::Regex(_) => "string",
+            Value::Bytes(_) | Value::Regex(_) => "string",
             Value::Timestamp(_) => "timestamp",
             Value::Integer(_) => "integer",
             Value::Float(_) => "float",

--- a/lib/vector-core/src/event/value.rs
+++ b/lib/vector-core/src/event/value.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::result::Result as StdResult;
 use toml::value::Value as TomlValue;
 
+use crate::event::value_regex::ValueRegex;
 use crate::{
     event::{error::EventError, timestamp_to_string},
     ByteSizeOf, Result,
@@ -24,6 +25,10 @@ use crate::{
 #[derive(PartialOrd, Debug, Clone)]
 pub enum Value {
     Bytes(Bytes),
+
+    /// When used in the context of Vector this is treated identically to Bytes. It has
+    /// additional meaning in the context of VRL
+    Regex(ValueRegex),
     Integer(i64),
     Float(NotNan<f64>),
     Boolean(bool),
@@ -474,6 +479,7 @@ impl Value {
     pub fn as_bytes(&self) -> Bytes {
         match self {
             Value::Bytes(bytes) => bytes.clone(), // cloning a Bytes is cheap
+            Value::ByRegextes(regex) => ,
             Value::Timestamp(timestamp) => Bytes::from(timestamp_to_string(timestamp)),
             Value::Integer(num) => Bytes::from(format!("{}", num)),
             Value::Float(num) => Bytes::from(format!("{}", num)),
@@ -557,6 +563,7 @@ impl Value {
     pub fn kind(&self) -> &str {
         match self {
             Value::Bytes(_) => "string",
+            Value::Regex(_) => "string",
             Value::Timestamp(_) => "timestamp",
             Value::Integer(_) => "integer",
             Value::Float(_) => "float",
@@ -609,6 +616,7 @@ impl Value {
         match &self {
             Value::Boolean(_)
             | Value::Bytes(_)
+            | Value::Regex(_)
             | Value::Timestamp(_)
             | Value::Float(_)
             | Value::Integer(_) => false,
@@ -876,6 +884,7 @@ impl Value {
             // if the type is one of the following, the field is modified to be a map.
             (Some(segment), Value::Boolean(_))
             | (Some(segment), Value::Bytes(_))
+            | (Some(segment), Value::Regex(_))
             | (Some(segment), Value::Timestamp(_))
             | (Some(segment), Value::Float(_))
             | (Some(segment), Value::Integer(_))
@@ -962,6 +971,7 @@ impl Value {
             // This is just not allowed!
             (Some(segment), Value::Boolean(_))
             | (Some(segment), Value::Bytes(_))
+            | (Some(segment), Value::Regex(_))
             | (Some(segment), Value::Timestamp(_))
             | (Some(segment), Value::Float(_))
             | (Some(segment), Value::Integer(_))
@@ -1148,6 +1158,7 @@ impl Value {
             // This is just not allowed!
             (Some(_s), Value::Boolean(_))
             | (Some(_s), Value::Bytes(_))
+            | (Some(_s), Value::Regex(_))
             | (Some(_s), Value::Timestamp(_))
             | (Some(_s), Value::Float(_))
             | (Some(_s), Value::Integer(_))
@@ -1197,6 +1208,7 @@ impl Value {
             // This is just not allowed!
             (_, Value::Boolean(_))
             | (_, Value::Bytes(_))
+            | (_, Value::Regex(_))
             | (_, Value::Timestamp(_))
             | (_, Value::Float(_))
             | (_, Value::Integer(_))
@@ -1308,6 +1320,7 @@ impl Value {
         match &self {
             Value::Boolean(_)
             | Value::Bytes(_)
+            | Value::Regex(_)
             | Value::Timestamp(_)
             | Value::Float(_)
             | Value::Integer(_)
@@ -1414,6 +1427,7 @@ impl Value {
         match &self {
             Value::Boolean(_)
             | Value::Bytes(_)
+            | Value::Regex(_)
             | Value::Timestamp(_)
             | Value::Float(_)
             | Value::Integer(_)

--- a/lib/vector-core/src/event/value_regex.rs
+++ b/lib/vector-core/src/event/value_regex.rs
@@ -37,7 +37,7 @@ impl PartialEq for ValueRegex {
 
 impl Hash for ValueRegex {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.as_str().hash(state)
+        self.0.as_str().hash(state);
     }
 }
 

--- a/lib/vector-core/src/event/value_regex.rs
+++ b/lib/vector-core/src/event/value_regex.rs
@@ -1,0 +1,57 @@
+//! This was copied from VRL code, to make the Vector Value more similar to the VRL value.
+//! Both copies will eventually be merged when the value types are merged
+
+use bytes::Bytes;
+use std::cmp::Ordering;
+use std::{
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
+
+#[derive(Debug, Clone)]
+pub struct ValueRegex(regex::Regex);
+
+impl ValueRegex {
+    pub fn as_bytes(&self) -> Bytes {
+        bytes::Bytes::copy_from_slice(self.as_bytes_slice())
+    }
+
+    pub fn as_bytes_slice(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
+
+impl PartialEq for ValueRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Hash for ValueRegex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_str().hash(state)
+    }
+}
+
+impl Deref for ValueRegex {
+    type Target = regex::Regex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<regex::Regex> for ValueRegex {
+    fn from(regex: regex::Regex) -> Self {
+        Self(regex)
+    }
+}
+
+impl PartialOrd for ValueRegex {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0
+            .as_str()
+            .as_bytes()
+            .partial_cmp(other.0.as_str().as_bytes())
+    }
+}

--- a/lib/vector-core/src/event/value_regex.rs
+++ b/lib/vector-core/src/event/value_regex.rs
@@ -12,12 +12,20 @@ use std::{
 pub struct ValueRegex(regex::Regex);
 
 impl ValueRegex {
+    pub fn new(regex: regex::Regex) -> Self {
+        Self(regex)
+    }
+
     pub fn as_bytes(&self) -> Bytes {
         bytes::Bytes::copy_from_slice(self.as_bytes_slice())
     }
 
     pub fn as_bytes_slice(&self) -> &[u8] {
         self.as_str().as_bytes()
+    }
+
+    pub fn into_inner(self) -> regex::Regex {
+        self.0
     }
 }
 

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -141,6 +141,7 @@ const fn type_id_for_value(val: &Value) -> TypeId {
         Value::Map(_) => 5,
         Value::Array(_) => 6,
         Value::Null => 7,
+        Value::Regex(_) => 8,
     }
 }
 

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -523,6 +523,7 @@ impl From<Value> for Box<dyn ReduceValueMerger> {
             Value::Null => Box::new(DiscardMerger::new(v)),
             Value::Boolean(_) => Box::new(DiscardMerger::new(v)),
             Value::Bytes(_) => Box::new(DiscardMerger::new(v)),
+            Value::Regex(_) => Box::new(DiscardMerger::new(v)),
             Value::Array(_) => Box::new(DiscardMerger::new(v)),
         }
     }


### PR DESCRIPTION
This is part 2 in a series of PR's to unify the Vector and VRL Value types.

The VRL Value has a Regex variant, and the Vector Value does not. The behavior for converting between the 2 types when a Regex is involved is already well defined today, it is simply converted to the Bytes variant. This PR adds a Regex variant to the Vector Value. Whenever it is accessed, it behaves the exact same as it did before.