### PR TITLE
chore: Move soak build jobs to test runners

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -140,7 +140,9 @@ jobs:
 
   build-image-baseline:
     name: Build baseline 'soak-vector' container
-    runs-on: [linux, soak, soak-builder]
+    # separate soak builder group seems to not pick up jobs
+    # runs-on: [linux, soak, soak-builder]
+    runs-on: [linux, test]
     needs: [compute-soak-meta]
     steps:
       - uses: colpal/actions-clean@v1
@@ -185,7 +187,9 @@ jobs:
 
   build-image-comparison:
     name: Build comparison 'soak-vector' container
-    runs-on: [linux, soak, soak-builder]
+    # separate soak builder group seems to not pick up jobs
+    # runs-on: [linux, soak, soak-builder]
+    runs-on: [linux, test]
     needs: [compute-soak-meta]
     steps:
       - uses: colpal/actions-clean@v1


### PR DESCRIPTION
The soak-builder runners seem to have stopped picking up jobs. We've
reached out to Github support, but trying this until they get back to us.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>