### PR TITLE
fix(vrl): fix remaining VM bugs

### DIFF
--- a/lib/vrl/compiler/src/expression/unary.rs
+++ b/lib/vrl/compiler/src/expression/unary.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::{
     expression::{Not, Resolved},
-    vm::{OpCode, Vm},
+    vm::Vm,
     Context, Expression, State, TypeDef,
 };
 
@@ -47,7 +47,6 @@ impl Expression for Unary {
         match &self.variant {
             Variant::Not(v) => {
                 v.compile_to_vm(vm, state)?;
-                vm.write_opcode(OpCode::Not);
             }
         }
 

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -350,13 +350,15 @@ impl Vm {
                 }
                 OpCode::JumpIfTruthy => {
                     // If the value at the top of the stack is true, jump by the given amount.
+                    // Used by OR operations.
                     let jump = state.next_primitive()?;
-                    if is_truthy(state.peek_stack()?) {
+                    if state.error.is_some() || is_truthy(state.peek_stack()?) {
                         state.instruction_pointer += jump;
                     }
                 }
                 OpCode::JumpAndSwapIfFalsey => {
                     // If the value at the top of the stack is true, jump by the given amount.
+                    // Used by AND operations.
                     let jump = state.next_primitive()?;
                     if state.error.is_some() {
                         // Break out if we are in an error.

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -352,7 +352,7 @@ impl Vm {
                     // If the value at the top of the stack is true, jump by the given amount.
                     // Used by OR operations.
                     let jump = state.next_primitive()?;
-                    if state.error.is_some() || is_truthy(state.peek_stack()?) {
+                    if is_truthy(state.peek_stack()?) {
                         state.instruction_pointer += jump;
                     }
                 }
@@ -360,10 +360,7 @@ impl Vm {
                     // If the value at the top of the stack is true, jump by the given amount.
                     // Used by AND operations.
                     let jump = state.next_primitive()?;
-                    if state.error.is_some() {
-                        // Break out if we are in an error.
-                        state.instruction_pointer += jump;
-                    } else if !is_truthy(state.peek_stack()?) {
+                    if !is_truthy(state.peek_stack()?) {
                         state.pop_stack()?;
                         state.push_stack(Value::Boolean(false));
                         state.instruction_pointer += jump;
@@ -588,6 +585,9 @@ where
             Ok(value) => state.stack.push(value),
             Err(err) => state.error = Some(err.into()),
         }
+    } else {
+        // If we are in error, we need
+        state.pop_stack()?;
     }
 
     Ok(())

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -173,7 +173,14 @@ impl Vm {
     /// If the constant already exists, the position of that element is returned without adding
     /// the value again.
     pub fn add_constant(&mut self, object: Value) -> usize {
-        match self.values.iter().position(|value| value == &object) {
+        // We need to do a specific match for types with `Float`s since the default
+        // implementation for `Eq` on Value type truncates the float values in the comparison.
+        // `lossy_eq` doesn't work either since that allows you to compare `Integer` against
+        // `Float`, which wouldn't work here.
+        match self.values.iter().position(|value| match (value, &object) {
+            (Value::Float(lhs), Value::Float(rhs)) => lhs == rhs,
+            (lhs, rhs) => lhs == rhs,
+        }) {
             None => {
                 self.values.push(object);
                 self.values.len() - 1

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -317,6 +317,8 @@ impl Vm {
                         let rhs = state.pop_stack()?;
                         let lhs = state.pop_stack()?;
                         state.stack.push((!lhs.eq_lossy(&rhs)).into());
+                    } else {
+                        state.pop_stack()?;
                     }
                 }
                 OpCode::Equal => {
@@ -324,6 +326,8 @@ impl Vm {
                         let rhs = state.pop_stack()?;
                         let lhs = state.pop_stack()?;
                         state.stack.push(lhs.eq_lossy(&rhs).into());
+                    } else {
+                        state.pop_stack()?;
                     }
                 }
                 OpCode::Pop => {
@@ -586,7 +590,10 @@ where
             Err(err) => state.error = Some(err.into()),
         }
     } else {
-        // If we are in error, we need
+        // If we are in error, we need to pop the stack to remove the lhs
+        // value from the stack.
+        // (If the lhs had errored, a Jump will have already been evoked to jump
+        // past the binary op.)
         state.pop_stack()?;
     }
 

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -66,6 +66,7 @@ impl Function for EncodeLogfmt {
 
     fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Resolved {
         let value = args.required("value");
+        let fields = args.optional("fields_ordering");
 
         let key_value_delimiter = Value::from("=");
         let field_delimiter = Value::from(" ");

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -66,19 +66,10 @@ impl Function for EncodeLogfmt {
 
     fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Resolved {
         let value = args.required("value");
-        let fields = args.optional("fields_ordering");
 
-        let key_value_delimiter = args
-            .optional("key_value_delimiter")
-            .unwrap_or_else(|| Value::from("="));
-
-        let field_delimiter = args
-            .optional("field_delimiter")
-            .unwrap_or_else(|| Value::from(" "));
-
-        let flatten_boolean = args
-            .optional("flatten_boolean")
-            .unwrap_or_else(|| Value::from(true));
+        let key_value_delimiter = Value::from("=");
+        let field_delimiter = Value::from(" ");
+        let flatten_boolean = Value::from(true);
 
         super::encode_key_value::encode_key_value(
             fields,

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -145,11 +145,7 @@ impl Function for ParseGrok {
         match (name, expr) {
             ("pattern", Some(expr)) => {
                 let pattern = expr
-                    .as_value()
-                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "pattern",
-                        expr: expr.clone(),
-                    })?
+                    .as_literal("pattern")?
                     .try_bytes_utf8_lossy()
                     .expect("grok pattern not bytes")
                     .into_owned();

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -59,18 +59,11 @@ impl Function for ParseLogFmt {
 
     fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Resolved {
         let bytes = args.required("value");
-        let key_value_delimiter = args
-            .optional("key_value_delimiter")
-            .unwrap_or_else(|| value!("="));
-        let field_delimiter = args
-            .optional("field_delimiter")
-            .unwrap_or_else(|| value!(" "));
 
+        let key_value_delimiter = Value::from("=");
+        let field_delimiter = Value::from(" ");
         let whitespace = Whitespace::Lenient;
-
-        let standalone_key = args
-            .optional("accept_standalone_key")
-            .unwrap_or_else(|| value!(true));
+        let standalone_key = Value::from(true);
 
         super::parse_key_value::parse_key_value(
             bytes,

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -325,6 +325,7 @@ fn main() {
     print_result(failed_count)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_vrl(
     mut runtime: Runtime,
     functions: Vec<Box<dyn vrl::Function>>,

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -338,7 +338,7 @@ fn run_vrl(
     match vrl_runtime {
         VrlRuntime::Vm => {
             let vm = runtime.compile(functions, &program, state).unwrap();
-            test_enrichment.finish_load();
+
             runtime.run_vm(&vm, &mut test.object, &timezone)
         }
         VrlRuntime::Ast => {

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -338,7 +338,7 @@ fn run_vrl(
     match vrl_runtime {
         VrlRuntime::Vm => {
             let vm = runtime.compile(functions, &program, state).unwrap();
-
+            test_enrichment.finish_load();
             runtime.run_vm(&vm, &mut test.object, &timezone)
         }
         VrlRuntime::Ast => {

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -152,7 +152,6 @@ fn main() {
         state.set_external_context(test_enrichment.clone());
 
         let program = vrl::compile_with_state(&test.source, &functions, &mut state);
-        test_enrichment.finish_load();
 
         let want = test.result.clone();
         let timezone = cmd.timezone();
@@ -166,6 +165,8 @@ fn main() {
                     &mut test,
                     timezone,
                     cmd.runtime,
+                    state,
+                    test_enrichment,
                 );
 
                 match result {
@@ -331,15 +332,19 @@ fn run_vrl(
     test: &mut Test,
     timezone: TimeZone,
     vrl_runtime: VrlRuntime,
+    state: vrl::state::Compiler,
+    test_enrichment: enrichment::TableRegistry,
 ) -> Result<Value, Terminate> {
     match vrl_runtime {
         VrlRuntime::Vm => {
-            let vm = runtime
-                .compile(functions, &program, Default::default())
-                .unwrap();
+            let vm = runtime.compile(functions, &program, state).unwrap();
+            test_enrichment.finish_load();
             runtime.run_vm(&vm, &mut test.object, &timezone)
         }
-        VrlRuntime::Ast => runtime.resolve(&mut test.object, &program, &timezone),
+        VrlRuntime::Ast => {
+            test_enrichment.finish_load();
+            runtime.resolve(&mut test.object, &program, &timezone)
+        }
     }
 }
 

--- a/lib/vrl/tests/tests/internal/coalesced_fallible_op.vrl
+++ b/lib/vrl/tests/tests/internal/coalesced_fallible_op.vrl
@@ -3,7 +3,8 @@
 #          false, false, false, false, false, false, false, false, false, false,
 #          true, true,
 #          false, false, false, false, false, false, false, false, false, false,
-#          false, false, false, false, false, false, false, false, false, false]
+#          false, false, false, false, false, false, false, false, false, false,
+#          false, false, false, 42, 42, 42, 42, 42, 42]
 
 [
  (.foo == "this" || match(.bar, r'')) ?? false,
@@ -52,4 +53,14 @@
  match(.bar, r'') ?? false && .zub == true && .foo == "thunk",
  .zub == true && match(.bar, r'') ?? false && .foo == "thunk",
  .zub == true && .foo == "thunk" && match(.bar, r'') ?? false,
+
+ length(.blob) + length(.bloob) ?? false,
+ length(.foo) + length(.bloob) ?? false,
+ length(.blob) + length(.foo) ?? false,
+ length(.blob) == length(.bloob) ?? 42,
+ length(.foo) == length(.bloob) ?? 42,
+ length(.blob) == length(.foo) ?? 42,
+ length(.blob) != length(.bloob) ?? 42,
+ length(.foo) != length(.bloob) ?? 42,
+ length(.blob) != length(.foo) ?? 42,
  ]

--- a/scripts/test-vrl.sh
+++ b/scripts/test-vrl.sh
@@ -10,6 +10,5 @@ set -euo pipefail
 (
   cd "$(dirname "${BASH_SOURCE[0]}")/../lib/vrl/tests"
 
-  cargo run
+  cargo run && cargo run -- --runtime=vm
 )
-

--- a/scripts/test-vrl.sh
+++ b/scripts/test-vrl.sh
@@ -10,5 +10,5 @@ set -euo pipefail
 (
   cd "$(dirname "${BASH_SOURCE[0]}")/../lib/vrl/tests"
 
-  cargo run && cargo run -- --runtime=vm
+  cargo run -- --runtime=ast && cargo run -- --runtime=vm
 )


### PR DESCRIPTION
There were a number of remaining bugs highlighted by running the VRL tests after all the stdlib functions had been implemented.

This fixes them so all tests now pass.

I have also updated the tests so that the VRL tests are run for both AST and VM runtimes.

It may make more sense to review this PR commit by commit, since for the most part each commit covers one bug. (Ignore `Or should jump out if there is an error.` as it get's fixed properly in `Binary operations need to jump to the end on error`)