### PR TITLE
chore(vrl): improve VRL parser compilation times

### DIFF
--- a/lib/vrl/parser/Cargo.toml
+++ b/lib/vrl/parser/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1"
 test-case = "2"
 
 [build-dependencies]
-lalrpop = "0.19.7"
+lalrpop = { version = "0.19.7", default-features = false }
 
 [features]
 fuzz = ["arbitrary"]

--- a/lib/vrl/parser/build.rs
+++ b/lib/vrl/parser/build.rs
@@ -1,9 +1,9 @@
 extern crate lalrpop;
 
 fn main() {
-    println!("cargo:rerun-if-changed=src/parser.lalrpop");
     lalrpop::Configuration::new()
         .always_use_colors()
+        .emit_rerun_directives(true)
         .emit_whitespace(false)
         .process_current_dir()
         .unwrap();

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -233,9 +233,6 @@ pub enum Token<S> {
     // Reserved for future use.
     ReservedIdentifier(S),
 
-    // A token used by the internal parser unit tests.
-    InternalTest(S),
-
     InvalidToken(char),
 
     // keywords
@@ -259,12 +256,10 @@ pub enum Token<S> {
     RParen,
     SemiColon,
     Underscore,
-    Escape,
 
     Equals,
     MergeEquals,
     Bang,
-    Question,
 
     /// The {L,R}Query token is an "instruction" token. It does not represent
     /// any character in the source, instead it represents the start or end of a
@@ -320,8 +315,6 @@ impl<S> Token<S> {
 
             ReservedIdentifier(s) => ReservedIdentifier(f(s)),
 
-            InternalTest(s) => InternalTest(f(s)),
-
             InvalidToken(s) => InvalidToken(s),
 
             Else => Else,
@@ -344,12 +337,10 @@ impl<S> Token<S> {
             RParen => RParen,
             SemiColon => SemiColon,
             Underscore => Underscore,
-            Escape => Escape,
 
             Equals => Equals,
             MergeEquals => MergeEquals,
             Bang => Bang,
-            Question => Question,
 
             LQuery => LQuery,
             RQuery => RQuery,
@@ -375,7 +366,6 @@ where
             RegexLiteral(_) => "RegexLiteral",
             TimestampLiteral(_) => "TimestampLiteral",
             ReservedIdentifier(_) => "ReservedIdentifier",
-            InternalTest(_) => "InternalTest",
             InvalidToken(_) => "InvalidToken",
 
             Else => "Else",
@@ -398,12 +388,10 @@ where
             RParen => "RParen",
             SemiColon => "SemiColon",
             Underscore => "Underscore",
-            Escape => "Escape",
 
             Equals => "Equals",
             MergeEquals => "MergeEquals",
             Bang => "Bang",
-            Question => "Question",
 
             LQuery => "LQuery",
             RQuery => "RQuery",
@@ -499,7 +487,6 @@ impl<'input> Iterator for Lexer<'input> {
 
                     ';' => Some(Ok(self.token(start, SemiColon))),
                     '\n' => Some(Ok(self.token(start, Newline))),
-                    '\\' => Some(Ok(self.token(start, Escape))),
 
                     '(' => Some(Ok(self.open(start, LParen))),
                     '[' => Some(Ok(self.open(start, LBracket))),
@@ -514,10 +501,6 @@ impl<'input> Iterator for Lexer<'input> {
 
                     '_' if !self.test_peek(is_ident_continue) => {
                         Some(Ok(self.token(start, Underscore)))
-                    }
-
-                    '?' if self.test_peek(char::is_alphabetic) => {
-                        Some(Ok(self.internal_test(start)))
                     }
 
                     '!' if self.test_peek(|ch| ch == '!' || !is_operator(ch)) => {
@@ -1003,18 +986,10 @@ impl<'input> Lexer<'input> {
         let token = match op {
             "=" => Token::Equals,
             "|=" => Token::MergeEquals,
-            "?" => Token::Question,
             op => Token::Operator(op),
         };
 
         (start, token, end)
-    }
-
-    fn internal_test(&mut self, start: usize) -> Spanned<'input, usize> {
-        self.bump();
-        let (end, test) = self.take_while(start, char::is_alphabetic);
-
-        (start, Token::InternalTest(test), end)
     }
 
     fn quoted_literal(
@@ -1157,7 +1132,7 @@ fn is_digit(ch: char) -> bool {
 pub fn is_operator(ch: char) -> bool {
     matches!(
         ch,
-        '!' | '%' | '&' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '?' | '|'
+        '!' | '%' | '&' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|'
     )
 }
 

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -256,6 +256,7 @@ pub enum Token<S> {
     RParen,
     SemiColon,
     Underscore,
+    Escape,
 
     Equals,
     MergeEquals,
@@ -337,6 +338,7 @@ impl<S> Token<S> {
             RParen => RParen,
             SemiColon => SemiColon,
             Underscore => Underscore,
+            Escape => Escape,
 
             Equals => Equals,
             MergeEquals => MergeEquals,
@@ -388,6 +390,7 @@ where
             RParen => "RParen",
             SemiColon => "SemiColon",
             Underscore => "Underscore",
+            Escape => "Escape",
 
             Equals => "Equals",
             MergeEquals => "MergeEquals",
@@ -487,6 +490,7 @@ impl<'input> Iterator for Lexer<'input> {
 
                     ';' => Some(Ok(self.token(start, SemiColon))),
                     '\n' => Some(Ok(self.token(start, Newline))),
+                    '\\' => Some(Ok(self.token(start, Escape))),
 
                     '(' => Some(Ok(self.open(start, LParen))),
                     '[' => Some(Ok(self.open(start, LBracket))),

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -261,6 +261,7 @@ pub enum Token<S> {
     Equals,
     MergeEquals,
     Bang,
+    Question,
 
     /// The {L,R}Query token is an "instruction" token. It does not represent
     /// any character in the source, instead it represents the start or end of a
@@ -343,6 +344,7 @@ impl<S> Token<S> {
             Equals => Equals,
             MergeEquals => MergeEquals,
             Bang => Bang,
+            Question => Question,
 
             LQuery => LQuery,
             RQuery => RQuery,
@@ -395,6 +397,7 @@ where
             Equals => "Equals",
             MergeEquals => "MergeEquals",
             Bang => "Bang",
+            Question => "Question",
 
             LQuery => "LQuery",
             RQuery => "RQuery",
@@ -505,6 +508,10 @@ impl<'input> Iterator for Lexer<'input> {
 
                     '_' if !self.test_peek(is_ident_continue) => {
                         Some(Ok(self.token(start, Underscore)))
+                    }
+
+                    '?' if self.test_peek(char::is_alphabetic) => {
+                        Some(Ok(self.internal_test(start)))
                     }
 
                     '!' if self.test_peek(|ch| ch == '!' || !is_operator(ch)) => {
@@ -990,6 +997,7 @@ impl<'input> Lexer<'input> {
         let token = match op {
             "=" => Token::Equals,
             "|=" => Token::MergeEquals,
+            "?" => Token::Question,
             op => Token::Operator(op),
         };
 
@@ -1136,7 +1144,7 @@ fn is_digit(ch: char) -> bool {
 pub fn is_operator(ch: char) -> bool {
     matches!(
         ch,
-        '!' | '%' | '&' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '|'
+        '!' | '%' | '&' | '*' | '+' | '-' | '/' | '<' | '=' | '>' | '?' | '|'
     )
 }
 

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -510,10 +510,6 @@ impl<'input> Iterator for Lexer<'input> {
                         Some(Ok(self.token(start, Underscore)))
                     }
 
-                    '?' if self.test_peek(char::is_alphabetic) => {
-                        Some(Ok(self.internal_test(start)))
-                    }
-
                     '!' if self.test_peek(|ch| ch == '!' || !is_operator(ch)) => {
                         Some(Ok(self.token(start, Bang)))
                     }

--- a/lib/vrl/parser/src/lib.rs
+++ b/lib/vrl/parser/src/lib.rs
@@ -64,7 +64,3 @@ pub fn parse_literal(input: impl AsRef<str>) -> Result<Literal, Error> {
             dropped_tokens: vec![],
         })
 }
-
-pub mod test {
-    pub use super::parser::TestParser as Parser;
-}

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -40,7 +40,6 @@ extern {
 
         ";" => Token::SemiColon,
         "\n" => Token::Newline,
-        "?" => Token::Question,
         "|" => Token::Pipe,
         "=" => Token::Equals,
         "|=" => Token::MergeEquals,
@@ -49,7 +48,6 @@ extern {
         ":" => Token::Colon,
         "." => Token::Dot,
         "!" => Token::Bang,
-        "escape" => Token::Escape,
 
         "+" => Token::Operator("+"),
         "*" => Token::Operator("*"),
@@ -75,15 +73,6 @@ extern {
         "]" => Token::RBracket,
         "}" => Token::RBrace,
         ")" => Token::RParen,
-
-        "?r" => Token::InternalTest("?r"),
-        "?e" => Token::InternalTest("?e"),
-        "?m" => Token::InternalTest("?m"),
-        "?a" => Token::InternalTest("?a"),
-        "?q" => Token::InternalTest("?q"),
-        "?c" => Token::InternalTest("?c"),
-        "?as" => Token::InternalTest("?as"),
-        "?fn" => Token::InternalTest("?fn"),
     }
 }
 
@@ -96,44 +85,11 @@ extern {
 // A program consists of one or more expressions.
 pub Program: Program = NonterminalNewline* <RootExprs> => Program(<>);
 
-// This nonterminal exists to aid in unit-testing. It exposes individual rules
-// through the "t ..." declaration, to allow testing individual rules without
-// having to generate parser functions for each rule, which kills build-times
-// and exposes entries into the parser that we don't want or need.
-pub Test: Test = {
-    // root
-    "?r" <Expr> => Test::Expr(<>),
-
-    // expressions
-    "?e" <Literal> => Test::Literal(<>),
-    "?e" <Container> => Test::Container(<>),
-
-    // arithmetic (math)
-    "?m" <ArithmeticExpr> => Test::Arithmetic(<>),
-
-    // atoms
-    "?a" <String> => Test::String(<>),
-    "?a" <Integer> => Test::Integer(<>),
-    "?a" <Float> => Test::Float(<>),
-    "?a" <Boolean> => Test::Boolean(<>),
-    "?a" <Null> => Test::Null(()),
-    "?a" <Regex> => Test::Regex(<>),
-
-    // collections
-    "?c" <Block> => Test::Block(<>),
-    "?c" <Array> => Test::Array(<>),
-    "?c" <Object> => Test::Object(<>),
-
-    // other
-    "?as" <Assignment> => Test::Assignment(<>),
-    "?fn" <FunctionCall> => Test::FunctionCall(<>),
-    "?q" <Query> => Test::Query(<>),
-};
-
 // -----------------------------------------------------------------------------
 // root expressions
 // -----------------------------------------------------------------------------
 
+#[inline]
 RootExprs: Vec<Node<RootExpr>> = {
     RootExpr => vec![<>],
     (<RootExpr> EndOfExpression)*,
@@ -195,6 +151,7 @@ RootExpr: Node<RootExpr> = {
 // expressions
 // -----------------------------------------------------------------------------
 
+#[inline]
 Exprs: Vec<Node<Expr>> = {
     Expr => vec![<>],
     <v:(<Expr> EndOfExpression)+> <e:(<Expr>)?> => match e {
@@ -223,14 +180,13 @@ NonterminalNewline: () = "\n";
 
 Ident: Ident = "identifier" => Ident(<>.to_owned());
 
-PathField: Ident = "path field" => Ident(<>.to_owned());
-
 AbortExpr: Expr = {
     Sp<"abort"> => Expr::Abort(<>.map(|_| Abort { message: None })),
     <n: Sp<"abort">> <message: Expr> => Expr::Abort(n.map(|_| Abort { message: Some(Box::new(message.clone())) })),
 }
 
 // An identifier that is allowed to include reserved keywords.
+#[inline]
 AnyIdent: Ident = {
     "identifier" => Ident(<>.to_owned()),
     "reserved identifier" => Ident(<>.to_owned()),
@@ -251,6 +207,7 @@ AssignmentExpr: Node<Expr> = {
     ArithmeticExpr,
 };
 
+#[inline]
 Assignment: Node<Assignment> = {
     Sp<AssignmentSingle>,
     Sp<AssignmentInfallible>,
@@ -261,6 +218,7 @@ AssignmentOp: AssignmentOp = {
     "|=" => AssignmentOp::Merge,
 }
 
+#[inline]
 AssignmentSingle: Assignment = {
     <target: Sp<AssignmentTarget>>
         <op: AssignmentOp>
@@ -268,6 +226,7 @@ AssignmentSingle: Assignment = {
         <expr: Box<Expr>> => Assignment::Single { target, op, expr },
 }
 
+#[inline]
 AssignmentInfallible: Assignment = {
     <ok: Sp<AssignmentTarget>> ","
         <err: Sp<AssignmentTarget>>
@@ -343,6 +302,7 @@ Not: Expr = {
     Term,
 };
 
+#[inline]
 Term: Expr = {
     Sp<Literal> => Expr::Literal(<>),
     Sp<Container> => Expr::Container(<>),
@@ -366,6 +326,7 @@ pub Query: Query = {
     LQuery <target: Sp<QueryTarget>> <path: Sp<Path>> RQuery => Query { target, path },
 };
 
+#[inline]
 QueryTarget: QueryTarget = {
     Ident => QueryTarget::Internal(<>),
     "." => QueryTarget::External,
@@ -377,8 +338,16 @@ QueryTarget: QueryTarget = {
 // path
 // -----------------------------------------------------------------------------
 
+pub Field: FieldBuf = {
+    AnyIdent => FieldBuf::from(<>.to_string()),
+    PathField => FieldBuf::from(<>.to_string()),
+    String => FieldBuf::from(<>.to_string()),
+}
+
+#[inline]
 Path: LookupBuf = PathSegment+ => LookupBuf::from_segments(<>);
 
+#[inline]
 PathSegment: SegmentBuf = {
     "."? <Field> => SegmentBuf::field(<>),
     "[" <Integer> "]" => SegmentBuf::index(<> as isize),
@@ -389,11 +358,8 @@ PathSegment: SegmentBuf = {
         },
 };
 
-pub Field: FieldBuf = {
-    AnyIdent => FieldBuf::from(<>.to_string()),
-    PathField => FieldBuf::from(<>.to_string()),
-    String => FieldBuf::from(<>.to_string()),
-}
+#[inline]
+PathField: Ident = "path field" => Ident(<>.to_owned());
 
 // -----------------------------------------------------------------------------
 // function call
@@ -440,6 +406,7 @@ IfStatement: IfStatement =
         IfStatement { predicate, consequent, alternative }
 };
 
+#[inline]
 ElseIf: IfStatement =
     "else" NonterminalNewline* "if"
     <predicate: Sp<Predicate>>
@@ -448,6 +415,7 @@ ElseIf: IfStatement =
     IfStatement { predicate, consequent, alternative: None }
 };
 
+#[inline]
 StatementSeparator: () = {
     NonterminalNewline, ";"
 };
@@ -479,15 +447,18 @@ Container: Container = {
     Sp<Object> => Container::Object(<>),
 };
 
+#[inline]
 Group: Group = "(" <AssignmentExpr> ")" => Group(<>);
 
 Block: Block = "{" NonterminalNewline* <Exprs>  "}" => Block(<>);
 
+#[inline]
 Array: Array = {
     "[" NonterminalNewline* "]" => Array(vec![]),
     "[" NonterminalNewline* <CommaMultiline<ArithmeticExpr>> "]" => Array(<>),
 };
 
+#[inline]
 Object: Object = {
     "{" NonterminalNewline* "}" => Object(BTreeMap::default()),
     "{" NonterminalNewline* <CommaMultiline<(<Sp<String>> ":" <ArithmeticExpr>)>> "}" => {
@@ -522,13 +493,10 @@ Timestamp: String = "timestamp literal" => <>.replace("\\'", "'");
 // macros
 // -----------------------------------------------------------------------------
 
-#[inline]
 Box<T>: Box<T> = T => Box::new(<>);
 
-#[inline]
 Sp<T>: Node<T> = <l: @L> <rule: T> <r: @R> => Node::new(span(l, r), rule);
 
-#[inline]
 Op<L, Code, R>: Expr = Sp<(<Sp<L>> <Sp<Code>> NonterminalNewline* <Sp<R>>)> => {
     let op = <>.map(|(lhs, code, rhs)| {
         let (span, code) = code.take();
@@ -543,7 +511,6 @@ Op<L, Code, R>: Expr = Sp<(<Sp<L>> <Sp<Code>> NonterminalNewline* <Sp<R>>)> => {
     Expr::Op(op)
 };
 
-#[inline]
 CommaMultiline<T>: Vec<T> = {
     <T> NonterminalNewline* => vec![<>],
     <v:(<T> "," NonterminalNewline*)+> <e:(<T> NonterminalNewline*)?> => match e {


### PR DESCRIPTION
This PR improves the compilation time of the `vrl-parser` crate.

Specifically, here are the before/after runs:

```
cargo clean && cargo build -p vrl-parser
...
Finished dev [unoptimized + debuginfo] target(s) in 2m 12s
```

```
cargo clean && cargo build -p vrl-parser
...
Finished dev [unoptimized + debuginfo] target(s) in 59.76s
```