### PR TITLE
fix(releasing): Fix debian packaging

### DIFF
--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-slim AS builder
 
-COPY vector-*.deb ./
-RUN dpkg -i vector-*-$(dpkg --print-architecture).deb
+COPY vector_*.deb ./
+RUN dpkg -i vector_*_$(dpkg --print-architecture).deb
 
 FROM debian:bullseye-slim
 

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-slim AS builder
 
-COPY vector-*.deb ./
-RUN dpkg -i vector-*-$(dpkg --print-architecture).deb
+COPY vector_*.deb ./
+RUN dpkg -i vector_*_$(dpkg --print-architecture).deb
 
 FROM gcr.io/distroless/cc-debian10
 

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -77,8 +77,10 @@ cargo deb --target "$TARGET" --deb-version "${PACKAGE_VERSION}-1" --variant "$TA
 for file in target/"${TARGET}"/debian/*.deb; do
   base=$(basename "${file}")
   nbase=${base//-${TARGET}/}
-  # -f since the deb won't have TARGET in its name if not a "variant"
-  mv -f "${file}" target/"${TARGET}"/debian/"${nbase}"
+  # the file won't have TARGET in its name if not a "variant"
+  if [[ "${file}" != target/"${TARGET}"/debian/"${nbase}" ]] ; then
+    mv "${file}" target/"${TARGET}"/debian/"${nbase}"
+  fi
 done
 
 #

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -77,7 +77,8 @@ cargo deb --target "$TARGET" --deb-version "${PACKAGE_VERSION}-1" --variant "$TA
 for file in target/"${TARGET}"/debian/*.deb; do
   base=$(basename "${file}")
   nbase=${base//-${TARGET}/}
-  mv "${file}" target/"${TARGET}"/debian/"${nbase}";
+  # -f since the deb won't have TARGET in its name if not a "variant"
+  mv -f "${file}" target/"${TARGET}"/debian/"${nbase}"
 done
 
 #


### PR DESCRIPTION
Accidentally broke this in
https://github.com/vectordotdev/vector/pull/11887

See failure in https://github.com/vectordotdev/vector/runs/5592337799?check_suite_focus=true

```
+ mv target/x86_64-unknown-linux-gnu/debian/vector_0.21.0-1_amd64.deb target/x86_64-unknown-linux-gnu/debian/vector_0.21.0-1_amd64.deb
mv: 'target/x86_64-unknown-linux-gnu/debian/vector_0.21.0-1_amd64.deb' and 'target/x86_64-unknown-linux-gnu/debian/vector_0.21.0-1_amd64.deb' are the same file
make: *** [Makefile:548: package-deb-x86_64-unknown-linux-gnu] Error 1
rm target/x86_64-unknown-linux-gnu/release/vector.tar.gz
```

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
