### PR TITLE
enhancement: Add vector user to systemd-journal-remote group

### DIFF
--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -4,8 +4,7 @@ set -e
 # Add Vector to adm group to read /var/logs
 usermod --append --groups adm vector || true
 
-# If the systemd-journal group is present
-if getent group | grep 'systemd-journal'
+if getent group 'systemd-journal'
 then
   # Add Vector to systemd-journal to read journald logs
   usermod --append --groups systemd-journal vector || true

--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -8,7 +8,13 @@ if getent group 'systemd-journal'
 then
   # Add Vector to systemd-journal to read journald logs
   usermod --append --groups systemd-journal vector || true
-  # Reload the daemon to reflect new group membership
+  systemctl daemon-reload || true
+fi
+
+if getent group 'systemd-journal-remote'
+then
+  # Add Vector to systemd-journal-remote to read remote journald logs
+  usermod --append --groups systemd-journal-remote vector || true
   systemctl daemon-reload || true
 fi
 


### PR DESCRIPTION
Current `postinst` script in Debian packages doesn't add vector user to the `systemd-journal-remote`.