### PR TITLE
chore: Move Linux tests to GHA custom runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,6 @@ jobs:
       CARGO_INCREMENTAL: 0
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
-      - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
         name: Cache Cargo registry + index
@@ -106,21 +105,9 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
-      # We always make sure to stop any previous sccache process before starting it fresh, that
-      # way we can be sure we're using the right credentials for storage, etc.
-      - name: Start sccache
-        env:
-          SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          sccache --stop-server || true
-          sccache --start-server
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test
         env:
           CARGO_BUILD_JOBS: 5
-      - name: Stop sccache
-        run: sccache --stop-server
       - name: Upload test results
         run: scripts/upload-test-results.sh
         if: always()
@@ -133,34 +120,12 @@ jobs:
       CARGO_INCREMENTAL: 0
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
-      - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
-      - run: make ci-sweep
       - uses: actions/cache@v2.1.7
-        name: Cache Cargo registry + index
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
-      # We always make sure to stop any previous sccache process before starting it fresh, that
-      # way we can be sure we're using the right credentials for storage, etc.
-      - name: Start sccache
-        env:
-          SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          sccache --stop-server || true
-          sccache --start-server
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test-cli
-      - name: Stop sccache
-        run: sccache --stop-server
       - name: Upload test results
         run: scripts/upload-test-results.sh
         if: always()
@@ -173,9 +138,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
-      - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
-      - run: make ci-sweep
       - uses: actions/cache@v2.1.7
         name: Cache Cargo registry + index
         with:
@@ -188,21 +151,9 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
-      # We always make sure to stop any previous sccache process before starting it fresh, that
-      # way we can be sure we're using the right credentials for storage, etc.
-      - name: Start sccache
-        env:
-          SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          sccache --stop-server || true
-          sccache --start-server
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test-behavior
       - run: make check-examples
       - run: make test-docs
-      - name: Stop sccache
-        run: sccache --stop-server
 
   cross-linux:
     name: Cross - ${{ matrix.target }}
@@ -225,7 +176,6 @@ jobs:
     if: ${{ needs.changes.outputs.dependencies == 'true' }}
     steps:
       - uses: actions/checkout@v3
-      - run: make ci-sweep
       - uses: actions/cache@v2.1.7
         name: Cache Cargo registry + index
         with:
@@ -315,50 +265,10 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.cue == 'true' }}
     steps:
-      - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
-      # We always make sure to stop any previous sccache process before starting it fresh, that
-      # way we can be sure we're using the right credentials for storage, etc.
-      - name: Start sccache
-        env:
-          SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          sccache --stop-server || true
-          sccache --start-server
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: make test-vrl
-      - name: Stop sccache
-        run: sccache --stop-server
-
-  check-stdlib-features:
-    name: VRL Stdlib Features - Linux
-    continue-on-error: true
-    runs-on: [linux, test-runner]
-    needs: changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
-    steps:
-      - uses: colpal/actions-clean@v1
-      - uses: actions/checkout@v3
-      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: bash scripts/environment/prepare.sh
-      - run: echo "::add-matcher::.github/matchers/rust.json"
-      # We always make sure to stop any previous sccache process before starting it fresh, that
-      # way we can be sure we're using the right credentials for storage, etc.
-      - name: Start sccache
-        env:
-          SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          sccache --stop-server || true
-          sccache --start-server
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - run: cargo install cargo-hack
-      - run: make check-stdlib-features
-      - name: Stop sccache
-        run: sccache --stop-server
 
   check-component-features:
     name: Component Features - Linux
@@ -366,25 +276,12 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
-      - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
-      # We always make sure to stop any previous sccache process before starting it fresh, that
-      # way we can be sure we're using the right credentials for storage, etc.
-      - name: Start sccache
-        env:
-          SCCACHE_REDIS: ${{ secrets.SCCACHE_REDIS }}
-          SCCACHE_IDLE_TIMEOUT: 0
-        run: |
-          sccache --stop-server || true
-          sccache --start-server
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - run: cargo install cargo-hack
       - run: make check-component-features
-      - name: Stop sccache
-        run: sccache --stop-server
 
   check-msrv:
     name: Check MSRV
@@ -392,7 +289,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
-      - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: cargo install cargo-msrv --version 0.15.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
   # Then, modify the `cross-linux` job to run `test` instead of `build`.
   test-linux:
     name: Unit - x86_64-unknown-linux-gnu
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -127,7 +127,7 @@ jobs:
 
   test-cli:
     name: CLI - Linux
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -167,7 +167,7 @@ jobs:
 
   test-misc:
     name: Miscellaneous - Linux
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -311,7 +311,7 @@ jobs:
   test-vrl:
     name: VRL - Linux
     continue-on-error: true
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.cue == 'true' }}
     steps:
