### PR TITLE
chore: Make http_gen payloads smaller

### DIFF
--- a/soaks/common/configs/http_gen_datadog_source.yaml
+++ b/soaks/common/configs/http_gen_datadog_source.yaml
@@ -4,6 +4,7 @@ prometheus_addr: "0.0.0.0:9090"
 targets:
   vector:
     seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+    batch_sizes: ["1Mb", "500Kb", "250Kb", "100Kb", "50Kb", "25Kb", "10Kb", "1Kb"]
     headers:
       dd-api-key: "DEADBEEF"
     target_uri: "http://vector:8282/v1/input"

--- a/soaks/common/configs/http_gen_http_source.yaml
+++ b/soaks/common/configs/http_gen_http_source.yaml
@@ -4,6 +4,7 @@ prometheus_addr: "0.0.0.0:9090"
 targets:
   vector:
     seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+    batch_sizes: ["1Mb", "500Kb", "250Kb", "100Kb", "50Kb", "25Kb", "10Kb", "1Kb"]
     target_uri: "http://vector:8282/"
     bytes_per_second: "100 Mb"
     parallel_connections: 10

--- a/soaks/common/configs/http_gen_http_source_json.yaml
+++ b/soaks/common/configs/http_gen_http_source_json.yaml
@@ -4,6 +4,7 @@ prometheus_addr: "0.0.0.0:9090"
 targets:
   vector:
     seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+    batch_sizes: ["1Mb", "500Kb", "250Kb", "100Kb", "50Kb", "25Kb", "10Kb", "1Kb"]
     target_uri: "http://vector:8282/"
     bytes_per_second: "100 Mb"
     parallel_connections: 10

--- a/soaks/common/configs/http_gen_splunk_source.yaml
+++ b/soaks/common/configs/http_gen_splunk_source.yaml
@@ -4,6 +4,7 @@ prometheus_addr: "0.0.0.0:9090"
 targets:
   vector:
     seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+    batch_sizes: ["1Mb", "500Kb", "250Kb", "100Kb", "50Kb", "25Kb", "10Kb", "1Kb"]
     headers:
       dd-api-key: "DEADBEEF"
     target_uri: "http://vector:8282/services/collector/event/1.0"


### PR DESCRIPTION
While working on #11655 with Will it occurred to me that we _might_ be seeing
erratic behavior from Vector because the payloads we send it are large enough
that lading can't smoothly push load. That is, a payload explodes into a large
enough series of events that Vector sees internally smooth load but an external
observer cannot make forward progress.

I'm curious to see what happens to the CoV of our http sourced soaks if we make
the payloads smaller.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
