### PR TITLE
chore(schemas): disable schema integration by default

### DIFF
--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -11,7 +11,7 @@ use super::api;
 #[cfg(feature = "datadog-pipelines")]
 use super::datadog;
 use super::{
-    compiler, provider, ComponentKey, Config, EnrichmentTableConfig, EnrichmentTableOuter,
+    compiler, provider, schema, ComponentKey, Config, EnrichmentTableConfig, EnrichmentTableOuter,
     HealthcheckOptions, SinkConfig, SinkOuter, SourceConfig, SourceOuter, TestDefinition,
     TransformOuter,
 };
@@ -24,6 +24,8 @@ pub struct ConfigBuilder {
     #[cfg(feature = "api")]
     #[serde(default)]
     pub api: api::Options,
+    #[serde(default)]
+    pub schema: schema::Options,
     #[cfg(feature = "datadog-pipelines")]
     #[serde(default)]
     pub datadog: Option<datadog::Options>,
@@ -75,6 +77,7 @@ impl From<Config> for ConfigBuilder {
             global,
             #[cfg(feature = "api")]
             api,
+            schema,
             #[cfg(feature = "datadog-pipelines")]
             datadog,
             healthchecks,
@@ -103,6 +106,7 @@ impl From<Config> for ConfigBuilder {
             #[cfg(feature = "api")]
             api,
             #[cfg(feature = "datadog-pipelines")]
+            schema,
             datadog,
             healthchecks,
             enrichment_tables,

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -48,6 +48,7 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
         global,
         #[cfg(feature = "api")]
         api,
+        schema,
         #[cfg(feature = "datadog-pipelines")]
         datadog,
         healthchecks,
@@ -101,6 +102,7 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
             global,
             #[cfg(feature = "api")]
             api,
+            schema,
             #[cfg(feature = "datadog-pipelines")]
             datadog,
             version,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,7 +19,6 @@ pub use vector_core::{
 use crate::{
     conditions,
     event::Metric,
-    schema,
     serde::bool_or_struct,
     shutdown::ShutdownSignal,
     sinks::{self, util::UriSerde},
@@ -41,6 +40,7 @@ mod id;
 mod loading;
 pub mod provider;
 mod recursive;
+mod schema;
 mod unit_test;
 mod validation;
 mod vars;
@@ -100,6 +100,7 @@ impl ConfigPath {
 pub struct Config {
     #[cfg(feature = "api")]
     pub api: api::Options,
+    pub schema: schema::Options,
     pub version: Option<String>,
     #[cfg(feature = "datadog-pipelines")]
     pub datadog: Option<datadog::Options>,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1,0 +1,22 @@
+pub(crate) use crate::schema::{Definition, Id};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Copy, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub struct Options {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+        }
+    }
+}
+
+const fn default_enabled() -> bool {
+    false
+}

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -263,8 +263,11 @@ pub async fn build_pieces(
         .filter(|(key, _)| diff.transforms.contains_new(key))
     {
         let mut schema_ids = HashMap::new();
-        let merged_definition =
-            schema::merged_definition(&transform.inputs, config, &mut definition_cache);
+        let merged_definition = if config.schema.enabled {
+            schema::merged_definition(&transform.inputs, config, &mut definition_cache)
+        } else {
+            schema::Definition::empty()
+        };
 
         for output in transform.inner.outputs(&merged_definition) {
             let definition = match output.log_schema_definition {


### PR DESCRIPTION
Follow-up to #11385.

That PR was merged accidentally, as the auto-merge feature failed to stop the merge because of failed soak tests. This PR rectifies that by disabling the schema feature by default.