### PR TITLE
fix(buffers): Require buffer sizes to be non-zero

### DIFF
--- a/lib/vector-buffers/benches/sized_records.rs
+++ b/lib/vector-buffers/benches/sized_records.rs
@@ -1,4 +1,9 @@
-use std::{mem, path::PathBuf, time::Duration};
+use std::{
+    mem,
+    num::{NonZeroU64, NonZeroUsize},
+    path::PathBuf,
+    time::Duration,
+};
 
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, BenchmarkId,
@@ -69,21 +74,21 @@ impl Drop for PathGuard {
 
 fn create_disk_v1_variant(_max_events: usize, max_size: u64) -> BufferType {
     BufferType::DiskV1 {
-        max_size,
+        max_size: NonZeroU64::new(max_size).unwrap(),
         when_full: WhenFull::DropNewest,
     }
 }
 
 fn create_disk_v2_variant(_max_events: usize, max_size: u64) -> BufferType {
     BufferType::DiskV2 {
-        max_size,
+        max_size: NonZeroU64::new(max_size).unwrap(),
         when_full: WhenFull::DropNewest,
     }
 }
 
 fn create_in_memory_variant(max_events: usize, _max_size: u64) -> BufferType {
     BufferType::Memory {
-        max_events,
+        max_events: NonZeroUsize::new(max_events).unwrap(),
         when_full: WhenFull::DropNewest,
     }
 }

--- a/lib/vector-buffers/examples/buffer_perf.rs
+++ b/lib/vector-buffers/examples/buffer_perf.rs
@@ -229,8 +229,8 @@ where
 {
     let data_dir = PathBuf::from("/tmp/vector");
     let id = format!("{}-buffer-perf-testing", buffer_type);
-    let max_size_events = 500;
-    let max_size_bytes = 32 * 1024 * 1024 * 1024;
+    let max_size_events = std::num::NonZeroUsize::new(500).unwrap();
+    let max_size_bytes = std::num::NonZeroU64::new(32 * 1024 * 1024 * 1024).unwrap();
     let when_full = WhenFull::Block;
 
     let mut builder = TopologyBuilder::default();

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -355,6 +355,7 @@ impl BufferConfig {
 #[cfg(test)]
 mod test {
     use crate::{BufferConfig, BufferType, WhenFull};
+    use std::num::{NonZeroU64, NonZeroUsize};
 
     fn check_single_stage(source: &str, expected: BufferType) {
         let config: BufferConfig = serde_yaml::from_str(source).unwrap();
@@ -407,7 +408,7 @@ max_events: 42
           max_events: 100
           "#,
             BufferType::Memory {
-                max_events: 100,
+                max_events: NonZeroUsize::new(100).unwrap(),
                 when_full: WhenFull::Block,
             },
         );
@@ -423,11 +424,11 @@ max_events: 42
           "#,
             &[
                 BufferType::Memory {
-                    max_events: 42,
+                    max_events: NonZeroUsize::new(42).unwrap(),
                     when_full: WhenFull::Block,
                 },
                 BufferType::Memory {
-                    max_events: 100,
+                    max_events: NonZeroUsize::new(100).unwrap(),
                     when_full: WhenFull::DropNewest,
                 },
             ],
@@ -442,7 +443,7 @@ max_events: 42
           max_size: 1024
           "#,
             BufferType::DiskV1 {
-                max_size: 1024,
+                max_size: NonZeroU64::new(1024).unwrap(),
                 when_full: WhenFull::Block,
             },
         );
@@ -452,7 +453,7 @@ max_events: 42
           type: memory
           "#,
             BufferType::Memory {
-                max_events: 500,
+                max_events: NonZeroUsize::new(500).unwrap(),
                 when_full: WhenFull::Block,
             },
         );
@@ -463,7 +464,7 @@ max_events: 42
           max_events: 100
           "#,
             BufferType::Memory {
-                max_events: 100,
+                max_events: NonZeroUsize::new(100).unwrap(),
                 when_full: WhenFull::Block,
             },
         );
@@ -474,7 +475,7 @@ max_events: 42
           when_full: drop_newest
           "#,
             BufferType::Memory {
-                max_events: 500,
+                max_events: NonZeroUsize::new(500).unwrap(),
                 when_full: WhenFull::DropNewest,
             },
         );
