### PR TITLE
docs: Update instance type recommendation

### DIFF
--- a/website/content/en/docs/setup/going-to-prod/sizing.md
+++ b/website/content/en/docs/setup/going-to-prod/sizing.md
@@ -30,7 +30,7 @@ Instances with at least 8 vCPUs and 16 GiB of memory are good units for scaling.
 
 | Cloud | Recommendations |
 | --- | --- |
-| AWS | c6g.2xlarge (recommended) or c6i.2xlarge |
+| AWS | c6i.2xlarge (recommended) or c6g.2xlarge |
 | Azure | f8 |
 | GCP | c2 (8 vCPUs, 16 GiB memory) |
 


### PR DESCRIPTION
Some benchmarking against 89ca645cfd8822d78c175a69355bea787cdf5bfc
showed a significant regression in performance on ARM (40% in some
cases) for c6g vs c6i which doesn't justify the ~20% cost savings.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
