### PR TITLE
chore: Fix naming for VRL runtime benches

### DIFF
--- a/lib/vrl/vrl/Cargo.toml
+++ b/lib/vrl/vrl/Cargo.toml
@@ -23,5 +23,5 @@ indoc = "1"
 vrl-stdlib = { path = "../stdlib" }
 
 [[bench]]
-name = "vm"
+name = "runtime"
 harness = false

--- a/lib/vrl/vrl/benches/runtime.rs
+++ b/lib/vrl/vrl/benches/runtime.rs
@@ -39,7 +39,7 @@ static SOURCES: [Source; 2] = [
 ];
 
 fn benchmark_kind_display(c: &mut Criterion) {
-    let mut group = c.benchmark_group("vrl_compiler/value::kind::display");
+    let mut group = c.benchmark_group("vrl/runtime");
     for source in &SOURCES {
         let state = state::Runtime::default();
         let runtime = Runtime::new(state);


### PR DESCRIPTION
Just noticed that some labels were off when adding the LLVM alternative to the benches.