### PR TITLE
docs(sinks): Always render batch config options

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -41,7 +41,7 @@ components: sinks: [Name=string]: {
 								description: "The maximum size of a batch, in bytes, before it is flushed."
 								required:    false
 								type: uint: {
-									default: features.send.batch.max_bytes
+									default: features.send.batch.max_bytes | *null
 									unit:    "bytes"
 								}
 							}
@@ -50,7 +50,7 @@ components: sinks: [Name=string]: {
 								description: "The maximum size of a batch, in events, before it is flushed."
 								required:    false
 								type: uint: {
-									default: features.send.batch.max_events
+									default: features.send.batch.max_events | *null
 									unit:    "events"
 								}
 							}

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -36,37 +36,31 @@ components: sinks: [Name=string]: {
 					type: object: {
 						examples: []
 						options: {
-							if features.send.batch.max_bytes != _|_ {
-								max_bytes: {
-									common:      true
-									description: "The maximum size of a batch, in bytes, before it is flushed."
-									required:    false
-									type: uint: {
-										default: features.send.batch.max_bytes
-										unit:    "bytes"
-									}
+							max_bytes: {
+								common:      true
+								description: "The maximum size of a batch, in bytes, before it is flushed."
+								required:    false
+								type: uint: {
+									default: features.send.batch.max_bytes
+									unit:    "bytes"
 								}
 							}
-							if features.send.batch.max_events != _|_ {
-								max_events: {
-									common:      true
-									description: "The maximum size of a batch, in events, before it is flushed."
-									required:    false
-									type: uint: {
-										default: features.send.batch.max_events
-										unit:    "events"
-									}
+							max_events: {
+								common:      true
+								description: "The maximum size of a batch, in events, before it is flushed."
+								required:    false
+								type: uint: {
+									default: features.send.batch.max_events
+									unit:    "events"
 								}
 							}
-							if features.send.batch.timeout_secs != null {
-								timeout_secs: {
-									common:      true
-									description: "The maximum age of a batch before it is flushed."
-									required:    false
-									type: uint: {
-										default: features.send.batch.timeout_secs
-										unit:    "seconds"
-									}
+							timeout_secs: {
+								common:      true
+								description: "The maximum age of a batch before it is flushed."
+								required:    false
+								type: uint: {
+									default: features.send.batch.timeout_secs
+									unit:    "seconds"
 								}
 							}
 						}


### PR DESCRIPTION
These settings are always available on any sinks that support batching.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
