### PR TITLE
chore(buffers): don't drop events when we yield for non-capacity reasons (v0.20.x)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8137,7 +8137,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "approx",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -238,7 +238,7 @@ impl<T: Bufferable> Sink<T> for BufferSender<T> {
     type Error = ();
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let this = self.project();
+        let mut this = self.project();
 
         // For whatever reason, the caller is calling `poll_ready` again after a successful previous
         // call.  Since we already know we're ready, and `start_send` has not yet been called, we
@@ -247,7 +247,7 @@ impl<T: Bufferable> Sink<T> for BufferSender<T> {
             return Poll::Ready(Ok(()));
         }
 
-        let (result, next_state) = match this.base.poll_ready(cx) {
+        let (result, next_state) = match this.base.as_mut().poll_ready(cx) {
             Poll::Ready(result) => match result {
                 // We reserved a sending slot in the base channel.
                 Ok(()) => (Poll::Ready(Ok(())), SendState::BaseReady),
@@ -259,23 +259,24 @@ impl<T: Bufferable> Sink<T> for BufferSender<T> {
                 // We need to block.  Nothing else to do, as the base sender will notify us when
                 // there's capacity to do the send.
                 WhenFull::Block => (Poll::Pending, SendState::Idle),
-                // We need to drop the next item.  We have to wait until the caller hands it over to
-                // us in order to drop it, though, so we pretend we're ready and mark ourselves to
-                // drop the next item when `start_send` is called.
-                //
-                // One "gotcha" here is that the base sender is still trying to reserve a sending
-                // slot for us, so technically it could complete between now and when we get to
-                // `start_send` and actually drop the item.
-                //
-                // Based on the current behavior of `PollSender<T>`, the best thing we can do here
-                // is to simply to drop the item and not abort the send, since that will leave
-                // `PollSender<T>` armed for the next time we call `poll_reserve`.  Since buffers
-                // are SPSC, there's no risk in trying up a sender slot.
-                //
-                // TODO: In the future, `PollSender<T>::start_send` may be tweaked to attempt a
-                // call to `Sender<T>::try_send` as a last ditch effort when `PollSender<T>` has not
-                // yet reserved the sending slot.  We could take advantage of this ourselves.
-                WhenFull::DropNewest => (Poll::Ready(Ok(())), SendState::DropNext),
+                WhenFull::DropNewest => {
+                    // If we tried to check for readiness, but got told that the base sender was not
+                    // yet ready, we need to also check to see if the base sender has capacity.  If
+                    // it does, then we've hit a situation where the Tokio cooperative scheduling
+                    // budget has been exceeded, and we're being asked to cooperatively yield to
+                    // allow other tasks to run.
+                    //
+                    // If we don't have capacity, though, then we should in fact drop this event.
+                    // One caveat here is that the disk buffers, aka the "opaque" senders, have no
+                    // concept of per-event capacity, so we'll always assume they are in fact at
+                    // their limit and we should drop.
+                    let has_capacity = this.base.capacity().map_or(false, |capacity| capacity > 0);
+                    if has_capacity {
+                        (Poll::Pending, SendState::Idle)
+                    } else {
+                        (Poll::Ready(Ok(())), SendState::DropNext)
+                    }
+                }
                 // We're supposed to overflow.  Quickly check to make sure we even have an overflow
                 // sender configured, and then figure out if the overflow sender can actually accept
                 // a send at the moment.

--- a/lib/vector-buffers/src/topology/channel/tests.rs
+++ b/lib/vector-buffers/src/topology/channel/tests.rs
@@ -187,6 +187,17 @@ async fn test_sender_overflow_drop_newest() {
 }
 
 #[tokio::test]
+async fn test_sender_overflow_drop_newest_when_semaphore_yields() {
+    // TODO: essentially, we want to try and test that the code does _not_ drop an event when
+    // there's sender capacity but the `poll_ready` call to `SenderAdapter` results in
+    // `Poll::Pending`.
+    //
+    // this exercises the logic that prevents us from indiscriminately discarding events when
+    // tokio's coop budget kicks in against an in-memory channel, but there's still actual capacity
+    // that could be consumed.
+}
+
+#[tokio::test]
 async fn test_buffer_metrics_normal() {
     // Get a regular blocking buffer.
     let (mut tx, rx, handle) = build_buffer(5, WhenFull::Block, None).await;


### PR DESCRIPTION
This PR addresses a subtle issue with the new buffer topology code when it comes to running a buffer in the `DropNewest` mode.

At a high level, we use a wrapper type around Tokio's bounded MPSC channels, `PollSender`, that allows us to provide the necessary `Sink` interface that wires up into `BufferSender` and higher in the stack.  Under the hood, `tokio::sync::mpsc::Sender` uses a semaphore -- Tokio's own `tokio::sync::Semaphore` -- to handle managing capacity, specifically in the case of the sender knowing when it can send into the channel.

As part of Tokio's goal of providing deterministic executor latencies, they have a feature called "cooperative scheduling", where Tokio-provided primitives -- such as sockets, channels, timers, and more -- all tap into a thread-local coop "budget" counter.  This budget is used to track how many times an async task itself has called an asynchronous primitive at an await point.  The goal is, essentially, to take advantage of natural await points -- asking a semaphore if it has a permit available, in our case -- to forcefully return `Poll::Pending` (and immediately schedule a wake-up for the task) even if the resource itself may have been ready, which in turn lets other tasks have a chance to run.

While this demonstrably works for normal async tasks and futures, it breaks in the presence of our logic for handling readiness when in `DropNewest` mode.  As our code specifically ignores yielding when it sees `Poll::Pending`, `BufferSender` is essentially allowed to run until there is a lack of events upstream that cause the task to go to sleep.  Even with capacity available, when the coop budget limiter fires off, we don't stop trying to send.. but since we're configured to drop events when the underlying buffer implementation is not ready, we end up dropping far more events than we should.

This PR adds a fix that causes us to also yield when we detect that the buffer is not ready but that there _is_ available capacity, knowing that it wouldn't itself return being not ready if there was capacity, and that we must be in a situation where Tokio is asking us to yield temporarily.