### PR TITLE
chore: Unify logic to (de)serialize `OwnedPath`s

### DIFF
--- a/lib/lookup/src/lookup_v2/mod.rs
+++ b/lib/lookup/src/lookup_v2/mod.rs
@@ -1,14 +1,34 @@
 mod jit;
 
 use crate::lookup_v2::jit::{JitLookup, JitPath};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::iter::Cloned;
 use std::slice::Iter;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OwnedPath {
     pub segments: Vec<OwnedSegment>,
+}
+
+impl<'de> Deserialize<'de> for OwnedPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let path: String = Deserialize::deserialize(deserializer)?;
+        Ok(parse_path(&path))
+    }
+}
+
+impl Serialize for OwnedPath {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // TODO: Implement canonical way to serialize segments.
+        todo!()
+    }
 }
 
 impl OwnedPath {
@@ -47,8 +67,8 @@ impl From<Vec<OwnedSegment>> for OwnedPath {
     }
 }
 
-/// Use if you want to pre-parse paths so it can be used multiple times
-/// The return value implements `Path` so it can be used directly
+/// Use if you want to pre-parse paths so it can be used multiple times.
+/// The return value implements `Path` so it can be used directly.
 pub fn parse_path(path: &str) -> OwnedPath {
     let segments = JitPath::new(path)
         .segment_iter()
@@ -131,7 +151,7 @@ impl<'a> Path<'a> for &'a str {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum OwnedSegment {
     Field(String),
     Index(usize),

--- a/src/sinks/datadog/events/request_builder.rs
+++ b/src/sinks/datadog/events/request_builder.rs
@@ -116,7 +116,7 @@ fn encoder() -> EncodingConfigFixed<StandardJsonEncoding> {
                 "title",
             ]
             .iter()
-            .map(|field| vec![OwnedSegment::Field((*field).into())])
+            .map(|field| vec![OwnedSegment::Field((*field).into())].into())
             .collect(),
         ),
         // DataDog Event API requires unix timestamp.

--- a/src/sinks/util/encoding/adapter.rs
+++ b/src/sinks/util/encoding/adapter.rs
@@ -1,13 +1,14 @@
 #![deny(missing_docs)]
 
-use super::{EncodingConfiguration, TimestampFormat};
+use super::{validate_fields, EncodingConfiguration, TimestampFormat};
 use crate::{
     codecs::encoding::{Framer, FramingConfig, Serializer, SerializerConfig},
     event::Event,
+    serde::skip_serializing_if_default,
 };
 use core::fmt::Debug;
-use lookup::lookup_v2::OwnedSegment;
-use serde::{Deserialize, Serialize};
+use lookup::lookup_v2::OwnedPath;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::marker::PhantomData;
 
 /// Trait used to migrate from a sink-specific `Codec` enum to the new
@@ -52,7 +53,8 @@ where
             framing,
             encoding: EncodingWithTransformationConfig {
                 encoding,
-                filter: None,
+                only_fields: None,
+                except_fields: None,
                 timestamp_format: None,
             },
         })
