### PR TITLE
fix(aws_sqs source): Fix handling of acknowledgements

### DIFF
--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -93,7 +93,7 @@ impl SqsSource {
         if let Some(messages) = receive_message_output.messages {
             let mut receipts_to_ack = vec![];
 
-            let mut batch_receiver = None;
+            let (batch, batch_receiver) = BatchNotifier::maybe_new_with_receiver(acknowledgements);
             for message in messages {
                 if let Some(body) = message.body {
                     emit!(&AwsSqsBytesReceived {
@@ -102,10 +102,8 @@ impl SqsSource {
                     let timestamp = get_timestamp(&message.attributes);
                     let stream = decode_message(self.decoder.clone(), &body, timestamp);
                     pin!(stream);
-                    let send_result = if acknowledgements {
-                        let (batch, receiver) = BatchNotifier::new_with_receiver();
-                        let mut stream = stream.map(|event| event.with_batch_notifier(&batch));
-                        batch_receiver = Some(receiver);
+                    let send_result = if let Some(batch) = batch.as_ref() {
+                        let mut stream = stream.map(|event| event.with_batch_notifier(batch));
                         out.send_event_stream(&mut stream).await
                     } else {
                         out.send_event_stream(&mut stream).await
@@ -122,6 +120,7 @@ impl SqsSource {
                     }
                 }
             }
+            drop(batch);
 
             if let Some(receiver) = batch_receiver {
                 let client = self.client.clone();


### PR DESCRIPTION
When an received SQS record contained multiple messages, this source
would create a new batch notifier for each message, but drop all but the
last one. This would ignore the acknowledgements for all but the last
message.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
