### PR TITLE
enhancement(codecs): Implement `BytesEncoder` framing

### DIFF
--- a/lib/codecs/src/encoding/framing/bytes.rs
+++ b/lib/codecs/src/encoding/framing/bytes.rs
@@ -1,0 +1,61 @@
+use bytes::BytesMut;
+use serde::{Deserialize, Serialize};
+use tokio_util::codec::Encoder;
+
+use super::BoxedFramingError;
+
+/// Config used to build a `BytesEncoder`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BytesEncoderConfig;
+
+impl BytesEncoderConfig {
+    /// Creates a `BytesEncoderConfig`.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Build the `BytesEncoder` from this configuration.
+    pub const fn build(&self) -> BytesEncoder {
+        BytesEncoder::new()
+    }
+}
+
+/// An encoder for handling of plain bytes.
+///
+/// This encoder does nothing, really. It mainly exists as a symmetric
+/// counterpart to `BytesDeserializer`. `BytesEncoder` can be used to explicitly
+/// disable framing for formats that encode intrinsic length information - since
+/// a sink might set a framing configuration by default depending on the
+/// streaming or message based nature of the sink.
+#[derive(Debug, Clone)]
+pub struct BytesEncoder;
+
+impl BytesEncoder {
+    /// Creates a `BytesEncoder`.
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Encoder<()> for BytesEncoder {
+    type Error = BoxedFramingError;
+
+    fn encode(&mut self, _: (), _: &mut BytesMut) -> Result<(), BoxedFramingError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode() {
+        let mut codec = BytesEncoder::new();
+
+        let mut buffer = BytesMut::from("abc");
+        codec.encode((), &mut buffer).unwrap();
+
+        assert_eq!(b"abc", &buffer[..]);
+    }
+}

--- a/lib/codecs/src/encoding/framing/mod.rs
+++ b/lib/codecs/src/encoding/framing/mod.rs
@@ -3,9 +3,11 @@
 
 #![deny(missing_docs)]
 
+mod bytes;
 mod character_delimited;
 mod newline_delimited;
 
+pub use self::bytes::{BytesEncoder, BytesEncoderConfig};
 pub use character_delimited::{
     CharacterDelimitedEncoder, CharacterDelimitedEncoderConfig, CharacterDelimitedEncoderOptions,
 };

--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -17,8 +17,8 @@ pub use decoding::{
 #[cfg(feature = "syslog")]
 pub use decoding::{SyslogDeserializer, SyslogDeserializerConfig};
 pub use encoding::{
-    CharacterDelimitedEncoder, CharacterDelimitedEncoderConfig, JsonSerializer,
-    JsonSerializerConfig, NativeJsonSerializer, NativeJsonSerializerConfig, NativeSerializer,
-    NativeSerializerConfig, NewlineDelimitedEncoder, NewlineDelimitedEncoderConfig,
-    RawMessageSerializer, RawMessageSerializerConfig,
+    BytesEncoder, BytesEncoderConfig, CharacterDelimitedEncoder, CharacterDelimitedEncoderConfig,
+    JsonSerializer, JsonSerializerConfig, NativeJsonSerializer, NativeJsonSerializerConfig,
+    NativeSerializer, NativeSerializerConfig, NewlineDelimitedEncoder,
+    NewlineDelimitedEncoderConfig, RawMessageSerializer, RawMessageSerializerConfig,
 };


### PR DESCRIPTION
Part of #12080, https://github.com/vectordotdev/vector/pull/10684#pullrequestreview-907897403 for context.