### PR TITLE
docs: Unabbreviate High Availability

### DIFF
--- a/website/content/en/docs/setup/going-to-prod/high-availability.md
+++ b/website/content/en/docs/setup/going-to-prod/high-availability.md
@@ -1,7 +1,7 @@
 ---
 title: High Availability
 description: Meet the stringent uptime requirements of infrastructure-level software.
-short: HA
+short: High Availability
 weight: 3
 ---
 


### PR DESCRIPTION
This `short` metadata field seems to be used in the bread crumbs and
elsewhere and I think spelling it out is better to reduce acronym
alphabet soup.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
