### PR TITLE
revert(schemas, remap transform): modify schema definitions using VRL compiler

### DIFF
--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -29,7 +29,7 @@ pub struct Definition {
 }
 
 impl Definition {
-    /// Create an "empty" definition.
+    /// Create an "empty" output schema.
     ///
     /// This means no type information is known about the event.
     pub fn empty() -> Self {
@@ -178,16 +178,6 @@ impl Definition {
     /// Returns `true` if the provided field is marked as optional.
     fn is_optional_field(&self, path: &LookupBuf) -> bool {
         self.optional.contains(path)
-    }
-}
-
-impl From<Collection<Field>> for Definition {
-    fn from(collection: Collection<Field>) -> Self {
-        Self {
-            collection,
-            meaning: HashMap::default(),
-            optional: HashSet::default(),
-        }
     }
 }
 

--- a/lib/vector-core/src/transform/config.rs
+++ b/lib/vector-core/src/transform/config.rs
@@ -79,11 +79,7 @@ pub trait TransformConfig: core::fmt::Debug + Send + Sync + dyn_clone::DynClone 
 
     fn input(&self) -> Input;
 
-    /// Returns a list of outputs to which this transform can deliver events.
-    ///
-    /// The provided `merged_definition` can be used by transforms to understand the expected shape
-    /// of events flowing through the transform.
-    fn outputs(&self, merged_definition: &schema::Definition) -> Vec<Output>;
+    fn outputs(&self) -> Vec<Output>;
 
     fn transform_type(&self) -> &'static str;
 

--- a/src/api/schema/components/mod.rs
+++ b/src/api/schema/components/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         relay, sort,
     },
     config::{ComponentKey, Config},
-    filter_check, schema,
+    filter_check,
 };
 
 #[derive(Debug, Clone, Interface)]
@@ -283,7 +283,7 @@ pub fn update_config(config: &Config) {
                 inputs: transform.inputs.clone(),
                 outputs: transform
                     .inner
-                    .outputs(&schema::Definition::empty())
+                    .outputs()
                     .into_iter()
                     .map(|output| output.port.unwrap_or_else(|| DEFAULT_OUTPUT.to_string()))
                     .collect(),

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 
 use indexmap::{IndexMap, IndexSet};
 
-use super::{
-    builder::ConfigBuilder, graph::Graph, schema, validation, ComponentKey, Config, OutputId,
-};
+use super::{builder::ConfigBuilder, graph::Graph, validation, ComponentKey, Config, OutputId};
 
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();
@@ -164,13 +162,10 @@ pub(crate) fn expand_globs(config: &mut ConfigBuilder) {
             })
         })
         .chain(config.transforms.iter().flat_map(|(key, t)| {
-            t.inner
-                .outputs(&schema::Definition::empty())
-                .into_iter()
-                .map(|output| OutputId {
-                    component: key.clone(),
-                    port: output.port,
-                })
+            t.inner.outputs().into_iter().map(|output| OutputId {
+                component: key.clone(),
+                port: output.port,
+            })
         }))
         .map(|output_id| output_id.to_string())
         .collect::<IndexSet<String>>();
@@ -284,7 +279,7 @@ mod test {
             Input::all()
         }
 
-        fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+        fn outputs(&self) -> Vec<Output> {
             vec![Output::default(DataType::all())]
         }
     }

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -2,9 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use indexmap::{set::IndexSet, IndexMap};
 
