### PR TITLE
chore(core): Disambiguate `LogEvent` and `TraceEvent`

### DIFF
--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -180,8 +180,9 @@ impl From<MetricArray> for EventArray {
 impl ByteSizeOf for EventArray {
     fn allocated_bytes(&self) -> usize {
         match self {
-            Self::Logs(a) | Self::Traces(a) => a.allocated_bytes(),
+            Self::Logs(a) => a.allocated_bytes(),
             Self::Metrics(a) => a.allocated_bytes(),
+            Self::Traces(a) => a.allocated_bytes(),
         }
     }
 }
@@ -189,8 +190,9 @@ impl ByteSizeOf for EventArray {
 impl EventCount for EventArray {
     fn event_count(&self) -> usize {
         match self {
-            Self::Logs(a) | Self::Traces(a) => a.len(),
+            Self::Logs(a) => a.len(),
             Self::Metrics(a) => a.len(),
+            Self::Traces(a) => a.len(),
         }
     }
 }
@@ -200,8 +202,9 @@ impl EventContainer for EventArray {
 
     fn len(&self) -> usize {
         match self {
-            Self::Logs(a) | Self::Traces(a) => a.len(),
+            Self::Logs(a) => a.len(),
             Self::Metrics(a) => a.len(),
+            Self::Traces(a) => a.len(),
         }
     }
 
@@ -217,10 +220,9 @@ impl EventContainer for EventArray {
 impl EventDataEq for EventArray {
     fn event_data_eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Logs(a), Self::Logs(b)) | (Self::Traces(a), Self::Traces(b)) => {
-                a.event_data_eq(b)
-            }
+            (Self::Logs(a), Self::Logs(b)) => a.event_data_eq(b),
             (Self::Metrics(a), Self::Metrics(b)) => a.event_data_eq(b),
+            (Self::Traces(a), Self::Traces(b)) => a.event_data_eq(b),
             _ => false,
         }
     }
@@ -273,8 +275,9 @@ impl<'a> Iterator for EventArrayIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            Self::Logs(i) | Self::Traces(i) => i.next().map(EventRef::from),
+            Self::Logs(i) => i.next().map(EventRef::from),
             Self::Metrics(i) => i.next().map(EventRef::from),
+            Self::Traces(i) => i.next().map(EventRef::from),
         }
     }
 }
@@ -286,8 +289,8 @@ pub enum EventArrayIntoIter {
     Logs(vec::IntoIter<LogEvent>),
     /// An iterator over type `Metric`.
     Metrics(vec::IntoIter<Metric>),
-    /// An iterator over type `LogEvent` but for Traces.
-    Traces(vec::IntoIter<LogEvent>),
+    /// An iterator over type `TraceEvent`.
+    Traces(vec::IntoIter<TraceEvent>),
 }
 
 impl Iterator for EventArrayIntoIter {

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -104,7 +104,7 @@ impl From<Trace> for event::TraceEvent {
             .filter_map(|(k, v)| decode_value(v).map(|value| (k, value)))
             .collect::<BTreeMap<_, _>>();
 
-        Self::from(fields)
+        Self::from(event::LogEvent::from(fields))
     }
 }
 

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -8,7 +8,8 @@ use quickcheck::{empty_shrinker, Arbitrary, Gen};
 
 use crate::event::{
     metric::{Bucket, MetricData, MetricName, MetricSeries, Quantile, Sample},
-    Event, EventMetadata, LogEvent, Metric, MetricKind, MetricValue, StatisticKind, Value,
+    Event, EventMetadata, LogEvent, Metric, MetricKind, MetricValue, StatisticKind, TraceEvent,
+    Value,
 };
 
 const MAX_F64_SIZE: f64 = 1_000_000.0;
