### PR TITLE
fix(kafka source): read message key as bytes instead of string

### DIFF
--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -213,7 +213,7 @@ async fn kafka_source(
 
                 let msg_key = msg
                     .key()
-                    .map(|key| Value::from(String::from_utf8_lossy(key).to_string()))
+                    .map(|key| Value::from(Bytes::from(key.to_owned())))
                     .unwrap_or(Value::Null);
 
                 let mut headers_map = BTreeMap::new();


### PR DESCRIPTION
Fixes: #11878

When having other types as keys than string, the lossy conversion messes them up, e.g. when sending a Long value, it will become a 10-byte string, which is impossible to reverse on the receiver's side.