-use super::{
-    schema, ComponentKey, DataType, Output, OutputId, SinkOuter, SourceOuter, TransformOuter,
-};
+use super::{ComponentKey, DataType, Output, OutputId, SinkOuter, SourceOuter, TransformOuter};
 
 #[derive(Debug, Clone)]
 pub enum Node {
@@ -73,7 +71,7 @@ impl Graph {
                 id.clone(),
                 Node::Transform {
                     in_ty: config.inner.input().data_type(),
-                    outputs: config.inner.outputs(&schema::Definition::empty()),
+                    outputs: config.inner.outputs(),
                 },
             );
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -519,14 +519,6 @@ pub struct TransformOuter<T> {
 }
 
 impl<T> TransformOuter<T> {
-    #[cfg(test)]
-    pub(crate) fn new(transform: impl TransformConfig + 'static) -> Self {
-        Self {
-            inputs: vec![],
-            inner: Box::new(transform),
-        }
-    }
-
     fn map_inputs<U>(self, f: impl Fn(&T) -> U) -> TransformOuter<U> {
         let inputs = self.inputs.iter().map(f).collect();
         self.with_inputs(inputs)

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -9,7 +9,6 @@ use crate::{
         SinkOuter, SourceOuter, TestDefinition, TestInput, TestInputValue, TestOutput,
     },
     event::{Event, Value},
-    schema,
     topology::{
         self,
         builder::{self, Pieces},
@@ -167,7 +166,7 @@ impl UnitTestBuildMetadata {
             .flat_map(|(key, transform)| {
                 transform
                     .inner
-                    .outputs(&schema::Definition::empty())
+                    .outputs()
                     .into_iter()
                     .map(|output| OutputId {
                         component: key.clone(),
@@ -432,7 +431,7 @@ fn get_loose_end_outputs_sink(config: &ConfigBuilder) -> Option<SinkOuter<String
     let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
         transform
             .inner
-            .outputs(&schema::Definition::empty())
+            .outputs()
             .iter()
             .map(|output| {
                 if let Some(port) = &output.port {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use vector_core::internal_event::DEFAULT_OUTPUT;
 
-use super::{builder::ConfigBuilder, schema, ComponentKey, Config, OutputId, Resource};
+use super::{builder::ConfigBuilder, ComponentKey, Config, OutputId, Resource};
 
 /// Check that provide + topology config aren't present in the same builder, which is an error.
 pub fn check_provider(config: &ConfigBuilder) -> Result<(), Vec<String>> {
@@ -159,7 +159,7 @@ pub fn check_outputs(config: &ConfigBuilder) -> Result<(), Vec<String>> {
     }
 
     for (key, transform) in config.transforms.iter() {
-        let outputs = transform.inner.outputs(&schema::Definition::empty());
+        let outputs = transform.inner.outputs();
         if outputs
             .iter()
             .map(|output| output.port.as_deref().unwrap_or(""))
@@ -198,7 +198,7 @@ pub fn warnings(config: &Config) -> Vec<String> {
     let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
         transform
             .inner
-            .outputs(&schema::Definition::empty())
+            .outputs()
             .iter()
             .map(|output| {
                 if let Some(port) = &output.port {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -260,13 +260,11 @@ pub async fn build_pieces(
         .iter()
         .filter(|(key, _)| diff.transforms.contains_new(key))
     {
-        let mut schema_ids = HashMap::new();
-        let merged_definition = schema::merged_definition(&transform.inputs, config);
-
-        for output in transform.inner.outputs(&merged_definition) {
+        let mut schema_ids = HashMap::with_capacity(transform.inner.outputs().len());
+        for output in transform.inner.outputs() {
             let definition = match output.log_schema_definition {
                 Some(definition) => definition,
-                None => merged_definition.clone(),
+                None => schema::merged_definition(&transform.inputs, config),
             };
 
             let schema_id = schema_registry
@@ -288,7 +286,7 @@ pub async fn build_pieces(
             typetag: transform.inner.transform_type(),
             inputs: transform.inputs.clone(),
             input_details: transform.inner.input(),
-            outputs: transform.inner.outputs(&merged_definition),
+            outputs: transform.inner.outputs(),
             enable_concurrency: transform.inner.enable_concurrency(),
         };
 

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -83,24 +83,18 @@ fn inner_merged_definition(
         // change anything in the schema from its inputs, in which case we need to recursively get
         // the schemas of the transform inputs.
         } else if let Some(transform) = config.transforms.get(key) {
-            let merged_definition = merged_definition(&transform.inputs, config);
-
             // After getting the transform matching to the given input, we need to further narrow
             // the actual output of the transform feeding into this input, and then get the
             // definition belonging to that output.
-            let maybe_transform_definition = transform
-                .inner
-                .outputs(&merged_definition)
-                .iter()
-                .find_map(|output| {
-                    if output.port == input.port {
-                        // For transforms, a `None` schema definition is equal to "pass-through merged
-                        // input schemas".
-                        output.log_schema_definition.clone()
-                    } else {
-                        None
-                    }
-                });
+            let maybe_transform_definition = transform.inner.outputs().iter().find_map(|output| {
+                if output.port == input.port {
+                    // For transforms, a `None` schema definition is equal to "pass-through merged
+                    // input schemas".
+                    output.log_schema_definition.clone()
+                } else {
+                    None
+                }
+            });
 
             let transform_definition = match maybe_transform_definition {
                 Some(transform_definition) => transform_definition,
@@ -116,182 +110,4 @@ fn inner_merged_definition(
     cache.insert(inputs.to_vec(), definition.clone());
 
     definition
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use indexmap::IndexMap;
-    use serde::{Deserialize, Serialize};
-    use value::Kind;
-    use vector_core::{
-        config::{DataType, Input, Output},
-        source::Source,
-        transform::{Transform, TransformConfig, TransformContext},
-    };
-
-    use crate::config::{SourceConfig, SourceContext, SourceOuter, TransformOuter};
-
-    use super::*;
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    struct MockComponent {
-        #[serde(skip)]
-        outputs: Vec<Output>,
-    }
-
-    #[async_trait::async_trait]
-    #[typetag::serde(name = "mock_source")]
-    impl SourceConfig for MockComponent {
-        async fn build(&self, _: SourceContext) -> crate::Result<Source> {
-            unimplemented!()
-        }
-
-        fn outputs(&self) -> Vec<Output> {
-            self.outputs.clone()
-        }
-
-        fn source_type(&self) -> &'static str {
-            unimplemented!()
-        }
-
-        fn can_acknowledge(&self) -> bool {
-            false
-        }
-    }
-
-    #[async_trait::async_trait]
-    #[typetag::serde(name = "mock_transform")]
-    impl TransformConfig for MockComponent {
-        async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-            unimplemented!()
-        }
-
-        fn outputs(&self, _: &Definition) -> Vec<Output> {
-            self.outputs.clone()
-        }
-
-        fn transform_type(&self) -> &'static str {
-            unimplemented!()
-        }
-
-        fn input(&self) -> Input {
-            unimplemented!()
-        }
-    }
-
-    #[test]
-    fn test_merged_definition() {
-        struct TestCase {
-            inputs: Vec<(&'static str, Option<String>)>,
-            sources: IndexMap<&'static str, Vec<Output>>,
-            transforms: IndexMap<&'static str, Vec<Output>>,
-            want: Definition,
-        }
-
-        for (
-            title,
-            TestCase {
-                inputs,
-                sources,
-                transforms,
-                want,
-            },
-        ) in HashMap::from([
-            (
-                "no inputs",
-                TestCase {
-                    inputs: vec![],
-                    sources: IndexMap::default(),
-                    transforms: IndexMap::default(),
-                    want: Definition::empty(),
-                },
-            ),
-            (
-                "single input, source with empty schema",
-                TestCase {
-                    inputs: vec![("foo", None)],
-                    sources: IndexMap::from([("foo", vec![Output::default(DataType::all())])]),
-                    transforms: IndexMap::default(),
-                    want: Definition::empty(),
-                },
-            ),
-            (
-                "single input, source with schema",
-                TestCase {
-                    inputs: vec![("source-foo", None)],
-                    sources: IndexMap::from([(
-                        "source-foo",
-                        vec![Output::default(DataType::all()).with_schema_definition(
-                            Definition::empty().required_field(
-                                "foo",
-                                Kind::integer().or_bytes(),
-                                Some("foo bar"),
-                            ),
-                        )],
-                    )]),
-                    transforms: IndexMap::default(),
-                    want: Definition::empty().required_field(
-                        "foo",
-                        Kind::integer().or_bytes(),
-                        Some("foo bar"),
-                    ),
-                },
-            ),
-            (
-                "multiple inputs, sources with schema",
-                TestCase {
-                    inputs: vec![("source-foo", None), ("source-bar", None)],
-                    sources: IndexMap::from([
-                        (
-                            "source-foo",
-                            vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
-                                    "foo",
-                                    Kind::integer().or_bytes(),
-                                    Some("foo bar"),
-                                ),
-                            )],
-                        ),
-                        (
-                            "source-bar",
-                            vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
-                                    "foo",
-                                    Kind::timestamp(),
-                                    Some("baz qux"),
-                                ),
-                            )],
-                        ),
-                    ]),
-                    transforms: IndexMap::default(),
-                    want: Definition::empty()
-                        .required_field("foo", Kind::integer().or_bytes(), Some("foo bar"))
-                        .required_field("foo", Kind::timestamp(), Some("baz qux")),
-                },
-            ),
-        ]) {
-            let mut config = topology::Config::default();
-            config.sources = sources
-                .into_iter()
-                .map(|(key, outputs)| (key.into(), SourceOuter::new(MockComponent { outputs })))
-                .collect::<IndexMap<_, _>>();
-            config.transforms = transforms
-                .into_iter()
-                .map(|(key, outputs)| (key.into(), TransformOuter::new(MockComponent { outputs })))
-                .collect::<IndexMap<_, _>>();
-
-            let inputs = inputs
-                .into_iter()
-                .map(|(key, port)| OutputId {
-                    component: key.into(),
-                    port,
-                })
-                .collect::<Vec<_>>();
-
-            let got = merged_definition(&inputs, &config);
-            assert_eq!(got, want, "{}", title);
-        }
-    }
 }

--- a/src/transforms/add_fields.rs
+++ b/src/transforms/add_fields.rs
@@ -13,7 +13,6 @@ use crate::{
     internal_events::{
         AddFieldsFieldNotOverwritten, AddFieldsFieldOverwritten, TemplateRenderingError,
     },
-    schema,
     serde::Fields,
     template::Template,
     transforms::{FunctionTransform, OutputBuffer, Transform},
@@ -77,7 +76,7 @@ impl TransformConfig for AddFieldsConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     event::Event,
     internal_events::{AddTagsTagNotOverwritten, AddTagsTagOverwritten},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -56,7 +55,7 @@ impl TransformConfig for AddTagsConfig {
         Input::metric()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Metric)]
     }
 

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -12,7 +12,6 @@ use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::{metric, Event, EventMetadata},
     internal_events::{AggregateEventRecorded, AggregateFlushed, AggregateUpdateFailed},
-    schema,
     transforms::{TaskTransform, Transform},
 };
 
@@ -45,7 +44,7 @@ impl TransformConfig for AggregateConfig {
         Input::metric()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Metric)]
     }
 

--- a/src/transforms/ansi_stripper.rs
+++ b/src/transforms/ansi_stripper.rs
@@ -9,7 +9,6 @@ use crate::{
     internal_events::{
         AnsiStripperError, AnsiStripperFieldInvalidError, AnsiStripperFieldMissingError,
     },
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     Result,
 };
@@ -46,7 +45,7 @@ impl TransformConfig for AnsiStripperConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/transforms/aws_cloudwatch_logs_subscription_parser.rs
@@ -13,7 +13,6 @@ use crate::{
     },
     event::Event,
     internal_events::AwsCloudwatchLogsSubscriptionParserError,
-    schema,
     transforms::{FunctionTransform, OutputBuffer},
 };
 
@@ -41,7 +40,7 @@ impl TransformConfig for AwsCloudwatchLogsSubscriptionParserConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -26,7 +26,6 @@ use crate::{
     event::Event,
     http::HttpClient,
     internal_events::{AwsEc2MetadataRefreshError, AwsEc2MetadataRefreshSuccessful},
-    schema,
     transforms::{TaskTransform, Transform},
 };
 
@@ -182,7 +181,7 @@ impl TransformConfig for Ec2Metadata {
         Input::new(DataType::Metric | DataType::Log)
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Metric | DataType::Log)]
     }
 

--- a/src/transforms/coercer.rs
+++ b/src/transforms/coercer.rs
@@ -7,7 +7,6 @@ use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, LogEvent, Value},
     internal_events::CoercerConversionError,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
@@ -42,7 +41,7 @@ impl TransformConfig for CoercerConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/compound.rs
+++ b/src/transforms/compound.rs
@@ -6,7 +6,6 @@ use crate::{
         DataType, ExpandType, GenerateConfig, Input, Output, TransformConfig, TransformContext,
         TransformDescription,
     },
-    schema,
     transforms::Transform,
 };
 
@@ -67,7 +66,7 @@ impl TransformConfig for CompoundConfig {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::all())]
     }
 

--- a/src/transforms/concat.rs
+++ b/src/transforms/concat.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     event::{Event, Value},
     internal_events::{ConcatSubstringError, ConcatSubstringSourceMissing},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -61,7 +60,7 @@ impl TransformConfig for ConcatConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     event::{Event, Value},
     internal_events::DedupeEventDiscarded,
-    schema,
     transforms::{TaskTransform, Transform},
 };
 
@@ -91,7 +90,7 @@ impl TransformConfig for DedupeConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/field_filter.rs
+++ b/src/transforms/field_filter.rs
@@ -6,7 +6,6 @@ use crate::{
         TransformDescription,
     },
     event::Event,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -49,7 +48,7 @@ impl TransformConfig for FieldFilterConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     event::Event,
     internal_events::FilterEventDiscarded,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -51,7 +50,7 @@ impl TransformConfig for FilterConfig {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::all())]
     }
 

--- a/src/transforms/geoip.rs
+++ b/src/transforms/geoip.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     event::Event,
     internal_events::{GeoipIpAddressParseError, ParserMissingFieldError},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     Result,
 };
@@ -79,7 +78,7 @@ impl TransformConfig for GeoipConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -13,7 +13,6 @@ use crate::{
     },
     event::{Event, PathComponent, PathIter, Value},
     internal_events::{ParserConversionError, ParserMatchError, ParserMissingFieldError},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
@@ -74,7 +73,7 @@ impl TransformConfig for GrokParserConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/json_parser.rs
+++ b/src/transforms/json_parser.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     event::Event,
     internal_events::{JsonParserError, ParserTargetExistsError},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -41,7 +40,7 @@ impl TransformConfig for JsonParserConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/key_value_parser.rs
+++ b/src/transforms/key_value_parser.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     event::{Event, Value},
     internal_events::{KeyValueParserError, ParserMissingFieldError, ParserTargetExistsError},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
@@ -86,7 +85,7 @@ impl TransformConfig for KeyValueConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -16,7 +16,6 @@ use crate::{
         LogToMetricFieldNullError, LogToMetricParseFloatError, LogToMetricTemplateParseError,
         ParserMissingFieldError,
     },
-    schema,
     template::{Template, TemplateParseError, TemplateRenderingError},
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
@@ -137,7 +136,7 @@ impl TransformConfig for LogToMetricConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Metric)]
     }
 

