### PR TITLE
fix(topology): correct fix for topology reloading around rebuilt sinks

### DIFF
--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -57,7 +57,7 @@ impl Fanout {
     pub fn add(&mut self, id: ComponentKey, sink: GenericEventSink) {
         assert!(
             !self.sinks.iter().any(|(n, _)| n == &id),
-            "Duplicate output id in fanout"
+            "Duplicate output id in fanout: {id}"
         );
 
         self.sinks.push((id, Some(sink)));
@@ -82,7 +82,7 @@ impl Fanout {
         if let Some((_, existing)) = self.sinks.iter_mut().find(|(n, _)| n == id) {
             *existing = sink;
         } else {
-            panic!("Tried to replace a sink that's not already present");
+            panic!("Tried to replace a sink that's not already present: {id}");
         }
     }
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -426,7 +426,14 @@ impl RunningTopology {
                 let buffer = previous.await.unwrap().unwrap();
 
                 if reuse_buffers.contains(key) {
-                    let tx = self.inputs.remove(key).unwrap();
+                    // We clone instead of removing here because otherwise the input will be
+                    // missing for the rest of the reload process, which violates the assumption
+                    // that all previous inputs for components not being removed are still
+                    // available. It's simpler to allow the "old" input to stick around and be
+                    // replaced (even though that's basically a no-op since we're reusing the same
+                    // buffer) than it is to pass around info about which sinks are having their
+                    // buffers reused and treat them differently at other stages.
+                    let tx = self.inputs.get(key).unwrap().clone();
                     let (rx, acker) = match buffer {
                         TaskOutput::Sink(rx, acker) => (rx.into_inner(), acker),
                         _ => unreachable!(),
@@ -471,7 +478,7 @@ impl RunningTopology {
         }
 
         for key in &diff.transforms.to_change {
-            self.replace_inputs(key, new_pieces, diff).await;
+            self.replace_inputs(key, new_pieces).await;
         }
 
         for key in &diff.transforms.to_add {
@@ -480,7 +487,7 @@ impl RunningTopology {
 
         // Sinks
         for key in &diff.sinks.to_change {
-            self.replace_inputs(key, new_pieces, diff).await;
+            self.replace_inputs(key, new_pieces).await;
         }
 
         for key in &diff.sinks.to_add {
@@ -706,12 +713,7 @@ impl RunningTopology {
             .map(|trigger| self.detach_triggers.insert(key.clone(), trigger.into()));
     }
 
-    async fn replace_inputs(
-        &mut self,
-        key: &ComponentKey,
-        new_pieces: &mut builder::Pieces,
-        diff: &ConfigDiff,
-    ) {
+    async fn replace_inputs(&mut self, key: &ComponentKey, new_pieces: &mut builder::Pieces) {
         let (tx, inputs) = new_pieces.inputs.remove(key).unwrap();
 
         let sink_inputs = self.config.sinks.get(key).map(|s| &s.inputs);
@@ -725,24 +727,8 @@ impl RunningTopology {
         let new_inputs = inputs.iter().collect::<HashSet<_>>();
 
         let inputs_to_remove = &old_inputs - &new_inputs;
-        let mut inputs_to_add = &new_inputs - &old_inputs;
-        let replace_candidates = old_inputs.intersection(&new_inputs);
-        let mut inputs_to_replace = HashSet::new();
-
-        // If the source component of an input was also rebuilt, we need to send an add message
-        // instead of a replace message.
-        for input in replace_candidates {
-            if diff
-                .sources
-                .changed_and_added()
-                .chain(diff.transforms.changed_and_added())
-                .any(|key| key == &input.component)
-            {
-                inputs_to_add.insert(input);
-            } else {
-                inputs_to_replace.insert(input);
-            }
-        }
+        let inputs_to_add = &new_inputs - &old_inputs;
+        let inputs_to_replace = old_inputs.intersection(&new_inputs);
 
         for input in inputs_to_remove {
             if let Some(output) = self.outputs.get_mut(input) {

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -522,6 +522,51 @@ async fn topology_rebuild_connected() {
 }
 
 #[tokio::test]
+async fn topology_rebuild_connected_transform() {
+    vector::trace::init(true, false, "info");
+
+    let (mut in1, source1) = source_with_data("v1");
+    let transform1 = transform(" transformed", 0.0);
+    let transform2 = transform(" transformed", 0.0);
+    let (_out1, sink1) = sink_with_data(10, "v1");
+
+    let mut config = Config::builder();
+    config.add_source("in1", source1);
+    config.add_transform("t1", &["in1"], transform1);
+    config.add_transform("t2", &["t1"], transform2);
+    config.add_sink("out1", &["t2"], sink1);
+
+    let (mut topology, _crash) = start_topology(config.build().unwrap(), false).await;
+
+    let (_in1, source1) = source_with_data("v1"); // not changing
+    let transform1 = transform("", 0.0);
+    let transform2 = transform("", 0.0);
+    let (out1, sink1) = sink_with_data(10, "v2");
+
+    let mut config = Config::builder();
+    config.add_source("in1", source1);
+    config.add_transform("t1", &["in1"], transform1);
+    config.add_transform("t2", &["t1"], transform2);
+    config.add_sink("out1", &["t2"], sink1);
+
+    assert!(topology
+        .reload_config_and_respawn(config.build().unwrap())
+        .await
+        .unwrap());
+    sleep(Duration::from_millis(10)).await;
+
+    let event1 = Event::from("this");
+    let event2 = Event::from("that");
+    let h_out1 = tokio::spawn(out1.collect::<Vec<_>>());
+    in1.send(event1.clone()).await.unwrap();
+    in1.send(event2.clone()).await.unwrap();
+    topology.stop().await;
+
+    let res = h_out1.await.unwrap();
+    assert_eq!(vec![event1, event2], res);
+}
+
+#[tokio::test]
 async fn topology_required_healthcheck_fails_start() {
     let mut config = basic_config_with_sink_failing_healthcheck();
     config.healthchecks.require_healthy = true;


### PR DESCRIPTION
Fixes #10412

It turns out that the fix for #9173 in #9536 was based on a misunderstanding of the underlying issue. In that commit, I noted that:

> When replacing the upstream component, the new input for the rebuilt downstream component has not yet been registered and therefore doesn't get readded to the rebuilt `Fanout`.

It's correct that the new input has not yet been registered, but it misses that the previous version of the input is still present and does get readded to the rebuilt `Fanout`. This is because we only remove existing inputs for components that are being removed from the topology entirely.

The actual issue in that case stemmed from the logic we have to reuse buffers for rebuilt sinks where the buffer config itself has not changed. To facilitate that reuse, we removed the existing input of the sink (i.e. the buffer sender) in order to stash it in a collection of buffers to be passed along and reused later in the reload process. This created a special case where the previous input actually would not be present and therefore not readded to a rebuilt `Fanout` that previously contained it.

The fix we implemented for that issue (based on the misunderstood cause) was to send `Add` instead of `Replace` messages to `Fanout`s that had been rebuilt when the downstream component itself was being rebuilt. This worked for sinks that fell into the category described above, but created issues for other types of components whose inputs were not removed. That is the direct cause of #10412, where we're sending an `Add` message for a rebuilt transform when its previous input was already present.

This change undoes the previous fix and makes it so we simply don't remove the input for sinks that are being rebuilt. This eliminates the special case and lets the original logic work fine in both scenarios.