### PR TITLE
feat(blackhole sink): Allow disabling reporting

### DIFF
--- a/website/cue/reference/components/sinks/blackhole.cue
+++ b/website/cue/reference/components/sinks/blackhole.cue
@@ -32,7 +32,7 @@ components: sinks: blackhole: {
 	configuration: {
 		print_interval_secs: {
 			common:      false
-			description: "The number of seconds between reporting a summary of activity."
+			description: "The number of seconds between reporting a summary of activity. Set to 0 to disable reporting."
 			required:    false
 			type: uint: {
 				default: 1


### PR DESCRIPTION
By setting `print_interval_secs` to `0`. Previously this would panic
which also wasn't great.

I recommend viewing this without whitespace changes except @spencergilbert who goes his own way.

Closes: #11909

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
