### PR TITLE
doc: add dependency with tabulate

### DIFF
--- a/soaks/README.md
+++ b/soaks/README.md
@@ -22,6 +22,7 @@ In order to run a soak locally you will need:
 * terraform
 * python-pandas
 * python-numpy
+* python-tabulate
 
 The CPU and RAM requirements are currently hard-coded but might be made
 flexible, possibly on a per-soak basis.


### PR DESCRIPTION
When running the soak tests locally I ended up having the error `ModuleNotFoundError: No module named 'tabulate'`.
Running `pip install tabulate` should fix the issue.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
