### PR TITLE
chore(ci): Re-order soak results

### DIFF
--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -74,6 +74,7 @@ for exp in bytes_written.experiment.unique():
     results.append({'experiment': exp,
                     'Δ mean': diff.mean(),
                     'Δ mean %': percent_change,
+                    'confidence': common.confidence(res.pvalue),
                     'baseline mean': baseline_mean,
                     'baseline stdev': baseline_stdev,
                     'baseline stderr': baseline_stderr,
@@ -90,6 +91,10 @@ for exp in bytes_written.experiment.unique():
                     })
 
 results = pd.DataFrame.from_records(results)
+results = (results
+  .assign(delta_mean_abs=results['Δ mean %'].abs())
+  .sort_values(['p-value', 'delta_mean_abs'], ascending=(True, False))
+   .drop(columns=['delta_mean_abs']))
 
 print(f'''
 # Soak Test Results
@@ -127,16 +132,13 @@ p_value_violation = results['p-value'] < args.p_value
 erratic_violation = results.erratic == True
 
 changes = results[p_value_violation & drift_filter & ~declared_erratic].copy(deep=True)
-changes['Δ confidence'] = changes['p-value'].apply(common.confidence)
 changes = changes.drop(labels=['p-value', 'baseline mean',
                                'baseline stdev', 'comparison mean',
                                'baseline outlier %', 'baseline CoV',
                                'comparison outlier %', 'comparison CoV', 'erratic',
-                               'comparison stdev', 'declared erratic'], axis=1)
-changes = changes.sort_values('Δ mean %', ascending=False)
+                               'comparison stdev', 'declared erratic', 'baseline stderr',
+                               'comparison stderr'], axis=1)
 changes['Δ mean'] = changes['Δ mean'].apply(common.human_bytes)
-changes['baseline stderr'] = changes['baseline stderr'].apply(common.human_bytes)
-changes['comparison stderr'] = changes['comparison stderr'].apply(common.human_bytes)
 
 no_longer_erratic = results[~erratic_violation & declared_erratic].copy(deep=True)
 no_longer_erratic = no_longer_erratic.drop(labels=['p-value', 'baseline mean',
@@ -183,7 +185,6 @@ print()
 print("<details>")
 print("<summary>Fine details of change detection per experiment.</summary>")
 print()
-results = results.sort_values('Δ mean %', ascending=False)
 results['Δ mean'] = results['Δ mean'].apply(common.human_bytes)
 results['baseline mean'] = results['baseline mean'].apply(common.human_bytes)
 results['baseline stdev'] = results['baseline stdev'].apply(common.human_bytes)

--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -91,10 +91,6 @@ for exp in bytes_written.experiment.unique():
                     })
 
 results = pd.DataFrame.from_records(results)
-results = (results
-  .assign(delta_mean_abs=results['Δ mean %'].abs())
-  .sort_values(['p-value', 'delta_mean_abs'], ascending=(True, False))
-   .drop(columns=['delta_mean_abs']))
 
 print(f'''
 # Soak Test Results
@@ -138,6 +134,7 @@ changes = changes.drop(labels=['p-value', 'baseline mean',
                                'comparison outlier %', 'comparison CoV', 'erratic',
                                'comparison stdev', 'declared erratic', 'baseline stderr',
                                'comparison stderr'], axis=1)
+changes = changes.sort_values('Δ mean %', ascending=False)
 changes['Δ mean'] = changes['Δ mean'].apply(common.human_bytes)
 
 no_longer_erratic = results[~erratic_violation & declared_erratic].copy(deep=True)
@@ -185,6 +182,7 @@ print()
 print("<details>")
 print("<summary>Fine details of change detection per experiment.</summary>")
 print()
+results = results.sort_values('Δ mean %', ascending=False)
 results = results.drop(labels=["p-value"], axis=1) # only used for detecting changes
 results['Δ mean'] = results['Δ mean'].apply(common.human_bytes)
 results['baseline mean'] = results['baseline mean'].apply(common.human_bytes)

--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -185,6 +185,7 @@ print()
 print("<details>")
 print("<summary>Fine details of change detection per experiment.</summary>")
 print()
+results = results.drop(labels=["p-value"], axis=1) # only used for detecting changes
 results['Δ mean'] = results['Δ mean'].apply(common.human_bytes)
 results['baseline mean'] = results['baseline mean'].apply(common.human_bytes)
 results['baseline stdev'] = results['baseline stdev'].apply(common.human_bytes)


### PR DESCRIPTION
This:

* Adds `confidence` as a column to the detail table. Nathan mentioned
  this is easier to scan than the p-values and I agree.
* Removes the stderr columns from the summary table. I don't think this
  information is needed there. People generally just want to see the
  change in mean and confidence.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
