### PR TITLE
chore: Improve issue template community note

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,10 +10,9 @@ body:
 
 - type: textarea
   attributes:
-    label: A note for the community (please keep)
+    label: A note for the community
     value: |
       <!-- Please keep this note for the community -->
-      ### Community Note
       * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
       * If you are interested in working on this issue or have submitted a pull request, please leave a comment
       <!-- Thank you for keeping this note for the community -->

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -13,10 +13,9 @@ body:
 
 - type: textarea
   attributes:
-    label: A note for the community (please keep)
+    label: A note for the community
     value: |
       <!-- Please keep this note for the community -->
-      ### Community Note
       * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
       * If you are interested in working on this issue or have submitted a pull request, please leave a comment
       <!-- Thank you for keeping this note for the community -->


### PR DESCRIPTION
While creating an issue, I discovered that the form creates redundant
headers for the community note. This cleans that up.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
