### PR TITLE
fix(tests): add dataDir config option to values.yml in k8s-e2e-tests

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -21,6 +21,7 @@ const HELM_VALUES_EXISTING_CONFIGMAP: &str = indoc! {r#"
     role: "Agent"
     existingConfigMaps:
     - vector-agent-config
+    dataDir: /vector-data-dir
 "#};
 
 const CUSTOM_RESOURCE_VECTOR_CONFIG: &str = indoc! {r#"


### PR DESCRIPTION
Due to a change [here](https://github.com/vectordotdev/helm-charts/commit/87ca537b54f9956c434ddbbd3cfcc9942d7e9c07) the k8s-e2e tests stopped running with 

```
Error: INSTALLATION FAILED: execution error at (vector/templates/daemonset.yaml:40:10): Specify `dataDir` if you're using `existingConfigMaps`
```

This adds a `dataDir` option to the test that uses the `existingConfigMaps` option.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>




