### PR TITLE
docs: Audit tls settings

### DIFF
--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -18,7 +18,7 @@ use crate::{
         util::{http::HttpStatusRetryLogic, ServiceBuilderExt, TowerRequestConfig},
         Healthcheck, VectorSink,
     },
-    tls::TlsConfig,
+    tls::{MaybeTlsSettings, TlsConfig},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -30,7 +30,6 @@ pub struct DatadogEventsConfig {
     pub site: Option<String>,
     pub default_api_key: String,
 
-    // Deprecated, not sure it actually makes sense to allow messing with TLS configuration?
     pub(super) tls: Option<TlsConfig>,
 
     #[serde(default)]
@@ -61,7 +60,8 @@ impl DatadogEventsConfig {
     }
 
     fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
-        let client = HttpClient::new(None, proxy)?;
+        let tls = MaybeTlsSettings::from_config(&self.tls, false)?;
+        let client = HttpClient::new(tls, proxy)?;
         Ok(client)
     }
 

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -410,7 +410,6 @@ components: {
 		enabled: bool
 
 		if enabled {
-			can_enable:             bool
 			can_verify_certificate: bool
 			if Args.mode == "connect" {
 				can_verify_hostname: bool
@@ -569,7 +568,6 @@ components: {
 
 			_tls_accept: {
 				_args: {
-					can_enable:             bool
 					can_verify_certificate: bool | *true
 					enabled_default:        bool
 				}
@@ -579,13 +577,11 @@ components: {
 				description: "Configures the TLS options for incoming connections."
 				required:    false
 				type: object: options: {
-					if Args.can_enable {
-						enabled: {
-							common:      false
-							description: "Require TLS for incoming connections. If this is set, an identity certificate is also required."
-							required:    false
-							type: bool: default: Args.enabled_default
-						}
+					enabled: {
+						common:      false
+						description: "Require TLS for incoming connections. If this is set, an identity certificate is also required."
+						required:    false
+						type: bool: default: Args.enabled_default
 					}
 
 					ca_file: {
@@ -638,7 +634,6 @@ components: {
 
 			_tls_connect: {
 				_args: {
-					can_enable:             bool
 					can_verify_certificate: bool | *true
 					can_verify_hostname:    bool | *false
 					enabled_default:        bool
@@ -649,13 +644,11 @@ components: {
 				description: "Configures the TLS options for outgoing connections."
 				required:    false
 				type: object: options: {
-					if Args.can_enable {
-						enabled: {
-							common:      true
-							description: "Enable TLS during connections to the remote."
-							required:    false
-							type: bool: default: Args.enabled_default
-						}
+					enabled: {
+						common:      true
+						description: "Enable TLS during connections to the remote."
+						required:    false
+						type: bool: default: Args.enabled_default
 					}
 
 					ca_file: {

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -465,6 +465,15 @@ components: sinks: [Name=string]: {
 				}}
 			}
 		}
+
+		if features.exposes != _|_ {
+			if features.exposes.tls.enabled {
+				tls: configuration._tls_accept & {_args: {
+					can_verify_certificate: features.exposes.tls.can_verify_certificate
+					enabled_default:        features.exposes.tls.enabled_default
+				}}
+			}
+		}
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -459,8 +459,7 @@ components: sinks: [Name=string]: {
 
 			if features.send.tls.enabled {
 				tls: configuration._tls_connect & {_args: {
-					can_enable:             features.send.tls.can_enable
-					can_verify_certificate: features.send.tls.can_enable
+					can_verify_certificate: features.send.tls.can_verify_certificate
 					can_verify_hostname:    features.send.tls.can_verify_hostname
 					enabled_default:        features.send.tls.enabled_default
 				}}

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -43,10 +43,9 @@ components: sinks: aws_cloudwatch_logs: components._aws_new_sdk & {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.aws_cloudwatch_logs

--- a/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -33,10 +33,9 @@ components: sinks: aws_cloudwatch_metrics: components._aws_new_sdk & {
 			request: enabled:  false
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.aws_cloudwatch_metrics

--- a/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
@@ -43,10 +43,9 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.aws_kinesis_firehose

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -43,10 +43,9 @@ components: sinks: aws_kinesis_streams: components._aws & {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.aws_kinesis_data_streams

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -43,10 +43,9 @@ components: sinks: aws_s3: components._aws & {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.aws_s3

--- a/website/cue/reference/components/sinks/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/aws_sqs.cue
@@ -36,10 +36,9 @@ components: sinks: aws_sqs: components._aws_new_sdk & {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.aws_sqs

--- a/website/cue/reference/components/sinks/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/azure_monitor_logs.cue
@@ -31,10 +31,9 @@ components: sinks: azure_monitor_logs: {
 			request: enabled: false
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.azure_monitor_logs

--- a/website/cue/reference/components/sinks/clickhouse.cue
+++ b/website/cue/reference/components/sinks/clickhouse.cue
@@ -39,7 +39,6 @@ components: sinks: clickhouse: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/datadog_archives.cue
+++ b/website/cue/reference/components/sinks/datadog_archives.cue
@@ -30,7 +30,6 @@ components: sinks: datadog_archives: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -25,10 +25,9 @@ components: sinks: datadog_events: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.datadog_events

--- a/website/cue/reference/components/sinks/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/datadog_logs.cue
@@ -33,7 +33,6 @@ components: sinks: datadog_logs: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -29,7 +29,6 @@ components: sinks: datadog_metrics: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -39,7 +39,6 @@ components: sinks: elasticsearch: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -44,7 +44,6 @@ components: sinks: gcp_cloud_storage: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/gcp_pubsub.cue
@@ -35,7 +35,6 @@ components: sinks: gcp_pubsub: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -35,7 +35,6 @@ components: sinks: gcp_stackdriver_logs: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -35,10 +35,9 @@ components: sinks: gcp_stackdriver_metrics: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
 			}
 			to: {
 				service: services.gcp_cloud_monitoring

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -43,7 +43,6 @@ components: sinks: http: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -51,7 +51,6 @@ components: sinks: _humio: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/influxdb.cue
+++ b/website/cue/reference/components/sinks/influxdb.cue
@@ -4,7 +4,12 @@ components: sinks: _influxdb: {
 	features: {
 		send: {
 			proxy: enabled: true
-			tls: enabled:   false
+			tls: {
+				enabled:                true
+				can_verify_certificate: true
+				can_verify_hostname:    true
+				enabled_default:        false
+			}
 			to: {
 				service: services.influxdb
 

--- a/website/cue/reference/components/sinks/kafka.cue
+++ b/website/cue/reference/components/sinks/kafka.cue
@@ -37,13 +37,7 @@ components: sinks: kafka: {
 				}
 			}
 			request: enabled: false
-			tls: {
-				enabled:                true
-				can_enable:             true
-				can_verify_certificate: false
-				can_verify_hostname:    false
-				enabled_default:        false
-			}
+			tls: enabled:     false
 			to: components._kafka.features.send.to
 		}
 	}

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -43,7 +43,6 @@ components: sinks: loki: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -27,7 +27,6 @@ components: sinks: nats: {
 			request: enabled: false
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/papertrail.cue
+++ b/website/cue/reference/components/sinks/papertrail.cue
@@ -29,7 +29,6 @@ components: sinks: papertrail: {
 			request: enabled:           false
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true

--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -21,8 +21,8 @@ components: sinks: prometheus_exporter: {
 		exposes: {
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
+				can_verify_hostname:    true
 				enabled_default:        false
 			}
 

--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -22,7 +22,6 @@ components: sinks: prometheus_exporter: {
 			tls: {
 				enabled:                true
 				can_verify_certificate: true
-				can_verify_hostname:    true
 				enabled_default:        false
 			}
 

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -37,7 +37,6 @@ components: sinks: prometheus_remote_write: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -34,13 +34,7 @@ components: sinks: redis: {
 				concurrency: 1
 				headers:     false
 			}
-			tls: {
-				enabled:                true
-				can_enable:             true
-				can_verify_certificate: false
-				can_verify_hostname:    false
-				enabled_default:        false
-			}
+			tls: enabled: false
 			to: {
 				service: services.redis
 				interface: {

--- a/website/cue/reference/components/sinks/socket.cue
+++ b/website/cue/reference/components/sinks/socket.cue
@@ -32,7 +32,6 @@ components: sinks: socket: {
 			request: enabled:   false
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -43,7 +43,6 @@ components: sinks: splunk_hec_logs: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_metrics.cue
@@ -36,7 +36,6 @@ components: sinks: splunk_hec_metrics: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -39,7 +39,6 @@ components: sinks: vector: {
 
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -208,8 +208,7 @@ components: sources: [Name=string]: {
 			if features.collect.tls != _|_ {
 				if features.collect.tls.enabled {
 					tls: configuration._tls_connect & {_args: {
-						can_enable:             features.collect.tls.can_enable
-						can_verify_certificate: features.collect.tls.can_enable
+						can_verify_certificate: features.collect.tls.can_verify_certificate
 						can_verify_hostname:    features.collect.tls.can_verify_hostname
 						enabled_default:        features.collect.tls.enabled_default
 					}}
@@ -258,8 +257,7 @@ components: sources: [Name=string]: {
 
 			if features.receive.tls.enabled {
 				tls: configuration._tls_accept & {_args: {
-					can_enable:             features.receive.tls.can_enable
-					can_verify_certificate: features.receive.tls.can_enable
+					can_verify_certificate: features.receive.tls.can_verify_certificate
 					enabled_default:        features.receive.tls.enabled_default
 				}}
 			}

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -35,7 +35,6 @@ components: sources: aws_kinesis_firehose: {
 
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}}

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -9,9 +9,8 @@ components: sources: aws_s3: components._aws & {
 		collect: {
 			tls: {
 				enabled:                true
-				can_enable:             true
-				can_verify_certificate: false
-				can_verify_hostname:    false
+				can_verify_certificate: true
+				can_verify_hostname:    true
 				enabled_default:        false
 			}
 			checkpoint: enabled: false

--- a/website/cue/reference/components/sources/aws_sqs.cue
+++ b/website/cue/reference/components/sources/aws_sqs.cue
@@ -6,7 +6,12 @@ components: sources: aws_sqs: components._aws_new_sdk & {
 	features: {
 		acknowledgements: true
 		collect: {
-			tls: enabled:        false
+			tls: {
+				enabled:                true
+				can_verify_certificate: true
+				can_verify_hostname:    true
+				enabled_default:        false
+			}
 			checkpoint: enabled: false
 			proxy: enabled:      true
 			from: service:       services.aws_sqs

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -40,7 +40,6 @@ components: sources: datadog_agent: {
 
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -45,7 +45,6 @@ components: sources: heroku_logs: {
 
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}

--- a/website/cue/reference/components/sources/http.cue
+++ b/website/cue/reference/components/sources/http.cue
@@ -37,7 +37,6 @@ components: sources: http: {
 
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}

--- a/website/cue/reference/components/sources/kafka.cue
+++ b/website/cue/reference/components/sources/kafka.cue
@@ -7,13 +7,7 @@ components: sources: kafka: {
 		acknowledgements: true
 		collect: {
 			checkpoint: enabled: false
-			tls: {
-				enabled:                true
-				can_enable:             true
-				can_verify_certificate: false
-				can_verify_hostname:    false
-				enabled_default:        false
-			}
+			tls: enabled:        false
 			from: components._kafka.features.collect.from
 		}
 		multiline: enabled: false

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -77,7 +77,6 @@ components: sources: nginx_metrics: {
 			}
 		}
 		tls: configuration._tls_connect & {_args: {
-			can_enable:             true
 			can_verify_certificate: true
 			can_verify_hostname:    true
 			enabled_default:        false

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -32,7 +32,6 @@ components: sources: prometheus_remote_write: {
 			}
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -33,7 +33,6 @@ components: sources: prometheus_scrape: {
 			proxy: enabled: true
 			tls: {
 				enabled:                true
-				can_enable:             false
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false

--- a/website/cue/reference/components/sources/redis.cue
+++ b/website/cue/reference/components/sources/redis.cue
@@ -7,13 +7,7 @@ components: sources: redis: {
 		acknowledgements: false
 		collect: {
 			checkpoint: enabled: false
-			tls: {
-				enabled:                true
-				can_enable:             true
-				can_verify_certificate: false
-				can_verify_hostname:    false
-				enabled_default:        false
-			}
+			tls: enabled:        false
 			from: {
 				service: services.redis
 				interface: {

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -38,7 +38,6 @@ components: sources: socket: {
 			keepalive: enabled: true
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}

--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -35,7 +35,6 @@ components: sources: splunk_hec: {
 
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -36,7 +36,11 @@ components: sources: statsd: {
 				relevant_when: "mode = `tcp` or mode = `udp`"
 			}
 			keepalive: enabled: true
-			tls: enabled:       false
+			tls: {
+				enabled:                true
+				can_verify_certificate: true
+				enabled_default:        false
+			}
 		}
 	}
 

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -36,7 +36,6 @@ components: sources: vector: {
 			keepalive: enabled:            true
 			tls: {
 				enabled:                true
-				can_enable:             true
 				can_verify_certificate: true
 				enabled_default:        false
 			}


### PR DESCRIPTION
I did a sweep of the docs to make sure the `tls` settings lined up with
reality.

As part of this I:

* dropped the `tls.can_enable` cue field since any source that had
  `tls.enabled = true` supports enabling it
* Adds support for the `tls` settings to the `datadog_events` sink.
  These settings were previously being ignored

Note there is a difference here with which components literally support
connecting over TLS and which allow configuration of the `tls` settings.
`tls.enabled` currently indicates which components support configuration
of the settings. I could see us adding another field in the future to
indicate which components support TLS connections. An example of this is
the `redis` source which supports connecting over TLS, but doesn't
support configuration of the `tls` settings.

Closes: #6132
Closes: #11979

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
