### PR TITLE
chore(splunk_hec sink): Update upgrade guide and docs with Splunk channel behavior

### DIFF
--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -157,7 +157,7 @@ header value. Splunk accepts this header regardless of whether indexer
 acknowledgements is enabled, so the `splunk_hec` sinks always attach the header.
 In other words, disabling indexer acknowledgements for the sink will not disable
 this header value. You can read more about channels in the [official Splunk
-docs](https://docs.splunk.com/Documentation/Splunk/8.2.4/Data/FormateventsforHTTPEventCollector#Channel_identifier_header)
+docs](https://docs.splunk.com/Documentation/Splunk/8.2.4/Data/FormateventsforHTTPEventCollector#Channel_identifier_header).
 
 If your setup involves a `splunk_hec` sink sending into a separate `splunk_hec`
 source, you will now see a `splunk_channel` field in events output from the

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -21,6 +21,10 @@ And **deprecations**:
 
 1. [Splunk HEC sinks rename `token` to `default_token`](#splunk-hec-token)
 
+And **behavioral changes**:
+
+1. [Splunk HEC sinks now include a channel header in requests](#splunk-hec-channel-header)
+
 We cover them below to help you upgrade quickly:
 
 ## Upgrade guide
@@ -141,4 +145,31 @@ You can migrate your configuration by renaming `token` to  `default_token`:
 -  token = "MY-TOKEN"
 +  default_token = "MY-TOKEN"
    ...
+```
+
+### Behavioral Changes
+
+#### Splunk HEC sinks now include a channel header in requests {#splunk-hec-channel-header}
+
+As part of our work to support Splunk HEC indexer acknowledgements, `splunk_hec`
+sinks will generate a random UUID to use as the `X-Splunk-Request-Channel`
+header value. Splunk accepts this header regardless of whether indexer
+acknowledgements is enabled, so the `splunk_hec` sinks always attach the header.
+In other words, disabling indexer acknowledgements for the sink will not disable
+this header value. You can read more about channels in the [official Splunk
+docs](https://docs.splunk.com/Documentation/Splunk/8.2.4/Data/FormateventsforHTTPEventCollector#Channel_identifier_header)
+
+If your setup involves a `splunk_hec` sink sending into a separate `splunk_hec`
+source, you will now see a `splunk_channel` field in events output from the
+`splunk_hec` source. This is because `splunk_hec` sources have always parsed and
+included channel information from requests in their events. If you want to
+remove this field, you can simply drop it with a `remap` transform like follows:
+
+```toml
+[transforms.foo]
+type = "remap"
+inputs = ["bar"] # where bar is the splunk_hec source
+source = '''
+  del(.splunk_channel)
+'''
 ```

--- a/website/cue/reference/components/sinks/splunk_hec.cue
+++ b/website/cue/reference/components/sinks/splunk_hec.cue
@@ -70,5 +70,14 @@ components: sinks: _splunk_hec: {
 				(5 minutes) per `ackID`.
 				"""
 		}
+		splunk_channel: {
+			title: "Splunk HEC Channel Header"
+			body:  """
+				Splunk HEC requests will include the `X-Splunk-Request-Channel` header with a randomly generated UUID as the channel value.
+				Splunk requires [a channel value](\(urls.splunk_hec_channel_header)) when using indexer acknowledgements, but also accepts
+				channel values when indexer acknowledgements is disabled. Thus, this channel value is included regardless of indexer
+				acknowledgement settings.
+				"""
+		}
 	}
 }

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -437,6 +437,7 @@ urls: {
 	socket:                                                   "\(wikipedia)/wiki/Network_socket"
 	splunk:                                                   "https://www.splunk.com"
 	splunk_hec:                                               "https://dev.splunk.com/enterprise/docs/dataapps/httpeventcollector/"
+	splunk_hec_channel_header:                                "https://docs.splunk.com/Documentation/Splunk/8.2.4/Data/FormateventsforHTTPEventCollector#Channel_identifier_header"
 	splunk_hec_event_endpoint:                                "https://docs.splunk.com/Documentation/Splunk/8.0.0/RESTREF/RESTinput#services.2Fcollector.2Fevent"
 	splunk_hec_indexed_fields:                                "https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC"
 	splunk_hec_indexer_acknowledgements:                      "https://docs.splunk.com/Documentation/Splunk/8.2.3/Data/AboutHECIDXAck"


### PR DESCRIPTION
Closes #11387 

This PR updates the `0.19.0` upgrade guide and `How It Works` section of the `splunk_hec sink` docs to highlight the channel behavior in `splunk_hec` sinks introduced alongside indexer acknowledgements work.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
