### PR TITLE
chore: Avoid using registry for soak images

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -163,13 +163,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1.13.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681
@@ -178,7 +171,7 @@ jobs:
             latest=false
             prefix=
             suffix=
-          images: ghcr.io/${{ github.repository }}/soak-vector
+          images: vector
           tags: type=raw, value=${{ needs.compute-soak-meta.outputs.baseline-tag }}
 
       - name: Build and push 'soak-vector' image
@@ -187,9 +180,15 @@ jobs:
           context: baseline-vector/
           file: soaks/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=/tmp/baseline-image.tar
+
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: baseline-image
+          path: /tmp/baseline-image.tar
 
   build-image-comparison:
     name: Build comparison 'soak-vector' container
@@ -210,13 +209,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1.13.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681
@@ -225,18 +217,24 @@ jobs:
             latest=false
             prefix=
             suffix=
-          images: ghcr.io/${{ github.repository }}/soak-vector
+          images: vector
           tags: type=raw, value=${{ needs.compute-soak-meta.outputs.comparison-tag }}
 
-      - name: Build and push 'soak-vector' image
+      - name: Build 'soak-vector' image
         uses: docker/build-push-action@v2.9.0
         with:
           context: comparison-vector/
           file: soaks/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=/tmp/comparison-image.tar
+
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: comparison-image
+          path: /tmp/comparison-image.tar
 
   soak-baseline:
     name: Soak (${{ matrix.target }}) - baseline - replica ${{ matrix.replica }}
@@ -251,12 +249,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2.4.0
 
+      - name: Download baseline image
+        uses: actions/download-artifact@v2
+        with:
+          name: baseline-image
+
+      - name: Load baseline image
+        run: |
+          docker load --input /tmp/baseline-image.tar
+
       - name: Run baseline experiment
         run: |
           rm -rf /tmp/${{ github.event.number }}-${{ github.run_attempt }}/
           mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
-                                  --local-image "false" \
+                                  --build-image "false" \
                                   --variant "baseline" \
                                   --tag ${{ needs.compute-soak-meta.outputs.baseline-tag }} \
                                   --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \
@@ -329,12 +336,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2.4.0
 
+      - name: Download comparison image
+        uses: actions/download-artifact@v2
+        with:
+          name: comparison-image
+
+      - name: Load comparison image
+        run: |
+          docker load --input /tmp/comparison-image.tar
+
       - name: Run comparison experiment
         run: |
           rm -rf /tmp/${{ github.event.number }}-${{ github.run_attempt }}/
           mkdir -p /tmp/${{ github.event.number }}-${{ github.run_attempt }}/${{ matrix.target }}/
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
-                                  --local-image "false" \
+                                  --build-image "false" \
                                   --variant "comparison" \
                                   --tag ${{ needs.compute-soak-meta.outputs.comparison-tag }} \
                                   --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -24,9 +24,6 @@ jobs:
   cancel-previous:
     runs-on: ubuntu-20.04
     timeout-minutes: 3
-    if: |
-      github.ref != 'refs/heads/master' &&
-      ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
         with:
@@ -35,7 +32,6 @@ jobs:
 
   compute-soak-meta:
     name: Compute metadata for soaks
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     outputs:
       pr-number: ${{ steps.pr-metadata.outputs.PR_NUMBER }}
@@ -110,7 +106,6 @@ jobs:
 
   compute-test-plan:
     name: Compute soak test plan
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     needs: [compute-soak-meta]
     outputs:
@@ -146,7 +141,6 @@ jobs:
 
   build-image-baseline:
     name: Build baseline 'soak-vector' container
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: [self-hosted, linux, x64, soak_builder]
     needs: [compute-soak-meta]
     steps:
@@ -192,7 +186,6 @@ jobs:
 
   build-image-comparison:
     name: Build comparison 'soak-vector' container
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: [self-hosted, linux, x64, soak_builder]
     needs: [compute-soak-meta]
     steps:
@@ -238,7 +231,6 @@ jobs:
 
   soak-baseline:
     name: Soak (${{ matrix.target }}) - baseline - replica ${{ matrix.replica }}
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: [self-hosted, linux, x64, soak]
     needs: [compute-soak-meta, compute-test-plan, build-image-baseline]
     strategy:
@@ -286,7 +278,6 @@ jobs:
 
   detect-erratic-baseline:
     name: Erratic detection - baseline
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     needs:
       - compute-soak-meta
