### PR TITLE
chore: Try out nextest in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+retries = 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
       - run: make test
         env:
           CARGO_BUILD_JOBS: 5
-      - run: make test-doc
+      - run: make test-docs
         env:
           CARGO_BUILD_JOBS: 5
       - run: make test-benches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,9 @@ jobs:
       - run: make test
         env:
           CARGO_BUILD_JOBS: 5
+      - run: make test-doc
+        env:
+          CARGO_BUILD_JOBS: 5
       - run: make test-benches
         env:
           CARGO_BUILD_JOBS: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,12 +117,6 @@ jobs:
       - run: make test
         env:
           CARGO_BUILD_JOBS: 5
-      - run: make test-docs
-        env:
-          CARGO_BUILD_JOBS: 5
-      - run: make test-benches
-        env:
-          CARGO_BUILD_JOBS: 5
       - name: Stop sccache
         run: sccache --stop-server
 
@@ -163,6 +157,7 @@ jobs:
       - run: make test-cli
       - run: make test-behavior
       - run: make check-examples
+      - run: make test-docs
       - name: Stop sccache
         run: sccache --stop-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,9 @@ jobs:
       - run: make test
         env:
           CARGO_BUILD_JOBS: 5
+      - run: make test-benches
+        env:
+          CARGO_BUILD_JOBS: 5
       - name: Stop sccache
         run: sccache --stop-server
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -816,44 +816,37 @@ enrichment-tables-benches = ["enrichment-tables-file"]
 [[bench]]
 name = "default"
 harness = false
-test = true
 required-features = ["benches"]
 
 [[bench]]
 name = "dnstap"
 path = "benches/dnstap/mod.rs"
 harness = false
-test = true
 required-features = ["dnstap-benches"]
 
 [[bench]]
 name = "remap"
 harness = false
-test = true
 required-features = ["remap-benches"]
 
 [[bench]]
 name = "enrichment_tables_file"
 harness = false
-test = true
 required-features = ["enrichment-tables-benches"]
 
 [[bench]]
 name = "languages"
 harness = false
-test = true
 required-features = ["language-benches"]
 
 [[bench]]
 name = "loki"
 harness = false
-test = true
 required-features = ["loki-benches"]
 
 [[bench]]
 name = "distribution_statistic"
 harness = false
-test = true
 required-features = ["statistic-benches"]
 
 [[bench]]
@@ -867,5 +860,4 @@ required-features = ["transform-benches"]
 name = "codecs"
 path = "benches/codecs/main.rs"
 harness = false
-test = false
 required-features = ["codecs-benches"]

--- a/Makefile
+++ b/Makefile
@@ -283,20 +283,27 @@ target/%/vector.tar.gz: target/%/vector CARGO_HANDLES_FRESHNESS
 
 ##@ Testing (Supports `ENVIRONMENT=true`)
 
+# nextest doesn't support running doc tests yet so this is split out as
+# `test-docs`
+# https://github.com/nextest-rs/nextest/issues/16
+#
+# criterion doesn't support the flags needed by nextest to run so these are left
+# out for now
+# https://github.com/bheisler/criterion.rs/issues/562
+#
+# `cargo test` lacks support for testing _just_ benches otherwise we'd have
+# a target for that
+# https://github.com/rust-lang/cargo/issues/6454
 .PHONY: test
 test: ## Run the unit test suite
 	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES}" ${SCOPE}
-
-.PHONY: test-benches
-test-benches: ## Run the bench test suite
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --benches --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches codecs-benches language-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE} -- --bench
 
 .PHONY: test-docs
 test-docs: ## Run the docs test suite
 	${MAYBE_ENVIRONMENT_EXEC} cargo test --doc --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES}" ${SCOPE}
 
 .PHONY: test-all
-test-all: test test-benches test-docs test-behavior test-integration ## Runs all tests: unit, benches, docs, behaviorial, and integration.
+test-all: test test-docs test-behavior test-integration ## Runs all tests: unit, docs, behaviorial, and integration.
 
 .PHONY: test-x86_64-unknown-linux-gnu
 test-x86_64-unknown-linux-gnu: cross-test-x86_64-unknown-linux-gnu ## Runs unit tests on the x86_64-unknown-linux-gnu triple

--- a/Makefile
+++ b/Makefile
@@ -285,10 +285,14 @@ target/%/vector.tar.gz: target/%/vector CARGO_HANDLES_FRESHNESS
 
 .PHONY: test
 test: ## Run the unit test suite
-	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run -- --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches codecs-benches language-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE}
+	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES}" ${SCOPE}
+
+.PHONY: test-benches
+test-benches: ## Run the bench test suite
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --benches --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches codecs-benches language-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE} -- --bench
 
 .PHONY: test-all
-test-all: test test-behavior test-integration ## Runs all tests, unit, behaviorial, and integration.
+test-all: test test-benches test-behavior test-integration ## Runs all tests, unit, benches, behaviorial, and integration.
 
 .PHONY: test-x86_64-unknown-linux-gnu
 test-x86_64-unknown-linux-gnu: cross-test-x86_64-unknown-linux-gnu ## Runs unit tests on the x86_64-unknown-linux-gnu triple

--- a/Makefile
+++ b/Makefile
@@ -291,8 +291,12 @@ test: ## Run the unit test suite
 test-benches: ## Run the bench test suite
 	${MAYBE_ENVIRONMENT_EXEC} cargo test --benches --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches codecs-benches language-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE} -- --bench
 
