### PR TITLE
enhancement(config): extend environment variables interpolation syntax

### DIFF
--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -255,7 +255,7 @@ pub fn prepare_input<R: std::io::Read>(mut input: R) -> Result<(String, Vec<Stri
             vars.insert("HOSTNAME".into(), hostname);
         }
     }
-    Ok(vars::interpolate(&source_string, &vars))
+    vars::interpolate(&source_string, &vars)
 }
 
 pub fn load<R: std::io::Read, T>(input: R, format: Format) -> Result<(T, Vec<String>), Vec<String>>

--- a/src/config/vars.rs
+++ b/src/config/vars.rs
@@ -27,8 +27,8 @@ pub fn interpolate(
 
     let interpolated = re
         .replace_all(input, |caps: &Captures<'_>| {
-            let flags = caps.get(3).map(|m| m.as_str()).unwrap_or("");
-            let def_or_err = caps.get(4).map(|m| m.as_str()).unwrap_or("");
+            let flags = caps.get(3).map(|m| m.as_str()).unwrap_or_default();
+            let def_or_err = caps.get(4).map(|m| m.as_str()).unwrap_or_default();
             caps.get(1)
                 .or_else(|| caps.get(2))
                 .map(|m| m.as_str())

--- a/src/config/vars.rs
+++ b/src/config/vars.rs
@@ -42,44 +42,30 @@ pub fn interpolate(
                                 def_or_err
                             }
                         }
-                        "-" => {
-                            if let Some(v) = val {
-                                v
-                            } else {
-                                def_or_err
-                            }
-                        }
+                        "-" => val.unwrap_or(def_or_err),
                         ":?" => {
                             if matches!(val, Some(v) if !v.is_empty()) {
                                 val.unwrap()
                             } else {
                                 errors.push(format!(
-                                "Non-empty env var required in config. name = {:?}, error = {:?}",
-                                name, def_or_err
-                            ));
-                                ""
-                            }
-                        }
-                        "?" => {
-                            if let Some(v) = val {
-                                v
-                            } else {
-                                errors.push(format!(
-                                    "Missing env var required in config. name = {:?}, error = {:?}",
+                                    "Non-empty env var required in config. name = {:?}, error = {:?}",
                                     name, def_or_err
                                 ));
                                 ""
                             }
                         }
-                        _ => {
-                            if let Some(v) = val {
-                                v
-                            } else {
-                                warnings
-                                    .push(format!("Unknown env var in config. name = {:?}", name));
-                                ""
-                            }
-                        }
+                        "?" => val.unwrap_or_else(|| {
+                            errors.push(format!(
+                                "Missing env var required in config. name = {:?}, error = {:?}",
+                                name, def_or_err
+                            ));
+                            ""
+                        }),
+                        _ => val.unwrap_or_else(|| {
+                            warnings
+                                .push(format!("Unknown env var in config. name = {:?}", name));
+                            ""
+                        }),
                     }
                 })
                 .unwrap_or("$")

--- a/src/config/vars.rs
+++ b/src/config/vars.rs
@@ -3,8 +3,13 @@ use std::collections::HashMap;
 use regex::{Captures, Regex};
 
 /// (result, warnings)
-pub fn interpolate(input: &str, vars: &HashMap<String, String>) -> (String, Vec<String>) {
+pub fn interpolate(
+    input: &str,
+    vars: &HashMap<String, String>,
+) -> Result<(String, Vec<String>), Vec<String>> {
+    let mut errors = Vec::new();
     let mut warnings = Vec::new();
+
     // Environment variable names can have any characters from the Portable Character Set other
     // than NUL.  However, for Vector's intepolation, we are closer to what a shell supports which
     // is solely of uppercase letters, digits, and the '_' (that is, the `[:word:]` regex class).
@@ -16,27 +21,59 @@ pub fn interpolate(input: &str, vars: &HashMap<String, String>) -> (String, Vec<
         r"(?x)
         \$\$|
         \$([[:word:].]+)|
-        \$\{([[:word:].]+)(?::-([^}]+)?)?\}",
+        \$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}",
     )
     .unwrap();
+
     let interpolated = re
         .replace_all(input, |caps: &Captures<'_>| {
+            let flags = caps.get(3).map(|m| m.as_str()).unwrap_or("");
+            let def_or_err = caps.get(4).map(|m| m.as_str()).unwrap_or("");
             caps.get(1)
                 .or_else(|| caps.get(2))
                 .map(|m| m.as_str())
                 .map(|name| {
-                    vars.get(name).map(|val| val.as_str()).unwrap_or_else(|| {
-                        caps.get(3).map(|m| m.as_str()).unwrap_or_else(|| {
-                            warnings.push(format!("Unknown env var in config. name = {:?}", name));
-                            ""
+                    vars.get(name)
+                        .map(|val| match val.as_str() {
+                            "" => match flags {
+                                ":-" => def_or_err,
+                                ":?" => {
+                                    errors.push(format!(
+                                        "Non-empty env var required in config. name = {:?}, error = {:?}",
+                                        name, def_or_err
+                                    ));
+                                    ""
+                                }
+                                _ => "",
+                            },
+                            val => val,
                         })
-                    })
+                        .unwrap_or_else(|| match flags {
+                            ":-" | "-" => def_or_err,
+                            ":?" | "?" => {
+                                errors.push(format!(
+                                    "Unkown env var in config. name = {:?}, error = {:?}",
+                                    name, def_or_err
+                                ));
+                                ""
+                            }
+                            _ => {
+                                warnings
+                                    .push(format!("Unknown env var in config. name = {:?}", name));
+                                ""
+                            }
+                        })
                 })
                 .unwrap_or("$")
                 .to_string()
         })
         .into_owned();
-    (interpolated, warnings)
+
+    if errors.is_empty() {
+        Ok((interpolated, warnings))
+    } else {
+        Err(errors)
+    }
 }
 
 #[cfg(test)]
