### PR TITLE
chore: Some small `pub` changes, code removal in pipelines

### DIFF
--- a/lib/vector-core/src/transform/config.rs
+++ b/lib/vector-core/src/transform/config.rs
@@ -8,7 +8,7 @@ use crate::{
     schema,
 };
 
-#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug)]
 pub enum ExpandType {
     /// Chain components together one after another. Components will be named according
     /// to this order (e.g. component_name.0 and so on). If alias is set to true,

--- a/src/transforms/pipelines/expander.rs
+++ b/src/transforms/pipelines/expander.rs
@@ -36,7 +36,7 @@ impl TransformConfig for ExpanderConfig {
     fn expand(
         &mut self,
     ) -> crate::Result<Option<(IndexMap<String, Box<dyn TransformConfig>>, ExpandType)>> {
-        Ok(Some((self.inner.clone(), self.mode.clone())))
+        Ok(Some((self.inner.clone(), self.mode)))
     }
 
     fn input(&self) -> Input {

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -91,6 +91,7 @@ pub(crate) struct PipelineConfig {
 
 #[cfg(test)]
 impl PipelineConfig {
+    #[cfg(feature = "transforms-logs")]
     pub(crate) fn transforms(&self) -> &Vec<Box<dyn TransformConfig>> {
         &self.transforms
     }
@@ -140,10 +141,12 @@ pub(crate) struct EventTypeConfig {
 
 #[cfg(test)]
 impl EventTypeConfig {
+    #[cfg(feature = "transforms-logs")]
     pub(crate) const fn order(&self) -> &Option<Vec<String>> {
         &self.order
     }
 
+    #[cfg(feature = "transforms-logs")]
     pub(crate) const fn pipelines(&self) -> &IndexMap<String, PipelineConfig> {
         &self.pipelines
     }
@@ -194,10 +197,12 @@ pub(crate) struct PipelinesConfig {
 
 #[cfg(test)]
 impl PipelinesConfig {
+    #[cfg(feature = "transforms-logs")]
     pub(crate) const fn logs(&self) -> &EventTypeConfig {
         &self.logs
     }
 
+    #[cfg(feature = "transforms-logs")]
     pub(crate) const fn metrics(&self) -> &EventTypeConfig {
         &self.metrics
     }

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -82,7 +82,7 @@ inventory::submit! {
 /// This represents the configuration of a single pipeline, not the pipelines transform
 /// itself, which can contain multiple individual pipelines
 #[derive(Debug, Default, Deserialize, Serialize)]
-pub struct PipelineConfig {
+pub(crate) struct PipelineConfig {
     name: String,
     filter: Option<AnyCondition>,
     #[serde(default)]
@@ -91,7 +91,7 @@ pub struct PipelineConfig {
 
 #[cfg(test)]
 impl PipelineConfig {
-    pub fn transforms(&self) -> &Vec<Box<dyn TransformConfig>> {
+    pub(crate) fn transforms(&self) -> &Vec<Box<dyn TransformConfig>> {
         &self.transforms
     }
 }
@@ -132,7 +132,7 @@ impl PipelineConfig {
 /// This represent an ordered list of pipelines depending on the event type.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct EventTypeConfig {
+pub(crate) struct EventTypeConfig {
     #[serde(default)]
     order: Option<Vec<String>>,
     pipelines: IndexMap<String, PipelineConfig>,
@@ -140,11 +140,11 @@ pub struct EventTypeConfig {
 
 #[cfg(test)]
 impl EventTypeConfig {
-    pub const fn order(&self) -> &Option<Vec<String>> {
+    pub(crate) const fn order(&self) -> &Option<Vec<String>> {
         &self.order
     }
 
-    pub const fn pipelines(&self) -> &IndexMap<String, PipelineConfig> {
+    pub(crate) const fn pipelines(&self) -> &IndexMap<String, PipelineConfig> {
         &self.pipelines
     }
 }
@@ -185,7 +185,7 @@ impl EventTypeConfig {
 
 /// The configuration of the pipelines transform itself.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct PipelinesConfig {
+pub(crate) struct PipelinesConfig {
     #[serde(default)]
     logs: EventTypeConfig,
     #[serde(default)]
@@ -194,11 +194,11 @@ pub struct PipelinesConfig {
 
 #[cfg(test)]
 impl PipelinesConfig {
-    pub const fn logs(&self) -> &EventTypeConfig {
+    pub(crate) const fn logs(&self) -> &EventTypeConfig {
         &self.logs
     }
 
-    pub const fn metrics(&self) -> &EventTypeConfig {
+    pub(crate) const fn metrics(&self) -> &EventTypeConfig {
         &self.metrics
     }
 }
@@ -291,13 +291,6 @@ impl GenerateConfig for PipelinesConfig {
             condition = ""
         "#})
         .unwrap()
-    }
-}
-
-#[cfg(test)]
-impl PipelinesConfig {
-    pub fn from_toml(input: &str) -> Self {
-        crate::config::format::deserialize(input, crate::config::format::Format::Toml).unwrap()
     }
 }
 

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -91,7 +91,7 @@ pub(crate) struct PipelineConfig {
 
 #[cfg(test)]
 impl PipelineConfig {
-    #[cfg(feature = "transforms-logs")]
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
     pub(crate) fn transforms(&self) -> &Vec<Box<dyn TransformConfig>> {
         &self.transforms
     }
@@ -141,12 +141,12 @@ pub(crate) struct EventTypeConfig {
 
 #[cfg(test)]
 impl EventTypeConfig {
-    #[cfg(feature = "transforms-logs")]
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
     pub(crate) const fn order(&self) -> &Option<Vec<String>> {
         &self.order
     }
 
-    #[cfg(feature = "transforms-logs")]
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
     pub(crate) const fn pipelines(&self) -> &IndexMap<String, PipelineConfig> {
         &self.pipelines
     }
@@ -197,12 +197,12 @@ pub(crate) struct PipelinesConfig {
 
 #[cfg(test)]
 impl PipelinesConfig {
-    #[cfg(feature = "transforms-logs")]
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
     pub(crate) const fn logs(&self) -> &EventTypeConfig {
         &self.logs
     }
 
-    #[cfg(feature = "transforms-logs")]
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
     pub(crate) const fn metrics(&self) -> &EventTypeConfig {
         &self.metrics
     }

--- a/src/transforms/pipelines/router.rs
+++ b/src/transforms/pipelines/router.rs
@@ -8,7 +8,7 @@ use crate::{
     transforms::{FunctionTransform, OutputBuffer, Transform},
 };
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum EventType {
     Log,
     Metric,
@@ -77,9 +77,7 @@ impl TransformConfig for EventRouterConfig {
             let mut res: IndexMap<String, Box<dyn TransformConfig>> = IndexMap::new();
             res.insert(
                 "filter".to_string(),
-                Box::new(EventFilterConfig {
-                    inner: self.filter.clone(),
-                }),
+                Box::new(EventFilterConfig { inner: self.filter }),
             );
             res.insert("pipelines".to_string(), inner.clone());
             Ok(Some((res, ExpandType::Serial { alias: true })))

--- a/src/transforms/pipelines/router.rs
+++ b/src/transforms/pipelines/router.rs
@@ -21,14 +21,14 @@ impl Default for EventType {
 }
 
 impl EventType {
-    const fn validate(&self, event: &Event) -> bool {
+    const fn validate(self, event: &Event) -> bool {
         match self {
             Self::Log => matches!(event, Event::Log(_)),
             Self::Metric => matches!(event, Event::Metric(_)),
         }
     }
 
-    const fn data_type(&self) -> DataType {
+    const fn data_type(self) -> DataType {
         match self {
             Self::Log => DataType::Log,
             Self::Metric => DataType::Metric,


### PR DESCRIPTION
I'm going through the pipelines config code with a close eye. This commit is
consistent with my recent work to remove uncessary `pub`s from the project,
which netted us a bit of code removal.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
