### PR TITLE
chore(api): Remove deprecated subscriptions and deprecate unnecessary subscriptions

### DIFF
--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -224,178 +224,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "ComponentEventsInThroughput",
-          "description": null,
-          "fields": [
-            {
-              "name": "componentId",
-              "description": "Component id",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "throughput",
-              "description": "Events processed throughput",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ComponentEventsInTotal",
-          "description": null,
-          "fields": [
-            {
-              "name": "componentId",
-              "description": "Component id",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "metric",
-              "description": "Total incoming events metric",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "EventsInTotal",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ComponentEventsOutThroughput",
-          "description": null,
-          "fields": [
-            {
-              "name": "componentId",
-              "description": "Component id",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "throughput",
-              "description": "Events processed throughput",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ComponentEventsOutTotal",
-          "description": null,
-          "fields": [
-            {
-              "name": "componentId",
-              "description": "Component id",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "metric",
-              "description": "Total outgoing events metric",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "EventsOutTotal",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "ENUM",
           "name": "ComponentKind",
           "description": null,
@@ -5132,37 +4960,6 @@
               "deprecationReason": null
             },
             {
-              "name": "eventsInTotal",
-              "description": "Total incoming events metrics",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "EventsInTotal",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use received_events_total instead"
-            },
-            {
               "name": "receivedEventsTotal",
               "description": "Total received events metrics",
               "args": [
@@ -5190,39 +4987,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "eventsInThroughput",
-              "description": "Total incoming events throughput sampled over the provided millisecond `interval`",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
               "isDeprecated": true,
-              "deprecationReason": "Use received_events_throughput instead"
+              "deprecationReason": "Use component_received_events_totals instead"
             },
             {
               "name": "receivedEventsThroughput",
@@ -5250,45 +5016,6 @@
                   "kind": "SCALAR",
                   "name": "Int",
                   "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "componentEventsInThroughputs",
-              "description": "Total incoming component events throughput metrics over `interval`",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ComponentEventsInThroughput",
-                      "ofType": null
-                    }
-                  }
                 }
               },
               "isDeprecated": true,
@@ -5334,45 +5061,6 @@
               "deprecationReason": null
             },
             {
-              "name": "componentEventsInTotals",
-              "description": "Total incoming component event metrics over `interval`",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ComponentEventsInTotal",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use component_received_events_totals instead"
-            },
-            {
               "name": "componentReceivedEventsTotals",
               "description": "Total received component event metrics over `interval`",
               "args": [
@@ -5412,37 +5100,6 @@
               "deprecationReason": null
             },
             {
-              "name": "eventsOutTotal",
-              "description": "Total outgoing events metrics",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "EventsOutTotal",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use sent_events_total instead"
-            },
-            {
               "name": "sentEventsTotal",
               "description": "Total sent events metrics",
               "args": [
@@ -5470,39 +5127,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "eventsOutThroughput",
-              "description": "Total outgoing events throughput sampled over the provided millisecond `interval`",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
               "isDeprecated": true,
-              "deprecationReason": "Use sent_events_throughput instead"
+              "deprecationReason": "Use component_sent_events_totals instead"
             },
             {
               "name": "sentEventsThroughput",
@@ -5530,45 +5156,6 @@
                   "kind": "SCALAR",
                   "name": "Int",
                   "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "componentEventsOutThroughputs",
-              "description": "Total outgoing component event throughput metrics over `interval`",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ComponentEventsOutThroughput",
-                      "ofType": null
-                    }
-                  }
                 }
               },
               "isDeprecated": true,
@@ -5612,45 +5199,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "componentEventsOutTotals",
-              "description": "Total outgoing component event metrics over `interval`",
-              "args": [
-                {
-                  "name": "interval",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "1000"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ComponentEventsOutTotal",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use component_sent_events_totals instead"
             },
             {
               "name": "componentSentEventsTotals",

--- a/lib/vector-api-client/graphql/subscriptions/received_events_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/received_events_throughput.graphql
@@ -1,3 +1,0 @@
-subscription ReceivedEventsThroughputSubscription($interval: Int!) {
-    receivedEventsThroughput(interval: $interval)
-}

--- a/lib/vector-api-client/graphql/subscriptions/received_events_total.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/received_events_total.graphql
@@ -1,5 +1,0 @@
-subscription ReceivedEventsTotalSubscription($interval: Int!) {
-  receivedEventsTotal(interval: $interval) {
-    receivedEventsTotal
-  }
-}

--- a/lib/vector-api-client/graphql/subscriptions/sent_events_throughput.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/sent_events_throughput.graphql
@@ -1,3 +1,0 @@
-subscription SentEventsThroughputSubscription($interval: Int!) {
-    sentEventsThroughput(interval: $interval)
-}

--- a/lib/vector-api-client/graphql/subscriptions/sent_events_total.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/sent_events_total.graphql
@@ -1,5 +1,0 @@
-subscription SentEventsTotalSubscription($interval: Int!) {
-  sentEventsTotal(interval: $interval) {
-    sentEventsTotal
-  }
-}

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -44,16 +44,6 @@ pub struct ProcessedEventsThroughputSubscription;
 )]
 pub struct ProcessedBytesThroughputSubscription;
 
-/// ReceivedEventsTotalSubscription contains metrics on the number of events
-/// that have been accepted for processing by a Vector instance.
-#[derive(GraphQLQuery, Debug, Copy, Clone)]
-#[graphql(
-    schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/received_events_total.graphql",
-    response_derives = "Debug"
-)]
-pub struct ReceivedEventsTotalSubscription;
-
 /// ReceivedEventsThroughputSubscription contains metrics on the number of events
 /// that have been accepted for processing between `interval` samples.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
@@ -220,12 +210,6 @@ pub trait MetricsSubscriptionExt {
         interval: i64,
     ) -> crate::BoxedSubscription<ProcessedBytesThroughputSubscription>;
 
-    /// Executes a received events total metrics subscription
-    fn received_events_total_subscription(
-        &self,
-        interval: i64,
-    ) -> crate::BoxedSubscription<ReceivedEventsTotalSubscription>;
-
     /// Executes a received events throughput subscription.
     fn received_events_throughput_subscription(
         &self,
@@ -335,18 +319,6 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         );
 
         self.start::<ProcessedBytesThroughputSubscription>(&request_body)
-    }
-
-    /// Executes a received events total metrics subscription.
-    fn received_events_total_subscription(
-        &self,
-        interval: i64,
-    ) -> BoxedSubscription<ReceivedEventsTotalSubscription> {
-        let request_body = ReceivedEventsTotalSubscription::build_query(
-            received_events_total_subscription::Variables { interval },
-        );
-
-        self.start::<ReceivedEventsTotalSubscription>(&request_body)
     }
 
     /// Executes a received events throughput subscription.

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -54,16 +54,6 @@ pub struct ProcessedBytesThroughputSubscription;
 )]
 pub struct ReceivedEventsThroughputSubscription;
 
