### PR TITLE
fix(socket source): Prevent idle connections from hoarding permits 

### DIFF
--- a/src/sources/util/tcp/mod.rs
+++ b/src/sources/util/tcp/mod.rs
@@ -153,10 +153,7 @@ where
             let connection_gauge = OpenGauge::new();
             let shutdown_clone = cx.shutdown.clone();
 
-            // TODO: REVERT THIS - THIS IS FOR TESTING ONLY
-            // let max_requests = num_cpus::get();
-            let max_requests = 1;
-            let request_limiter = RequestLimiter::new(MAX_IN_FLIGHT_EVENTS_TARGET, max_requests);
+            let request_limiter = RequestLimiter::new(MAX_IN_FLIGHT_EVENTS_TARGET, num_cpus::get());
 
             listener
                 .accept_stream_limited(max_connections)


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/11475

A request limiter was recently added to the TCP source to limit the amount of memory consumed during back-pressure. This worked by requiring a connection to hold a permit before it's allowed to read any data.
However, if there are many connections that are idle they will consume all the permits and prevent active connections from being processed correctly.

A small read timeout was added, and if a connection does not receive any data during that time it will release its permit (and try to obtain a new one) allowing other connections to read.