### PR TITLE
chore(api): Warn on invalid matches in vector tap

### DIFF
--- a/lib/vector-api-client/graphql/schema.json
+++ b/lib/vector-api-client/graphql/schema.json
@@ -1213,6 +1213,26 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "invalidMatches",
+              "description": "Any invalid matches for the pattern",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1237,6 +1257,18 @@
             {
               "name": "NOT_MATCHED",
               "description": "There isn't currently a component that matches this pattern",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID_INPUT_PATTERN_MATCH",
+              "description": "The input pattern matched source(s) which cannot be tapped for inputs",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID_OUTPUT_PATTERN_MATCH",
+              "description": "The output pattern matched sink(s) which cannot be tapped for outputs",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/lib/vector-api-client/graphql/subscriptions/output_events_by_component_id_patterns.graphql
+++ b/lib/vector-api-client/graphql/subscriptions/output_events_by_component_id_patterns.graphql
@@ -16,6 +16,7 @@ subscription OutputEventsByComponentIdPatternsSubscription(
         ... on EventNotification {
             pattern
             notification
+            invalidMatches
         }
     }
 }

--- a/src/api/schema/events/notification.rs
+++ b/src/api/schema/events/notification.rs
@@ -7,6 +7,10 @@ pub enum EventNotificationType {
     Matched,
     /// There isn't currently a component that matches this pattern
     NotMatched,
+    /// The input pattern matched source(s) which cannot be tapped for inputs
+    InvalidInputPatternMatch,
+    /// The output pattern matched sink(s) which cannot be tapped for outputs
+    InvalidOutputPatternMatch,
 }
 
 #[derive(Debug, SimpleObject, Clone, PartialEq)]
@@ -17,6 +21,9 @@ pub struct EventNotification {
 
     /// Event notification type
     notification: EventNotificationType,
+
+    /// Any invalid matches for the pattern
+    invalid_matches: Option<Vec<String>>,
 }
 
 impl EventNotification {
@@ -24,6 +31,19 @@ impl EventNotification {
         Self {
             pattern,
             notification,
+            invalid_matches: None,
+        }
+    }
+
+    pub const fn new_with_invalid_matches(
+        pattern: String,
+        notification: EventNotificationType,
+        invalid_matches: Vec<String>,
+    ) -> Self {
+        Self {
+            pattern,
+            notification,
+            invalid_matches: Some(invalid_matches),
         }
     }
 }