@@ -87,6 +88,22 @@ impl Arbitrary for LogEvent {
             fields
                 .shrink()
                 .map(move |x| LogEvent::from_parts(x, metadata.clone())),
+        )
+    }
+}
+
+impl Arbitrary for TraceEvent {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self::from(LogEvent::arbitrary(g))
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let (fields, metadata) = self.clone().into_parts();
+
+        Box::new(
+            fields
+                .shrink()
+                .map(move |x| TraceEvent::from_parts(x, metadata.clone())),
         )
     }
 }

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -1,0 +1,120 @@
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+
+use vector_buffers::EventCount;
+use vector_common::EventDataEq;
+
+use super::{
+    util, BatchNotifier, EventFinalizer, EventFinalizers, EventMetadata, Finalizable, LogEvent,
+    Value,
+};
+use crate::ByteSizeOf;
+
+/// Traces are a newtype of `LogEvent`
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize)]
+pub struct TraceEvent(LogEvent);
+
+impl TraceEvent {
+    pub fn into_parts(self) -> (BTreeMap<String, Value>, EventMetadata) {
+        self.0.into_parts()
+    }
+
+    pub fn from_parts(fields: BTreeMap<String, Value>, metadata: EventMetadata) -> Self {
+        Self(LogEvent::from_parts(fields, metadata))
+    }
+
+    pub fn metadata(&self) -> &EventMetadata {
+        self.0.metadata()
+    }
+
+    pub fn metadata_mut(&mut self) -> &mut EventMetadata {
+        self.0.metadata_mut()
+    }
+
+    pub fn add_finalizer(&mut self, finalizer: EventFinalizer) {
+        self.0.add_finalizer(finalizer);
+    }
+
+    pub fn with_batch_notifier(self, batch: &Arc<BatchNotifier>) -> Self {
+        Self(self.0.with_batch_notifier(batch))
+    }
+
+    pub fn with_batch_notifier_option(self, batch: &Option<Arc<BatchNotifier>>) -> Self {
+        Self(self.0.with_batch_notifier_option(batch))
+    }
+
+    pub fn as_map(&self) -> &BTreeMap<String, Value> {
+        self.0.as_map()
+    }
+
+    #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
+    pub fn get(&self, key: impl AsRef<str>) -> Option<&Value> {
+        util::log::get(self.0.as_map(), key.as_ref())
+    }
+
+    #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
+    pub fn get_flat(&self, key: impl AsRef<str>) -> Option<&Value> {
+        self.0.as_map().get(key.as_ref())
+    }
+
+    #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
+    pub fn get_mut(&mut self, key: impl AsRef<str>) -> Option<&mut Value> {
+        util::log::get_mut(self.0.as_map_mut(), key.as_ref())
+    }
+
+    #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
+    pub fn contains(&self, key: impl AsRef<str>) -> bool {
+        util::log::contains(self.0.as_map(), key.as_ref())
+    }
+
+    #[instrument(level = "trace", skip(self, key), fields(key = %key.as_ref()))]
+    pub fn insert(
+        &mut self,
+        key: impl AsRef<str>,
+        value: impl Into<Value> + Debug,
+    ) -> Option<Value> {
+        util::log::insert(self.0.as_map_mut(), key.as_ref(), value.into())
+    }
+}
+
+impl From<LogEvent> for TraceEvent {
+    fn from(log: LogEvent) -> Self {
+        Self(log)
+    }
+}
+
+impl ByteSizeOf for TraceEvent {
+    fn allocated_bytes(&self) -> usize {
+        self.0.allocated_bytes()
+    }
+}
+
+impl EventCount for TraceEvent {
+    fn event_count(&self) -> usize {
+        1
+    }
+}
+
+impl EventDataEq for TraceEvent {
+    fn event_data_eq(&self, other: &Self) -> bool {
+        self.0.event_data_eq(&other.0)
+    }
+}
+
+impl Finalizable for TraceEvent {
+    fn take_finalizers(&mut self) -> EventFinalizers {
+        self.0.take_finalizers()
+    }
+}
+
+impl AsRef<LogEvent> for TraceEvent {
+    fn as_ref(&self) -> &LogEvent {
+        &self.0
+    }
+}
+
+impl AsMut<LogEvent> for TraceEvent {
+    fn as_mut(&mut self) -> &mut LogEvent {
+        &mut self.0
+    }
+}

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -4,7 +4,7 @@ use lookup::LookupBuf;
 use snafu::Snafu;
 use vrl_lib::prelude::VrlValueConvert;
 
-use super::{Event, EventMetadata, LogEvent, Metric, MetricKind, Value};
+use super::{Event, EventMetadata, LogEvent, Metric, MetricKind, TraceEvent, Value};
 use crate::config::log_schema;
 
 const VALID_METRIC_PATHS_SET: &str = ".name, .namespace, .timestamp, .kind, .tags";
@@ -56,10 +56,10 @@ impl VrlTarget {
             VrlTarget::Metric(metric) => {
                 Box::new(std::iter::once(Event::Metric(metric))) as Box<dyn Iterator<Item = Event>>
             }
-            VrlTarget::Trace(value, metadata) => {
-                Box::new(value_into_logevents(value, metadata).map(Event::Trace))
-                    as Box<dyn Iterator<Item = Event>>
-            }
+            VrlTarget::Trace(value, metadata) => Box::new(
+                value_into_logevents(value, metadata)
+                    .map(|log| Event::Trace(TraceEvent::from(log))),
+            ) as Box<dyn Iterator<Item = Event>>,
         }
     }
 }

--- a/src/sinks/util/encoding/codec.rs
+++ b/src/sinks/util/encoding/codec.rs
@@ -1,10 +1,10 @@
 use std::io;
 
 use serde::{Deserialize, Serialize};
-use vector_core::{config::log_schema, event::Event};
+use vector_core::config::log_schema;
+use vector_core::event::{Event, LogEvent, TraceEvent};
 
 use super::Encoder;
-use crate::event::LogEvent;
 
 static DEFAULT_TEXT_ENCODER: StandardTextEncoding = StandardTextEncoding;
 static DEFAULT_JSON_ENCODER: StandardJsonEncoding = StandardJsonEncoding;
@@ -176,6 +176,14 @@ impl Encoder<Event> for StandardJsonEncoding {
 impl Encoder<LogEvent> for StandardJsonEncoding {
     fn encode_input(&self, log: LogEvent, writer: &mut dyn io::Write) -> io::Result<usize> {
         as_tracked_write(writer, &log, |writer, item| {
+            serde_json::to_writer(writer, item)
+        })
+    }
+}
+
+impl Encoder<TraceEvent> for StandardJsonEncoding {
+    fn encode_input(&self, trace: TraceEvent, writer: &mut dyn io::Write) -> io::Result<usize> {
+        as_tracked_write(writer, &trace, |writer, item| {
             serde_json::to_writer(writer, item)
         })
     }


### PR DESCRIPTION
The current trace event type is simply a type alias for the log event
type. This leads to silent ambiguities, particularly in the presence of
things like `impl From<LogEvent> for X`. This change converts
`TraceEvent` into a newtype wrapper for `LogEvent` to prevent that
ambiguity.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
