### PR TITLE
chore: Update mold, add matrix to soak_infra workflow

### DIFF
--- a/.github/workflows/soak_infra.yml
+++ b/.github/workflows/soak_infra.yml
@@ -28,8 +28,11 @@ jobs:
           all_but_latest: true # can cancel workflows scheduled later
 
   observer:
-    name: Build and push 'observer' to Github CR
+    name: Build and push 'observer' (${{ matrix.platform }})
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -68,15 +71,18 @@ jobs:
           context: .
           file: lib/soak/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   soak-builder:
-    name: Build and push 'soak-builder' to Github CR
+    name: Build and push 'soak-builder' (${{ matrix.platform }})
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -113,7 +119,7 @@ jobs:
           context: .
           file: soaks/Dockerfile.builder
           push: ${{ github.ref == 'refs/heads/master' }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/soaks/Dockerfile.builder
+++ b/soaks/Dockerfile.builder
@@ -1,8 +1,11 @@
-FROM docker.io/rust:1.58-bullseye@sha256:d83bf5ea7b4c3d18c2f46d5f3d288bfca085c3e7ac57822e3b8e5a1ad22ccc1a as builder
-RUN apt-get update && apt-get -y install build-essential git clang cmake libclang-dev libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g
-RUN git clone https://github.com/rui314/mold.git
-RUN cd mold && git checkout v1.0.1 && make -j$(nproc) && make install
-RUN rm -rf mold
+FROM docker.io/rust:1.58-bullseye@sha256:e4979d36d5d30838126ea5ef05eb59c4c25ede7f064985e676feb21402d0661b as builder
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get -y install build-essential git clang cmake libclang-dev \
+    libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g
+
+# Build mold, a fast linker
+RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.1.1 && make -j$(nproc) && make install
 
 # Smoke test
 RUN ["/usr/local/bin/mold", "--version"]


### PR DESCRIPTION
This commit updates the mold linker for use in soak builder and, additionally,
makes the platforms the images are built for a matrix. This is intended to allow
parallel builds for platforms, especially as the ARM build is very slow.

Extracted from #11891

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
