### PR TITLE
fix(docker platform)!: Remove VOLUME declarations from Dockerfiles

### DIFF
--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -10,7 +10,6 @@ RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
-VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y ca-certificates tzdata systemd && rm -r
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
 COPY --from=builder /etc/vector /etc/vector
-VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -8,7 +8,6 @@ FROM gcr.io/distroless/cc-debian10
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
 COPY --from=builder /etc/vector /etc/vector
-VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -9,7 +9,6 @@ FROM gcr.io/distroless/static
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
-VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -22,7 +22,6 @@ FROM docker.io/debian:bullseye-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dede
 RUN apt-get update && apt-get dist-upgrade -y && apt-get -y install zlib1g ca-certificates
 COPY --from=lading /usr/bin/lading /usr/bin/lading
 COPY --from=builder /vector/vector /usr/bin/vector
-VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["/usr/bin/lading", "--help"]

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -27,7 +27,6 @@ RUN --mount=type=cache,target=/vector/target \
 FROM debian:${DEBIAN_RELEASE}-slim
 RUN apt-get update && apt-get -y install zlib1g
 COPY --from=builder /vector/vector /usr/bin/vector
-VOLUME /var/lib/vector/
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -24,6 +24,7 @@ Vector's 0.21.0 release includes **breaking changes**:
 9. [Route transform metric `event_discarded_total` removed](#transform-route-metric)
 10. [`buffer_discarded_events_total` now includes received events](#buffer-discarded-events)
 11. [`kubernetes_logs` source rewritten to use `kube-rs`](#kubernetes-logs)
+12. [Published docker images no longer create implicit volumes](#docker-volume)
 
 And **deprecations**:
 
@@ -288,6 +289,24 @@ make sure to add it to your manifest.
 configuration in your `kubeconfig`.
 
 See the [highlight](/highlights/2022-03-28-kube-for-kubernetes_logs) for more information.
+
+#### Published docker images no longer create implicit volumes {#docker-volume}
+
+Previously `/var/lib/vector` was defined as a volume in the `Dockerfile`s for
+the published Vector images. This led to the creation of the volume each time
+you ran a Vector container from these images whether you wanted it or not.
+
+Instead, if you need a volume for the data directory, you should provide one
+when launching the container.
+
+When migrating from an earlier version to 0.21.0 or later using Docker compose
+and implicit volumes, you need to use docker inspect to find out which volumes
+your container is mapped to so that you can map them to the upgraded container
+as well.
+
+See
+[https://github.com/vectordotdev/vector/issues/11982](vectordotdev/vector#11982)
+for additional rationale.
 
 ### Deprecations
 


### PR DESCRIPTION
This declaration automatically creates an anonymous volume whenever the
Vector image is run, regardless of whether it actually needs it.

It seems better to, instead, rely on the user to provide a volume if
they want it.

See https://github.com/vectordotdev/vector/issues/11982 for additional
rationale.

Closes: #11982

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
