### PR TITLE
docs(vrl): minor fixes/improvements to literals documentation

### DIFF
--- a/website/cue/reference/remap/literals/regular_expression.cue
+++ b/website/cue/reference/remap/literals/regular_expression.cue
@@ -12,7 +12,7 @@ remap: literals: regular_expression: {
 
 	examples: [
 		#"r'^Hello, World!$'"#,
-		#"r'^Hello, World!$'i"#,
+		#"r'(?i)^Hello, World!$'"#,
 		#"r'^\d{4}-\d{2}-\d{2}$'"#,
 		#"r'(?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2})'"#,
 	]

--- a/website/cue/reference/remap/literals/string.cue
+++ b/website/cue/reference/remap/literals/string.cue
@@ -19,7 +19,7 @@ remap: literals: string: {
 			"Hello, world! 🌎"
 			"""#,
 		#"""
-			"Hello, world! \\u1F30E"
+			"Hello, world! \u1F30E"
 			"""#,
 		#"""
 			"Hello, \
@@ -40,14 +40,14 @@ remap: literals: string: {
 				Special characters, such as newlines, can be expressed with a backslash escape.
 				"""
 			enum: {
-				"`\\u{7FFF}`": "24-bit Unicode character code (up to 6 digits)"
-				"`\\n`":       "Newline"
-				"`\\r`":       "Carriage return"
-				"`\\t`":       "Tab"
-				"`\\\\`":      "Backslash"
-				"`\\0`":       "Null"
-				"`\\\"`":      "Double quote"
-				"`\\'`":       "Single quote"
+				"\\u{7FFF}": "24-bit Unicode character code (up to 6 digits)"
+				"\\n":       "Newline"
+				"\\r":       "Carriage return"
+				"\\t":       "Tab"
+				"\\\\":      "Backslash"
+				"\\0":       "Null"
+				"\\\"":      "Double quote"
+				"\\'":       "Single quote"
 			}
 		}
 		multiline_strings: {


### PR DESCRIPTION
This simple PR fixes/improves two minor aspects I noticed while reading the VRL literals documentation:
* fix incorrect example for regular expression literals
* improve string literals documentation
  * do not double-escape unicode example (already is in a raw string block)
  * do not use backticks in enum options (enums automatically adds them)

I ran `make check-docs CI=true` to verify formatting and correctness of the changes.