### PR TITLE
chore(aws_sqs source): Convert decoder to iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc8b61f005b3feb772f94ffe8cd8370762aa6ba7ecbe86b79c6ab9fbcc94c6d"
+checksum = "9f90f923965331aec34c31d22d8c5e158ddae5a41d5e0c4c7826cd0f6c4f22f6"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986a15277ad7adf67c32059359d60584426b4fa0c30ef34d153bbe47a83cbad7"
+checksum = "c4fd99b22cbdb894925468005ad55defcfe0ce294fadcc5f7be9d9119646b0de"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972226c639e0dc1eca2cb0220c1b5799e2bfc62eda37845b662c5d0cb972371"
+checksum = "775b1de8d55fd1cda393c3d81cb5c3dc0e1cac38170883049e2d7a8e16cefad1"
 dependencies = [
  "aws-smithy-types",
  "bytes 1.1.0",

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -215,7 +215,7 @@ trait FoldFinallyExt: Sized {
     /// This adapter applies the `folder` function to every element in
     /// the iterator, much as `Iterator::fold` does. However, instead
     /// of returning the resulting folded value, it calls the
-    /// `funally` function after the last element. This function
+    /// `finally` function after the last element. This function
     /// returns an iterator over the original values.
     fn fold_finally<A, Fo, Fi>(
         self,

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -101,7 +101,7 @@ impl SqsSource {
                     let timestamp = get_timestamp(&message.attributes);
                     let events = decode_message(self.decoder.clone(), body.as_bytes(), timestamp);
                     let send_result = if let Some(batch) = batch.as_ref() {
-                        let mut events = events.map(|event| event.with_batch_notifier(batch));
+                        let events = events.map(|event| event.with_batch_notifier(batch));
                         out.send_batch(events).await
                     } else {
                         out.send_batch(events).await

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -212,6 +212,11 @@ fn decode_message(
 }
 
 trait FoldFinallyExt: Sized {
+    /// This adapter applies the `folder` function to every element in
+    /// the iterator, much as `Iterator::fold` does. However, instead
+    /// of returning the resulting folded value, it calls the
+    /// `funally` function after the last element. This function
+    /// returns an iterator over the original values.
     fn fold_finally<A, Fo, Fi>(
         self,
         initial: A,


### PR DESCRIPTION
The message decoder in the `aws_sqs` source does a lot of `async` work for no real gain, as none of the code paths will ever actually wait asynchronously. This PR converts it all to an iterator.

The bulk of the code additions are the `FoldFinally` iterator adapter, for which I couldn't find an equivalent. The stream handles it by emitting the final value after the last `yield` with an internalized state machine built up by the compiler. This is an equivalent mechanism for an iterator, exposed as a struct.

This is partially related to #11908, as this kind of work may be required in other places if we have to move away from tokio's `FramedRead`.