@@ -77,42 +79,13 @@ where
     /// Build a `Transformer` that applies the encoding rules to an event before serialization.
     pub fn transformer(&self) -> Transformer {
         match self {
-            Self::Encoding(config) => {
-                let only_fields = config
-                    .encoding
-                    .filter
-                    .as_ref()
-                    .and_then(|filter| match filter {
-                        OnlyOrExceptFieldsConfig::OnlyFields(fields) => {
-                            Some(fields.only_fields.clone())
-                        }
-                        _ => None,
-                    });
-                let except_fields =
-                    config
-                        .encoding
-                        .filter
-                        .as_ref()
-                        .and_then(|filter| match filter {
-                            OnlyOrExceptFieldsConfig::ExceptFields(fields) => {
-                                Some(fields.except_fields.clone())
-                            }
-                            _ => None,
-                        });
-                let timestamp_format = config.encoding.timestamp_format;
-
-                Transformer {
-                    only_fields,
-                    except_fields,
-                    timestamp_format,
-                }
-            }
+            Self::Encoding(config) => Transformer {
+                only_fields: config.encoding.only_fields.clone(),
+                except_fields: config.encoding.except_fields.clone(),
+                timestamp_format: config.encoding.timestamp_format,
+            },
             Self::LegacyEncodingConfig(config) => Transformer {
-                only_fields: config
-                    .encoding
-                    .only_fields()
-                    .as_ref()
-                    .map(|fields| fields.iter().map(|field| field.to_vec()).collect()),
+                only_fields: config.encoding.only_fields().clone(),
                 except_fields: config.encoding.except_fields().clone(),
                 timestamp_format: *config.encoding.timestamp_format(),
             },
@@ -154,36 +127,40 @@ pub struct EncodingConfig {
     encoding: EncodingWithTransformationConfig,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct EncodingWithTransformationConfigValidated(EncodingWithTransformationConfig);
+
+impl<'de> Deserialize<'de> for EncodingWithTransformationConfigValidated {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let config: EncodingWithTransformationConfig = Deserialize::deserialize(deserializer)?;
+        validate_fields(
+            config.only_fields.as_deref(),
+            config.except_fields.as_deref(),
+        )
+        .map_err(serde::de::Error::custom)?;
+        Ok(Self(config))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EncodingWithTransformationConfig {
     #[serde(flatten)]
     encoding: SerializerConfig,
-    #[serde(flatten)]
-    filter: Option<OnlyOrExceptFieldsConfig>,
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    only_fields: Option<Vec<OwnedPath>>,
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    except_fields: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     timestamp_format: Option<TimestampFormat>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum OnlyOrExceptFieldsConfig {
-    OnlyFields(OnlyFieldsConfig),
-    ExceptFields(ExceptFieldsConfig),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OnlyFieldsConfig {
-    only_fields: Vec<Vec<OwnedSegment>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExceptFieldsConfig {
-    except_fields: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
 /// Transformations to prepare an event for serialization.
 pub struct Transformer {
-    only_fields: Option<Vec<Vec<OwnedSegment>>>,
+    only_fields: Option<Vec<OwnedPath>>,
     except_fields: Option<Vec<String>>,
     timestamp_format: Option<TimestampFormat>,
 }
@@ -206,7 +183,7 @@ impl EncodingConfiguration for Transformer {
         &None
     }
 
-    fn only_fields(&self) -> &Option<Vec<Vec<OwnedSegment>>> {
+    fn only_fields(&self) -> &Option<Vec<OwnedPath>> {
         &self.only_fields
     }
 
@@ -222,6 +199,7 @@ impl EncodingConfiguration for Transformer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lookup::lookup_v2::parse_path;
 
     #[test]
     fn deserialize_encoding_with_transformation() {
@@ -229,8 +207,9 @@ mod tests {
             {
                 "encoding": {
                     "codec": "raw_message",
-                    "timestamp_format": "unix",
-                    "except_fields": ["ignore_me"]
+                    "only_fields": ["a.b[0]"],
+                    "except_fields": ["ignore_me"],
+                    "timestamp_format": "unix"
                 }
             }
         "#;
@@ -238,14 +217,9 @@ mod tests {
         let config = serde_json::from_str::<EncodingConfig>(string).unwrap();
         let encoding = config.encoding;
 
+        assert_eq!(encoding.only_fields, Some(vec![parse_path("a.b[0]")]));
+        assert_eq!(encoding.except_fields, Some(vec!["ignore_me".to_owned()]));
         assert_eq!(encoding.timestamp_format.unwrap(), TimestampFormat::Unix);
-        assert_eq!(
-            match encoding.filter.unwrap() {
-                OnlyOrExceptFieldsConfig::ExceptFields(config) => config.except_fields,
-                _ => panic!(),
-            },
-            vec!["ignore_me".to_owned()]
-        );
     }
 
     #[test]

--- a/src/sinks/util/encoding/fixed.rs
+++ b/src/sinks/util/encoding/fixed.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
-use lookup::lookup_v2::OwnedSegment;
+use lookup::lookup_v2::OwnedPath;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     serde::skip_serializing_if_default,
-    sinks::util::encoding::{deserialize_path_components, EncodingConfiguration, TimestampFormat},
+    sinks::util::encoding::{EncodingConfiguration, TimestampFormat},
 };
 
 /// A structure to wrap sink encodings and enforce field privacy.
@@ -21,13 +21,8 @@ pub struct EncodingConfigFixed<E: Default + PartialEq> {
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) schema: Option<String>,
     /// Keep only the following fields of the message. (Items mutually exclusive with `except_fields`)
-    // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-    #[serde(
-        default,
-        skip_serializing_if = "skip_serializing_if_default",
-        deserialize_with = "deserialize_path_components"
-    )]
-    pub(crate) only_fields: Option<Vec<Vec<OwnedSegment>>>,
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    pub(crate) only_fields: Option<Vec<OwnedPath>>,
     /// Remove the following fields of the message. (Items mutually exclusive with `only_fields`)
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) except_fields: Option<Vec<String>>,
@@ -47,8 +42,7 @@ impl<E: Default + PartialEq> EncodingConfiguration for EncodingConfigFixed<E> {
         &self.schema
     }
 
-    // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-    fn only_fields(&self) -> &Option<Vec<Vec<OwnedSegment>>> {
+    fn only_fields(&self) -> &Option<Vec<OwnedPath>> {
         &self.only_fields
     }
 

--- a/src/sinks/util/encoding/with_default.rs
+++ b/src/sinks/util/encoding/with_default.rs
@@ -3,7 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
-use lookup::lookup_v2::OwnedSegment;
+use lookup::lookup_v2::OwnedPath;
 use serde::{
     de::{self, DeserializeOwned, Deserializer, IntoDeserializer, MapAccess, Visitor},
     Deserialize, Serialize,
@@ -11,7 +11,7 @@ use serde::{
 
 use crate::{
     serde::skip_serializing_if_default,
-    sinks::util::encoding::{deserialize_path_components, EncodingConfiguration, TimestampFormat},
+    sinks::util::encoding::{EncodingConfiguration, TimestampFormat},
 };
 
 /// A structure to wrap sink encodings and enforce field privacy.
@@ -27,8 +27,7 @@ pub struct EncodingConfigWithDefault<E: Default + PartialEq> {
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) schema: Option<String>,
     /// Keep only the following fields of the message. (Items mutually exclusive with `except_fields`)
-    // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-    pub(crate) only_fields: Option<Vec<Vec<OwnedSegment>>>,
+    pub(crate) only_fields: Option<Vec<OwnedPath>>,
     /// Remove the following fields of the message. (Items mutually exclusive with `only_fields`)
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub(crate) except_fields: Option<Vec<String>>,
@@ -48,8 +47,7 @@ impl<E: Default + PartialEq> EncodingConfiguration for EncodingConfigWithDefault
         &self.schema
     }
 
-    // TODO(2410): Using PathComponents here is a hack for #2407, #2410 should fix this fully.
-    fn only_fields(&self) -> &Option<Vec<Vec<OwnedSegment>>> {
+    fn only_fields(&self) -> &Option<Vec<OwnedPath>> {
         &self.only_fields
     }
 
@@ -152,8 +150,8 @@ pub struct InnerWithDefault<E: Default> {
     codec: E,
     #[serde(default)]
     schema: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_path_components")]
-    only_fields: Option<Vec<Vec<OwnedSegment>>>,
+    #[serde(default)]
+    only_fields: Option<Vec<OwnedPath>>,
     #[serde(default)]
     except_fields: Option<Vec<String>>,
     #[serde(default)]

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -28,7 +28,7 @@ use dnstap_proto::{
     message::Type as DnstapMessageType, Dnstap, Message as DnstapMessage, SocketFamily,
     SocketProtocol,
 };
-use lookup::lookup_v2::OwnedSegment;
+use lookup::lookup_v2::OwnedPath;
 
 use super::{
     dns_message::{
@@ -76,7 +76,7 @@ static DNSTAP_MESSAGE_RESPONSE_TYPE_IDS: Lazy<HashSet<i32>> = Lazy::new(|| {
 
 pub struct DnstapParser<'a> {
     event_schema: &'a DnstapEventSchema,
-    parent_key_path: Vec<OwnedSegment>,
+    parent_key_path: OwnedPath,
     log_event: &'a mut LogEvent,
 }
 
@@ -92,7 +92,7 @@ impl<'a> DnstapParser<'a> {
     pub fn new(event_schema: &'a DnstapEventSchema, log_event: &'a mut LogEvent) -> Self {
         Self {
             event_schema,
-            parent_key_path: Vec::new(),
+            parent_key_path: Vec::new().into(),
             log_event,
         }
     }
@@ -102,7 +102,7 @@ impl<'a> DnstapParser<'a> {
         V: Into<Value> + Debug,
     {
         let mut node_path = self.parent_key_path.clone();
-        node_path.push(OwnedSegment::Field(key.into()));
+        node_path.push_field(key);
         self.log_event.insert(&node_path, value)
     }
 
@@ -292,8 +292,7 @@ impl<'a> DnstapParser<'a> {
             }
 
             if dnstap_message.query_message != None {
-                self.parent_key_path
-                    .push(OwnedSegment::Field(request_message_key.into()));
+                self.parent_key_path.push_field(request_message_key);
 
                 let time_key_name = if dnstap_message_type_id <= MAX_DNSTAP_QUERY_MESSAGE_TYPE_ID {
                     self.event_schema.dns_query_message_schema().time()
@@ -319,7 +318,7 @@ impl<'a> DnstapParser<'a> {
                     "ns",
                 );
 
-                self.parent_key_path.pop();
+                self.parent_key_path.segments.pop();
             }
         }
 
@@ -349,8 +348,7 @@ impl<'a> DnstapParser<'a> {
             }
 
             if dnstap_message.response_message != None {
-                self.parent_key_path
-                    .push(OwnedSegment::Field(response_message_key.into()));
+                self.parent_key_path.push_field(response_message_key);
 
                 let time_key_name = if dnstap_message_type_id <= MAX_DNSTAP_QUERY_MESSAGE_TYPE_ID {
                     self.event_schema.dns_query_message_schema().time()
@@ -376,7 +374,7 @@ impl<'a> DnstapParser<'a> {
                     "ns",
                 );
 
-                self.parent_key_path.pop();
+                self.parent_key_path.segments.pop();
             }
         }
 
@@ -468,15 +466,14 @@ impl<'a> DnstapParser<'a> {
     }
 
     fn log_raw_dns_message(&mut self, key_prefix: &'static str, raw_dns_message: &[u8]) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_prefix.into()));
+        self.parent_key_path.push_field(key_prefix);
 
         self.insert(
             self.event_schema.dns_query_message_schema().raw_data(),
             base64::encode(raw_dns_message),
         );
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn parse_dns_query_message(
@@ -486,8 +483,7 @@ impl<'a> DnstapParser<'a> {
     ) -> Result<()> {
         let msg = dns_message_parser.parse_as_query_message()?;
 
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_prefix.into()));
+        self.parent_key_path.push_field(key_prefix);
 
         self.insert(
             self.event_schema.dns_query_message_schema().response_code(),
@@ -541,13 +537,12 @@ impl<'a> DnstapParser<'a> {
             &msg.opt_pserdo_section,
         );
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
         Ok(())
     }
 
     fn log_dns_query_message_header(&mut self, parent_key: &'static str, header: &QueryHeader) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(parent_key.into()));
+        self.parent_key_path.push_field(parent_key);
 
         self.insert(self.event_schema.dns_query_header_schema().id(), header.id);
 
@@ -617,7 +612,7 @@ impl<'a> DnstapParser<'a> {
             header.additional_count,
         );
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn log_dns_query_message_query_section(
@@ -625,16 +620,15 @@ impl<'a> DnstapParser<'a> {
         key_path: &'static str,
         questions: &[QueryQuestion],
     ) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_path.into()));
+        self.parent_key_path.push_field(key_path);
 
         for (i, query) in questions.iter().enumerate() {
-            self.parent_key_path.push(OwnedSegment::Index(i));
+            self.parent_key_path.push_index(i);
             self.log_dns_query_question(query);
-            self.parent_key_path.pop();
+            self.parent_key_path.segments.pop();
         }
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn log_dns_query_question(&mut self, question: &QueryQuestion) {
@@ -669,8 +663,7 @@ impl<'a> DnstapParser<'a> {
     ) -> Result<()> {
         let msg = dns_message_parser.parse_as_update_message()?;
 
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_prefix.into()));
+        self.parent_key_path.push_field(key_prefix);
 
         self.insert(
             self.event_schema
@@ -717,13 +710,12 @@ impl<'a> DnstapParser<'a> {
             &msg.additional_section,
         );
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
         Ok(())
     }
 
     fn log_dns_update_message_header(&mut self, key_prefix: &'static str, header: &UpdateHeader) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_prefix.into()));
+        self.parent_key_path.push_field(key_prefix);
 
         self.insert(self.event_schema.dns_update_header_schema().id(), header.id);
 
@@ -763,12 +755,11 @@ impl<'a> DnstapParser<'a> {
             header.additional_count,
         );
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn log_dns_update_message_zone_section(&mut self, key_path: &'static str, zone: &ZoneInfo) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_path.into()));
+        self.parent_key_path.push_field(key_path);
 
         self.insert(
             self.event_schema.dns_update_zone_info_schema().zone_name(),
@@ -791,12 +782,11 @@ impl<'a> DnstapParser<'a> {
             zone.class.clone(),
         );
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn log_edns(&mut self, key_prefix: &'static str, opt_section: &Option<OptPseudoSection>) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_prefix.into()));
+        self.parent_key_path.push_field(key_prefix);
 
         if let Some(edns) = opt_section {
             self.insert(
@@ -831,20 +821,19 @@ impl<'a> DnstapParser<'a> {
             );
         }
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn log_edns_options(&mut self, key_path: &'static str, options: &[EdnsOptionEntry]) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_path.into()));
+        self.parent_key_path.push_field(key_path);
 
         options.iter().enumerate().for_each(|(i, opt)| {
-            self.parent_key_path.push(OwnedSegment::Index(i));
+            self.parent_key_path.push_index(i);
             self.log_edns_opt(opt);
-            self.parent_key_path.pop();
+            self.parent_key_path.segments.pop();
         });
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn log_edns_opt(&mut self, opt: &EdnsOptionEntry) {
@@ -863,16 +852,15 @@ impl<'a> DnstapParser<'a> {
     }
 
     fn log_dns_message_record_section(&mut self, key_path: &'static str, records: &[DnsRecord]) {
-        self.parent_key_path
-            .push(OwnedSegment::Field(key_path.into()));
+        self.parent_key_path.push_field(key_path);
 
         for (i, record) in records.iter().enumerate() {
-            self.parent_key_path.push(OwnedSegment::Index(i));
+            self.parent_key_path.push_index(i);
             self.log_dns_record(record);
-            self.parent_key_path.pop();
+            self.parent_key_path.segments.pop();
         }
 
-        self.parent_key_path.pop();
+        self.parent_key_path.segments.pop();
     }
 
     fn log_dns_record(&mut self, record: &DnsRecord) {

--- a/src/transforms/grok_parser.rs
+++ b/src/transforms/grok_parser.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str};
 
 use bytes::Bytes;
 use grok::Pattern;
-use lookup::lookup_v2::{parse_path, OwnedSegment};
+use lookup::lookup_v2::{parse_path, OwnedPath};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use vector_common::TimeZone;
@@ -97,7 +97,7 @@ pub struct GrokParser {
     field: String,
     drop_field: bool,
     types: HashMap<String, Conversion>,
-    paths: HashMap<String, Vec<OwnedSegment>>,
+    paths: HashMap<String, OwnedPath>,
 }
 
 impl Clone for GrokParser {
@@ -130,7 +130,7 @@ impl FunctionTransform for GrokParser {
                                 event.insert(path, value);
                             } else {
                                 let path = parse_path(name);
-                                self.paths.insert(name.to_string(), path.segments.clone());
+                                self.paths.insert(name.to_string(), path.clone());
                                 event.insert(&path, value);
                             }
                         }

--- a/src/transforms/tokenizer.rs
+++ b/src/transforms/tokenizer.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, str};
 
 use bytes::Bytes;
-use lookup::lookup_v2::{parse_path, OwnedSegment};
+use lookup::lookup_v2::{parse_path, OwnedPath};
 use serde::{Deserialize, Serialize};
 use vector_common::{tokenize::parse, TimeZone};
 
@@ -72,7 +72,7 @@ impl TransformConfig for TokenizerConfig {
 
 #[derive(Clone, Debug)]
 pub struct Tokenizer {
-    field_names: Vec<(String, Vec<OwnedSegment>, Conversion)>,
+    field_names: Vec<(String, OwnedPath, Conversion)>,
     field: String,
     drop_field: bool,
 }
@@ -88,7 +88,7 @@ impl Tokenizer {
             .into_iter()
             .map(|name| {
                 let conversion = types.get(&name).unwrap_or(&Conversion::Bytes).clone();
-                let path = parse_path(&name).segments;
+                let path = parse_path(&name);
                 (name, path, conversion)
             })
             .collect();


### PR DESCRIPTION
This PR is a follow-up to https://github.com/vectordotdev/vector/pull/11198#pullrequestreview-873565962 and should fix some latent bugs within structs that have not explicitly used `deserialize_path_components` yet.  This work is done in preparation to integrate `encoding::Encoder` by using `EncodingConfigMigrator` in sinks, e.g. https://github.com/vectordotdev/vector/pull/11647.

tl;dr: Replaces

```
#[serde(deserialize_with = "deserialize_path_components")]
only_fields: Option<Vec<Vec<OwnedSegment>>>,
```

with

```
only_fields: Option<Vec<OwnedPath>>,
```