### PR TITLE
chore: Address off-by-one error in soak.sh replicas

### DIFF
--- a/soaks/soak.sh
+++ b/soaks/soak.sh
@@ -85,7 +85,7 @@ while [[ $# -gt 0 ]]; do
           shift # past value
           ;;
       --replicas)
-          REPLICAS=$(($2 - 1))
+          REPLICAS=$2
           shift # past argument
           shift # past value
           ;;


### PR DESCRIPTION
This commit removes an off-by-one error in the `soak.sh` script with regard to
replica settings. I copied the logic up from `soak_one` which means that the
replica setting is -2 of what the user specifies by the time we get into
`soak_one`.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
