### PR TITLE
feat(internal_metrics source): Let scrape_interval_secs have fractional seconds

### DIFF
--- a/src/config/datadog.rs
+++ b/src/config/datadog.rs
@@ -24,7 +24,7 @@ pub struct Options {
     pub configuration_key: String,
 
     #[serde(default = "default_reporting_interval_secs")]
-    pub reporting_interval_secs: u64,
+    pub reporting_interval_secs: f64,
 }
 
 impl Default for Options {
@@ -44,8 +44,8 @@ const fn default_enabled() -> bool {
 }
 
 /// By default, report to Datadog every 5 seconds.
-const fn default_reporting_interval_secs() -> u64 {
-    5
+const fn default_reporting_interval_secs() -> f64 {
+    5.0
 }
 
 /// Augment configuration with observability via Datadog if the feature is enabled and

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -65,7 +65,7 @@ impl Default for Namespace {
 #[serde(deny_unknown_fields)]
 pub struct HostMetricsConfig {
     #[serde(default = "default_scrape_interval")]
-    scrape_interval_secs: u64,
+    scrape_interval_secs: f64,
 
     collectors: Option<Vec<Collector>>,
     #[serde(default)]
@@ -86,8 +86,8 @@ pub struct HostMetricsConfig {
     network: network::NetworkConfig,
 }
 
-const fn default_scrape_interval() -> u64 {
-    15
+const fn default_scrape_interval() -> f64 {
+    15.0
 }
 
 inventory::submit! {
@@ -133,12 +133,12 @@ impl HostMetricsConfig {
     }
 
     /// Set the interval to collect internal metrics.
-    pub fn scrape_interval_secs(&mut self, value: u64) {
+    pub fn scrape_interval_secs(&mut self, value: f64) {
         self.scrape_interval_secs = value;
     }
 
     async fn run(self, mut out: SourceSender, shutdown: ShutdownSignal) -> Result<(), ()> {
-        let duration = time::Duration::from_secs(self.scrape_interval_secs);
+        let duration = time::Duration::from_secs_f64(self.scrape_interval_secs);
         let mut interval = IntervalStream::new(time::interval(duration)).take_until(shutdown);
 
         let generator = HostMetrics::new(self);

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -16,8 +16,8 @@ use crate::{
 #[derivative(Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct InternalMetricsConfig {
-    #[derivative(Default(value = "2"))]
-    scrape_interval_secs: u64,
+    #[derivative(Default(value = "2.0"))]
+    scrape_interval_secs: f64,
     tags: TagsConfig,
     namespace: Option<String>,
     #[serde(skip)]
@@ -38,7 +38,7 @@ impl InternalMetricsConfig {
     }
 
     /// Set the interval to collect internal metrics.
-    pub fn scrape_interval_secs(&mut self, value: u64) {
+    pub fn scrape_interval_secs(&mut self, value: f64) {
         self.scrape_interval_secs = value;
     }
 }
@@ -61,12 +61,12 @@ impl_generate_config_from_default!(InternalMetricsConfig);
 #[typetag::serde(name = "internal_metrics")]
 impl SourceConfig for InternalMetricsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        if self.scrape_interval_secs == 0 {
+        if self.scrape_interval_secs == 0.0 {
             warn!(
                 "Interval set to 0 secs, this could result in high CPU utilization. It is suggested to use interval >= 1 secs.",
             );
         }
-        let interval = time::Duration::from_secs(self.scrape_interval_secs);
+        let interval = time::Duration::from_secs_f64(self.scrape_interval_secs);
         let namespace = self.namespace.clone();
         let version = self.version.clone();
         let configuration_key = self.configuration_key.clone();

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -516,6 +516,10 @@ _values: {
 	// when examples cannot be derived from the `default` or `enum`
 	// options.
 	examples?: [float, ...float]
+
+	// `unit` clarifies the value's unit. While this should be included
+	// as the suffix in the name, this helps to explicitly clarify that.
+	unit: #Unit | *null
 }
 
 #TypeObject: {

--- a/website/cue/reference/components/sources/host_metrics.cue
+++ b/website/cue/reference/components/sources/host_metrics.cue
@@ -99,8 +99,8 @@ components: sources: host_metrics: {
 			description: "The interval between metric gathering, in seconds."
 			common:      true
 			required:    false
-			type: uint: {
-				default: 15
+			type: float: {
+				default: 15.0
 				unit:    "seconds"
 			}
 		}

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -49,8 +49,8 @@ components: sources: internal_metrics: {
 			description: "The interval between metric gathering, in seconds."
 			common:      true
 			required:    false
-			type: uint: {
-				default: 2
+			type: float: {
+				default: 2.0
 				unit:    "seconds"
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