@@ -485,7 +486,7 @@ max_events: 42
           when_full: overflow
           "#,
             BufferType::Memory {
-                max_events: 500,
+                max_events: NonZeroUsize::new(500).unwrap(),
                 when_full: WhenFull::Overflow,
             },
         );
@@ -496,7 +497,7 @@ max_events: 42
           max_size: 1024
           "#,
             BufferType::DiskV2 {
-                max_size: 1024,
+                max_size: NonZeroU64::new(1024).unwrap(),
                 when_full: WhenFull::Block,
             },
         );

--- a/lib/vector-buffers/src/test/common/variant.rs
+++ b/lib/vector-buffers/src/test/common/variant.rs
@@ -1,4 +1,7 @@
-use std::{num::NonZeroU16, path::PathBuf};
+use std::{
+    num::{NonZeroU16, NonZeroU64, NonZeroUsize},
+    path::PathBuf,
+};
 
 #[cfg(test)]
 use quickcheck::{Arbitrary, Gen};
@@ -27,17 +30,17 @@ const ALPHABET: [&str; 27] = [
 #[derive(Debug, Clone)]
 pub enum Variant {
     Memory {
-        max_events: usize,
+        max_events: NonZeroUsize,
         when_full: WhenFull,
     },
     DiskV1 {
-        max_size: u64,
+        max_size: NonZeroU64,
         when_full: WhenFull,
         data_dir: PathBuf,
         id: String,
     },
     DiskV2 {
-        max_size: u64,
+        max_size: NonZeroU64,
         when_full: WhenFull,
         data_dir: PathBuf,
         id: String,
@@ -117,10 +120,12 @@ impl Arbitrary for Variant {
 
         // Using a u16 ensures we avoid any allocation errors for our holding buffers, etc.
         let max_events = NonZeroU16::arbitrary(g)
-            .get()
             .try_into()
             .expect("we don't support 16-bit platforms");
-        let max_size = u64::from(NonZeroU16::arbitrary(g).get());
+        let max_size = NonZeroU16::arbitrary(g)
+            .try_into()
+            .expect("we don't support 16-bit platforms");
+
         let when_full = WhenFull::arbitrary(g);
 
         match idx {

--- a/lib/vector-buffers/src/test/model/in_memory.rs
+++ b/lib/vector-buffers/src/test/model/in_memory.rs
@@ -24,8 +24,8 @@ impl InMemory {
                 when_full,
                 ..
             } => InMemory {
-                inner: VecDeque::with_capacity(*max_events),
-                capacity: *max_events,
+                inner: VecDeque::with_capacity(max_events.get()),
+                capacity: max_events.get(),
                 when_full: *when_full,
             },
             _ => unreachable!(),

--- a/lib/vector-buffers/src/test/model/on_disk_v1.rs
+++ b/lib/vector-buffers/src/test/model/on_disk_v1.rs
@@ -26,9 +26,9 @@ impl OnDiskV1 {
                 when_full,
                 ..
             } => OnDiskV1 {
-                inner: VecDeque::with_capacity((*max_size).try_into().unwrap_or(usize::MAX)),
+                inner: VecDeque::with_capacity((max_size.get()).try_into().unwrap_or(usize::MAX)),
                 current_bytes: 0,
-                capacity: (*max_size).try_into().unwrap_or(usize::MAX),
+                capacity: (max_size.get()).try_into().unwrap_or(usize::MAX),
                 when_full: *when_full,
             },
             _ => unreachable!(),

--- a/lib/vector-buffers/src/test/model/on_disk_v2.rs
+++ b/lib/vector-buffers/src/test/model/on_disk_v2.rs
@@ -26,9 +26,9 @@ impl OnDiskV2 {
                 when_full,
                 ..
             } => OnDiskV2 {
-                inner: VecDeque::with_capacity((*max_size).try_into().unwrap_or(usize::MAX)),
+                inner: VecDeque::with_capacity((max_size.get()).try_into().unwrap_or(usize::MAX)),
                 current_bytes: 0,
-                capacity: (*max_size).try_into().unwrap_or(usize::MAX),
+                capacity: (max_size.get()).try_into().unwrap_or(usize::MAX),
                 when_full: *when_full,
             },
             _ => unreachable!(),

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -246,7 +246,7 @@ where
     /// create the stage, installing buffer usage metrics that aren't required, and so on.
     #[cfg(test)]
     pub async fn standalone_memory_test(
-        max_events: usize,
+        max_events: NonZeroUsize,
         when_full: WhenFull,
         usage_handle: BufferUsageHandle,
     ) -> (BufferSender<T>, BufferReceiver<T>) {
@@ -287,10 +287,15 @@ mod tests {
         WhenFull,
     };
 
+    use std::num::NonZeroUsize;
+
     #[tokio::test]
     async fn single_stage_topology_block() {
         let mut builder = TopologyBuilder::<u64>::default();
-        builder.stage(MemoryBuffer::new(1), WhenFull::Block);
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Block,
+        );
         let result = builder.build(Span::none()).await;
         assert!(result.is_ok());
 
@@ -301,7 +306,10 @@ mod tests {
     #[tokio::test]
     async fn single_stage_topology_drop_newest() {
         let mut builder = TopologyBuilder::<u64>::default();
-        builder.stage(MemoryBuffer::new(1), WhenFull::DropNewest);
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::DropNewest,
+        );
         let result = builder.build(Span::none()).await;
         assert!(result.is_ok());
 
@@ -312,7 +320,10 @@ mod tests {
     #[tokio::test]
     async fn single_stage_topology_overflow() {
         let mut builder = TopologyBuilder::<u64>::default();
-        builder.stage(MemoryBuffer::new(1), WhenFull::Overflow);
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Overflow,
+        );
         let result = builder.build(Span::none()).await;
         match result {
             Err(TopologyError::OverflowWhenLast) => {}
@@ -323,8 +334,14 @@ mod tests {
     #[tokio::test]
     async fn two_stage_topology_block() {
         let mut builder = TopologyBuilder::<u64>::default();
-        builder.stage(MemoryBuffer::new(1), WhenFull::Block);
-        builder.stage(MemoryBuffer::new(1), WhenFull::Block);
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Block,
+        );
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Block,
+        );
         let result = builder.build(Span::none()).await;
         match result {
             Err(TopologyError::NextStageNotUsed { stage_idx }) => assert_eq!(stage_idx, 0),
@@ -335,8 +352,14 @@ mod tests {
     #[tokio::test]
     async fn two_stage_topology_drop_newest() {
         let mut builder = TopologyBuilder::<u64>::default();
-        builder.stage(MemoryBuffer::new(1), WhenFull::DropNewest);
-        builder.stage(MemoryBuffer::new(1), WhenFull::Block);
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::DropNewest,
+        );
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Block,
+        );
         let result = builder.build(Span::none()).await;
         match result {
             Err(TopologyError::NextStageNotUsed { stage_idx }) => assert_eq!(stage_idx, 0),
@@ -347,8 +370,14 @@ mod tests {
     #[tokio::test]
     async fn two_stage_topology_overflow() {
         let mut builder = TopologyBuilder::<u64>::default();
-        builder.stage(MemoryBuffer::new(1), WhenFull::Overflow);
-        builder.stage(MemoryBuffer::new(1), WhenFull::Block);
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Overflow,
+        );
+        builder.stage(
+            MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Block,
+        );
 
         let result = builder.build(Span::none()).await;
         assert!(result.is_ok());

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{error::Error, num::NonZeroUsize};
 
 use async_trait::async_trait;
 use snafu::{ResultExt, Snafu};
@@ -210,7 +210,7 @@ where
     /// can simplifying needing to require callers to do all the boilerplate to create the builder,
     /// create the stage, installing buffer usage metrics that aren't required, and so on.
     pub async fn standalone_memory(
-        max_events: usize,
+        max_events: NonZeroUsize,
         when_full: WhenFull,
     ) -> (BufferSender<T>, BufferReceiver<T>) {
         let usage_handle = BufferUsageHandle::noop(when_full);

--- a/lib/vector-buffers/src/topology/test_util.rs
+++ b/lib/vector-buffers/src/topology/test_util.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use std::{error, fmt, num::NonZeroUsize};
 
 use bytes::{Buf, BufMut};
 
@@ -67,11 +67,14 @@ pub async fn build_buffer(
     let (tx, rx) = match mode {
         WhenFull::Overflow => {
             let overflow_mode = overflow_mode.expect("overflow mode cannot be empty");
-            let (overflow_sender, overflow_receiver) =
-                TopologyBuilder::standalone_memory_test(capacity, overflow_mode, handle.clone())
-                    .await;
+            let (overflow_sender, overflow_receiver) = TopologyBuilder::standalone_memory_test(
+                NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
+                overflow_mode,
+                handle.clone(),
+            )
+            .await;
             let (mut base_sender, mut base_receiver) = TopologyBuilder::standalone_memory_test(
-                capacity,
+                NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
                 WhenFull::Overflow,
                 handle.clone(),
             )
@@ -81,7 +84,14 @@ pub async fn build_buffer(
 
             (base_sender, base_receiver)
         }
-        m => TopologyBuilder::standalone_memory_test(capacity, m, handle.clone()).await,
+        m => {
+            TopologyBuilder::standalone_memory_test(
+                NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
+                m,
+                handle.clone(),
+            )
+            .await
+        }
     };
 
     (tx, rx, handle)

--- a/lib/vector-buffers/src/variants/disk_v1/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/mod.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{num::NonZeroU64, path::Path};
 
 use futures::StreamExt;
 use tokio_test::{assert_pending, task::spawn};
@@ -17,7 +17,8 @@ mod event_count;
 mod naming;
 
 // Default of 1GB.
-const DEFAULT_DISK_BUFFER_V1_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+const DEFAULT_DISK_BUFFER_V1_SIZE_BYTES: NonZeroU64 =
+    unsafe { NonZeroU64::new_unchecked(1024 * 1024 * 1024) };
 
 pub(crate) fn create_default_buffer_v1<P, R>(data_dir: P) -> (Writer<R>, Reader<R>, Acker)
 where

--- a/lib/vector-buffers/src/variants/disk_v2/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/mod.rs
@@ -138,6 +138,7 @@
 use std::{
     error::Error,
     marker::PhantomData,
+    num::NonZeroU64,
     path::PathBuf,
     pin::Pin,
     sync::Arc,
@@ -271,11 +272,11 @@ where
 pub struct DiskV2Buffer {
     id: String,
     data_dir: PathBuf,
-    max_size: u64,
+    max_size: NonZeroU64,
 }
 
 impl DiskV2Buffer {
-    pub fn new(id: String, data_dir: PathBuf, max_size: u64) -> Self {
+    pub fn new(id: String, data_dir: PathBuf, max_size: NonZeroU64) -> Self {
         Self {
             id,
             data_dir,
@@ -298,12 +299,12 @@ where
         usage_handle: BufferUsageHandle,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>, Option<Acker>), Box<dyn Error + Send + Sync>>
     {
-        usage_handle.set_buffer_limits(Some(self.max_size), None);
+        usage_handle.set_buffer_limits(Some(self.max_size.get()), None);
 
         // Create the actual buffer subcomponents.
         let buffer_path = self.data_dir.join("buffer").join("v2").join(self.id);
         let config = DiskBufferConfigBuilder::from_path(buffer_path)
-            .max_buffer_size(self.max_size as u64)
+            .max_buffer_size(self.max_size.get())
             .build()?;
         let (writer, reader, acker) = Buffer::from_config(config, usage_handle).await?;
 

--- a/lib/vector-buffers/src/variants/in_memory.rs
+++ b/lib/vector-buffers/src/variants/in_memory.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{error::Error, num::NonZeroUsize};
 
 use async_trait::async_trait;
 
@@ -12,11 +12,11 @@ use crate::{
 };
 
 pub struct MemoryBuffer {
-    capacity: usize,
+    capacity: NonZeroUsize,
 }
 
 impl MemoryBuffer {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new(capacity: NonZeroUsize) -> Self {
         MemoryBuffer { capacity }
     }
 }
@@ -31,9 +31,9 @@ where
         usage_handle: BufferUsageHandle,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>, Option<Acker>), Box<dyn Error + Send + Sync>>
     {
-        usage_handle.set_buffer_limits(None, Some(self.capacity));
+        usage_handle.set_buffer_limits(None, Some(self.capacity.get()));
 
-        let (tx, rx) = limited(self.capacity);
+        let (tx, rx) = limited(self.capacity.get());
         Ok((
             SenderAdapter::channel(tx),
             ReceiverAdapter::channel(rx),

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -1,6 +1,6 @@
 use bitmask_enum::bitmask;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, num::NonZeroUsize};
 
 mod global_options;
 mod id;
@@ -13,7 +13,7 @@ pub use log_schema::{init_log_schema, log_schema, LogSchema};
 
 use crate::schema;
 
-pub const MEMORY_BUFFER_DEFAULT_MAX_EVENTS: usize =
+pub const MEMORY_BUFFER_DEFAULT_MAX_EVENTS: NonZeroUsize =
     vector_buffers::config::memory_buffer_default_max_events();
 
 // This enum should be kept alphabetically sorted as the bitmask value is used when

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -370,6 +370,7 @@ impl Future for Sender {
 #[cfg(test)]
 mod tests {
     use std::mem;
+    use std::num::NonZeroUsize;
 
     use futures::{poll, StreamExt};
     use tokio::sync::mpsc::UnboundedSender;
@@ -390,7 +391,11 @@ mod tests {
     async fn build_sender_pair(
         capacity: usize,
     ) -> (BufferSender<EventArray>, BufferReceiver<EventArray>) {
-        TopologyBuilder::standalone_memory(capacity, WhenFull::Block).await
+        TopologyBuilder::standalone_memory(
+            NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
+            WhenFull::Block,
+        )
+        .await
     }
 
     async fn build_sender_pairs(

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     future::ready,
+    num::NonZeroUsize,
     sync::{Arc, Mutex},
     time::Instant,
 };
@@ -47,6 +48,8 @@ static ENRICHMENT_TABLES: Lazy<enrichment::TableRegistry> =
     Lazy::new(enrichment::TableRegistry::default);
 
 pub(crate) const SOURCE_SENDER_BUFFER_SIZE: usize = 1000;
+
+pub(crate) const TOPOLOGY_BUFFER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(100) };
 
 static TRANSFORM_CONCURRENCY_LIMIT: Lazy<usize> = Lazy::new(|| {
     crate::app::WORKER_THREADS
@@ -293,7 +296,8 @@ pub async fn build_pieces(
             Ok(transform) => transform,
         };
 
-        let (input_tx, input_rx) = TopologyBuilder::standalone_memory(100, WhenFull::Block).await;
+        let (input_tx, input_rx) =
+            TopologyBuilder::standalone_memory(TOPOLOGY_BUFFER_SIZE, WhenFull::Block).await;
 
         inputs.insert(key.clone(), (input_tx, node.inputs.clone()));
 

--- a/src/topology/test/backpressure.rs
+++ b/src/topology/test/backpressure.rs
@@ -24,7 +24,7 @@ async fn serial_backpressure() {
     let events_to_sink = 100;
 
     let expected_sourced_events = events_to_sink
-        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS
+        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS.get()
         + SOURCE_SENDER_BUFFER_SIZE
         + EXTRA_SOURCE_PUMP_EVENT;
 
@@ -62,7 +62,7 @@ async fn default_fan_out() {
     let events_to_sink = 100;
 
     let expected_sourced_events = events_to_sink
-        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS
+        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS.get()
         + SOURCE_SENDER_BUFFER_SIZE
         + EXTRA_SOURCE_PUMP_EVENT;
 
@@ -109,7 +109,7 @@ async fn buffer_drop_fan_out() {
     let events_to_sink = 100;
 
     let expected_sourced_events = events_to_sink
-        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS
+        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS.get()
         + SOURCE_SENDER_BUFFER_SIZE
         + EXTRA_SOURCE_PUMP_EVENT;
 
@@ -161,7 +161,7 @@ async fn multiple_inputs_backpressure() {
     let events_to_sink = 100;
 
     let expected_sourced_events = events_to_sink
-        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS
+        + MEMORY_BUFFER_DEFAULT_MAX_EVENTS.get()
         + SOURCE_SENDER_BUFFER_SIZE * 2
         + EXTRA_SOURCE_PUMP_EVENT * 2;
 

--- a/tests/topology.rs
+++ b/tests/topology.rs
@@ -664,7 +664,7 @@ async fn topology_disk_buffer_flushes_on_idle() {
     );
     sink1_outer.buffer = BufferConfig {
         stages: vec![BufferType::DiskV1 {
-            max_size: 1024,
+            max_size: std::num::NonZeroU64::new(1024).unwrap(),
             when_full: WhenFull::DropNewest,
         }],
     };


### PR DESCRIPTION
Providing 0 for in-memory buffers causes a panic. I'm guessing providing
0 for disk buffers will also mean you are going to have a bad time so
guarded against that here too.

Closes: #11770

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
