### PR TITLE
fix(observability): Ensure tasks are instrumented with active spans

### DIFF
--- a/lib/vector-buffers/src/buffer_usage_data.rs
+++ b/lib/vector-buffers/src/buffer_usage_data.rs
@@ -225,7 +225,7 @@ impl BufferUsage {
                     }
                 }
             }
-            .instrument(span),
+            .instrument(span.or_current()),
         );
     }
 }

--- a/lib/vector-buffers/src/variants/disk_v1/tests/acknowledgements.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/acknowledgements.rs
@@ -316,7 +316,7 @@ async fn acking_when_undecodable_records_present() {
         });
 
         let parent = trace_span!("acking_when_undecodable_records_present");
-        fut.instrument(parent).await;
+        fut.instrument(parent.or_current()).await;
 
         tokio::time::resume();
     }

--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -136,7 +136,7 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
     });
 
     let parent = trace_span!("reader_exits_cleanly_when_writer_done_and_in_flight_acks");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]

--- a/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
@@ -75,7 +75,7 @@ async fn pending_read_returns_none_when_writer_closed_with_unflushed_write() {
     });
 
     let parent = trace_span!("pending_read_returns_none_when_writer_closed_with_unflushed_write");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]
@@ -118,7 +118,7 @@ async fn last_record_is_valid_during_load_when_buffer_correctly_flushed_and_stop
 
     let parent =
         trace_span!("last_record_is_valid_during_load_when_buffer_correctly_flushed_and_stopped");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]
@@ -319,7 +319,7 @@ async fn writer_stops_when_hitting_file_that_reader_is_still_on() {
     });
 
     let parent = trace_span!("writer_stops_when_hitting_file_that_reader_is_still_on");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]
@@ -574,7 +574,7 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
     });
 
     let parent = trace_span!("reader_deletes_data_file_around_record_id_wraparound");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]
@@ -737,7 +737,7 @@ async fn writer_waits_for_reader_after_validate_last_write_fails_and_data_file_s
     let parent = trace_span!(
         "writer_waits_for_reader_after_validate_last_write_fails_and_data_file_skip_triggered"
     );
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]

--- a/lib/vector-buffers/src/variants/disk_v2/tests/known_errors.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/known_errors.rs
@@ -426,7 +426,7 @@ async fn writer_detects_when_last_record_has_scrambled_archive_data() {
     });
 
     let parent = trace_span!("writer_detects_when_last_record_has_scrambled_archive_data");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]
@@ -536,7 +536,7 @@ async fn writer_detects_when_last_record_has_invalid_checksum() {
     });
 
     let parent = trace_span!("writer_detects_when_last_record_has_invalid_checksum");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]
@@ -609,7 +609,7 @@ async fn writer_detects_when_last_record_wasnt_flushed() {
     });
 
     let parent = trace_span!("writer_detects_when_last_record_wasnt_flushed");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]
@@ -678,7 +678,7 @@ async fn writer_detects_when_last_record_was_flushed_but_id_wasnt_incremented() 
 
     let parent =
         trace_span!("writer_detects_when_last_record_was_flushed_but_id_wasnt_incremented");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]

--- a/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
@@ -202,7 +202,7 @@ async fn writer_waits_when_buffer_is_full() {
     });
 
     let parent = trace_span!("writer_waits_when_buffer_is_full");
-    fut.instrument(parent).await;
+    fut.instrument(parent.or_current()).await;
 }
 
 #[tokio::test]

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -294,7 +294,7 @@ where
                                 };
                                 (seq_num, ack_size)
                             })
-                            .instrument(info_span!("request", request_id));
+                            .instrument(info_span!("request", request_id).or_current());
 
                         in_flight.push(fut);
                     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -118,7 +118,7 @@ where
             });
             Ok(response)
         }
-        .instrument(span.clone());
+        .instrument(span.clone().or_current());
 
         Box::pin(fut)
     }

--- a/src/sinks/aws_kinesis_firehose/service.rs
+++ b/src/sinks/aws_kinesis_firehose/service.rs
@@ -71,7 +71,7 @@ impl Service<Vec<KinesisRequest>> for KinesisService {
         Box::pin(async move {
             client
                 .put_record_batch(request)
-                .instrument(info_span!("request"))
+                .instrument(info_span!("request").or_current())
                 .await?;
 
             emit!(&AwsBytesSent {

--- a/src/sinks/aws_kinesis_streams/service.rs
+++ b/src/sinks/aws_kinesis_streams/service.rs
@@ -87,7 +87,7 @@ impl Service<Vec<KinesisRequest>> for KinesisService {
                         byte_size: processed_bytes_total
                     });
                 })
-                .instrument(info_span!("request"))
+                .instrument(info_span!("request").or_current())
                 .await?;
 
             Ok(KinesisResponse {

--- a/src/sinks/aws_sqs.rs
+++ b/src/sinks/aws_sqs.rs
@@ -259,7 +259,7 @@ impl Service<Vec<SendMessageEntry>> for SqsSink {
                         message_id: result.message_id.as_ref()
                     })
                 })
-                .instrument(info_span!("request"))
+                .instrument(info_span!("request").or_current())
                 .await
         })
     }

