### PR TITLE
fix(ci): Fix Windows build

### DIFF
--- a/src/internal_events/open.rs
+++ b/src/internal_events/open.rs
@@ -42,7 +42,7 @@ impl OpenGauge {
         }
     }
 
-    #[cfg(feature = "sources-utils-unix")]
+    #[cfg(all(unix, feature = "sources-utils-unix"))]
     pub fn any_open(&self) -> bool {
         self.gauge.load(Ordering::Acquire) != 0
     }


### PR DESCRIPTION
Currently failing because this function is never called on Windows.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
