### PR TITLE
chore(unit tests): Avoid warning logs for unconsumed outputs

### DIFF
--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -402,6 +402,11 @@ async fn build_unit_test(
             .collect::<Vec<_>>();
     }
 
+    if let Some(sink) = get_loose_end_outputs_sink(&config_builder) {
+        config_builder
+            .sinks
+            .insert(ComponentKey::from(Uuid::new_v4().to_string()), sink);
+    }
     let config = config_builder.build()?;
     let diff = config::ConfigDiff::initial(&config);
     let pieces = builder::build_pieces(&config, &diff, HashMap::new()).await?;
@@ -412,6 +417,56 @@ async fn build_unit_test(
         pieces,
         test_result_rxs,
     })
+}
+
+/// Near the end of building a unit test, it's possible that we've included a
+/// transform(s) with multiple outputs where at least one of its output is
+/// consumed but its other outputs are left unconsumed.
+///
+/// To avoid warning logs that occur when building such topologies, we construct
+/// a NoOp sink here whose sole purpose is to consume any "loose end" outputs.
+fn get_loose_end_outputs_sink(config: &ConfigBuilder) -> Option<SinkOuter<String>> {
+    let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
+        transform
+            .inner
+            .outputs()
+            .iter()
+            .map(|output| {
+                if let Some(port) = &output.port {
+                    OutputId::from((key, port.clone())).to_string()
+                } else {
+                    key.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+    });
+
+    let mut loose_end_outputs = Vec::new();
+    for id in transform_ids {
+        if !config
+            .transforms
+            .iter()
+            .any(|(_, transform)| transform.inputs.contains(&id))
+            && !config
+                .sinks
+                .iter()
+                .any(|(_, sink)| sink.inputs.contains(&id))
+        {
+            loose_end_outputs.push(id);
+        }
+    }
+
+    if loose_end_outputs.is_empty() {
+        None
+    } else {
+        let noop_sink = UnitTestSinkConfig {
+            test_name: "".to_string(),
+            transform_id: "".to_string(),
+            result_tx: Arc::new(Mutex::new(None)),
+            check: UnitTestSinkCheck::NoOp,
+        };
+        Some(SinkOuter::new(loose_end_outputs, Box::new(noop_sink)))
+    }
 }
 
 fn build_and_validate_inputs(

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -426,6 +426,8 @@ async fn build_unit_test(
 /// To avoid warning logs that occur when building such topologies, we construct
 /// a NoOp sink here whose sole purpose is to consume any "loose end" outputs.
 fn get_loose_end_outputs_sink(config: &ConfigBuilder) -> Option<SinkOuter<String>> {
+    let mut config = config.clone();
+    let _ = expand_macros(&mut config);
     let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
         transform
             .inner


### PR DESCRIPTION
Closes #11335

This PR adjusts the unit test internals to avoid emitting warnings for unconsumed component outputs (emitted during topology building). While these warnings don't impact test execution/results, they are confusing to users.

For the example in #11335, output used to show
```zsh
Running tests
2022-02-11T21:20:40.274345Z  WARN vector::config::builder: Transform "log_event_router.bar" has no consumers
test test__1 ... passed
```
and is now
```zsh
Running tests
test test__1 ... passed
```
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