--- a/src/sinks/azure_common/service.rs
+++ b/src/sinks/azure_common/service.rs
@@ -69,7 +69,7 @@ impl Service<AzureBlobRequest> for AzureBlobService {
                         byte_size
                     })
                 })
-                .instrument(info_span!("request"))
+                .instrument(info_span!("request").or_current())
                 .await;
 
             result.map(|inner| AzureBlobResponse {

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -467,7 +467,7 @@ where
                 // ignore for now.
                 let _ = tx.send((seqno, batch_size));
             })
-            .instrument(info_span!("request", %request_id))
+            .instrument(info_span!("request", %request_id).or_current())
             .boxed()
     }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -396,7 +396,11 @@ pub fn file_source(
             }
             event
         });
-        tokio::spawn(async move { out.send_event_stream(&mut messages).instrument(span).await });
+        tokio::spawn(async move {
+            out.send_event_stream(&mut messages)
+                .instrument(span.or_current())
+                .await
+        });
 
         let span = info_span!("file_server");
         spawn_blocking(move || {

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -509,7 +509,7 @@ pub fn build_framestream_unix_source(
 
                     info!("Finished sending.");
                 };
-                tokio::spawn(handler.instrument(span));
+                tokio::spawn(handler.instrument(span.or_current()));
             } else {
                 let handler = async move {
                     frames
@@ -535,7 +535,7 @@ pub fn build_framestream_unix_source(
                         .await;
                     info!("Finished sending.");
                 };
-                tokio::spawn(handler.instrument(span));
+                tokio::spawn(handler.instrument(span.or_current()));
             }
         }
 

--- a/src/sources/util/tcp/mod.rs
+++ b/src/sources/util/tcp/mod.rs
@@ -190,7 +190,7 @@ where
                             })
                             .boxed();
 
-                        span.in_scope(|| {
+                        span.clone().in_scope(|| {
                             debug!(message = "Accepted a new connection.", peer_addr = %peer_addr);
 
                             let open_token =
@@ -214,7 +214,7 @@ where
                                     drop(open_token);
                                     drop(tcp_connection_permit);
                                 })
-                                .instrument(span.clone()),
+                                .instrument(span.or_current()),
                             );
                         });
                     }

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -125,7 +125,7 @@ pub fn build_unix_stream_source(
                         error!(message = "Failed shutting down socket.", %error);
                     }
                 }
-                .instrument(span),
+                .instrument(span.or_current()),
             );
         }
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -586,7 +586,7 @@ impl RunningTopology {
             // maintained for compatibility
             component_name = %task.id(),
         );
-        let task = handle_errors(task, self.abort_tx.clone()).instrument(span);
+        let task = handle_errors(task, self.abort_tx.clone()).instrument(span.or_current());
         let spawned = tokio::spawn(task);
         if let Some(previous) = self.tasks.insert(key.clone(), spawned) {
             drop(previous); // detach and forget
@@ -603,7 +603,7 @@ impl RunningTopology {
             // maintained for compatibility
             component_name = %task.id(),
         );
-        let task = handle_errors(task, self.abort_tx.clone()).instrument(span);
+        let task = handle_errors(task, self.abort_tx.clone()).instrument(span.or_current());
         let spawned = tokio::spawn(task);
         if let Some(previous) = self.tasks.insert(key.clone(), spawned) {
             drop(previous); // detach and forget
@@ -620,7 +620,7 @@ impl RunningTopology {
             // maintained for compatibility
             component_name = %task.id(),
         );
-        let task = handle_errors(task, self.abort_tx.clone()).instrument(span.clone());
+        let task = handle_errors(task, self.abort_tx.clone()).instrument(span.clone().or_current());
         let spawned = tokio::spawn(task);
         if let Some(previous) = self.tasks.insert(key.clone(), spawned) {
             drop(previous); // detach and forget
@@ -630,7 +630,8 @@ impl RunningTopology {
             .takeover_source(key, &mut new_pieces.shutdown_coordinator);
 
         let source_task = new_pieces.source_tasks.remove(key).unwrap();
-        let source_task = handle_errors(source_task, self.abort_tx.clone()).instrument(span);
+        let source_task =
+            handle_errors(source_task, self.abort_tx.clone()).instrument(span.or_current());
         self.source_tasks
             .insert(key.clone(), tokio::spawn(source_task));
     }

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -172,7 +172,7 @@ impl TransformConfig for Ec2Metadata {
                 client.run().await;
             }
             // TODO: Once #1338 is done we can fetch the current span
-            .instrument(info_span!("aws_ec2_metadata: worker")),
+            .instrument(info_span!("aws_ec2_metadata: worker").or_current()),
         );
 
         Ok(Transform::event_task(Ec2MetadataTransform { state }))


### PR DESCRIPTION
Instrumenting with an inactive span seems to divorce it from the parent
span altogether so that, for example, if Vector is run with a lower log
level so that the span being used to instrument is disabled, any metrics
published in that span lack the tags from the tracing context of parent spans.

This gotcha is mentioned on https://docs.rs/tracing/latest/tracing/trait.Instrument.html#provided-methods

> The Span::or_current combinator can be used in combination with
> instrument to ensure that the current span is attached to the future if
> the span passed to instrument is disabled:

Fixes: #11844

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