@@ -326,7 +317,6 @@ jobs:
 
   soak-comparison:
     name: Soak (${{ matrix.target }}) - comparison - replica ${{ matrix.replica }}
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: [self-hosted, linux, x64, soak]
     needs: [compute-soak-meta, compute-test-plan, build-image-comparison]
     strategy:
@@ -374,7 +364,6 @@ jobs:
 
   detect-erratic-comparison:
     name: Erratic detection - comparison
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     needs:
       - compute-soak-meta
@@ -414,7 +403,6 @@ jobs:
 
   analyze-results:
     name: Soak analysis
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     needs:
       - compute-soak-meta
@@ -470,7 +458,6 @@ jobs:
 
   detect-regressions:
     name: Regression analysis
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     needs:
       - compute-soak-meta
@@ -509,7 +496,6 @@ jobs:
 
   plot-analysis:
     name: Plot analysis
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     needs:
       - compute-soak-meta

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -253,6 +253,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: baseline-image
+          path: /tmp
 
       - name: Load baseline image
         run: |
@@ -340,6 +341,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: comparison-image
+          path: /tmp
 
       - name: Load comparison image
         run: |

--- a/soaks/README.md
+++ b/soaks/README.md
@@ -34,7 +34,7 @@ support programs in a minikube and some glue code to observe vector in
 operation. Consider this command:
 
 ```shell
-> ./soaks/soak.sh --local-image --soak datadog_agent_remap_datadog_logs --baseline a32c7fd09978f76a3f1bd360c3a8d07a49538b70 --comparison be8ceafbf994d06f505bdd9fb392b00e0ba661f2
+> ./soaks/soak.sh --soak datadog_agent_remap_datadog_logs --baseline a32c7fd09978f76a3f1bd360c3a8d07a49538b70 --comparison be8ceafbf994d06f505bdd9fb392b00e0ba661f2
 ```
 
 Here we run the soak test `datadog_agent_remap_datadog_logs` comparing vector at

--- a/soaks/bin/soak_one.sh
+++ b/soaks/bin/soak_one.sh
@@ -14,7 +14,7 @@ display_usage() {
     echo "Options:"
     echo "  --help: display this information"
     echo "  --soak: the experiment to run"
-    echo "  --local-image: whether to use a local vector image or remote, local if true"
+    echo "  --build-image: build the soak image if needed, default true"
     echo "  --variant: the variation of test in play, either 'baseline' or 'comparison'"
     echo "  --tag: the tag this test covers"
     echo "  --capture-dir: the directory in which to write captures"
@@ -25,8 +25,7 @@ display_usage() {
     echo ""
 }
 
-
-USE_LOCAL_IMAGE="true"
+BUILD_IMAGE="true"
 
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -47,8 +46,8 @@ while [[ $# -gt 0 ]]; do
           shift # past argument
           shift # past value
           ;;
-      --local-image)
-          USE_LOCAL_IMAGE=$2
+      --build-image)
+          USE_BUILD_IMAGE=$2
           shift # past argument
           shift # past value
           ;;
@@ -91,15 +90,17 @@ done
 
 pushd "${__dir}"
 
+
 IMAGE="vector:${TAG}"
-if [ "${USE_LOCAL_IMAGE}" = "true" ]; then
-    echo "Building images locally..."
+if [[ "$(docker images -q $IMAGE 2> /dev/null)" == "" ]]; then
+  if [ "${BUILD_IMAGE}" = "true" ]; then
+    echo "Image $IMAGE doesn't exist, building"
 
     ./build_container.sh "${TAG}" "${IMAGE}"
-else
-    REMOTE_IMAGE="ghcr.io/vectordotdev/vector/soak-vector:${TAG}"
-    docker pull "${REMOTE_IMAGE}"
-    docker image tag "${REMOTE_IMAGE}" "${IMAGE}"
+  else
+    echo "Image $IMAGE doesn't exist and --build-image was false"
+    exit 1
+  fi
 fi
 
 ./run_experiment.sh --capture-dir "${CAPTURE_DIR}" \

--- a/soaks/bin/soak_one.sh
+++ b/soaks/bin/soak_one.sh
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
           shift # past value
           ;;
       --build-image)
-          USE_BUILD_IMAGE=$2
+          BUILD_IMAGE=$2
           shift # past argument
           shift # past value
           ;;
@@ -92,7 +92,7 @@ pushd "${__dir}"
 
 
 IMAGE="vector:${TAG}"
-if [[ "$(docker images -q $IMAGE 2> /dev/null)" == "" ]]; then
+if [[ "$(docker images -q "$IMAGE" 2> /dev/null)" == "" ]]; then
   if [ "${BUILD_IMAGE}" = "true" ]; then
     echo "Image $IMAGE doesn't exist, building"
 

