### PR TITLE
fix(observability): Refine error codes

### DIFF
--- a/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
+++ b/src/internal_events/aws_cloudwatch_logs_subscription_parser.rs
@@ -1,4 +1,4 @@
-use super::prelude::{error_stage, error_type};
+use super::prelude::{error_stage, error_type, io_error_code};
 use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
@@ -18,6 +18,11 @@ impl InternalEvent for AwsCloudwatchLogsSubscriptionParserError {
         );
         counter!(
             "component_errors_total", 1,
+            "error_type" => error_type::PARSER_FAILED,
+            "stage" => error_stage::PROCESSING,
+        );
+        counter!(
+            "component_discarded_events_total", 1,
             "error_type" => error_type::PARSER_FAILED,
             "stage" => error_stage::PROCESSING,
         );
@@ -72,16 +77,19 @@ impl InternalEvent for AwsCloudwatchLogsEncoderError {
             error = %self.error,
             error_type = error_type::ENCODER_FAILED,
             stage = error_stage::PROCESSING,
+            error_code = io_error_code(&self.error),
             internal_log_rate_secs = 10,
         );
         counter!(
             "component_errors_total", 1,
             "error_type" => error_type::ENCODER_FAILED,
+            "error_code" => io_error_code(&self.error),
             "stage" => error_stage::PROCESSING,
         );
         counter!(
             "component_discarded_events_total", 1,
             "error_type" => error_type::ENCODER_FAILED,
+            "error_code" => io_error_code(&self.error),
             "stage" => error_stage::PROCESSING,
         );
     }

