### PR TITLE
fix(codecs): Fix deserialization of `only_fields` in YAML for fixed encodings

### DIFF
--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -278,7 +278,7 @@ fn deserialize_path_components<'de, D>(
 where
     D: serde::de::Deserializer<'de>,
 {
-    let fields: Option<Vec<&str>> = serde::de::Deserialize::deserialize(deserializer)?;
+    let fields: Option<Vec<String>> = serde::de::Deserialize::deserialize(deserializer)?;
     Ok(fields.map(|fields| {
         fields
             .iter()


### PR DESCRIPTION
Fixes: https://github.com/vectordotdev/vector/pull/11198#issuecomment-1034789883

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
