### PR TITLE
chore(aws_cloudwatch_metrics sink): Migrate to AWS SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,28 +609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-cloudwatchlogs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cefdd4806407b31b7a06672ddc02eb37d97a7ea0ce41dc71ffe6787b6a9369"
-dependencies = [
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
- "bytes 1.1.0",
- "http",
- "tokio-stream",
- "tower",
-]
-
-[[package]]
 name = "aws-sdk-sqs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8375,7 +8353,6 @@ dependencies = [
  "avro-rs",
  "aws-config",
  "aws-sdk-cloudwatch",
- "aws-sdk-cloudwatchlogs",
  "aws-sdk-sqs",
  "aws-smithy-client",
  "aws-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudwatch"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8196fee59818e0097765fce8ed5fb824be526a4b5e33ae3c4d173059828cb1"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes 1.1.0",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
 name = "aws-sdk-sqs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6036,20 +6059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusoto_cloudwatch"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b42eaedbdf15b452446aa00aee94230c41443673985807f1c12fb1fb1cc5799"
-dependencies = [
- "async-trait",
- "bytes 1.1.0",
- "futures 0.3.21",
- "rusoto_core",
- "serde_urlencoded 0.7.0",
- "xml-rs",
-]
-
-[[package]]
 name = "rusoto_core"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8343,6 +8352,7 @@ dependencies = [
  "atty",
  "avro-rs",
  "aws-config",
+ "aws-sdk-cloudwatch",
  "aws-sdk-sqs",
  "aws-smithy-client",
  "aws-types",
@@ -8439,7 +8449,6 @@ dependencies = [
  "rmp-serde",
  "rmpv",
  "roaring",
- "rusoto_cloudwatch",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_es",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudwatchlogs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9cefdd4806407b31b7a06672ddc02eb37d97a7ea0ce41dc71ffe6787b6a9369"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.1.0",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
 name = "aws-sdk-sqs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8353,6 +8375,7 @@ dependencies = [
  "avro-rs",
  "aws-config",
  "aws-sdk-cloudwatch",
+ "aws-sdk-cloudwatchlogs",
  "aws-sdk-sqs",
  "aws-smithy-client",
  "aws-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ aws-config = { version = "0.8.0", optional = true }
 aws-types = { version = "0.8.0", optional = true, features = ["hardcoded-credentials"]}
 aws-sdk-sqs = { version = "0.8.0", optional = true }
 aws-sdk-cloudwatch = { version = "0.8.0", optional = true }
+aws-sdk-cloudwatchlogs = { version = "0.8.0", optional = true }
 aws-smithy-client = { version = "0.38.0", optional = true }
 
 # Azure
@@ -629,7 +630,7 @@ sinks-metrics = [
 ]
 
 sinks-aws_cloudwatch_logs = ["rusoto", "rusoto_logs"]
-sinks-aws_cloudwatch_metrics = ["rusoto", "aws-sdk-cloudwatch"]
+sinks-aws_cloudwatch_metrics = ["aws-sdk-cloudwatch", "aws-sdk-cloudwatchlogs"]
 sinks-aws_kinesis_firehose = ["rusoto", "rusoto_firehose"]
 sinks-aws_kinesis_streams = ["rusoto", "rusoto_kinesis"]
 sinks-aws_s3 = ["base64", "md-5", "rusoto", "rusoto_s3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,6 @@ metrics = { version = "0.17.1", default-features = false, features = ["std"] }
 metrics-tracing-context = { version = "0.9.0", default-features = false }
 
 # AWS - Rusoto
-rusoto_cloudwatch = { version = "0.47.0", optional = true }
 rusoto_core = { version = "0.47.0", features = ["encoding"], optional = true }
 rusoto_credential = { version = "0.47.0", optional = true }
 rusoto_es = { version = "0.47.0", optional = true }
@@ -153,6 +152,7 @@ rusoto_sts = { version = "0.47.0", optional = true }
 aws-config = { version = "0.8.0", optional = true }
 aws-types = { version = "0.8.0", optional = true, features = ["hardcoded-credentials"]}
 aws-sdk-sqs = { version = "0.8.0", optional = true }
+aws-sdk-cloudwatch = { version = "0.8.0", optional = true }
 aws-smithy-client = { version = "0.38.0", optional = true }
 
 # Azure
@@ -629,7 +629,7 @@ sinks-metrics = [
 ]
 
 sinks-aws_cloudwatch_logs = ["rusoto", "rusoto_logs"]
-sinks-aws_cloudwatch_metrics = ["rusoto", "rusoto_cloudwatch"]
+sinks-aws_cloudwatch_metrics = ["rusoto", "aws-sdk-cloudwatch"]
 sinks-aws_kinesis_firehose = ["rusoto", "rusoto_firehose"]
 sinks-aws_kinesis_streams = ["rusoto", "rusoto_kinesis"]
 sinks-aws_s3 = ["base64", "md-5", "rusoto", "rusoto_s3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,6 @@ aws-config = { version = "0.8.0", optional = true }
 aws-types = { version = "0.8.0", optional = true, features = ["hardcoded-credentials"]}
 aws-sdk-sqs = { version = "0.8.0", optional = true }
 aws-sdk-cloudwatch = { version = "0.8.0", optional = true }
-aws-sdk-cloudwatchlogs = { version = "0.8.0", optional = true }
 aws-smithy-client = { version = "0.38.0", optional = true }
 
 # Azure
@@ -630,7 +629,7 @@ sinks-metrics = [
 ]
 
 sinks-aws_cloudwatch_logs = ["rusoto", "rusoto_logs"]
-sinks-aws_cloudwatch_metrics = ["aws-sdk-cloudwatch", "aws-sdk-cloudwatchlogs"]
+sinks-aws_cloudwatch_metrics = ["aws-sdk-cloudwatch"]
 sinks-aws_kinesis_firehose = ["rusoto", "rusoto_firehose"]
 sinks-aws_kinesis_streams = ["rusoto", "rusoto_kinesis"]
 sinks-aws_s3 = ["base64", "md-5", "rusoto", "rusoto_s3"]

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroU64;
 
 use futures::FutureExt;
-use rusoto_logs::CloudWatchLogsClient;
 use serde::{Deserialize, Serialize};
 use vector_core::config::log_schema;
 

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU64;
 
 use futures::FutureExt;
+use rusoto_logs::CloudWatchLogsClient;
 use serde::{Deserialize, Serialize};
 use vector_core::config::log_schema;
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -4,16 +4,12 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{future, future::BoxFuture, stream, FutureExt, SinkExt};
-// use rusoto_cloudwatch::{
-//     CloudWatch, CloudWatchClient, Dimension, MetricDatum, PutMetricDataError, PutMetricDataInput,
-// };
-// use rusoto_core::{Region, RusotoError};
 use aws_sdk_cloudwatch::error::{PutMetricDataError, PutMetricDataErrorKind};
 use aws_sdk_cloudwatch::model::{Dimension, MetricDatum};
 use aws_sdk_cloudwatch::types::DateTime as AwsDateTime;
 use aws_sdk_cloudwatch::types::SdkError;
 use aws_sdk_cloudwatch::{Client as CloudwatchClient, Region};
+use futures::{future, future::BoxFuture, stream, FutureExt, SinkExt};
 use serde::{Deserialize, Serialize};
 use tower::Service;
 use vector_core::ByteSizeOf;

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -138,7 +138,7 @@ impl CloudWatchMetricsSinkConfig {
 
         let region = if cfg!(test) {
             // Moto (used for mocking AWS) doesn't recognize 'custom' as valid region name
-            Region::new("us-east-1")
+            Some(Region::new("us-east-1"))
         } else {
             self.region.region()
         };


### PR DESCRIPTION
This migrates the `aws_cloudwatch_metrics` sink from rusoto to the AWS SDK.