@@ -49,30 +86,39 @@ mod test {
             ("FOOBAR".into(), "cats".into()),
             // Java commonly uses .s in env var names
             ("FOO.BAR".into(), "turtles".into()),
+            ("EMPTY".into(), "".into()),
         ]
         .into_iter()
         .collect();
 
-        assert_eq!("dogs", interpolate("$FOO", &vars).0);
-        assert_eq!("dogs", interpolate("${FOO}", &vars).0);
-        assert_eq!("cats", interpolate("${FOOBAR}", &vars).0);
-        assert_eq!("xcatsy", interpolate("x${FOOBAR}y", &vars).0);
-        assert_eq!("x", interpolate("x$FOOBARy", &vars).0);
-        assert_eq!("$ x", interpolate("$ x", &vars).0);
-        assert_eq!("$FOO", interpolate("$$FOO", &vars).0);
-        assert_eq!("dogs=bar", interpolate("$FOO=bar", &vars).0);
-        assert_eq!("", interpolate("$NOT_FOO", &vars).0);
-        assert_eq!("-FOO", interpolate("$NOT-FOO", &vars).0);
-        assert_eq!("turtles", interpolate("$FOO.BAR", &vars).0);
-        assert_eq!("${FOO x", interpolate("${FOO x", &vars).0);
-        assert_eq!("${}", interpolate("${}", &vars).0);
-        assert_eq!("dogs", interpolate("${FOO:-cats}", &vars).0);
-        assert_eq!("dogcats", interpolate("${NOT:-dogcats}", &vars).0);
+        assert_eq!("dogs", interpolate("$FOO", &vars).unwrap().0);
+        assert_eq!("dogs", interpolate("${FOO}", &vars).unwrap().0);
+        assert_eq!("cats", interpolate("${FOOBAR}", &vars).unwrap().0);
+        assert_eq!("xcatsy", interpolate("x${FOOBAR}y", &vars).unwrap().0);
+        assert_eq!("x", interpolate("x$FOOBARy", &vars).unwrap().0);
+        assert_eq!("$ x", interpolate("$ x", &vars).unwrap().0);
+        assert_eq!("$FOO", interpolate("$$FOO", &vars).unwrap().0);
+        assert_eq!("dogs=bar", interpolate("$FOO=bar", &vars).unwrap().0);
+        assert_eq!("", interpolate("$NOT_FOO", &vars).unwrap().0);
+        assert_eq!("-FOO", interpolate("$NOT-FOO", &vars).unwrap().0);
+        assert_eq!("turtles", interpolate("$FOO.BAR", &vars).unwrap().0);
+        assert_eq!("${FOO x", interpolate("${FOO x", &vars).unwrap().0);
+        assert_eq!("${}", interpolate("${}", &vars).unwrap().0);
+        assert_eq!("dogs", interpolate("${FOO:-cats}", &vars).unwrap().0);
+        assert_eq!("dogcats", interpolate("${NOT:-dogcats}", &vars).unwrap().0);
         assert_eq!(
             "dogs and cats",
-            interpolate("${NOT:-dogs and cats}", &vars).0
+            interpolate("${NOT:-dogs and cats}", &vars).unwrap().0
         );
-        assert_eq!("${:-cats}", interpolate("${:-cats}", &vars).0);
-        assert_eq!("", interpolate("${NOT:-}", &vars).0);
+        assert_eq!("${:-cats}", interpolate("${:-cats}", &vars).unwrap().0);
+        assert_eq!("", interpolate("${NOT:-}", &vars).unwrap().0);
+        assert_eq!("cats", interpolate("${NOT-cats}", &vars).unwrap().0);
+        assert_eq!("", interpolate("${EMPTY-cats}", &vars).unwrap().0);
+        assert_eq!("dogs", interpolate("${FOO:?error cats}", &vars).unwrap().0);
+        assert_eq!("dogs", interpolate("${FOO?error cats}", &vars).unwrap().0);
+        assert_eq!("", interpolate("${EMPTY?error cats}", &vars).unwrap().0);
+        assert!(interpolate("${NOT:?error cats}", &vars).is_err());
+        assert!(interpolate("${NOT?error cats}", &vars).is_err());
+        assert!(interpolate("${EMPTY:?error cats}", &vars).is_err());
     }
 }

