### PR TITLE
fix(socket source): emit metric with good count for tcp

### DIFF
--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -39,10 +39,10 @@ impl InternalEvent for SocketEventsReceived {
     }
 
     fn emit_metrics(&self) {
-        counter!("component_received_events_total", 1, "mode" => self.mode.as_str());
-        counter!("component_received_event_bytes_total", 1, "mode" => self.mode.as_str());
+        counter!("component_received_events_total", self.count as u64, "mode" => self.mode.as_str());
+        counter!("component_received_event_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
         // deprecated
-        counter!("events_in_total", 1, "mode" => self.mode.as_str());
+        counter!("events_in_total", self.count as u64, "mode" => self.mode.as_str());
         counter!("processed_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
     }
 }


### PR DESCRIPTION
Fix the emitted metric that was left to one when switching from processing one by one to processing events by batches.

closes #11468

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
