### PR TITLE
chore: Replace trivial `format!("{}")` with `to_string`

### DIFF
--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -23,7 +23,7 @@ fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
     controller.reset();
 
     for idx in 0..cardinality {
-        metrics::counter!("test", 1, "idx" => format!("{}", idx));
+        metrics::counter!("test", 1, "idx" => idx.to_string());
     }
 
     controller

--- a/lib/datadog/grok/src/matchers/date.rs
+++ b/lib/datadog/grok/src/matchers/date.rs
@@ -118,7 +118,7 @@ fn parse_offset(tz: &str) -> Result<FixedOffset, String> {
     let date_str = format!("2020-04-12 22:10:57 {}", tz);
     let datetime =
         DateTime::parse_from_str(&date_str, &format!("%Y-%m-%d %H:%M:%S {}", offset_format))
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| e.to_string())?;
     Ok(datetime.timezone())
 }
 

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -421,7 +421,7 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(
-            format!("{}", err),
+            err.to_string(),
             "Circular dependency found in the alias 'pattern1'"
         );
     }

--- a/lib/lookup/src/parser.rs
+++ b/lib/lookup/src/parser.rs
@@ -12,5 +12,5 @@ lalrpop_mod!(
 pub fn parse_lookup(s: &str) -> Result<Lookup, String> {
     path::LookupParser::new()
         .parse(s)
-        .map_err(|err| format!("{}", err))
+        .map_err(|err| err.to_string())
 }

--- a/lib/value/src/value/display.rs
+++ b/lib/value/src/value/display.rs
@@ -1,6 +1,6 @@
 use crate::Value;
 use chrono::SecondsFormat;
-use std::fmt;
+use std::{fmt, string::ToString};
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -27,7 +27,7 @@ impl fmt::Display for Value {
             Value::Array(array) => {
                 let joined = array
                     .iter()
-                    .map(|val| format!("{}", val))
+                    .map(ToString::to_string)
                     .collect::<Vec<_>>()
                     .join(", ");
                 write!(f, "[{}]", joined)

--- a/lib/value/src/value/serde.rs
+++ b/lib/value/src/value/serde.rs
@@ -14,9 +14,9 @@ impl Value {
             Value::Bytes(bytes) => bytes.clone(), // cloning `Bytes` is cheap
             Value::Regex(regex) => regex.as_bytes(),
             Value::Timestamp(timestamp) => Bytes::from(timestamp_to_string(timestamp)),
-            Value::Integer(num) => Bytes::from(format!("{}", num)),
-            Value::Float(num) => Bytes::from(format!("{}", num)),
-            Value::Boolean(b) => Bytes::from(format!("{}", b)),
+            Value::Integer(num) => Bytes::from(num.to_string()),
+            Value::Float(num) => Bytes::from(num.to_string()),
+            Value::Boolean(b) => Bytes::from(b.to_string()),
             Value::Object(map) => {
                 Bytes::from(serde_json::to_vec(map).expect("Cannot serialize map"))
             }
@@ -34,9 +34,9 @@ impl Value {
             Value::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
             Value::Regex(regex) => regex.as_str().to_string(),
             Value::Timestamp(timestamp) => timestamp_to_string(timestamp),
-            Value::Integer(num) => format!("{}", num),
-            Value::Float(num) => format!("{}", num),
-            Value::Boolean(b) => format!("{}", b),
+            Value::Integer(num) => num.to_string(),
+            Value::Float(num) => num.to_string(),
+            Value::Boolean(b) => b.to_string(),
             Value::Object(map) => serde_json::to_string(map).expect("Cannot serialize map"),
             Value::Array(arr) => serde_json::to_string(arr).expect("Cannot serialize array"),
             Value::Null => "<null>".to_string(),

--- a/lib/vector-core/src/event/metric.rs
+++ b/lib/vector-core/src/event/metric.rs
@@ -423,7 +423,7 @@ impl Quantile {
     /// "9999".
     pub fn as_percentile(&self) -> String {
         let clamped = self.quantile.clamp(0.0, 1.0);
-        let raw = format!("{}", (clamped * 100.0));
+        let raw = (clamped * 100.0).to_string();
         raw.chars()
             .take(5)
             .filter(|c| c.is_numeric())

--- a/lib/vrl/compiler/benches/kind.rs
+++ b/lib/vrl/compiler/benches/kind.rs
@@ -32,7 +32,7 @@ fn benchmark_kind_display(c: &mut Criterion) {
         let kind = parameter.kind();
 
         group.bench_with_input(BenchmarkId::from_parameter(param), &kind, |b, kind| {
-            b.iter(|| format!("{}", kind))
+            b.iter(|| kind.to_string())
         });
     }
 }

--- a/lib/vrl/compiler/src/test_util.rs
+++ b/lib/vrl/compiler/src/test_util.rs
@@ -47,7 +47,7 @@ macro_rules! bench_function {
             let mut group = c.benchmark_group(&format!("vrl_stdlib/functions/{}", stringify!($name)));
             group.throughput(criterion::Throughput::Elements(1));
             $(
-                group.bench_function(&format!("{}", stringify!($case)), |b| {
+                group.bench_function(&stringify!($case).to_string(), |b| {
                     let mut compiler_state = $crate::state::Compiler::default();
                     let (expression, want) = $crate::__prep_bench_or_test!($func, compiler_state, $args, $(Ok($crate::Value::from($ok)))? $(Err($err.to_owned()))?);
                     let expression = expression.unwrap();

--- a/lib/vrl/proptests/src/main.rs
+++ b/lib/vrl/proptests/src/main.rs
@@ -277,22 +277,22 @@ proptest! {
     #[test]
     fn expr_parses(expr in expr()) {
         let expr = program(expr);
-        let source = format!("{}", expr);
+        let source = expr.to_string();
         let program = parser::parse(source.clone()).unwrap();
 
-        assert_eq!(format!("{}", program),
-                   format!("{}", expr),
+        assert_eq!(program.to_string(),
+                   expr.to_string(),
                    "{}", source);
     }
 
     #[test]
     fn if_parses(expr in if_statement()) {
         let expr = program(expr);
-        let source = format!("{}", expr);
+        let source = expr.to_string();
         let program = parser::parse(source.clone()).unwrap();
 
-        assert_eq!(format!("{}", program),
-                   format!("{}", expr),
+        assert_eq!(program.to_string(),
+                   expr.to_string(),
                    "{}", source);
     }
 }

--- a/lib/vrl/stdlib/src/only_fields.rs
+++ b/lib/vrl/stdlib/src/only_fields.rs
@@ -28,7 +28,7 @@ impl Function for OnlyFields {
         paths.push(arguments.required_path("1")?);
 
         for i in 2..=16 {
-            if let Some(path) = arguments.optional_path(&format!("{}", i))? {
+            if let Some(path) = arguments.optional_path(&i.to_string())? {
                 paths.push(path)
             }
         }

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -280,7 +280,7 @@ fn parse<'a>(
             // Create a descriptive error message if possible.
             nom::error::convert_error(input, e)
         }
-        _ => format!("{}", e),
+        _ => e.to_string(),
     })?;
 
     if rest.trim().is_empty() {

--- a/lib/vrl/stdlib/src/parse_timestamp.rs
+++ b/lib/vrl/stdlib/src/parse_timestamp.rs
@@ -60,7 +60,7 @@ impl Expression for ParseTimestampFn {
                 let bytes = self.format.resolve(ctx)?;
                 let format = bytes.try_bytes_utf8_lossy()?;
                 Conversion::parse(format!("timestamp|{}", format), ctx.timezone().to_owned())
-                    .map_err(|e| format!("{}", e))?
+                    .map_err(|e| e.to_string())?
                     .convert(v)
                     .map_err(|e| e.to_string().into())
             }

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -230,9 +230,9 @@ impl NotEqualsPredicate {
             arg: match arg {
                 CheckFieldsPredicateArg::String(s) => vec![s.clone()],
                 CheckFieldsPredicateArg::VecString(ss) => ss.clone(),
-                CheckFieldsPredicateArg::Integer(a) => vec![format!("{}", a)],
-                CheckFieldsPredicateArg::Float(a) => vec![format!("{}", a)],
-                CheckFieldsPredicateArg::Boolean(a) => vec![format!("{}", a)],
+                CheckFieldsPredicateArg::Integer(a) => vec![a.to_string()],
+                CheckFieldsPredicateArg::Float(a) => vec![a.to_string()],
+                CheckFieldsPredicateArg::Boolean(a) => vec![a.to_string()],
             },
         }))
     }

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -358,7 +358,7 @@ async fn cloudwatch_insert_log_event_partitioned() {
         .enumerate()
         .map(|(i, e)| {
             let mut event = Event::from(e);
-            let stream = format!("{}", (i % 2));
+            let stream = (i % 2).to_string();
             event.as_mut_log().insert("key", stream);
             event
         })

--- a/src/sinks/aws_s3/tests.rs
+++ b/src/sinks/aws_s3/tests.rs
@@ -130,7 +130,7 @@ mod integration_tests {
             } else {
                 3
             };
-            e.insert("i", format!("{}", i));
+            e.insert("i", i.to_string());
             Event::from(e)
         });
 

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -187,7 +187,7 @@ impl DatadogArchivesSinkConfig {
                 let client = service.client();
                 let svc = self
                     .build_s3_sink(&s3_config.options, service, cx)
-                    .map_err(|error| format!("{}", error))?;
+                    .map_err(|error| error.to_string())?;
                 Ok((
                     svc,
                     s3_common::config::build_healthcheck(self.bucket.clone(), client)?,
@@ -204,7 +204,7 @@ impl DatadogArchivesSinkConfig {
                 )?;
                 let svc = self
                     .build_azure_sink(Arc::<ContainerClient>::clone(&client), cx)
-                    .map_err(|error| format!("{}", error))?;
+                    .map_err(|error| error.to_string())?;
                 let healthcheck =
                     azure_common::config::build_healthcheck(self.bucket.clone(), client)?;
                 Ok((svc, healthcheck))
@@ -229,7 +229,7 @@ impl DatadogArchivesSinkConfig {
                 )?;
                 let sink = self
                     .build_gcs_sink(client, base_url, creds, cx)
-                    .map_err(|error| format!("{}", error))?;
+                    .map_err(|error| error.to_string())?;
                 Ok((sink, healthcheck))
             }
 

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -150,7 +150,7 @@ impl RetryLogic for GcsRetryLogic {
             StatusCode::NOT_IMPLEMENTED => {
                 RetryAction::DontRetry("endpoint not implemented".into())
             }
-            _ if status.is_server_error() => RetryAction::Retry(format!("{}", status).into()),
+            _ if status.is_server_error() => RetryAction::Retry(status.to_string().into()),
             _ if status.is_success() => RetryAction::Successful,
             _ => RetryAction::DontRetry(format!("response status: {}", status).into()),
         }

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -117,7 +117,7 @@ impl Service<GcsRequest> for GcsService {
         headers.insert("content-type", settings.content_type);
         headers.insert(
             "content-length",
-            HeaderValue::from_str(&format!("{}", request.body.len())).unwrap(),
+            HeaderValue::from_str(&request.body.len().to_string()).unwrap(),
         );
         settings
             .content_encoding

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -642,7 +642,7 @@ mod tests {
         user = "waldo"
         password = "hunter2"
     "#
-        .replace("$IN_ADDR", &format!("{}", in_addr));
+        .replace("$IN_ADDR", &in_addr.to_string());
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 
         let cx = SinkContext::new_test();

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -715,7 +715,7 @@ mod tests {
             .to_vec(),
         );
 
-        assert_eq!(format!("{}", (i + 1) * 1000000000), line_protocol.3);
+        assert_eq!(((i + 1) * 1000000000).to_string(), line_protocol.3);
     }
 
     fn create_sink(

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -526,7 +526,7 @@ mod tests {
         let config: InfluxDbTestConfig = toml::from_str(config).unwrap();
         let settings = influxdb_settings(config.influxdb1_settings, config.influxdb2_settings);
         assert_eq!(
-            format!("{}", settings.expect_err("expected error")),
+            settings.expect_err("expected error").to_string(),
             "Unclear settings. Both version configured v1: InfluxDb1Settings { database: \"my-database\", consistency: None, retention_policy_name: None, username: None, password: None }, v2: InfluxDb2Settings { org: \"my-org\", bucket: \"my-bucket\", token: \"my-token\" }.".to_owned()
         );
     }
@@ -538,7 +538,7 @@ mod tests {
         let config: InfluxDbTestConfig = toml::from_str(config).unwrap();
         let settings = influxdb_settings(config.influxdb1_settings, config.influxdb2_settings);
         assert_eq!(
-            format!("{}", settings.expect_err("expected error")),
+            settings.expect_err("expected error").to_string(),
             "InfluxDB v1 or v2 should be configured as endpoint.".to_owned()
         );
     }

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -254,7 +254,7 @@ impl HttpSink for LogdnaConfig {
             .as_millis();
 
         query.append_pair("hostname", &key.hostname);
-        query.append_pair("now", &format!("{}", now));
+        query.append_pair("now", &now.to_string());
 
         if let Some(mac) = &self.mac {
             query.append_pair("mac", mac);

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -221,7 +221,7 @@ mod tests {
         let http_config = nr_config.create_config().unwrap();
 
         assert_eq!(
-            format!("{}", http_config.uri.uri),
+            http_config.uri.uri.to_string(),
             "https://log-api.newrelic.com/log/v1".to_string()
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
@@ -252,7 +252,7 @@ mod tests {
         let http_config = nr_config.create_config().unwrap();
 
         assert_eq!(
-            format!("{}", http_config.uri.uri),
+            http_config.uri.uri.to_string(),
             "https://log-api.eu.newrelic.com/log/v1".to_string()
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));
@@ -290,7 +290,7 @@ mod tests {
         let http_config = nr_config.create_config().unwrap();
 
         assert_eq!(
-            format!("{}", http_config.uri.uri),
+            http_config.uri.uri.to_string(),
             "https://log-api.eu.newrelic.com/log/v1".to_string()
         );
         assert_eq!(http_config.method, Some(HttpMethod::Post));

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -1175,7 +1175,7 @@ mod tests {
 
     impl Partition<Bytes> for (usize, usize) {
         fn partition(&self) -> Bytes {
-            format!("{}", self.0).into()
+            self.0.to_string().into()
         }
     }
 

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -391,7 +391,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
                             tags.get("endpoint"),
                             Some(&format!("http://{}/metrics", in_addr))
                         );
-                        assert_eq!(tags.get("host"), Some(&format!("{}", in_addr)));
+                        assert_eq!(tags.get("host"), Some(&in_addr.to_string()));
                     }
                     None => error!(message = "No tags for metric.", metric = ?m),
                 }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -688,7 +688,7 @@ mod test {
 
         assert_eq!(
             events[0].as_log()[log_schema().host_key()],
-            format!("{}", from).into()
+            from.to_string().into()
         );
     }
 

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -152,7 +152,7 @@ impl<'a> Widgets<'a> {
                 Style::default().fg(Color::Gray),
             ),
             Span::from(" | "),
-            Span::styled(format!("{}", connection_status), connection_status.style()),
+            Span::styled(connection_status.to_string(), connection_status.style()),
         ])];
 
         let block = Block::default().borders(Borders::ALL).title(Span::styled(

--- a/src/transforms/split.rs
+++ b/src/transforms/split.rs
@@ -41,7 +41,7 @@ impl TransformConfig for SplitConfig {
 
         let timezone = self.timezone.unwrap_or(context.globals.timezone);
         let types = parse_check_conversion_map(&self.types, &self.field_names, timezone)
-            .map_err(|error| format!("{}", error))?;
+            .map_err(|error| error.to_string())?;
 
         // don't drop the source field if it's getting overwritten by a parsed value
         let drop_field = self.drop_field && !self.field_names.iter().any(|f| **f == *field);

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -258,7 +258,7 @@ fn create_tmp_directory(config: &mut Config, fmt: &mut Formatter) -> Option<Path
             Some(path)
         }
         Err(error) => {
-            fmt.error(format!("{}", error));
+            fmt.error(error.to_string());
             None
         }
     }
@@ -288,17 +288,17 @@ impl Formatter {
             max_line_width: 0,
             print_space: false,
             error_intro: if color {
-                format!("{}", "x".red())
+                "x".red().to_string()
             } else {
                 "x".to_owned()
             },
             warning_intro: if color {
-                format!("{}", "~".yellow())
+                "~".yellow().to_string()
             } else {
                 "~".to_owned()
             },
             success_intro: if color {
-                format!("{}", "√".green())
+                "√".green().to_string()
             } else {
                 "√".to_owned()
             },

--- a/tests/metrics_snapshot.rs
+++ b/tests/metrics_snapshot.rs
@@ -6,7 +6,7 @@ fn prepare_metrics(cardinality: usize) -> &'static Controller {
     controller.reset();
 
     for idx in 0..cardinality {
-        metrics::counter!("test", 1, "idx" => format!("{}", idx));
+        metrics::counter!("test", 1, "idx" => idx.to_string());
     }
 
     assert_eq!(controller.capture_metrics().len(), cardinality + 1);

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -90,7 +90,7 @@ fn vector_with(config_path: PathBuf, address: SocketAddr, quiet: bool) -> Comman
         .arg(if quiet { "--quiet" } else { "-v" })
         .env("VECTOR_DATA_DIR", create_directory())
         .env("VECTOR_TEST_UNIX_PATH", temp_file())
-        .env("VECTOR_TEST_ADDRESS", format!("{}", address));
+        .env("VECTOR_TEST_ADDRESS", address.to_string());
 
     cmd
 }


### PR DESCRIPTION
This is just a simple `comby` search and replace with a couple manual fixups. I'm curious if any of these are in a hot path.