-/// SentEventsTotalSubscription contains metrics on the number of events
-/// that have been emitted by a Vector instance.
-#[derive(GraphQLQuery, Debug, Copy, Clone)]
-#[graphql(
-    schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/sent_events_total.graphql",
-    response_derives = "Debug"
-)]
-pub struct SentEventsTotalSubscription;
-
 /// SentEventsThroughputSubscription contains metrics on the number of events
 /// that have been emitted between `interval` samples.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
@@ -216,12 +206,6 @@ pub trait MetricsSubscriptionExt {
         interval: i64,
     ) -> crate::BoxedSubscription<ReceivedEventsThroughputSubscription>;
 
-    /// Executes a sent events total metrics subscription.
-    fn sent_events_total_subscription(
-        &self,
-        interval: i64,
-    ) -> crate::BoxedSubscription<SentEventsTotalSubscription>;
-
     /// Executes a sent events throughput subscription.
     fn sent_events_throughput_subscription(
         &self,
@@ -331,19 +315,6 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         );
 
         self.start::<ReceivedEventsThroughputSubscription>(&request_body)
-    }
-
-    /// Executes a sent events total metrics subscription.
-    fn sent_events_total_subscription(
-        &self,
-        interval: i64,
-    ) -> BoxedSubscription<SentEventsTotalSubscription> {
-        let request_body =
-            SentEventsTotalSubscription::build_query(sent_events_total_subscription::Variables {
-                interval,
-            });
-
-        self.start::<SentEventsTotalSubscription>(&request_body)
     }
 
     /// Executes a sent events throughput subscription.

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -44,16 +44,6 @@ pub struct ProcessedEventsThroughputSubscription;
 )]
 pub struct ProcessedBytesThroughputSubscription;
 
