### PR TITLE
docs(elasticsearch sink): Fix documentation of `query`

### DIFF
--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -283,7 +283,18 @@ components: sinks: elasticsearch: {
 			required:    false
 			type: object: {
 				examples: [{"X-Powered-By": "Vector"}]
-				options: {}
+				options: {
+					"*": {
+						common:      false
+						description: "Any query key"
+						required:    false
+						type: string: {
+							default: null
+							examples: ["Vector"]
+							syntax: "literal"
+						}
+					}
+				}
 			}
 		}
 		suppress_type_name: {


### PR DESCRIPTION
Prompted by https://github.com/vectordotdev/vector/pull/12033#issuecomment-1087956363

Documentation of these key/value maps still doesn't render great on the website, but at least this is an improvement.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
