### PR TITLE
chore: update component spec

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -115,9 +115,8 @@ There is leeway in the implementation of these events:
 
 #### BytesReceived
 
-*Sources* MUST emit a `BytesReceived` event immediately after receiving
-and (optionally) filtering bytes from the upstream source and before the
-creation of a Vector event.
+*Sources* MUST emit a `BytesReceived` event immediately after receiving, decompressing
+and filtering bytes from the upstream source and before the creation of a Vector event.
 
 * Properties
   * `byte_size`


### PR DESCRIPTION
closes #9855

Specifies when the `component_received_bytes_total` should be emitted.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
