### PR TITLE
fix(ci): add unix flag to `any_open`.

### DIFF
--- a/src/internal_events/open.rs
+++ b/src/internal_events/open.rs
@@ -42,7 +42,7 @@ impl OpenGauge {
         }
     }
 
-    #[cfg(feature = "sources-utils-unix")]
+    #[cfg(all(feature = "sources-utils-unix", unix))]
     pub fn any_open(&self) -> bool {
         self.gauge.load(Ordering::Acquire) != 0
     }


### PR DESCRIPTION
The Windows builds are breaking with:

```
error: associated function is never used: `any_open`
  --> src\internal_events\open.rs:46:12
   |
46 |     pub fn any_open(&self) -> bool {
   |            ^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
```

This hopefully fixes it.