-/// ReceivedEventsThroughputSubscription contains metrics on the number of events
-/// that have been accepted for processing between `interval` samples.
-#[derive(GraphQLQuery, Debug, Copy, Clone)]
-#[graphql(
-    schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/received_events_throughput.graphql",
-    response_derives = "Debug"
-)]
-pub struct ReceivedEventsThroughputSubscription;
-
 /// ComponentProcessedEventsThroughputsSubscription contains metrics on the number of events
 /// that have been processed between `interval` samples, against specific components.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
@@ -190,12 +180,6 @@ pub trait MetricsSubscriptionExt {
         interval: i64,
     ) -> crate::BoxedSubscription<ProcessedBytesThroughputSubscription>;
 
-    /// Executes a received events throughput subscription.
-    fn received_events_throughput_subscription(
-        &self,
-        interval: i64,
-    ) -> crate::BoxedSubscription<ReceivedEventsThroughputSubscription>;
-
     /// Executes a component events processed totals subscription
     fn component_processed_events_totals_subscription(
         &self,
@@ -287,18 +271,6 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         );
 
         self.start::<ProcessedBytesThroughputSubscription>(&request_body)
-    }
-
-    /// Executes a received events throughput subscription.
-    fn received_events_throughput_subscription(
-        &self,
-        interval: i64,
-    ) -> BoxedSubscription<ReceivedEventsThroughputSubscription> {
-        let request_body = ReceivedEventsThroughputSubscription::build_query(
-            received_events_throughput_subscription::Variables { interval },
-        );
-
-        self.start::<ReceivedEventsThroughputSubscription>(&request_body)
     }
 
     /// Executes an all component events processed totals subscription.

--- a/lib/vector-api-client/src/gql/metrics.rs
+++ b/lib/vector-api-client/src/gql/metrics.rs
@@ -54,16 +54,6 @@ pub struct ProcessedBytesThroughputSubscription;
 )]
 pub struct ReceivedEventsThroughputSubscription;
 
-/// SentEventsThroughputSubscription contains metrics on the number of events
-/// that have been emitted between `interval` samples.
-#[derive(GraphQLQuery, Debug, Copy, Clone)]
-#[graphql(
-    schema_path = "graphql/schema.json",
-    query_path = "graphql/subscriptions/sent_events_throughput.graphql",
-    response_derives = "Debug"
-)]
-pub struct SentEventsThroughputSubscription;
-
 /// ComponentProcessedEventsThroughputsSubscription contains metrics on the number of events
 /// that have been processed between `interval` samples, against specific components.
 #[derive(GraphQLQuery, Debug, Copy, Clone)]
@@ -206,12 +196,6 @@ pub trait MetricsSubscriptionExt {
         interval: i64,
     ) -> crate::BoxedSubscription<ReceivedEventsThroughputSubscription>;
 
