### PR TITLE
fix(json_parser transform): Remove `value` tag from metrics

### DIFF
--- a/src/internal_events/json_parser.rs
+++ b/src/internal_events/json_parser.rs
@@ -32,7 +32,6 @@ impl<'a> InternalEvent for JsonParserError<'a> {
             "error_type" => "parser_failed",
             "stage" => error_stage::PROCESSING,
             "field" => self.field.to_string(),
-            "value" => self.value.to_string(),
         );
         if self.drop_invalid {
             counter!(
@@ -41,7 +40,6 @@ impl<'a> InternalEvent for JsonParserError<'a> {
                 "error_type" => "parser_failed",
                 "stage" => error_stage::PROCESSING,
                 "field" => self.field.to_string(),
-                "value" => self.value.to_string(),
             );
         }
         // deprecated


### PR DESCRIPTION
`value` is the literal string that could not be parsed as JSON which
will result in this tag having infinite cardinality as well as very
awkward metric tags.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
