### PR TITLE
docs(loki sink): Clarify endpoint path

### DIFF
--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -70,7 +70,7 @@ components: sinks: loki: {
 
 	configuration: {
 		endpoint: {
-			description: "The base URL of the Loki instance."
+			description: "The base URL of the Loki instance. Vector will append `/loki/api/v1/push` to this."
 			required:    true
 			type: string: {
 				examples: ["http://localhost:3100"]


### PR DESCRIPTION
A user was confused because they tried to specify the full URL and got
a 404.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
