### PR TITLE
chore: Remove dynamic dispatch in Conditions

### DIFF
--- a/src/conditions/is_log.rs
+++ b/src/conditions/is_log.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    conditions::{Condition, ConditionConfig, ConditionDescription},
+    conditions::{Condition, ConditionConfig, ConditionDescription, Conditional},
     event::Event,
 };
 
@@ -18,20 +18,17 @@ impl_generate_config_from_default!(IsLogConfig);
 
 #[typetag::serde(name = "is_log")]
 impl ConditionConfig for IsLogConfig {
-    fn build(
-        &self,
-        _enrichment_tables: &enrichment::TableRegistry,
-    ) -> crate::Result<Box<dyn Condition>> {
-        Ok(Box::new(IsLog {}))
+    fn build(&self, _enrichment_tables: &enrichment::TableRegistry) -> crate::Result<Condition> {
+        Ok(Condition::IsLog(IsLog {}))
     }
 }
 
 //------------------------------------------------------------------------------
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct IsLog {}
 
-impl Condition for IsLog {
+impl Conditional for IsLog {
     fn check(&self, e: &Event) -> bool {
         matches!(e, Event::Log(_))
     }

--- a/src/conditions/is_metric.rs
+++ b/src/conditions/is_metric.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    conditions::{Condition, ConditionConfig, ConditionDescription},
+    conditions::{Condition, ConditionConfig, ConditionDescription, Conditional},
     event::Event,
 };
 
@@ -18,20 +18,17 @@ impl_generate_config_from_default!(IsMetricConfig);
 
 #[typetag::serde(name = "is_metric")]
 impl ConditionConfig for IsMetricConfig {
-    fn build(
-        &self,
-        _enrichment_tables: &enrichment::TableRegistry,
-    ) -> crate::Result<Box<dyn Condition>> {
-        Ok(Box::new(IsMetric {}))
+    fn build(&self, _enrichment_tables: &enrichment::TableRegistry) -> crate::Result<Condition> {
+        Ok(Condition::IsMetric(IsMetric {}))
     }
 }
 
 //------------------------------------------------------------------------------
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct IsMetric {}
 
-impl Condition for IsMetric {
+impl Conditional for IsMetric {
     fn check(&self, e: &Event) -> bool {
         matches!(e, Event::Metric(_))
     }

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -9,11 +9,46 @@ pub mod is_metric;
 pub mod not;
 pub mod vrl;
 
+pub use self::vrl::VrlConfig;
 pub use check_fields::CheckFieldsConfig;
 
-pub use self::vrl::VrlConfig;
+#[derive(Debug, Clone)]
+pub enum Condition {
+    Not(not::Not),
+    IsLog(is_log::IsLog),
+    IsMetric(is_metric::IsMetric),
+    Vrl(vrl::Vrl),
+    CheckFields(check_fields::CheckFields),
+    DatadogSearch(datadog_search::DatadogSearchRunner),
+}
 
-pub trait Condition: Send + Sync + dyn_clone::DynClone {
+impl Condition {
+    pub(crate) fn check(&self, e: &Event) -> bool {
+        match self {
+            Condition::IsLog(x) => x.check(e),
+            Condition::IsMetric(x) => x.check(e),
+            Condition::Not(x) => x.check(e),
+            Condition::CheckFields(x) => x.check(e),
+            Condition::DatadogSearch(x) => x.check(e),
+            Condition::Vrl(x) => x.check(e),
+        }
+    }
+
+    /// Provides context for a failure. This is potentially mildly expensive if
+    /// it involves string building and so should be avoided in hot paths.
+    pub(crate) fn check_with_context(&self, e: &Event) -> Result<(), String> {
+        match self {
+            Condition::IsLog(x) => x.check_with_context(e),
+            Condition::IsMetric(x) => x.check_with_context(e),
+            Condition::Not(x) => x.check_with_context(e),
+            Condition::CheckFields(x) => x.check_with_context(e),
+            Condition::DatadogSearch(x) => x.check_with_context(e),
+            Condition::Vrl(x) => x.check_with_context(e),
+        }
+    }
+}
+
+pub trait Conditional {
     fn check(&self, e: &Event) -> bool;
 
     /// Provides context for a failure. This is potentially mildly expensive if
@@ -27,14 +62,9 @@ pub trait Condition: Send + Sync + dyn_clone::DynClone {
     }
 }
 
-dyn_clone::clone_trait_object!(Condition);
-
 #[typetag::serde(tag = "type")]
 pub trait ConditionConfig: std::fmt::Debug + Send + Sync + dyn_clone::DynClone {
-    fn build(
-        &self,
-        enrichment_tables: &enrichment::TableRegistry,
-    ) -> crate::Result<Box<dyn Condition>>;
+    fn build(&self, enrichment_tables: &enrichment::TableRegistry) -> crate::Result<Condition>;
 }
 
 dyn_clone::clone_trait_object!(ConditionConfig);
@@ -70,10 +100,7 @@ pub enum AnyCondition {
 }
 
 impl AnyCondition {
-    pub fn build(
-        &self,
-        enrichment_tables: &enrichment::TableRegistry,
-    ) -> crate::Result<Box<dyn Condition>> {
+    pub fn build(&self, enrichment_tables: &enrichment::TableRegistry) -> crate::Result<Condition> {
         match self {
             AnyCondition::String(s) => VrlConfig { source: s.clone() }.build(enrichment_tables),
             AnyCondition::Map(m) => m.build(enrichment_tables),

--- a/src/conditions/not.rs
+++ b/src/conditions/not.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{AnyCondition, Condition, ConditionConfig};
+use super::{AnyCondition, Condition, ConditionConfig, Conditional};
 use crate::event::Event;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -14,18 +14,17 @@ impl From<AnyCondition> for NotConfig {
 
 #[typetag::serde(name = "not")]
 impl ConditionConfig for NotConfig {
-    fn build(
-        &self,
-        enrichment_tables: &enrichment::TableRegistry,
-    ) -> crate::Result<Box<dyn Condition>> {
-        Ok(Box::new(Not(self.0.build(enrichment_tables)?)))
+    fn build(&self, enrichment_tables: &enrichment::TableRegistry) -> crate::Result<Condition> {
+        Ok(Condition::Not(Not(Box::new(
+            self.0.build(enrichment_tables)?,
+        ))))
     }
 }
 
-#[derive(Clone)]
-struct Not(Box<dyn Condition>);
+#[derive(Debug, Clone)]
+pub struct Not(Box<Condition>);
 
-impl Condition for Not {
+impl Conditional for Not {
     fn check(&self, e: &Event) -> bool {
         !self.0.check(e)
     }

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -455,8 +455,8 @@ fn build_and_validate_inputs(
 
 fn build_outputs(
     test_outputs: &[TestOutput],
-) -> Result<IndexMap<OutputId, Vec<Vec<Box<dyn Condition>>>>, Vec<String>> {
-    let mut outputs: IndexMap<OutputId, Vec<Vec<Box<dyn Condition>>>> = IndexMap::new();
+) -> Result<IndexMap<OutputId, Vec<Vec<Condition>>>, Vec<String>> {
+    let mut outputs: IndexMap<OutputId, Vec<Vec<Condition>>> = IndexMap::new();
     let mut errors = Vec::new();
 
     for output in test_outputs {

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -56,7 +56,7 @@ impl SourceConfig for UnitTestSourceConfig {
 #[derive(Clone)]
 pub enum UnitTestSinkCheck {
     // Check sets of conditions against received events
-    Checks(Vec<Vec<Box<dyn Condition>>>),
+    Checks(Vec<Vec<Condition>>),
     // Check that no events were received
     NoOutputs,
     // Do nothing

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -67,11 +67,11 @@ impl TransformConfig for FilterConfig {
 #[derivative(Debug)]
 pub struct Filter {
     #[derivative(Debug = "ignore")]
-    condition: Box<dyn Condition>,
+    condition: Condition,
 }
 
 impl Filter {
-    pub fn new(condition: Box<dyn Condition>) -> Self {
+    pub const fn new(condition: Condition) -> Self {
         Self { condition }
     }
 }

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -152,8 +152,8 @@ pub struct Reduce {
     group_by: Vec<String>,
     merge_strategies: IndexMap<String, MergeStrategy>,
     reduce_merge_states: HashMap<Discriminant, ReduceState>,
-    ends_when: Option<Box<dyn Condition>>,
-    starts_when: Option<Box<dyn Condition>>,
+    ends_when: Option<Condition>,
+    starts_when: Option<Condition>,
 }
 
 impl Reduce {

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -17,7 +17,7 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Route {
-    conditions: IndexMap<String, Box<dyn Condition>>,
+    conditions: IndexMap<String, Condition>,
 }
 
 impl Route {

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -93,12 +93,12 @@ impl TransformConfig for SampleCompatConfig {
 pub struct Sample {
     rate: u64,
     key_field: Option<String>,
-    exclude: Option<Box<dyn Condition>>,
+    exclude: Option<Condition>,
     count: u64,
 }
 
 impl Sample {
-    pub fn new(rate: u64, key_field: Option<String>, exclude: Option<Box<dyn Condition>>) -> Self {
+    pub const fn new(rate: u64, key_field: Option<String>, exclude: Option<Condition>) -> Self {
         Self {
             rate,
             key_field,
@@ -155,7 +155,7 @@ mod tests {
         transforms::test::transform_one,
     };
 
-    fn condition_contains(key: &str, needle: &str) -> Box<dyn Condition> {
+    fn condition_contains(key: &str, needle: &str) -> Condition {
         VrlConfig {
             source: format!(r#"contains!(."{}", "{}")"#, key, needle),
         }

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -55,7 +55,7 @@ pub struct Throttle<C: clock::Clock<Instant = I>, I: clock::Reference> {
     quota: Quota,
     flush_keys_interval: Duration,
     key_field: Option<Template>,
-    exclude: Option<Box<dyn Condition>>,
+    exclude: Option<Condition>,
     clock: C,
 }
 


### PR DESCRIPTION
This commit removes the notion of `Box<dyn Condition>` from the code base, using
a Big Old Enum approach instead. This is suggested by the work on #10144 where
Condition always ranks highly in on-cpu/off-cpu measures. It is hoped but not
known that removing dynamic dispatch in this hotspot will have a measurable
bump on condition heavy configurations, of which pipeline is a notable
instance.

This is roughly similar to the approach seen in #11200 but in a different area.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
