### PR TITLE
chore(schemas, codecs): integrate schema support into encoding formats

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -53,35 +53,35 @@ impl Input {
     pub fn new(ty: DataType) -> Self {
         Self {
             ty,
-            log_schema_requirement: schema::Requirement,
+            log_schema_requirement: schema::Requirement::empty(),
         }
     }
 
     pub fn log() -> Self {
         Self {
             ty: DataType::Log,
-            log_schema_requirement: schema::Requirement,
+            log_schema_requirement: schema::Requirement::empty(),
         }
     }
 
     pub fn metric() -> Self {
         Self {
             ty: DataType::Metric,
-            log_schema_requirement: schema::Requirement,
+            log_schema_requirement: schema::Requirement::empty(),
         }
     }
 
     pub fn trace() -> Self {
         Self {
             ty: DataType::Trace,
-            log_schema_requirement: schema::Requirement,
+            log_schema_requirement: schema::Requirement::empty(),
         }
     }
 
     pub fn all() -> Self {
         Self {
             ty: DataType::all(),
-            log_schema_requirement: schema::Requirement,
+            log_schema_requirement: schema::Requirement::empty(),
         }
     }
 }

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -106,6 +106,14 @@ impl LogEvent {
         util::log::get(self.as_map(), key.as_ref())
     }
 
+    #[instrument(level = "trace", skip(self, meaning), fields(meaning = %meaning.as_ref()))]
+    pub fn get_by_meaning(&self, meaning: impl AsRef<str>) -> Option<&Value> {
+        self.metadata()
+            .schema_definition()
+            .meaning_path(meaning.as_ref())
+            .and_then(|path| self.fields.get_by_path(path))
+    }
+
     #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
     pub fn get_flat(&self, key: impl AsRef<str>) -> Option<&Value> {
         self.as_map().get(key.as_ref())

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -175,6 +175,13 @@ impl Definition {
         self
     }
 
+    /// Returns a `Lookup` into an event, based on the provided `meaning`, if the meaning exists.
+    ///
+    /// TODO(Jean): return `Lookup` here, but it requires some changes to `Value`s API first.
+    pub fn meaning_path(&self, meaning: &str) -> Option<&LookupBuf> {
+        self.meaning.get(meaning)
+    }
+
     /// Returns `true` if the provided field is marked as optional.
     fn is_optional_field(&self, path: &LookupBuf) -> bool {
         self.optional.contains(path)

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -1,9 +1,70 @@
+use std::collections::BTreeMap;
+
+use lookup::LookupBuf;
+use value::{
+    kind::{Collection, Field, Unknown},
+    Kind,
+};
+
+/// The input schema for a given component.
+///
+/// This schema defines the (semantic) fields a component expects to receive from its input
+/// components.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Requirement;
+pub struct Requirement {
+    /// The collection of fields and their types required to be present in the event.
+    ///
+    /// While this can be used to define *exact* requirements on schema fields, it is primarily
+    /// intended for sinks that want to add a type requirement to _all_ fields in the event (e.g.
+    /// JSON encoding).
+    collection: Collection<Field>,
+
+    /// Semantic meaning required to exists for a given event.
+    meaning: BTreeMap<&'static str, Kind>,
+}
 
 impl Requirement {
-    #[allow(clippy::unused_self)]
+    /// Create a new empty schema.
+    ///
+    /// An empty schema is the most "open" schema, in that there are no restrictions.
+    pub fn empty() -> Self {
+        Self {
+            collection: Collection::any(),
+            meaning: BTreeMap::default(),
+        }
+    }
+
+    /// Check if the requirement is "empty", meaning:
+    ///
+    /// 1. There are no required fields defined.
+    /// 2. The unknown fields are set to "any".
+    /// 3. There are no required meanings defined.
     pub fn is_empty(&self) -> bool {
-        true
+        self.collection.known().is_empty()
+            && self.collection.unknown().map_or(false, Unknown::is_any)
+            && self.meaning.is_empty()
+    }
+
+    /// Add a restriction to the schema.
+    pub fn require_meaning(mut self, meaning: &'static str, kind: Kind) -> Self {
+        self.meaning.insert(meaning, kind);
+        self
+    }
+
+    /// Set a hard requirement for an event field.
+    ///
+    /// # Panics
+    ///
+    /// Non-root fields are not supported at this time.
+    pub fn require_field(mut self, path: &LookupBuf, kind: Kind) -> Self {
+        // There is no reason why we can't support this, but there's no need yet, and it might
+        // actually be something we want to actively discourage, so this panic serves as a reminder
+        // that we probably want a brief discussion before enabling support for this.
+        if !path.is_root() {
+            panic!("requiring exact field kind is currently unsupported")
+        }
+
+        self.collection.set_unknown(kind);
+        self
     }
 }

--- a/src/codecs/encoding/format/json.rs
+++ b/src/codecs/encoding/format/json.rs
@@ -1,8 +1,10 @@
 use bytes::{BufMut, BytesMut};
+use lookup::LookupBuf;
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Encoder;
+use value::Kind;
 
-use crate::event::Event;
+use crate::{event::Event, schema};
 
 /// Config used to build a `JsonSerializer`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -17,6 +19,13 @@ impl JsonSerializerConfig {
     /// Build the `JsonSerializer` from this configuration.
     pub const fn build(&self) -> JsonSerializer {
         JsonSerializer
+    }
+
+    /// The schema required by the serializer.
+    pub fn schema_requirement(&self) -> schema::Requirement {
+        // Technically we can serialize any type of `Value` to JSON, even "non-JSON" types such as
+        // `timestamp`, but it's not a lossless serialization. Should we allow it in the schema?
+        schema::Requirement::empty().require_field(&LookupBuf::root(), Kind::json())
     }
 }
 

--- a/src/codecs/encoding/mod.rs
+++ b/src/codecs/encoding/mod.rs
@@ -16,6 +16,7 @@ pub use framing::{
 use crate::{
     event::Event,
     internal_events::{EncoderFramingFailed, EncoderSerializeFailed},
+    schema,
 };
 use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
@@ -152,6 +153,14 @@ impl SerializerConfig {
             SerializerConfig::RawMessage => {
                 Serializer::RawMessage(RawMessageSerializerConfig.build())
             }
+        }
+    }
+
+    /// The schema required by the serializer.
+    pub fn schema_requirement(&self) -> schema::Requirement {
+        match self {
+            SerializerConfig::Json => JsonSerializerConfig.schema_requirement(),
+            SerializerConfig::RawMessage => RawMessageSerializerConfig.schema_requirement(),
         }
     }
 }


### PR DESCRIPTION
Follow-up to #11440.

This PR integrates the internal schema support into the existing encoding formats. This isn't enabled yet in the topology, so there's no breaking change here. Once the integration is enabled (opt-in, through a config flag that'll be integrated in one of the upcoming PRs), Vector will fail to boot if a sink enables an encoding format with a schema requirement to which incoming events to not adhere.

closes #11307.