--- a/src/config/vars.rs
+++ b/src/config/vars.rs
@@ -35,24 +35,20 @@ pub fn interpolate(
                 .map(|name| {
                     let val = vars.get(name).map(|v| v.as_str());
                     match flags {
-                        ":-" => {
-                            if matches!(val, Some(v) if !v.is_empty()) {
-                                val.unwrap()
-                            } else {
-                                def_or_err
-                            }
-                        }
+                        ":-" => match val {
+                            Some(v) if !v.is_empty() => v,
+                            _ => def_or_err,
+                        },
                         "-" => val.unwrap_or(def_or_err),
-                        ":?" => {
-                            if matches!(val, Some(v) if !v.is_empty()) {
-                                val.unwrap()
-                            } else {
+                        ":?" => match val {
+                            Some(v) if !v.is_empty() => v,
+                            _ => {
                                 errors.push(format!(
                                     "Non-empty env var required in config. name = {:?}, error = {:?}",
                                     name, def_or_err
                                 ));
                                 ""
-                            }
+                            },
                         }
                         "?" => val.unwrap_or_else(|| {
                             errors.push(format!(

--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -224,14 +224,25 @@ type = "add_fields"
 [transforms.add_host.fields]
 host = "${HOSTNAME}" # or "$HOSTNAME"
 environment = "${ENV:-development}" # default value when not present
+tenant = "${TENANT:?tenant must be supplied}" # required environment variable
 ```
 
 #### Default values
 
-Default values can be supplied using `:-` syntax:
+Default values can be supplied using `:-` or `-` syntax:
 
 ```toml
-option = "${ENV_VAR:-default}"
+option = "${ENV_VAR:-default}" # default value if variable is unset or empty
+option = "${ENV_VAR-default}" # default value only if variable is unset
+```
+
+#### Required variables
+
+Environment variables that are required can be specified using `:?` or `?` syntax:
+
+```toml
+option = "${ENV_VAR:?err}" # Vector exits with 'err' message if variable is unset or empty
+option = "${ENV_VAR?err}" # Vector exits with 'err' message only if variable is unset
 ```
 
 #### Escaping

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -322,7 +322,7 @@ configuration: {
 		environment_variables: {
 			title: "Environment variables"
 			body: """
-				Vector will interpolate environment variables within your configuration file
+				Vector interpolates environment variables within your configuration file
 				with the following syntax:
 
 				```toml title="vector.toml"
@@ -330,8 +330,9 @@ configuration: {
 				  type = "add_fields"
 
 				  [transforms.add_host.fields]
-				    host = "${HOSTNAME}"
+				    host = "${HOSTNAME}" # or "$HOSTNAME"
 				    environment = "${ENV:-development}" # default value when not present
+				    tenant = "${TENANT:?tenant must be supplied}" # required environment variable
 				```
 				"""
 
@@ -339,10 +340,22 @@ configuration: {
 				{
 					title: "Default values"
 					body: """
-						Default values can be supplied via the `:-` syntax:
+						Default values can be supplied using `:-` or `-` syntax:
 
 						```toml
-						option = "${ENV_VAR:-default}"
+						option = "${ENV_VAR:-default}" # default value if variable is unset or empty
+						option = "${ENV_VAR-default}" # default value only if variable is unset
+						```
+						"""
+				},
+				{
+					title: "Required variables"
+					body: """
+						Environment variables that are required can be specified using `:?` or `?` syntax:
+
+						```toml
+						option = "${ENV_VAR:?err}" # Vector exits with 'err' message if variable is unset or empty
+						option = "${ENV_VAR?err}" # Vector exits with 'err' message only if variable is unset
 						```
 						"""
 				},
@@ -350,7 +363,7 @@ configuration: {
 					title: "Escaping"
 					body: """
 						You can escape environment variable by preceding them with a `$` character. For
-						example `$${HOSTNAME}` will be treated _literally_ in the above environment
+						example `$${HOSTNAME}` or `$$HOSTNAME` is treated literally in the above environment
 						variable example.
 						"""
 				},


### PR DESCRIPTION
This PR improves the current environment variables interpolator to fully mimic the Docker compose syntax:

* `${VARIABLE:-default}` evaluates to `default` if `VARIABLE` is unset or empty in the environment.
* `${VARIABLE-default}` evaluates to `default` only if `VARIABLE` is unset in the environment.
* `${VARIABLE:?err}` exits with an error message containing `err` if `VARIABLE` is unset or empty in the environment.
* `${VARIABLE?err}` exits with an error message containing `err` if `VARIABLE` is unset in the environment.

**Note:** The last two cases (_exits with an error message ..._) will not show properly until #12149 is resolved.

In addition, the improved regex also allows for `default` and `err` to be empty strings, fixing the linked issue.

I was not sure where exactly to update the documentation, as there are two places with the same content (CUE content and Markdown content). So I just updated/aligned both to have the same content for now.

Closes #10420 