### PR TITLE
chore: Remove trivial instances of getset use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8617,7 +8617,6 @@ dependencies = [
  "float_eq",
  "futures 0.3.21",
  "futures-util",
- "getset",
  "http",
  "hyper-proxy",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,18 +2691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.84",
-]
-
-[[package]]
 name = "ghost"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8366,7 +8354,6 @@ dependencies = [
  "flate2",
  "futures 0.3.21",
  "futures-util",
- "getset",
  "glob",
  "goauth",
  "gouth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,6 @@ evmap = { version = "10.0.2", default-features = false, optional = true }
 exitcode = { version = "1.1.2", default-features = false }
 flate2 = { version = "1.0.21", default-features = false, features = ["default"] }
 futures-util = { version = "0.3.21", default-features = false }
-getset = { version = "0.1.2", default-features = false, optional = true }
 glob = { version = "0.3.0", default-features = false }
 governor = { version = "0.4.1", default-features = false, features = ["dashmap", "jitter", "std"], optional = true }
 grok = { version = "1.2.0", default-features = false, optional = true }
@@ -456,7 +455,7 @@ sources-aws_kinesis_firehose = ["base64", "infer", "sources-utils-tls", "codecs"
 sources-aws_s3 = ["rusoto", "rusoto_s3", "rusoto_sqs", "semver", "codecs", "async-compression"]
 sources-aws_sqs = ["aws-config", "aws-types", "aws-sdk-sqs", "codecs", "aws-smithy-client"]
 sources-datadog_agent = ["sources-utils-tls", "sources-utils-http-error", "protobuf-build", "codecs", "value"]
-sources-dnstap = ["base64", "trust-dns-proto", "dnsmsg-parser", "protobuf-build", "getset"]
+sources-dnstap = ["base64", "trust-dns-proto", "dnsmsg-parser", "protobuf-build"]
 sources-docker_logs = ["docker"]
 sources-eventstoredb_metrics = []
 sources-exec = ["codecs"]
@@ -477,7 +476,7 @@ sources-mongodb_metrics = ["mongodb"]
 sources-nginx_metrics = ["nom"]
 sources-postgresql_metrics = ["postgres-openssl", "tokio-postgres"]
 sources-prometheus = ["prometheus-parser", "sinks-prometheus", "sources-utils-http"]
-sources-socket = ["listenfd", "tokio-util/net", "sources-utils-udp", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls", "sources-utils-unix", "codecs", "getset"]
+sources-socket = ["listenfd", "tokio-util/net", "sources-utils-udp", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls", "sources-utils-unix", "codecs"]
 sources-splunk_hec = ["sources-utils-tls", "roaring"]
 sources-statsd = ["listenfd", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls", "sources-utils-udp", "sources-utils-unix", "tokio-util/net", "codecs"]
 sources-stdin = ["codecs", "tokio-util/io"]
@@ -493,7 +492,7 @@ sources-utils-tcp-socket = []
 sources-utils-tls = []
 sources-utils-udp = []
 sources-utils-unix = []
-sources-vector = ["listenfd", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls", "tonic", "protobuf-build", "codecs", "getset"]
+sources-vector = ["listenfd", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls", "tonic", "protobuf-build", "codecs"]
 
 # Transforms
 transforms = ["transforms-logs", "transforms-metrics"]
@@ -668,7 +667,7 @@ sinks-socket = ["sinks-utils-udp"]
 sinks-splunk_hec = []
 sinks-statsd = ["sinks-utils-udp", "tokio-util/net"]
 sinks-utils-udp = []
-sinks-vector = ["sinks-utils-udp", "tonic", "protobuf-build", "getset"]
+sinks-vector = ["sinks-utils-udp", "tonic", "protobuf-build"]
 
 # Datadog integration
 datadog-pipelines = [

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -20,7 +20,6 @@ enumflags2 = { version = "0.7.3", default-features = false }
 float_eq = { version = "0.7", default-features = false }
 futures = { version = "0.3.21", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.21", default-features = false, features = ["std"] }
-getset = { version = "0.1.2", default-features = false }
 http = { version = "0.2.6", default-features = false }
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["openssl-tls"] }
 indexmap = { version = "~1.8.0", default-features = false, features = ["serde"] }

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -1,4 +1,3 @@
-use getset::{Getters, Setters};
 use once_cell::sync::{Lazy, OnceCell};
 use serde::{Deserialize, Serialize};
 
@@ -35,7 +34,7 @@ pub fn log_schema() -> &'static LogSchema {
     LOG_SCHEMA.get().unwrap_or(&LOG_SCHEMA_DEFAULT)
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Getters, Setters)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(default)]
 pub struct LogSchema {
     #[serde(default = "LogSchema::default_message_key")]

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -9,7 +9,6 @@ use std::{
 use bytes::Bytes;
 use chrono::Utc;
 use derivative::Derivative;
-use getset::{Getters, MutGetters};
 use serde::{Deserialize, Serialize, Serializer};
 use vector_common::EventDataEq;
 
@@ -20,16 +19,25 @@ use super::{
 };
 use crate::{config::log_schema, event::MaybeAsLogMut, ByteSizeOf};
 
-#[derive(Clone, Debug, Getters, MutGetters, PartialEq, PartialOrd, Derivative, Deserialize)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Derivative, Deserialize)]
 pub struct LogEvent {
     // **IMPORTANT:** Due to numerous legacy reasons this **must** be a Map variant.
     #[derivative(Default(value = "Arc::new(Value::from(BTreeMap::default()))"))]
     #[serde(flatten)]
     fields: Arc<Value>,
 
-    #[getset(get = "pub", get_mut = "pub")]
     #[serde(skip)]
     metadata: EventMetadata,
+}
+
+impl LogEvent {
+    pub fn metadata(&self) -> &EventMetadata {
+        &self.metadata
+    }
+
+    pub fn metadata_mut(&mut self) -> &mut EventMetadata {
+        &mut self.metadata
+    }
 }
 
 impl Default for LogEvent {

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 use vector_common::EventDataEq;
 
@@ -11,14 +10,12 @@ use crate::{schema, ByteSizeOf};
 
 /// The top-level metadata structure contained by both `struct Metric`
 /// and `struct LogEvent` types.
-#[derive(Clone, Debug, Deserialize, Getters, PartialEq, PartialOrd, Serialize, Setters)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct EventMetadata {
     /// Used to store the datadog API from sources to sinks
-    #[getset(get = "pub", set = "pub")]
     #[serde(default, skip)]
     datadog_api_key: Option<Arc<str>>,
     /// Used to store the Splunk HEC auth token from sources to sinks
-    #[getset(get = "pub", set = "pub")]
     #[serde(default, skip)]
     splunk_hec_token: Option<Arc<str>>,
     #[serde(default, skip)]
@@ -30,6 +27,28 @@ pub struct EventMetadata {
     /// TODO(Jean): must not skip serialization to track schemas across restarts.
     #[serde(default = "default_schema_definition", skip)]
     schema_definition: Arc<schema::Definition>,
+}
+
+impl EventMetadata {
+    /// Return the datadog API key, if it exists
+    pub fn datadog_api_key(&self) -> &Option<Arc<str>> {
+        &self.datadog_api_key
+    }
+
+    /// Set the datadog API key to passed value
+    pub fn set_datadog_api_key(&mut self, key: Option<Arc<str>>) {
+        self.datadog_api_key = key;
+    }
+
+    /// Return the splunk hec token, if it exists
+    pub fn splunk_hec_token(&self) -> &Option<Arc<str>> {
+        &self.splunk_hec_token
+    }
+
+    /// Set the splunk hec token to passed value
+    pub fn set_splunk_hec_token(&mut self, token: Option<Arc<str>>) {
+        self.splunk_hec_token = token;
+    }
 }
 
 impl Default for EventMetadata {

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -9,7 +9,6 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use float_eq::FloatEq;
-use getset::{Getters, MutGetters};
 use serde::{Deserialize, Serialize};
 use vector_common::EventDataEq;
 #[cfg(feature = "vrl")]
@@ -21,19 +20,38 @@ use crate::{
     ByteSizeOf,
 };
 
-#[derive(Clone, Debug, Deserialize, Getters, MutGetters, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct Metric {
-    #[getset(get = "pub")]
     #[serde(flatten)]
     pub(super) series: MetricSeries,
 
-    #[getset(get = "pub", get_mut = "pub")]
     #[serde(flatten)]
     pub(super) data: MetricData,
 
-    #[getset(get = "pub", get_mut = "pub")]
     #[serde(skip_serializing, default = "EventMetadata::default")]
     metadata: EventMetadata,
+}
+
+impl Metric {
+    pub fn series(&self) -> &MetricSeries {
+        &self.series
+    }
+
+    pub fn data(&self) -> &MetricData {
+        &self.data
+    }
+
+    pub fn data_mut(&mut self) -> &mut MetricData {
+        &mut self.data
+    }
+
+    pub fn metadata(&self) -> &EventMetadata {
+        &self.metadata
+    }
+
+    pub fn metadata_mut(&mut self) -> &mut EventMetadata {
+        &mut self.metadata
+    }
 }
 
 impl ByteSizeOf for Metric {
@@ -91,18 +109,29 @@ impl ByteSizeOf for MetricName {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Getters, MutGetters, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MetricData {
-    #[getset(get = "pub")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<DateTime<Utc>>,
 
-    #[getset(get = "pub")]
     pub kind: MetricKind,
 
-    #[getset(get = "pub", get_mut = "pub")]
     #[serde(flatten)]
     pub value: MetricValue,
+}
+
+impl MetricData {
+    pub fn timestamp(&self) -> &Option<DateTime<Utc>> {
+        &self.timestamp
+    }
+
+    pub fn value(&self) -> &MetricValue {
+        &self.value
+    }
+
+    pub fn value_mut(&mut self) -> &mut MetricValue {
+        &mut self.value
+    }
 }
 
 impl PartialOrd for MetricData {

--- a/src/sinks/vector/v1.rs
+++ b/src/sinks/vector/v1.rs
@@ -1,5 +1,4 @@
 use bytes::{BufMut, Bytes, BytesMut};
-use getset::Setters;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -12,17 +11,20 @@ use crate::{
     tls::TlsConfig,
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone, Setters)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfig {
     address: String,
     keepalive: Option<TcpKeepaliveConfig>,
-    #[set = "pub"]
     tls: Option<TlsConfig>,
     send_buffer_bytes: Option<usize>,
 }
 
 impl VectorConfig {
+    pub fn set_tls(&mut self, config: Option<TlsConfig>) {
+        self.tls = config;
+    }
+
     pub const fn new(
         address: String,
         keepalive: Option<TcpKeepaliveConfig>,

--- a/src/sources/dnstap/schema.rs
+++ b/src/sources/dnstap/schema.rs
@@ -1,9 +1,5 @@
-use getset::{CopyGetters, Getters, MutGetters, Setters};
-
-#[derive(Getters, MutGetters, Default, Debug, Clone)]
-#[get = "pub"]
+#[derive(Default, Debug, Clone)]
 pub struct DnstapEventSchema {
-    #[getset(get = "pub", get_mut = "pub")]
     dnstap_root_data_schema: DnstapRootDataSchema,
     dnstap_message_schema: DnstapMessageSchema,
     dns_query_message_schema: DnsQueryMessageSchema,
@@ -18,6 +14,54 @@ pub struct DnstapEventSchema {
 }
 
 impl DnstapEventSchema {
+    pub const fn dnstap_root_data_schema(&self) -> &DnstapRootDataSchema {
+        &self.dnstap_root_data_schema
+    }
+
+    pub const fn dnstap_message_schema(&self) -> &DnstapMessageSchema {
+        &self.dnstap_message_schema
+    }
+
+    pub const fn dns_query_message_schema(&self) -> &DnsQueryMessageSchema {
+        &self.dns_query_message_schema
+    }
+
+    pub const fn dns_query_header_schema(&self) -> &DnsQueryHeaderSchema {
+        &self.dns_query_header_schema
+    }
+
+    pub const fn dns_update_message_schema(&self) -> &DnsUpdateMessageSchema {
+        &self.dns_update_message_schema
+    }
+
+    pub const fn dns_update_header_schema(&self) -> &DnsUpdateHeaderSchema {
+        &self.dns_update_header_schema
+    }
+
+    pub const fn dns_message_opt_pseudo_section_schema(&self) -> &DnsMessageOptPseudoSectionSchema {
+        &self.dns_message_opt_pseudo_section_schema
+    }
+
+    pub const fn dns_message_option_schema(&self) -> &DnsMessageOptionSchema {
+        &self.dns_message_option_schema
+    }
+
+    pub const fn dns_record_schema(&self) -> &DnsRecordSchema {
+        &self.dns_record_schema
+    }
+
+    pub const fn dns_query_question_schema(&self) -> &DnsQueryQuestionSchema {
+        &self.dns_query_question_schema
+    }
+
+    pub const fn dns_update_zone_info_schema(&self) -> &DnsUpdateZoneInfoSchema {
+        &self.dns_update_zone_info_schema
+    }
+
+    pub fn dnstap_root_data_schema_mut(&mut self) -> &mut DnstapRootDataSchema {
+        &mut self.dnstap_root_data_schema
+    }
+
     pub fn new() -> Self {
         Self {
             dnstap_root_data_schema: DnstapRootDataSchema::default(),
@@ -35,15 +79,13 @@ impl DnstapEventSchema {
     }
 }
 
-#[derive(CopyGetters, Setters, Debug, Clone)]
-#[get_copy = "pub"]
+#[derive(Debug, Clone)]
 pub struct DnstapRootDataSchema {
     server_identity: &'static str,
     server_version: &'static str,
     extra: &'static str,
     data_type: &'static str,
     data_type_id: &'static str,
-    #[getset(get = "pub", set = "pub")]
     timestamp: &'static str,
     time: &'static str,
     time_precision: &'static str,
@@ -68,8 +110,54 @@ impl Default for DnstapRootDataSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnstapRootDataSchema {
+    pub const fn server_identity(&self) -> &'static str {
+        self.server_identity
+    }
+
+    pub const fn server_version(&self) -> &'static str {
+        self.server_version
+    }
+
+    pub const fn extra(&self) -> &'static str {
+        self.extra
+    }
+
+    pub const fn data_type(&self) -> &'static str {
+        self.data_type
+    }
+
+    pub const fn data_type_id(&self) -> &'static str {
+        self.data_type_id
+    }
+
+    pub const fn timestamp(&self) -> &'static str {
+        self.timestamp
+    }
+
+    pub const fn time(&self) -> &'static str {
+        self.time
+    }
+
+    pub const fn time_precision(&self) -> &'static str {
+        self.time_precision
+    }
+
+    pub const fn error(&self) -> &'static str {
+        self.error
+    }
+
+    pub const fn raw_data(&self) -> &'static str {
+        self.raw_data
+    }
+
+    pub fn set_timestamp(&mut self, val: &'static str) -> &mut Self {
+        self.timestamp = val;
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnstapMessageSchema {
     socket_family: &'static str,
     socket_protocol: &'static str,
@@ -102,8 +190,53 @@ impl Default for DnstapMessageSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnstapMessageSchema {
+    pub const fn socket_family(&self) -> &'static str {
+        self.socket_family
+    }
+
+    pub const fn socket_protocol(&self) -> &'static str {
+        self.socket_protocol
+    }
+
+    pub const fn query_address(&self) -> &'static str {
+        self.query_address
+    }
+
+    pub const fn query_port(&self) -> &'static str {
+        self.query_port
+    }
+
+    pub const fn response_address(&self) -> &'static str {
+        self.response_address
+    }
+
+    pub const fn response_port(&self) -> &'static str {
+        self.response_port
+    }
+
+    pub const fn query_zone(&self) -> &'static str {
+        self.query_zone
+    }
+
+    pub const fn dnstap_message_type(&self) -> &'static str {
+        self.dnstap_message_type
+    }
+
+    pub const fn dnstap_message_type_id(&self) -> &'static str {
+        self.dnstap_message_type_id
+    }
+
+    pub const fn request_message(&self) -> &'static str {
+        self.request_message
+    }
+
+    pub const fn response_message(&self) -> &'static str {
+        self.response_message
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsMessageCommonSchema {
     response_code: &'static str,
     response: &'static str,
@@ -126,8 +259,33 @@ impl Default for DnsMessageCommonSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsMessageCommonSchema {
+    pub const fn response_code(&self) -> &'static str {
+        self.response_code
+    }
+
+    pub const fn response(&self) -> &'static str {
+        self.response
+    }
+
+    pub const fn time(&self) -> &'static str {
+        self.time
+    }
+
+    pub const fn time_precision(&self) -> &'static str {
+        self.time_precision
+    }
+
+    pub const fn raw_data(&self) -> &'static str {
+        self.raw_data
+    }
+
+    pub const fn header(&self) -> &'static str {
+        self.header
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsQueryMessageSchema {
     response_code: &'static str,
     response: &'static str,
@@ -161,8 +319,53 @@ impl Default for DnsQueryMessageSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsQueryMessageSchema {
+    pub const fn response_code(&self) -> &'static str {
+        self.response_code
+    }
+
+    pub const fn response(&self) -> &'static str {
+        self.response
+    }
+
+    pub const fn time(&self) -> &'static str {
+        self.time
+    }
+
+    pub const fn time_precision(&self) -> &'static str {
+        self.time_precision
+    }
+
+    pub const fn raw_data(&self) -> &'static str {
+        self.raw_data
+    }
+
+    pub const fn header(&self) -> &'static str {
+        self.header
+    }
+
+    pub const fn question_section(&self) -> &'static str {
+        self.question_section
+    }
+
+    pub const fn answer_section(&self) -> &'static str {
+        self.answer_section
+    }
+
+    pub const fn authority_section(&self) -> &'static str {
+        self.authority_section
+    }
+
+    pub const fn additional_section(&self) -> &'static str {
+        self.additional_section
+    }
+
+    pub const fn opt_pseudo_section(&self) -> &'static str {
+        self.opt_pseudo_section
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsUpdateMessageSchema {
     response_code: &'static str,
     response: &'static str,
@@ -194,8 +397,49 @@ impl Default for DnsUpdateMessageSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsUpdateMessageSchema {
+    pub const fn response_code(&self) -> &'static str {
+        self.response_code
+    }
+
+    pub const fn response(&self) -> &'static str {
+        self.response
+    }
+
+    pub const fn time(&self) -> &'static str {
+        self.time
+    }
+
+    pub const fn time_precision(&self) -> &'static str {
+        self.time_precision
+    }
+
+    pub const fn raw_data(&self) -> &'static str {
+        self.raw_data
+    }
+
+    pub const fn header(&self) -> &'static str {
+        self.header
+    }
+
+    pub const fn zone_section(&self) -> &'static str {
+        self.zone_section
+    }
+
+    pub const fn prerequisite_section(&self) -> &'static str {
+        self.prerequisite_section
+    }
+
+    pub const fn update_section(&self) -> &'static str {
+        self.update_section
+    }
+
+    pub const fn additional_section(&self) -> &'static str {
+        self.additional_section
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsMessageHeaderCommonSchema {
     id: &'static str,
     opcode: &'static str,
@@ -214,8 +458,83 @@ impl Default for DnsMessageHeaderCommonSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsMessageHeaderCommonSchema {
+    pub const fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub const fn opcode(&self) -> &'static str {
+        self.opcode
+    }
+
+    pub const fn rcode(&self) -> &'static str {
+        self.rcode
+    }
+
+    pub const fn qr(&self) -> &'static str {
+        self.qr
+    }
+}
+
+impl DnsQueryHeaderSchema {
+    pub const fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub const fn opcode(&self) -> &'static str {
+        self.opcode
+    }
+
+    pub const fn rcode(&self) -> &'static str {
+        self.rcode
+    }
+
+    pub const fn qr(&self) -> &'static str {
+        self.qr
+    }
+
+    pub const fn aa(&self) -> &'static str {
+        self.aa
+    }
+
+    pub const fn tc(&self) -> &'static str {
+        self.tc
+    }
+
+    pub const fn rd(&self) -> &'static str {
+        self.rd
+    }
+
+    pub const fn ra(&self) -> &'static str {
+        self.ra
+    }
+
+    pub const fn ad(&self) -> &'static str {
+        self.ad
+    }
+
+    pub const fn cd(&self) -> &'static str {
+        self.cd
+    }
+
+    pub const fn question_count(&self) -> &'static str {
+        self.question_count
+    }
+
+    pub const fn answer_count(&self) -> &'static str {
+        self.answer_count
+    }
+
+    pub const fn authority_count(&self) -> &'static str {
+        self.authority_count
+    }
+
+    pub const fn additional_count(&self) -> &'static str {
+        self.additional_count
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsQueryHeaderSchema {
     id: &'static str,
     opcode: &'static str,
@@ -255,8 +574,41 @@ impl Default for DnsQueryHeaderSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsUpdateHeaderSchema {
+    pub const fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub const fn opcode(&self) -> &'static str {
+        self.opcode
+    }
+
+    pub const fn rcode(&self) -> &'static str {
+        self.rcode
+    }
+
+    pub const fn qr(&self) -> &'static str {
+        self.qr
+    }
+
+    pub const fn zone_count(&self) -> &'static str {
+        self.zone_count
+    }
+
+    pub const fn prerequisite_count(&self) -> &'static str {
+        self.prerequisite_count
+    }
+
+    pub const fn update_count(&self) -> &'static str {
+        self.update_count
+    }
+
+    pub const fn additional_count(&self) -> &'static str {
+        self.additional_count
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsUpdateHeaderSchema {
     id: &'static str,
     opcode: &'static str,
@@ -284,8 +636,7 @@ impl Default for DnsUpdateHeaderSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+#[derive(Debug, Clone)]
 pub struct DnsMessageOptPseudoSectionSchema {
     extended_rcode: &'static str,
     version: &'static str,
@@ -306,8 +657,29 @@ impl Default for DnsMessageOptPseudoSectionSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsMessageOptPseudoSectionSchema {
+    pub const fn extended_rcode(&self) -> &'static str {
+        self.extended_rcode
+    }
+
+    pub const fn version(&self) -> &'static str {
+        self.version
+    }
+
+    pub const fn do_flag(&self) -> &'static str {
+        self.do_flag
+    }
+
+    pub const fn udp_max_payload_size(&self) -> &'static str {
+        self.udp_max_payload_size
+    }
+
+    pub const fn options(&self) -> &'static str {
+        self.options
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsMessageOptionSchema {
     opt_code: &'static str,
     opt_name: &'static str,
@@ -324,8 +696,21 @@ impl Default for DnsMessageOptionSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsMessageOptionSchema {
+    pub const fn opt_code(&self) -> &'static str {
+        self.opt_code
+    }
+
+    pub const fn opt_name(&self) -> &'static str {
+        self.opt_name
+    }
+
+    pub const fn opt_data(&self) -> &'static str {
+        self.opt_data
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsRecordSchema {
     name: &'static str,
     record_type: &'static str,
@@ -350,8 +735,37 @@ impl Default for DnsRecordSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsRecordSchema {
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub const fn record_type(&self) -> &'static str {
+        self.record_type
+    }
+
+    pub const fn record_type_id(&self) -> &'static str {
+        self.record_type_id
+    }
+
+    pub const fn ttl(&self) -> &'static str {
+        self.ttl
+    }
+
+    pub const fn class(&self) -> &'static str {
+        self.class
+    }
+
+    pub const fn rdata(&self) -> &'static str {
+        self.rdata
+    }
+
+    pub const fn rdata_bytes(&self) -> &'static str {
+        self.rdata_bytes
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsQueryQuestionSchema {
     name: &'static str,
     question_type: &'static str,
@@ -370,13 +784,48 @@ impl Default for DnsQueryQuestionSchema {
     }
 }
 
