### PR TITLE
chore: Add rust-version documenting MSRV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -345,14 +345,13 @@ jobs:
 
   check-msrv:
     name: Check MSRV
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, x64, general]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: bash scripts/environment/prepare.sh
       - run: cargo install cargo-msrv --version 0.15.1
       - run: cargo msrv verify
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,6 +343,19 @@ jobs:
       - name: Stop sccache
         run: sccache --stop-server
 
+  check-msrv:
+    name: Check MSRV
+    runs-on: ubuntu-20.04
+    needs: changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    steps:
+      - uses: colpal/actions-clean@v1
+      - uses: actions/checkout@v3
+      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: cargo install cargo-msrv --version 0.15.1
+      - run: cargo msrv verify
+
   checks:
     name: Checks
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 publish = false
 default-run = "vector"
 autobenches = false # our benchmarks are not runnable on their own either way
+rust-version = "1.58.1"
 
 [[bin]]
 name = "graphql-schema"


### PR DESCRIPTION
A user in Discord was wondering what the last Vector version was that
supported 1.54 of Rust. I realized this would be easier to tell if we
started tracking it. I ran `cargo msrv` to figure out the current MSRV. We
are using the "Captured identifiers in format strings" feature from 1.58 so
that is our current MSRV.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
