### PR TITLE
docs: we have just one Runtime transform now

### DIFF
--- a/website/content/en/guides/level-up/transformation.md
+++ b/website/content/en/guides/level-up/transformation.md
@@ -39,7 +39,7 @@ choice for transforming data in Vector:
   and no type mismatches.
 
 In cases where VRL doesn't fit your use case, Vector also offers a [Lua runtime
-transform](#runtime-transform) that offer a bit more flexibility than VRL but
+transform](#lua-runtime-transform) that offer a bit more flexibility than VRL but
 also come with downsides (listed below) that should always be borne in mind.
 
 ## Transforming data using VRL

--- a/website/content/en/guides/level-up/transformation.md
+++ b/website/content/en/guides/level-up/transformation.md
@@ -38,8 +38,8 @@ choice for transforming data in Vector:
   ensure that your VRL code is sound, meaning no dead code, no unhandled errors,
   and no type mismatches.
 
-In cases where VRL doesn't fit your use case, Vector also offers two [runtime
-transforms](#runtime-transforms) that offer a bit more flexibility than VRL but
+In cases where VRL doesn't fit your use case, Vector also offers a [Lua runtime
+transform](#runtime-transform) that offer a bit more flexibility than VRL but
 also come with downsides (listed below) that should always be borne in mind.
 
 ## Transforming data using VRL
@@ -173,7 +173,7 @@ recommend checking out the following documentation:
 * [VRL expressions][docs.vrl.expressions], which describes things VRL's syntax
   and type system in great detail
 
-## Runtime transforms
+## Lua runtime transform
 
 If VRL doesn't cover your use case—and that should happen rarely—Vector also
 offers a [`lua`][docs.lua] **runtime transform** that you can use instead of


### PR DESCRIPTION
Should of been part of f0f71de28447dc716fc1dd0eac3f2681f61c0f3f

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
