### PR TITLE
chore: Experiment with autoscale soak runners

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -231,7 +231,7 @@ jobs:
 
   soak-baseline:
     name: Soak (${{ matrix.target }}) - baseline - replica ${{ matrix.replica }}
-    runs-on: [self-hosted, linux, x64, soak]
+    runs-on: [linux, soak, soak-runner]
     needs: [compute-soak-meta, compute-test-plan, build-image-baseline]
     strategy:
       matrix: ${{ fromJson(needs.compute-test-plan.outputs.matrix) }}
@@ -317,7 +317,7 @@ jobs:
 
   soak-comparison:
     name: Soak (${{ matrix.target }}) - comparison - replica ${{ matrix.replica }}
-    runs-on: [self-hosted, linux, x64, soak]
+    runs-on: [linux, soak, soak-runner]
     needs: [compute-soak-meta, compute-test-plan, build-image-comparison]
     strategy:
       matrix: ${{ fromJson(needs.compute-test-plan.outputs.matrix) }}

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -144,8 +144,6 @@ jobs:
     runs-on: [linux, soak, soak-builder]
     needs: [compute-soak-meta]
     steps:
-      - uses: colpal/actions-clean@v1
-
       - uses: actions/checkout@v3
 
       - uses: actions/checkout@v3
@@ -189,8 +187,6 @@ jobs:
     runs-on: [linux, soak, soak-builder]
     needs: [compute-soak-meta]
     steps:
-      - uses: colpal/actions-clean@v1
-
       - uses: actions/checkout@v3
 
       - uses: actions/checkout@v3
@@ -236,8 +232,6 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.compute-test-plan.outputs.matrix) }}
     steps:
-      - uses: colpal/actions-clean@v1
-
       - name: Check out the repo
         uses: actions/checkout@v3
 
@@ -322,8 +316,6 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.compute-test-plan.outputs.matrix) }}
     steps:
-      - uses: colpal/actions-clean@v1
-
       - name: Check out the repo
         uses: actions/checkout@v3
 


### PR DESCRIPTION
This commit follows up on #11728 and experiments with the Github custom runners
for running soaks. We have previously used our own very quiet instances for this
kind of work to avoid adding any more noise than we must, but I'm curious what
the results of this will look like.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
