### PR TITLE
fix(splunk_hec sink): Fix handling of indexer acknowledgements config

### DIFF
--- a/benches/files.rs
+++ b/benches/files.rs
@@ -56,6 +56,7 @@ fn benchmark_files_no_partitions(c: &mut Criterion) {
                         idle_timeout_secs: None,
                         encoding: sinks::file::Encoding::Text.into(),
                         compression: sinks::file::Compression::None,
+                        acknowledgements: Default::default(),
                     },
                 );
 

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -56,6 +56,7 @@ fn benchmark_http(c: &mut Criterion) {
                                 encoding: sinks::http::Encoding::Text.into(),
                                 request: Default::default(),
                                 tls: Default::default(),
+                                acknowledgements: Default::default(),
                             },
                         );
 

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -516,6 +516,7 @@ mod tests {
             BlackholeConfig {
                 print_interval_secs: 1,
                 rate: None,
+                acknowledgements: Default::default(),
             },
         );
 
@@ -570,6 +571,7 @@ mod tests {
             BlackholeConfig {
                 print_interval_secs: 1,
                 rate: None,
+                acknowledgements: Default::default(),
             },
         );
 
@@ -617,6 +619,7 @@ mod tests {
             BlackholeConfig {
                 print_interval_secs: 1,
                 rate: None,
+                acknowledgements: Default::default(),
             },
         );
 
@@ -667,6 +670,7 @@ mod tests {
             BlackholeConfig {
                 print_interval_secs: 1,
                 rate: None,
+                acknowledgements: Default::default(),
             },
         );
 
@@ -733,6 +737,7 @@ mod tests {
             BlackholeConfig {
                 print_interval_secs: 1,
                 rate: None,
+                acknowledgements: Default::default(),
             },
         );
 
@@ -790,6 +795,7 @@ mod tests {
             BlackholeConfig {
                 print_interval_secs: 1,
                 rate: None,
+                acknowledgements: Default::default(),
             },
         );
 
@@ -866,6 +872,7 @@ mod tests {
             BlackholeConfig {
                 print_interval_secs: 1,
                 rate: None,
+                acknowledgements: Default::default(),
             },
         );
 

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -234,8 +234,8 @@ mod test {
     use super::*;
     use crate::{
         config::{
-            DataType, Input, Output, SinkConfig, SinkContext, SourceConfig, SourceContext,
-            TransformConfig, TransformContext,
+            AcknowledgementsConfig, DataType, Input, Output, SinkConfig, SinkContext, SourceConfig,
+            SourceContext, TransformConfig, TransformContext,
         },
         sinks::{Healthcheck, VectorSink},
         sources::Source,
@@ -306,8 +306,8 @@ mod test {
             Input::all()
         }
 
-        fn can_acknowledge(&self) -> bool {
-            false
+        fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+            None
         }
     }
 

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -5,10 +5,7 @@ use vector_buffers::{Acker, BufferConfig, BufferType};
 use vector_core::config::{AcknowledgementsConfig, GlobalOptions, Input};
 
 use super::{component, ComponentKey, ProxyConfig, Resource};
-use crate::{
-    serde::bool_or_struct,
-    sinks::{self, util::UriSerde},
-};
+use crate::sinks::{self, util::UriSerde};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct SinkOuter<T> {
@@ -33,13 +30,6 @@ pub struct SinkOuter<T> {
 
     #[serde(flatten)]
     pub inner: Box<dyn SinkConfig>,
-
-    #[serde(
-        default,
-        deserialize_with = "bool_or_struct",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
-    pub acknowledgements: AcknowledgementsConfig,
 }
 
 impl<T> SinkOuter<T> {
@@ -51,7 +41,6 @@ impl<T> SinkOuter<T> {
             healthcheck_uri: None,
             inner,
             proxy: Default::default(),
-            acknowledgements: Default::default(),
         }
     }
 
@@ -103,7 +92,6 @@ impl<T> SinkOuter<T> {
             healthcheck: self.healthcheck,
             healthcheck_uri: self.healthcheck_uri,
             proxy: self.proxy,
-            acknowledgements: self.acknowledgements,
         }
     }
 }
@@ -156,7 +144,7 @@ pub trait SinkConfig: core::fmt::Debug + Send + Sync {
         Vec::new()
     }
 
