### PR TITLE
chore(ci): Only upload junit results when CI=true

### DIFF
--- a/scripts/upload-test-results.sh
+++ b/scripts/upload-test-results.sh
@@ -8,6 +8,11 @@ IFS=$'\n\t'
 #
 #   Upload `cargo-nextest` JUnit output to Datadog
 
+if ! (${CI:-false}); then
+  # Only run in CI
+  exit 0
+fi
+
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -x
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
