### PR TITLE
feat(vector sink): compression support for vector v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,6 +7917,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bytes 1.1.0",
+ "flate2",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,7 @@ syslog = { version = "6.0.1", default-features = false, optional = true }
 tikv-jemallocator = { version = "0.4.3", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.4", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 toml = { version = "0.5.8", default-features = false }
-tonic = { version = "0.6", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls"] }
+tonic = { version = "0.6", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "compression"] }
 trust-dns-proto = { version = "0.21", features = ["dnssec"], optional = true }
 typetag = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
@@ -305,7 +305,7 @@ nix = "0.23.1"
 
 [build-dependencies]
 prost-build = { version = "0.9", optional = true }
-tonic-build = { version = "0.6", default-features = false, features = ["transport", "prost"], optional = true }
+tonic-build = { version = "0.6", default-features = false, features = ["transport", "prost", "compression"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/sinks/vector/v2/config.rs
+++ b/src/sinks/vector/v2/config.rs
@@ -31,6 +31,8 @@ use crate::{
 pub struct VectorConfig {
     address: String,
     #[serde(default)]
+    compression: bool,
+    #[serde(default)]
     pub batch: BatchConfig<RealtimeEventBasedDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
@@ -53,6 +55,7 @@ impl GenerateConfig for VectorConfig {
 fn default_config(address: &str) -> VectorConfig {
     VectorConfig {
         address: address.to_owned(),
+        compression: false,
         batch: BatchConfig::default(),
         request: TowerRequestConfig::default(),
         tls: None,
@@ -76,9 +79,9 @@ impl VectorConfig {
             .clone()
             .map(|uri| uri.uri)
             .unwrap_or_else(|| uri.clone());
-        let healthcheck_client = VectorService::new(client.clone(), healthcheck_uri);
+        let healthcheck_client = VectorService::new(client.clone(), healthcheck_uri, false);
         let healthcheck = healthcheck(healthcheck_client, cx.healthcheck.clone());
-        let service = VectorService::new(client, uri);
+        let service = VectorService::new(client, uri, self.compression);
         let request_settings = self.request.unwrap_with(&TowerRequestConfig::default());
         let batch_settings = self.batch.into_batcher_settings()?;
 

--- a/src/sinks/vector/v2/service.rs
+++ b/src/sinks/vector/v2/service.rs
@@ -70,12 +70,17 @@ impl VectorService {
     pub fn new(
         hyper_client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
         uri: Uri,
+        compression: bool
     ) -> Self {
         let (protocol, endpoint) = uri::protocol_endpoint(uri.clone());
-        let proto_client = proto_vector::Client::new(HyperSvc {
+        let mut proto_client = proto_vector::Client::new(HyperSvc {
             uri,
             client: hyper_client,
         });
+
+        if compression {
+            proto_client = proto_client.send_gzip();
+        }
         Self {
             client: proto_client,
             protocol,

--- a/src/sinks/vector/v2/service.rs
+++ b/src/sinks/vector/v2/service.rs
@@ -70,7 +70,7 @@ impl VectorService {
     pub fn new(
         hyper_client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
         uri: Uri,
-        compression: bool
+        compression: bool,
     ) -> Self {
         let (protocol, endpoint) = uri::protocol_endpoint(uri.clone());
         let mut proto_client = proto_vector::Client::new(HyperSvc {

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -154,7 +154,8 @@ async fn run(
     let service = proto::Server::new(Service {
         pipeline: cx.out,
         acknowledgements,
-    });
+    }).accept_gzip();
+
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
 
     let listener = tls_settings.bind(&address).await?;
@@ -239,6 +240,38 @@ mod tests {
         // but the sink side already does such a test and this is good
         // to ensure interoperability.
         let config = format!(r#"address = "{}""#, addr);
+        let sink: SinkConfig = toml::from_str(&config).unwrap();
+        let cx = SinkContext::new_test();
+        let (sink, _) = sink.build(cx).await.unwrap();
+
+        let (events, stream) = test_util::random_events_with_stream(100, 100, None);
+        sink.run(stream).await.unwrap();
+        components::SOURCE_TESTS.assert(&components::TCP_SOURCE_TAGS);
+
+        let output = test_util::collect_ready(rx).await;
+        assert_event_data_eq!(events, output);
+    }
+    
+    #[tokio::test]
+    async fn receive_compressed_message() {
+        let addr = test_util::next_addr();
+        let config = format!(r#"address = "{}""#, addr);
+        let source: VectorConfig = toml::from_str(&config).unwrap();
+
+        components::init_test();
+        let (tx, rx) = SourceSender::new_test();
+        let server = source
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+        tokio::spawn(server);
+        test_util::wait_for_tcp(addr).await;
+
+        // Ideally, this would be a fully custom agent to send the data,
+        // but the sink side already does such a test and this is good
+        // to ensure interoperability.
+        let config = format!(r#"address = "{}"
+        compression=true"#, addr);
         let sink: SinkConfig = toml::from_str(&config).unwrap();
         let cx = SinkContext::new_test();
         let (sink, _) = sink.build(cx).await.unwrap();

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -154,7 +154,8 @@ async fn run(
     let service = proto::Server::new(Service {
         pipeline: cx.out,
         acknowledgements,
-    }).accept_gzip();
+    })
+    .accept_gzip();
 
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
 
@@ -251,7 +252,7 @@ mod tests {
         let output = test_util::collect_ready(rx).await;
         assert_event_data_eq!(events, output);
     }
-    
+
     #[tokio::test]
     async fn receive_compressed_message() {
         let addr = test_util::next_addr();
@@ -270,8 +271,11 @@ mod tests {
         // Ideally, this would be a fully custom agent to send the data,
         // but the sink side already does such a test and this is good
         // to ensure interoperability.
-        let config = format!(r#"address = "{}"
-        compression=true"#, addr);
+        let config = format!(
+            r#"address = "{}"
+        compression=true"#,
+            addr
+        );
         let sink: SinkConfig = toml::from_str(&config).unwrap();
         let cx = SinkContext::new_test();
         let (sink, _) = sink.build(cx).await.unwrap();

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -84,7 +84,7 @@ components: sinks: vector: {
 			}
 		}
 		compression: {
-			description: "Enable gRPC compression"
+			description: "Enable gRPC compression with gzip."
 			common:      true
 			required:    false
 			type: bool: default: false

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -83,6 +83,12 @@ components: sinks: vector: {
 				examples: ["92.12.333.224:\(_port)"]
 			}
 		}
+		compression: {
+			description: "Enable gRPC compression"
+			common:      true
+			required:    false
+			type: bool: default: false
+		}
 		version: {
 			description: "Sink API version. Specifying this version ensures that Vector does not break backward compatibility."
 			common:      true


### PR DESCRIPTION
Forewarning: I don't daily develop rust. Compared to this code-base, I'm a beginner. Appologies if I havent done anything the way you need it done.

Fixes #9558

Adds `compression` to the sink. v2 source gets the ability to receive compressed messages if supplied.

I wouldnt mind if someone more experienced than I added a test that confirmed the sink is sending compressed messages.