### PR TITLE
chore: Apply clippy lints from 1.59.0

### DIFF
--- a/lib/datadog/grok/src/matchers/date.rs
+++ b/lib/datadog/grok/src/matchers/date.rs
@@ -108,17 +108,12 @@ fn parse_tz_id_or_name(tz: &str) -> Result<FixedOffset, String> {
 }
 
 fn parse_offset(tz: &str) -> Result<FixedOffset, String> {
-    let offset_format;
     if tz.len() <= 3 {
         // +5, -12
         let hours_diff = tz.parse::<i32>().map_err(|e| e.to_string())?;
         return Ok(FixedOffset::east(hours_diff * 3600));
     }
-    if tz.contains(':') {
-        offset_format = "%:z";
-    } else {
-        offset_format = "%z";
-    }
+    let offset_format = if tz.contains(':') { "%:z" } else { "%z" };
     // apparently the easiest way to parse tz offset is parsing the complete datetime
     let date_str = format!("2020-04-12 22:10:57 {}", tz);
     let datetime =

--- a/lib/datadog/search-syntax/src/field.rs
+++ b/lib/datadog/search-syntax/src/field.rs
@@ -59,7 +59,7 @@ pub fn normalize_fields<T: AsRef<str>>(value: T) -> Vec<Field> {
             .collect();
     }
 
-    let field = match value.replace("@", "custom.") {
+    let field = match value.replace('@', "custom.") {
         v if value.starts_with('@') => Field::Facet(v),
         v if DEFAULT_FIELDS.contains(&v.as_ref()) => Field::Default(v),
         v if RESERVED_ATTRIBUTES.contains(&v.as_ref()) => Field::Reserved(v),

--- a/lib/dnsmsg-parser/src/dns_message_parser.rs
+++ b/lib/dnsmsg-parser/src/dns_message_parser.rs
@@ -1033,7 +1033,7 @@ fn parse_character_string(decoder: &mut BinDecoder<'_>) -> DnsParserResult<Strin
                 "Unexpected data length: expected {}, got {}. Raw data {}",
                 len,
                 raw_data.len(),
-                format_bytes_as_hex_string(&raw_data.to_vec())
+                format_bytes_as_hex_string(raw_data)
             ),
         }),
     }
