### PR TITLE
chore(schemas, vrl): update `fn target_type_def` to return `Kind`

### DIFF
--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -1,5 +1,7 @@
 use std::{any::Any, collections::HashMap};
 
+use value::Kind;
+
 use crate::{expression::assignment, parser::ast::Ident, TypeDef, Value};
 
 /// The state held by the compiler.
@@ -50,6 +52,13 @@ impl Compiler {
         }
     }
 
+    /// Get the kind information of the program target (e.g. the type accessed through `.`).
+    pub fn target_kind(&self) -> Option<&Kind> {
+        self.target()
+            .as_ref()
+            .map(|details| details.type_def.kind())
+    }
+
     pub(crate) fn variable_idents(&self) -> impl Iterator<Item = &Ident> + '_ {
         self.variables.keys()
     }
@@ -94,11 +103,6 @@ impl Compiler {
             *self = *snapshot;
             self.external_context = context;
         }
-    }
-
-    /// Returns the root typedef for the paths (not the variables) of the object.
-    pub fn target_type_def(&self) -> Option<&TypeDef> {
-        self.target.as_ref().map(|assignment| &assignment.type_def)
     }
 
     /// Sets the external context data for VRL functions to use.

--- a/lib/vrl/stdlib/src/unnest.rs
+++ b/lib/vrl/stdlib/src/unnest.rs
@@ -124,8 +124,8 @@ impl Expression for UnnestFn {
         use expression::Target;
 
         match self.path.target() {
-            Target::External => match state.target_type_def() {
-                Some(root_type_def) => invert_array_at_path(root_type_def, self.path.path()),
+            Target::External => match state.target_kind().cloned().map(TypeDef::from) {
+                Some(root_type_def) => invert_array_at_path(&root_type_def, self.path.path()),
                 None => self.path.type_def(state).restrict_array().add_null(),
             },
             Target::Internal(v) => invert_array_at_path(&v.type_def(state), self.path.path()),


### PR DESCRIPTION
Tiny PR to change the API of the compiler state, to directly return the `Kind`, instead of the `TypeDef`. There's no concept of fallibility for an external target, so this was a useless indirection.