### PR TITLE
enhancement(codecs): Warn when `RawMessageSerializer` reads an empty message

### DIFF
--- a/src/codecs/encoding/format/raw_message.rs
+++ b/src/codecs/encoding/format/raw_message.rs
@@ -1,6 +1,6 @@
-use crate::{config::log_schema, event::Event, schema};
+use crate::{config::log_schema, event::Event, internal_events::RawMessageEmpty, schema};
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Encoder;
 use value::Kind;
@@ -51,6 +51,10 @@ impl Encoder<Event> for RawMessageSerializer {
             Event::Metric(_) => None,
             Event::Trace(_) => None,
         };
+
+        if bytes.as_ref().map(Bytes::is_empty).unwrap_or(true) {
+            emit!(&RawMessageEmpty);
+        }
 
         if let Some(bytes) = bytes {
             buffer.put(bytes);

--- a/src/internal_events/decoding.rs
+++ b/src/internal_events/decoding.rs
@@ -30,33 +30,3 @@ impl<'a> InternalEvent for DecoderDeserializeFailed<'a> {
         counter!("decoder_deserialize_errors_total", 1);
     }
 }
-
-#[derive(Debug)]
-pub struct EncoderFramingFailed<'a> {
-    pub error: &'a crate::codecs::encoding::BoxedFramingError,
-}
-
-impl<'a> InternalEvent for EncoderFramingFailed<'a> {
-    fn emit_logs(&self) {
-        warn!(message = "Failed framing bytes.", error = %self.error, internal_log_rate_secs = 10);
-    }
-
-    fn emit_metrics(&self) {
-        counter!("encoder_framing_errors_total", 1);
-    }
-}
-
-#[derive(Debug)]
-pub struct EncoderSerializeFailed<'a> {
-    pub error: &'a crate::Error,
-}
-
-impl<'a> InternalEvent for EncoderSerializeFailed<'a> {
-    fn emit_logs(&self) {
-        warn!(message = "Failed serializing frame.", error = %self.error, internal_log_rate_secs = 10);
-    }
-
-    fn emit_metrics(&self) {
-        counter!("encoder_serialize_errors_total", 1);
-    }
-}

--- a/src/internal_events/encoding.rs
+++ b/src/internal_events/encoding.rs
@@ -1,0 +1,48 @@
+use metrics::counter;
+use vector_core::internal_event::InternalEvent;
+
+#[derive(Debug)]
+pub struct EncoderFramingFailed<'a> {
+    pub error: &'a crate::codecs::encoding::BoxedFramingError,
+}
+
+impl<'a> InternalEvent for EncoderFramingFailed<'a> {
+    fn emit_logs(&self) {
+        warn!(message = "Failed framing bytes.", error = %self.error, internal_log_rate_secs = 10);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("encoder_framing_errors_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct EncoderSerializeFailed<'a> {
+    pub error: &'a crate::Error,
+}
+
+impl<'a> InternalEvent for EncoderSerializeFailed<'a> {
+    fn emit_logs(&self) {
+        warn!(message = "Failed serializing frame.", error = %self.error, internal_log_rate_secs = 10);
+    }
+
+    fn emit_metrics(&self) {
+        counter!("encoder_serialize_errors_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct RawMessageEmpty;
+
+impl InternalEvent for RawMessageEmpty {
+    fn emit_logs(&self) {
+        warn!(
+            message = "Received empty message while encoding message key.",
+            internal_log_rate_secs = 10
+        );
+    }
+
+    fn emit_metrics(&self) {
+        counter!("raw_message_empty_total", 1);
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -41,7 +41,7 @@ mod datadog_events;
 #[cfg(feature = "sinks-datadog_metrics")]
 mod datadog_metrics;
 #[cfg(any(feature = "codecs"))]
-mod decoder;
+mod decoding;
 #[cfg(feature = "transforms-dedupe")]
 mod dedupe;
 #[cfg(feature = "sources-demo_logs")]
@@ -51,6 +51,8 @@ mod dnstap;
 #[cfg(feature = "sources-docker_logs")]
 mod docker_logs;
 mod elasticsearch;
+#[cfg(any(feature = "codecs"))]
+mod encoding;
 mod encoding_transcode;
 #[cfg(feature = "sources-eventstoredb_metrics")]
 mod eventstoredb_metrics;
@@ -198,7 +200,7 @@ pub(crate) use self::datadog_events::*;
 #[cfg(feature = "sinks-datadog_metrics")]
 pub(crate) use self::datadog_metrics::*;
 #[cfg(any(feature = "codecs"))]
-pub(crate) use self::decoder::*;
+pub(crate) use self::decoding::*;
 #[cfg(feature = "transforms-dedupe")]
 pub(crate) use self::dedupe::*;
 #[cfg(feature = "sources-demo_logs")]
@@ -209,6 +211,8 @@ pub(crate) use self::dnstap::*;
 pub(crate) use self::docker_logs::*;
 #[cfg(feature = "sinks-elasticsearch")]
 pub(crate) use self::elasticsearch::*;
+#[cfg(any(feature = "codecs"))]
+pub(crate) use self::encoding::*;
 #[cfg(feature = "sources-eventstoredb_metrics")]
 pub(crate) use self::eventstoredb_metrics::*;
 #[cfg(feature = "sources-exec")]


### PR DESCRIPTION
E.g. for the old HTTP sink encoding we warned in that case, and I think it would be generally useful.