--- a/src/transforms/logfmt_parser.rs
+++ b/src/transforms/logfmt_parser.rs
@@ -7,7 +7,6 @@ use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, Value},
     internal_events::{ParserConversionError, ParserMissingFieldError},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_conversion_map, Conversion},
 };
@@ -49,7 +48,7 @@ impl TransformConfig for LogfmtConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -7,7 +7,6 @@ use crate::{
     config::{
         GenerateConfig, Input, Output, TransformConfig, TransformContext, TransformDescription,
     },
-    schema,
     transforms::Transform,
 };
 
@@ -77,10 +76,10 @@ impl TransformConfig for LuaConfig {
         }
     }
 
-    fn outputs(&self, merged_definition: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         match self {
-            LuaConfig::V1(v1) => v1.config.outputs(merged_definition),
-            LuaConfig::V2(v2) => v2.config.outputs(merged_definition),
+            LuaConfig::V1(v1) => v1.config.outputs(),
+            LuaConfig::V2(v2) => v2.config.outputs(),
         }
     }
 

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     config::{DataType, Input, Output},
     event::{Event, Value},
     internal_events::{LuaGcTriggered, LuaScriptError},
-    schema,
     transforms::{TaskTransform, Transform},
 };
 
@@ -42,7 +41,7 @@ impl LuaConfig {
         Input::log()
     }
 
