### PR TITLE
chore: [retypist] `src/topology`

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -119,7 +119,7 @@ pub struct Pieces {
     pub healthchecks: HashMap<ComponentKey, Task>,
     pub shutdown_coordinator: SourceShutdownCoordinator,
     pub detach_triggers: HashMap<ComponentKey, Trigger>,
-    pub enrichment_tables: enrichment::TableRegistry,
+    pub(super) enrichment_tables: enrichment::TableRegistry,
 }
 
 /// Builds only the new pieces, and doesn't check their topology.

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -118,7 +118,7 @@ pub struct Pieces {
     pub source_tasks: HashMap<ComponentKey, Task>,
     pub healthchecks: HashMap<ComponentKey, Task>,
     pub shutdown_coordinator: SourceShutdownCoordinator,
-    pub detach_triggers: HashMap<ComponentKey, Trigger>,
+    pub(crate) detach_triggers: HashMap<ComponentKey, Trigger>,
     pub(super) enrichment_tables: enrichment::TableRegistry,
 }
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -116,7 +116,7 @@ pub struct Pieces {
     pub outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
     pub(super) tasks: HashMap<ComponentKey, Task>,
     pub source_tasks: HashMap<ComponentKey, Task>,
-    pub healthchecks: HashMap<ComponentKey, Task>,
+    pub(super) healthchecks: HashMap<ComponentKey, Task>,
     pub shutdown_coordinator: SourceShutdownCoordinator,
     pub(crate) detach_triggers: HashMap<ComponentKey, Trigger>,
     pub(super) enrichment_tables: enrichment::TableRegistry,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -46,7 +46,7 @@ use crate::{
 static ENRICHMENT_TABLES: Lazy<enrichment::TableRegistry> =
     Lazy::new(enrichment::TableRegistry::default);
 
-pub const SOURCE_SENDER_BUFFER_SIZE: usize = 1000;
+pub(crate) const SOURCE_SENDER_BUFFER_SIZE: usize = 1000;
 
 static TRANSFORM_CONCURRENCY_LIMIT: Lazy<usize> = Lazy::new(|| {
     crate::app::WORKER_THREADS

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -119,7 +119,6 @@ pub struct Pieces {
     pub(super) healthchecks: HashMap<ComponentKey, Task>,
     pub(crate) shutdown_coordinator: SourceShutdownCoordinator,
     pub(crate) detach_triggers: HashMap<ComponentKey, Trigger>,
-    pub(super) enrichment_tables: enrichment::TableRegistry,
 }
 
 /// Builds only the new pieces, and doesn't check their topology.
@@ -473,7 +472,6 @@ pub async fn build_pieces(
             healthchecks,
             shutdown_coordinator,
             detach_triggers,
-            enrichment_tables: enrichment_tables.clone(),
         };
 
         Ok(pieces)

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -113,7 +113,7 @@ pub(self) async fn load_enrichment_tables<'a>(
 
 pub struct Pieces {
     pub(super) inputs: HashMap<ComponentKey, (BufferSender<Event>, Vec<OutputId>)>,
-    pub outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
+    pub(crate) outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
     pub(super) tasks: HashMap<ComponentKey, Task>,
     pub source_tasks: HashMap<ComponentKey, Task>,
     pub(super) healthchecks: HashMap<ComponentKey, Task>,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -55,7 +55,7 @@ static TRANSFORM_CONCURRENCY_LIMIT: Lazy<usize> = Lazy::new(|| {
         .unwrap_or_else(num_cpus::get)
 });
 
-pub async fn load_enrichment_tables<'a>(
+pub(self) async fn load_enrichment_tables<'a>(
     config: &'a super::Config,
     diff: &'a ConfigDiff,
 ) -> (&'static enrichment::TableRegistry, Vec<String>) {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -117,7 +117,7 @@ pub struct Pieces {
     pub(super) tasks: HashMap<ComponentKey, Task>,
     pub source_tasks: HashMap<ComponentKey, Task>,
     pub(super) healthchecks: HashMap<ComponentKey, Task>,
-    pub shutdown_coordinator: SourceShutdownCoordinator,
+    pub(crate) shutdown_coordinator: SourceShutdownCoordinator,
     pub(crate) detach_triggers: HashMap<ComponentKey, Trigger>,
     pub(super) enrichment_tables: enrichment::TableRegistry,
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -115,7 +115,7 @@ pub struct Pieces {
     pub(super) inputs: HashMap<ComponentKey, (BufferSender<Event>, Vec<OutputId>)>,
     pub(crate) outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
     pub(super) tasks: HashMap<ComponentKey, Task>,
-    pub source_tasks: HashMap<ComponentKey, Task>,
+    pub(crate) source_tasks: HashMap<ComponentKey, Task>,
     pub(super) healthchecks: HashMap<ComponentKey, Task>,
     pub(crate) shutdown_coordinator: SourceShutdownCoordinator,
     pub(crate) detach_triggers: HashMap<ComponentKey, Trigger>,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -112,7 +112,7 @@ pub(self) async fn load_enrichment_tables<'a>(
 }
 
 pub struct Pieces {
-    pub inputs: HashMap<ComponentKey, (BufferSender<Event>, Vec<OutputId>)>,
+    pub(super) inputs: HashMap<ComponentKey, (BufferSender<Event>, Vec<OutputId>)>,
     pub outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
     pub(super) tasks: HashMap<ComponentKey, Task>,
     pub source_tasks: HashMap<ComponentKey, Task>,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -114,7 +114,7 @@ pub(self) async fn load_enrichment_tables<'a>(
 pub struct Pieces {
     pub inputs: HashMap<ComponentKey, (BufferSender<Event>, Vec<OutputId>)>,
     pub outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
-    pub tasks: HashMap<ComponentKey, Task>,
+    pub(super) tasks: HashMap<ComponentKey, Task>,
     pub source_tasks: HashMap<ComponentKey, Task>,
     pub healthchecks: HashMap<ComponentKey, Task>,
     pub shutdown_coordinator: SourceShutdownCoordinator,

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use futures::{Future, FutureExt};
-pub use running::RunningTopology;
+pub(super) use running::RunningTopology;
 use tokio::sync::{mpsc, watch};
 use vector_buffers::{
     topology::channel::{BufferReceiver, BufferSender},

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -91,7 +91,10 @@ pub async fn build_or_log_errors(
     }
 }
 
-pub fn take_healthchecks(diff: &ConfigDiff, pieces: &mut Pieces) -> Vec<(ComponentKey, Task)> {
+pub(super) fn take_healthchecks(
+    diff: &ConfigDiff,
+    pieces: &mut Pieces,
+) -> Vec<(ComponentKey, Task)> {
     (&diff.sinks.to_change | &diff.sinks.to_add)
         .into_iter()
         .filter_map(|id| pieces.healthchecks.remove(&id).map(move |task| (id, task)))

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -7,7 +7,7 @@
 //! each type of component.
 
 pub mod builder;
-pub use vector_core::fanout;
+pub(super) use vector_core::fanout;
 mod running;
 mod schema;
 mod task;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -52,7 +52,7 @@ type Outputs = HashMap<OutputId, fanout::ControlChannel>;
 // `Outputs`. This could be expanded in the future to send an enum of types if,
 // for example, this included a new 'Inputs' type.
 type WatchTx = watch::Sender<Outputs>;
-pub type WatchRx = watch::Receiver<Outputs>;
+pub(super) type WatchRx = watch::Receiver<Outputs>;
 
 pub async fn start_validated(
     config: Config,

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -24,7 +24,7 @@ pub enum TaskOutput {
 
 /// High level topology task.
 #[pin_project]
-pub struct Task {
+pub(crate) struct Task {
     #[pin]
     inner: BoxFuture<'static, Result<TaskOutput, ()>>,
     key: ComponentKey,

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -44,10 +44,6 @@ impl Task {
         }
     }
 
-    pub const fn key(&self) -> &ComponentKey {
-        &self.key
-    }
-
     pub fn id(&self) -> &str {
         self.key.id()
     }

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -14,7 +14,7 @@ use vector_core::{
 
 use crate::{config::ComponentKey, utilization::Utilization};
 
-pub enum TaskOutput {
+pub(crate) enum TaskOutput {
     Source,
     Transform,
     /// Buffer of sink

--- a/src/topology/test/backpressure.rs
+++ b/src/topology/test/backpressure.rs
@@ -13,7 +13,7 @@ use vector_core::config::MEMORY_BUFFER_DEFAULT_MAX_EVENTS;
 
 // Based on how we pump events from `SourceSender` into `Fanout`, there's always one extra event we
 // may pull out of `SourceSender` but can't yet send into `Fanout`, so we account for that here.
-pub const EXTRA_SOURCE_PUMP_EVENT: usize = 1;
+pub(self) const EXTRA_SOURCE_PUMP_EVENT: usize = 1;
 
 /// Connects a single source to a single sink and makes sure the sink backpressure is propagated
 /// to the source.


### PR DESCRIPTION
This PR is a [`retypist`](https://github.com/blt/retypist) run on `src/topology`. The intention is to make review, manual intervention more approachable compared to #11393. 