--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -14,7 +14,7 @@ display_usage() {
     echo "Options:"
     echo "  --help: display this information"
     echo "  --soak: the experiment to run, default all; space delimited"
-    echo "  --remote-image|--local-image: whether to use a local vector image or remote"
+    echo "  --build-image: build the soak image if needed, default true"
     echo "  --baseline: the baseline SHA to compare against"
     echo "  --comparison: the SHA to compare against 'baseline'"
     echo "  --cpus: the total number of CPUs to dedicate to the soak minikube, default 7"
@@ -23,7 +23,7 @@ display_usage() {
     echo ""
 }
 
-USE_LOCAL_IMAGE="true"
+BUILD_IMAGE="true"
 SOAK_CPUS="7"
 SOAK_MEMORY="8g"
 VECTOR_CPUS="4"
@@ -49,12 +49,8 @@ while [[ $# -gt 0 ]]; do
           shift # past argument
           shift # past value
           ;;
-      --remote-image)
-          USE_LOCAL_IMAGE="false"
-          shift # past argument
-          ;;
-      --local-image)
-          USE_LOCAL_IMAGE="true"
+      --no-build-image)
+          NO_BUILD_IMAGE="true"
           shift # past argument
           ;;
       --vector-cpus)
@@ -103,7 +99,7 @@ for SOAK_NAME in ${SOAKS}; do
     capture_dir_replica_two="${capture_dir}/2"
     capture_dir_replica_three="${capture_dir}/3"
     # shellcheck disable=SC2015
-    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+    ./bin/soak_one.sh --build-image "${BUILD_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "baseline" \
                       --tag "${BASELINE}" \
@@ -112,7 +108,7 @@ for SOAK_NAME in ${SOAKS}; do
                       --memory "${SOAK_MEMORY}" \
                       --warmup-seconds "${WARMUP_SECONDS}" \
                       --vector-cpus "${VECTOR_CPUS}" && \
-    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+    ./bin/soak_one.sh --build-image "${USE_BUILD_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "baseline" \
                       --tag "${BASELINE}" \
@@ -121,7 +117,7 @@ for SOAK_NAME in ${SOAKS}; do
                       --memory "${SOAK_MEMORY}" \
                       --warmup-seconds "${WARMUP_SECONDS}" \
                       --vector-cpus "${VECTOR_CPUS}" && \
-    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+    ./bin/soak_one.sh --build-image "${USE_BUILD_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "baseline" \
                       --tag "${BASELINE}" \
@@ -130,7 +126,7 @@ for SOAK_NAME in ${SOAKS}; do
                       --memory "${SOAK_MEMORY}" \
                       --warmup-seconds "${WARMUP_SECONDS}" \
                       --vector-cpus "${VECTOR_CPUS}" && \
-    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+    ./bin/soak_one.sh --build-image "${USE_BUILD_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "comparison" \
                       --tag "${COMPARISON}" \
@@ -139,7 +135,7 @@ for SOAK_NAME in ${SOAKS}; do
                       --memory "${SOAK_MEMORY}" \
                       --warmup-seconds "${WARMUP_SECONDS}" \
                       --vector-cpus "${VECTOR_CPUS}" && \
-    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+    ./bin/soak_one.sh --build-image "${USE_BUILD_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "comparison" \
                       --tag "${COMPARISON}" \
@@ -148,7 +144,7 @@ for SOAK_NAME in ${SOAKS}; do
                       --memory "${SOAK_MEMORY}" \
                       --warmup-seconds "${WARMUP_SECONDS}" \
                       --vector-cpus "${VECTOR_CPUS}" && \
-    ./bin/soak_one.sh --local-image "${USE_LOCAL_IMAGE}" \
+    ./bin/soak_one.sh --build-image "${USE_BUILD_IMAGE}" \
                       --soak "${SOAK_NAME}" \
                       --variant "comparison" \
                       --tag "${COMPARISON}" \

--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -50,7 +50,7 @@ while [[ $# -gt 0 ]]; do
           shift # past value
           ;;
       --no-build-image)
-          NO_BUILD_IMAGE="true"
+          BUILD_IMAGE="true"
           shift # past argument
           ;;
       --vector-cpus)


### PR DESCRIPTION
Since contributor PRs do not have write access to the GH registry, instead just store them in artifacts to pass them between jobs.

I thought maybe this would slow the build down due to the lack of image layer caching in the registry, but we didn't seem to be taking advantage of that anyway at the moment.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
