### PR TITLE
chore: Fix lookup of issue number in soak comment posting

### DIFF
--- a/.github/workflows/soak_comment.yml
+++ b/.github/workflows/soak_comment.yml
@@ -108,6 +108,6 @@ jobs:
       - name: Post Results To PR
         uses: peter-evans/create-or-update-comment@v1
         with:
-          issue-number: ${{ needs.pr-number.outputs.content }}
+          issue-number: ${{ steps.pr-number.outputs.content }}
           edit-mode: replace
           body: ${{ steps.read-analysis.outputs.content }}


### PR DESCRIPTION
This should be `steps`. I'd copied over `needs` from the `soak.yml`
workflow where the pr-number was output from a different job.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
