### PR TITLE
Experiment with over-large topology buffers

### DIFF
--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -633,7 +633,7 @@ mod tests {
                 let tx = SenderAdapter::opaque(tx.sink_map_err(|_| ()));
                 BufferSender::new(tx, WhenFull::Block)
             } else {
-                let (tx, rx) = TopologyBuilder::standalone_memory(1, WhenFull::Block).await;
+                let (tx, rx) = TopologyBuilder::standalone_memory(10_000, WhenFull::Block).await;
                 receivers.push(rx);
                 tx
             };

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -292,7 +292,8 @@ pub async fn build_pieces(
             Ok(transform) => transform,
         };
 
-        let (input_tx, input_rx) = TopologyBuilder::standalone_memory(100, WhenFull::Block).await;
+        let (input_tx, input_rx) =
+            TopologyBuilder::standalone_memory(10_000, WhenFull::Block).await;
 
         inputs.insert(key.clone(), (input_tx, node.inputs.clone()));
 


### PR DESCRIPTION
Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
