### PR TITLE
fix(config): fix error processing when loading configuration files

### DIFF
--- a/src/config/loading/loader.rs
+++ b/src/config/loading/loader.rs
@@ -221,7 +221,7 @@ where
     /// Deserializes a file with the provided format, and makes the result available via `take`.
     /// Returns a vector of non-fatal warnings on success, or a vector of error strings on failure.
     fn load_from_file(&mut self, path: &Path, format: Format) -> Result<Vec<String>, Vec<String>> {
-        if let Ok(Some((_, table, warnings))) = self.load_file(path, format) {
+        if let Some((_, table, warnings)) = self.load_file(path, format)? {
             self.merge(table, None)?;
             Ok(warnings)
         } else {


### PR DESCRIPTION
While developing the implementation for #10420, I discovered that configuration file loading errors are not properly propagated in the current `master` branch of Vector.

For example, consider the following configuration with a deliberate YAML syntax error on the top:
```yaml
sources: &
  logs:
    type: demo_logs
    format: syslog
sinks:
  console:
    type: console
    inputs:
      - logs
    encoding: json
```

When you try to start Vector in current `master` with the above configuration file, you get these results:
```
$ vector -c vector.yaml
2022-04-09T21:19:43.427912Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info"
2022-04-09T21:19:43.432056Z  INFO vector::app: Loading configs. paths=["vector.yaml"]
2022-04-09T21:19:43.447913Z ERROR vector::cli: Configuration error. error=No sources defined in the config.
2022-04-09T21:19:43.448265Z ERROR vector::cli: Configuration error. error=No sinks defined in the config.
```
```
$ vector validate vector.yaml
Failed to load ["vector.yaml"]
------------------------------
x No sources defined in the config.
x No sinks defined in the config.
```
```
$ vector test vector.yaml
Running tests
No tests found.
```

I.e., the YAML parsing error was not propagated properly and instead the loader just returned an empty configuration.

The same configuration in Vector `0.20.1` and also current `master` with this PR applied, correctly gives these results:
```
$ vector -c vector.yaml
2022-04-09T20:32:06.255077Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info"
2022-04-09T20:32:06.278291Z  INFO vector::app: Loading configs. paths=["vector.yaml"]
2022-04-09T20:32:06.348648Z ERROR vector::cli: Configuration error. error=while scanning an anchor or alias, did not find expected alphabetic or numeric character at line 1 column 10
```
```
$ vector validate vector.yaml
Failed to load ["vector.yaml"]
------------------------------
x while scanning an anchor or alias, did not find expected alphabetic or numeric character at line 1 column 10
```
```
$ vector test vector.yaml
Running tests
2022-04-09T21:05:53.811416Z ERROR vector::unit_test: Failed to execute tests:
while scanning an anchor or alias, did not find expected alphabetic or numeric character at line 1 column 10.
```

I tried to trace when this regression was introduced, and seems to be PR #11442.
Therefore, maybe @leebenson can validate that this fix is correct here?
