### PR TITLE
Quick experiment to understand emission costs

### DIFF
--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -42,9 +42,11 @@ impl SyncTransform for Route {
             if condition.check(&event) {
                 output.push_named(output_name, event.clone());
             } else {
-                emit!(&RouteEventDiscarded {
-                    output: output_name.as_ref()
-                });
+                // Nothing, intentionally.
+                //
+                // emit!(&RouteEventDiscarded {
+                //     output: output_name.as_ref()
+                // });
             }
         }
     }


### PR DESCRIPTION
This commit is meant to determine how much time we're paying the soaks for
emitting discarded metrics.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
