### PR TITLE
docs: fix prometheus_scrape warnings typo

### DIFF
--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -55,7 +55,7 @@ components: sources: prometheus_scrape: {
 		endpoints: {
 			description: "Endpoints to scrape metrics from."
 			required:    true
-			warnings: ["You must explicitly add the path to your endpoints. Vector will _not_ automatically add `/metics`."]
+			warnings: ["You must explicitly add the path to your endpoints. Vector will _not_ automatically add `/metrics`."]
 			type: array: {
 				items: type: string: {
 					examples: ["http://localhost:9090/metrics"]


### PR DESCRIPTION
Signed-off-by: Ali Reza Yahya <ali.reza.yahya@wolt.com>

fix typo on warning docs on prometheus_scrape
