### PR TITLE
chore: Add ca-certificates in soak runner

### DIFF
--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # TARGET
 #
 FROM docker.io/debian:bullseye-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dedea30abcd8f584b23d583ec6dadc7
-RUN apt-get update && apt-get -y install zlib1g
+RUN apt-get update && apt-get -y install zlib1g ca-certificates
 COPY --from=builder /vector/vector /usr/bin/vector
 VOLUME /var/lib/vector/
 


### PR DESCRIPTION
It appears that the aws_firehose soaks are hanging for want of
ca-certificates. In #11891 it's obvious from the logs that the vector process
crashes with the following error message:

```
2022-03-24T02:17:59.513654Z  INFO vector::app: Log level is enabled. level="info"
2022-03-24T02:17:59.513723Z  INFO vector::app: Loading configs. paths=["/etc/vector/vector.toml"]
2022-03-24T02:17:59.515117Z  WARN load_region{provider=ProfileFileRegionProvider { fs: Fs(Real), env: Env(Real), profile_override: None }}: aws_config::profile::parser::source: could not determine home directory but home expansion was requested
2022-03-24T02:17:59.515152Z  WARN load_region{provider=ProfileFileRegionProvider { fs: Fs(Real), env: Env(Real), profile_override: None }}: aws_config::profile::parser::source: could not determine home directory but home expansion was requested
thread 'main' panicked at 'no CA certificates found', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-rustls-0.22.1/src/connector.rs:45:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
