### PR TITLE
docs: Fix link to logfmt

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -192,10 +192,10 @@ components: sinks: [Name=string]: {
 											}
 											if codec == "logfmt" {
 												if batched {
-													logfmt: "Newline delimited list of events encoded by [logfmt]\(urls.logfmt)."
+													logfmt: "Newline delimited list of events encoded by [logfmt](\(urls.logfmt))."
 												}
 												if !batched {
-													logfmt: "[logfmt]\(urls.logfmt) encoded event."
+													logfmt: "[logfmt](\(urls.logfmt)) encoded event."
 												}
 											}
 											if codec == "json" {


### PR DESCRIPTION
Was missing the () required by markdown

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