-    /// Executes a sent events throughput subscription.
-    fn sent_events_throughput_subscription(
-        &self,
-        interval: i64,
-    ) -> crate::BoxedSubscription<SentEventsThroughputSubscription>;
-
     /// Executes a component events processed totals subscription
     fn component_processed_events_totals_subscription(
         &self,
@@ -315,18 +299,6 @@ impl MetricsSubscriptionExt for crate::SubscriptionClient {
         );
 
         self.start::<ReceivedEventsThroughputSubscription>(&request_body)
-    }
-
-    /// Executes a sent events throughput subscription.
-    fn sent_events_throughput_subscription(
-        &self,
-        interval: i64,
-    ) -> crate::BoxedSubscription<SentEventsThroughputSubscription> {
-        let request_body = SentEventsThroughputSubscription::build_query(
-            sent_events_throughput_subscription::Variables { interval },
-        );
-
-        self.start::<SentEventsThroughputSubscription>(&request_body)
     }
 
     /// Executes an all component events processed totals subscription.

--- a/src/api/schema/metrics/events_in.rs
+++ b/src/api/schema/metrics/events_in.rs
@@ -1,10 +1,7 @@
 use async_graphql::Object;
 use chrono::{DateTime, Utc};
 
-use crate::{
-    config::ComponentKey,
-    event::{Metric, MetricValue},
-};
+use crate::event::{Metric, MetricValue};
 
 pub struct EventsInTotal(Metric);
 
@@ -41,39 +38,5 @@ impl EventsInTotal {
 impl From<Metric> for EventsInTotal {
     fn from(m: Metric) -> Self {
         Self(m)
-    }
-}
-
-pub struct ComponentEventsInTotal {
-    component_key: ComponentKey,
-    metric: Metric,
-}
-
-impl ComponentEventsInTotal {
-    /// Returns a new `ComponentEventsInTotal` struct, which is a GraphQL type. The
-    /// component id is hoisted for clear field resolution in the resulting payload.
-    pub fn new(metric: Metric) -> Self {
-        let component_key = metric.tag_value("component_id").expect(
-            "Returned a metric without a `component_id`, which shouldn't happen. Please report.",
-        );
-        let component_key = ComponentKey::from(component_key);
-
-        Self {
-            component_key,
-            metric,
-        }
-    }
-}
-
-#[Object]
-impl ComponentEventsInTotal {
-    /// Component id
-    async fn component_id(&self) -> &str {
-        self.component_key.id()
-    }
-
-    /// Total incoming events metric
-    async fn metric(&self) -> EventsInTotal {
-        EventsInTotal::new(self.metric.clone())
     }
 }

--- a/src/api/schema/metrics/events_in.rs
+++ b/src/api/schema/metrics/events_in.rs
@@ -77,31 +77,3 @@ impl ComponentEventsInTotal {
         EventsInTotal::new(self.metric.clone())
     }
 }
-
-pub struct ComponentEventsInThroughput {
-    component_key: ComponentKey,
-    throughput: i64,
-}
-
-impl ComponentEventsInThroughput {
-    /// Returns a new `ComponentEventsInThroughput`, set to the provided id/throughput values.
-    pub const fn new(component_key: ComponentKey, throughput: i64) -> Self {
-        Self {
-            component_key,
-            throughput,
-        }
-    }
-}
-
-#[Object]
-impl ComponentEventsInThroughput {
-    /// Component id
-    async fn component_id(&self) -> &str {
-        self.component_key.id()
-    }
-
-    /// Events processed throughput
-    async fn throughput(&self) -> i64 {
-        self.throughput
-    }
-}

--- a/src/api/schema/metrics/events_out.rs
+++ b/src/api/schema/metrics/events_out.rs
@@ -1,10 +1,7 @@
 use async_graphql::Object;
 use chrono::{DateTime, Utc};
 
-use crate::{
-    config::ComponentKey,
-    event::{Metric, MetricValue},
-};
+use crate::event::{Metric, MetricValue};
 
 pub struct EventsOutTotal(Metric);
 
