### PR TITLE
chore(sinks): clean up duplicate code for setting tower layers

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -65,7 +65,7 @@ jobs:
           - test: 'datadog-logs'
           - test: 'datadog-metrics'
           - test: 'dnstap'
-          - test: 'docker'
+          - test: 'docker-logs'
           - test: 'elasticsearch'
           - test: 'eventstoredb'
           - test: 'fluent'

--- a/scripts/integration/docker-compose.aws.yml
+++ b/scripts/integration/docker-compose.aws.yml
@@ -5,19 +5,16 @@ services:
     image: timberiodev/mock-ec2-metadata:latest
     networks:
       - backend
-
   mock-localstack:
     image: localstack/localstack-full:0.11.6
     environment:
       - SERVICES=kinesis,s3,cloudwatch,elasticsearch,es,firehose,sqs
     networks:
       - backend
-
   mock-watchlogs:
     image: luciofranco/mockwatchlogs:latest
     networks:
       - backend
-
   mock-ecs:
     image: amazon/amazon-ecs-local-container-endpoints:latest
     networks:
@@ -25,7 +22,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - $HOME/.aws/:/home/.aws/
-
   runner:
     build:
       context: ${PWD}
@@ -64,14 +60,13 @@ services:
     networks:
       - backend
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
-
-# this is made to improve the build when running locally
-volumes:
-  cargogit: {}
-  cargoregistry: {}
 
 networks:
   backend: {}
+
+volumes:
+  cargogit: {}
+  cargoregistry: {}

--- a/scripts/integration/docker-compose.azure.yml
+++ b/scripts/integration/docker-compose.azure.yml
@@ -1,10 +1,11 @@
+version: "3"
+
 services:
   local-azure-blob:
     image: mcr.microsoft.com/azure-storage/azurite:3.11.0
     command: azurite --blobHost 0.0.0.0 --loose
     volumes:
       - /var/run:/var/run
-
   runner:
     build:
       context: ${PWD}
@@ -35,8 +36,6 @@ services:
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.clickhouse.yml
+++ b/scripts/integration/docker-compose.clickhouse.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   clickhouse:
     image: yandex/clickhouse-server:19
@@ -30,8 +32,6 @@ services:
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.datadog-agent.yml
+++ b/scripts/integration/docker-compose.datadog-agent.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 
 services:
   datadog-agent:
@@ -16,7 +16,6 @@ services:
       - DD_USE_DOGSTATSD=false
     volumes:
       - ${PWD}/tests/data/datadog-agent/conf.yaml:/etc/datadog-agent/conf.d/test.d/conf.yaml
-
   datadog-trace-agent:
     # Using 7.31.0 image to have the ability mimic tracing lib using json
     image: datadog/agent:7.31.0
@@ -28,7 +27,6 @@ services:
       - DD_HEALTH_PORT=8183
       - DD_CMD_PORT=5002
       - DD_USE_DOGSTATSD=false
-
   runner:
     build:
       context: ${PWD}
@@ -53,12 +51,10 @@ services:
       - datadog-agent
       - datadog-trace-agent
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.datadog-logs.yml
+++ b/scripts/integration/docker-compose.datadog-logs.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   runner:
     build:
@@ -22,3 +24,9 @@ services:
       - TEST_DATADOG_API_KEY
     volumes:
       - ${PWD}:/code
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
+
+volumes:
+  cargogit: {}
+  cargoregistry: {}

--- a/scripts/integration/docker-compose.datadog-metrics.yml
+++ b/scripts/integration/docker-compose.datadog-metrics.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   runner:
     build:
@@ -24,9 +26,9 @@ services:
       - TEST_DATADOG_API_KEY
     volumes:
       - ${PWD}:/code
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.dnstap.yml
+++ b/scripts/integration/docker-compose.dnstap.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   dnstap:
     build:
@@ -8,7 +10,6 @@ services:
       - ${PWD}/tests/data/dnstap/socket:/bind1/etc/bind/socket
       - ${PWD}/tests/data/dnstap/socket:/bind2/etc/bind/socket
       - ${PWD}/tests/data/dnstap/socket:/bind3/etc/bind/socket
-
   runner:
     build:
       context: ${PWD}
@@ -33,18 +34,16 @@ services:
     environment:
       - BIND_SOCKET=/run/bind/socket
     volumes:
