### PR TITLE
docs(buffers): Clarify buffer metrics

### DIFF
--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -481,19 +481,19 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		buffer_discarded_events_total: {
-			description:       "The number of events dropped by this non-blocking buffer."
+			description:       "The number of events dropped by this non-blocking buffer before receipt."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
 		buffer_received_event_bytes_total: {
-			description:       "The number of bytes received by this buffer."
+			description:       "The number of bytes received by this buffer. This does not include discarded events."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
 		buffer_received_events_total: {
-			description:       "The number of events received by this buffer."
+			description:       "The number of events received by this buffer. This does not include discarded events."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags


### PR DESCRIPTION
A user was confused about whether `buffer_discarded_events_total`
includes the number of events in `buffer_received_events_total`.

This is actually different from the `component_discarded_events_total`
and `component_received_events_total` where events are typically
discarded after receipt so an alternative would be to bring this in line
with that (a breaking change).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
