### PR TITLE
docs(external docs): update docs for template missing fields

### DIFF
--- a/website/content/en/docs/reference/configuration/template-syntax.md
+++ b/website/content/en/docs/reference/configuration/template-syntax.md
@@ -101,7 +101,8 @@ Vector doesn't currently support fallback values. [Issue 1692][1692] is open to 
 
 ### Missing fields
 
-If a field is missing, an error is logged and Vector drops the event.
+If a field is missing, an error is logged and Vector drops the event. The `component_errors_total` internal
+metric is incremented with `error_type` = `template_failed`.
 
 ### Nested fields
 

--- a/website/content/en/docs/reference/configuration/template-syntax.md
+++ b/website/content/en/docs/reference/configuration/template-syntax.md
@@ -101,7 +101,7 @@ Vector doesn't currently support fallback values. [Issue 1692][1692] is open to 
 
 ### Missing fields
 
-If a field is missing, a blank string is inserted in its place. In that case, Vector neither errors nor drops the event nor logs anything.
+If a field is missing, an error is logged and Vector drops the event.
 
 ### Nested fields
 


### PR DESCRIPTION
Closes #4585

We had another user on Discord come up against this. The docs for what happens when a field specified in a template is missing.

This updates the docs.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

