### PR TITLE
chore: Update Loki soak to not reorder timestamps

### DIFF
--- a/soaks/tests/syslog_loki/terraform/vector.toml
+++ b/soaks/tests/syslog_loki/terraform/vector.toml
@@ -27,6 +27,7 @@ type = "loki"
 inputs = ["syslog"]
 endpoint = "http://http-blackhole:8080"
 encoding.codec = "json"
+out_of_order_action = "accept"
 
 [sinks.loki.labels]
 host = "{{ .host }}"


### PR DESCRIPTION
We should also see a performance bump with
https://github.com/vectordotdev/vector/pull/11761 which re-enables
concurrency when the out_of_order_action is `accept`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