@@ -41,39 +38,5 @@ impl EventsOutTotal {
 impl From<Metric> for EventsOutTotal {
     fn from(m: Metric) -> Self {
         Self(m)
-    }
-}
-
-pub struct ComponentEventsOutTotal {
-    component_key: ComponentKey,
-    metric: Metric,
-}
-
-impl ComponentEventsOutTotal {
-    /// Returns a new `ComponentEventsOutTotal` struct, which is a GraphQL type. The
-    /// component id is hoisted for clear field resolution in the resulting payload.
-    pub fn new(metric: Metric) -> Self {
-        let component_key = metric.tag_value("component_id").expect(
-            "Returned a metric without a `component_id`, which shouldn't happen. Please report.",
-        );
-        let component_key = ComponentKey::from(component_key);
-
-        Self {
-            component_key,
-            metric,
-        }
-    }
-}
-
-#[Object]
-impl ComponentEventsOutTotal {
-    /// Component id
-    async fn component_id(&self) -> &str {
-        self.component_key.id()
-    }
-
-    /// Total outgoing events metric
-    async fn metric(&self) -> EventsOutTotal {
-        EventsOutTotal::new(self.metric.clone())
     }
 }

--- a/src/api/schema/metrics/events_out.rs
+++ b/src/api/schema/metrics/events_out.rs
@@ -77,31 +77,3 @@ impl ComponentEventsOutTotal {
         EventsOutTotal::new(self.metric.clone())
     }
 }
-
-pub struct ComponentEventsOutThroughput {
-    component_key: ComponentKey,
-    throughput: i64,
-}
-
-impl ComponentEventsOutThroughput {
-    /// Returns a new `ComponentEventsOutThroughput`, set to the provided id/throughput values
-    pub const fn new(component_key: ComponentKey, throughput: i64) -> Self {
-        Self {
-            component_key,
-            throughput,
-        }
-    }
-}
-
-#[Object]
-impl ComponentEventsOutThroughput {
-    /// Component id
-    async fn component_id(&self) -> &str {
-        self.component_key.id()
-    }
-
-    /// Events processed throughput
-    async fn throughput(&self) -> i64 {
-        self.throughput
-    }
-}

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -19,7 +19,7 @@ use async_graphql::{Interface, Object, Subscription};
 use chrono::{DateTime, Utc};
 pub use errors::{ComponentErrorsTotal, ErrorsTotal};
 pub use events_in::EventsInTotal;
-pub use events_out::{ComponentEventsOutThroughput, ComponentEventsOutTotal, EventsOutTotal};
+pub use events_out::{ComponentEventsOutTotal, EventsOutTotal};
 pub use filter::*;
 pub use output::*;
 pub use processed_bytes::{
@@ -209,24 +209,6 @@ impl MetricsSubscription {
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "component_sent_events_total")
             .map(|(_, throughput)| throughput as i64)
-    }
-
-    /// Total outgoing component event throughput metrics over `interval`
-    #[graphql(deprecation = "Use component_sent_events_throughputs instead")]
-    async fn component_events_out_throughputs(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = Vec<ComponentEventsOutThroughput>> {
-        component_counter_throughputs(interval, &|m| m.name() == "events_out_total").map(|m| {
-            m.into_iter()
-                .map(|(m, throughput)| {
-                    ComponentEventsOutThroughput::new(
-                        ComponentKey::from(m.tag_value("component_id").unwrap()),
-                        throughput as i64,
-                    )
-                })
-                .collect()
-        })
     }
 
     /// Total outgoing component event throughput metrics over `interval`

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -18,7 +18,7 @@ mod host;
 use async_graphql::{Interface, Object, Subscription};
 use chrono::{DateTime, Utc};
 pub use errors::{ComponentErrorsTotal, ErrorsTotal};
-pub use events_in::{ComponentEventsInTotal, EventsInTotal};
+pub use events_in::EventsInTotal;
 pub use events_out::{ComponentEventsOutThroughput, ComponentEventsOutTotal, EventsOutTotal};
 pub use filter::*;
 pub use output::*;
@@ -164,16 +164,6 @@ impl MetricsSubscription {
                     })
                     .collect()
             })
