### PR TITLE
chore: Correct soak NaN crash bug

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -287,12 +287,12 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.1"
+          python-version: "3.10.2"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install scipy==1.7.* pandas==1.3.* tabulate==0.8.*
+          pip install scipy==1.8.* pandas==1.4.* tabulate==0.8.*
 
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -373,12 +373,12 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.1"
+          python-version: "3.10.2"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install scipy==1.7.* pandas==1.3.* tabulate==0.8.*
+          pip install scipy==1.8.* pandas==1.4.* tabulate==0.8.*
 
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -413,12 +413,12 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.1"
+          python-version: "3.10.2"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install scipy==1.7.* pandas==1.3.* tabulate==0.8.*
+          pip install scipy==1.8.* pandas==1.4.* tabulate==0.8.*
 
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -481,12 +481,12 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.1"
+          python-version: "3.10.2"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install scipy==1.7.* pandas==1.3.* tabulate==0.8.*
+          pip install scipy==1.8.* pandas==1.4.* tabulate==0.8.*
 
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -519,12 +519,12 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.1"
+          python-version: "3.10.2"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install scipy==1.7.* pandas==1.3.* seaborn==0.11.* tabulate==0.8.*
+          pip install scipy==1.8.* pandas==1.4.* seaborn==0.11.* tabulate==0.8.*
 
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
We have started to see in some soaks --
https://github.com/vectordotdev/vector/actions/runs/1936805810 -- that we are
crashing with a NaN bug deep in pandas. I am unable to replicate this locally
but have a more updated version of pandas on hand. As a first attempt I will
upgrade pandas.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
