### PR TITLE
fix(splunk_hec source): Ignore the HEC token for health checks

### DIFF
--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -1472,6 +1472,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn health() {
+        let (_source, address) = source(None).await;
+
+        let res = reqwest::Client::new()
+            .get(&format!("http://{}/services/collector/health", address))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(200, res.status().as_u16());
+    }
+
+    #[tokio::test]
     async fn secondary_token() {
         let message = r#"{"event":"first", "color": "blue"}"#;
         let (_source, address) = source_with(None, Some(VALID_TOKENS), None, false).await;

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -364,25 +364,20 @@ impl SplunkSource {
     }
 
     fn health_service(&self) -> BoxedFilter<(Response,)> {
-        let valid_credentials = self.valid_credentials.clone();
-        let authorize =
-            warp::header::optional("Authorization").and_then(move |token: Option<String>| {
-                let valid_credentials = valid_credentials.clone();
-                async move {
-                    if valid_credentials.is_empty() {
-                        return Ok(());
-                    }
-                    match token {
-                        Some(token) if valid_credentials.contains(&token) => Ok(()),
-                        _ => Err(Rejection::from(ApiError::BadRequest)),
-                    }
-                }
-            });
-
+        // The Splunk docs document this endpoint as returning a 400 if given an invalid Splunk
+        // token, but, in practice, it seems to ignore the token altogether
+        //
+        // The response body was taken from Splunk 8.2.4
+        //
+        // https://docs.splunk.com/Documentation/Splunk/8.2.5/RESTREF/RESTinput#services.2Fcollector.2Fhealth
         warp::get()
             .and(path!("health" / "1.0").or(path!("health")))
-            .and(authorize)
-            .map(move |_, _| warp::reply().into_response())
+            .map(move |_| {
+                http::Response::builder()
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(hyper::Body::from(r#"{"text":"HEC is healthy","code":17}"#))
+                    .expect("static response")
+            })
             .boxed()
     }
 
@@ -1460,6 +1455,20 @@ mod tests {
             401,
             send_with(address, "services/collector/event", "", "nope", &opts).await
         );
+    }
+
+    #[tokio::test]
+    async fn health_ignores_token() {
+        let (_source, address) = source(None).await;
+
+        let res = reqwest::Client::new()
+            .get(&format!("http://{}/services/collector/health", address))
+            .header("Authorization", format!("Splunk {}", "invalid token"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(200, res.status().as_u16());
     }
 
     #[tokio::test]


### PR DESCRIPTION
I verified with Splunk 8.2.4 that it doesn't actually check the token.

Addresses https://github.com/vectordotdev/vector/discussions/12097

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