--- a/src/api/schema/events/output.rs
+++ b/src/api/schema/events/output.rs
@@ -26,15 +26,29 @@ impl From<TapPayload> for OutputEventsPayload {
         match t {
             TapPayload::Log(output_id, ev) => Self::Log(Log::new(output_id, ev)),
             TapPayload::Metric(output_id, ev) => Self::Metric(Metric::new(output_id, ev)),
-            TapPayload::Notification(component_key, n) => match n {
+            TapPayload::Notification(pattern, n) => match n {
                 TapNotification::Matched => Self::Notification(EventNotification::new(
-                    component_key,
+                    pattern,
                     EventNotificationType::Matched,
                 )),
                 TapNotification::NotMatched => Self::Notification(EventNotification::new(
-                    component_key,
+                    pattern,
                     EventNotificationType::NotMatched,
                 )),
+                TapNotification::InvalidInputPatternMatch(invalid_matches) => {
+                    Self::Notification(EventNotification::new_with_invalid_matches(
+                        pattern,
+                        EventNotificationType::InvalidInputPatternMatch,
+                        invalid_matches,
+                    ))
+                }
+                TapNotification::InvalidOutputPatternMatch(invalid_matches) => {
+                    Self::Notification(EventNotification::new_with_invalid_matches(
+                        pattern,
+                        EventNotificationType::InvalidOutputPatternMatch,
+                        invalid_matches,
+                    ))
+                }
             },
         }
     }

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -87,7 +87,7 @@ pub async fn cmd(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitC
             Some(SignalTo::Shutdown | SignalTo::Quit) = signal_rx.recv() => break,
             Some(Some(res)) = stream.next() => {
                 if let Some(d) = res.data {
-                    for tap_event in d.output_events_by_component_id_patterns.iter() {
+                    for tap_event in d.output_events_by_component_id_patterns {
                         match tap_event {
                             OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns::Log(ev) => {
                                 println!("{}", ev.string);
@@ -100,6 +100,8 @@ pub async fn cmd(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitC
                                     match ev.notification {
                                         EventNotificationType::MATCHED => eprintln!(r#"[tap] Pattern "{}" successfully matched."#, ev.pattern),
                                         EventNotificationType::NOT_MATCHED => eprintln!(r#"[tap] Pattern "{}" failed to match: will retry on configuration reload."#, ev.pattern),
+                                        EventNotificationType::INVALID_INPUT_PATTERN_MATCH => eprintln!(r#"[tap] Warning: source inputs cannot be tapped. Input pattern "{}" matches sources {:?}"#, ev.pattern, ev.invalid_matches.unwrap_or_default()),
+                                        EventNotificationType::INVALID_OUTPUT_PATTERN_MATCH => eprintln!(r#"[tap] Warning: sink outputs cannot be tapped. Output pattern "{}" matches sinks {:?}"#, ev.pattern, ev.invalid_matches.unwrap_or_default()),
                                         EventNotificationType::Other(_) => {},
                                     }
                                 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -53,6 +53,10 @@ pub struct TapResource {
     pub outputs: HashMap<OutputId, fanout::ControlChannel>,
     // Components (transforms, sinks) and their corresponding inputs
     pub inputs: HashMap<ComponentKey, Vec<OutputId>>,
+    // Source component keys used to warn against invalid pattern matches
+    pub source_keys: Vec<String>,
+    // Sink component keys used to warn against invalid pattern amtches
+    pub sink_keys: Vec<String>,
 }
 
 // Watcher types for topology changes.

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -487,6 +487,18 @@ impl RunningTopology {
                 .send(TapResource {
                     outputs: self.outputs.clone(),
                     inputs: watch_inputs,
+                    source_keys: self
+                        .config
+                        .sources
+                        .keys()
+                        .map(|key| key.to_string())
+                        .collect(),
+                    sink_keys: self
+                        .config
+                        .sinks
+                        .keys()
+                        .map(|key| key.to_string())
+                        .collect(),
                 })
                 .expect("Couldn't broadcast config changes.");
         }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -487,16 +487,14 @@ impl RunningTopology {
                 .send(TapResource {
                     outputs: self.outputs.clone(),
                     inputs: watch_inputs,
-                    source_keys: self
-                        .config
+                    source_keys: diff
                         .sources
-                        .keys()
+                        .changed_and_added()
                         .map(|key| key.to_string())
                         .collect(),
-                    sink_keys: self
-                        .config
+                    sink_keys: diff
                         .sinks
-                        .keys()
+                        .changed_and_added()
                         .map(|key| key.to_string())
                         .collect(),
                 })


### PR DESCRIPTION
Closes #11368 

Opening as a draft as this is stacked on: #11321

This PR adds a warning message if user-provided patterns may result in invalid matches to avoid misuse. Invalid matches are an input pattern (`--inputs-of`) matching a source or an output pattern (`--outputs-of`) matching a sink.

### Example
For the following config:
```toml
[api]
enabled = true

[sources.test]
type = "demo_logs"
format = "shuffle"
lines = [
  "test1",
]

[sources.test2]
type = "demo_logs"
format = "shuffle"
lines = [
  "test2",
]

[transforms.remap]
type = "remap"
inputs = ["test*"]
source = '''
  .new_field = "new"
'''

[sinks.out]
type = "blackhole"
inputs = ["remap"]
```

Running 
```
target/debug/vector tap --inputs-of "test"
```
you'll see
```shell
[tap] Pattern "test" failed to match: will retry on configuration reload.
[tap] Warning: source inputs cannot be tapped. Input pattern "test" matches sources ["test"]
```

Similarly, running `target/debug/vector tap --inputs-of "test*"`, you'll see
```shell
[tap] Pattern "test*" failed to match: will retry on configuration reload.
[tap] Warning: source inputs cannot be tapped. Input pattern "test*" matches sources ["test", "test2"]
```

Invalid output pattern warnings will also be shown. Running 
```shell
target/debug/vector tap --inputs-of "test*" --outputs-of "out"
```
you'll see
```shell
[tap] Pattern "test*" failed to match: will retry on configuration reload.
[tap] Pattern "out" failed to match: will retry on configuration reload.
[tap] Warning: source inputs cannot be tapped. Input pattern "test*" matches sources ["test", "test2"]
[tap] Warning: sink outputs cannot be tapped. Output pattern "out" matches sinks ["out"]
```
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
