### PR TITLE
fix(datadog_metrics sink): fix TLS behaviour on windows

### DIFF
--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -23,6 +23,7 @@ use crate::{
         },
         Healthcheck, UriParseSnafu, VectorSink,
     },
+    tls::MaybeTlsSettings,
 };
 
 // TODO: revisit our concurrency and batching defaults
@@ -188,7 +189,8 @@ impl DatadogMetricsConfig {
     }
 
     fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
-        let client = HttpClient::new(None, proxy)?;
+        let settings = MaybeTlsSettings::enable_client()?;
+        let client = HttpClient::new(settings, proxy)?;
         Ok(client)
     }
 


### PR DESCRIPTION
Fixes 

```
ERROR vector::topology::builder: msg="Healthcheck: Failed Reason." error=Failed to make HTTP(S) request: error trying to connect: error:1416F086:SS
L routines:tls_process_server_certificate:certificate verify failed:ssl\statem\statem_clnt.c:1916:: unable to get local issuer certificate component_kind="sink" component_type
="datadog_metrics"
````

on Windows.

This is not happening with the `datadog_logs` sink because withtout TLS settings it [defaults](https://github.com/vectordotdev/vector/blob/master/src/sinks/datadog/logs/config.rs#L153-L158) to  `TlsConfig::enabled ` whereas the `datadog_metrics` does [not specify anything](https://github.com/vectordotdev/vector/blob/master/src/sinks/datadog/metrics/config.rs#L190-L193) and thus [loading all CAs from the windows cert store](https://github.com/vectordotdev/vector/blob/master/src/tls/settings.rs#L270-L296) is not happening (while default CAs location is usually fine on Linux without doing anything)