### PR TITLE
chore(nats sink): Update from async_nats to nats::asynk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,16 +354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-nats"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dae854440faecce70f0664f41f09a588de1e7a4366931ec3962ded3d8f903c5"
-dependencies = [
- "blocking",
- "nats",
-]
-
-[[package]]
 name = "async-net"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,7 +674,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
- "time 0.3.5",
+ "time 0.3.7",
  "tracing 0.1.31",
 ]
 
@@ -787,7 +777,7 @@ dependencies = [
  "itoa 1.0.1",
  "num-integer",
  "ryu",
- "time 0.3.5",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -2750,7 +2740,7 @@ dependencies = [
  "serde_json",
  "simpl",
  "smpl_jwt",
- "time 0.3.5",
+ "time 0.3.7",
  "tokio",
 ]
 
@@ -4263,16 +4253,18 @@ dependencies = [
 
 [[package]]
 name = "nats"
-version = "0.10.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0cfa3903c3e613edddaa4a2f86b2053a1d6fbcf315a3ff352c25ba9f0a8585"
+checksum = "603b57313fd7ff9ddf81b833923ee872264bec6426bff89b3c8c90c0de2267cb"
 dependencies = [
  "base64 0.13.0",
  "base64-url",
+ "blocking",
  "crossbeam-channel",
  "fastrand",
  "itoa 0.4.8",
  "json",
+ "lazy_static",
  "libc",
  "log",
  "memchr",
@@ -4283,6 +4275,13 @@ dependencies = [
  "regex",
  "rustls 0.19.1",
  "rustls-native-certs",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "time 0.3.7",
+ "url",
  "webpki",
  "winapi 0.3.9",
 ]
@@ -4632,6 +4631,15 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "syn 1.0.84",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6571,6 +6579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44969a61f5d316be20a42ff97816efb3b407a924d06824c3d8a49fa8450de0e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6588,6 +6605,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7217,7 +7245,7 @@ dependencies = [
  "hostname",
  "libc",
  "log",
- "time 0.3.5",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -7398,12 +7426,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "libc",
+ "num_threads",
+ "serde",
 ]
 
 [[package]]
@@ -8298,7 +8328,6 @@ dependencies = [
  "async-compression",
  "async-graphql",
  "async-graphql-warp",
- "async-nats",
  "async-stream",
  "async-trait",
  "atty",
@@ -8377,6 +8406,7 @@ dependencies = [
  "metrics-util",
  "mlua",
  "mongodb",
+ "nats",
  "nix",
  "nom 7.1.0",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,6 @@ lookup = { path = "lib/lookup" }
 # External libs
 arc-swap = { version = "1.5", default-features = false }
 async-compression = { version = "0.3.7", default-features = false, features = ["tokio", "gzip", "zstd"] }
-async-nats = { version = "0.10.1", default-features = false, optional = true }
 avro-rs = { version = "0.13.0", default-features = false, optional = true }
 base64 = { version = "0.13.0", default-features = false, optional = true }
 bitmask-enum = { version = "1.1.3", default-features = false }
@@ -261,6 +260,7 @@ maxminddb = { version = "0.21.0", default-features = false, optional = true }
 md-5 = { version = "0.10", optional = true }
 memchr = { version = "2.4", default-features = false, optional = true }
 mongodb = { version = "2.1.0", default-features = false, features = ["tokio-runtime"], optional = true }
+nats = { version = "0.18.1", default-features = false, optional = true }
 nom = { version = "7.1.0", default-features = false, optional = true }
 notify = { version = "4.0.17", default-features = false }
 num_cpus = { version = "1.13.1", default-features = false }
@@ -498,7 +498,7 @@ sources-internal_logs = []
 sources-internal_metrics = []
 sources-journald = ["codecs"]
 sources-kafka = ["rdkafka", "codecs"]
-sources-nats = ["async-nats", "codecs"]
+sources-nats = ["nats", "codecs"]
 sources-logstash = ["listenfd", "tokio-util/net", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls", "codecs"]
 sources-kubernetes_logs = ["file-source", "kubernetes", "transforms-merge", "transforms-regex_parser"]
 sources-mongodb_metrics = ["mongodb"]
@@ -684,7 +684,7 @@ sinks-influxdb = []
 sinks-kafka = ["rdkafka", "zstd"]
 sinks-logdna = []
 sinks-loki = []
-sinks-nats = ["async-nats"]
+sinks-nats = ["nats"]
 sinks-new_relic_logs = ["sinks-http"]
 sinks-new_relic = []
 sinks-papertrail = ["syslog"]

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -86,15 +86,15 @@ impl SinkConfig for NatsSinkConfig {
 }
 
 impl NatsSinkConfig {
-    fn to_nats_options(&self) -> async_nats::Options {
+    fn to_nats_options(&self) -> nats::asynk::Options {
         // Set reconnect_buffer_size on the nats client to 0 bytes so that the
         // client doesn't buffer internally (to avoid message loss).
-        async_nats::Options::new()
+        nats::asynk::Options::new()
             .with_name(&self.connection_name)
             .reconnect_buffer_size(0)
     }
 
-    async fn connect(&self) -> crate::Result<async_nats::Connection> {
+    async fn connect(&self) -> crate::Result<nats::asynk::Connection> {
         self.to_nats_options()
             .connect(&self.url)
             .map_err(|e| e.into())
@@ -135,9 +135,9 @@ impl NatsSink {
     }
 }
 
-impl From<NatsOptions> for async_nats::Options {
+impl From<NatsOptions> for nats::asynk::Options {
     fn from(options: NatsOptions) -> Self {
-        async_nats::Options::new()
+        nats::asynk::Options::new()
             .with_name(&options.connection_name)
             .reconnect_buffer_size(0)
     }
@@ -154,7 +154,7 @@ impl From<&NatsSinkConfig> for NatsOptions {
 #[async_trait]
 impl StreamSink<Event> for NatsSink {
     async fn run(self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let nats_options: async_nats::Options = self.options.into();
+        let nats_options: nats::asynk::Options = self.options.into();
 
         let nc = nats_options.connect(&self.url).await.map_err(|_| ())?;
 


### PR DESCRIPTION
The async_nats crate was merged into the standard nats crate as a module and is no longer maintained. https://github.com/nats-io/nats.rs/pull/192

This will unblock jetstream support #10534.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
