### PR TITLE
feat(journald source): add a since_now option

### DIFF
--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -60,6 +60,12 @@ components: sources: journald: {
 			required:    false
 			type: bool: default: true
 		}
+		since_now: {
+			common:      true
+			description: "Include only future entries."
+			required:    false
+			type: bool: default: false
+		}
 		exclude_units: {
 			common:      true
 			description: "The list of unit names to exclude from monitoring. Unit names lacking a `\".\"` will have `\".service\"` appended to make them a valid service unit name."


### PR DESCRIPTION
The `since_now` option is used to tell journalctl to start from now,
instead of the begining. It is useful when migrating to a new logging
stack (here vector) to not replay and resend all already collected
logs by another software.

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
