### PR TITLE
fix(tests): add service.ports config option to values.yml in k8s-e2e-tests

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -21,6 +21,11 @@ const HELM_VALUES_EXISTING_CONFIGMAP: &str = indoc! {r#"
     existingConfigMaps:
     - vector-agent-config
     dataDir: /vector-data-dir
+    service:
+      ports:
+      - name: prom-exporter
+        port: 9090
+        protocol: TCP
 "#};
 
 const CUSTOM_RESOURCE_VECTOR_CONFIG: &str = indoc! {r#"


### PR DESCRIPTION
The k8s tests were failing with this error:

```
Error: INSTALLATION FAILED: release vector failed, and has been uninstalled due to atomic being set: Service "vector-qywu3-vector-agent" is invalid: spec.ports: Required value
```

This should fix that error by specifying the ports.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

