### PR TITLE
docs(blackhole sink): Add backticks around `print_interval_secs` value

### DIFF
--- a/website/cue/reference/components/sinks/blackhole.cue
+++ b/website/cue/reference/components/sinks/blackhole.cue
@@ -32,7 +32,7 @@ components: sinks: blackhole: {
 	configuration: {
 		print_interval_secs: {
 			common:      false
-			description: "The number of seconds between reporting a summary of activity. Set to 0 to disable reporting."
+			description: "The number of seconds between reporting a summary of activity. Set to `0` to disable reporting."
 			required:    false
 			type: uint: {
 				default: 1


### PR DESCRIPTION
https://github.com/vectordotdev/vector/pull/11912#discussion_r830349081

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