-    pub fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    pub fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     config::{self, DataType, Input, Output, CONFIG_PATHS},
     event::Event,
     internal_events::{LuaBuildError, LuaGcTriggered},
-    schema,
     transforms::Transform,
 };
 
@@ -99,7 +98,7 @@ impl LuaConfig {
         Input::new(DataType::Metric | DataType::Log)
     }
 
-    pub fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    pub fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Metric | DataType::Log)]
     }
 

--- a/src/transforms/merge.rs
+++ b/src/transforms/merge.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::{self, discriminant::Discriminant, merge_state::LogEventMergeState, Event},
-    schema,
     transforms::{TaskTransform, Transform},
 };
 
@@ -64,7 +63,7 @@ impl TransformConfig for MergeConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     event::{self, Event, LogEvent, Metric},
     internal_events::MetricToLogSerializeError,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::Conversion,
 };
@@ -50,7 +49,7 @@ impl TransformConfig for MetricToLogConfig {
         Input::metric()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/noop.rs
+++ b/src/transforms/noop.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext},
     event::Event,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -21,7 +20,7 @@ impl TransformConfig for Noop {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::all())]
     }
 

--- a/src/transforms/pipelines/expander.rs
+++ b/src/transforms/pipelines/expander.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     config::{DataType, ExpandType, Input, Output, TransformConfig, TransformContext},
-    schema,
     transforms::Transform,
 };
 
