### PR TITLE
fix(gcp_stackdriver_logs sink): Allow literal 'ER' as a log level type ERROR

### DIFF
--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -263,7 +263,7 @@ fn remap_severity(severity: Value) -> Value {
                     s if s.starts_with("EMERG") || s.starts_with("FATAL") => 800,
                     s if s.starts_with("ALERT") => 700,
                     s if s.starts_with("CRIT") => 600,
-                    s if s.starts_with("ERR") => 500,
+                    s if s.starts_with("ERR") || s == "ER" => 500,
                     s if s.starts_with("WARN") => 400,
                     s if s.starts_with("NOTICE") => 300,
                     s if s.starts_with("INFO") => 200,


### PR DESCRIPTION
In my implementation, I'm seeing the occasional warning: `Unknown severity value string, using DEFAULT. value=er internal_log_rate_secs=10`.  Assuming I'm reading the message correctly, it's complaining as my log leve severity is the string `er`.

If I'm reading the supported grok pattern defined at https://github.com/daschl/grok/blob/master/patterns/grok.pattern#L94-L95 correctly, the pattern allows both `err` and `er`.  However, the `remap_serverity` function only allows errors starting with `err` (ignoring case).  The PR allows for `er` if the log level equals `er` (intentionally chose equivalency vs starts_with to avoid false positives).