### PR TITLE
chore: Avoid `mem::take` when we can make Copy

### DIFF
--- a/lib/vector-core/src/event/util/log/path_iter.rs
+++ b/lib/vector-core/src/event/util/log/path_iter.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, mem, str::Chars};
+use std::{borrow::Cow, str::Chars};
 
 use serde::{Deserialize, Serialize};
 use substring::Substring;
@@ -45,6 +45,7 @@ impl<'a> PathIter<'a> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 enum State {
     Start,
     Key(usize),
@@ -75,7 +76,7 @@ impl<'a> Iterator for PathIter<'a> {
             }
 
             let c = self.chars.next();
-            self.state = match mem::take(&mut self.state) {
+            self.state = match self.state {
                 State::Start => match c {
                     Some('.') | Some('[') | Some(']') | None => State::Invalid,
                     Some('\\') => State::Escape,


### PR DESCRIPTION
In the path iteration code we have this loop where we do a `mem::take` and then,
as a consequence of a match statement, reset the thing we've taken. There's no
need for us, then, to have a temporary default value popped into `mem::take`.

This change came up while I was exploring the stack for #10144. I don't believe
it will have a material impact on throughput, but it does tidy up the stack
some.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
