### PR TITLE
fix(ci): Use correct env var for Datatog integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7303,9 +7303,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]

--- a/scripts/integration/docker-compose.datadog-agent.yml
+++ b/scripts/integration/docker-compose.datadog-agent.yml
@@ -5,7 +5,7 @@ services:
     image: datadog/agent:7
     network_mode: host
     environment:
-      - DD_API_KEY=${CI_TEST_DATADOG_API_KEY}
+      - DD_API_KEY=${TEST_DATADOG_API_KEY}
       - DD_APM_ENABLED=false
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_LOGS_DD_URL=0.0.0.0:8080
@@ -22,7 +22,7 @@ services:
     image: datadog/agent:7.31.0
     network_mode: host
     environment:
-      - DD_API_KEY=${CI_TEST_DATADOG_API_KEY}
+      - DD_API_KEY=${TEST_DATADOG_API_KEY}
       - DD_APM_ENABLED=true
       - DD_APM_DD_URL=http://127.0.0.1:8081
       - DD_HEALTH_PORT=8183

--- a/src/sources/datadog/agent/integration_tests.rs
+++ b/src/sources/datadog/agent/integration_tests.rs
@@ -91,7 +91,11 @@ async fn wait_for_message() {
 async fn wait_for_traces() {
     wait_for_agent(Some(8183)).await;
     let (sender, recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-    let context = SourceContext::new_test(sender, None);
+    let schema_definitions = HashMap::from([
+        (Some(LOGS.to_owned()), schema::Definition::empty()),
+        (Some(METRICS.to_owned()), schema::Definition::empty()),
+    ]);
+    let context = SourceContext::new_test(sender, Some(schema_definitions));
     tokio::spawn(async move {
         let config = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
                 address = "0.0.0.0:8081"


### PR DESCRIPTION
#11033 merge inadvertently overwrote an env var name that was recently changed in datadog integration tests.
Another merge issue related to a missing schema is also fixed.