### PR TITLE
fix(unit tests): Error on non-existent extract_from, no_outputs_from targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -791,6 +791,19 @@ dnstap-integration-tests = ["sources-dnstap", "bollard"]
 disable-resolv-conf = []
 shutdown-tests = ["rdkafka", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-log_to_metric", "transforms-lua", "unix"]
 cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file"]
+vector-unit-test-tests = [
+  "sources-demo_logs",
+  "transforms-add_fields",
+  "transforms-remap",
+  "transforms-route",
+  "transforms-filter",
+  "transforms-reduce",
+  "transforms-compound",
+  "transforms-add_tags",
+  "transforms-log_to_metric",
+  "transforms-remove_fields",
+  "sinks-console"
+]
 
 # grouping together features for benchmarks
 # excluing API client due to running out of memory during linking in Github Actions

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -92,7 +92,7 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
     let tests = tests
         .into_iter()
         .map(|test| test.resolve_outputs(&graph))
-        .collect();
+        .collect::<Result<Vec<_>, Vec<_>>>()?;
 
     if errors.is_empty() {
         let config = Config {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -631,7 +631,10 @@ pub struct TestDefinition<T = OutputId> {
 }
 
 impl TestDefinition<String> {
-    fn resolve_outputs(self, graph: &graph::Graph) -> TestDefinition<OutputId> {
+    fn resolve_outputs(
+        self,
+        graph: &graph::Graph,
+    ) -> Result<TestDefinition<OutputId>, Vec<String>> {
         let TestDefinition {
             name,
             input,
@@ -639,28 +642,47 @@ impl TestDefinition<String> {
             outputs,
             no_outputs_from,
         } = self;
+        let mut errors = Vec::new();
 
         let output_map = graph.input_map().expect("ambiguous outputs");
 
         let outputs = outputs
             .into_iter()
-            .map(|old| TestOutput {
-                extract_from: output_map.get(&old.extract_from).unwrap().clone(),
-                conditions: old.conditions,
+            .filter_map(|old| {
+                if let Some(output_id) = output_map.get(&old.extract_from) {
+                    Some(TestOutput {
+                        extract_from: output_id.clone(),
+                        conditions: old.conditions,
+                    })
+                } else {
+                    errors.push(format!(r#"Invalid extract_from target in test '{}': transform '{}' does not exist"#, name, old.extract_from));
+                    None
+                }
             })
             .collect();
 
         let no_outputs_from = no_outputs_from
             .into_iter()
-            .map(|o| output_map.get(&o).unwrap().clone())
+            .filter_map(|o| {
+                if let Some(output_id) = output_map.get(&o) {
+                    Some(output_id.clone())
+                } else {
+                    errors.push(format!(r#"Invalid no_outputs_from target in test '{}': transform '{}' does not exist"#, name, o));
+                    None
+                }
+            })
             .collect();
 
-        TestDefinition {
-            name,
-            input,
-            inputs,
-            outputs,
-            no_outputs_from,
+        if errors.is_empty() {
+            Ok(TestDefinition {
+                name,
+                input,
+                inputs,
+                outputs,
+                no_outputs_from,
+            })
+        } else {
+            Err(errors)
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -655,7 +655,10 @@ impl TestDefinition<String> {
                         conditions: old.conditions,
                     })
                 } else {
-                    errors.push(format!(r#"Invalid extract_from target in test '{}': transform '{}' does not exist"#, name, old.extract_from));
+                    errors.push(format!(
+                        r#"Invalid extract_from target in test '{}': '{}' does not exist"#,
+                        name, old.extract_from
+                    ));
                     None
                 }
             })
@@ -667,7 +670,10 @@ impl TestDefinition<String> {
                 if let Some(output_id) = output_map.get(&o) {
                     Some(output_id.clone())
                 } else {
-                    errors.push(format!(r#"Invalid no_outputs_from target in test '{}': transform '{}' does not exist"#, name, o));
+                    errors.push(format!(
+                        r#"Invalid no_outputs_from target in test '{}': '{}' does not exist"#,
+                        name, o
+                    ));
                     None
                 }
             })

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(all(test, feature = "transforms-add_fields", feature = "transforms-route"))]
+#[cfg(all(test, feature = "vector-unit-test-tests"))]
 mod tests;
 mod unit_test_components;
 

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -343,7 +343,7 @@ async fn build_unit_test(
         &transform_only_config.transforms,
         &transform_only_config.sinks,
     );
-    let test = test.resolve_outputs(&transform_only_graph);
+    let test = test.resolve_outputs(&transform_only_graph)?;
 
     let sources = metadata.hydrate_into_sources(&test.inputs)?;
     let (test_result_rxs, sinks) =

--- a/src/config/unit_test/tests.rs
+++ b/src/config/unit_test/tests.rs
@@ -130,6 +130,66 @@ async fn parse_no_outputs() {
 }
 
 #[tokio::test]
+async fn parse_invalid_output_targets() {
+    let config: ConfigBuilder = toml::from_str(indoc! {r#"
+        [transforms.bar]
+          inputs = ["foo"]
+          type = "add_fields"
+          [transforms.bar.fields]
+            my_string_field = "string value"
+
+          [[tests]]
+            name = "broken test"
+
+          [tests.input]
+            insert_at = "bar"
+            value = "any value"
+
+          [[tests.outputs]]
+            extract_from = "non-existent"
+            [[tests.outputs.conditions]]
+              type = "vrl"
+              source = ""
+    "#})
+    .unwrap();
+
+    let errs = build_unit_tests(config).await.err().unwrap();
+    assert_eq!(
+        errs,
+        vec![indoc! {r#"
+            Failed to build test 'broken test':
+              Invalid extract_from target in test 'broken test': transform 'non-existent' does not exist"#}
+        .to_owned(),]
+    );
+
+    let config: ConfigBuilder = toml::from_str(indoc! {r#"
+        [transforms.bar]
+          inputs = ["foo"]
+          type = "add_fields"
+          [transforms.bar.fields]
+            my_string_field = "string value"
+
+          [[tests]]
+            name = "broken test"
+            no_outputs_from = [ "non-existent" ]
+
+          [[tests.inputs]]
+            insert_at = "bar"
+            value = "any value"
+    "#})
+    .unwrap();
+
+    let errs = build_unit_tests(config).await.err().unwrap();
+    assert_eq!(
+        errs,
+        vec![indoc! {r#"
+            Failed to build test 'broken test':
+              Invalid no_outputs_from target in test 'broken test': transform 'non-existent' does not exist"#}
+        .to_owned(),]
+    );
+}
+
+#[tokio::test]
 async fn parse_broken_topology() {
     let config: ConfigBuilder = toml::from_str(indoc! {r#"
         [transforms.foo]

--- a/src/config/unit_test/tests.rs
+++ b/src/config/unit_test/tests.rs
@@ -158,7 +158,7 @@ async fn parse_invalid_output_targets() {
         errs,
         vec![indoc! {r#"
             Failed to build test 'broken test':
-              Invalid extract_from target in test 'broken test': transform 'non-existent' does not exist"#}
+              Invalid extract_from target in test 'broken test': 'non-existent' does not exist"#}
         .to_owned(),]
     );
 
@@ -184,7 +184,7 @@ async fn parse_invalid_output_targets() {
         errs,
         vec![indoc! {r#"
             Failed to build test 'broken test':
-              Invalid no_outputs_from target in test 'broken test': transform 'non-existent' does not exist"#}
+              Invalid no_outputs_from target in test 'broken test': 'non-existent' does not exist"#}
         .to_owned(),]
     );
 }

--- a/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-02-08-0-20-0-upgrade-guide.md
@@ -18,6 +18,7 @@ Vector's 0.20.0 release includes **breaking changes**:
 1. [`if` statement predicates in `VRL` need to handle errors](#vrl-fallible-predicates)
 1. [Division by a literal nonzero number in `VRL` is no longer fallible](#vrl-infallible-division)
 1. ['syslog' decoder will raise an error if the incoming message cannot be decoded successfully](#syslog-decoder)
+1. [Unit tests no longer allow non-existent targets in `extract_from`/`no_outputs_from` configurations](#unit-test-non-existent-build-error)
 
 And **deprecations**:
 
@@ -144,6 +145,15 @@ could not be parsed as a syslog message it would not raise an error - instead
 the whole message would be received in the `.message` field.
 
 This has now been changed to raise an error instead.
+
+#### Unit tests no longer allow non-existent targets in `extract_from`/`no_outputs_from` configurations {#unit-test-non-existent-build-error}
+
+Previously, including non-existent targets in `extract_from` or
+`no_outputs_from` in a unit test configuration was allowed. However, these
+non-existent targets had no outputs and could result in misleading test results.
+Now, errors will be raised at unit test build time if non-existent targets are
+included. Note in `v0.20.0`, a panic occurs while in `v0.20.1` informative
+error messages are output.
 
 ### Deprecations
 

--- a/website/cue/reference/releases/0.20.0.cue
+++ b/website/cue/reference/releases/0.20.0.cue
@@ -4,7 +4,9 @@ releases: "0.20.0": {
 	date:     "2022-02-08"
 	codename: ""
 
-	known_issues: []
+	known_issues: [
+		"If non-existent extract_from/no_outputs_from targets are included in unit testing configurations, `vector test` will panic. Fixed in `0.20.1`.",
+	]
 
 	description: """
 		The Vector team is pleased to announce version 0.20.0!


### PR DESCRIPTION
Closes #11338

This PR adds informative error messages at unit test build time when non-existent targets are specified in `extract_from` and `no_outputs_from`, avoiding a panic. Note, when any build errors occur, no tests are run.

For the example described in #11338, you'll now see the following output:
```
Failed to build test 'crash':
  Invalid extract_from target in test 'crash': transform 'parse-ssyslog' does not exist
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
