### PR TITLE
feat(socket source, syslog source): allow custom permissions on socket

### DIFF
--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -22,6 +22,7 @@ use crate::{
 #[serde(deny_unknown_fields)]
 pub struct UnixConfig {
     pub path: PathBuf,
+    pub socket_file_mode: Option<u32>,
     pub max_length: Option<usize>,
     pub host_key: Option<String>,
     #[serde(default)]
@@ -34,6 +35,7 @@ impl UnixConfig {
     pub fn new(path: PathBuf) -> Self {
         Self {
             path,
+            socket_file_mode: None,
             max_length: Some(crate::serde::default_max_length()),
             host_key: None,
             framing: None,
@@ -61,14 +63,16 @@ fn handle_events(events: &mut [Event], host_key: &str, received_from: Option<Byt
 
 pub(super) fn unix_datagram(
     path: PathBuf,
+    socket_file_mode: Option<u32>,
     max_length: usize,
     host_key: String,
     decoder: Decoder,
     shutdown: ShutdownSignal,
     out: SourceSender,
-) -> Source {
+) -> crate::Result<Source> {
     build_unix_datagram_source(
         path,
+        socket_file_mode,
         max_length,
         decoder,
         move |events, received_from| handle_events(events, &host_key, received_from),
@@ -79,13 +83,15 @@ pub(super) fn unix_datagram(
 
 pub(super) fn unix_stream(
     path: PathBuf,
+    socket_file_mode: Option<u32>,
     host_key: String,
     decoder: Decoder,
     shutdown: ShutdownSignal,
     out: SourceSender,
-) -> Source {
+) -> crate::Result<Source> {
     build_unix_stream_source(
         path,
+        socket_file_mode,
         decoder,
         move |events, received_from| handle_events(events, &host_key, received_from),
         shutdown,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -128,7 +128,7 @@ impl SourceConfig for StatsdConfig {
                 )
             }
             #[cfg(unix)]
-            StatsdConfig::Unix(config) => Ok(statsd_unix(config.clone(), cx.shutdown, cx.out)),
+            StatsdConfig::Unix(config) => statsd_unix(config.clone(), cx.shutdown, cx.out),
         }
     }
 

--- a/src/sources/statsd/unix.rs
+++ b/src/sources/statsd/unix.rs
@@ -19,11 +19,22 @@ pub struct UnixConfig {
     pub path: PathBuf,
 }
 
-pub fn statsd_unix(config: UnixConfig, shutdown: ShutdownSignal, out: SourceSender) -> Source {
+pub fn statsd_unix(
+    config: UnixConfig,
+    shutdown: ShutdownSignal,
+    out: SourceSender,
+) -> crate::Result<Source> {
     let decoder = Decoder::new(
         Framer::NewlineDelimited(NewlineDelimitedDecoder::new()),
         Deserializer::Boxed(Box::new(StatsdDeserializer)),
     );
 
-    build_unix_stream_source(config.path, decoder, |_events, _host| {}, shutdown, out)
+    build_unix_stream_source(
+        config.path,
+        None,
+        decoder,
+        |_events, _host| {},
+        shutdown,
+        out,
+    )
 }

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -20,15 +20,7 @@ mod http;
 pub mod multiline_config;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 mod tcp;
-#[cfg(all(
-    unix,
-    feature = "sources-socket",
-    feature = "sources-utils-unix",
-    feature = "sources-metrics",
-    feature = "all-metrics",
-    feature = "sources-statsd",
-    feature = "sources-syslog"
-))]
+#[cfg(all(unix))]
 mod unix;
 #[cfg(all(unix, feature = "sources-socket"))]
 mod unix_datagram;
@@ -42,6 +34,8 @@ pub use encoding_config::EncodingConfig;
 pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 pub use tcp::{SocketListenAddr, TcpNullAcker, TcpSource, TcpSourceAck, TcpSourceAcker};
+#[cfg(all(unix))]
+pub use unix::change_socket_permissions;
 #[cfg(all(unix, feature = "sources-socket",))]
 pub use unix_datagram::build_unix_datagram_source;
 #[cfg(all(unix, feature = "sources-utils-unix",))]

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -20,6 +20,8 @@ mod http;
 pub mod multiline_config;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 mod tcp;
+#[cfg(all(unix, feature = "sources-socket", feature = "sources-utils-unix"))]
+mod unix;
 #[cfg(all(unix, feature = "sources-socket"))]
 mod unix_datagram;
 #[cfg(all(unix, feature = "sources-utils-unix"))]

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -20,7 +20,7 @@ mod http;
 pub mod multiline_config;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 mod tcp;
-#[cfg(all(unix))]
+#[cfg(all(unix, any(feature = "sources-socket", feature = "sources-utils-unix",)))]
 mod unix;
 #[cfg(all(unix, feature = "sources-socket"))]
 mod unix_datagram;
@@ -34,7 +34,7 @@ pub use encoding_config::EncodingConfig;
 pub use multiline_config::MultilineConfig;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 pub use tcp::{SocketListenAddr, TcpNullAcker, TcpSource, TcpSourceAck, TcpSourceAcker};
-#[cfg(all(unix))]
+#[cfg(all(unix, any(feature = "sources-socket", feature = "sources-utils-unix",)))]
 pub use unix::change_socket_permissions;
 #[cfg(all(unix, feature = "sources-socket",))]
 pub use unix_datagram::build_unix_datagram_source;

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -20,7 +20,15 @@ mod http;
 pub mod multiline_config;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 mod tcp;
-#[cfg(all(unix, feature = "sources-socket", feature = "sources-utils-unix"))]
+#[cfg(all(
+    unix,
+    feature = "sources-socket",
+    feature = "sources-utils-unix",
+    feature = "sources-metrics",
+    feature = "all-metrics",
+    feature = "sources-statsd",
+    feature = "sources-syslog"
+))]
 mod unix;
 #[cfg(all(unix, feature = "sources-socket"))]
 mod unix_datagram;

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -6,7 +6,7 @@ use crate::internal_events::UnixSocketFileDeleteError;
 pub fn change_socket_permissions(path: &Path, perms: Option<u32>) -> crate::Result<()> {
     if let Some(mode) = perms {
         match fs::set_permissions(path, fs::Permissions::from_mode(mode)) {
-            Ok(_) => info!(message = "Socket permissions updated.", permission = mode),
+            Ok(_) => debug!(message = "Socket permissions updated.", permission = mode),
             Err(e) => {
                 if let Err(error) = remove_file(path) {
                     emit!(UnixSocketFileDeleteError { path, error });

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -1,0 +1,19 @@
+use std::os::unix::fs::PermissionsExt;
+use std::{fs, fs::remove_file, path::Path};
+
+use crate::internal_events::UnixSocketFileDeleteError;
+
+pub fn change_socket_permissions(path: &Path, perms: Option<u32>) -> crate::Result<()> {
+    if let Some(mode) = perms {
+        match fs::set_permissions(path, fs::Permissions::from_mode(mode)) {
+            Ok(_) => info!(message = "Socket permissions updated.", permission = mode),
+            Err(e) => {
+                if let Err(error) = remove_file(path) {
+                    emit!(UnixSocketFileDeleteError { path, error });
+                }
+                return Err(Box::new(e));
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -16,7 +16,7 @@ use crate::{
         UnixSocketFileDeleteError,
     },
     shutdown::ShutdownSignal,
-    sources::util::unix::change_socket_permissions,
+    sources::util::change_socket_permissions,
     sources::Source,
     SourceSender,
 };

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -37,9 +37,7 @@ pub fn build_unix_datagram_source(
     let socket = UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
     info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
 
-    if let Err(e) = change_socket_permissions(&listen_path, socket_file_mode) {
-        return Err(e);
-    }
+    change_socket_permissions(&listen_path, socket_file_mode)?;
 
     Ok(Box::pin(async move {
         let result = listen(socket, max_length, decoder, shutdown, handle_events, out).await;

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -16,6 +16,7 @@ use crate::{
         UnixSocketFileDeleteError,
     },
     shutdown::ShutdownSignal,
+    sources::util::unix::change_socket_permissions,
     sources::Source,
     SourceSender,
 };
@@ -26,16 +27,21 @@ use crate::{
 /// syslog source).
 pub fn build_unix_datagram_source(
     listen_path: PathBuf,
+    socket_file_mode: Option<u32>,
     max_length: usize,
     decoder: Decoder,
     handle_events: impl Fn(&mut [Event], Option<Bytes>) + Clone + Send + Sync + 'static,
     shutdown: ShutdownSignal,
     out: SourceSender,
-) -> Source {
-    Box::pin(async move {
-        let socket = UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
-        info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
+) -> crate::Result<Source> {
+    let socket = UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
+    info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
 
+    if let Err(e) = change_socket_permissions(&listen_path, socket_file_mode) {
+        return Err(e);
+    }
+
+    Ok(Box::pin(async move {
         let result = listen(socket, max_length, decoder, shutdown, handle_events, out).await;
 
         // Delete socket file.
@@ -47,7 +53,7 @@ pub fn build_unix_datagram_source(
         }
 
         result
-    })
+    }))
 }
 
 async fn listen(

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -44,9 +44,7 @@ pub fn build_unix_stream_source(
     let listener = UnixListener::bind(&listen_path).expect("Failed to bind to listener socket");
     info!(message = "Listening.", path = ?listen_path, r#type = "unix");
 
-    if let Err(e) = change_socket_permissions(&listen_path, socket_file_mode) {
-        return Err(e);
-    }
+    change_socket_permissions(&listen_path, socket_file_mode)?;
 
     Ok(Box::pin(async move {
         let connection_open = OpenGauge::new();

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -24,7 +24,7 @@ use crate::{
         StreamClosedError, UnixSocketError, UnixSocketFileDeleteError,
     },
     shutdown::ShutdownSignal,
-    sources::util::unix::change_socket_permissions,
+    sources::util::change_socket_permissions,
     sources::Source,
     SourceSender,
 };

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -24,6 +24,7 @@ use crate::{
         StreamClosedError, UnixSocketError, UnixSocketFileDeleteError,
     },
     shutdown::ShutdownSignal,
+    sources::util::unix::change_socket_permissions,
     sources::Source,
     SourceSender,
 };
@@ -34,15 +35,20 @@ use crate::{
 /// syslog source).
 pub fn build_unix_stream_source(
     listen_path: PathBuf,
+    socket_file_mode: Option<u32>,
     decoder: Decoder,
     handle_events: impl Fn(&mut [Event], Option<Bytes>) + Clone + Send + Sync + 'static,
     shutdown: ShutdownSignal,
     out: SourceSender,
-) -> Source {
-    Box::pin(async move {
-        let listener = UnixListener::bind(&listen_path).expect("Failed to bind to listener socket");
-        info!(message = "Listening.", path = ?listen_path, r#type = "unix");
+) -> crate::Result<Source> {
+    let listener = UnixListener::bind(&listen_path).expect("Failed to bind to listener socket");
+    info!(message = "Listening.", path = ?listen_path, r#type = "unix");
 
+    if let Err(e) = change_socket_permissions(&listen_path, socket_file_mode) {
+        return Err(e);
+    }
+
+    Ok(Box::pin(async move {
         let connection_open = OpenGauge::new();
         let stream = UnixListenerStream::new(listener).take_until(shutdown.clone());
         tokio::pin!(stream);
@@ -146,5 +152,5 @@ pub fn build_unix_stream_source(
         }
 
         Ok(())
-    })
+    }))
 }

--- a/tests/syslog.rs
+++ b/tests/syslog.rs
@@ -91,6 +91,7 @@ async fn test_unix_stream_syslog() {
         "in",
         SyslogConfig::from_mode(Mode::Unix {
             path: in_path.clone(),
+            socket_file_mode: None,
         }),
     );
     config.add_sink("out", &["in"], tcp_json_sink(out_addr.to_string()));

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -104,6 +104,22 @@ components: sources: socket: {
 				examples: ["/path/to/socket"]
 			}
 		}
+		socket_file_mode: {
+			common: false
+			description: """
+				Unix file mode bits to be applied to the unix socket file
+				as its designated file permissions.
+				Note that the file mode value can be specified in any numeric format
+				supported by your configuration language, but it is most intuitive to use an octal number.
+				"""
+			relevant_when: "mode = `unix_datagram` or `unix_stream`"
+			required:      false
+			type: uint: {
+				default: null
+				unit:    null
+				examples: [0o777, 0o600, 508]
+			}
+		}
 		shutdown_timeout_secs: {
 			common:        false
 			description:   "The timeout before a connection is forcefully closed during shutdown."

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -97,6 +97,7 @@ components: sources: syslog: {
 				examples: ["/path/to/socket"]
 			}
 		}
+		socket_file_mode: sources.socket.configuration.socket_file_mode
 		connection_limit: {
 			common:        false
 			description:   "The max number of TCP connections that will be processed."


### PR DESCRIPTION
This patch adds a new option : `socket_file_mode` to the socket and
syslog sources to set the permission on the created unix socket.

Fixes #9241

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
