### PR TITLE
fix(releasing): Fix version calculation

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -10,6 +10,6 @@ set -euo pipefail
 #   An optional "nightly" suffix is added if the build channel
 #   is nightly.
 
-VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
+VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /^version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
 CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
 echo "$VERSION"


### PR DESCRIPTION
Adding `rust-version` to `Cargo.toml` in #11754  was causing the `awk` script to match it as well.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
