### PR TITLE
chore: Utilize k8s static CPU manager policy for soaks

### DIFF
--- a/soaks/bin/boot_minikube.sh
+++ b/soaks/bin/boot_minikube.sh
@@ -43,4 +43,10 @@ done
 
 minikube stop || true
 minikube delete || true
-minikube start --cpus="${SOAK_CPUS}" --memory="${SOAK_MEMORY}" --driver=docker
+minikube start \
+  --feature-gates="CPUManager=true" `# enable CPU management flags` \
+  --extra-config="kubelet.cpu-manager-policy=static" `# use static policy to let "Guaranteed" pods (those with limits=requests) and integer CPU requests have CPU affinity` \
+  --extra-config "kubelet.kube-reserved=cpu=1" `# reserve 1 CPU for kube` \
+  --cpus="${SOAK_CPUS}" `# ensure this is higher than the number of CPUs requested by all soak pods or you will see throttling by CFS via the docker driver` \
+  --memory="${SOAK_MEMORY}" `# ensure this is higher than the amount of memory requested by all soak pods or you will see OOMs` \
+  --driver=docker

--- a/soaks/common/terraform/modules/vector/main.tf
+++ b/soaks/common/terraform/modules/vector/main.tf
@@ -91,16 +91,16 @@ resource "kubernetes_deployment" "vector" {
             read_only  = true
           }
 
+          # WARNING limits should match requests and both cpu and memory should be specified
+          # This guarantees that the Vector pod is given a QOS of Guaranteed
           resources {
-            # Because we do not have the ability to self-constrain vector's
-            # memory consumption we only make a request here on memory. This
-            # avoids vector crashing for want of a malloc.
             limits = {
               cpu = var.vector_cpus
+              memory = "4Gi"
             }
             requests = {
               cpu    = var.vector_cpus
-              memory = "512Mi"
+              memory = "4Gi"
             }
           }
 


### PR DESCRIPTION
This allows for k8s to give pods CPU affinity if they have a QOS of
Guaranteed and request a whole number of CPUs.

This PR also adds a memory limit for Vector since this is required to
receive a QOS of Guaranteed.

I discussed this with Brian and we are hoping this results in less throttling of Vector which could be causing additional soak variance.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