-    fn can_acknowledge(&self) -> bool;
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig>;
 }
 
 #[derive(Debug, Clone)]

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -11,7 +11,7 @@ use vector_core::{
 
 use crate::{
     conditions::Condition,
-    config::{SinkConfig, SinkContext, SourceConfig, SourceContext},
+    config::{AcknowledgementsConfig, SinkConfig, SinkContext, SourceConfig, SourceContext},
     sinks::Healthcheck,
     sources,
 };
@@ -113,8 +113,8 @@ impl SinkConfig for UnitTestSinkConfig {
         Input::all()
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -7,7 +7,7 @@ use vector_core::config::log_schema;
 
 use crate::{
     aws::{rusoto, AwsAuthentication, RegionOrEndpoint},
-    config::{GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
     sinks::{
         aws_cloudwatch_logs::{
             healthcheck::healthcheck, request_builder::CloudwatchRequestBuilder,
@@ -44,6 +44,12 @@ pub struct CloudwatchLogsSinkConfig {
     pub assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 impl CloudwatchLogsSinkConfig {
@@ -95,8 +101,8 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
         "aws_cloudwatch_logs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 
@@ -121,6 +127,7 @@ fn default_config(e: StandardEncodings) -> CloudwatchLogsSinkConfig {
         tls: Default::default(),
         assume_role: Default::default(),
         auth: Default::default(),
+        acknowledgements: Default::default(),
     }
 }
 

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -48,6 +48,7 @@ async fn cloudwatch_insert_log_event() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -96,6 +97,7 @@ async fn cloudwatch_insert_log_events_sorted() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -163,6 +165,7 @@ async fn cloudwatch_insert_out_of_range_timestamp() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -236,6 +239,7 @@ async fn cloudwatch_dynamic_group_and_stream_creation() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -289,6 +293,7 @@ async fn cloudwatch_insert_log_event_batched() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -338,6 +343,7 @@ async fn cloudwatch_insert_log_event_partitioned() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
@@ -426,6 +432,7 @@ async fn cloudwatch_healthcheck() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let client = config.create_client(&ProxyConfig::default()).unwrap();

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -21,7 +21,9 @@ use crate::{
         auth::AwsAuthentication,
         rusoto::{self, RegionOrEndpoint},
     },
-    config::{Input, ProxyConfig, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, Input, ProxyConfig, SinkConfig, SinkContext, SinkDescription,
+    },
     event::{
         metric::{Metric, MetricValue},
         Event,
@@ -68,6 +70,12 @@ pub struct CloudWatchMetricsSinkConfig {
     assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 inventory::submit! {
@@ -97,8 +105,8 @@ impl SinkConfig for CloudWatchMetricsSinkConfig {
         "aws_cloudwatch_metrics"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/aws_kinesis_firehose/config.rs
+++ b/src/sinks/aws_kinesis_firehose/config.rs
@@ -12,7 +12,7 @@ use tower::ServiceBuilder;
 
 use crate::{
     aws::{rusoto, AwsAuthentication, RegionOrEndpoint},
-    config::{GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
     sinks::{
         aws_kinesis_firehose::{
             request_builder::KinesisRequestBuilder,
@@ -61,6 +61,12 @@ pub struct KinesisFirehoseSinkConfig {
     pub assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 #[derive(Debug, PartialEq, Snafu)]
@@ -145,8 +151,8 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
         "aws_kinesis_firehose"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/aws_kinesis_firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis_firehose/integration_tests.rs
@@ -67,6 +67,7 @@ async fn firehose_put_records() {
         tls: None,
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let cx = SinkContext::new_test();

--- a/src/sinks/aws_kinesis_firehose/tests.rs
+++ b/src/sinks/aws_kinesis_firehose/tests.rs
@@ -37,6 +37,7 @@ async fn check_batch_size() {
         tls: None,
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let cx = SinkContext::new_test();
@@ -65,6 +66,7 @@ async fn check_batch_events() {
         tls: None,
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let cx = SinkContext::new_test();

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -13,7 +13,7 @@ use crate::{
         rusoto,
         rusoto::{AwsAuthentication, RegionOrEndpoint},
     },
-    config::{GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
     sinks::{
         aws_kinesis_streams::{
             request_builder::KinesisRequestBuilder, service::KinesisService, sink::KinesisSink,
@@ -71,6 +71,12 @@ pub struct KinesisSinkConfig {
     pub assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 impl KinesisSinkConfig {
@@ -151,8 +157,8 @@ impl SinkConfig for KinesisSinkConfig {
         "aws_kinesis_streams"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/aws_kinesis_streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis_streams/integration_tests.rs
@@ -44,6 +44,7 @@ async fn kinesis_put_records() {
         tls: Default::default(),
         assume_role: None,
         auth: Default::default(),
+        acknowledgements: Default::default(),
     };
 
     let cx = SinkContext::new_test();

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -8,7 +8,7 @@ use vector_core::sink::VectorSink;
 use super::sink::S3RequestOptions;
 use crate::{
     aws::rusoto::{AwsAuthentication, RegionOrEndpoint},
-    config::{GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
     sinks::{
         s3_common::{
             self,
@@ -55,6 +55,12 @@ pub struct S3SinkConfig {
     pub assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for S3SinkConfig {
@@ -74,6 +80,7 @@ impl GenerateConfig for S3SinkConfig {
             tls: Some(TlsOptions::default()),
             assume_role: None,
             auth: AwsAuthentication::default(),
+            acknowledgements: Default::default(),
         })
         .unwrap()
     }
@@ -97,8 +104,8 @@ impl SinkConfig for S3SinkConfig {
         "aws_s3"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/aws_s3/tests.rs
+++ b/src/sinks/aws_s3/tests.rs
@@ -331,6 +331,7 @@ mod integration_tests {
             tls: Default::default(),
             assume_role: None,
             auth: Default::default(),
+            acknowledgements: Default::default(),
         }
     }
 

--- a/src/sinks/aws_sqs.rs
+++ b/src/sinks/aws_sqs.rs
@@ -20,7 +20,8 @@ use super::util::SinkBatchSettings;
 use crate::{
     aws::rusoto::{self, AwsAuthentication, RegionOrEndpoint},
     config::{
-        log_schema, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext, SinkDescription,
+        log_schema, AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig,
+        SinkContext, SinkDescription,
     },
     event::Event,
     internal_events::{AwsSqsEventSent, TemplateRenderingError},
@@ -85,6 +86,12 @@ pub struct SqsSinkConfig {
     assume_role: Option<String>,
     #[serde(default)]
     pub auth: AwsAuthentication,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -133,8 +140,8 @@ impl SinkConfig for SqsSinkConfig {
         "aws_sqs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 
@@ -436,6 +443,7 @@ mod integration_tests {
             tls: Default::default(),
             assume_role: None,
             auth: Default::default(),
+            acknowledgements: Default::default(),
         };
 
         config.clone().healthcheck(client.clone()).await.unwrap();

--- a/src/sinks/azure_blob.rs
+++ b/src/sinks/azure_blob.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use vector_core::ByteSizeOf;
 
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     event::{Event, Finalizable},
     sinks::{
         azure_common::{
@@ -44,6 +44,12 @@ pub struct AzureBlobSinkConfig {
     pub batch: BatchConfig<BulkSizeBasedDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for AzureBlobSinkConfig {
@@ -58,6 +64,7 @@ impl GenerateConfig for AzureBlobSinkConfig {
             compression: Compression::gzip_default(),
             batch: BatchConfig::default(),
             request: TowerRequestConfig::default(),
+            acknowledgements: Default::default(),
         })
         .unwrap()
     }
@@ -87,8 +94,8 @@ impl SinkConfig for AzureBlobSinkConfig {
         "azure_blob"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 
@@ -240,6 +247,7 @@ fn default_config(e: StandardEncodings) -> AzureBlobSinkConfig {
         compression: Compression::gzip_default(),
         batch: Default::default(),
         request: Default::default(),
+        acknowledgements: Default::default(),
     }
 }
 
@@ -611,6 +619,7 @@ mod integration_tests {
                 compression: Compression::None,
                 batch: Default::default(),
                 request: TowerRequestConfig::default(),
+                acknowledgements: Default::default(),
             };
 
             config.ensure_container().await;

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -14,7 +14,7 @@ use serde_json::Value as JsonValue;
 
 use super::util::batch::RealtimeSizeBasedDefaultBatchSettings;
 use crate::{
-    config::{log_schema, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{log_schema, AcknowledgementsConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::{Event, Value},
     http::HttpClient,
     sinks::{
@@ -51,6 +51,12 @@ pub struct AzureMonitorLogsConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -128,8 +134,8 @@ impl SinkConfig for AzureMonitorLogsConfig {
         "azure_monitor_logs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/blackhole/config.rs
+++ b/src/sinks/blackhole/config.rs
@@ -2,7 +2,7 @@ use futures::{future, FutureExt};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     sinks::{blackhole::sink::BlackholeSink, Healthcheck, VectorSink},
 };
 
@@ -18,6 +18,12 @@ pub struct BlackholeConfig {
     #[serde(default = "default_print_interval_secs")]
     pub print_interval_secs: u64,
     pub rate: Option<usize>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 #[async_trait::async_trait]
@@ -38,8 +44,8 @@ impl SinkConfig for BlackholeConfig {
         "blackhole"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/blackhole/mod.rs
+++ b/src/sinks/blackhole/mod.rs
@@ -27,6 +27,7 @@ mod tests {
         let config = BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         };
         let sink = BlackholeSink::new(config, Acker::passthrough());
         let sink = VectorSink::from_event_streamsink(sink);

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -7,7 +7,7 @@ use snafu::ResultExt;
 
 use super::util::batch::RealtimeSizeBasedDefaultBatchSettings;
 use crate::{
-    config::{Input, SinkConfig, SinkContext, SinkDescription},
+    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::Event,
     http::{Auth, HttpClient, HttpError, MaybeAuth},
     sinks::util::{
@@ -42,6 +42,12 @@ pub struct ClickhouseConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     pub tls: Option<TlsOptions>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 inventory::submit! {
@@ -99,8 +105,8 @@ impl SinkConfig for ClickhouseConfig {
         "clickhouse"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io;
 
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     sinks::{
         console::sink::WriterSink,
         util::encoding::{EncodingConfig, StandardEncodings},
@@ -68,8 +68,8 @@ impl SinkConfig for ConsoleSinkConfig {
         "console"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -5,7 +5,7 @@ use tower::ServiceBuilder;
 use vector_core::config::proxy::ProxyConfig;
 
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
         datadog::{
@@ -35,6 +35,13 @@ pub struct DatadogEventsConfig {
 
     #[serde(default)]
     pub request: TowerRequestConfig,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for DatadogEventsConfig {
@@ -107,8 +114,8 @@ impl SinkConfig for DatadogEventsConfig {
         "datadog_events"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -11,7 +11,7 @@ use super::{
     sink::{DatadogLogsJsonEncoding, LogSinkBuilder},
 };
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
         datadog::{get_api_validate_endpoint, healthcheck, logs::service::LogApiService, Region},
@@ -71,6 +71,13 @@ pub(crate) struct DatadogLogsConfig {
 
     #[serde(default)]
     request: TowerRequestConfig,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for DatadogLogsConfig {
@@ -170,8 +177,8 @@ impl SinkConfig for DatadogLogsConfig {
         "datadog_logs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -13,7 +13,7 @@ use super::{
     sink::DatadogMetricsSink,
 };
 use crate::{
-    config::{Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
         datadog::{get_api_validate_endpoint, get_base_domain, healthcheck, Region},
@@ -111,6 +111,12 @@ pub struct DatadogMetricsConfig {
     pub batch: BatchConfig<DatadogMetricsDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 impl_generate_config_from_default!(DatadogMetricsConfig);
@@ -134,8 +140,8 @@ impl SinkConfig for DatadogMetricsConfig {
         "datadog_metrics"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -10,7 +10,7 @@ use tower::ServiceBuilder;
 
 use crate::{
     aws::rusoto::RegionOrEndpoint,
-    config::{log_schema, DataType, Input, SinkConfig, SinkContext},
+    config::{log_schema, AcknowledgementsConfig, DataType, Input, SinkConfig, SinkContext},
     event::{EventRef, LogEvent, Value},
     http::HttpClient,
     internal_events::TemplateRenderingError,
@@ -72,6 +72,13 @@ pub struct ElasticsearchConfig {
     pub bulk: Option<BulkConfig>,
     pub data_stream: Option<DataStreamConfig>,
     pub metrics: Option<MetricToLogConfig>,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 #[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
@@ -349,8 +356,8 @@ impl SinkConfig for ElasticsearchConfig {
         "elasticsearch"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -16,7 +16,9 @@ use vector_core::{event::Finalizable, ByteSizeOf};
 
 use super::{GcpAuthConfig, GcpCredentials, Scope};
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     event::Event,
     http::HttpClient,
     serde::json::to_string,
@@ -65,6 +67,12 @@ pub struct GcsSinkConfig {
     #[serde(flatten)]
     auth: GcpAuthConfig,
     tls: Option<TlsOptions>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 #[cfg(test)]
@@ -84,6 +92,7 @@ fn default_config(e: StandardEncodings) -> GcsSinkConfig {
         request: Default::default(),
         auth: Default::default(),
         tls: Default::default(),
+        acknowledgements: Default::default(),
     }
 }
 
@@ -132,8 +141,8 @@ impl SinkConfig for GcsSinkConfig {
         NAME
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -10,7 +10,7 @@ use snafu::{ResultExt, Snafu};
 
 use super::{GcpAuthConfig, GcpCredentials, Scope};
 use crate::{
-    config::{Input, SinkConfig, SinkContext, SinkDescription},
+    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::Event,
     http::HttpClient,
     sinks::{
@@ -65,6 +65,13 @@ pub struct PubsubConfig {
     pub encoding: EncodingConfigWithDefault<Encoding>,
 
     pub tls: Option<TlsOptions>,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 const fn default_skip_authentication() -> bool {
@@ -122,8 +129,8 @@ impl SinkConfig for PubsubConfig {
         "gcp_pubsub"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -10,7 +10,7 @@ use snafu::Snafu;
 
 use super::{GcpAuthConfig, GcpCredentials, Scope};
 use crate::{
-    config::{log_schema, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{log_schema, AcknowledgementsConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::{Event, Value},
     http::HttpClient,
     sinks::{
@@ -57,6 +57,13 @@ pub struct StackdriverConfig {
     pub request: TowerRequestConfig,
 
     pub tls: Option<TlsOptions>,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -157,8 +164,8 @@ impl SinkConfig for StackdriverConfig {
         "gcp_stackdriver_logs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -7,7 +7,7 @@ use http::{header::AUTHORIZATION, HeaderValue, Uri};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    config::{Input, SinkConfig, SinkContext, SinkDescription},
+    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::{Event, Metric, MetricValue},
     http::HttpClient,
     sinks::{
@@ -44,6 +44,12 @@ pub struct StackdriverConfig {
     #[serde(default)]
     pub batch: BatchConfig<StackdriverMetricsDefaultBatchSettings>,
     pub tls: Option<TlsOptions>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 fn default_metric_namespace_value() -> String {
@@ -111,8 +117,8 @@ impl SinkConfig for StackdriverConfig {
         "gcp_stackdriver_metrics"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -9,7 +9,10 @@ use serde_json::json;
 
 use super::util::SinkBatchSettings;
 use crate::{
-    config::{log_schema, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        log_schema, AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext,
+        SinkDescription,
+    },
     event::{Event, Value},
     http::HttpClient,
     sinks::util::{
@@ -33,6 +36,13 @@ pub(super) struct HoneycombConfig {
 
     #[serde(default)]
     request: TowerRequestConfig,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -95,8 +105,8 @@ impl SinkConfig for HoneycombConfig {
         "honeycomb"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     event::Event,
     http::{Auth, HttpClient, MaybeAuth},
     internal_events::{HttpEventEncoded, HttpEventMissingMessage},
@@ -56,6 +58,12 @@ pub struct HttpSinkConfig {
     #[serde(default)]
     pub request: RequestConfig,
     pub tls: Option<TlsOptions>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 #[cfg(test)]
@@ -70,6 +78,7 @@ fn default_config(e: Encoding) -> HttpSinkConfig {
         encoding: e.into(),
         request: Default::default(),
         tls: Default::default(),
+        acknowledgements: Default::default(),
     }
 }
 
@@ -170,8 +179,8 @@ impl SinkConfig for HttpSinkConfig {
         "http"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/kafka/tests.rs
+++ b/src/sinks/kafka/tests.rs
@@ -67,6 +67,7 @@ mod integration_test {
             message_timeout_ms: 300000,
             librdkafka_options: HashMap::new(),
             headers_key: None,
+            acknowledgements: Default::default(),
         };
         self::sink::healthcheck(config).await.unwrap();
     }
@@ -121,6 +122,7 @@ mod integration_test {
             batch,
             librdkafka_options,
             headers_key: None,
+            acknowledgements: Default::default(),
         };
         let (acker, _ack_counter) = Acker::basic();
         config.clone().to_rdkafka(KafkaRole::Consumer)?;
@@ -263,6 +265,7 @@ mod integration_test {
             message_timeout_ms: 300000,
             librdkafka_options: HashMap::new(),
             headers_key: Some(headers_key.clone()),
+            acknowledgements: Default::default(),
         };
         let topic = format!("{}-{}", topic, chrono::Utc::now().format("%Y%m%d"));
         println!("Topic name generated in test: {:?}", topic);

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     event::Event,
     http::{Auth, HttpClient},
     sinks::util::{
@@ -50,6 +52,13 @@ pub(super) struct LogdnaConfig {
 
     #[serde(default)]
     request: TowerRequestConfig,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 inventory::submit! {
@@ -108,8 +117,8 @@ impl SinkConfig for LogdnaConfig {
         "logdna"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::{healthcheck::healthcheck, sink::LokiSink};
 use crate::sinks::util::Compression;
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::{Auth, HttpClient, MaybeAuth},
     sinks::{
         util::{
@@ -45,6 +45,13 @@ pub struct LokiConfig {
     pub batch: BatchConfig<LokiDefaultBatchSettings>,
 
     pub tls: Option<TlsOptions>,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -131,8 +138,8 @@ impl SinkConfig for LokiConfig {
         "loki"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -7,7 +7,9 @@ use snafu::{ResultExt, Snafu};
 use vector_buffers::Acker;
 
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     event::Event,
     internal_events::{NatsEventSendFail, NatsEventSendSuccess, TemplateRenderingError},
     sinks::util::{
@@ -84,8 +86,8 @@ impl SinkConfig for NatsSinkConfig {
         "nats"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -2,7 +2,7 @@ use super::{
     healthcheck, Encoding, NewRelicApiResponse, NewRelicApiService, NewRelicSink, NewRelicSinkError,
 };
 use crate::{
-    config::{DataType, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, DataType, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::util::{
         encoding::EncodingConfigFixed, retries::RetryLogic, service::ServiceBuilderExt,
@@ -75,6 +75,12 @@ pub struct NewRelicConfig {
     pub batch: BatchConfig<NewRelicDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 impl_generate_config_from_default!(NewRelicConfig);
@@ -135,8 +141,8 @@ impl SinkConfig for NewRelicConfig {
         "new_relic"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -7,7 +7,9 @@ use snafu::Snafu;
 
 use super::util::SinkBatchSettings;
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     sinks::{
         http::{HttpMethod, HttpSinkConfig},
         util::{
@@ -65,6 +67,12 @@ pub struct NewRelicLogsConfig {
 
     #[serde(default)]
     pub request: TowerRequestConfig,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 inventory::submit! {
@@ -112,8 +120,8 @@ impl SinkConfig for NewRelicLogsConfig {
         "new_relic_logs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 
@@ -127,6 +135,7 @@ impl NewRelicLogsConfig {
             compression: Compression::default(),
             batch: BatchConfig::default(),
             request: TowerRequestConfig::default(),
+            acknowledgements: Default::default(),
         }
     }
 
@@ -161,6 +170,7 @@ impl NewRelicLogsConfig {
             batch: batch_settings.into(),
             request,
             tls: None,
+            acknowledgements: self.acknowledgements,
         })
     }
 }

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 use syslog::{Facility, Formatter3164, LogFormat, Severity};
 
 use crate::{
-    config::{log_schema, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        log_schema, AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext,
+        SinkDescription,
+    },
     event::Event,
     internal_events::TemplateRenderingError,
     sinks::util::{
@@ -82,8 +85,8 @@ impl SinkConfig for PapertrailConfig {
         "papertrail"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -23,7 +23,10 @@ use vector_core::{buffers::Acker, event::metric::MetricSeries};
 
 use super::collector::{MetricCollector, StringCollector};
 use crate::{
-    config::{GenerateConfig, Input, Resource, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, Resource, SinkConfig, SinkContext,
+        SinkDescription,
+    },
     event::{
         metric::{Metric, MetricData, MetricKind, MetricValue},
         Event,
@@ -140,8 +143,8 @@ impl SinkConfig for PrometheusExporterConfig {
         vec![Resource::tcp(self.address)]
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 
@@ -172,8 +175,8 @@ impl SinkConfig for PrometheusCompatConfig {
         self.config.resources()
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -11,7 +11,7 @@ use vector_core::ByteSizeOf;
 
 use super::collector::{self, MetricCollector as _};
 use crate::{
-    config::{self, Input, SinkConfig, SinkDescription},
+    config::{self, AcknowledgementsConfig, Input, SinkConfig, SinkDescription},
     event::{Event, Metric},
     http::{Auth, HttpClient},
     internal_events::TemplateRenderingError,
@@ -148,8 +148,8 @@ impl SinkConfig for RemoteWriteConfig {
         "prometheus_remote_write"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -14,7 +14,10 @@ use snafu::{ResultExt, Snafu};
 use vector_buffers::Acker;
 
 use crate::{
-    config::{log_schema, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        log_schema, AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext,
+        SinkDescription,
+    },
     event::Event,
     internal_events::PulsarEncodeEventFailed,
     sinks::util::encoding::{EncodingConfig, EncodingConfiguration},
@@ -118,8 +121,8 @@ impl SinkConfig for PulsarSinkConfig {
         "pulsar"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -13,7 +13,10 @@ use vector_core::ByteSizeOf;
 
 use super::util::SinkBatchSettings;
 use crate::{
-    config::{log_schema, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        log_schema, AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext,
+        SinkDescription,
+    },
     event::Event,
     internal_events::{RedisEventSent, RedisSendEventFailed, TemplateRenderingError},
     sinks::util::{
@@ -102,6 +105,12 @@ pub struct RedisSinkConfig {
     batch: BatchConfig<RedisDefaultBatchSettings>,
     #[serde(default)]
     request: TowerRequestConfig,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for RedisSinkConfig {
@@ -144,8 +153,8 @@ impl SinkConfig for RedisSinkConfig {
         "redis"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 
@@ -458,6 +467,7 @@ mod integration_tests {
                 rate_limit_num: Option::from(u64::MAX),
                 ..Default::default()
             },
+            acknowledgements: Default::default(),
         };
 
         // Publish events.
@@ -516,6 +526,7 @@ mod integration_tests {
                 rate_limit_num: Option::from(u64::MAX),
                 ..Default::default()
             },
+            acknowledgements: Default::default(),
         };
 
         // Publish events.
@@ -587,6 +598,7 @@ mod integration_tests {
                 rate_limit_num: Option::from(u64::MAX),
                 ..Default::default()
             },
+            acknowledgements: Default::default(),
         };
 
         // Publish events.

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use super::Region;
 use crate::sinks::elasticsearch::BulkConfig;
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     event::EventArray,
     sinks::{
         elasticsearch::{ElasticsearchConfig, ElasticsearchEncoder},
@@ -37,6 +39,13 @@ pub struct SematextLogsConfig {
 
     #[serde(default)]
     batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
+
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 inventory::submit! {
@@ -104,8 +113,8 @@ impl SinkConfig for SematextLogsConfig {
         "sematext_logs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -11,7 +11,9 @@ use vector_core::ByteSizeOf;
 
 use super::Region;
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     event::{
         metric::{Metric, MetricValue},
         Event,
@@ -55,6 +57,12 @@ struct SematextMetricsConfig {
     pub(self) batch: BatchConfig<SematextMetricsDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 inventory::submit! {
@@ -123,8 +131,8 @@ impl SinkConfig for SematextMetricsConfig {
         "sematext_metrics"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use crate::sinks::util::unix::UnixSinkConfig;
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     sinks::util::{
         encode_log, encoding::EncodingConfig, tcp::TcpSinkConfig, udp::UdpSinkConfig, Encoding,
     },
@@ -80,8 +82,8 @@ impl SinkConfig for SocketSinkConfig {
         "socket"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/splunk_hec/common/acknowledgements.rs
+++ b/src/sinks/splunk_hec/common/acknowledgements.rs
@@ -12,6 +12,7 @@ use vector_core::event::EventStatus;
 
 use super::service::HttpRequestBuilder;
 use crate::{
+    config::AcknowledgementsConfig,
     http::HttpClient,
     internal_events::{
         SplunkIndexerAcknowledgementAPIError, SplunkIndexerAcknowledgementAckAdded,
@@ -26,6 +27,13 @@ pub struct HecClientAcknowledgementsConfig {
     pub query_interval: NonZeroU8,
     pub retry_limit: NonZeroU8,
     pub max_pending_acks: NonZeroU64,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        flatten,
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub inner: AcknowledgementsConfig,
 }
 
 impl Default for HecClientAcknowledgementsConfig {
@@ -35,6 +43,7 @@ impl Default for HecClientAcknowledgementsConfig {
             query_interval: NonZeroU8::new(10).unwrap(),
             retry_limit: NonZeroU8::new(30).unwrap(),
             max_pending_acks: NonZeroU64::new(1_000_000).unwrap(),
+            inner: Default::default(),
         }
     }
 }

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -7,7 +7,7 @@ use vector_core::sink::VectorSink;
 
 use super::{encoder::HecLogsEncoder, request_builder::HecLogsRequestBuilder, sink::HecLogsSink};
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
         splunk_hec::common::{
@@ -100,8 +100,8 @@ impl SinkConfig for HecLogsSinkConfig {
         "splunk_hec_logs"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements.inner)
     }
 }
 
@@ -184,8 +184,8 @@ impl SinkConfig for HecSinkCompatConfig {
         "splunk_hec"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        self.config.acknowledgements()
     }
 }
 

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -7,7 +7,7 @@ use vector_core::sink::VectorSink;
 
 use super::{request_builder::HecMetricsRequestBuilder, sink::HecMetricsSink};
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
         splunk_hec::common::{
@@ -92,8 +92,8 @@ impl SinkConfig for HecMetricsSinkConfig {
         "splunk_hec_metrics"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements.inner)
     }
 }
 

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -15,7 +15,9 @@ use super::util::SinkBatchSettings;
 #[cfg(unix)]
 use crate::sinks::util::unix::UnixSinkConfig;
 use crate::{
-    config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
     event::{
         metric::{Metric, MetricKind, MetricTags, MetricValue, StatisticKind},
         Event,
@@ -149,8 +151,8 @@ impl SinkConfig for StatsdSinkConfig {
         "statsd"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -28,7 +28,7 @@ use tower::Service;
 
 use super::controller::ControllerStatistics;
 use crate::{
-    config::{self, Input, SinkConfig, SinkContext},
+    config::{self, AcknowledgementsConfig, Input, SinkConfig, SinkContext},
     event::{metric::MetricValue, Event},
     metrics::{self},
     sinks::{
@@ -198,8 +198,8 @@ impl SinkConfig for TestConfig {
         unimplemented!("not intended for use in real configs")
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -3,7 +3,9 @@ pub mod v2;
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::{GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription};
+use crate::config::{
+    AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 enum V1 {
@@ -76,8 +78,11 @@ impl SinkConfig for VectorConfig {
         "vector"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        true
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        match self {
+            Self::V1(_) => None,
+            Self::V2(v2) => Some(&v2.config.acknowledgements),
+        }
     }
 }
 

--- a/src/sinks/vector/v2/config.rs
+++ b/src/sinks/vector/v2/config.rs
@@ -7,7 +7,9 @@ use tonic::body::BoxBody;
 use tower::ServiceBuilder;
 
 use crate::{
-    config::{GenerateConfig, ProxyConfig, SinkContext, SinkHealthcheckOptions},
+    config::{
+        AcknowledgementsConfig, GenerateConfig, ProxyConfig, SinkContext, SinkHealthcheckOptions,
+    },
     proto::vector as proto,
     sinks::{
         util::{
@@ -34,6 +36,12 @@ pub struct VectorConfig {
     pub request: TowerRequestConfig,
     #[serde(default)]
     tls: Option<TlsConfig>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub(in crate::sinks::vector) acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for VectorConfig {
@@ -48,6 +56,7 @@ fn default_config(address: &str) -> VectorConfig {
         batch: BatchConfig::default(),
         request: TowerRequestConfig::default(),
         tls: None,
+        acknowledgements: Default::default(),
     }
 }
 

--- a/src/topology/test/backpressure.rs
+++ b/src/topology/test/backpressure.rs
@@ -208,7 +208,7 @@ async fn multiple_inputs_backpressure() {
 }
 
 mod test_sink {
-    use crate::config::{Input, SinkConfig, SinkContext};
+    use crate::config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext};
     use crate::event::Event;
     use crate::sinks::util::StreamSink;
     use crate::sinks::{Healthcheck, VectorSink};
@@ -256,8 +256,8 @@ mod test_sink {
             "test-backpressure-sink"
         }
 
-        fn can_acknowledge(&self) -> bool {
-            false
+        fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+            None
         }
     }
 }

--- a/src/topology/test/transient_state.rs
+++ b/src/topology/test/transient_state.rs
@@ -85,6 +85,7 @@ async fn closed_source() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
     old_config.add_sink(
@@ -93,6 +94,7 @@ async fn closed_source() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
 
@@ -113,6 +115,7 @@ async fn closed_source() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
 
@@ -148,6 +151,7 @@ async fn remove_sink() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
     old_config.add_sink(
@@ -156,6 +160,7 @@ async fn remove_sink() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
 
@@ -175,6 +180,7 @@ async fn remove_sink() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
 
@@ -213,6 +219,7 @@ async fn remove_transform() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
     old_config.add_sink(
@@ -221,6 +228,7 @@ async fn remove_transform() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
 
@@ -240,6 +248,7 @@ async fn remove_transform() {
         BlackholeConfig {
             print_interval_secs: 10,
             rate: None,
+            acknowledgements: Default::default(),
         },
     );
 

--- a/tests/crash.rs
+++ b/tests/crash.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use vector::{
-    config::{self, Input, SinkConfig, SinkContext, SourceConfig, SourceContext},
+    config::{
+        self, AcknowledgementsConfig, Input, SinkConfig, SinkContext, SourceConfig, SourceContext,
+    },
     event::Event,
     sinks::{self, Healthcheck, VectorSink},
     sources,
@@ -40,8 +42,8 @@ impl SinkConfig for PanicSink {
         "panic"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 
@@ -130,8 +132,8 @@ impl SinkConfig for ErrorSink {
         "panic"
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -27,8 +27,8 @@ use snafu::Snafu;
 use tracing::{error, info};
 use vector::{
     config::{
-        DataType, Input, Output, SinkConfig, SinkContext, SourceConfig, SourceContext,
-        TransformConfig, TransformContext,
+        AcknowledgementsConfig, DataType, Input, Output, SinkConfig, SinkContext, SourceConfig,
+        SourceContext, TransformConfig, TransformContext,
     },
     event::{
         metric::{self, MetricData, MetricValue},
@@ -408,8 +408,8 @@ impl SinkConfig for MockSinkConfig {
         unimplemented!("not intended for use in real configs")
     }
 
-    fn can_acknowledge(&self) -> bool {
-        false
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
     }
 }
 


### PR DESCRIPTION
This moves the `acknowledgements` configuration from `struct SinkOuter` into
the individual sinks, and exposes it through a new `fn acknowledgements` in the
`SinkConfig` trait. Most of the changes except for the core config and
splunk_hec sink are purely mechanical.

Closes #11615

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
