### PR TITLE
chore(performance): try leaking socket source peers

### DIFF
--- a/src/internal_events/tcp.rs
+++ b/src/internal_events/tcp.rs
@@ -1,7 +1,5 @@
 // ## skip check-events ##
 
-use std::net::IpAddr;
-
 use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
@@ -118,19 +116,19 @@ impl InternalEvent for TcpSendAckError {
 #[derive(Debug)]
 pub struct TcpBytesReceived {
     pub byte_size: usize,
-    pub peer_addr: IpAddr,
+    pub peer_addr: &'static str,
 }
 
 impl InternalEvent for TcpBytesReceived {
     fn emit_logs(&self) {
-        trace!(message = "Bytes received.", byte_size = %self.byte_size, peer_addr = %self.peer_addr);
+        trace!(message = "Bytes received.", byte_size = %self.byte_size, peer_addr = self.peer_addr);
     }
 
     fn emit_metrics(&self) {
         counter!(
             "component_received_bytes_total", self.byte_size as u64,
             "protocol" => "tcp",
-            "peer_addr" => self.peer_addr.to_string()
+            "peer_addr" => self.peer_addr,
         );
     }
 }

--- a/src/sources/util/tcp/mod.rs
+++ b/src/sources/util/tcp/mod.rs
@@ -262,10 +262,12 @@ async fn handle_stream<T>(
         }
     }
 
+    // TODO: leaking memory is probably bad
+    let leaked_peer_addr: &'static str = Box::leak(peer_addr.to_string().into_boxed_str());
     let socket = socket.after_read(move |byte_size| {
         emit!(&TcpBytesReceived {
             byte_size,
-            peer_addr
+            peer_addr: &leaked_peer_addr,
         });
     });
     let reader = FramedRead::new(socket, source.decoder());

--- a/src/sources/util/tcp/mod.rs
+++ b/src/sources/util/tcp/mod.rs
@@ -267,7 +267,7 @@ async fn handle_stream<T>(
     let socket = socket.after_read(move |byte_size| {
         emit!(&TcpBytesReceived {
             byte_size,
-            peer_addr: &leaked_peer_addr,
+            peer_addr: leaked_peer_addr,
         });
     });
     let reader = FramedRead::new(socket, source.decoder());

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -160,7 +160,15 @@ async fn run(
     let listener = tls_settings.bind(&address).await?;
     let stream = listener.accept_stream().map(|result| {
         result.map(|socket| {
-            let peer_addr = socket.connect_info().remote_addr.ip();
+            // TODO: leaks bad
+            let peer_addr: &'static str = Box::leak(
+                socket
+                    .connect_info()
+                    .remote_addr
+                    .ip()
+                    .to_string()
+                    .into_boxed_str(),
+            );
             socket.after_read(move |byte_size| {
                 emit!(&TcpBytesReceived {
                     byte_size,


### PR DESCRIPTION
I don't think we'll actually merge this, but I'm curious how much it moves the soak numbers.