### PR TITLE
fix(ci): Adjust soak workflow PR comment

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -447,6 +447,12 @@ jobs:
           name: soak-analysis
           path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}-analysis
 
+      - name: Read analysis file
+        id: read-analysis
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}-analysis
+
       - name: Post Results To PR
         uses: peter-evans/create-or-update-comment@v1
         continue-on-error: true

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -442,11 +442,18 @@ jobs:
                                          --coefficient-of-variation-limit ${{ needs.compute-soak-meta.outputs.coefficient-of-variation }} \
                                          --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }} \
                                          --p-value 0.1 > /tmp/${{ github.event.number}}-${{ github.run_attempt }}-analysis
-
       - uses: actions/upload-artifact@v2
         with:
           name: soak-analysis
           path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}-analysis
+
+      - name: Post Results To PR
+        uses: peter-evans/create-or-update-comment@v1
+        continue-on-error: true
+        with:
+          issue-number: ${{ needs.compute-soak-meta.outputs.pr-number }}
+          edit-mode: replace
+          body: ${{ steps.read-analysis.outputs.content }}
 
   detect-regressions:
     name: Regression analysis

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -443,18 +443,10 @@ jobs:
                                          --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }} \
                                          --p-value 0.1 > /tmp/${{ github.event.number}}-${{ github.run_attempt }}-analysis
 
-      - name: Read analysis file
-        id: read-analysis
-        uses: juliangruber/read-file-action@v1
+      - uses: actions/upload-artifact@v2
         with:
+          name: soak-analysis
           path: /tmp/${{ github.event.number }}-${{ github.run_attempt }}-analysis
-
-      - name: Post Results To PR
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ needs.compute-soak-meta.outputs.pr-number }}
-          edit-mode: replace
-          body: ${{ steps.read-analysis.outputs.content }}
 
   detect-regressions:
     name: Regression analysis

--- a/.github/workflows/soak_comment.yml
+++ b/.github/workflows/soak_comment.yml
@@ -1,0 +1,53 @@
+# Based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# This workflow runs separately to have access to post PR comments for fork PRs
+# which only have read access
+
+name: Post soak analysis comment
+
+on:
+  workflow_run:
+    workflows: ["Soak"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download soak analysis'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "soak-analysis"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('/tmp/soak-analysis.zip', Buffer.from(download.data));
+      - run: unzip -d /tmp /tmp/soak-analysis.zip
+
+      - name: Read analysis file
+        id: read-analysis
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: /tmp/${{ github.workflow_run.event.number }}-${{ github.workflow_run.run_attempt }}-analysis
+
+      - name: Post Results To PR
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ needs.compute-soak-meta.outputs.pr-number }}
+          edit-mode: replace
+          body: ${{ steps.read-analysis.outputs.content }}


### PR DESCRIPTION
The soaks were adjusted in
https://github.com/vectordotdev/vector/pull/11474 to allow outside
contributor PRs to run them, but workflows running on these PRs still
couldn't publish the comment with the soak results due to only having
read access. This commit follows the example laid out by
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
to move the PR comment posting bit to its own workflow with expanded
permissions.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