@@ -336,7 +336,7 @@ jobs:
   check-stdlib-features:
     name: VRL Stdlib Features - Linux
     continue-on-error: true
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
@@ -362,7 +362,7 @@ jobs:
 
   check-component-features:
     name: Component Features - Linux
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
@@ -388,7 +388,7 @@ jobs:
 
   check-msrv:
     name: Check MSRV
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
+        name: Cache Cargo registry + index
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
            restore-keys: |
              ${{ runner.os }}-cargo-
@@ -132,7 +131,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
            restore-keys: |
              ${{ runner.os }}-cargo-
@@ -161,7 +159,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
            restore-keys: |
              ${{ runner.os }}-cargo-
@@ -201,7 +198,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
            restore-keys: |
              ${{ runner.os }}-cargo-
@@ -245,7 +241,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
            restore-keys: |
              ${{ runner.os }}-cargo-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,9 +101,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-           restore-keys: |
-             ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -131,9 +131,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-           restore-keys: |
-             ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -159,9 +159,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-           restore-keys: |
-             ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -198,9 +198,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-           restore-keys: |
-             ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: echo "::add-matcher::.github/matchers/rust.json"
       # Why is this build, not check? Because we need to make sure the linking phase works.
       # aarch64 and musl in particular are notoriously hard to link.
@@ -241,9 +241,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-           restore-keys: |
-             ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -332,10 +332,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-           restore-keys: |
-             ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Enable Rust matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Check style

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
   # Then, modify the `cross-linux` job to run `test` instead of `build`.
   test-linux:
     name: Unit - x86_64-unknown-linux-gnu
-    runs-on: [linux, test]
+    runs-on: [linux, test-runner]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -127,7 +127,7 @@ jobs:
 
   test-cli:
     name: CLI - Linux
-    runs-on: [linux, test]
+    runs-on: [linux, test-runner]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -167,7 +167,7 @@ jobs:
 
   test-misc:
     name: Miscellaneous - Linux
-    runs-on: [linux, test]
+    runs-on: [linux, test-runner]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -311,7 +311,7 @@ jobs:
   test-vrl:
     name: VRL - Linux
     continue-on-error: true
-    runs-on: [linux, test]
+    runs-on: [linux, test-runner]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.cue == 'true' }}
     steps:
@@ -336,7 +336,7 @@ jobs:
   check-stdlib-features:
     name: VRL Stdlib Features - Linux
     continue-on-error: true
-    runs-on: [linux, test]
+    runs-on: [linux, test-runner]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
@@ -362,7 +362,7 @@ jobs:
 
   check-component-features:
     name: Component Features - Linux
-    runs-on: [linux, test]
+    runs-on: [linux, test-runner]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
@@ -388,7 +388,7 @@ jobs:
 
   check-msrv:
     name: Check MSRV
-    runs-on: [linux, test]
+    runs-on: [linux, test-runner]
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,11 +97,14 @@ jobs:
         name: Cache Cargo registry + index
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+           restore-keys: |
+             ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -125,11 +128,14 @@ jobs:
         name: Cache Cargo registry + index
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+           restore-keys: |
+             ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -151,11 +157,14 @@ jobs:
         name: Cache Cargo registry + index
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+           restore-keys: |
+             ${{ runner.os }}-cargo-
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -188,11 +197,14 @@ jobs:
         name: Cache Cargo registry + index
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+           restore-keys: |
+             ${{ runner.os }}-cargo-
       - run: echo "::add-matcher::.github/matchers/rust.json"
       # Why is this build, not check? Because we need to make sure the linking phase works.
       # aarch64 and musl in particular are notoriously hard to link.
@@ -229,11 +241,14 @@ jobs:
         name: Cache Cargo registry + index
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+           restore-keys: |
+             ${{ runner.os }}-cargo-
       - run: bash scripts/environment/bootstrap-macos-10.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
@@ -318,11 +333,14 @@ jobs:
         name: Cache Cargo registry + index
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+           restore-keys: |
+             ${{ runner.os }}-cargo-
       - name: Enable Rust matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Check style

--- a/Makefile
+++ b/Makefile
@@ -621,10 +621,6 @@ sync-install: ## Sync the install.sh script for access via sh.vector.dev
 test-vrl: ## Run the VRL test suite
 	@scripts/test-vrl.sh
 
-.PHONY: check-stdlib-features
-check-stdlib-features: ## Ensure VRL stdlib features build
-	${MAYBE_ENVIRONMENT_EXEC} env RUSTFLAGS="-D warnings" cargo hack check --each-feature --package vrl-stdlib --exclude-features default
-
 ##@ Utility
 
 .PHONY: build-ci-docker-images


### PR DESCRIPTION
The test times are longer because they start from a clean slate each time, but I think the trade-off is worth it to not need to maintain the custom runners. We can iterate on improving these times by:

* Doing less setup: not all jobs need all of the setup steps in the shared setup scripts
* Installing the cargo tools as binaries instead of building them on the fly

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>