+      - ${PWD}:/code
+      - ${PWD}/tests/data/dnstap/socket:/run/bind/socket
       - /var/run/docker.sock:/var/run/docker.sock
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}/tests/data/dnstap/socket:/run/bind/socket
-      - ${PWD}:/code
 
 networks:
   public: {}
   proxy: {}
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.docker-logs.yml
+++ b/scripts/integration/docker-compose.docker-logs.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   runner:
     build:
@@ -24,8 +26,6 @@ services:
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.elasticsearch.yml
+++ b/scripts/integration/docker-compose.elasticsearch.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   localstack:
     image: localstack/localstack@sha256:f21f1fc770ee4bfd5012afdc902154c56b7fb18c14cf672de151b65569c8251e
@@ -5,7 +7,6 @@ services:
       - SERVICES=elasticsearch:4571
     networks:
       - backend
-
   elasticsearch:
     image: elasticsearch:7.13.1
     environment:
@@ -13,7 +14,6 @@ services:
       - "ES_JAVA_OPTS=-Xms400m -Xmx400m"
     networks:
       - backend
-
   elasticsearch-secure:
     image: elasticsearch:7.13.1
     environment:
@@ -31,7 +31,6 @@ services:
       - backend
     volumes:
       - ${PWD}/tests/data:/usr/share/elasticsearch/config/certs:ro
-
   runner:
     build:
       context: ${PWD}
@@ -64,15 +63,13 @@ services:
     networks:
       - backend
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
 networks:
   backend: {}
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.eventstoredb.yml
+++ b/scripts/integration/docker-compose.eventstoredb.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 
 services:
   eventstoredb:
@@ -7,7 +7,6 @@ services:
     network_mode: host
     volumes:
       - ${PWD}/tests/data:/etc/vector:ro
-
   runner:
     build:
       context: ${PWD}
@@ -31,12 +30,10 @@ services:
     depends_on:
       - eventstoredb
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.fluent.yml
+++ b/scripts/integration/docker-compose.fluent.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   runner:
     build:
@@ -20,14 +22,12 @@ services:
       - "--"
       - "--nocapture"
     volumes:
+      - ${PWD}:/code
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.gcp.yml
+++ b/scripts/integration/docker-compose.gcp.yml
@@ -1,9 +1,10 @@
+version: "3"
+
 services:
   gcloud-pubsub:
     image: messagebird/gcloud-pubsub-emulator
     environment:
       - PUBSUB_PROJECT1=testproject,topic1:subscription1
-
   runner:
     build:
       context: ${PWD}
@@ -32,8 +33,6 @@ services:
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.humio.yml
+++ b/scripts/integration/docker-compose.humio.yml
@@ -1,8 +1,9 @@
+version: "3"
+
 services:
   humio:
     image: humio/humio:${HUMIO_VERSION:-1.13.1}
     network_mode: host
-
   runner:
     build:
       context: ${PWD}
@@ -32,8 +33,6 @@ services:
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.influxdb.yml
+++ b/scripts/integration/docker-compose.influxdb.yml
@@ -1,9 +1,10 @@
+version: "3"
+
 services:
   influxdb-v1:
     image: influxdb:${INFLUXDB_V1_VERSION:-1.8}
     environment:
       - INFLUXDB_REPORTING_DISABLED=true
-
   influxdb-v1-tls:
     image: influxdb:${INFLUXDB_V1_VERSION:-1.8}
     environment:
@@ -13,13 +14,11 @@ services:
       - INFLUXDB_HTTP_HTTPS_PRIVATE_KEY=/etc/ssl/influxdb.key
     volumes:
       - ${PWD}/tests/data:/etc/ssl:ro
-
   influxdb-v2:
     image: influxdb:2.0
     command: influxd --reporting-disabled
     environment:
       - INFLUXDB_REPORTING_DISABLED=true
-
   runner:
     build:
       context: ${PWD}
@@ -48,12 +47,10 @@ services:
       - INFLUXDB_V1_HTTPS_ADDRESS=https://influxdb-v1-tls:8086
       - INFLUXDB_V2_ADDRESS=http://influxdb-v2:8086
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.kafka.yml
+++ b/scripts/integration/docker-compose.kafka.yml
@@ -1,9 +1,10 @@
+version: "3"
+
 services:
   zookeeper:
     image: wurstmeister/zookeeper
     ports:
       - 2181:2181
-
   kafka:
     image: wurstmeister/kafka:2.13-2.6.0
     depends_on:
