### PR TITLE
chore: Try reading legacy encoding config first

### DIFF
--- a/src/sinks/util/encoding/adapter.rs
+++ b/src/sinks/util/encoding/adapter.rs
@@ -34,10 +34,10 @@ where
         + Debug
         + Clone,
 {
-    /// The encoding configuration.
-    Encoding(EncodingConfig),
     /// The legacy sink-specific encoding configuration.
     LegacyEncodingConfig(LegacyEncodingConfigWrapper<LegacyEncodingConfig, Migrator>),
+    /// The encoding configuration.
+    Encoding(EncodingConfig),
 }
 
 impl<LegacyEncodingConfig, Migrator> EncodingConfigAdapter<LegacyEncodingConfig, Migrator>


### PR DESCRIPTION
While testing the HTTP integration in https://github.com/vectordotdev/vector/pull/11647 I noticed that backwards-compatibility is not granted if the new encoding config matches the old one. This PR fixes that.

(This is marked as "chore" rather than "fix", since it's not used anywhere yet.)