### PR TITLE
chore: Restore http-to-http-noack soak

### DIFF
--- a/soaks/tests/http_to_http_noack/README.md
+++ b/soaks/tests/http_to_http_noack/README.md
@@ -1,0 +1,11 @@
+# HTTP -> HTTP
+
+This soak tests the simplest pipeline receiving data from a HTTP source
+and sending to a HTTP sink. It is a straight pipe with no transforms or
+other work going on, meant to test the best case performance of Vector's
+HTTP stack.
+
+## Method
+
+Lading `http_gen` is used to generate log load into vector, `http_blackhole`
+acts as a HTTP sink.

--- a/soaks/tests/http_to_http_noack/terraform/main.tf
+++ b/soaks/tests/http_to_http_noack/terraform/main.tf
@@ -1,0 +1,62 @@
+# Set up the providers needed to run this soak and other terraform related
+# business. Here we only require 'kubernetes' to interact with the soak
+# minikube.
+terraform {
+  required_providers {
+    kubernetes = {
+      version = "~> 2.5.0"
+      source  = "hashicorp/kubernetes"
+    }
+  }
+}
+
+# Rig the kubernetes provider to communicate with minikube. The details of
+# adjusting `~/.kube/config` are addressed by the soak control scripts.
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+# Setup background monitoring details. These are needed by the soak control to
+# understand what vector et al's running behavior is.
+module "monitoring" {
+  source          = "../../../common/terraform/modules/monitoring"
+  experiment_name = var.experiment_name
+  variant         = var.type
+  vector_image    = var.vector_image
+  depends_on      = [module.vector, module.http-gen, module.http-blackhole]
+}
+
+# Setup the soak pieces
+#
+# This soak config sets up a vector soak with lading/http-gen feeding into vector,
+# lading/http-blackhole receiving.
+resource "kubernetes_namespace" "soak" {
+  metadata {
+    name = "soak"
+  }
+}
+
+module "vector" {
+  source       = "../../../common/terraform/modules/vector"
+  type         = var.type
+  vector_image = var.vector_image
+  vector-toml  = file("${path.module}/vector.toml")
+  namespace    = kubernetes_namespace.soak.metadata[0].name
+  vector_cpus  = var.vector_cpus
+  depends_on   = [module.http-blackhole]
+}
+module "http-blackhole" {
+  source              = "../../../common/terraform/modules/lading_http_blackhole"
+  type                = var.type
+  http-blackhole-yaml = file("${path.module}/../../../common/configs/http_blackhole.yaml")
+  namespace           = kubernetes_namespace.soak.metadata[0].name
+  lading_image        = var.lading_image
+}
+module "http-gen" {
+  source        = "../../../common/terraform/modules/lading_http_gen"
+  type          = var.type
+  http-gen-yaml = file("${path.module}/../../../common/configs/http_gen_http_source.yaml")
+  namespace     = kubernetes_namespace.soak.metadata[0].name
+  lading_image  = var.lading_image
+  depends_on    = [module.vector]
+}

--- a/soaks/tests/http_to_http_noack/terraform/variables.tf
+++ b/soaks/tests/http_to_http_noack/terraform/variables.tf
@@ -1,0 +1,24 @@
+variable "experiment_name" {
+  description = "The name of the vector experiment"
+  type        = string
+}
+
+variable "type" {
+  description = "The type of the vector install, whether 'baseline' or 'comparison'"
+  type        = string
+}
+
+variable "vector_image" {
+  description = "The image of vector to use in this investigation"
+  type        = string
+}
+
+variable "vector_cpus" {
+  description = "The total number of CPUs to give to vector"
+  type        = number
+}
+
+variable "lading_image" {
+  description = "The lading image to run"
+  type        = string
+}

--- a/soaks/tests/http_to_http_noack/terraform/vector.toml
+++ b/soaks/tests/http_to_http_noack/terraform/vector.toml
@@ -1,0 +1,31 @@
+data_dir = "/var/lib/vector"
+
+##
+## Sources
+##
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sources.http_source]
+type = "http"
+acknowledgements = false
+address = "0.0.0.0:8282"
+
+##
+## Sinks
+##
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+address = "0.0.0.0:9090"
+
+[sinks.http_sink]
+type = "http"
+inputs = ["http_source"]
+uri = "http://http-blackhole:8080"
+encoding = "text"
+healthcheck.enabled = false
+buffer.type = "memory"
+buffer.max_events = 50000 # buffer 50 payloads at a time


### PR DESCRIPTION
Ref #11633 

This soak was removed (#11717) as part of investigating the lock up issue in #11633 which is now resolved.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