@@ -46,10 +45,10 @@ impl TransformConfig for ExpanderConfig {
             .unwrap_or_else(Input::all)
     }
 
-    fn outputs(&self, merged_definition: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         self.inner
             .last()
-            .map(|(_, item)| item.outputs(merged_definition))
+            .map(|(_, item)| item.outputs())
             .unwrap_or_else(|| vec![Output::default(DataType::all())])
     }
 

--- a/src/transforms/pipelines/filter.rs
+++ b/src/transforms/pipelines/filter.rs
@@ -5,7 +5,6 @@ use super::expander::ExpanderConfig;
 use crate::{
     conditions::{not::NotConfig, AnyCondition},
     config::{ExpandType, Input, Output, TransformConfig, TransformContext},
-    schema,
     transforms::{filter::FilterConfig, Transform},
 };
 
@@ -65,8 +64,8 @@ impl TransformConfig for PipelineFilterConfig {
         self.inner.input()
     }
 
-    fn outputs(&self, merged_definition: &schema::Definition) -> Vec<Output> {
-        self.inner.outputs(merged_definition)
+    fn outputs(&self) -> Vec<Output> {
+        self.inner.outputs()
     }
 
     fn transform_type(&self) -> &'static str {

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -71,7 +71,6 @@ use crate::{
         DataType, ExpandType, GenerateConfig, Input, Output, TransformConfig, TransformContext,
         TransformDescription,
     },
-    schema,
     transforms::Transform,
 };
 
