### PR TITLE
fix(socket source): Remove port from `host` for `udp`

### DIFF
--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -702,7 +702,7 @@ mod test {
 
         assert_eq!(
             events[0].as_log()[log_schema().host_key()],
-            from.to_string().into()
+            from.ip().to_string().into()
         );
     }
 

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -140,7 +140,7 @@ pub fn udp(
                                     if let Event::Log(ref mut log) = event {
                                         log.try_insert(log_schema().source_type_key(), Bytes::from("socket"));
                                         log.try_insert(log_schema().timestamp_key(), now);
-                                        log.try_insert(host_key.as_str(), address.to_string());
+                                        log.try_insert(host_key.as_str(), address.ip().to_string());
                                     }
                                 }
 


### PR DESCRIPTION
For the `socket` source when `mode` is `udp`, the `host` key on events
includes the port of the peer address, but this is inconsistent with
other sources where the `host` is only the IP or domain name.

This will be followed up with a PR to allow annotating with `port` too.

Prompted by #11476

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
