### PR TITLE
chore: Move upload of test results to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,49 @@ jobs:
           CARGO_BUILD_JOBS: 5
       - name: Stop sccache
         run: sccache --stop-server
+      - name: Upload test results
+        run: scripts/upload-test-results.sh
+        if: always()
+
+  test-cli:
+    name: CLI - Linux
+    runs-on: [self-hosted, linux, x64, general]
+    needs: changes
+    env:
+      CARGO_INCREMENTAL: 0
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    steps:
+      - uses: colpal/actions-clean@v1
+      - uses: actions/checkout@v3
+      - run: make ci-sweep
+      - uses: actions/cache@v2.1.7
+        name: Cache Cargo registry + index
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      # We always make sure to stop any previous sccache process before starting it fresh, that
+      # way we can be sure we're using the right credentials for storage, etc.
+      - name: Start sccache
+        env:
+          SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
+          SCCACHE_IDLE_TIMEOUT: 0
+        run: |
+          sccache --stop-server || true
+          sccache --start-server
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - run: make test-cli
+      - name: Stop sccache
+        run: sccache --stop-server
+      - name: Upload test results
+        run: scripts/upload-test-results.sh
+        if: always()
 
   test-misc:
     name: Miscellaneous - Linux
@@ -155,7 +198,6 @@ jobs:
           sccache --stop-server || true
           sccache --start-server
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - run: make test-cli
       - run: make test-behavior
       - run: make check-examples
       - run: make test-docs

--- a/Makefile
+++ b/Makefile
@@ -297,10 +297,6 @@ target/%/vector.tar.gz: target/%/vector CARGO_HANDLES_FRESHNESS
 .PHONY: test
 test: ## Run the unit test suite
 	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --workspace --no-fail-fast --no-default-features --features "${DEFAULT_FEATURES}" ${SCOPE}
-# https://github.com/vectordotdev/vector/issues/11762
-ifneq ($(OPERATING_SYSTEM), Windows)
-	@scripts/upload-test-results.sh
-endif
 
 .PHONY: test-docs
 test-docs: ## Run the docs test suite
@@ -351,10 +347,6 @@ ifeq ($(AUTOSPAWN), true)
 	sleep 10 # Many services are very slow... Give them a sec..
 endif
 	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --no-fail-fast --no-default-features --features nats-integration-tests --lib ::nats::
-# https://github.com/vectordotdev/vector/issues/11762
-ifneq ($(OPERATING_SYSTEM), Windows)
-	@scripts/upload-test-results.sh
-endif
 ifeq ($(AUTODESPAWN), true)
 	@scripts/setup_integration_env.sh nats stop
 endif
@@ -386,10 +378,6 @@ test-e2e-kubernetes: ## Runs Kubernetes E2E tests (Sorry, no `ENVIRONMENT=true` 
 .PHONY: test-cli
 test-cli: ## Runs cli tests
 	${MAYBE_ENVIRONMENT_EXEC} cargo nextest run --no-fail-fast --no-default-features --features cli-tests --test cli --test-threads 4
-# https://github.com/vectordotdev/vector/issues/11762
-ifneq ($(OPERATING_SYSTEM), Windows)
-	@scripts/upload-test-results.sh
-endif
 
 ##@ Benching (Supports `ENVIRONMENT=true`)
 


### PR DESCRIPTION
Instead of the Makefile. I think they fit better here since we should
only be uploading the reports in CI.

I split out `make test-cli` since it was uploading test results. I plan
to continue to split up the `test-misc` job to run one job per test.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