+.PHONY: test-docs
+test-docs: ## Run the docs test suite
+	${MAYBE_ENVIRONMENT_EXEC} cargo test --doc --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES}" ${SCOPE}
+
 .PHONY: test-all
-test-all: test test-benches test-behavior test-integration ## Runs all tests, unit, benches, behaviorial, and integration.
+test-all: test test-benches test-docs test-behavior test-integration ## Runs all tests: unit, benches, docs, behaviorial, and integration.
 
 .PHONY: test-x86_64-unknown-linux-gnu
 test-x86_64-unknown-linux-gnu: cross-test-x86_64-unknown-linux-gnu ## Runs unit tests on the x86_64-unknown-linux-gnu triple

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ test-shutdown-cleanup:
 
 .PHONY: test-cli
 test-cli: ## Runs cli tests
-	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --no-fail-fast --no-default-features --features cli-tests --test cli -- --test-threads 4
+	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --no-fail-fast --no-default-features --features cli-tests --test cli --test-threads 4
 
 ##@ Benching (Supports `ENVIRONMENT=true`)
 

--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ target/%/vector.tar.gz: target/%/vector CARGO_HANDLES_FRESHNESS
 
 .PHONY: test
 test: ## Run the unit test suite
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches codecs-benches language-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE}
+	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run -- --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES} metrics-benches codecs-benches language-benches remap-benches statistic-benches ${DNSTAP_BENCHES} benches" ${SCOPE}
 
 .PHONY: test-all
 test-all: test test-behavior test-integration ## Runs all tests, unit, behaviorial, and integration.
@@ -330,7 +330,7 @@ ifeq ($(AUTOSPAWN), true)
 	@scripts/setup_integration_env.sh nats start
 	sleep 10 # Many services are very slow... Give them a sec..
 endif
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features nats-integration-tests --lib ::nats::
+	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --no-fail-fast --no-default-features --features nats-integration-tests --lib ::nats::
 ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh nats stop
 endif
@@ -369,7 +369,7 @@ test-shutdown-cleanup:
 
 .PHONY: test-cli
 test-cli: ## Runs cli tests
-	${MAYBE_ENVIRONMENT_EXEC} cargo test --no-fail-fast --no-default-features --features cli-tests --test cli -- --test-threads 4
+	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --no-fail-fast --no-default-features --features cli-tests --test cli -- --test-threads 4
 
 ##@ Benching (Supports `ENVIRONMENT=true`)
 

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -79,4 +79,3 @@ pretty_assertions = "1.1.0"
 [[bench]]
 name = "buffer"
 harness = false
-test = true

--- a/lib/tracing-limit/Cargo.toml
+++ b/lib/tracing-limit/Cargo.toml
@@ -21,4 +21,3 @@ tracing-subscriber = { version = "0.3.9", default-features = false, features = [
 [[bench]]
 name = "limit"
 harness = false
-test = true

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -35,7 +35,6 @@ vector_common = { path = "../../vector-common", default-features = false, featur
 [[bench]]
 name = "kind"
 harness = false
-test = true
 
 [features]
 test = []

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -303,5 +303,4 @@ bench = false
 [[bench]]
 name = "benches"
 harness = false
-test = true
 required-features = ["default"]

--- a/lib/vrl/vrl/Cargo.toml
+++ b/lib/vrl/vrl/Cargo.toml
@@ -25,4 +25,3 @@ vrl-stdlib = { path = "../stdlib" }
 [[bench]]
 name = "vm"
 harness = false
-test = true

--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -5,3 +5,5 @@ if ($env:CI -ne $null) {
 } else {
     $env:Path += ";$HOME\.cargo\bin"
 }
+
+rustup run stable cargo install cargo-nextest --version 0.9.8

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -5,6 +5,7 @@ rustup show # causes installation of version from rust-toolchain.toml
 rustup default "$(rustup show active-toolchain | awk '{print $1;}')"
 rustup run stable cargo install cargo-deb --version 1.29.2
 rustup run stable cargo install cross --version 0.2.1
+rustup run stable cargo install nextest --version 0.9.8
 
 cd scripts
 bundle install

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -5,7 +5,7 @@ rustup show # causes installation of version from rust-toolchain.toml
 rustup default "$(rustup show active-toolchain | awk '{print $1;}')"
 rustup run stable cargo install cargo-deb --version 1.29.2
 rustup run stable cargo install cross --version 0.2.1
-rustup run stable cargo install nextest --version 0.9.8
+rustup run stable cargo install cargo-nextest --version 0.9.8
 
 cd scripts
 bundle install


### PR DESCRIPTION
I added flakey test retrying but otherwise haven't taken advantage of any other nextest features yet. I hope to expand this to output JUnit compatible output to integrate with Datadog's CI product. Even without that integration, I think this is a worthwhile change for the flakey test behavior and improved output so I think this can safely go in first.

There are a couple of things to be aware of:

* `cargo-nextest` [doesn't support running docs tests](https://github.com/nextest-rs/nextest/issues/16) so these are split out into `make test-docs`
* `cargo-nextest` and `criterion` [don't play well yet](https://github.com/bheisler/criterion.rs/issues/562) so this PR drops testing of benches. `make check-clippy` should still ensure they compile though.

Assuming we like this, I'll expand it out to the integration tests and see if I can get the JUnit parts wired up.

Closes: #11377

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
