### PR TITLE
chore: Set mean drift threshold to 7% from 5% in soaks

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -440,6 +440,7 @@ jobs:
                                          --warmup-seconds 30 \
                                          --coefficient-of-variation-limit ${{ needs.compute-soak-meta.outputs.coefficient-of-variation }} \
                                          --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }} \
+                                         --mean-drift-percentage 7 \
                                          --p-value 0.1 > /tmp/${{ github.run_id}}-${{ github.run_attempt }}-analysis
       - uses: actions/upload-artifact@v2
         with:
@@ -490,6 +491,7 @@ jobs:
           ./soaks/bin/detect_regressions --capture-dir ${{ github.run_id }}-${{ github.run_attempt }}-captures/ \
                                          --warmup-seconds 30 \
                                          --erratic-soaks ${{ needs.compute-soak-meta.outputs.erratic-soaks }} \
+                                         --mean-drift-percentage 7 \
                                          --p-value 0.1
 
   plot-analysis:


### PR DESCRIPTION
In the past we set the threshold for mean drift at the 9th quartile. Feeling
that this was too high a bar we moved the threshold down to 5%. This, for the
most part, has worked out well, except for some soaks that are, for reasons
unknown, inclined to walk back and forth across that line. 6% is also regularly
violated but 7% rarely is.

In the longer term we'd like to make tolerances here tighter, of course, but
have a need to not force devs to re-run soaks just to see if the results are
accurate or random chance.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
