### PR TITLE
chore: Introduce 'up' plots

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -531,6 +531,12 @@ jobs:
                                     --output-dir ${{ github.run_id }}-${{ github.run_attempt }}-captures/plots/ \
                                     --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }}
 
+      - name: Plot up analysis
+        run: |
+          mkdir -p ${{ github.run_id }}-${{ github.run_attempt }}-captures/plots/
+          ./soaks/bin/plot_up --capture-dir ${{ github.run_id }}-${{ github.run_attempt }}-captures/ \
+                              --output-dir ${{ github.run_id }}-${{ github.run_attempt }}-captures/plots/
+
       - name: Upload plots
         uses: actions/upload-artifact@v1
         with:

--- a/soaks/bin/plot_analysis
+++ b/soaks/bin/plot_analysis
@@ -11,7 +11,7 @@ import pathlib
 
 np.seterr(all='raise')
 
-parser = argparse.ArgumentParser(description='t-test experiments with Welch method')
+parser = argparse.ArgumentParser(description='Plot throughput results from soak run')
 parser.add_argument('--capture-dir', type=str, help='the directory to search for capture files')
 parser.add_argument('--output-dir', type=str, help='the directory to search for capture files')
 parser.add_argument('--vector-cpus', type=int, help='the total number of CPUs given to vector during the experiment')

--- a/soaks/bin/plot_up
+++ b/soaks/bin/plot_up
@@ -11,7 +11,7 @@ import pathlib
 
 np.seterr(all='raise')
 
-parser = argparse.ArgumentParser(description='t-test experiments with Welch method')
+parser = argparse.ArgumentParser(description='Plot up results from soak run')
 parser.add_argument('--capture-dir', type=str, help='the directory to search for capture files')
 parser.add_argument('--output-dir', type=str, help='the directory to search for capture files')
 args = parser.parse_args()
@@ -33,6 +33,4 @@ for exp in up.experiment.unique():
                     x="fetch_index", y="value",
                     hue="run_id")
     plt.savefig(os.path.join(args.output_dir, "{}/up.png".format(exp)), dpi=200)
-    plt.close()
-
     plt.close()

--- a/soaks/bin/plot_up
+++ b/soaks/bin/plot_up
@@ -18,7 +18,7 @@ args = parser.parse_args()
 
 up = pd.concat(common.open_captures(args.capture_dir,
                                     'up',
-                                    unwanted_labels=['metric_name', 'metric_kind', 'target', 'time']))
+                                    unwanted_labels=['metric_name', 'metric_kind', 'time']))
 
 for exp in up.experiment.unique():
     print(exp)
@@ -26,7 +26,7 @@ for exp in up.experiment.unique():
 
     pathlib.Path(os.path.join(args.output_dir, "{}".format(exp))).mkdir(parents=True, exist_ok=True)
 
-    data = up[up.experiment == exp].sort_values(by=['variant']).reset_index()
+    data = up[(up.experiment == exp) & (up.target == "vector")].sort_values(by=['variant']).reset_index()
     print(data)
 
     sns.scatterplot(data=data,

--- a/soaks/bin/plot_up
+++ b/soaks/bin/plot_up
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import seaborn as sns
+import numpy as np
+import pandas as pd
+import scipy.stats
+import argparse
+import common
+import matplotlib.pyplot as plt
+import os
+import pathlib
+
+np.seterr(all='raise')
+
+parser = argparse.ArgumentParser(description='t-test experiments with Welch method')
+parser.add_argument('--capture-dir', type=str, help='the directory to search for capture files')
+parser.add_argument('--output-dir', type=str, help='the directory to search for capture files')
+args = parser.parse_args()
+
+up = pd.concat(common.open_captures(args.capture_dir,
+                                    'up',
+                                    unwanted_labels=['metric_name', 'metric_kind', 'target', 'time']))
+
+for exp in up.experiment.unique():
+    print(exp)
+    sns.set_theme()
+
+    pathlib.Path(os.path.join(args.output_dir, "{}".format(exp))).mkdir(parents=True, exist_ok=True)
+
+    data = up[up.experiment == exp].sort_values(by=['variant']).reset_index()
+    print(data)
+
+    sns.scatterplot(data=data,
+                    x="fetch_index", y="value",
+                    hue="run_id")
+    plt.savefig(os.path.join(args.output_dir, "{}/up.png".format(exp)), dpi=200)
+    plt.close()
+
+    plt.close()


### PR DESCRIPTION
The soak observer keeps a record of every time it reaches out to Vector to
collect metrics and is unable to get a response. This is a 'down'
state. Previously we rarely saw Vector down, although now a see-saw pattern has
developed. This is a problem as Vector's health in soak is also measured by
whether it responds to metrics queries.

REF #11772

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
