### PR TITLE
chore: Moderately improve the micro behavior of route transform

### DIFF
--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -18,15 +18,15 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Route {
-    conditions: IndexMap<String, Condition>,
+    conditions: Vec<(String, Condition)>,
 }
 
 impl Route {
     pub fn new(config: &RouteConfig, context: &TransformContext) -> crate::Result<Self> {
-        let mut conditions = IndexMap::new();
+        let mut conditions = Vec::with_capacity(config.route.len());
         for (output_name, condition) in config.route.iter() {
             let condition = condition.build(&context.enrichment_tables)?;
-            conditions.insert(output_name.clone(), condition);
+            conditions.push((output_name.clone(), condition));
         }
         Ok(Self { conditions })
     }
@@ -38,13 +38,13 @@ impl SyncTransform for Route {
         event: Event,
         output: &mut vector_core::transform::TransformOutputsBuf,
     ) {
-        for (output_name, condition) in self.conditions.iter() {
+        for (output_name, condition) in &self.conditions {
             if condition.check(&event) {
                 output.push_named(output_name, event.clone());
             } else {
                 emit!(&RouteEventDiscarded {
                     output: output_name.as_ref()
-                });
+                })
             }
         }
     }


### PR DESCRIPTION
This commit is a follow-up to #11697. We don't actually need to iterate an
`IndexMap` repeatedly here as we never actually use the map capabilities of the
conditions field: a vec is enough. This is worth a small boost in the micro but
I suspect nothing in the macro.

If we are to actually optimize route we'll probably need to run multiple copies
of them, run an `EventArray` through it and/or dramatically improve the behavior
of `condition.check`.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>