### PR TITLE
docs(route transform): Separate out note about _default route

### DIFF
--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -30,10 +30,11 @@ components: transforms: route: {
 	configuration: {
 		route: {
 			description: """
-				A table of route identifiers to logical conditions representing the filter of the route. Each route
-				can then be referenced as an input by other components with the name `<transform_name>.<route_id>`.
-				If an event doesn't match any route, it will be sent to the `<transform_name>._unmatched` output.
-				Note, `_default` and `_unmatched` are reserved output names and cannot be used as route names.
+				A table of route identifiers to logical conditions representing the filter of the route. Each route can
+				then be referenced as an input by other components with the name `<transform_name>.<route_id>`. If an
+				event doesn't match any route, it will be sent to the `<transform_name>._unmatched` output. Note,
+				`_unmatched` is a reserved output name and cannot be used as a route name. `_default` is also reserved
+				for future use.
 				"""
 			required: true
 			type: object: {


### PR DESCRIPTION
The current wording makes it sound like this route is used right now,
but it is just reserved for the future.

Closes: #12143

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