-    }
-
-    /// Total incoming component event metrics over `interval`
-    #[graphql(deprecation = "Use component_received_events_totals instead")]
-    async fn component_events_in_totals(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = Vec<ComponentEventsInTotal>> {
-        component_counter_metrics(interval, &|m| m.name() == "events_in_total")
-            .map(|m| m.into_iter().map(ComponentEventsInTotal::new).collect())
     }
 
     /// Total received component event metrics over `interval`

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -140,6 +140,7 @@ impl MetricsSubscription {
     }
 
     /// Total received events throughput sampled over the provided millisecond `interval`
+    #[graphql(deprecation = "Use component_received_events_throughputs instead")]
     async fn received_events_throughput(
         &self,
         #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -19,7 +19,7 @@ use async_graphql::{Interface, Object, Subscription};
 use chrono::{DateTime, Utc};
 pub use errors::{ComponentErrorsTotal, ErrorsTotal};
 pub use events_in::EventsInTotal;
-pub use events_out::{ComponentEventsOutTotal, EventsOutTotal};
+pub use events_out::EventsOutTotal;
 pub use filter::*;
 pub use output::*;
 pub use processed_bytes::{
@@ -223,16 +223,6 @@ impl MetricsSubscription {
                 })
                 .collect()
         })
-    }
-
-    /// Total outgoing component event metrics over `interval`
-    #[graphql(deprecation = "Use component_sent_events_totals instead")]
-    async fn component_events_out_totals(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = Vec<ComponentEventsOutTotal>> {
-        component_counter_metrics(interval, &|m| m.name() == "events_out_total")
-            .map(|m| m.into_iter().map(ComponentEventsOutTotal::new).collect())
     }
 
     /// Total outgoing component event metrics over `interval`

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -127,19 +127,8 @@ impl MetricsSubscription {
         })
     }
 
