### PR TITLE
fix(docker_logs source): break source when reader fails deserializing

### DIFF
--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -480,7 +480,13 @@ impl DockerLogsSource {
                                 _ => {},
                             };
                         }
-                        Some(Err(error)) => emit!(&DockerLogsCommunicationError{error,container_id:None}),
+                        Some(Err(error)) => {
+                            emit!(&DockerLogsCommunicationError {
+                                error,
+                                container_id: None,
+                            });
+                            return;
+                        },
                         None => {
                             // TODO: this could be fixed, but should be tried with some timeoff and exponential backoff
                             error!(message = "Docker log event stream has ended unexpectedly.");


### PR DESCRIPTION
I didn't find a way to reproduce the bug but this kind of error seems to block the event stream. Returning should kill the component and force vector to stop/restart.

Maybe we should add a system of autorestart and not create the event stream while building the component. That way we could handle this case by just restarting the source itself.

Fixes [OBPS-1](https://datadoghq.atlassian.net/browse/OBPS-1)

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
