### PR TITLE
chore(sources): Send specific event types into `SourceSender`

### DIFF
--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -1,10 +1,6 @@
 use std::sync::Arc;
 
-use futures_util::{
-    future,
-    stream::{self, BoxStream},
-    FutureExt, StreamExt,
-};
+use futures_util::{future, stream::BoxStream, FutureExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{oneshot, Mutex};
 use vector_core::{
@@ -37,9 +33,7 @@ impl SourceConfig for UnitTestSourceConfig {
             // To appropriately shut down the topology after the source is done
             // sending events, we need to hold on to this shutdown trigger.
             let _shutdown = cx.shutdown;
-            out.send_all(&mut stream::iter(events))
-                .await
-                .map_err(|_| ())?;
+            out.send_batch(events).await.map_err(|_| ())?;
             Ok(())
         }))
     }

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -154,7 +154,11 @@ impl SourceSender {
             .await
     }
 
-    pub async fn send_batch(&mut self, events: Vec<Event>) -> Result<(), ClosedError> {
+    pub async fn send_batch<T, I>(&mut self, events: I) -> Result<(), ClosedError>
+    where
+        T: Into<Event> + ByteSizeOf,
+        I: IntoIterator<Item = T>,
+    {
         self.inner
             .as_mut()
             .expect("no default output")
@@ -162,11 +166,11 @@ impl SourceSender {
             .await
     }
 
-    pub async fn send_batch_named(
-        &mut self,
-        name: &str,
-        events: Vec<Event>,
-    ) -> Result<(), ClosedError> {
+    pub async fn send_batch_named<T, I>(&mut self, name: &str, events: I) -> Result<(), ClosedError>
+    where
+        T: Into<Event> + ByteSizeOf,
+        I: IntoIterator<Item = T>,
+    {
         self.named_inners
             .get_mut(name)
             .expect("unknown output")
@@ -205,18 +209,22 @@ impl Inner {
     ) -> Result<(), ClosedError> {
         let mut stream = events.ready_chunks(CHUNK_SIZE);
         while let Some(events) = stream.next().await {
-            self.send_batch(events).await?;
+            self.send_batch(events.into_iter()).await?;
         }
         Ok(())
     }
 
-    async fn send_batch(&mut self, events: Vec<Event>) -> Result<(), ClosedError> {
+    async fn send_batch<T, I>(&mut self, events: I) -> Result<(), ClosedError>
+    where
+        T: Into<Event> + ByteSizeOf,
+        I: IntoIterator<Item = T>,
+    {
         let mut count = 0;
         let mut byte_size = 0;
 
-        for event in events {
+        for event in events.into_iter() {
             let event_size = event.size_of();
-            match self.inner.send(event).await {
+            match self.inner.send(event.into()).await {
                 Ok(()) => {
                     count += 1;
                     byte_size += event_size;

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -143,18 +143,6 @@ impl SourceSender {
             .await
     }
 
-    pub async fn send_all_named(
-        &mut self,
-        name: &str,
-        events: impl Stream<Item = Event> + Unpin,
-    ) -> Result<(), ClosedError> {
-        self.named_inners
-            .get_mut(name)
-            .expect("unknown output")
-            .send_all(events)
-            .await
-    }
-
     pub async fn send_all(
         &mut self,
         events: impl Stream<Item = Event> + Unpin,

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -106,9 +106,9 @@ impl SqsSource {
                         let (batch, receiver) = BatchNotifier::new_with_receiver();
                         let mut stream = stream.map(|event| event.with_batch_notifier(&batch));
                         batch_receiver = Some(receiver);
-                        out.send_all(&mut stream).await
+                        out.send_stream(&mut stream).await
                     } else {
-                        out.send_all(&mut stream).await
+                        out.send_stream(&mut stream).await
                     };
 
                     match send_result {

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, fmt, path::Path};
 
 use chrono::{DateTime, Utc};
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use glob::{Pattern, PatternError};
 #[cfg(not(target_os = "windows"))]
 use heim::units::ratio::ratio;
@@ -18,10 +18,7 @@ use vector_core::ByteSizeOf;
 
 use crate::{
     config::{DataType, Output, SourceConfig, SourceContext, SourceDescription},
-    event::{
-        metric::{Metric, MetricKind, MetricValue},
-        Event,
-    },
+    event::metric::{Metric, MetricKind, MetricValue},
     internal_events::{BytesReceived, EventsReceived, StreamClosedError},
     shutdown::ShutdownSignal,
     SourceSender,
@@ -148,8 +145,8 @@ impl HostMetricsConfig {
                 protocol: "none"
             });
             let metrics = generator.capture_metrics().await;
-            let (count, _) = metrics.size_hint();
-            if let Err(error) = out.send_all(&mut stream::iter(metrics)).await {
+            let count = metrics.len();
+            if let Err(error) = out.send_batch(metrics).await {
                 emit!(&StreamClosedError {
                     count,
                     error: error.clone()
@@ -191,7 +188,7 @@ impl HostMetrics {
         }
     }
 
-    async fn capture_metrics(&self) -> impl Iterator<Item = Event> {
+    async fn capture_metrics(&self) -> Vec<Metric> {
         let hostname = crate::get_hostname();
         let version = self.config.version.clone();
         let configuration_key = self.config.configuration_key.clone();
@@ -242,7 +239,7 @@ impl HostMetrics {
             count: metrics.len(),
             byte_size: metrics.size_of(),
         });
-        metrics.into_iter().map(Into::into)
+        metrics
     }
 
     pub async fn loadavg_metrics(&self) -> Vec<Metric> {
@@ -561,7 +558,7 @@ pub(self) mod tests {
         let all_metrics_count = HostMetrics::new(HostMetricsConfig::default())
             .capture_metrics()
             .await
-            .count();
+            .len();
 
         for collector in &[
             #[cfg(target_os = "linux")]
@@ -582,7 +579,7 @@ pub(self) mod tests {
             .await;
 
             assert!(
-                all_metrics_count > some_metrics.count(),
+                all_metrics_count > some_metrics.len(),
                 "collector={:?}",
                 collector
             );
@@ -591,12 +588,11 @@ pub(self) mod tests {
 
     #[tokio::test]
     async fn are_tagged_with_hostname() {
-        let mut metrics = HostMetrics::new(HostMetricsConfig::default())
+        let metrics = HostMetrics::new(HostMetricsConfig::default())
             .capture_metrics()
             .await;
         let hostname = crate::get_hostname().expect("Broken hostname");
-        assert!(!metrics.any(|event| event
-            .into_metric()
+        assert!(!metrics.into_iter().any(|event| event
             .tags()
             .expect("Missing tags")
             .get("host")
@@ -606,23 +602,27 @@ pub(self) mod tests {
 
     #[tokio::test]
     async fn uses_custom_namespace() {
-        let mut metrics = HostMetrics::new(HostMetricsConfig {
+        let metrics = HostMetrics::new(HostMetricsConfig {
             namespace: Namespace(Some("other".into())),
             ..Default::default()
         })
         .capture_metrics()
         .await;
 
-        assert!(metrics.all(|event| event.into_metric().namespace() == Some("other")));
+        assert!(metrics
+            .into_iter()
+            .all(|event| event.namespace() == Some("other")));
     }
 
     #[tokio::test]
     async fn uses_default_namespace() {
-        let mut metrics = HostMetrics::new(HostMetricsConfig::default())
+        let metrics = HostMetrics::new(HostMetricsConfig::default())
             .capture_metrics()
             .await;
 
-        assert!(metrics.all(|event| event.into_metric().namespace() == Some("host")));
+        assert!(metrics
+            .iter()
+            .all(|event| event.namespace() == Some("host")));
     }
 
     // Windows does not produce load average metrics.

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -126,34 +126,31 @@ async fn run(
         let byte_size = metrics.size_of();
         emit!(&EventsReceived { count, byte_size });
 
-        let batch = metrics
-            .into_iter()
-            .map(|mut metric| {
-                // A metric starts out with a default "vector" namespace, but will be overridden
-                // if an explicit namespace is provided to this source.
-                if namespace.is_some() {
-                    metric = metric.with_namespace(namespace.as_ref());
-                }
+        let batch = metrics.into_iter().map(|mut metric| {
+            // A metric starts out with a default "vector" namespace, but will be overridden
+            // if an explicit namespace is provided to this source.
+            if namespace.is_some() {
+                metric = metric.with_namespace(namespace.as_ref());
+            }
 
-                // Version and configuration key are reported in enterprise.
-                if let Some(version) = &version {
-                    metric.insert_tag("version".to_owned(), version.clone());
-                }
-                if let Some(configuration_key) = &configuration_key {
-                    metric.insert_tag("configuration_key".to_owned(), configuration_key.clone());
-                }
+            // Version and configuration key are reported in enterprise.
+            if let Some(version) = &version {
+                metric.insert_tag("version".to_owned(), version.clone());
+            }
+            if let Some(configuration_key) = &configuration_key {
+                metric.insert_tag("configuration_key".to_owned(), configuration_key.clone());
+            }
 
-                if let Some(host_key) = host_key {
-                    if let Ok(hostname) = &hostname {
-                        metric.insert_tag(host_key.to_owned(), hostname.to_owned());
-                    }
+            if let Some(host_key) = host_key {
+                if let Ok(hostname) = &hostname {
+                    metric.insert_tag(host_key.to_owned(), hostname.to_owned());
                 }
-                if let Some(pid_key) = pid_key {
-                    metric.insert_tag(pid_key.to_owned(), pid.clone());
-                }
-                metric.into()
-            })
-            .collect();
+            }
+            if let Some(pid_key) = pid_key {
+                metric.insert_tag(pid_key.to_owned(), pid.clone());
+            }
+            metric
+        });
 
         if let Err(error) = out.send_batch(batch).await {
             emit!(&StreamClosedError { error, count });

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -278,7 +278,7 @@ async fn kafka_source(
                     Some(finalizer) => {
                         let (batch, receiver) = BatchNotifier::new_with_receiver();
                         let mut stream = stream.map(|event| event.with_batch_notifier(&batch));
-                        match out.send_all(&mut stream).await {
+                        match out.send_stream(&mut stream).await {
                             Err(error) => {
                                 emit!(&StreamClosedError { error, count });
                             }
@@ -290,7 +290,7 @@ async fn kafka_source(
                             }
                         }
                     }
-                    None => match out.send_all(&mut stream).await {
+                    None => match out.send_stream(&mut stream).await {
                         Err(error) => {
                             emit!(&StreamClosedError { error, count });
                         }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -446,7 +446,7 @@ impl Source {
         let (events_count, _) = events.size_hint();
 
         let mut stream = partial_events_merger.transform(Box::pin(events));
-        let event_processing_loop = out.send_all(&mut stream);
+        let event_processing_loop = out.send_stream(&mut stream);
 
         let mut lifecycle = Lifecycle::new();
         {

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -149,15 +149,15 @@ async fn nats_source(
 
                     let now = Utc::now();
 
-                    let events = stream::iter(events.into_iter().map(|mut event| {
+                    let events = events.into_iter().map(|mut event| {
                         if let Event::Log(ref mut log) = event {
                             log.try_insert(log_schema().source_type_key(), Bytes::from("nats"));
                             log.try_insert(log_schema().timestamp_key(), now);
                         }
                         event
-                    }));
+                    });
 
-                    out.send_all(events).await.map_err(|error| {
+                    out.send_batch(events).await.map_err(|error| {
                         emit!(&StreamClosedError { error, count });
                     })?;
                 }

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -368,7 +368,7 @@ fn prometheus(
             .flatten()
             .boxed();
 
-        match out.send_all(&mut stream).await {
+        match out.send_stream(&mut stream).await {
             Ok(()) => {
                 info!("Finished sending.");
                 Ok(())

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use bytes::{Bytes, BytesMut};
 use chrono::Utc;
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
@@ -128,7 +128,7 @@ pub fn udp(
                                 }
 
                                 tokio::select!{
-                                    result = out.send_all(stream::iter(events)) => {
+                                    result = out.send_batch(events) => {
                                         if let Err(error) = result {
                                             emit!(&StreamClosedError { error, count });
                                             return Ok(())

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -159,7 +159,7 @@ where
         }
         .boxed();
 
-        match out.send_all(&mut stream).await {
+        match out.send_stream(&mut stream).await {
             Ok(()) => {
                 info!("Finished sending.");
                 Ok(())

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -256,7 +256,7 @@ pub fn udp(
         })
         .boxed();
 
-        match out.send_all(&mut stream).await {
+        match out.send_stream(&mut stream).await {
             Ok(()) => {
                 info!("Finished sending.");
                 Ok(())

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -503,7 +503,7 @@ pub fn build_framestream_unix_source(
                 });
 
                 let handler = async move {
-                    if let Err(e) = event_sink.send_all(&mut events).await {
+                    if let Err(e) = event_sink.send_stream(&mut events).await {
                         error!("Error sending event: {:?}.", e);
                     }
 

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -1,7 +1,7 @@
 use std::{fs::remove_file, path::PathBuf};
 
 use bytes::{Bytes, BytesMut};
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use tokio::net::UnixDatagram;
 use tokio_util::codec::FramedRead;
 use tracing::field;
@@ -100,9 +100,8 @@ async fn listen(
                             handle_events(&mut events, received_from.clone());
 
                             let count = events.len();
-                            if let Err(error) = out.send_all(stream::iter(events)).await {
+                            if let Err(error) = out.send_batch(events).await {
                                 emit!(&StreamClosedError { error, count });
-                                return Err(());
                             }
                         },
                         Some(Err(error)) => {

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -1,7 +1,7 @@
 use std::{fs::remove_file, path::PathBuf, time::Duration};
 
 use bytes::Bytes;
-use futures::{stream, FutureExt, StreamExt};
+use futures::{FutureExt, StreamExt};
 use tokio::{
     io::AsyncWriteExt,
     net::{UnixListener, UnixStream},
@@ -101,7 +101,7 @@ pub fn build_unix_stream_source(
                                 handle_events(&mut events, received_from.clone());
 
                                 let count = events.len();
-                                if let Err(error) = out.send_all(stream::iter(events)).await {
+                                if let Err(error) = out.send_batch(events).await {
                                     emit!(&StreamClosedError { error, count });
                                 }
                             }

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -52,7 +52,7 @@ impl proto::Service for Service {
 
         self.pipeline
             .clone()
-            .send_all(&mut futures::stream::iter(events))
+            .send_batch(events)
             .map_err(|error| {
                 let message = error.to_string();
                 emit!(&StreamClosedError { error, count });

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -198,7 +198,7 @@ impl SourceConfig for MockSourceConfig {
                 }
             });
 
-            match out.send_all(&mut stream).await {
+            match out.send_stream(&mut stream).await {
                 Ok(()) => {
                     info!("Finished sending.");
                     Ok(())

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -9,7 +9,7 @@ use std::{
     },
 };
 
-use futures::{future, stream, StreamExt};
+use futures::{future, StreamExt};
 use tokio::time::{sleep, Duration};
 use vector::{
     config::{Config, SinkOuter},
@@ -66,7 +66,7 @@ async fn topology_shutdown_while_active() {
 
     let pump_handle = tokio::spawn(async move {
         let mut stream = futures::stream::repeat(Event::from("test"));
-        in1.send_all(&mut stream).await
+        in1.send_stream(&mut stream).await
     });
 
     // Wait until at least 100 events have been seen by the source so we know the pump is running
@@ -441,9 +441,8 @@ async fn topology_swap_transform_is_atomic() {
             None
         }
     };
-    let mut input = stream::iter(iter::from_fn(events));
     let input = async move {
-        in1.send_all(&mut input).await.unwrap();
+        in1.send_batch(iter::from_fn(events)).await.unwrap();
     };
     let output = out1.for_each(move |_| {
         recv_counter.fetch_add(1, Ordering::Release);


### PR DESCRIPTION
This is a bit of an scatter shot batch of changes to update sources to send specific event types (ie `LogEvent` or `Metric`) into `SourceSender` to help with future event array conversion.

Closes #11350