### PR TITLE
fix(ci): Allow test result upload to fail without failing the ci job

### DIFF
--- a/scripts/upload-test-results.sh
+++ b/scripts/upload-test-results.sh
@@ -17,6 +17,8 @@ _os_architecture="$(uname -m)"
 export DD_TAGS="os.platform:$_os_platform,os.architecture:$_os_architecture"
 export DD_ENV="${DD_ENV:-"local"}"
 
+# TODO: outside contributors don't have access to the
+# CI secrets, so allowing this to fail for now
 datadog-ci junit upload \
   --service vector \
-  target/nextest/default/junit.xml
+  target/nextest/default/junit.xml || echo "Failed to upload results"


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
