### PR TITLE
chore: Experiment with memoization in datadog/filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,7 @@ version = "0.1.0"
 dependencies = [
  "datadog-search-syntax",
  "dyn-clone",
+ "memoize",
  "regex",
 ]
 
@@ -3898,6 +3899,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memoize"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f58373c9600033ce4829bca4b6f36a65de097c4ca7e8d66ee7cfbba3ec878a"
+dependencies = [
+ "lazy_static",
+ "memoize-inner",
+]
+
+[[package]]
+name = "memoize-inner"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217a1e7f586ba063a4dc87a2dfb26f7700e150c9b378cb2aef511cd42013f8a3"
+dependencies = [
+ "lazy_static",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.84",
 ]
 
 [[package]]

--- a/lib/datadog/filter/Cargo.toml
+++ b/lib/datadog/filter/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 [dependencies]
 datadog-search-syntax = { path = "../search-syntax" }
 
-regex = "1"
+regex = { version = "1.5", default-features = false, features = ["std", "perf"] }
+memoize = { version = "0.2", default-features = false }
 dyn-clone = { version = "1.0.4", default-features = false }

--- a/lib/datadog/filter/src/regex.rs
+++ b/lib/datadog/filter/src/regex.rs
@@ -1,6 +1,8 @@
+use memoize::memoize;
 use regex::Regex;
 
 /// Returns compiled word boundary regex.
+#[memoize(Capacity: 1023)]
 pub fn word_regex(to_match: &str) -> Regex {
     Regex::new(&format!(
         r#"\b{}\b"#,
@@ -10,6 +12,7 @@ pub fn word_regex(to_match: &str) -> Regex {
 }
 
 /// Returns compiled wildcard regex.
+#[memoize(Capacity: 1023)]
 pub fn wildcard_regex(to_match: &str) -> Regex {
     Regex::new(&format!(
         "^{}$",

--- a/lib/datadog/search-syntax/Cargo.toml
+++ b/lib/datadog/search-syntax/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-pest = "2.1.3"
-pest_derive = "2.1.0"
-ordered-float = "2"
-regex = "1"
-itertools = "0.10.3"
-once_cell = { version = "1.9", default-features = false }
+pest = { version = "2.1.3" }
+pest_derive = { version = "2.1.0" }
+ordered-float = { version = "2.10" }
+regex = { version = "1.5" }
+itertools = { version = "0.10.3" }
+once_cell = { version = "1.9", default-features = false, features = ["std"] }


### PR DESCRIPTION
Datadog filter has two *_regex functions that create a regex at runtime. This
commit experiments with memoizing the results of these functions. If there is no
general lift here I'll back out the memoization but make a follow-up commit to
tidy up the Cargo.toml here.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
