### PR TITLE
chore: Remove redundant soak comment tasks

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -455,20 +455,6 @@ jobs:
           name: pr-number
           path: /tmp/pr.txt
 
-      - name: Read analysis file
-        id: read-analysis
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: /tmp/${{ github.run_id }}-${{ github.run_attempt }}-analysis
-
-      - name: Post Results To PR
-        uses: peter-evans/create-or-update-comment@v1
-        continue-on-error: true
-        with:
-          issue-number: ${{ needs.compute-soak-meta.outputs.pr-number }}
-          edit-mode: replace
-          body: ${{ steps.read-analysis.outputs.content }}
-
   detect-regressions:
     name: Regression analysis
     runs-on: ubuntu-20.04


### PR DESCRIPTION
These have been moved to a separate workflow, `soak_comment.yml`, so
that they are posted correctly for contributor PRs which lack the
requisite access to post from the `soak.yml` workflow.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
