### PR TITLE
chore: Batch default should be f64 for `datadog_traces`

### DIFF
--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU64, sync::Arc};
+use std::sync::Arc;
 
 use futures::FutureExt;
 use http::Uri;
@@ -35,7 +35,7 @@ use crate::{
 // limit as a safety margin.
 pub const BATCH_GOAL_BYTES: usize = 3_000_000;
 pub const BATCH_MAX_EVENTS: usize = 1_000;
-pub const BATCH_DEFAULT_TIMEOUT_SECS: u64 = 10;
+pub const BATCH_DEFAULT_TIMEOUT_SECS: f64 = 10.0;
 
 pub const PAYLOAD_LIMIT: usize = 3_200_000;
 
@@ -49,8 +49,7 @@ pub struct DatadogTracesDefaultBatchSettings;
 impl SinkBatchSettings for DatadogTracesDefaultBatchSettings {
     const MAX_EVENTS: Option<usize> = Some(BATCH_MAX_EVENTS);
     const MAX_BYTES: Option<usize> = Some(BATCH_GOAL_BYTES);
-    const TIMEOUT_SECS: NonZeroU64 =
-        unsafe { NonZeroU64::new_unchecked(BATCH_DEFAULT_TIMEOUT_SECS) };
+    const TIMEOUT_SECS: f64 = BATCH_DEFAULT_TIMEOUT_SECS;
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/website/cue/reference/components/sinks/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/datadog_traces.cue
@@ -14,7 +14,7 @@ components: sinks: datadog_traces: {
 				common:       false
 				max_bytes:    2_300_000
 				max_events:   1_000
-				timeout_secs: 5
+				timeout_secs: 5.0
 			}
 			compression: {
 				enabled: true


### PR DESCRIPTION
This was a silent merge conflict between
623b18263ff4281c6c42cb9635a5403eb3991747 and
6fe2010d6542323aaf3e6030266957d44e0da517

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