-#[derive(CopyGetters, Debug, Clone)]
-#[get_copy = "pub"]
+impl DnsQueryQuestionSchema {
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub const fn question_type(&self) -> &'static str {
+        self.question_type
+    }
+
+    pub const fn question_type_id(&self) -> &'static str {
+        self.question_type_id
+    }
+
+    pub const fn class(&self) -> &'static str {
+        self.class
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct DnsUpdateZoneInfoSchema {
     zone_name: &'static str,
     zone_class: &'static str,
     zone_type: &'static str,
     zone_type_id: &'static str,
+}
+
+impl DnsUpdateZoneInfoSchema {
+    pub const fn zone_name(&self) -> &'static str {
+        self.zone_name
+    }
+
+    pub const fn zone_class(&self) -> &'static str {
+        self.zone_class
+    }
+
+    pub const fn zone_type(&self) -> &'static str {
+        self.zone_type
+    }
+
+    pub const fn zone_type_id(&self) -> &'static str {
+        self.zone_type_id
+    }
 }
 
 impl Default for DnsUpdateZoneInfoSchema {

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -1,6 +1,5 @@
 use bytes::Bytes;
 use chrono::Utc;
-use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
@@ -17,27 +16,18 @@ use crate::{
     tls::TlsConfig,
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone, Getters, CopyGetters, Setters)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct TcpConfig {
-    #[get_copy = "pub"]
     address: SocketListenAddr,
-    #[get_copy = "pub"]
     keepalive: Option<TcpKeepaliveConfig>,
-    #[getset(get_copy = "pub", set = "pub")]
     max_length: Option<usize>,
     #[serde(default = "default_shutdown_timeout_secs")]
-    #[getset(get_copy = "pub", set = "pub")]
     shutdown_timeout_secs: u64,
-    #[get = "pub"]
     host_key: Option<String>,
-    #[getset(get = "pub", set = "pub")]
     tls: Option<TlsConfig>,
-    #[get_copy = "pub"]
     receive_buffer_bytes: Option<usize>,
-    #[getset(get = "pub", set = "pub")]
     framing: Option<FramingConfig>,
     #[serde(default = "default_decoding")]
-    #[getset(get = "pub", set = "pub")]
     decoding: DeserializerConfig,
     pub connection_limit: Option<u32>,
 }
@@ -86,6 +76,67 @@ impl TcpConfig {
             decoding: default_decoding(),
             connection_limit: None,
         }
+    }
+
+    pub const fn host_key(&self) -> &Option<String> {
+        &self.host_key
+    }
+
+    pub const fn tls(&self) -> &Option<TlsConfig> {
+        &self.tls
+    }
+
+    pub const fn framing(&self) -> &Option<FramingConfig> {
+        &self.framing
+    }
+
+    pub const fn decoding(&self) -> &DeserializerConfig {
+        &self.decoding
+    }
+
+    pub const fn address(&self) -> SocketListenAddr {
+        self.address
+    }
+
+    pub const fn keepalive(&self) -> Option<TcpKeepaliveConfig> {
+        self.keepalive
+    }
+
+    pub const fn max_length(&self) -> Option<usize> {
+        self.max_length
+    }
+
+    pub const fn shutdown_timeout_secs(&self) -> u64 {
+        self.shutdown_timeout_secs
+    }
+
+    pub const fn receive_buffer_bytes(&self) -> Option<usize> {
+        self.receive_buffer_bytes
+    }
+
+    pub fn set_max_length(&mut self, val: Option<usize>) -> &mut Self {
+        self.max_length = val;
+        self
+    }
+
+    pub fn set_shutdown_timeout_secs(&mut self, val: u64) -> &mut Self {
+        self.shutdown_timeout_secs = val;
+        self
+    }
+
+    pub fn set_tls(&mut self, val: Option<TlsConfig>) -> &mut Self {
+        self.tls = val;
+        self
+    }
+
+    pub fn set_framing(&mut self, val: Option<FramingConfig>) -> &mut Self {
+        self.framing = val;
+        self
+    }
+
+    pub fn set_decoding(&mut self, val: DeserializerConfig) -> &mut Self {
+        self.decoding = val;
+        self
     }
 }
 

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -3,7 +3,6 @@ use std::net::SocketAddr;
 use bytes::{Bytes, BytesMut};
 use chrono::Utc;
 use futures::StreamExt;
