### PR TITLE
fix(api): Change vector top --human_metrics short flag

### DIFF
--- a/src/top/mod.rs
+++ b/src/top/mod.rs
@@ -20,6 +20,6 @@ pub struct Opts {
     url: Option<Url>,
 
     /// Humanize metrics, using numeric suffixes - e.g. 1,100 = 1.10 k, 1,000,000 = 1.00 M
-    #[clap(short, long)]
+    #[clap(visible_alias = "hm", long)]
     human_metrics: bool,
 }

--- a/src/top/mod.rs
+++ b/src/top/mod.rs
@@ -20,6 +20,6 @@ pub struct Opts {
     url: Option<Url>,
 
     /// Humanize metrics, using numeric suffixes - e.g. 1,100 = 1.10 k, 1,000,000 = 1.00 M
-    #[clap(visible_alias = "hm", long)]
+    #[clap(short = 'H', long)]
     human_metrics: bool,
 }

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -15,7 +15,7 @@ Vector's 0.21.0 release includes **breaking changes**:
 1. [GraphQL API outputEventsByComponentIdPatterns subscription argument `patterns` changed to `outputsPatterns`](#api-patterns-to-outputspatterns)
 2. [Deprecated GraphQL API subscriptions have been removed](#removed-deprecated-subscriptions)
 3. [The `vector vrl` timezone flag `-tz` is now `-z`](#vector-vrl-timezone)
-4. [The `vector top` human_metrics flag `-h` is now `--hm`](#vector-top-human-metrics)
+4. [The `vector top` human_metrics flag `-h` is now `-H`](#vector-top-human-metrics)
 
 And **deprecations**:
 
@@ -75,12 +75,12 @@ type, meaning they are restricted to single characters.
 As a consequence, the shortened form of our `vector vrl --timezone` flag
 (previously `--tz`) has been updated to the more succinct `-z`.
 
-#### The `vector top` human_metrics short flag `-h` is now `--hm` {#vector-top-human-metrics}
+#### The `vector top` human_metrics short flag `-h` is now `-H` {#vector-top-human-metrics}
 
 To avoid clashing and issues with our upgrade to [Clap
 v3](https://crates.io/crates/clap), the short `-h` from `--help` and `-h` from
 `--human_metrics` in the `vector top` command have been disambiguated. The
-shortened form for `--human_metrics` is now `--hm` and `-h` is reserved for
+shortened form for `--human_metrics` is now `-H` and `-h` is reserved for
 `--help`.
 
 ### Deprecations

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -79,8 +79,9 @@ As a consequence, the shortened form of our `vector vrl --timezone` flag
 
 To avoid clashing and issues with our upgrade to [Clap
 v3](https://crates.io/crates/clap), the short `-h` from `--help` and `-h` from
-`--human_metrics` have been disambiguated. The shortened form for
-`--human_metrics` is now `--hm` and `-h` is reserved for `--help`.
+`--human_metrics` in the `vector top` command have been disambiguated. The
+shortened form for `--human_metrics` is now `--hm` and `-h` is reserved for
+`--help`.
 
 ### Deprecations
 

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -15,6 +15,7 @@ Vector's 0.21.0 release includes **breaking changes**:
 1. [GraphQL API outputEventsByComponentIdPatterns subscription argument `patterns` changed to `outputsPatterns`](#api-patterns-to-outputspatterns)
 2. [Deprecated GraphQL API subscriptions have been removed](#removed-deprecated-subscriptions)
 3. [The `vector vrl` timezone flag `-tz` is now `-z`](#vector-vrl-timezone)
+4. [The `vector top` human_metrics flag `-h` is now `--hm`](#vector-top-human-metrics)
 
 And **deprecations**:
 
@@ -73,6 +74,13 @@ type, meaning they are restricted to single characters.
 
 As a consequence, the shortened form of our `vector vrl --timezone` flag
 (previously `--tz`) has been updated to the more succinct `-z`.
+
+#### The `vector top` human_metrics short flag `-h` is now `--hm` {#vector-top-human-metrics}
+
+To avoid clashing and issues with our upgrade to [Clap
+v3](https://crates.io/crates/clap), the short `-h` from `--help` and `-h` from
+`--human_metrics` have been disambiguated. The shortened form for
+`--human_metrics` is now `--hm` and `-h` is reserved for `--help`.
 
 ### Deprecations
 

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -335,7 +335,7 @@ cli: {
 
 			flags: _default_flags & {
 				"human-metrics": {
-					_short: "hm"
+					_short: "H"
 					description: """
 						Humanize metrics, using numeric suffixes - e.g. 1,100 = 1.10 k,
 						1,000,000 = 1.00 M

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -335,7 +335,7 @@ cli: {
 
 			flags: _default_flags & {
 				"human-metrics": {
-					_short: "h"
+					_short: "hm"
 					description: """
 						Humanize metrics, using numeric suffixes - e.g. 1,100 = 1.10 k,
 						1,000,000 = 1.00 M


### PR DESCRIPTION
This PR fixes a small bug in `vector top` wherein running `top` leads to a panic because `-h` from `--help` and `-h` from `--human_metrics` clashes. ~~I've added `--hm` as an alias for `--human_metrics`~~ since `clap` only supports shortened versions with a single character -- open to suggestions. 

Going with `-H` as the short flag for `--human_metrics`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
