### PR TITLE
enhancement(loki sink): Re-enable concurrency

### DIFF
--- a/src/sinks/loki/service.rs
+++ b/src/sinks/loki/service.rs
@@ -15,8 +15,28 @@ use vector_core::{
 
 use crate::{
     http::{Auth, HttpClient},
-    sinks::util::{Compression, UriSerde},
+    sinks::util::{retries::RetryLogic, Compression, UriSerde},
 };
+
+#[derive(Clone)]
+pub struct LokiRetryLogic;
+
+impl RetryLogic for LokiRetryLogic {
+    type Error = LokiError;
+    type Response = LokiResponse;
+
+    fn is_retriable_error(&self, error: &Self::Error) -> bool {
+        match error {
+            LokiError::ServerError { code } => match code {
+                &StatusCode::TOO_MANY_REQUESTS => true,
+                &StatusCode::NOT_IMPLEMENTED => false,
+                _ if code.is_server_error() => true,
+                _ => false,
+            },
+            LokiError::HttpError { .. } => true,
+        }
+    }
+}
 
 #[derive(Debug, Snafu)]
 pub enum LokiError {
@@ -46,6 +66,7 @@ impl DriverResponse for LokiResponse {
     }
 }
 
+#[derive(Clone)]
 pub struct LokiRequest {
     pub compression: Compression,
     pub batch_size: usize,

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -16,7 +16,7 @@ use vector_core::{
 use super::{
     config::{Encoding, LokiConfig, OutOfOrderAction},
     event::{LokiBatchEncoder, LokiEvent, LokiRecord, PartitionKey},
-    service::{LokiRequest, LokiService},
+    service::{LokiRequest, LokiResponse, LokiRetryLogic, LokiService},
 };
 use crate::{
     config::{log_schema, SinkContext},
@@ -28,6 +28,7 @@ use crate::{
     sinks::util::{
         builder::SinkBuilderExt,
         encoding::{EncodingConfig, EncodingConfiguration},
+        service::ServiceBuilderExt,
         Compression, RequestBuilder,
     },
     template::Template,
@@ -311,20 +312,40 @@ impl RecordFilter {
     }
 }
 
-#[derive(Clone)]
 pub struct LokiSink {
     acker: Acker,
     request_builder: LokiRequestBuilder,
     pub(super) encoder: EventEncoder,
     batch_settings: BatcherSettings,
     out_of_order_action: OutOfOrderAction,
-    service: LokiService,
+    service: tower::util::BoxService<LokiRequest, LokiResponse, crate::Error>,
 }
 
 impl LokiSink {
     #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
     pub fn new(config: LokiConfig, client: HttpClient, cx: SinkContext) -> crate::Result<Self> {
         let compression = config.compression;
+
+        // if Vector is configured to allow events with out of order timestamps, then then we can
+        // safely enable concurrency settings.
+        //
+        // For rewritten timestamps, we use a static concurrency of 1 to avoid out-of-order
+        // timestamps across requests. We used to support concurrency across partitions (Loki
+        // streams) but this was lost in #9506. Rather than try to re-add it, since Loki no longer
+        // requires in-order processing for version >= 2.4, instead we just keep the static limit
+        // of 1 for now.
+        let request_limits = match config.out_of_order_action {
+            OutOfOrderAction::Accept => config.request.unwrap_with(&Default::default()),
+            OutOfOrderAction::Drop | OutOfOrderAction::RewriteTimestamp => {
+                let mut settings = config.request.unwrap_with(&Default::default());
+                settings.concurrency = Some(1);
+                settings
+            }
+        };
+
+        let service = tower::ServiceBuilder::new()
+            .settings(request_limits, LokiRetryLogic)
+            .service(LokiService::new(client, config.endpoint, config.auth)?);
 
         Ok(Self {
             acker: cx.acker(),
@@ -341,15 +362,11 @@ impl LokiSink {
             },
             batch_settings: config.batch.into_batcher_settings()?,
             out_of_order_action: config.out_of_order_action,
-            service: LokiService::new(client, config.endpoint, config.auth)?,
+            service,
         })
     }
 
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let service = tower::ServiceBuilder::new()
-            .concurrency_limit(1)
-            .service(self.service);
-
         let encoder = self.encoder.clone();
         let mut filter = RecordFilter::new(self.out_of_order_action);
 
@@ -379,7 +396,7 @@ impl LokiSink {
                     None
                 }
             })
-            .request_builder(NonZeroUsize::new(1), self.request_builder)
+            .request_builder(NonZeroUsize::new(50), self.request_builder)
             .filter_map(|request| async move {
                 match request {
                     Err(e) => {
@@ -389,7 +406,7 @@ impl LokiSink {
                     Ok(req) => Some(req),
                 }
             })
-            .into_driver(service, self.acker);
+            .into_driver(self.service, self.acker);
 
         sink.run().await
     }


### PR DESCRIPTION
This re-enables concurrency in the Loki sink if the out-of-order action
is `Drop` or `Allow` since there is no risk of concurrent requests
causing out-of-order issues.

It also adds retry logic, mostly incidentally since I was just trying to
use the scaffolding we already have for service building from
`TowerRequestConfig` which requires retry logic to be provided.
I cribbed and modified it from the `http` sink retry logic.

Closes: #11758

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
