### PR TITLE
chore: move baseline timings workflows to GHA hosted runners

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   release-build-optimized:
     name: "Release Build (optimized)"
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test-runner]
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
 
   release-build-normal:
     name: "Release Build (normal)"
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test-runner]
     env:
       # We're not actually doing a debug build, we're just turning off the logic
       # in release-flags.sh so that we don't override the Cargo "release" profile
@@ -38,7 +38,7 @@ jobs:
 
   debug-build:
     name: "Debug Build"
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test-runner]
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
 
   debug-rebuild:
     name: "Debug Rebuild"
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test-runner]
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -62,7 +62,7 @@ jobs:
 
   check:
     name: "Cargo Check"
-    runs-on: [self-hosted, linux, x64, general]
+    runs-on: [linux, test-runner]
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3


### PR DESCRIPTION
I missed these before when moving the other tests.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
