### PR TITLE
feat(loki sink): convert objects to Loki labels

### DIFF
--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -151,7 +151,14 @@ pub fn valid_label_name(label: &Template) -> bool {
         // The closest mention is in section about Parser Expression https://grafana.com/docs/loki/latest/logql/
         //
         // [a-zA-Z_][a-zA-Z0-9_]*
-        let label_trim = label.get_ref().trim();
+        //
+        // '_*' symbol at the end of the label name will be treated as a prefix for
+        // underlying object keys.
+        let mut label_trim = label.get_ref().trim();
+        if let Some(without_opening_end) = label_trim.strip_suffix("_*") {
+            label_trim = without_opening_end
+        }
+
         let mut label_chars = label_trim.chars();
         if let Some(ch) = label_chars.next() {
             (ch.is_ascii_alphabetic() || ch == '_')
@@ -174,11 +181,13 @@ mod tests {
         assert!(valid_label_name(&" name ".try_into().unwrap()));
         assert!(valid_label_name(&"bee_bop".try_into().unwrap()));
         assert!(valid_label_name(&"a09b".try_into().unwrap()));
+        assert!(valid_label_name(&"abc_*".try_into().unwrap()));
 
         assert!(!valid_label_name(&"0ab".try_into().unwrap()));
         assert!(!valid_label_name(&"*".try_into().unwrap()));
         assert!(!valid_label_name(&"".try_into().unwrap()));
         assert!(!valid_label_name(&" ".try_into().unwrap()));
+        assert!(!valid_label_name(&"_*".try_into().unwrap()));
 
         assert!(valid_label_name(&"{{field}}".try_into().unwrap()));
     }

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -152,10 +152,10 @@ pub fn valid_label_name(label: &Template) -> bool {
         //
         // [a-zA-Z_][a-zA-Z0-9_]*
         //
-        // '_*' symbol at the end of the label name will be treated as a prefix for
+        // '*' symbol at the end of the label name will be treated as a prefix for
         // underlying object keys.
         let mut label_trim = label.get_ref().trim();
-        if let Some(without_opening_end) = label_trim.strip_suffix("_*") {
+        if let Some(without_opening_end) = label_trim.strip_suffix('*') {
             label_trim = without_opening_end
         }
 
@@ -182,12 +182,12 @@ mod tests {
         assert!(valid_label_name(&"bee_bop".try_into().unwrap()));
         assert!(valid_label_name(&"a09b".try_into().unwrap()));
         assert!(valid_label_name(&"abc_*".try_into().unwrap()));
+        assert!(valid_label_name(&"_*".try_into().unwrap()));
 
         assert!(!valid_label_name(&"0ab".try_into().unwrap()));
         assert!(!valid_label_name(&"*".try_into().unwrap()));
         assert!(!valid_label_name(&"".try_into().unwrap()));
         assert!(!valid_label_name(&" ".try_into().unwrap()));
-        assert!(!valid_label_name(&"_*".try_into().unwrap()));
 
         assert!(valid_label_name(&"{{field}}".try_into().unwrap()));
     }

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -1,4 +1,5 @@
 use std::{collections::HashMap, num::NonZeroUsize};
+use once_cell::sync::Lazy;
 
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
@@ -164,7 +165,7 @@ impl EventEncoder {
                 value_template.render_string(event),
             ) {
                 if key.ends_with("_*") {
-                    let pkey = key.trim_end_matches("*");
+                    let pkey = key.trim_end_matches('*');
                     let output: serde_json::map::Map<String, serde_json::Value> =
                         serde_json::from_str(value.as_str()).unwrap();
 
@@ -180,7 +181,7 @@ impl EventEncoder {
                 }
             }
         }
-        return vec;
+        vec
     }
 
     fn remove_label_fields(&self, event: &mut Event) {
@@ -412,10 +413,11 @@ impl StreamSink<Event> for LokiSink {
     }
 }
 
-fn slugify_text(s: String) -> String {
-    let re = Regex::new(r"[^0-9A-Za-z_]").unwrap();
-    let result = re.replace_all(&s, "_");
-    return result.to_lowercase();
+static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^0-9A-Za-z_]").unwrap());
+
+fn slugify_text(input: String) -> String {
+    let result = RE.replace_all(&input, "_");
+    result.to_lowercase()
 }
 
 #[cfg(test)]

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -165,15 +165,17 @@ impl EventEncoder {
                 value_template.render_string(event),
             ) {
                 if let Some(opening_prefix) = key.strip_suffix('*') {
-                    let output: serde_json::map::Map<String, serde_json::Value> =
-                        serde_json::from_str(value.as_str()).unwrap_or_default();
+                    let output: Result<serde_json::map::Map<String, serde_json::Value>, _> =
+                        serde_json::from_str(value.as_str());
 
-                    // key_* -> key_one, key_two, key_three
-                    for (k, v) in output {
-                        vec.push((
-                            slugify_text(format!("{}{}", opening_prefix, k)),
-                            Value::from(v).to_string_lossy(),
-                        ))
+                    if let Ok(output) = output {
+                        // key_* -> key_one, key_two, key_three
+                        for (k, v) in output {
+                            vec.push((
+                                slugify_text(format!("{}{}", opening_prefix, k)),
+                                Value::from(v).to_string_lossy(),
+                            ))
+                        }
                     }
                 } else {
                     vec.push((key, value));

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, num::NonZeroUsize};
 
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
+use regex::Regex;
 use snafu::Snafu;
 use vector_common::encode_logfmt;
 use vector_core::{
@@ -155,19 +156,31 @@ pub(super) struct EventEncoder {
 
 impl EventEncoder {
     fn build_labels(&self, event: &Event) -> Vec<(String, String)> {
-        self.labels
-            .iter()
-            .filter_map(|(key_template, value_template)| {
-                if let (Ok(key), Ok(value)) = (
-                    key_template.render_string(event),
-                    value_template.render_string(event),
-                ) {
-                    Some((key, value))
+        let mut vec: Vec<(String, String)> = Vec::new();
+
+        for (key_template, value_template) in self.labels.iter() {
+            if let (Ok(key), Ok(value)) = (
+                key_template.render_string(event),
+                value_template.render_string(event),
+            ) {
+                if key.ends_with("_*") {
+                    let pkey = key.trim_end_matches("*");
+                    let output: serde_json::map::Map<String, serde_json::Value> =
+                        serde_json::from_str(value.as_str()).unwrap();
+
+                    // key_* -> key_one, key_two, key_three
+                    for (k, v) in output {
+                        vec.push((
+                            slugify_text(format!("{}{}", pkey, k)),
+                            Value::from(v).to_string_lossy(),
+                        ))
+                    }
                 } else {
-                    None
+                    vec.push((key, value));
                 }
-            })
-            .collect()
+            }
+        }
+        return vec;
     }
 
     fn remove_label_fields(&self, event: &mut Event) {
@@ -399,12 +412,21 @@ impl StreamSink<Event> for LokiSink {
     }
 }
 
+fn slugify_text(s: String) -> String {
+    let re = Regex::new(r"[^0-9A-Za-z_]").unwrap();
+    let result = re.replace_all(&s, "_");
+    return result.to_lowercase();
+}
+
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, convert::TryFrom};
+    use std::{
+        collections::{BTreeMap, HashMap},
+        convert::TryFrom,
+    };
 
     use futures::stream::StreamExt;
-    use vector_core::event::Event;
+    use vector_core::event::{Event, Value};
 
     use super::{EventEncoder, KeyPartitioner, RecordFilter};
     use crate::{
@@ -449,6 +471,10 @@ mod tests {
             Template::try_from("{{ name }}").unwrap(),
             Template::try_from("{{ value }}").unwrap(),
         );
+        labels.insert(
+            Template::try_from("test_key_*").unwrap(),
+            Template::try_from("{{ dict }}").unwrap(),
+        );
         let encoder = EventEncoder {
             key_partitioner: KeyPartitioner::new(None),
             encoding: EncodingConfig::from(Encoding::Json),
@@ -461,12 +487,21 @@ mod tests {
         log.insert(log_schema().timestamp_key(), chrono::Utc::now());
         log.insert("name", "foo");
         log.insert("value", "bar");
+
+        let mut test_dict = BTreeMap::default();
+        test_dict.insert("one".to_string(), Value::from("foo"));
+        test_dict.insert("two".to_string(), Value::from("baz"));
+        log.insert("dict", Value::from(test_dict));
+
         let record = encoder.encode_event(event);
         assert!(record.event.event.contains(log_schema().timestamp_key()));
-        assert_eq!(record.labels.len(), 2);
+        assert_eq!(record.labels.len(), 4);
+
         let labels: HashMap<String, String> = record.labels.into_iter().collect();
         assert_eq!(labels["static"], "value".to_string());
         assert_eq!(labels["foo"], "bar".to_string());
+        assert_eq!(labels["test_key_one"], "foo".to_string());
+        assert_eq!(labels["test_key_two"], "baz".to_string());
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

Closes https://github.com/vectordotdev/vector/issues/9549

### Description
This PR allows expanding objects as log entry labels for Loki. It is useful when you don't know the exact keys of the object, e.g., when you want to extract all labels of a Kubernetes pod.

Raw entry part:
```json
{"kubernetes":{"pod_labels":{"app":"web-server","name":"unicorn"}}}
```

Vector config part:
```
labels:
  pod_labels_*: {{ kubernetes.pod_labels }}
```

Result:
```
pod_labels_app: "web-server"
pod_labels_name: "unicorn"
``` 

### Additional information

You can do the same thing in promtail like this:
```
- action: labelmap
  regex: __meta_kubernetes_pod_label_(.+)
  replacement: pod_labels_$1
```
