### PR TITLE
chore: Remove `order` concept from pipelines config

### DIFF
--- a/soaks/tests/http_pipelines_blackhole/terraform/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole/terraform/vector.toml
@@ -36,43 +36,6 @@ type = "pipelines"
 inputs = ["preprocessing"]
 
 [transforms.processing.logs]
-order = [
-    "nginx",
-    "redis",
-    "consul",
-    "python",
-    "rabbitmq",
-    "zookeeper",
-    "elasticsearch",
-    "kafka",
-    "couchdb",
-    "docker",
-    "datadog_agent",
-    "ruby",
-    "vault",
-    "nginx_ingress_controller",
-    "mysql",
-    "kubernetes_cluster_autoscaler",
-    "aws_alb_ingress_controller",
-    "proxysql",
-    "azure",
-    "azure_web",
-    "azure_storage",
-    "azure_network",
-    "azure_compute",
-    "etcd",
-    "glog_pipeline",
-    "auth0",
-    "kube_scheduler_glog",
-    "aws_ecs-agent",
-    "nodejs",
-    "postgresql",
-    "cassandra",
-    "apache_httpd",
-    "azure_recovery_services",
-    "c",
-    "web_browser_logs"
-]
 
 [transforms.processing.logs.pipelines.nginx]
 name = "nginx"

--- a/soaks/tests/http_pipelines_blackhole_acks/terraform/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole_acks/terraform/vector.toml
@@ -37,43 +37,6 @@ type = "pipelines"
 inputs = ["preprocessing"]
 
 [transforms.processing.logs]
-order = [
-    "nginx",
-    "redis",
-    "consul",
-    "python",
-    "rabbitmq",
-    "zookeeper",
-    "elasticsearch",
-    "kafka",
-    "couchdb",
-    "docker",
-    "datadog_agent",
-    "ruby",
-    "vault",
-    "nginx_ingress_controller",
-    "mysql",
-    "kubernetes_cluster_autoscaler",
-    "aws_alb_ingress_controller",
-    "proxysql",
-    "azure",
-    "azure_web",
-    "azure_storage",
-    "azure_network",
-    "azure_compute",
-    "etcd",
-    "glog_pipeline",
-    "auth0",
-    "kube_scheduler_glog",
-    "aws_ecs-agent",
-    "nodejs",
-    "postgresql",
-    "cassandra",
-    "apache_httpd",
-    "azure_recovery_services",
-    "c",
-    "web_browser_logs"
-]
 
 [transforms.processing.logs.pipelines.nginx]
 name = "nginx"

--- a/soaks/tests/http_pipelines_no_grok_blackhole/terraform/vector.toml
+++ b/soaks/tests/http_pipelines_no_grok_blackhole/terraform/vector.toml
@@ -29,43 +29,6 @@ type = "pipelines"
 inputs = ["preprocessing"]
 
 [transforms.processing.logs]
-order = [
-    "nginx",
-    "redis",
-    "consul",
-    "python",
-    "rabbitmq",
-    "zookeeper",
-    "elasticsearch",
-    "kafka",
-    "couchdb",
-    "docker",
-    "datadog_agent",
-    "ruby",
-    "vault",
-    "nginx_ingress_controller",
-    "mysql",
-    "kubernetes_cluster_autoscaler",
-    "aws_alb_ingress_controller",
-    "proxysql",
-    "azure",
-    "azure_web",
-    "azure_storage",
-    "azure_network",
-    "azure_compute",
-    "etcd",
-    "glog_pipeline",
-    "auth0",
-    "kube_scheduler__glog_",
-    "aws_ecs_agent",
-    "nodejs",
-    "postgresql",
-    "cassandra",
-    "apache_httpd",
-    "azure_recovery_services",
-    "c_",
-    "web_browser_logs",
-]
 
 [transforms.processing.logs.pipelines.nginx]
 name = "nginx"

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -332,8 +332,6 @@ mod tests {
             .unwrap();
         let output = serde_json::to_string_pretty(&processing.inner).unwrap();
         let processing: PipelinesConfig = serde_json::from_str(&output).unwrap();
-        assert!(processing.logs().order().is_some());
-        assert!(processing.metrics().order().is_none());
         assert!(processing.metrics().pipelines().is_empty());
         let logs = processing.logs().pipelines();
         let first = logs.get("first").unwrap();


### PR DESCRIPTION
This commit removes the `order` field from `EventTypeConfig`. It did not appear
to be used, order of the serial expansions actually being defined by the order
of sub-transforms in the configuration file. It is not clear from code context
why we would want the user to set the processing order themselves in any event.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
