### PR TITLE
chore: Add a global deny unreachable_pub, with carve outs

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -15,7 +15,7 @@ pub struct LookupIp(std::vec::IntoIter<SocketAddr>);
 pub(super) struct Resolver;
 
 impl Resolver {
-    pub async fn lookup_ip(self, name: String) -> Result<LookupIp, DnsError> {
+    pub(crate) async fn lookup_ip(self, name: String) -> Result<LookupIp, DnsError> {
         // We need to add port with the name so that `to_socket_addrs`
         // resolves it properly. We will be discarding the port afterwards.
         //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "256"] // for async-stream
+#![deny(unreachable_pub)]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::blocks_in_if_conditions)]
@@ -27,8 +28,10 @@ extern crate vrl_cli;
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[macro_use]
+#[allow(unreachable_pub)]
 pub mod config;
 pub mod cli;
+#[allow(unreachable_pub)]
 pub mod conditions;
 pub mod dns;
 #[cfg(feature = "docker")]
@@ -36,14 +39,17 @@ pub mod docker;
 pub mod expiring_hash_map;
 pub mod generate;
 #[macro_use]
+#[allow(unreachable_pub)]
 pub mod internal_events;
 #[cfg(feature = "api")]
+#[allow(unreachable_pub)]
 pub mod api;
 pub mod app;
 pub mod async_read;
 #[cfg(any(feature = "rusoto_core", feature = "aws-config"))]
 pub mod aws;
 #[cfg(feature = "codecs")]
+#[allow(unreachable_pub)]
 pub mod codecs;
 pub(crate) mod common;
 pub mod encoding_transcode;
@@ -52,10 +58,13 @@ pub mod graph;
 pub mod heartbeat;
 pub mod http;
 #[cfg(any(feature = "sources-kafka", feature = "sinks-kafka"))]
+#[allow(unreachable_pub)]
 pub(crate) mod kafka;
+#[allow(unreachable_pub)]
 pub mod kubernetes;
 pub mod line_agg;
 pub mod list;
+#[allow(unreachable_pub)]
 pub(crate) mod proto;
 pub mod providers;
 pub mod serde;
@@ -63,22 +72,30 @@ pub mod serde;
 pub mod service;
 pub mod shutdown;
 pub mod signal;
+#[deny(unreachable_pub)]
 pub mod sink;
+#[allow(unreachable_pub)]
 pub mod sinks;
 pub mod source_sender;
+#[allow(unreachable_pub)]
 pub mod sources;
 pub mod stats;
 pub mod stream;
 #[cfg(feature = "api-client")]
+#[allow(unreachable_pub)]
 mod tap;
 pub mod tcp;
 pub mod template;
 pub mod test_util;
+#[allow(unreachable_pub)]
 pub mod tls;
 #[cfg(feature = "api-client")]
+#[allow(unreachable_pub)]
 pub mod top;
+#[allow(unreachable_pub)]
 pub mod topology;
 pub mod trace;
+#[allow(unreachable_pub)]
 pub mod transforms;
 pub mod trigger;
 pub mod types;


### PR DESCRIPTION
This commit makes `deny(unreachable_pub)` the default in the project, allowing
for carve-outs for large sections of the tree. This is consistent with my
background work recently to reduce the exposed interface of vector. I now have
specific areas to aim retypist at and we scope growth of the problem to only a
subset of the tree.

This flag does not apply to any sub-crates.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