@@ -248,7 +247,7 @@ impl TransformConfig for PipelinesConfig {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::all())]
     }
 

--- a/src/transforms/pipelines/router.rs
+++ b/src/transforms/pipelines/router.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{DataType, ExpandType, Input, Output, TransformConfig, TransformContext},
     event::Event,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -92,7 +91,7 @@ impl TransformConfig for EventRouterConfig {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(self.filter.data_type())]
     }
 
@@ -119,7 +118,7 @@ impl TransformConfig for EventFilterConfig {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(self.inner.data_type())]
     }
 

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::{discriminant::Discriminant, Event, EventMetadata, LogEvent},
     internal_events::ReduceStaleEventFlushed,
-    schema,
     transforms::{TaskTransform, Transform},
 };
 
@@ -62,7 +61,7 @@ impl TransformConfig for ReduceConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -12,7 +12,6 @@ use crate::{
     internal_events::{
         ParserConversionError, ParserMatchError, ParserMissingFieldError, ParserTargetExistsError,
     },
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_check_conversion_map, Conversion},
 };
@@ -55,7 +54,7 @@ impl TransformConfig for RegexParserConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/remove_fields.rs
+++ b/src/transforms/remove_fields.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     event::Event,
     internal_events::RemoveFieldsFieldMissing,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -50,7 +49,7 @@ impl TransformConfig for RemoveFieldsConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -6,7 +6,6 @@ use crate::{
         TransformDescription,
     },
     event::Event,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -42,7 +41,7 @@ impl TransformConfig for RemoveTagsConfig {
         Input::metric()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Metric)]
     }
 