@@ -1106,7 +1106,7 @@ fn parse_domain_name(decoder: &mut BinDecoder<'_>) -> DnsParserResult<Name> {
 }
 
 fn escape_string_for_text_representation(original_string: String) -> String {
-    original_string.replace("\\", "\\\\").replace("\"", "\\\"")
+    original_string.replace('\\', "\\\\").replace('\"', "\\\"")
 }
 
 fn parse_unknown_record_type(rtype: u16) -> Option<String> {

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -456,7 +456,7 @@ mod test {
         let mut small_files = HashSet::new();
         assert!(fingerprinter
             .get_fingerprint_or_log_error(
-                &target_dir.path().to_owned(),
+                target_dir.path(),
                 &mut buf,
                 &mut small_files,
                 &NoErrors

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -455,12 +455,7 @@ mod test {
         let mut buf = Vec::new();
         let mut small_files = HashSet::new();
         assert!(fingerprinter
-            .get_fingerprint_or_log_error(
-                target_dir.path(),
-                &mut buf,
-                &mut small_files,
-                &NoErrors
-            )
+            .get_fingerprint_or_log_error(target_dir.path(), &mut buf, &mut small_files, &NoErrors)
             .is_none());
     }
 

--- a/lib/file-source/src/paths_provider/glob.rs
+++ b/lib/file-source/src/paths_provider/glob.rs
@@ -35,9 +35,7 @@ impl<E: FileSourceInternalEvents> Glob<E> {
             .collect::<Option<_>>()?;
 
         let exclude_patterns = exclude_patterns
-            .iter()
-            .map(|path| path.to_str().map(|path| Pattern::new(path).ok()))
-            .flatten()
+            .iter().filter_map(|path| path.to_str().map(|path| Pattern::new(path).ok()))
             .collect::<Option<Vec<_>>>()?;
 
         Some(Self {

--- a/lib/file-source/src/paths_provider/glob.rs
+++ b/lib/file-source/src/paths_provider/glob.rs
@@ -35,7 +35,8 @@ impl<E: FileSourceInternalEvents> Glob<E> {
             .collect::<Option<_>>()?;
 
         let exclude_patterns = exclude_patterns
-            .iter().filter_map(|path| path.to_str().map(|path| Pattern::new(path).ok()))
+            .iter()
+            .filter_map(|path| path.to_str().map(|path| Pattern::new(path).ok()))
             .collect::<Option<Vec<_>>>()?;
 
         Some(Self {

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -45,7 +45,7 @@ pub fn get_override_name(namespace: &str, suffix: &str) -> String {
 
 /// Is the MULTINODE environment variable set?
 pub fn is_multinode() -> bool {
-    env::var("MULTINODE".to_string()).is_ok()
+    env::var("MULTINODE").is_ok()
 }
 
 /// Create config adding fullnameOverride entry. This allows multiple tests

--- a/lib/k8s-test-framework/src/kubernetes_version.rs
+++ b/lib/k8s-test-framework/src/kubernetes_version.rs
@@ -23,14 +23,14 @@ pub async fn get(kubectl_command: &str) -> Result<K8sVersion> {
     let json: serde_json::Value = serde_json::from_slice(&reader.stdout)?;
 
     Ok(K8sVersion {
-        major: json["serverVersion"]["major"].to_string().replace("\"", ""),
-        minor: json["serverVersion"]["minor"].to_string().replace("\"", ""),
+        major: json["serverVersion"]["major"].to_string().replace('\"', ""),
+        minor: json["serverVersion"]["minor"].to_string().replace('\"', ""),
         platform: json["serverVersion"]["platform"]
             .to_string()
-            .replace("\"", ""),
+            .replace('\"', ""),
         git_version: json["serverVersion"]["gitVersion"]
             .to_string()
-            .replace("\"", ""),
+            .replace('\"', ""),
     })
 }
 

--- a/lib/lookup/src/lookup_buf/segmentbuf.rs
+++ b/lib/lookup/src/lookup_buf/segmentbuf.rs
@@ -64,7 +64,7 @@ impl Arbitrary for FieldBuf {
         let name = (0..len)
             .map(|_| chars[usize::arbitrary(g) % chars.len()])
             .collect::<String>()
-            .replace(r#"""#, r#"\""#);
+            .replace('"', r#"\""#);
         FieldBuf::from(name)
     }
 
@@ -74,7 +74,7 @@ impl Arbitrary for FieldBuf {
                 .shrink()
                 .filter(|name| !name.is_empty())
                 .map(|name| {
-                    let name = name.replace(r#"""#, r#"/""#);
+                    let name = name.replace('"', r#"/""#);
                     FieldBuf::from(name)
                 }),
         )

--- a/lib/value/src/value/api.rs
+++ b/lib/value/src/value/api.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::use_self)] // I don't think Self can be used here, it creates a cycle
+
 use async_graphql::scalar;
 
 use crate::value::Value;

--- a/lib/value/src/value/display.rs
+++ b/lib/value/src/value/display.rs
@@ -9,9 +9,9 @@ impl fmt::Display for Value {
                 f,
                 r#""{}""#,
                 String::from_utf8_lossy(val)
-                    .replace(r#"\"#, r#"\\"#)
-                    .replace(r#"""#, r#"\""#)
-                    .replace("\n", r#"\n"#)
+                    .replace('\\', r#"\\"#)
+                    .replace('"', r#"\""#)
+                    .replace('\n', r#"\n"#)
             ),
             Value::Integer(val) => write!(f, "{}", val),
             Value::Float(val) => write!(f, "{}", val),

--- a/lib/value/src/value/path.rs
+++ b/lib/value/src/value/path.rs
@@ -7,6 +7,7 @@ impl Value {
     ///
     /// For example, given the path `.foo.bar` and value `true`, the return
     /// value would be an object representing `{ "foo": { "bar": true } }`.
+    #[must_use]
     pub fn at_path(mut self, path: &LookupBuf) -> Self {
         for segment in path.as_segments().iter().rev() {
             match segment {

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -335,7 +335,7 @@ impl BufferConfig {
     {
         let mut builder = TopologyBuilder::default();
 
-        for stage in self.stages.iter().copied() {
+        for stage in &self.stages {
             stage.add_to_builder(&mut builder, data_dir.clone(), buffer_id.clone())?;
         }
 

--- a/lib/vector-core/src/config/id.rs
+++ b/lib/vector-core/src/config/id.rs
@@ -18,6 +18,7 @@ impl ComponentKey {
         &self.id
     }
 
+    #[must_use]
     pub fn join<D: fmt::Display>(&self, name: D) -> Self {
         Self {
             id: format!("{}.{}", self.id, name),

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -119,6 +119,7 @@ impl Output {
     }
 
     /// Set the schema definition for this output.
+    #[must_use]
     pub fn with_schema_definition(mut self, schema_definition: schema::Definition) -> Self {
         self.log_schema_definition = Some(schema_definition);
         self
@@ -141,6 +142,7 @@ pub struct AcknowledgementsConfig {
 }
 
 impl AcknowledgementsConfig {
+    #[must_use]
     pub fn merge_default(&self, other: &Self) -> Self {
         let enabled = self.enabled.or(other.enabled);
         Self { enabled }

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -89,6 +89,7 @@ impl ProxyConfig {
     // overrides current proxy configuration with other configuration
     // if `self` is the global config and `other` the component config,
     // if both have the `http` proxy set, the one from `other` should be kept
+    #[must_use]
     pub fn merge(&self, other: &Self) -> Self {
         let no_proxy = if other.no_proxy.is_empty() {
             self.no_proxy.clone()
@@ -188,7 +189,7 @@ mod tests {
         let result = first.merge(&second).merge(&third);
         assert_eq!(result.http, Some("http://1.2.3.4:5678".into()));
         assert_eq!(result.https, Some("https://2.3.4.5:9876".into()));
-        assert!(result.no_proxy.matches(&"localhost".to_string()));
+        assert!(result.no_proxy.matches("localhost"));
     }
 
     #[test]
@@ -207,8 +208,8 @@ mod tests {
         let result = first.merge(&second);
         assert_eq!(result.http, Some("http://1.2.3.4:5678".into()));
         assert_eq!(result.https, Some("https://2.3.4.5:9876".into()));
-        assert!(!result.no_proxy.matches(&"127.0.0.1".to_string()));
-        assert!(result.no_proxy.matches(&"localhost".to_string()));
+        assert!(!result.no_proxy.matches("127.0.0.1"));
+        assert!(result.no_proxy.matches("localhost"));
     }
 
     #[test]

--- a/lib/vector-core/src/event/finalization.rs
+++ b/lib/vector-core/src/event/finalization.rs
@@ -309,6 +309,7 @@ impl EventStatus {
     /// Passing a new status of `Dropped` is a programming error and
     /// will panic in debug/test builds.
     #[allow(clippy::match_same_arms)] // False positive: https://github.com/rust-lang/rust-clippy/issues/860
+    #[must_use]
     pub fn update(self, status: Self) -> Self {
         match (self, status) {
             // `Recorded` always overwrites existing status and is never updated

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -87,11 +87,13 @@ impl LogEvent {
         )
     }
 
+    #[must_use]
     pub fn with_batch_notifier(mut self, batch: &Arc<BatchNotifier>) -> Self {
         self.metadata = self.metadata.with_batch_notifier(batch);
         self
     }
 
+    #[must_use]
     pub fn with_batch_notifier_option(mut self, batch: &Option<Arc<BatchNotifier>>) -> Self {
         self.metadata = self.metadata.with_batch_notifier_option(batch);
         self

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -58,17 +58,20 @@ impl ByteSizeOf for EventMetadata {
 
 impl EventMetadata {
     /// Replace the finalizers array with the given one.
+    #[must_use]
     pub fn with_finalizer(mut self, finalizer: EventFinalizer) -> Self {
         self.finalizers = EventFinalizers::new(finalizer);
         self
     }
 
     /// Replace the finalizer with a new one created from the given batch notifier.
+    #[must_use]
     pub fn with_batch_notifier(self, batch: &Arc<BatchNotifier>) -> Self {
         self.with_finalizer(EventFinalizer::new(Arc::clone(batch)))
     }
 
     /// Replace the finalizer with a new one created from the given optional batch notifier.
+    #[must_use]
     pub fn with_batch_notifier_option(self, batch: &Option<Arc<BatchNotifier>>) -> Self {
         match batch {
             Some(batch) => self.with_finalizer(EventFinalizer::new(Arc::clone(batch))),
@@ -77,6 +80,7 @@ impl EventMetadata {
     }
 
     /// Replace the schema definition with the given one.
+    #[must_use]
     pub fn with_schema_definition(mut self, schema_definition: &Arc<schema::Definition>) -> Self {
         self.schema_definition = Arc::clone(schema_definition);
         self

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -560,18 +560,21 @@ impl Metric {
     }
 
     #[inline]
+    #[must_use]
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
         self.series.name.name = name.into();
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn with_namespace<T: Into<String>>(mut self, namespace: Option<T>) -> Self {
         self.series.name.namespace = namespace.map(Into::into);
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn with_timestamp(mut self, timestamp: Option<DateTime<Utc>>) -> Self {
         self.data.timestamp = timestamp;
         self
@@ -581,23 +584,27 @@ impl Metric {
         self.metadata.add_finalizer(finalizer);
     }
 
+    #[must_use]
     pub fn with_batch_notifier(mut self, batch: &Arc<BatchNotifier>) -> Self {
         self.metadata = self.metadata.with_batch_notifier(batch);
         self
     }
 
+    #[must_use]
     pub fn with_batch_notifier_option(mut self, batch: &Option<Arc<BatchNotifier>>) -> Self {
         self.metadata = self.metadata.with_batch_notifier_option(batch);
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn with_tags(mut self, tags: Option<MetricTags>) -> Self {
         self.series.tags = tags;
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn with_value(mut self, value: MetricValue) -> Self {
         self.data.value = value;
         self
@@ -618,6 +625,7 @@ impl Metric {
     }
 
     /// Rewrite this into a Metric with the data marked as absolute.
+    #[must_use]
     pub fn into_absolute(self) -> Self {
         Self {
             series: self.series,
@@ -627,6 +635,7 @@ impl Metric {
     }
 
     /// Rewrite this into a Metric with the data marked as incremental.
+    #[must_use]
     pub fn into_incremental(self) -> Self {
         Self {
             series: self.series,
@@ -811,6 +820,7 @@ impl MetricSeries {
 
 impl MetricData {
     /// Rewrite this data to mark it as absolute.
+    #[must_use]
     pub fn into_absolute(self) -> Self {
         Self {
             timestamp: self.timestamp,
@@ -820,6 +830,7 @@ impl MetricData {
     }
 
     /// Rewrite this data to mark it as incremental.
+    #[must_use]
     pub fn into_incremental(self) -> Self {
         Self {
             timestamp: self.timestamp,

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -257,6 +257,7 @@ impl Event {
         }
     }
 
+    #[must_use]
     pub fn with_batch_notifier(self, batch: &Arc<BatchNotifier>) -> Self {
         match self {
             Self::Log(log) => log.with_batch_notifier(batch).into(),
@@ -265,6 +266,7 @@ impl Event {
         }
     }
 
+    #[must_use]
     pub fn with_batch_notifier_option(self, batch: &Option<Arc<BatchNotifier>>) -> Self {
         match self {
             Self::Log(log) => log.with_batch_notifier_option(batch).into(),

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -382,7 +382,8 @@ impl From<sketch::AgentDdSketch> for MetricSketch {
             .into_iter()
             .map(|k| (k, k > 0))
             .map(|(k, pos)| {
-                k.try_into().unwrap_or(if pos { i16::MAX } else { i16::MIN })
+                k.try_into()
+                    .unwrap_or(if pos { i16::MAX } else { i16::MIN })
             })
             .collect::<Vec<_>>();
         let counts = sketch

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -382,8 +382,7 @@ impl From<sketch::AgentDdSketch> for MetricSketch {
             .into_iter()
             .map(|k| (k, k > 0))
             .map(|(k, pos)| {
-                k.try_into()
-                    .unwrap_or_else(|_| if pos { i16::MAX } else { i16::MIN })
+                k.try_into().unwrap_or(if pos { i16::MAX } else { i16::MIN })
             })
             .collect::<Vec<_>>();
         let counts = sketch

--- a/lib/vector-core/src/event/util/log/all_fields.rs
+++ b/lib/vector-core/src/event/util/log/all_fields.rs
@@ -75,7 +75,7 @@ impl<'a> FieldsIter<'a> {
                 None => return res,
                 Some(PathComponent::Key(key)) => {
                     if key.contains('.') {
-                        res.push_str(&key.replace(".", "\\."));
+                        res.push_str(&key.replace('.', "\\."));
                     } else {
                         res.push_str(key);
                     }

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -56,6 +56,7 @@ impl Definition {
     /// - Provided path is a root path (e.g. `.`).
     /// - Provided path points to a root-level array (e.g. `.[0]`).
     /// - Provided path has one or more coalesced segments (e.g. `.(foo | bar)`).
+    #[must_use]
     pub fn required_field(
         mut self,
         path: impl Into<LookupBuf>,
@@ -102,6 +103,7 @@ impl Definition {
     /// # Panics
     ///
     /// See `Definition::require_field`.
+    #[must_use]
     pub fn optional_field(
         mut self,
         path: impl Into<LookupBuf>,
@@ -115,6 +117,7 @@ impl Definition {
     }
 
     /// Set the kind for all unknown fields.
+    #[must_use]
     pub fn unknown_fields(mut self, unknown: impl Into<Option<Kind>>) -> Self {
         self.collection.set_unknown(unknown);
         self
@@ -134,6 +137,7 @@ impl Definition {
     /// example, `.foo` might be set as optional, but `.foo.bar` as required. In this case, it
     /// means that the object at `.foo` is allowed to be missing, but if it's present, then it's
     /// required to have a `bar` field.
+    #[must_use]
     pub fn merge(mut self, other: Self) -> Self {
         let mut optional = BTreeSet::default();
 

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -436,7 +436,7 @@ mod tests {
 
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             assert!(
-                !self.permit.is_some(),
+                self.permit.is_none(),
                 "should not call poll_ready again after a successful call"
             );
 

--- a/lib/vrl/diagnostic/src/diagnostic.rs
+++ b/lib/vrl/diagnostic/src/diagnostic.rs
@@ -132,7 +132,7 @@ impl From<Diagnostic> for diagnostic::Diagnostic<()> {
             severity: diag.severity.into(),
             code: Some(format!("E{:03}", diag.code)),
             message: diag.message.to_string(),
-            labels: diag.labels.to_vec().into_iter().map(Into::into).collect(),
+            labels: diag.labels.iter().cloned().map(Into::into).collect(),
             notes: notes.iter().map(ToString::to_string).collect(),
         }
     }

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -947,7 +947,7 @@ impl<'input> Lexer<'input> {
                 self.bump();
                 let (end, float) = self.take_while(start, |ch| is_digit(ch) || ch == '_');
 
-                match float.replace("_", "").parse() {
+                match float.replace('_', "").parse() {
                     Ok(float) => {
                         let float = NotNan::new(float).unwrap();
                         Ok((start, Token::FloatLiteral(float), end))
@@ -959,7 +959,7 @@ impl<'input> Lexer<'input> {
                     }),
                 }
             }
-            None | Some(_) => match int.replace("_", "").parse() {
+            None | Some(_) => match int.replace('_', "").parse() {
                 Ok(int) => Ok((start, Token::IntegerLiteral(int), end)),
                 Err(err) => Err(Error::NumericLiteral {
                     start,

--- a/lib/vrl/proptests/src/main.rs
+++ b/lib/vrl/proptests/src/main.rs
@@ -79,7 +79,7 @@ prop_compose! {
 
 prop_compose! {
     fn string_literal()(val in "[^\"\\\\\\)\\}]*") -> Literal {
-        Literal::String(val.replace("\\", "\\\\").replace("\"", "\\\""))
+        Literal::String(val.replace('\\', "\\\\").replace('\"', "\\\""))
     }
 }
 

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -150,7 +150,9 @@ impl Function for Log {
             .required_any("level")
             .downcast_ref::<LogInfo>()
             .unwrap();
-        let rate_limit_secs = args.optional("rate_limit_secs").unwrap_or(value!(1));
+        let rate_limit_secs = args
+            .optional("rate_limit_secs")
+            .unwrap_or_else(|| value!(1));
         log(rate_limit_secs, &info.level, value, info.span)
     }
 }

--- a/lib/vrl/stdlib/src/match_datadog_query.rs
+++ b/lib/vrl/stdlib/src/match_datadog_query.rs
@@ -410,7 +410,7 @@ impl Filter<Value> for VrlFilter {
             Field::Tag(_) => resolve_value(
                 buf,
                 Run::boxed(move |value| match value {
-                    Value::Array(v) => v.iter().any(|v| match string_value(v).split_once(":") {
+                    Value::Array(v) => v.iter().any(|v| match string_value(v).split_once(':') {
                         Some((_, lhs)) => {
                             let lhs = Cow::from(lhs);
 

--- a/lib/vrl/tests/src/docs.rs
+++ b/lib/vrl/tests/src/docs.rs
@@ -107,14 +107,12 @@ fn examples_to_tests(
 ) -> Box<dyn Iterator<Item = Test>> {
     Box::new(
         examples
-            .into_iter()
-            .map(move |(k, v)| {
+            .into_iter().flat_map(move |(k, v)| {
                 v.examples
                     .into_iter()
                     .map(|example| Test::from_cue_example(category, k.clone(), example))
                     .collect::<Vec<_>>()
-            })
-            .flatten(),
+            }),
     )
 }
 

--- a/lib/vrl/tests/src/docs.rs
+++ b/lib/vrl/tests/src/docs.rs
@@ -105,15 +105,12 @@ fn examples_to_tests(
     category: &'static str,
     examples: HashMap<String, Examples>,
 ) -> Box<dyn Iterator<Item = Test>> {
-    Box::new(
-        examples
-            .into_iter().flat_map(move |(k, v)| {
-                v.examples
-                    .into_iter()
-                    .map(|example| Test::from_cue_example(category, k.clone(), example))
-                    .collect::<Vec<_>>()
-            }),
-    )
+    Box::new(examples.into_iter().flat_map(move |(k, v)| {
+        v.examples
+            .into_iter()
+            .map(|example| Test::from_cue_example(category, k.clone(), example))
+            .collect::<Vec<_>>()
+    }))
 }
 
 impl Test {

--- a/lib/vrl/tests/src/test.rs
+++ b/lib/vrl/tests/src/test.rs
@@ -144,5 +144,5 @@ fn test_name(path: &Path) -> String {
         .unwrap()
         .1
         .trim_end_matches(".vrl")
-        .replace("_", " ")
+        .replace('_', " ")
 }

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -233,7 +233,7 @@ impl Filter<LogEvent> for EventFilter {
                 )
             }
             // Tag values need extracting by "key:value" to be compared.
-            Field::Tag(tag) => any_string_match("tags", move |value| match value.split_once(":") {
+            Field::Tag(tag) => any_string_match("tags", move |value| match value.split_once(':') {
                 Some((t, lhs)) if t == tag => {
                     let lhs = Cow::from(lhs);
 

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -103,7 +103,7 @@ pub async fn build_unit_tests(
             Err(errors) => {
                 let mut test_error = errors.join("\n");
                 // Indent all line breaks
-                test_error = test_error.replace("\n", "\n  ");
+                test_error = test_error.replace('\n', "\n  ");
                 test_error.insert_str(0, &format!("Failed to build test '{}':\n  ", test_name));
                 build_errors.push(test_error);
             }
@@ -183,7 +183,7 @@ impl UnitTestBuildMetadata {
                     key.clone(),
                     format!(
                         "{}-{}-{}",
-                        key.to_string().replace(".", "-"),
+                        key.to_string().replace('.', "-"),
                         "sink",
                         random_id
                     ),
@@ -375,7 +375,7 @@ async fn build_unit_test(
         .iter()
         .filter_map(|component| {
             component
-                .split_once(".")
+                .split_once('.')
                 .map(|(original_name, _)| original_name.to_string())
         })
         .collect::<Vec<_>>();
@@ -566,7 +566,7 @@ fn build_input_event(input: &TestInput) -> Result<Event, String> {
                             NotNan::new(*f).map_err(|_| "NaN value not supported".to_string())?,
                         ),
                     };
-                    event.as_mut_log().insert(path.to_owned(), value);
+                    event.as_mut_log().insert(path, value);
                 }
                 Ok(event)
             } else {

--- a/src/encoding_transcode.rs
+++ b/src/encoding_transcode.rs
@@ -206,7 +206,7 @@ mod tests {
     }
 
     const fn test_data_utf16le_vector_devanagari() -> &'static [u8] {
-        b"-\tG\t\x15\tM\t\x1f\tx00\t"
+        b"-\tG\t\x15\tM\t\x1f\t0\t"
     }
 
     // test UTF_16BE data
@@ -219,7 +219,7 @@ mod tests {
     }
 
     const fn test_data_utf16be_vector_devanagari() -> &'static [u8] {
-        b"\t-\tG\t\x15\tM\t\x1f\tx00"
+        b"\t-\tG\t\x15\tM\t\x1f\t0"
     }
 
     // test SHIFT_JIS data

--- a/src/encoding_transcode.rs
+++ b/src/encoding_transcode.rs
@@ -198,28 +198,28 @@ mod tests {
 
     // test UTF_16LE data
     const fn test_data_utf16le_123() -> &'static [u8] {
-        b"1\02\03\0"
+        b"1\x002\x003\x00"
     }
 
     const fn test_data_utf16le_crlf() -> &'static [u8] {
-        b"\r\0\n\0"
+        b"\r\x00\n\x00"
     }
 
     const fn test_data_utf16le_vector_devanagari() -> &'static [u8] {
-        b"-\tG\t\x15\tM\t\x1f\t0\t"
+        b"-\tG\t\x15\tM\t\x1f\tx00\t"
     }
 
     // test UTF_16BE data
     const fn test_data_utf16be_123() -> &'static [u8] {
-        b"\01\02\03"
+        b"\x001\x002\x003"
     }
 
     const fn test_data_utf16be_crlf() -> &'static [u8] {
-        b"\0\r\0\n"
+        b"\x00\r\x00\n"
     }
 
     const fn test_data_utf16be_vector_devanagari() -> &'static [u8] {
-        b"\t-\tG\t\x15\tM\t\x1f\t0"
+        b"\t-\tG\t\x15\tM\t\x1f\tx00"
     }
 
     // test SHIFT_JIS data

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -86,7 +86,7 @@ impl<V: 'static> Fields<V> {
     pub fn all_fields(self) -> impl Iterator<Item = (String, V)> {
         self.0
             .into_iter()
-            .map(|(k, v)| -> Box<dyn Iterator<Item = (String, V)>> {
+            .flat_map(|(k, v)| -> Box<dyn Iterator<Item = (String, V)>> {
                 match v {
                     // boxing is used as a way to avoid incompatible types of the match arms
                     FieldsOrValue::Value(v) => Box::new(std::iter::once((k, v))),
@@ -96,7 +96,6 @@ impl<V: 'static> Fields<V> {
                     ),
                 }
             })
-            .flatten()
     }
 }
 

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -175,7 +175,7 @@ fn set_uri_query(uri: &Uri, database: &str, table: &str, skip_unknown: bool) -> 
             format!(
                 "INSERT INTO \"{}\".\"{}\" FORMAT JSONEachRow",
                 database,
-                table.replace("\"", "\\\"")
+                table.replace('\"', "\\\"")
             )
             .as_str(),
         )

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -404,7 +404,7 @@ impl Default for DatadogArchivesEncoding {
     fn default() -> Self {
         Self {
             inner: StandardEncodings::Ndjson,
-            reserved_attributes: RESERVED_ATTRIBUTES.to_vec().into_iter().collect(),
+            reserved_attributes: RESERVED_ATTRIBUTES.iter().copied().collect(),
             id_rnd_bytes: thread_rng().gen::<[u8; 8]>(),
             id_seq_number: AtomicU32::new(0),
             log_schema: log_schema(),

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -171,7 +171,7 @@ impl HttpSink for InfluxDbLogsSink {
 
     fn encode_event(&self, event: Event) -> Option<Self::Input> {
         let mut event = event.into_log();
-        event.insert("metric_type".to_string(), "logs".to_string());
+        event.insert("metric_type", "logs".to_string());
         self.encoding.apply_rules(&mut event);
 
         // Timestamp

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -179,7 +179,7 @@ pub(in crate::sinks) fn influx_line_protocol(
     line_protocol: &mut BytesMut,
 ) -> Result<(), &'static str> {
     // Fields
-    let unwrapped_fields = fields.unwrap_or_else(HashMap::new);
+    let unwrapped_fields = fields.unwrap_or_default();
     // LineProtocol should have a field
     if unwrapped_fields.is_empty() {
         return Err("fields must not be empty");

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -91,7 +91,7 @@ impl LimitParams {
             self.knee_start
                 .map(|knee| {
                     self.knee_exp
-                        .unwrap_or_else(|| self.scale + 1.0)
+                        .unwrap_or(self.scale + 1.0)
                         .powf(level.saturating_sub(knee) as f64)
                         - 1.0
                 })

--- a/src/sinks/util/buffer/vec.rs
+++ b/src/sinks/util/buffer/vec.rs
@@ -55,7 +55,7 @@ impl<T: EncodedLength> Batch for VecBuffer<T> {
     }
 
     fn finish(self) -> Self::Output {
-        self.batch.unwrap_or_else(Vec::new)
+        self.batch.unwrap_or_default()
     }
 
     fn num_items(&self) -> usize {

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -201,12 +201,9 @@ pub fn protocol_endpoint(uri: Uri) -> (String, String) {
 mod tests {
     use super::*;
 
-    fn test_parse(input: &str, expected_uri: &str, expected_auth: Option<(&str, &str)>) {
+    fn test_parse(input: &str, expected_uri: &'static str, expected_auth: Option<(&str, &str)>) {
         let UriSerde { uri, auth } = input.parse().unwrap();
-        assert_eq!(
-            uri,
-            Uri::from_maybe_shared(expected_uri.to_owned()).unwrap()
-        );
+        assert_eq!(uri, Uri::from_static(expected_uri));
         assert_eq!(
             auth,
             expected_auth.map(|(user, password)| {

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -642,7 +642,7 @@ fn into_vector_metric(
         .unwrap_or_default()
         .iter()
         .map(|tag| {
-            let kv = tag.split_once(":").unwrap_or((tag, ""));
+            let kv = tag.split_once(':').unwrap_or((tag, ""));
             (kv.0.trim().into(), kv.1.trim().into())
         })
         .collect();

--- a/src/sources/datadog/sketch_parser.rs
+++ b/src/sources/datadog/sketch_parser.rs
@@ -32,7 +32,7 @@ pub(crate) fn decode_ddsketch(
                 .tags
                 .iter()
                 .map(|tag| {
-                    let kv = tag.split_once(":").unwrap_or((tag, ""));
+                    let kv = tag.split_once(':').unwrap_or((tag, ""));
                     (kv.0.trim().into(), kv.1.trim().into())
                 })
                 .collect();

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -169,7 +169,7 @@ impl<'a> DnstapParser<'a> {
         if need_raw_data {
             self.insert(
                 self.event_schema.dnstap_root_data_schema().raw_data(),
-                base64::encode(&frame.to_vec()),
+                base64::encode(&frame),
             );
         }
 

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -1048,7 +1048,7 @@ mod tests {
         };
 
         let hashset =
-            |v: &[&str]| -> HashSet<String> { v.to_vec().into_iter().map(String::from).collect() };
+            |v: &[&str]| -> HashSet<String> { v.iter().copied().map(String::from).collect() };
 
         let matches = journald_config.merged_include_matches().unwrap();
         let units = matches.get("_SYSTEMD_UNIT").unwrap();

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -511,7 +511,7 @@ impl PostgresqlMetrics {
                 });
                 emit!(&EventsReceived { count, byte_size });
                 self.client.set((client, client_version));
-                Ok(result.into_iter().map(|(metrics, _)| metrics).flatten())
+                Ok(result.into_iter().flat_map(|(metrics, _)| metrics))
             }
             Err(error) => Err(error.to_string()),
         }

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -165,7 +165,7 @@ fn parse_direction(input: &str) -> Result<Option<f64>, ParseError> {
 }
 
 fn sanitize_key(key: &str) -> String {
-    let s = key.replace("/", "-");
+    let s = key.replace('/', "'-");
     let s = WHITESPACE.replace_all(&s, "_");
     let s = NONALPHANUM.replace_all(&s, "");
     s.into()

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -490,7 +490,7 @@ mod test {
         }
 
         assert_event_data_eq!(
-            event_from_bytes(&"host".to_string(), None, raw.into()).unwrap(),
+            event_from_bytes("host", None, raw.into()).unwrap(),
             expected
         );
     }
@@ -520,7 +520,7 @@ mod test {
             expected.insert("procid", 8449);
         }
 
-        let event = event_from_bytes(&"host".to_string(), None, raw.into()).unwrap();
+        let event = event_from_bytes("host", None, raw.into()).unwrap();
         assert_event_data_eq!(event, expected);
 
         let raw = format!(
@@ -528,7 +528,7 @@ mod test {
             r#"[incorrect x=]"#, msg
         );
 
-        let event = event_from_bytes(&"host".to_string(), None, raw.into()).unwrap();
+        let event = event_from_bytes("host", None, raw.into()).unwrap();
         assert_event_data_eq!(event, expected);
     }
 
@@ -547,7 +547,7 @@ mod test {
             r#"[empty]"#
         );
 
-        let event = event_from_bytes(&"host".to_string(), None, msg.into()).unwrap();
+        let event = event_from_bytes("host", None, msg.into()).unwrap();
         assert!(there_is_map_called_empty(event));
 
         let msg = format!(
@@ -555,7 +555,7 @@ mod test {
             r#"[non_empty x="1"][empty]"#
         );
 
-        let event = event_from_bytes(&"host".to_string(), None, msg.into()).unwrap();
+        let event = event_from_bytes("host", None, msg.into()).unwrap();
         assert!(there_is_map_called_empty(event));
 
         let msg = format!(
@@ -563,7 +563,7 @@ mod test {
             r#"[empty][non_empty x="1"]"#
         );
 
-        let event = event_from_bytes(&"host".to_string(), None, msg.into()).unwrap();
+        let event = event_from_bytes("host", None, msg.into()).unwrap();
         assert!(there_is_map_called_empty(event));
 
         let msg = format!(
@@ -571,7 +571,7 @@ mod test {
             r#"[empty not_really="testing the test"]"#
         );
 
-        let event = event_from_bytes(&"host".to_string(), None, msg.into()).unwrap();
+        let event = event_from_bytes("host", None, msg.into()).unwrap();
         assert!(!there_is_map_called_empty(event));
     }
 
@@ -584,8 +584,8 @@ mod test {
         let cleaned = r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - [meta sequenceId="1"] i am foobar"#;
 
         assert_event_data_eq!(
-            event_from_bytes(&"host".to_string(), None, raw.to_owned().into()).unwrap(),
-            event_from_bytes(&"host".to_string(), None, cleaned.to_owned().into()).unwrap()
+            event_from_bytes("host", None, raw.to_owned().into()).unwrap(),
+            event_from_bytes("host", None, cleaned.to_owned().into()).unwrap()
         );
     }
 
@@ -593,7 +593,7 @@ mod test {
     fn syslog_ng_default_network() {
         let msg = "i am foobar";
         let raw = format!(r#"<13>Feb 13 20:07:26 74794bfb6795 root[8539]: {}"#, msg);
-        let event = event_from_bytes(&"host".to_string(), None, raw.into()).unwrap();
+        let event = event_from_bytes("host", None, raw.into()).unwrap();
 
         let mut expected = Event::from(msg);
         {
@@ -623,7 +623,7 @@ mod test {
             r#"<190>Feb 13 21:31:56 74794bfb6795 liblogging-stdlog:  [origin software="rsyslogd" swVersion="8.24.0" x-pid="8979" x-info="http://www.rsyslog.com"] {}"#,
             msg
         );
-        let event = event_from_bytes(&"host".to_string(), None, raw.into()).unwrap();
+        let event = event_from_bytes("host", None, raw.into()).unwrap();
 
         let mut expected = Event::from(msg);
         {
@@ -679,7 +679,7 @@ mod test {
         }
 
         assert_event_data_eq!(
-            event_from_bytes(&"host".to_string(), None, raw.into()).unwrap(),
+            event_from_bytes("host", None, raw.into()).unwrap(),
             expected
         );
     }

--- a/src/sources/util/tcp/mod.rs
+++ b/src/sources/util/tcp/mod.rs
@@ -312,7 +312,7 @@ async fn handle_stream<T>(
                         let (batch, receiver) = BatchNotifier::maybe_new_with_receiver(acknowledgements);
 
 
-                        let mut events = frames.into_iter().map(Into::into).flatten().collect::<Vec<Event>>();
+                        let mut events = frames.into_iter().flat_map(Into::into).collect::<Vec<Event>>();
                         let count = events.len();
 
                         emit!(&SocketEventsReceived {

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -141,7 +141,8 @@ impl ComponentTester {
     fn emitted_all_counters(&mut self, names: &[&str], tags: &[&str]) {
         let tag_suffix = (!tags.is_empty())
             .then(|| format!("{{{}}}", tags.join(",")))
-            .unwrap_or_else(String::new);
+            .unwrap_or_default();
+
         for name in names {
             if !self.metrics.iter().any(|m| {
                 matches!(m.value(), MetricValue::Counter { .. })

--- a/src/test_util/metrics.rs
+++ b/src/test_util/metrics.rs
@@ -92,21 +92,19 @@ impl<N: Default> Default for MetricState<N> {
 pub fn read_counter_value(metrics: &SplitMetrics, series: MetricSeries) -> Option<f64> {
     metrics
         .get(&series)
-        .map(|(data, _)| match data.value() {
+        .and_then(|(data, _)| match data.value() {
             MetricValue::Counter { value } => Some(*value),
             _ => None,
         })
-        .flatten()
 }
 
 pub fn read_gauge_value(metrics: &SplitMetrics, series: MetricSeries) -> Option<f64> {
     metrics
         .get(&series)
-        .map(|(data, _)| match data.value() {
+        .and_then(|(data, _)| match data.value() {
             MetricValue::Gauge { value } => Some(*value),
             _ => None,
         })
-        .flatten()
 }
 
 pub fn read_distribution_samples(
@@ -115,21 +113,19 @@ pub fn read_distribution_samples(
 ) -> Option<Vec<Sample>> {
     metrics
         .get(&series)
-        .map(|(data, _)| match data.value() {
+        .and_then(|(data, _)| match data.value() {
             MetricValue::Distribution { samples, .. } => Some(samples.clone()),
             _ => None,
         })
-        .flatten()
 }
 
 pub fn read_set_values(metrics: &SplitMetrics, series: MetricSeries) -> Option<HashSet<String>> {
     metrics
         .get(&series)
-        .map(|(data, _)| match data.value() {
+        .and_then(|(data, _)| match data.value() {
             MetricValue::Set { values } => Some(values.iter().cloned().collect()),
             _ => None,
         })
-        .flatten()
 }
 
 #[macro_export]

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -647,7 +647,7 @@ mod integration_tests {
 
         let metric = make_metric();
         let mut expected_metric = metric.clone();
-        for (k, v) in TEST_METADATA.iter().cloned() {
+        for (k, v) in TEST_METADATA.iter() {
             expected_metric.insert_tag(k.to_string(), v.to_string());
         }
 

--- a/src/transforms/key_value_parser.rs
+++ b/src/transforms/key_value_parser.rs
@@ -383,7 +383,7 @@ mod tests {
         .await;
         assert!(log.contains("foo"));
         assert!(log.contains("bop"));
-        assert!(log.contains(&"({score})".to_string()));
+        assert!(log.contains("({score})"));
     }
 
     #[tokio::test]

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -188,8 +188,7 @@ impl RegexParser {
 
         let names = &patterns
             .iter()
-            .map(|regex| regex.capture_names().flatten().collect::<Vec<_>>())
-            .flatten()
+            .flat_map(|regex| regex.capture_names().flatten().collect::<Vec<_>>())
             .collect::<Vec<_>>();
 
         let types =
@@ -228,8 +227,7 @@ impl RegexParser {
         drop_field = drop_field
             && !patterns
                 .iter()
-                .map(|p| &p.capture_names)
-                .flatten()
+                .flat_map(|p| &p.capture_names)
                 .any(|(_, f, _)| *f == field);
 
         Self {


### PR DESCRIPTION
The upgrade to 1.59.0 is blocked by https://github.com/rust-lang/rust-clippy/issues/8470 but I figured I'd apply the lints so far anyway.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
