### PR TITLE
chore: Fix clippy flag application

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.'cfg(all)']
+[build]
 rustflags = [
   "-Dclippy::print_stdout",
   "-Dclippy::print_stderr",


### PR DESCRIPTION
`[target.cfg(all)]` seems to not match anything.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