@@ -30,7 +31,6 @@ services:
     volumes:
       - ${PWD}/tests/data/kafka.p12:/certs/kafka.p12:ro
       - ${PWD}/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
-
   runner:
     build:
       context: ${PWD}
@@ -55,12 +55,10 @@ services:
     environment:
       - KAFKA_HOST=kafka
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.logstash.yml
+++ b/scripts/integration/docker-compose.logstash.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   beats-heartbeat:
     image: docker.elastic.co/beats/heartbeat:7.12.1
@@ -48,8 +50,6 @@ services:
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.loki.yml
+++ b/scripts/integration/docker-compose.loki.yml
@@ -1,9 +1,9 @@
-services:
+version: "3"
 
+services:
   loki:
     image: grafana/loki:${LOKI_VERSION:-2.4.1}
     command: -config.file=/etc/loki/local-config.yaml -auth.enabled=true
-
   runner:
     build:
       context: ${PWD}
@@ -28,15 +28,13 @@ services:
     environment:
       - LOKI_ADDRESS=http://loki:3100
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
 networks:
   backend: {}
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.mongo.yml
+++ b/scripts/integration/docker-compose.mongo.yml
@@ -1,5 +1,6 @@
-services:
+version: "3"
 
+services:
   mongodb-primary:
     image: bitnami/mongodb:${MONGO_VERSION:-4.2.10}
     environment:
@@ -9,7 +10,6 @@ services:
       - MONGODB_REPLICA_SET_KEY=vector
     networks:
       - backend
-
   mongodb-secondary:
     image: bitnami/mongodb:${MONGO_VERSION:-4.2.10}
     depends_on:
@@ -23,7 +23,6 @@ services:
       - MONGODB_REPLICA_SET_KEY=vector
     networks:
       - backend
-
   mongodb-arbiter:
     image: bitnami/mongodb:${MONGO_VERSION:-4.2.10}
     depends_on:
@@ -37,7 +36,6 @@ services:
       - MONGODB_REPLICA_SET_KEY=vector
     networks:
       - backend
-
   runner:
     build:
       context: ${PWD}
@@ -67,15 +65,13 @@ services:
     networks:
       - backend
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
 networks:
   backend: {}
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.nginx.yml
+++ b/scripts/integration/docker-compose.nginx.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   squid:
     image: babim/squid
@@ -6,21 +8,18 @@ services:
     networks:
       - public
       - proxy
-
   nginx:
     image: nginx:1.19.4
     networks:
       - public
     volumes:
       - ${PWD}/tests/data/nginx/:/etc/nginx:ro
-
   nginx-proxy:
     image: nginx:1.19.4
     networks:
       - proxy
     volumes:
       - ${PWD}/tests/data/nginx/:/etc/nginx:ro
-
   runner:
     build:
       context: ${PWD}
@@ -50,16 +49,14 @@ services:
     networks:
       - public
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
 networks:
   public: {}
   proxy: {}
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.postgres.yml
+++ b/scripts/integration/docker-compose.postgres.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   postgres:
     image: postgres:13.1
@@ -9,7 +11,6 @@ services:
       - socket:/var/run/postgresql
       - ${PWD}/tests/data/postgres-init.sh:/postgres-init.sh:ro
       - ${PWD}/tests/data:/certs:ro
-
   runner:
     build:
       context: ${PWD}
@@ -35,14 +36,12 @@ services:
       - PG_SOCKET=/socket
       - PG_HOST=postgres
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
       - socket:/socket
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
   socket: {}
-

--- a/scripts/integration/docker-compose.prometheus.yml
+++ b/scripts/integration/docker-compose.prometheus.yml
@@ -1,10 +1,11 @@
+version: "3"
+
 services:
   influxdb:
     image: influxdb:${INFLUXDB_VERSION:-1.8}
     network_mode: host
     environment:
       - INFLUXDB_REPORTING_DISABLED=true
-
   influxdb-tls:
     image: influxdb:${INFLUXDB_VERSION:-1.8}
     network_mode: host
@@ -17,14 +18,12 @@ services:
       - INFLUXDB_HTTP_HTTPS_PRIVATE_KEY=/etc/ssl/localhost.key
     volumes:
       - ${PWD}/tests/data:/etc/ssl:ro
