### PR TITLE
chore: Refactor `util::http::HttpSink` to allow mutable access to `self` in `encode_event`

### DIFF
--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -5,16 +5,16 @@ use hyper::Body;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
-use super::util::batch::RealtimeSizeBasedDefaultBatchSettings;
 use crate::{
     config::{Input, SinkConfig, SinkContext, SinkDescription},
     event::Event,
     http::{Auth, HttpClient, HttpError, MaybeAuth},
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
-        http::{BatchedHttpSink, HttpRetryLogic, HttpSink},
+        http::{BatchedHttpSink, HttpEventEncoder, HttpRetryLogic, HttpSink},
         retries::{RetryAction, RetryLogic},
-        BatchConfig, Buffer, Compression, TowerRequestConfig, UriSerde,
+        BatchConfig, Buffer, Compression, RealtimeSizeBasedDefaultBatchSettings,
+        TowerRequestConfig, UriSerde,
     },
     tls::{TlsOptions, TlsSettings},
 };
@@ -104,12 +104,12 @@ impl SinkConfig for ClickhouseConfig {
     }
 }
 
-#[async_trait::async_trait]
-impl HttpSink for ClickhouseConfig {
-    type Input = BytesMut;
-    type Output = BytesMut;
+pub struct ClickhouseEventEncoder {
+    encoding: EncodingConfigWithDefault<Encoding>,
+}
 
-    fn encode_event(&self, mut event: Event) -> Option<Self::Input> {
+impl HttpEventEncoder<BytesMut> for ClickhouseEventEncoder {
+    fn encode_event(&mut self, mut event: Event) -> Option<BytesMut> {
         self.encoding.apply_rules(&mut event);
         let log = event.into_log();
 
@@ -117,6 +117,19 @@ impl HttpSink for ClickhouseConfig {
         body.put_u8(b'\n');
 
         Some(body)
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpSink for ClickhouseConfig {
+    type Input = BytesMut;
+    type Output = BytesMut;
+    type Encoder = ClickhouseEventEncoder;
+
+    fn build_encoder(&self) -> Self::Encoder {
+        ClickhouseEventEncoder {
+            encoding: self.encoding.clone(),
+        }
     }
 
     async fn build_request(&self, events: Self::Output) -> crate::Result<http::Request<Bytes>> {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -17,7 +17,7 @@ use crate::{
         gcs_common::config::healthcheck_response,
         util::{
             encoding::{EncodingConfigWithDefault, EncodingConfiguration},
-            http::{BatchedHttpSink, HttpSink},
+            http::{BatchedHttpSink, HttpEventEncoder, HttpSink},
             BatchConfig, BoxedRawValue, JsonArrayBuffer, SinkBatchSettings, TowerRequestConfig,
         },
         Healthcheck, UriParseSnafu, VectorSink,
@@ -171,18 +171,31 @@ impl PubsubSink {
     }
 }
 
-#[async_trait::async_trait]
-impl HttpSink for PubsubSink {
-    type Input = Value;
-    type Output = Vec<BoxedRawValue>;
+struct PubSubSinkEventEncoder {
+    encoding: EncodingConfigWithDefault<Encoding>,
+}
 
-    fn encode_event(&self, mut event: Event) -> Option<Self::Input> {
+impl HttpEventEncoder<Value> for PubSubSinkEventEncoder {
+    fn encode_event(&mut self, mut event: Event) -> Option<Value> {
         self.encoding.apply_rules(&mut event);
         // Each event needs to be base64 encoded, and put into a JSON object
         // as the `data` item.
         let log = event.into_log();
         let json = serde_json::to_string(&log).unwrap();
         Some(json!({ "data": base64::encode(&json) }))
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpSink for PubsubSink {
+    type Input = Value;
+    type Output = Vec<BoxedRawValue>;
+    type Encoder = PubSubSinkEventEncoder;
+
+    fn build_encoder(&self) -> Self::Encoder {
+        PubSubSinkEventEncoder {
+            encoding: self.encoding.clone(),
+        }
     }
 
     async fn build_request(&self, events: Self::Output) -> crate::Result<Request<Bytes>> {

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -17,7 +17,7 @@ use crate::{
         gcs_common::config::healthcheck_response,
         util::{
             encoding::{EncodingConfigWithDefault, EncodingConfiguration},
-            http::{BatchedHttpSink, HttpSink},
+            http::{BatchedHttpSink, HttpEventEncoder, HttpSink},
             BatchConfig, BoxedRawValue, JsonArrayBuffer, RealtimeSizeBasedDefaultBatchSettings,
             TowerRequestConfig,
         },
@@ -162,12 +162,13 @@ impl SinkConfig for StackdriverConfig {
     }
 }
 
-#[async_trait::async_trait]
-impl HttpSink for StackdriverSink {
-    type Input = serde_json::Value;
-    type Output = Vec<BoxedRawValue>;
+struct StackdriverEventEncoder {
+    config: StackdriverConfig,
+    severity_key: Option<String>,
+}
 
-    fn encode_event(&self, event: Event) -> Option<Self::Input> {
+impl HttpEventEncoder<serde_json::Value> for StackdriverEventEncoder {
+    fn encode_event(&mut self, event: Event) -> Option<serde_json::Value> {
         let mut labels = HashMap::with_capacity(self.config.resource.labels.len());
         for (key, template) in &self.config.resource.labels {
             let value = template
@@ -225,6 +226,20 @@ impl HttpSink for StackdriverSink {
         }
 
         Some(json!(entry))
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpSink for StackdriverSink {
+    type Input = serde_json::Value;
+    type Output = Vec<BoxedRawValue>;
+    type Encoder = StackdriverEventEncoder;
+
+    fn build_encoder(&self) -> Self::Encoder {
+        StackdriverEventEncoder {
+            config: self.config.clone(),
+            severity_key: self.severity_key.clone(),
+        }
     }
 
     async fn build_request(&self, events: Self::Output) -> crate::Result<Request<Bytes>> {
@@ -339,6 +354,7 @@ mod tests {
             severity_key: Some("anumber".into()),
             uri: ENDPOINT_URI.parse().unwrap(),
         };
+        let mut encoder = sink.build_encoder();
 
         let log = [
             ("message", "hello world"),
@@ -349,7 +365,7 @@ mod tests {
         .iter()
         .copied()
         .collect::<LogEvent>();
-        let json = sink.encode_event(Event::from(log)).unwrap();
+        let json = encoder.encode_event(Event::from(log)).unwrap();
         assert_eq!(
             json,
             serde_json::json!({
@@ -380,6 +396,7 @@ mod tests {
             severity_key: Some("anumber".into()),
             uri: ENDPOINT_URI.parse().unwrap(),
         };
+        let mut encoder = sink.build_encoder();
 
         let mut log = LogEvent::default();
         log.insert("message", Value::Bytes("hello world".into()));
@@ -389,7 +406,7 @@ mod tests {
             Value::Timestamp(Utc.ymd(2020, 1, 1).and_hms(12, 30, 0)),
         );
 
-        let json = sink.encode_event(Event::from(log)).unwrap();
+        let json = encoder.encode_event(Event::from(log)).unwrap();
         assert_eq!(
             json,
             serde_json::json!({
@@ -448,11 +465,12 @@ mod tests {
             severity_key: None,
             uri: ENDPOINT_URI.parse().unwrap(),
         };
+        let mut encoder = sink.build_encoder();
 
         let log1 = [("message", "hello")].iter().copied().collect::<LogEvent>();
         let log2 = [("message", "world")].iter().copied().collect::<LogEvent>();
-        let event1 = sink.encode_event(Event::from(log1)).unwrap();
-        let event2 = sink.encode_event(Event::from(log2)).unwrap();
+        let event1 = encoder.encode_event(Event::from(log1)).unwrap();
+        let event2 = encoder.encode_event(Event::from(log2)).unwrap();
 
         let json1 = serde_json::to_string(&event1).unwrap();
         let json2 = serde_json::to_string(&event2).unwrap();

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -14,7 +14,7 @@ use crate::{
         gcp,
         util::{
             buffer::metrics::MetricsBuffer,
-            http::{BatchedHttpSink, HttpSink},
+            http::{BatchedHttpSink, HttpEventEncoder, HttpSink},
             BatchConfig, SinkBatchSettings, TowerRequestConfig,
         },
         Healthcheck, VectorSink,
@@ -122,12 +122,10 @@ struct HttpEventSink {
     token: gouth::Token,
 }
 
-#[async_trait::async_trait]
-impl HttpSink for HttpEventSink {
-    type Input = Metric;
-    type Output = Vec<Metric>;
+struct StackdriverMetricsEncoder;
 
-    fn encode_event(&self, event: Event) -> Option<Self::Input> {
+impl HttpEventEncoder<Metric> for StackdriverMetricsEncoder {
+    fn encode_event(&mut self, event: Event) -> Option<Metric> {
         let metric = event.into_metric();
 
         match metric.value() {
@@ -138,6 +136,17 @@ impl HttpSink for HttpEventSink {
                 None
             }
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpSink for HttpEventSink {
+    type Input = Metric;
+    type Output = Vec<Metric>;
+    type Encoder = StackdriverMetricsEncoder;
+
+    fn build_encoder(&self) -> Self::Encoder {
+        StackdriverMetricsEncoder
     }
 
     async fn build_request(

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -7,14 +7,13 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use super::util::SinkBatchSettings;
 use crate::{
     config::{log_schema, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::{Event, Value},
     http::HttpClient,
     sinks::util::{
-        http::{BatchedHttpSink, HttpSink},
-        BatchConfig, BoxedRawValue, JsonArrayBuffer, TowerRequestConfig,
+        http::{BatchedHttpSink, HttpEventEncoder, HttpSink},
+        BatchConfig, BoxedRawValue, JsonArrayBuffer, SinkBatchSettings, TowerRequestConfig,
     },
 };
 
@@ -100,12 +99,10 @@ impl SinkConfig for HoneycombConfig {
     }
 }
 
-#[async_trait::async_trait]
-impl HttpSink for HoneycombConfig {
-    type Input = serde_json::Value;
-    type Output = Vec<BoxedRawValue>;
+pub struct HoneycombEventEncoder;
 
-    fn encode_event(&self, event: Event) -> Option<Self::Input> {
+impl HttpEventEncoder<serde_json::Value> for HoneycombEventEncoder {
+    fn encode_event(&mut self, event: Event) -> Option<serde_json::Value> {
         let mut log = event.into_log();
 
         let timestamp = if let Some(Value::Timestamp(ts)) = log.remove(log_schema().timestamp_key())
@@ -121,6 +118,17 @@ impl HttpSink for HoneycombConfig {
         });
 
         Some(data)
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpSink for HoneycombConfig {
+    type Input = serde_json::Value;
+    type Output = Vec<BoxedRawValue>;
+    type Encoder = HoneycombEventEncoder;
+
+    fn build_encoder(&self) -> Self::Encoder {
+        HoneycombEventEncoder
     }
 
     async fn build_request(&self, events: Self::Output) -> crate::Result<http::Request<Bytes>> {

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -19,7 +19,7 @@ use crate::{
     internal_events::{HttpEventEncoded, HttpEventMissingMessageError},
     sinks::util::{
         encoding::{EncodingConfig, EncodingConfiguration},
-        http::{BatchedHttpSink, HttpSink, RequestConfig},
+        http::{BatchedHttpSink, HttpEventEncoder, HttpSink, RequestConfig},
         BatchConfig, Buffer, Compression, RealtimeSizeBasedDefaultBatchSettings,
         TowerRequestConfig, UriSerde,
     },
@@ -175,12 +175,12 @@ impl SinkConfig for HttpSinkConfig {
     }
 }
 
-#[async_trait::async_trait]
-impl HttpSink for HttpSinkConfig {
-    type Input = BytesMut;
-    type Output = BytesMut;
+pub struct HttpSinkEventEncoder {
+    encoding: EncodingConfig<Encoding>,
+}
 
-    fn encode_event(&self, mut event: Event) -> Option<Self::Input> {
+impl HttpEventEncoder<BytesMut> for HttpSinkEventEncoder {
+    fn encode_event(&mut self, mut event: Event) -> Option<BytesMut> {
         self.encoding.apply_rules(&mut event);
         let event = event.into_log();
 
@@ -217,6 +217,19 @@ impl HttpSink for HttpSinkConfig {
         });
 
         Some(body)
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpSink for HttpSinkConfig {
+    type Input = BytesMut;
+    type Output = BytesMut;
+    type Encoder = HttpSinkEventEncoder;
+
+    fn build_encoder(&self) -> Self::Encoder {
+        HttpSinkEventEncoder {
+            encoding: self.encoding.clone(),
+        }
     }
 
     async fn build_request(&self, mut body: Self::Output) -> crate::Result<http::Request<Bytes>> {
@@ -336,10 +349,7 @@ mod tests {
         config::SinkContext,
         sinks::{
             http::HttpSinkConfig,
-            util::{
-                http::HttpSink,
-                test::{build_test_server, build_test_server_generic, build_test_server_status},
-            },
+            util::test::{build_test_server, build_test_server_generic, build_test_server_status},
         },
         test_util::{components, components::HTTP_SINK_TAGS, next_addr, random_lines_with_stream},
     };
@@ -356,7 +366,8 @@ mod tests {
 
         let mut config = default_config(Encoding::Text);
         config.encoding = encoding;
-        let bytes = config.encode_event(event).unwrap();
+        let mut encoder = config.build_encoder();
+        let bytes = encoder.encode_event(event).unwrap();
 
         assert_eq!(bytes, Vec::from("hello world\n"));
     }
@@ -368,7 +379,8 @@ mod tests {
 
         let mut config = default_config(Encoding::Json);
         config.encoding = encoding;
-        let bytes = config.encode_event(event).unwrap();
+        let mut encoder = config.build_encoder();
+        let bytes = encoder.encode_event(event).unwrap();
 
         #[derive(Deserialize, Debug)]
         #[serde(deny_unknown_fields)]

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -13,7 +13,7 @@ use crate::{
     http::{Auth, HttpClient},
     sinks::util::{
         encoding::{EncodingConfigWithDefault, EncodingConfiguration},
-        http::{HttpSink, PartitionHttpSink},
+        http::{HttpEventEncoder, HttpSink, PartitionHttpSink},
         BatchConfig, BoxedRawValue, JsonArrayBuffer, PartitionBuffer, PartitionInnerBuffer,
         RealtimeSizeBasedDefaultBatchSettings, TowerRequestConfig, UriSerde,
     },
@@ -119,12 +119,45 @@ pub struct PartitionKey {
     tags: Option<Vec<String>>,
 }
 
-#[async_trait::async_trait]
-impl HttpSink for LogdnaConfig {
-    type Input = PartitionInnerBuffer<serde_json::Value, PartitionKey>;
-    type Output = PartitionInnerBuffer<Vec<BoxedRawValue>, PartitionKey>;
+pub struct LogdnaEventEncoder {
+    hostname: Template,
+    tags: Option<Vec<Template>>,
+    encoding: EncodingConfigWithDefault<Encoding>,
+    default_app: Option<String>,
+    default_env: Option<String>,
+}
 
-    fn encode_event(&self, mut event: Event) -> Option<Self::Input> {
+impl LogdnaEventEncoder {
+    fn render_key(
+        &self,
+        event: &Event,
+    ) -> Result<PartitionKey, (Option<&str>, TemplateRenderingError)> {
+        let hostname = self
+            .hostname
+            .render_string(event)
+            .map_err(|e| (Some("hostname"), e))?;
+        let tags = self
+            .tags
+            .as_ref()
+            .map(|tags| {
+                let mut vec = Vec::with_capacity(tags.len());
+                for tag in tags {
+                    vec.push(tag.render_string(event).map_err(|e| (None, e))?);
+                }
+                Ok(Some(vec))
+            })
+            .unwrap_or(Ok(None))?;
+        Ok(PartitionKey { hostname, tags })
+    }
+}
+
+impl HttpEventEncoder<PartitionInnerBuffer<serde_json::Value, PartitionKey>>
+    for LogdnaEventEncoder
+{
+    fn encode_event(
+        &mut self,
+        mut event: Event,
+    ) -> Option<PartitionInnerBuffer<serde_json::Value, PartitionKey>> {
         let key = self
             .render_key(&event)
             .map_err(|(field, error)| {
@@ -183,6 +216,23 @@ impl HttpSink for LogdnaConfig {
         }
 
         Some(PartitionInnerBuffer::new(map.into(), key))
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpSink for LogdnaConfig {
+    type Input = PartitionInnerBuffer<serde_json::Value, PartitionKey>;
+    type Output = PartitionInnerBuffer<Vec<BoxedRawValue>, PartitionKey>;
+    type Encoder = LogdnaEventEncoder;
+
+    fn build_encoder(&self) -> Self::Encoder {
+        LogdnaEventEncoder {
+            hostname: self.hostname.clone(),
+            tags: self.tags.clone(),
+            encoding: self.encoding.clone(),
+            default_app: self.default_app.clone(),
+            default_env: self.default_env.clone(),
+        }
     }
 
     async fn build_request(&self, output: Self::Output) -> crate::Result<http::Request<Bytes>> {
@@ -251,28 +301,6 @@ impl LogdnaConfig {
         uri.parse::<http::Uri>()
             .expect("This should be a valid uri")
     }
-
-    fn render_key(
-        &self,
-        event: &Event,
-    ) -> Result<PartitionKey, (Option<&str>, TemplateRenderingError)> {
-        let hostname = self
-            .hostname
-            .render_string(event)
-            .map_err(|e| (Some("hostname"), e))?;
-        let tags = self
-            .tags
-            .as_ref()
-            .map(|tags| {
-                let mut vec = Vec::with_capacity(tags.len());
-                for tag in tags {
-                    vec.push(tag.render_string(event).map_err(|e| (None, e))?);
-                }
-                Ok(Some(vec))
-            })
-            .unwrap_or(Ok(None))?;
-        Ok(PartitionKey { hostname, tags })
-    }
 }
 
 async fn healthcheck(config: LogdnaConfig, client: HttpClient) -> crate::Result<()> {
@@ -326,6 +354,7 @@ mod tests {
         "#,
         )
         .unwrap();
+        let mut encoder = config.build_encoder();
 
         let mut event1 = Event::from("hello world");
         event1.as_mut_log().insert("app", "notvector");
@@ -339,13 +368,13 @@ mod tests {
         let mut event4 = Event::from("hello world");
         event4.as_mut_log().insert("env", "staging");
 
-        let event1_out = config.encode_event(event1).unwrap().into_parts().0;
+        let event1_out = encoder.encode_event(event1).unwrap().into_parts().0;
         let event1_out = event1_out.as_object().unwrap();
-        let event2_out = config.encode_event(event2).unwrap().into_parts().0;
+        let event2_out = encoder.encode_event(event2).unwrap().into_parts().0;
         let event2_out = event2_out.as_object().unwrap();
-        let event3_out = config.encode_event(event3).unwrap().into_parts().0;
+        let event3_out = encoder.encode_event(event3).unwrap().into_parts().0;
         let event3_out = event3_out.as_object().unwrap();
-        let event4_out = config.encode_event(event4).unwrap().into_parts().0;
+        let event4_out = encoder.encode_event(event4).unwrap().into_parts().0;
         let event4_out = event4_out.as_object().unwrap();
 
         assert_eq!(event1_out.get("app").unwrap(), &json!("notvector"));


### PR DESCRIPTION
Part of https://github.com/vectordotdev/vector/issues/11579.

Note that this does not create a new encoder for each HTTP request yet. I haven't figured out yet if it's possible to determine the end of an HTTP request from the methods in 

https://github.com/vectordotdev/vector/blob/4d2fc7572fed5dcaaab525253fc061c52d6c9f77/src/sinks/util/http.rs#L145-L198