-use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
 use tokio_util::codec::FramedRead;
@@ -27,27 +26,45 @@ use crate::{
 };
 
 /// UDP processes messages per packet, where messages are separated by newline.
-#[derive(Deserialize, Serialize, Debug, Clone, Getters, CopyGetters)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct UdpConfig {
-    #[get_copy = "pub"]
     address: SocketAddr,
     #[serde(default = "crate::serde::default_max_length")]
-    #[get_copy = "pub"]
     max_length: usize,
-    #[get = "pub"]
     host_key: Option<String>,
-    #[get_copy = "pub"]
     receive_buffer_bytes: Option<usize>,
     #[serde(default = "default_framing_message_based")]
-    #[get = "pub"]
     framing: FramingConfig,
     #[serde(default = "default_decoding")]
-    #[get = "pub"]
     decoding: DeserializerConfig,
 }
 
 impl UdpConfig {
+    pub const fn host_key(&self) -> &Option<String> {
+        &self.host_key
+    }
+
+    pub const fn framing(&self) -> &FramingConfig {
+        &self.framing
+    }
+
+    pub const fn decoding(&self) -> &DeserializerConfig {
+        &self.decoding
+    }
+
+    pub const fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    pub const fn max_length(&self) -> usize {
+        self.max_length
+    }
+
+    pub const fn receive_buffer_bytes(&self) -> Option<usize> {
+        self.receive_buffer_bytes
+    }
+
     pub fn from_address(address: SocketAddr) -> Self {
         Self {
             address,

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use getset::Setters;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
@@ -21,14 +20,13 @@ use crate::{
     tls::{MaybeTlsSettings, TlsConfig},
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone, Setters)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct VectorConfig {
     address: SocketListenAddr,
     keepalive: Option<TcpKeepaliveConfig>,
     #[serde(default = "default_shutdown_timeout_secs")]
     shutdown_timeout_secs: u64,
-    #[set = "pub"]
     tls: Option<TlsConfig>,
     receive_buffer_bytes: Option<usize>,
 }
@@ -38,6 +36,11 @@ const fn default_shutdown_timeout_secs() -> u64 {
 }
 
 impl VectorConfig {
+    #[cfg(test)]
+    pub fn set_tls(&mut self, config: Option<TlsConfig>) {
+        self.tls = config;
+    }
+
     pub const fn from_address(address: SocketListenAddr) -> Self {
         Self {
             address,

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -37,6 +37,8 @@ const fn default_shutdown_timeout_secs() -> u64 {
 
 impl VectorConfig {
     #[cfg(test)]
+    #[allow(unused)] // this test function is not always used in test, breaking
+                     // our cargo-hack run
     pub fn set_tls(&mut self, config: Option<TlsConfig>) {
         self.tls = config;
     }


### PR DESCRIPTION
The crate getset is used in only a few places in the codebase and, in most of
those, does quiet trivial things. This commit removes those spots with the
intention of teeing up a PR to remove getset entirely. We're already seeing that
builds fail on some systems because our dependency (and thus link) list is too
long, hence the desire to remove trivial dependencies where possible.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