-
   prometheus:
     image: prom/prometheus:${PROMETHEUS_VERSION:-v2.33.4}
     command: --config.file=/etc/vector/prometheus.yaml
     network_mode: host
     volumes:
       - ${PWD}/tests/data:/etc/vector:ro
-
   runner:
     build:
       context: ${PWD}
@@ -50,11 +49,10 @@ services:
       - influxdb-tls
       - prometheus
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.pulsar.yml
+++ b/scripts/integration/docker-compose.pulsar.yml
@@ -1,10 +1,11 @@
+version: "3"
+
 services:
   pulsar:
     image: apachepulsar/pulsar
     command: bin/pulsar standalone
     ports:
       - 6650:6650
-
   runner:
     build:
       context: ${PWD}
@@ -29,12 +30,10 @@ services:
     environment:
       - PULSAR_ADDRESS=pulsar://pulsar:6650
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.redis.yml
+++ b/scripts/integration/docker-compose.redis.yml
@@ -1,9 +1,10 @@
+version: "3"
+
 services:
   redis:
     image: redis:6-alpine
     networks:
       - backend
-
   runner:
     build:
       context: ${PWD}
@@ -31,6 +32,12 @@ services:
       - backend
     volumes:
       - ${PWD}:/code
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
 
 networks:
   backend: {}
+
+volumes:
+  cargogit: {}
+  cargoregistry: {}

--- a/scripts/integration/docker-compose.shutdown.yml
+++ b/scripts/integration/docker-compose.shutdown.yml
@@ -1,10 +1,10 @@
-version: "2"
+version: "3"
+
 services:
   zookeeper:
     image: wurstmeister/zookeeper
     ports:
       - 2181:2181
-
   kafka:
     image: wurstmeister/kafka:2.13-2.6.0
     depends_on:
@@ -31,7 +31,6 @@ services:
     volumes:
       - ${PWD}/tests/data/kafka.p12:/certs/kafka.p12:ro
       - ${PWD}/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
-
   runner:
     build:
       context: ${PWD}
@@ -58,13 +57,11 @@ services:
     environment:
       - KAFKA_HOST=kafka
     volumes:
-      - cargogit:/usr/local/cargo/git
-      - cargoregistry:/usr/local/cargo/registry
       - ${PWD}:/code
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}
-

--- a/scripts/integration/docker-compose.splunk.yml
+++ b/scripts/integration/docker-compose.splunk.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   splunk-hec:
     image: splunk/splunk:${SPLUNK_VERSION:-8.2.4}
@@ -11,7 +13,6 @@ services:
       - 8000:8000
       - 8088:8088
       - 8089:8089
-
   runner:
     build:
       context: ${PWD}
@@ -37,11 +38,10 @@ services:
       - SPLUNK_HEC_ADDRESS=http://splunk-hec:8088
       - SPLUNK_API_ADDRESS=https://splunk-hec:8089
     volumes:
+      - ${PWD}:/code
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
-      - ${PWD}:/code
 
-# this is made to improve the build when running locally
 volumes:
   cargogit: {}
   cargoregistry: {}