--- a/src/internal_events/dnstap.rs
+++ b/src/internal_events/dnstap.rs
@@ -31,14 +31,13 @@ impl<'a> InternalEvent for DnstapParseError<'a> {
         error!(
             message = "Error occurred while parsing dnstap data.",
             error = ?self.error,
-            error_type = error_type::PARSER_FAILED,
             stage = error_stage::PROCESSING,
+            error_type = error_type::PARSER_FAILED,
             internal_log_rate_secs = 10,
         );
         counter!(
             "component_errors_total", 1,
             "stage" => error_stage::PROCESSING,
-            "error" => self.error.to_string(),
             "error_type" => error_type::PARSER_FAILED,
         );
         // deprecated

--- a/src/internal_events/eventstoredb_metrics.rs
+++ b/src/internal_events/eventstoredb_metrics.rs
@@ -31,13 +31,12 @@ impl InternalEvent for EventStoreDbMetricsHttpError {
         error!(
             message = "HTTP request processing error.",
             error = ?self.error,
-            error_type = error_type::REQUEST_FAILED,
             stage = error_stage::RECEIVING,
+            error_type = error_type::REQUEST_FAILED,
         );
         counter!(
             "component_errors_total", 1,
             "stage" => error_stage::RECEIVING,
-            "error" => self.error.to_string(),
             "error_type" => error_type::REQUEST_FAILED,
         );
         // deprecated
@@ -55,8 +54,8 @@ impl InternalEvent for EventStoreDbStatsParsingError {
         error!(
             message = "JSON parsing error.",
             error = ?self.error,
-            error_type = error_type::PARSER_FAILED,
             stage = error_stage::PROCESSING,
+            error_type = error_type::PARSER_FAILED,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use super::prelude::{error_stage, error_type};
+use super::prelude::{error_stage, error_type, io_error_code};
 use metrics::{counter, histogram};
 use tokio::time::error::Elapsed;
 use vector_core::internal_event::InternalEvent;
@@ -49,12 +49,14 @@ impl InternalEvent for ExecFailedError<'_> {
             command = %self.command,
             error = ?self.error,
             error_type = error_type::COMMAND_FAILED,
+            error_code = %io_error_code(&self.error),
             stage = error_stage::RECEIVING,
         );
         counter!(
             "component_errors_total", 1,
             "command" => self.command.to_owned(),
             "error_type" => error_type::COMMAND_FAILED,
+            "error_code" => io_error_code(&self.error),
             "stage" => error_stage::RECEIVING,
         );
         // deprecated

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -132,7 +132,7 @@ impl InternalEvent for KafkaHeaderExtractionError<'_> {
         );
         counter!(
             "component_errors_total", 1,
-            "error_code" => "extracing_field",
+            "error_code" => "extracing_header",
             "error_type" => error_type::PARSER_FAILED,
             "stage" => error_stage::RECEIVING,
         );

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -13,8 +13,8 @@ pub struct LogToMetricFieldNullError<'a> {
 impl<'a> InternalEvent for LogToMetricFieldNullError<'a> {
     fn emit(self) {
         error!(
-            message = %format!("Unable to convert null field {:?}.", self.field),
-            error = "field_null",
+            message = "Unable to convert null field",
+            error_code = "field_null",
             error_type = error_type::CONDITION_FAILED,
             stage = error_stage::PROCESSING,
             null_field = %self.field,
@@ -22,7 +22,7 @@ impl<'a> InternalEvent for LogToMetricFieldNullError<'a> {
         );
         counter!(
             "component_errors_total", 1,
-            "error" => "field_null",
+            "error_code" => "field_null",
             "error_type" => error_type::CONDITION_FAILED,
             "stage" => error_stage::PROCESSING,
             "null_field" => self.field.to_string(),
@@ -43,16 +43,17 @@ pub struct LogToMetricParseFloatError<'a> {
 impl<'a> InternalEvent for LogToMetricParseFloatError<'a> {
     fn emit(self) {
         error!(
-            message = %format!("Failed to parse field {:?} as float: {:?}", self.field, self.error),
+            message = "Failed to parse field as float",
+            error = ?self.error,
             field = %self.field,
-            error = "failed_parsing_float",
+            error_code = "failed_parsing_float",
             error_type = error_type::PARSER_FAILED,
             stage = error_stage::PROCESSING,
             internal_log_rate_secs = 30
         );
         counter!(
             "component_errors_total", 1,
-            "error" => "failed_parsing_float",
+            "error_code" => "failed_parsing_float",
             "error_type" => error_type::PARSER_FAILED,
             "stage" => error_stage::PROCESSING,
             "field" => self.field.to_string(),
@@ -72,15 +73,16 @@ pub struct LogToMetricTemplateParseError {
 impl InternalEvent for LogToMetricTemplateParseError {
     fn emit(self) {
         error!(
-            message = %format!("Failed to parse template: {:?}", self.error),
-            error = "failed_parsing_template",
+            message = "Failed to parse template",
+            error = ?self.error,
+            error_code = "failed_parsing_template",
             error_type = error_type::TEMPLATE_FAILED,
             stage = error_stage::PROCESSING,
             internal_log_rate_secs = 30,
         );
         counter!(
             "component_errors_total", 1,
-            "error" => "failed_parsing_template",
+            "error_code" => "failed_parsing_template",
             "error_type" => error_type::TEMPLATE_FAILED,
             "stage" => error_stage::PROCESSING,
         );

--- a/src/internal_events/logplex.rs
+++ b/src/internal_events/logplex.rs
@@ -1,4 +1,4 @@
-use super::prelude::{error_stage, error_type};
+use super::prelude::{error_stage, error_type, io_error_code};
 use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
@@ -34,11 +34,13 @@ impl InternalEvent for HerokuLogplexRequestReadError {
             error = ?self.error,
             internal_log_rate_secs = 10,
             error_type = error_type::READER_FAILED,
+            error_code = io_error_code(&self.error),
             stage = error_stage::PROCESSING,
         );
         counter!(
             "component_errors_total", 1,
             "error_type" => error_type::READER_FAILED,
+            "error_code" => io_error_code(&self.error),
             "stage" => error_stage::PROCESSING,
         );
         // deprecated

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -1,4 +1,5 @@
 use super::prelude::{error_stage, error_type};
+use crate::transforms::lua::v2::BuildError;
 use metrics::{counter, gauge};
 use vector_core::internal_event::InternalEvent;
 
@@ -23,20 +24,20 @@ impl InternalEvent for LuaScriptError {
         error!(
             message = "Error in lua script; discarding event.",
             error = ?self.error,
-            error_code = "execution",
+            error_code = mlua_error_code(&self.error),
             error_type = error_type::COMMAND_FAILED,
             stage = error_stage::PROCESSING,
             internal_log_rate_secs = 30,
         );
         counter!(
             "component_errors_total", 1,
-            "error_code" => "execution",
+            "error_code" => mlua_error_code(&self.error),
             "error_type" => error_type::SCRIPT_FAILED,
             "stage" => error_stage::PROCESSING,
         );
         counter!(
             "component_discarded_events_total", 1,
-            "error_code" => "execution",
+            "error_code" => mlua_error_code(&self.error),
             "error_type" => error_type::SCRIPT_FAILED,
             "stage" => error_stage::PROCESSING,
         );
@@ -47,7 +48,7 @@ impl InternalEvent for LuaScriptError {
 
 #[derive(Debug)]
 pub struct LuaBuildError {
-    pub error: crate::transforms::lua::v2::BuildError,
+    pub error: BuildError,
 }
 
 impl InternalEvent for LuaBuildError {
@@ -56,22 +57,72 @@ impl InternalEvent for LuaBuildError {
             message = "Error in lua script; discarding event.",
             error = ?self.error,
             error_type = error_type::SCRIPT_FAILED,
+            error_code = lua_build_error_code(&self.error),
             stage = error_stage::PROCESSING,
             internal_log_rate_secs = 30,
         );
         counter!(
             "component_errors_total", 1,
-            "error_code" => "build",
+            "error_code" => lua_build_error_code(&self.error),
             "error_type" => error_type::SCRIPT_FAILED,
-            "stage" => error_stage::PROCESSING,
+            "stage" => error_stage:: PROCESSING,
         );
         counter!(
             "component_discarded_events_total", 1,
-            "error_code" => "build",
+            "error_code" => lua_build_error_code(&self.error),
             "error_type" => error_type::SCRIPT_FAILED,
             "stage" => error_stage::PROCESSING,
         );
         // deprecated
         counter!("processing_errors_total", 1);
+    }
+}
+
+fn mlua_error_code(err: &mlua::Error) -> &'static str {
+    use mlua::Error::*;
+
+    match err {
+        SyntaxError { .. } => "syntax_error",
+        RuntimeError(_) => "runtime_error",
+        MemoryError(_) => "memory_error",
+        SafetyError(_) => "memory_safety_error",
+        MemoryLimitNotAvailable => "memory_limit_not_available",
+        MainThreadNotAvailable => "main_thread_not_available",
+        RecursiveMutCallback => "mutable_callback_called_recursively",
+        CallbackDestructed => "callback_destructed",
+        StackError => "out_of_stack",
+        BindError => "too_many_arguments_to_function_bind",
+        ToLuaConversionError { .. } => "error_converting_value_to_lua",
+        FromLuaConversionError { .. } => "error_converting_value_from_lua",
+        CoroutineInactive => "coroutine_inactive",
+        UserDataTypeMismatch => "userdata_type_mismatch",
+        UserDataDestructed => "userdata_destructed",
+        UserDataBorrowError => "userdata_borrow_error",
+        UserDataBorrowMutError => "userdata_already_borrowed",
+        MetaMethodRestricted(_) => "restricted_metamethod",
+        MetaMethodTypeError { .. } => "unsupported_metamethod_type",
+        MismatchedRegistryKey => "mismatched_registry_key",
+        CallbackError { .. } => "callback_error",
+        PreviouslyResumedPanic => "previously_resumed_panic",
+        ExternalError(_) => "external_error",
+        _ => "unknown",
+    }
+}
+
+fn lua_build_error_code(err: &BuildError) -> &'static str {
+    use BuildError::*;
+
+    match err {
+        InvalidSearchDirs { .. } => "invalid_search_dir",
+        InvalidSource { .. } => "invalid_source",
+        InvalidHooksInit { .. } => "invalid_hook_init",
+        InvalidHooksProcess { .. } => "invalid_hook_process",
+        InvalidHooksShutdown { .. } => "invalid_hook_shutdown",
+        InvalidTimerHandler { .. } => "invalid_timer_handler",
+        RuntimeErrorHooksInit { .. } => "runtime_error_hook_init",
+        RuntimeErrorHooksProcess { .. } => "runtime_error_hook_process",
+        RuntimeErrorHooksShutdown { .. } => "runtime_error_hook_shutdown",
+        RuntimeErrorTimerHandler { .. } => "runtime_error_timer_handler",
+        RuntimeErrorGc { .. } => "runtime_error_gc",
     }
 }

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -1,6 +1,6 @@
 use std::io::Error;
 
-use super::prelude::{error_stage, error_type};
+use super::prelude::{error_stage, error_type, io_error_code};
 use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
@@ -50,11 +50,13 @@ impl InternalEvent for NatsEventSendError {
             message = "Failed to send message.",
             error = %self.error,
             error_type = error_type::WRITER_FAILED,
+            error_code = io_error_code(&self.error),
             stage = error_stage::SENDING,
         );
         counter!(
             "component_errors_total", 1,
             "error_type" => error_type::WRITER_FAILED,
+            "error_code" => io_error_code(&self.error),
             "stage" => error_stage::SENDING,
         );
         // deprecated

--- a/src/internal_events/prelude.rs
+++ b/src/internal_events/prelude.rs
@@ -53,3 +53,58 @@ pub mod error_type {
 pub(crate) fn http_error_code(code: u16) -> String {
     format!("http_response_{}", code)
 }
+
+pub(crate) fn io_error_code(error: &std::io::Error) -> &'static str {
+    use std::io::ErrorKind::*;
+
+    // there are many more gated behind https://github.com/rust-lang/rust/issues/86442
+    match error.kind() {
+        AddrInUse => "address_in_use",
+        AddrNotAvailable => "address_not_available",
+        AlreadyExists => "entity_already_exists",
+        BrokenPipe => "broken_pipe",
+        ConnectionAborted => "connection_aborted",
+        ConnectionRefused => "connection_refused",
+        ConnectionReset => "connection_reset",
+        Interrupted => "operation_interrupted",
+        InvalidData => "invalid_data",
+        InvalidInput => "invalid_input_parameter",
+        NotConnected => "not_connected",
+        NotFound => "entity_not_found",
+        Other => "other_error",
+        OutOfMemory => "out_of_memory",
+        PermissionDenied => "permission_denied",
+        TimedOut => "timed_out",
+        UnexpectedEof => "unexpected_end_of_file",
+        Unsupported => "unsupported",
+        WouldBlock => "operation_would_block",
+        WriteZero => "write_zero",
+        _ => "unknown",
+    }
+}
+
+pub(crate) fn hyper_error_code(error: &hyper::Error) -> &'static str {
+    if error.is_body_write_aborted() {
+        "body_write_aborted"
+    } else if error.is_canceled() {
+        "cancelled"
+    } else if error.is_closed() {
+        "sender_closed"
+    } else if error.is_connect() {
+        "connect_error"
+    } else if error.is_incomplete_message() {
+        "incomplete_message"
+    } else if error.is_parse() {
+        "parse_error"
+    } else if error.is_parse_status() {
+        "parse_status_error"
+    } else if error.is_parse_too_large() {
+        "parse_too_large"
+    } else if error.is_timeout() {
+        "timeout"
+    } else if error.is_user() {
+        "user"
+    } else {
+        "unknown"
+    }
+}

--- a/src/internal_events/redis.rs
+++ b/src/internal_events/redis.rs
@@ -29,7 +29,7 @@ impl<'a> RedisSendEventError<'a> {
     pub fn new(error: &'a redis::RedisError) -> Self {
         Self {
             error,
-            error_code: error.code().unwrap_or_default().to_string(),
+            error_code: error.code().unwrap_or("UNKNOWN").to_string(),
         }
     }
 }
@@ -63,7 +63,7 @@ pub struct RedisReceiveEventError {
 
 impl From<redis::RedisError> for RedisReceiveEventError {
     fn from(error: redis::RedisError) -> Self {
-        let error_code = error.code().unwrap_or_default().to_string();
+        let error_code = error.code().unwrap_or("UNKNOWN").to_string();
         Self { error, error_code }
     }
 }

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -30,6 +30,13 @@ impl InternalEvent for RemapMappingError {
             "error_type" => error_type::CONVERSION_FAILED,
             "stage" => error_stage::PROCESSING,
         );
+        if self.event_dropped {
+            counter!(
+                "component_discarded_events_total", 1,
+                "error_type" => error_type::CONVERSION_FAILED,
+                "stage" => error_stage::PROCESSING,
+            );
+        }
         // deprecated
         counter!("processing_errors_total", 1);
     }
@@ -50,6 +57,14 @@ impl InternalEvent for RemapMappingAbort {
             "Event mapping aborted."
         };
 
-        debug!(message, internal_log_rate_secs = 30)
+        debug!(message, internal_log_rate_secs = 30);
+
+        if self.event_dropped {
+            counter!(
+                "component_discarded_events_total", 1,
+                "error_type" => error_type::CONVERSION_FAILED,
+                "stage" => error_stage::PROCESSING,
+            );
+        }
     }
 }


### PR DESCRIPTION
I did a pass to make sure we weren't tagging any error metrics with
a high cardinality label. I did a little clean up as I noticed things,
but left most other adjustments for
https://github.com/vectordotdev/vector/issues/11342 (see
https://github.com/vectordotdev/vector/issues/11342#issuecomment-1089492848).

I also reordered the tags sometimes to line them up between the logs and
metrics to make it easier to scan and ensure they match.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
