### PR TITLE
chore: Catastrophically fail if variant has no samples

### DIFF
--- a/soaks/bin/analyze_experiment
+++ b/soaks/bin/analyze_experiment
@@ -37,6 +37,9 @@ for exp in bytes_written.experiment.unique():
     baseline = bytes_written.loc[(bytes_written.experiment == exp) & (bytes_written.variant == 'baseline')]
     comparison = bytes_written.loc[(bytes_written.experiment == exp) & (bytes_written.variant == 'comparison')]
 
+    assert len(baseline) != 0, "Baseline has zero samples, unrecoverable failure."
+    assert len(comparison) != 0, "Comparison has zero samples, unrecoverable failure."
+
     baseline_mean = baseline.throughput.mean()
     baseline_stdev = baseline.throughput.std()
     baseline_stderr = scipy.stats.sem(baseline.throughput)


### PR DESCRIPTION
This commit adds an assert to fail the analysis if a variant has no samples, as
opposed to kicking out an inexplicable exception. This probably relates to
issue #11633 and appears to impact http-to-http-noacks most frequently.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