-    /// Total incoming events metrics
-    #[graphql(deprecation = "Use received_events_total instead")]
-    async fn events_in_total(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = EventsInTotal> {
-        get_metrics(interval).filter_map(|m| match m.name() {
-            "events_in_total" => Some(EventsInTotal::new(m)),
-            _ => None,
-        })
-    }
-
     /// Total received events metrics
+    #[graphql(deprecation = "Use component_received_events_totals instead")]
     async fn received_events_total(
         &self,
         #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
@@ -229,19 +218,8 @@ impl MetricsSubscription {
         )
     }
 
-    /// Total outgoing events metrics
-    #[graphql(deprecation = "Use sent_events_total instead")]
-    async fn events_out_total(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = EventsOutTotal> {
-        get_metrics(interval).filter_map(|m| match m.name() {
-            "events_out_total" => Some(EventsOutTotal::new(m)),
-            _ => None,
-        })
-    }
-
     /// Total sent events metrics
+    #[graphql(deprecation = "Use component_sent_events_totals instead")]
     async fn sent_events_total(
         &self,
         #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -18,7 +18,7 @@ mod host;
 use async_graphql::{Interface, Object, Subscription};
 use chrono::{DateTime, Utc};
 pub use errors::{ComponentErrorsTotal, ErrorsTotal};
-pub use events_in::{ComponentEventsInThroughput, ComponentEventsInTotal, EventsInTotal};
+pub use events_in::{ComponentEventsInTotal, EventsInTotal};
 pub use events_out::{ComponentEventsOutThroughput, ComponentEventsOutTotal, EventsOutTotal};
 pub use filter::*;
 pub use output::*;
@@ -146,24 +146,6 @@ impl MetricsSubscription {
     ) -> impl Stream<Item = i64> {
         counter_throughput(interval, &|m| m.name() == "component_received_events_total")
             .map(|(_, throughput)| throughput as i64)
-    }
-
-    /// Total incoming component events throughput metrics over `interval`
-    #[graphql(deprecation = "Use component_received_events_throughputs instead")]
-    async fn component_events_in_throughputs(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = Vec<ComponentEventsInThroughput>> {
-        component_counter_throughputs(interval, &|m| m.name() == "events_in_total").map(|m| {
-            m.into_iter()
-                .map(|(m, throughput)| {
-                    ComponentEventsInThroughput::new(
-                        ComponentKey::from(m.tag_value("component_id").unwrap()),
-                        throughput as i64,
-                    )
-                })
-                .collect()
-        })
     }
 
     /// Total incoming component events throughput metrics over `interval`

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -139,16 +139,6 @@ impl MetricsSubscription {
         })
     }
 
-    /// Total incoming events throughput sampled over the provided millisecond `interval`
-    #[graphql(deprecation = "Use received_events_throughput instead")]
-    async fn events_in_throughput(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = i64> {
-        counter_throughput(interval, &|m| m.name() == "events_in_total")
-            .map(|(_, throughput)| throughput as i64)
-    }
-
     /// Total received events throughput sampled over the provided millisecond `interval`
     async fn received_events_throughput(
         &self,

--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -193,16 +193,7 @@ impl MetricsSubscription {
     }
 
     /// Total outgoing events throughput sampled over the provided millisecond `interval`
-    #[graphql(deprecation = "Use sent_events_throughput instead")]
-    async fn events_out_throughput(
-        &self,
-        #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,
-    ) -> impl Stream<Item = i64> {
-        counter_throughput(interval, &|m| m.name() == "events_out_total")
-            .map(|(_, throughput)| throughput as i64)
-    }
-
-    /// Total outgoing events throughput sampled over the provided millisecond `interval`
+    #[graphql(deprecation = "Use component_sent_events_throughputs instead")]
     async fn sent_events_throughput(
         &self,
         #[graphql(default = 1000, validator(minimum = 10, maximum = 60_000))] interval: i32,

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -12,7 +12,6 @@ badges:
 
 Vector's 0.21.0 release includes **breaking changes**:
 
-1. [GraphQL API outputEventsByComponentIdPatterns subscription argument `patterns` changed to `outputsPatterns`](#api-patterns-to-outputspatterns)
 1. [Deprecated GraphQL API subscriptions have been removed](#removed-deprecated-subscriptions)
 
 And **deprecations**:
@@ -24,29 +23,6 @@ We cover them below to help you upgrade quickly:
 ## Upgrade guide
 
 ### Breaking changes
-
-#### GraphQL API `outputEventsByComponentIdPatterns` subscription argument `patterns` changed to `outputsPatterns` {#api-patterns-to-outputspatterns}
-
-To avoid confusion and align with the new `inputsPatterns` argument, we've
-renamed the original `patterns` argument to `outputsPatterns`. `outputsPatterns`
-allows you to specify patterns that will match against components (sources,
-transforms) and display their _outflowing_ events. `inputsPatterns` allows you
-to specify patterns that match against components (transforms, sinks) and
-display their _incoming_ events.
-
-Note that using an input pattern to match a component is effectively a
-shorthand. It's the same as using one or more output patterns to match against
-all the outputs flowing into a component.
-
-Updating your subscriptions is as simple as renaming `patterns` to
-`outputsPatterns`.
-
-```diff
-- subscription {
--  outputEventsByComponentIdPatterns(patterns: [...])
-+ subscription {
-+  outputEventsByComponentIdPatterns(outputsPatterns: [...])
-```
 
 #### Deprecated GraphQL API subscriptions have been removed {#removed-deprecated-subscriptions}
 

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -1,0 +1,78 @@
+---
+date: "2022-03-22"
+title: "0.21 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.21.0"
+authors: ["001wwang"]
+pr_numbers: []
+release: "0.21.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.21.0 release includes **breaking changes**:
+
+1. [GraphQL API outputEventsByComponentIdPatterns subscription argument `patterns` changed to `outputsPatterns`](#api-patterns-to-outputspatterns)
+1. [Deprecated GraphQL API subscriptions have been removed](#removed-deprecated-subscriptions)
+
+And **deprecations**:
+
+1. [`receivedEventsTotal`, `sentEventsTotal`, `sentEventsThroughput`, `receivedEventsThroughput` subscriptions have been deprecated](#deprecate-aggregate-subscriptions)
+
+We cover them below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Breaking changes
+
+#### GraphQL API `outputEventsByComponentIdPatterns` subscription argument `patterns` changed to `outputsPatterns` {#api-patterns-to-outputspatterns}
+
+To avoid confusion and align with the new `inputsPatterns` argument, we've
+renamed the original `patterns` argument to `outputsPatterns`. `outputsPatterns`
+allows you to specify patterns that will match against components (sources,
+transforms) and display their _outflowing_ events. `inputsPatterns` allows you
+to specify patterns that match against components (transforms, sinks) and
+display their _incoming_ events.
+
+Note that using an input pattern to match a component is effectively a
+shorthand. It's the same as using one or more output patterns to match against
+all the outputs flowing into a component.
+
+Updating your subscriptions is as simple as renaming `patterns` to
+`outputsPatterns`.
+
+```diff
+- subscription {
+-  outputEventsByComponentIdPatterns(patterns: [...])
++ subscription {
++  outputEventsByComponentIdPatterns(outputsPatterns: [...])
+```
+
+#### Deprecated GraphQL API subscriptions have been removed {#removed-deprecated-subscriptions}
+
+The following deprecated subscriptions have been removed in this release. Please
+use the listed alternatives.
+
+- `eventsInTotal`: use `componentReceivedEventsTotals`
+- `eventsOutTotal`: use `componentSentEventsTotals`
+- `componentEventsInThroughputs`: use `componentReceivedEventsThroughputs`
+- `componentEventsInTotals`: use `componentReceivedEventsTotals`
+- `componentEventsOutThroughputs`: use `componentSentEventsThroughputs`
+- `componentEventsOutTotals`: use `componentSentEventsTotals`
+- `eventsInThroughput`: use `componentReceivedEventsThroughputs`
+- `eventsOutThroughput`: use `componentSentEventsThroughputs`
+
+### Deprecations
+
+#### `receivedEventsTotal`, `sentEventsTotal`, `sentEventsThroughput`, `receivedEventsThroughput` subscriptions have been deprecated {#deprecate-aggregate-subscriptions}
+
+While these subscriptions were intended to display aggregate metrics across all
+components, they currently only show a per-component metric and are made
+redundant by more informative subscriptions that include specific component
+information. To avoid misuse and confusion, we are deprecating them in favor of
+the following alternatives.
+
+- `receivedEventsTotal`: use `componentReceivedEventsTotals`
+- `sentEventsTotal`: use `componentSentEventsTotals`
+- `sentEventsThroughput`: use `componentSentEventsThroughputs`
+- `receivedEventsThroughput`: use `componentReceivedEventsThroughputs`


### PR DESCRIPTION
Ref #11263

This PR removes the following already deprecated subscriptions (deprecated as of #9300, #9313)
- `eventsInTotal`: use `componentReceivedEventsTotals`
- `eventsOutTotal`: use `componentSentEventsTotals`
- `componentEventsInThroughputs`: use `componentReceivedEventsThroughputs`
- `componentEventsInTotals`: use `componentReceivedEventsTotals`
- `componentEventsOutThroughputs`: use `componentSentEventsThroughputs`
- `componentEventsOutTotals`: use `componentSentEventsTotals`
- `eventsInThroughput`: use `componentReceivedEventsThroughputs`
- `eventsOutThroughput`: use `componentSentEventsThroughputs`

and deprecates the following subscriptions
- `receivedEventsTotal`: use `componentReceivedEventsTotals`
- `sentEventsTotal`: use `componentSentEventsTotals`
- `sentEventsThroughput`: use `componentSentEventsThroughputs`
- `receivedEventsThroughput`: use `componentReceivedEventsThroughputs`

While the original discussion surrounding #11263 only mentioned axing `receivedEventsTotal` and `sentEventsTotal`, it seems like `receivedEventsThroughput` and `sentEventsThroughput` are in an analogous situation, so I deprecated them as well. Happy to revert if mistaken.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
