### PR TITLE
chore: Apply more deny unreachable_pub

### DIFF
--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -15,7 +15,7 @@ enum KafkaError {
 #[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
 #[serde(rename_all = "lowercase")]
-pub enum KafkaCompression {
+pub(crate) enum KafkaCompression {
     #[derivative(Default)]
     None,
     Gzip,
@@ -25,28 +25,28 @@ pub enum KafkaCompression {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct KafkaAuthConfig {
-    pub sasl: Option<KafkaSaslConfig>,
-    pub tls: Option<KafkaTlsConfig>,
+pub(crate) struct KafkaAuthConfig {
+    pub(crate) sasl: Option<KafkaSaslConfig>,
+    pub(crate) tls: Option<KafkaTlsConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct KafkaSaslConfig {
-    pub enabled: Option<bool>,
-    pub username: Option<String>,
-    pub password: Option<String>,
-    pub mechanism: Option<String>,
+pub(crate) struct KafkaSaslConfig {
+    pub(crate) enabled: Option<bool>,
+    pub(crate) username: Option<String>,
+    pub(crate) password: Option<String>,
+    pub(crate) mechanism: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct KafkaTlsConfig {
-    pub enabled: Option<bool>,
+pub(crate) struct KafkaTlsConfig {
+    pub(crate) enabled: Option<bool>,
     #[serde(flatten)]
-    pub options: TlsOptions,
+    pub(crate) options: TlsOptions,
 }
 
 impl KafkaAuthConfig {
-    pub fn apply(&self, client: &mut ClientConfig) -> crate::Result<()> {
+    pub(crate) fn apply(&self, client: &mut ClientConfig) -> crate::Result<()> {
         let sasl_enabled = self.sasl.as_ref().and_then(|s| s.enabled).unwrap_or(false);
         let tls_enabled = self.tls.as_ref().and_then(|s| s.enabled).unwrap_or(false);
 
@@ -96,7 +96,7 @@ fn pathbuf_to_string(path: &Path) -> crate::Result<&str> {
         .ok_or_else(|| KafkaError::InvalidPath { path: path.into() }.into())
 }
 
-pub struct KafkaStatisticsContext;
+pub(crate) struct KafkaStatisticsContext;
 
 impl ClientContext for KafkaStatisticsContext {
     fn stats(&self, statistics: Statistics) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@ pub mod graph;
 pub mod heartbeat;
 pub mod http;
 #[cfg(any(feature = "sources-kafka", feature = "sinks-kafka"))]
-#[allow(unreachable_pub)]
 pub(crate) mod kafka;
 #[allow(unreachable_pub)]
 pub mod kubernetes;

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -35,7 +35,7 @@ use futures::{ready, stream::Peekable, Sink, SinkExt, Stream, StreamExt};
 
 impl<T: ?Sized, Item> VecSinkExt<Item> for T where T: Sink<Item> {}
 
-pub trait VecSinkExt<Item>: Sink<Item> {
+pub(crate) trait VecSinkExt<Item>: Sink<Item> {
     /// A future that completes after the given stream has been fully processed
     /// into the sink, including flushing.
     /// Compare to `SinkExt::send_all` this future accept `Peekable` stream and
@@ -53,7 +53,7 @@ pub trait VecSinkExt<Item>: Sink<Item> {
 }
 
 /// Future for the [`send_all_peekable`](VecSinkExt::send_all_peekable) method.
-pub struct SendAll<'a, Si, St>
+pub(crate) struct SendAll<'a, Si, St>
 where
     St: Stream,
 {

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -70,7 +70,9 @@ pub struct KafkaService {
 }
 
 impl KafkaService {
-    pub const fn new(kafka_producer: FutureProducer<KafkaStatisticsContext>) -> KafkaService {
+    pub(crate) const fn new(
+        kafka_producer: FutureProducer<KafkaStatisticsContext>,
+    ) -> KafkaService {
         KafkaService { kafka_producer }
     }
 }

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -19,7 +19,7 @@ use crate::{
 
 /// CLI command func for issuing 'tap' queries, and communicating with a local/remote
 /// Vector API server via HTTP/WebSockets.
-pub async fn cmd(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitCode {
+pub(crate) async fn cmd(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitCode {
     // Use the provided URL as the Vector GraphQL API server, or default to the local port
     // provided by the API config. This will work despite `api` and `api-client` being distinct
     // features; the config is available even if `api` is disabled.

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -1,7 +1,7 @@
 mod cmd;
 
 use clap::Parser;
-pub use cmd::cmd;
+pub(crate) use cmd::cmd;
 use url::Url;
 use vector_api_client::gql::TapEncodingFormat;
 


### PR DESCRIPTION
This commit applies unreachable_pub to a few more modules in the tree, those
easily done by hand. This commit relates to #11538 and #11547.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
