### PR TITLE
feat(vrl): Add configurable unit for to_timestamp

### DIFF
--- a/lib/vrl/stdlib/src/to_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_timestamp.rs
@@ -103,14 +103,24 @@ impl Function for ToTimestamp {
                 result: Ok("t'2020-01-01T00:00:00Z'"),
             },
             Example {
-                title: "integer",
+                title: "integer as seconds",
                 source: "to_timestamp!(5)",
                 result: Ok("t'1970-01-01T00:00:05Z'"),
             },
             Example {
-                title: "float",
+                title: "float as seconds",
                 source: "to_timestamp!(5.6)",
                 result: Ok("t'1970-01-01T00:00:05.600Z'"),
+            },
+            Example {
+                title: "integer as milliseconds",
+                source: r#"to_timestamp!(5000, unit: "milliseconds")"#,
+                result: Ok("t'1970-01-01T00:00:05Z'"),
+            },
+            Example {
+                title: "float as nanoseconds",
+                source: r#"to_timestamp!(56000000000.7, unit: "nanoseconds")"#,
+                result: Ok("t'1970-01-01T00:00:56.000000001Z'"),
             },
             Example {
                 title: "string valid",

--- a/website/cue/reference/remap/functions/to_timestamp.cue
+++ b/website/cue/reference/remap/functions/to_timestamp.cue
@@ -5,6 +5,7 @@ remap: functions: to_timestamp: {
 	description: """
 		Coerces the `value` into a timestamp.
 		"""
+	notices: ["There is the possibility of precision loss due to float arithmetic when coercing floats"]
 
 	arguments: [
 		{
@@ -12,6 +13,18 @@ remap: functions: to_timestamp: {
 			description: "The value that is to be converted to a timestamp. If a string, must be a valid representation of a `timestamp`, and no `default` exists, an `ArgumentError` will be raised."
 			required:    true
 			type: ["string", "float", "integer", "timestamp"]
+		},
+		{
+			name:        "unit"
+			description: "The time unit."
+			type: ["string"]
+			required: false
+			enum: {
+				seconds:      "Express Unix time in seconds"
+				milliseconds: "Express Unix time in milliseconds"
+				nanoseconds:  "Express Unix time in nanoseconds"
+			}
+			default: "seconds"
 		},
 	]
 	internal_failure_reasons: [

--- a/website/cue/reference/remap/functions/to_timestamp.cue
+++ b/website/cue/reference/remap/functions/to_timestamp.cue
@@ -5,7 +5,7 @@ remap: functions: to_timestamp: {
 	description: """
 		Coerces the `value` into a timestamp.
 		"""
-	notices: ["There is the possibility of precision loss due to float arithmetic when coercing floats"]
+	notices: ["There is the possibility of precision loss due to float arithmetic when coercing floats."]
 
 	arguments: [
 		{


### PR DESCRIPTION
Closes: #11591

Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
