### PR TITLE
chore: Batch filter transform emissions

### DIFF
--- a/src/internal_events/filter.rs
+++ b/src/internal_events/filter.rs
@@ -2,10 +2,12 @@ use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
-pub struct FilterEventDiscarded;
+pub struct FilterEventDiscarded {
+    pub(crate) total: u64,
+}
 
 impl InternalEvent for FilterEventDiscarded {
     fn emit_metrics(&self) {
-        counter!("events_discarded_total", 1);
+        counter!("events_discarded_total", self.total);
     }
 }

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -89,16 +89,14 @@ impl FunctionTransform for Filter {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         if self.condition.check(&event) {
             output.push(event);
+        } else if self.last_emission.elapsed() >= self.emissions_max_delay {
+            emit!(&FilterEventDiscarded {
+                total: self.emissions_deferred,
+            });
+            self.emissions_deferred = 0;
+            self.last_emission = Instant::now();
         } else {
-            if self.last_emission.elapsed() >= self.emissions_max_delay {
-                emit!(&FilterEventDiscarded {
-                    total: self.emissions_deferred,
-                });
-                self.emissions_deferred = 0;
-                self.last_emission = Instant::now();
-            } else {
-                self.emissions_deferred += 1;
-            }
+            self.emissions_deferred += 1;
         }
     }
 }


### PR DESCRIPTION
This commit -- part of the ongoing work to improve #10144 -- batches up our
emission code in `transforms/filter.rs` so we don't pay the cost of emission on
every `Event` that passes through.

This commit is a WIP. As noted in a comment a slow sender might never see the
metric emitted based on the current approach.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
