### PR TITLE
chore(observability): better integration of tracing/tokio-console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8712,7 +8712,6 @@ dependencies = [
  "tracing-core 0.1.23",
  "tracing-futures 0.2.5",
  "tracing-limit",
- "tracing-log",
  "tracing-subscriber",
  "tracing-tower",
  "trust-dns-proto 0.21.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,7 @@ console-subscriber = { version = "0.1.3", optional = true }
 tracing = { version = "0.1.32", default-features = false }
 tracing-core = { version = "0.1.23", default-features = false }
 tracing-futures = { version = "0.2.5", default-features = false, features = ["futures-03"] }
-tracing-log = { version = "0.1.2", default-features = false, features = ["log-tracer", "std"] }
-tracing-subscriber = { version = "0.3.9", default-features = false, features = ["ansi", "env-filter", "fmt", "json", "registry"] }
+tracing-subscriber = { version = "0.3.9", default-features = false, features = ["ansi", "env-filter", "fmt", "json", "registry", "tracing-log"] }
 tracing-tower = { git = "https://github.com/tokio-rs/tracing", default-features = false, rev = "f470db1b0354b368f62f9ee4d763595d16373231" }
 
 # Metrics

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -221,6 +221,11 @@ where
     fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: Context<'_, S>) {
         self.inner.on_id_change(old, new, ctx);
     }
+
+    #[inline]
+    fn on_layer(&mut self, subscriber: &mut S) {
+        self.inner.on_layer(subscriber);
+    }
 }
 
 impl<S, L> RateLimitedLayer<S, L>

--- a/lib/vector-buffers/benches/common.rs
+++ b/lib/vector-buffers/benches/common.rs
@@ -118,7 +118,7 @@ pub async fn setup<const N: usize>(
         .add_to_builder(&mut builder, data_dir, id)
         .expect("should not fail to add variant to builder");
     let (tx, rx, _acker) = builder
-        .build(Span::none())
+        .build(String::from("benches"), Span::none())
         .await
         .expect("should not fail to build topology");
 

--- a/lib/vector-buffers/examples/buffer_perf.rs
+++ b/lib/vector-buffers/examples/buffer_perf.rs
@@ -277,7 +277,7 @@ where
         .expect("should not fail to to add variant to builder");
 
     builder
-        .build(Span::none())
+        .build(String::from("buffer_perf"), Span::none())
         .await
         .expect("build should not fail")
 }

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -346,7 +346,7 @@ impl BufferConfig {
         }
 
         builder
-            .build(span)
+            .build(buffer_id, span)
             .await
             .context(FailedToBuildTopologySnafu)
     }

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -82,3 +82,18 @@ impl<T> Bufferable for T where
 pub trait EventCount {
     fn event_count(&self) -> usize;
 }
+
+#[track_caller]
+pub(crate) fn spawn_named<T>(
+    task: impl std::future::Future<Output = T> + Send + 'static,
+    _name: &str,
+) -> tokio::task::JoinHandle<T>
+where
+    T: Send + 'static,
+{
+    #[cfg(tokio_unstable)]
+    return tokio::task::Builder::new().name(_name).spawn(task);
+
+    #[cfg(not(tokio_unstable))]
+    tokio::spawn(task)
+}

--- a/lib/vector-buffers/src/test/common/variant.rs
+++ b/lib/vector-buffers/src/test/common/variant.rs
@@ -86,7 +86,7 @@ impl Variant {
         };
 
         let (sender, receiver, _acker) = builder
