### PR TITLE
chore(external docs): Fix `check-docs.sh` compatibility with MacOS

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -14,7 +14,7 @@ ROOT=$(git rev-parse --show-toplevel)
 CUE="${ROOT}/website/scripts/cue.sh"
 
 read-all-docs() {
-  ${CUE} list | sort | xargs cat -A
+  ${CUE} list | sort | xargs cat -et
 }
 
 (


### PR DESCRIPTION
`cat` doesn't support `-A` in the stock macos command line tools, but `-et` is equivalent on both mac and Linux
