### PR TITLE
chore: Expose `sinks::util::encoding::Transformer`

### DIFF
--- a/src/sinks/util/encoding/adapter.rs
+++ b/src/sinks/util/encoding/adapter.rs
@@ -185,6 +185,8 @@ pub struct ExceptFieldsConfig {
     except_fields: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+/// Transformations to prepare an event for serialization.
 pub struct Transformer {
     only_fields: Option<Vec<Vec<PathComponent<'static>>>>,
     except_fields: Option<Vec<String>>,
@@ -192,6 +194,7 @@ pub struct Transformer {
 }
 
 impl Transformer {
+    /// Prepare an event for serialization by the given transformation rules.
     pub fn transform(&self, event: &mut Event) {
         self.apply_rules(event);
     }

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -74,7 +74,7 @@ use crate::{
 };
 
 #[cfg(feature = "codecs")]
-pub use adapter::{EncodingConfigAdapter, EncodingConfigMigrator};
+pub use adapter::{EncodingConfigAdapter, EncodingConfigMigrator, Transformer};
 pub use codec::{as_tracked_write, StandardEncodings, StandardJsonEncoding, StandardTextEncoding};
 pub use config::EncodingConfig;
 pub use fixed::EncodingConfigFixed;


### PR DESCRIPTION
The `encoding::Encoder` integration PRs need to instantiate/name the `Transformer` in a couple of places.