-            .build(Span::none())
+            .build(String::from("benches"), Span::none())
             .await
             .expect("topology build should not fail");
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,20 +66,6 @@ impl Application {
             })
             .unwrap_or_else(|_| match opts.log_level() {
                 "off" => "off".to_owned(),
-                #[cfg(feature = "tokio-console")]
-                level => [
-                    format!("vector={}", level),
-                    format!("codec={}", level),
-                    format!("vrl={}", level),
-                    format!("file_source={}", level),
-                    "tower_limit=trace".to_owned(),
-                    "runtime=trace".to_owned(),
-                    "tokio=trace".to_owned(),
-                    format!("rdkafka={}", level),
-                    format!("buffers={}", level),
-                ]
-                .join(","),
-                #[cfg(not(feature = "tokio-console"))]
                 level => [
                     format!("vector={}", level),
                     format!("codec={}", level),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,3 +147,18 @@ pub mod built_info {
 pub fn get_hostname() -> std::io::Result<String> {
     Ok(hostname::get()?.to_string_lossy().into())
 }
+
+#[track_caller]
+pub(crate) fn spawn_named<T>(
+    task: impl std::future::Future<Output = T> + Send + 'static,
+    _name: &str,
+) -> tokio::task::JoinHandle<T>
+where
+    T: Send + 'static,
+{
+    #[cfg(tokio_unstable)]
+    return tokio::task::Builder::new().name(_name).spawn(task);
+
+    #[cfg(not(tokio_unstable))]
+    tokio::spawn(task)
+}

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -40,6 +40,7 @@ use crate::{
     event::{EventArray, EventContainer},
     internal_events::EventsReceived,
     shutdown::SourceShutdownCoordinator,
+    spawn_named,
     transforms::{SyncTransform, TaskTransform, Transform, TransformOutputs, TransformOutputsBuf},
     SourceSender,
 };
@@ -152,6 +153,16 @@ pub async fn build_pieces(
         let typetag = source.inner.source_type();
         let source_outputs = source.inner.outputs();
 
+        let span = error_span!(
+            "source",
+            component_kind = "source",
+            component_id = %key.id(),
+            component_type = %source.inner.source_type(),
+            // maintained for compatibility
+            component_name = %key.id(),
+        );
+        let task_name = format!(">> {} ({}, pump) >>", source.inner.source_type(), key.id());
+
         let mut builder = SourceSender::builder().with_buffer(SOURCE_SENDER_BUFFER_SIZE);
         let mut pumps = Vec::new();
         let mut controls = HashMap::new();
@@ -168,7 +179,7 @@ pub async fn build_pieces(
                 Ok(TaskOutput::Source)
             };
 
-            pumps.push(pump);
+            pumps.push(pump.instrument(span.clone()));
             controls.insert(
                 OutputId {
                     component: key.clone(),
@@ -187,7 +198,7 @@ pub async fn build_pieces(
         let pump = async move {
             let mut handles = Vec::new();
             for pump in pumps {
-                handles.push(tokio::spawn(pump));
+                handles.push(spawn_named(pump, task_name.as_ref()));
             }
             for handle in handles {
                 handle.await.expect("join error")?;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -59,7 +59,7 @@ pub fn init(color: bool, json: bool, levels: &str) {
         let subscriber = subscriber.with(rate_limited.with_filter(fmt_filter));
 
         let subscriber = BroadcastSubscriber { subscriber };
-        subscriber.init()
+        let _ = subscriber.try_init();
     } else {
         let formatter = tracing_subscriber::fmt::layer()
             .with_ansi(color)
@@ -72,7 +72,7 @@ pub fn init(color: bool, json: bool, levels: &str) {
         let subscriber = subscriber.with(rate_limited.with_filter(fmt_filter));
 
         let subscriber = BroadcastSubscriber { subscriber };
-        subscriber.init()
+        let _ = subscriber.try_init();
     }
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -93,6 +93,7 @@ pub fn stop_buffering() {
     *early_buffer() = None;
 }
 
+/// Gets the current [`Span`].
 pub fn current_span() -> Span {
     Span::current()
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,19 +1,16 @@
-use std::sync::{Mutex, MutexGuard};
+use std::{
+    str::FromStr,
+    sync::{Mutex, MutexGuard},
+};
 
 use metrics_tracing_context::MetricsLayer;
 use once_cell::sync::OnceCell;
 use tokio::sync::broadcast::{self, Receiver, Sender};
-use tracing::{
-    dispatcher::{set_global_default, Dispatch},
-    span::Span,
-    subscriber::Interest,
-    Id, Metadata, Subscriber,
-};
+use tracing::{span::Span, subscriber::Interest, Id, Metadata, Subscriber};
 use tracing_core::span;
 pub use tracing_futures::Instrument;
 use tracing_limit::RateLimitedLayer;
-use tracing_log::LogTracer;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 pub use tracing_tower::{InstrumentableService, InstrumentedService};
 
 use crate::event::LogEvent;
@@ -34,72 +31,49 @@ fn metrics_layer_enabled() -> bool {
 
 pub fn init(color: bool, json: bool, levels: &str) {
     let _ = BUFFER.set(Mutex::new(Some(Vec::new())));
+    let fmt_filter = tracing_subscriber::filter::Targets::from_str(levels).expect(
+        "logging filter targets were not formatted correctly or did not specify a valid level",
+    );
 
-    // An escape hatch to disable injecting a mertics layer into tracing.
-    // May be used for performance reasons.
-    // This is a hidden and undocumented functionality.
-    let metrics_layer_enabled = metrics_layer_enabled();
+    let metrics_layer = metrics_layer_enabled()
+        .then(|| MetricsLayer::new().with_filter(tracing_subscriber::filter::LevelFilter::INFO));
+
+    let subscriber = tracing_subscriber::registry().with(metrics_layer);
 
     #[cfg(feature = "tokio-console")]
     let subscriber = {
-        let (tasks_layer, tasks_server) = console_subscriber::ConsoleLayer::new();
-        tokio::spawn(tasks_server.serve());
+        let console_layer = console_subscriber::ConsoleLayer::builder()
+            .with_default_env()
+            .spawn();
 
-        tracing_subscriber::registry::Registry::default()
-            .with(tasks_layer)
-            .with(tracing_subscriber::filter::EnvFilter::from(levels))
+        subscriber.with(console_layer)
     };
-    #[cfg(not(feature = "tokio-console"))]
-    let subscriber = tracing_subscriber::registry::Registry::default()
-        .with(tracing_subscriber::filter::EnvFilter::from(levels));
 
-    // dev note: we attempted to refactor to reduce duplication but it was starting to seem like
-    // the refactored code would be introducing more complexity than it was worth to remove this
-    // bit of duplication as we started to create a generic struct to wrap the formatters that also
-    // implemented `Layer`
-    let dispatch = if json {
-        #[cfg(not(test))]
-        let formatter = tracing_subscriber::fmt::Layer::default()
-            .json()
-            .flatten_event(true);
+    if json {
+        let formatter = tracing_subscriber::fmt::layer().json().flatten_event(true);
 
         #[cfg(test)]
-        let formatter = tracing_subscriber::fmt::Layer::default()
-            .json()
-            .flatten_event(true)
-            .with_test_writer(); // ensures output is captured
+        let formatter = formatter.with_test_writer();
 
-        let subscriber = subscriber.with(RateLimitedLayer::new(formatter));
+        let rate_limited = RateLimitedLayer::new(formatter);
+        let subscriber = subscriber.with(rate_limited.with_filter(fmt_filter));
 
-        if metrics_layer_enabled {
-            let subscriber = subscriber.with(MetricsLayer::new());
-            Dispatch::new(BroadcastSubscriber { subscriber })
-        } else {
-            Dispatch::new(BroadcastSubscriber { subscriber })
-        }
+        let subscriber = BroadcastSubscriber { subscriber };
+        subscriber.init()
     } else {
-        #[cfg(not(test))]
-        let formatter = tracing_subscriber::fmt::Layer::default()
+        let formatter = tracing_subscriber::fmt::layer()
             .with_ansi(color)
             .with_writer(std::io::stderr);
 
         #[cfg(test)]
-        let formatter = tracing_subscriber::fmt::Layer::default()
-            .with_ansi(color)
-            .with_test_writer(); // ensures output is captured
+        let formatter = formatter.with_test_writer();
 
-        let subscriber = subscriber.with(RateLimitedLayer::new(formatter));
+        let rate_limited = RateLimitedLayer::new(formatter);
+        let subscriber = subscriber.with(rate_limited.with_filter(fmt_filter));
 
-        if metrics_layer_enabled {
-            let subscriber = subscriber.with(MetricsLayer::new());
-            Dispatch::new(BroadcastSubscriber { subscriber })
-        } else {
-            Dispatch::new(BroadcastSubscriber { subscriber })
-        }
-    };
-
-    let _ = LogTracer::init();
-    let _ = set_global_default(dispatch);
+        let subscriber = BroadcastSubscriber { subscriber };
+        subscriber.init()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We have had code to support using `tokio-console` for a while now, but it resulted in subpar logging when actually compiled to work with `tokio-console` due a lack of using per-layer filtering.

This PR updates our tracing initialization to utilize per-layer filtering so that `console-subscriber` has accessed to the spans it needs while our normal application logging remains unaffected.  Additionally, we've been able to reduce a little bit of the boilerplate around tracing initialization.

As a cherry on top, we've also switched to utilizing more of the unstable tracing API in `tokio` in order to name some of our spawned tasks, namely component tasks.  This, essentially, gives us a `tokio-console` view that looks like this:

![Screen Shot 2022-03-23 at 11 46 16 AM](https://user-images.githubusercontent.com/222615/159739612-948c3411-4fd9-4579-80d0-e4212fef905c.png)

Now each top-level component task has a name based on the component ID/component type, and as well, directional arrows that indicate the general flow of the component.  This doesn't provide any sort of dependency graph information, but is merely meant to help provide some useful contextual/symbolic information when visually sifting through the output.

I also did the buffer usage reporter tasks, but there's definitely a lot of other spawns we do that could benefit from the `spawn_named` treatment, which is left as a future optimization as it become relevant for debugging or profiling work.