--- a/src/sinks/aws_cloudwatch_logs/sink.rs
+++ b/src/sinks/aws_cloudwatch_logs/sink.rs
@@ -1,11 +1,14 @@
+use std::fmt;
+
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use futures::{future, stream::BoxStream, StreamExt};
+use tower::Service;
 use vector_core::{
     buffers::{Ackable, Acker},
     partition::Partitioner,
     sink::StreamSink,
-    stream::BatcherSettings,
+    stream::{BatcherSettings, DriverResponse},
 };
 
 use crate::{
@@ -13,22 +16,26 @@ use crate::{
     sinks::{
         aws_cloudwatch_logs::{
             request_builder::{CloudwatchRequest, CloudwatchRequestBuilder},
-            retry::CloudwatchRetryLogic,
-            service::{CloudwatchLogsPartitionSvc, CloudwatchResponse},
             CloudwatchKey,
         },
-        util::{service::Svc, SinkBuilderExt},
+        util::SinkBuilderExt,
     },
 };
 
-pub struct CloudwatchSink {
+pub struct CloudwatchSink<S> {
     pub batcher_settings: BatcherSettings,
     pub(super) request_builder: CloudwatchRequestBuilder,
     pub acker: Acker,
-    pub service: Svc<CloudwatchLogsPartitionSvc, CloudwatchRetryLogic<CloudwatchResponse>>,
+    pub service: S,
 }
 
-impl CloudwatchSink {
+impl<S> CloudwatchSink<S>
+where
+    S: Service<BatchCloudwatchRequest> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: fmt::Debug + Into<crate::Error> + Send,
+{
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         let request_builder = self.request_builder;
         let batcher_settings = self.batcher_settings;
@@ -82,7 +89,13 @@ impl Partitioner for CloudwatchParititoner {
 }
 
 #[async_trait]
-impl StreamSink<Event> for CloudwatchSink {
+impl<S> StreamSink<Event> for CloudwatchSink<S>
+where
+    S: Service<BatchCloudwatchRequest> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: fmt::Debug + Into<crate::Error> + Send,
+{
     async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         self.run_inner(input).await
     }

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -123,11 +123,11 @@ impl SinkConfig for KinesisSinkConfig {
 
         let batch_settings = self.batch.into_batcher_settings()?;
 
-        let request_limits = self.request.unwrap_with(&TowerRequestConfig::default());
+        let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
 
         let region = self.region.clone().try_into()?;
         let service = ServiceBuilder::new()
-            .settings(request_limits, KinesisRetryLogic)
+            .settings(request_settings, KinesisRetryLogic)
             .service(KinesisService {
                 client,
                 stream_name: self.stream_name.clone(),

--- a/src/sinks/vector/v2/config.rs
+++ b/src/sinks/vector/v2/config.rs
@@ -81,7 +81,7 @@ impl VectorConfig {
         let service = VectorService::new(client, uri);
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
         let batch_settings = self.batch.into_batcher_settings()?;
-        //
+
         let service = ServiceBuilder::new()
             .settings(request_settings, VectorGrpcRetryLogic)
             .service(service);

--- a/src/sinks/vector/v2/sink.rs
+++ b/src/sinks/vector/v2/sink.rs
@@ -1,16 +1,21 @@
+use std::fmt;
+
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt};
 use prost::Message;
-use tower::util::BoxService;
-use vector_core::{buffers::Acker, stream::BatcherSettings, ByteSizeOf};
+use tower::Service;
+use vector_core::{
+    buffers::Acker,
+    stream::{BatcherSettings, DriverResponse},
+    ByteSizeOf,
+};
 
 use crate::{
     event::{proto::EventWrapper, Event, EventFinalizers, Finalizable},
     sinks::{
         util::{SinkBuilderExt, StreamSink},
-        vector::v2::service::{VectorRequest, VectorResponse},
+        vector::v2::service::VectorRequest,
     },
-    Error,
 };
 
 struct EventData {
@@ -19,13 +24,19 @@ struct EventData {
     wrapper: EventWrapper,
 }
 
-pub struct VectorSink {
+pub struct VectorSink<S> {
     pub batch_settings: BatcherSettings,
-    pub service: BoxService<VectorRequest, VectorResponse, Error>,
+    pub service: S,
     pub acker: Acker,
 }
 
-impl VectorSink {
+impl<S> VectorSink<S>
+where
+    S: Service<VectorRequest> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: fmt::Debug + Into<crate::Error> + Send,
+{
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         input
             .map(|mut event| EventData {
@@ -48,7 +59,13 @@ impl VectorSink {
 }
 
 #[async_trait]
-impl StreamSink<Event> for VectorSink {
+impl<S> StreamSink<Event> for VectorSink<S>
+where
+    S: Service<VectorRequest> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: fmt::Debug + Into<crate::Error> + Send,
+{
     async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         self.run_inner(input).await
     }


### PR DESCRIPTION
As mentioned in #11810, we have some sinks that currently do not emit metrics for the adaptive concurrency layer... because they don't actually _use_ the adaptive concurrency layer, due to a design pitfall where we provide two ways to apply `TowerRequestSettings` as a set of service layers, one of which uses the concurrency layer from the `tower` crate itself instead of our adaptive concurrency layer. As adaptive concurrency supports bounding concurrency, we never really want the fixed concurrency layer as it means we lose the ability to protect the downstream service.

This PR reworks the code to remove `TowerRequestSettings::service` and force callers to use the `tower::ServiceBuilder`/`ServiceBuilderExt::settings` helpers, where we use the adaptive concurrency layer.

Additionally, we've reworked a few sinks to take their service object generically so that we can avoid boxing the service, and we've standardized the integration test docker-compose configurations as it became apparent during local testing that they were all in various states of completeness.

Closes #11810.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>