### PR TITLE
fix(aws_s3 sink): allow the usage of `region` and `endpoint`

### DIFF
--- a/src/aws/rusoto/region.rs
+++ b/src/aws/rusoto/region.rs
@@ -12,8 +12,6 @@ pub enum ParseError {
     EndpointParseError { source: InvalidUri },
     #[snafu(display("Failed to parse region: {}", source))]
     RegionParseError { source: ParseRegionError },
-    #[snafu(display("Only one of 'region' or 'endpoint' can be specified"))]
-    BothRegionAndEndpoint,
     #[snafu(display("Must set either 'region' or 'endpoint'"))]
     MissingRegionAndEndpoint,
 }
@@ -25,7 +23,10 @@ impl TryFrom<&RegionOrEndpoint> for Region {
         match (&r.region, &r.endpoint) {
             (Some(region), None) => region.parse().context(RegionParseSnafu),
             (None, Some(endpoint)) => region_from_endpoint(endpoint),
-            (Some(_), Some(_)) => Err(ParseError::BothRegionAndEndpoint),
+            (Some(region), Some(endpoint)) => Ok(Region::Custom {
+                name: region.to_string(),
+                endpoint: endpoint.to_string(),
+            }),
             (None, None) => Err(ParseError::MissingRegionAndEndpoint),
         }
     }

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -65,7 +65,7 @@ components: _aws: {
 
 		endpoint: {
 			common:        false
-			description:   "Custom endpoint for use with AWS-compatible services. Providing a value for this option will make `region` moot."
+			description:   "Custom endpoint for use with AWS-compatible services."
 			relevant_when: "region = null"
 			required:      false
 			type: string: {


### PR DESCRIPTION
This patch allows to use both the `region` and `endpoint` field for the
aws_s3 sink.
This is necessary when using a different S3 provider than AWS
since the region is derived from the endpoint and mapped against a known
map of AWS region [1], which will result in the use of the default AWS
region.

[1] https://github.com/vectordotdev/vector/blob/1d9a34e24c416501c3f6377b8400253a3ad538f6/src/aws/rusoto/region.rs#L64

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>