### PR TITLE
chore(pipelines transform): Allow empty pipelines

### DIFF
--- a/src/transforms/pipelines/expander.rs
+++ b/src/transforms/pipelines/expander.rs
@@ -35,11 +35,7 @@ impl TransformConfig for ExpanderConfig {
     fn expand(
         &mut self,
     ) -> crate::Result<Option<(IndexMap<String, Box<dyn TransformConfig>>, ExpandType)>> {
-        if self.inner.is_empty() {
-            Err("must specify at least one transform".into())
-        } else {
-            Ok(Some((self.inner.clone(), self.mode.clone())))
-        }
+        Ok(Some((self.inner.clone(), self.mode.clone())))
     }
 
     fn input(&self) -> Input {

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -84,6 +84,7 @@ inventory::submit! {
 pub struct PipelineConfig {
     name: String,
     filter: Option<AnyCondition>,
+    #[serde(default)]
     transforms: Vec<Box<dyn TransformConfig>>,
 }
 


### PR DESCRIPTION
We were explicitly prohibiting this which is is blocking https://github.com/vectordotdev/vector/pull/11407

I think it's useful to be able to run without transforms while
developing or debugging Vector configurations (e.g. commenting out
transforms).

I could see us having a "strict" mode in Vector in the future that would
prohibit things like this, but I think this change is in-line with
Vector's other behavior of starting with configurations that users
probably wouldn't want to run in production (like sources that are not
consumed).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
