### PR TITLE
chore: Slightly re-organize the pipeline code

### DIFF
--- a/src/transforms/pipelines/config.rs
+++ b/src/transforms/pipelines/config.rs
@@ -1,0 +1,126 @@
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    conditions::AnyCondition,
+    config::TransformConfig,
+    transforms::pipelines::{expander, filter},
+};
+
+//------------------------------------------------------------------------------
+
+/// This represents the configuration of a single pipeline, not the pipelines transform
+/// itself, which can contain multiple individual pipelines
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct PipelineConfig {
+    name: String,
+    filter: Option<AnyCondition>,
+    #[serde(default)]
+    transforms: Vec<Box<dyn TransformConfig>>,
+}
+
+#[cfg(test)]
+impl PipelineConfig {
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
+    pub(crate) fn transforms(&self) -> &Vec<Box<dyn TransformConfig>> {
+        &self.transforms
+    }
+}
+
+impl Clone for PipelineConfig {
+    fn clone(&self) -> Self {
+        // This is a hack around the issue of cloning
+        // trait objects. So instead to clone the config
+        // we first serialize it into JSON, then back from
+        // JSON. Originally we used TOML here but TOML does not
+        // support serializing `None`.
+        let json = serde_json::to_value(self).unwrap();
+        serde_json::from_value(json).unwrap()
+    }
+}
+
+impl PipelineConfig {
+    /// Expands a single pipeline into a series of its transforms.
+    fn serial(&self) -> Box<dyn TransformConfig> {
+        let transforms: IndexMap<String, Box<dyn TransformConfig>> = self
+            .transforms
+            .iter()
+            .enumerate()
+            .map(|(index, config)| (index.to_string(), config.clone()))
+            .collect();
+        let transforms = Box::new(expander::ExpanderConfig::serial(transforms));
+        if let Some(ref filter) = self.filter {
+            Box::new(filter::PipelineFilterConfig::new(
+                filter.clone(),
+                transforms,
+            ))
+        } else {
+            transforms
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+
+/// This represent an ordered list of pipelines depending on the event type.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct EventTypeConfig {
+    #[serde(default)]
+    order: Option<Vec<String>>,
+    pipelines: IndexMap<String, PipelineConfig>,
+}
+
+#[cfg(test)]
+impl EventTypeConfig {
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
+    pub(crate) const fn order(&self) -> &Option<Vec<String>> {
+        &self.order
+    }
+
+    #[allow(dead_code)] // for some small subset of feature flags this code is dead
+    pub(crate) const fn pipelines(&self) -> &IndexMap<String, PipelineConfig> {
+        &self.pipelines
+    }
+}
+
+impl EventTypeConfig {
+    pub(super) fn is_empty(&self) -> bool {
+        self.pipelines.is_empty()
+    }
+
+    fn names(&self) -> Vec<String> {
+        if let Some(ref names) = self.order {
+            // This assumes all the pipelines are present in the `order` field.
+            // If a pipeline is missing, it won't be used.
+            names.clone()
+        } else {
+            let mut names = self.pipelines.keys().cloned().collect::<Vec<String>>();
+            names.sort();
+            names
+        }
+    }
+
+    /// Expand sub-pipelines configurations, preserving user defined order
+    ///
+    /// This function expands the sub-pipelines according to the order passed by
+    /// the user, or, absent an explicit order, by the position of the
+    /// sub-pipeline in the configuration file.
+    pub(super) fn expand(&self) -> IndexMap<String, Box<dyn TransformConfig>> {
+        self.names()
+            .into_iter()
+            .filter_map(|name: String| {
+                self.pipelines
+                    .get(&name)
+                    .map(|config: &PipelineConfig| (name, config.serial()))
+            })
+            .collect()
+    }
+
+    /// Expands a group of pipelines into a series of pipelines.
+    /// They will then be expanded into a series of transforms.
+    pub(super) fn serial(&self) -> Box<dyn TransformConfig> {
+        let pipelines: IndexMap<String, Box<dyn TransformConfig>> = self.expand();
+        Box::new(expander::ExpanderConfig::serial(pipelines))
+    }
+}

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -1,189 +1,83 @@
-/// This pipelines transform is a bit complex and needs a simple example.
-///
-/// If we consider the following example:
-///
-/// ```toml
-/// [transforms.my_pipelines]
-/// type = "pipelines"
-/// inputs = ["syslog"]
-///
-/// [transforms.my_pipelines.logs]
-/// order = ["foo", "bar"]
-///
-/// [transforms.my_pipelines.logs.pipelines.foo]
-/// name = "foo pipeline"
-///
-/// [[transforms.my_pipelines.logs.pipelines.foo.transforms]]
-/// # any transform configuration
-///
-/// [[transforms.my_pipelines.logs.pipelines.foo.transforms]]
-/// # any transform configuration
-///
-/// [transforms.my_pipelines.logs.pipelines.bar]
-/// name = "bar pipeline"
-///
-/// [transforms.my_pipelines.logs.pipelines.bar.transforms]]
-/// # any transform configuration
-///
-/// [transforms.my_pipelines.metrics]
-/// order = ["hello", "world"]
-///
-/// [transforms.my_pipelines.metrics.pipelines.hello]
-/// name = "hello pipeline"
-///
-/// [[transforms.my_pipelines.metrics.pipelines.hello.transforms]]
-/// # any transform configuration
-///
-/// [[transforms.my_pipelines.metrics.pipelines.hello.transforms]]
-/// # any transform configuration
-///
-/// [transforms.my_pipelines.metrics.pipelines.world]
-/// name = "world pipeline"
-///
-/// [[transforms.my_pipelines.metrics.pipelines.world.transforms]]
-/// # any transform configuration
-/// ```
-///
-/// The pipelines transform will first expand into 2 parallel transforms for `logs` and
-/// `metrics`. A `Noop` transform will be also added to aggregate `logs` and `metrics`
-/// into a single transform and to be able to use the transform name (`my_pipelines`) as an input.
-///
-/// Then the `logs` group of pipelines will be expanded into a `EventFilter` followed by
-/// a series `PipelineConfig` via the `EventRouter` transform. At the end, a `Noop` alias is added
-/// to be able to refer `logs` as `my_pipelines.logs`.
-/// Same thing for the `metrics` group of pipelines.
-///
-/// Each pipeline will then be expanded into a list of its transforms and at the end of each
-/// expansion, a `Noop` transform will be added to use the `pipeline` name as an alias
-/// (`my_pipelines.logs.transforms.foo`).
+//! This pipelines transform is a bit complex and needs a simple example.
+//!
+//! If we consider the following example:
+//!
+//! ```toml
+//! [transforms.my_pipelines]
+//! type = "pipelines"
+//! inputs = ["syslog"]
+//!
+//! [transforms.my_pipelines.logs]
+//! order = ["foo", "bar"]
+//!
+//! [transforms.my_pipelines.logs.pipelines.foo]
+//! name = "foo pipeline"
+//!
+//! [[transforms.my_pipelines.logs.pipelines.foo.transforms]]
+//! # any transform configuration
+//!
+//! [[transforms.my_pipelines.logs.pipelines.foo.transforms]]
+//! # any transform configuration
+//!
+//! [transforms.my_pipelines.logs.pipelines.bar]
+//! name = "bar pipeline"
+//!
+//! [transforms.my_pipelines.logs.pipelines.bar.transforms]]
+//! # any transform configuration
+//!
+//! [transforms.my_pipelines.metrics]
+//! order = ["hello", "world"]
+//!
+//! [transforms.my_pipelines.metrics.pipelines.hello]
+//! name = "hello pipeline"
+//!
+//! [[transforms.my_pipelines.metrics.pipelines.hello.transforms]]
+//! # any transform configuration
+//!
+//! [[transforms.my_pipelines.metrics.pipelines.hello.transforms]]
+//! # any transform configuration
+//!
+//! [transforms.my_pipelines.metrics.pipelines.world]
+//! name = "world pipeline"
+//!
+//! [[transforms.my_pipelines.metrics.pipelines.world.transforms]]
+//! # any transform configuration
+//! ```
+//!
+//! The pipelines transform will first expand into 2 parallel transforms for `logs` and
+//! `metrics`. A `Noop` transform will be also added to aggregate `logs` and `metrics`
+//! into a single transform and to be able to use the transform name (`my_pipelines`) as an input.
+//!
+//! Then the `logs` group of pipelines will be expanded into a `EventFilter` followed by
+//! a series `PipelineConfig` via the `EventRouter` transform. At the end, a `Noop` alias is added
+//! to be able to refer `logs` as `my_pipelines.logs`.
+//! Same thing for the `metrics` group of pipelines.
+//!
+//! Each pipeline will then be expanded into a list of its transforms and at the end of each
+//! expansion, a `Noop` transform will be added to use the `pipeline` name as an alias
+//! (`my_pipelines.logs.transforms.foo`).
+mod config;
 mod expander;
 mod filter;
 mod router;
 
-use std::collections::HashSet;
-
+use crate::{
+    config::{GenerateConfig, TransformDescription},
+    schema,
+};
+use config::EventTypeConfig;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-
-use crate::{
-    conditions::AnyCondition,
-    config::{
-        DataType, ExpandType, GenerateConfig, Input, Output, TransformConfig, TransformContext,
-        TransformDescription,
-    },
-    schema,
-    transforms::Transform,
+use std::{collections::HashSet, fmt::Debug};
+use vector_core::{
+    config::{DataType, Input, Output},
+    transform::{ExpandType, Transform, TransformConfig, TransformContext},
 };
+
+//------------------------------------------------------------------------------
 
 inventory::submit! {
     TransformDescription::new::<PipelinesConfig>("pipelines")
-}
-
-/// This represents the configuration of a single pipeline, not the pipelines transform
-/// itself, which can contain multiple individual pipelines
-#[derive(Debug, Default, Deserialize, Serialize)]
-pub(crate) struct PipelineConfig {
-    name: String,
-    filter: Option<AnyCondition>,
-    #[serde(default)]
-    transforms: Vec<Box<dyn TransformConfig>>,
-}
-
-#[cfg(test)]
-impl PipelineConfig {
-    #[allow(dead_code)] // for some small subset of feature flags this code is dead
-    pub(crate) fn transforms(&self) -> &Vec<Box<dyn TransformConfig>> {
-        &self.transforms
-    }
-}
-
-impl Clone for PipelineConfig {
-    fn clone(&self) -> Self {
-        // This is a hack around the issue of cloning
-        // trait objects. So instead to clone the config
-        // we first serialize it into JSON, then back from
-        // JSON. Originally we used TOML here but TOML does not
-        // support serializing `None`.
-        let json = serde_json::to_value(self).unwrap();
-        serde_json::from_value(json).unwrap()
-    }
-}
-
-impl PipelineConfig {
-    /// Expands a single pipeline into a series of its transforms.
-    fn serial(&self) -> Box<dyn TransformConfig> {
-        let transforms: IndexMap<String, Box<dyn TransformConfig>> = self
-            .transforms
-            .iter()
-            .enumerate()
-            .map(|(index, config)| (index.to_string(), config.clone()))
-            .collect();
-        let transforms = Box::new(expander::ExpanderConfig::serial(transforms));
-        if let Some(ref filter) = self.filter {
-            Box::new(filter::PipelineFilterConfig::new(
-                filter.clone(),
-                transforms,
-            ))
-        } else {
-            transforms
-        }
-    }
-}
-
-/// This represent an ordered list of pipelines depending on the event type.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct EventTypeConfig {
-    #[serde(default)]
-    order: Option<Vec<String>>,
-    pipelines: IndexMap<String, PipelineConfig>,
-}
-
-#[cfg(test)]
-impl EventTypeConfig {
-    #[allow(dead_code)] // for some small subset of feature flags this code is dead
-    pub(crate) const fn order(&self) -> &Option<Vec<String>> {
-        &self.order
-    }
-
-    #[allow(dead_code)] // for some small subset of feature flags this code is dead
-    pub(crate) const fn pipelines(&self) -> &IndexMap<String, PipelineConfig> {
-        &self.pipelines
-    }
-}
-
-impl EventTypeConfig {
-    fn is_empty(&self) -> bool {
-        self.pipelines.is_empty()
-    }
-
-    fn names(&self) -> Vec<String> {
-        if let Some(ref names) = self.order {
-            // This assumes all the pipelines are present in the `order` field.
-            // If a pipeline is missing, it won't be used.
-            names.clone()
-        } else {
-            let mut names = self.pipelines.keys().cloned().collect::<Vec<String>>();
-            names.sort();
-            names
-        }
-    }
-
-    /// Expands a group of pipelines into a series of pipelines.
-    /// They will then be expanded into a series of transforms.
-    fn serial(&self) -> Box<dyn TransformConfig> {
-        let pipelines: IndexMap<String, Box<dyn TransformConfig>> = self
-            .names()
-            .into_iter()
-            .filter_map(|name| {
-                self.pipelines
-                    .get(&name)
-                    .map(|config| (name, config.serial()))
-            })
-            .collect();
-
-        Box::new(expander::ExpanderConfig::serial(pipelines))
-    }
 }
 
 /// The configuration of the pipelines transform itself.
@@ -317,11 +211,11 @@ mod tests {
     fn parsing() {
         let config = PipelinesConfig::generate_config();
         let config: PipelinesConfig = config.try_into().unwrap();
-        assert_eq!(config.logs.pipelines.len(), 2);
-        let foo = config.logs.pipelines.get("foo").unwrap();
-        assert_eq!(foo.transforms.len(), 2);
-        let bar = config.logs.pipelines.get("bar").unwrap();
-        assert_eq!(bar.transforms.len(), 1);
+        assert_eq!(config.logs.pipelines().len(), 2);
+        let foo = config.logs.pipelines().get("foo").unwrap();
+        assert_eq!(foo.transforms().len(), 2);
+        let bar = config.logs.pipelines().get("bar").unwrap();
+        assert_eq!(bar.transforms().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
This commit is a mostly mechanical shuffle of our pipeline code, done
while investigating https://github.com/vectordotdev/vector/issues/10144. I found the previous organization
challenging to comprehend and this reads more clear to me. I've tried
to follow the section commenting style common to the rest of the
transform code.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>