--- a/src/transforms/rename_fields.rs
+++ b/src/transforms/rename_fields.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     event::Event,
     internal_events::{RenameFieldsFieldDoesNotExist, RenameFieldsFieldOverwritten},
-    schema,
     serde::Fields,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
@@ -54,7 +53,7 @@ impl TransformConfig for RenameFieldsConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     event::Event,
     internal_events::RouteEventDiscarded,
-    schema,
     transforms::Transform,
 };
 
@@ -89,7 +88,7 @@ impl TransformConfig for RouteConfig {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         self.route
             .keys()
             .map(|output_name| Output::from((output_name, DataType::all())))
@@ -116,8 +115,8 @@ impl TransformConfig for RouteCompatConfig {
         self.0.input()
     }
 
-    fn outputs(&self, merged_definition: &schema::Definition) -> Vec<Output> {
-        self.0.outputs(merged_definition)
+    fn outputs(&self) -> Vec<Output> {
+        self.0.outputs()
     }
 
     fn transform_type(&self) -> &'static str {

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     event::Event,
     internal_events::SampleEventDiscarded,
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
@@ -57,7 +56,7 @@ impl TransformConfig for SampleConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 
@@ -81,8 +80,8 @@ impl TransformConfig for SampleCompatConfig {
         self.0.input()
     }
 
-    fn outputs(&self, merged_definition: &schema::Definition) -> Vec<Output> {
-        self.0.outputs(merged_definition)
+    fn outputs(&self) -> Vec<Output> {
+        self.0.outputs()
     }
 
     fn transform_type(&self) -> &'static str {

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -8,7 +8,6 @@ use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, Value},
     internal_events::{ParserConversionError, ParserMissingFieldError},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_check_conversion_map, Conversion},
 };
@@ -59,7 +58,7 @@ impl TransformConfig for SplitConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -20,7 +20,6 @@ use crate::{
         TagCardinalityLimitRejectingEvent, TagCardinalityLimitRejectingTag,
         TagCardinalityValueLimitReached,
     },
-    schema,
     transforms::{TaskTransform, Transform},
 };
 
@@ -104,7 +103,7 @@ impl TransformConfig for TagCardinalityLimitConfig {
         Input::metric()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Metric)]
     }
 

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -11,7 +11,6 @@ use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::Event,
     internal_events::{TemplateRenderingError, ThrottleEventDiscarded},
-    schema,
     template::Template,
     transforms::{TaskTransform, Transform},
 };
@@ -42,7 +41,7 @@ impl TransformConfig for ThrottleConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -8,7 +8,6 @@ use crate::{
     config::{DataType, Input, Output, TransformConfig, TransformContext, TransformDescription},
     event::{Event, PathComponent, PathIter, Value},
     internal_events::{ParserConversionError, ParserMissingFieldError},
-    schema,
     transforms::{FunctionTransform, OutputBuffer, Transform},
     types::{parse_check_conversion_map, Conversion},
 };
@@ -56,7 +55,7 @@ impl TransformConfig for TokenizerConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::Log)]
     }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -34,7 +34,6 @@ use vector::{
         metric::{self, MetricData, MetricValue},
         Event, Value,
     },
-    schema,
     sinks::{util::StreamSink, Healthcheck, VectorSink},
     source_sender::{ReceiverStream, SourceSender},
     sources::Source,
@@ -315,7 +314,7 @@ impl TransformConfig for MockTransformConfig {
         Input::all()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+    fn outputs(&self) -> Vec<Output> {
         vec![Output::default(DataType::all())]
     }
 


### PR DESCRIPTION
Reverts vectordotdev/vector#11384

Currently breaking soaks. It auto-merged because the check was skipped.