### PR TITLE
chore: Remove unused dependabot reviewers and assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00" # UTC
-    reviewers:
-      - "timberio/vector-support"
-    assignees:
-      - "timberio/vector-support"
     labels:
       - "domain: deps"
     commit-message:


### PR DESCRIPTION
Just noticed this when checking the time Dependabot is supposed to run.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
