### PR TITLE
chore(codecs): Implement additional `Encoder`/`EncodingConfig` without framing

### DIFF
--- a/benches/http.rs
+++ b/benches/http.rs
@@ -9,7 +9,7 @@ use hyper::{
 use tokio::runtime::Runtime;
 use vector::{
     config, sinks,
-    sinks::util::{encoding::EncodingConfigAdapter, BatchConfig, Compression},
+    sinks::util::{encoding::EncodingConfigWithFramingAdapter, BatchConfig, Compression},
     sources,
     test_util::{next_addr, random_lines, runtime, send_lines, start_topology, wait_for_tcp},
     Error,
@@ -53,7 +53,7 @@ fn benchmark_http(c: &mut Criterion) {
                                 auth: Default::default(),
                                 headers: Default::default(),
                                 batch,
-                                encoding: EncodingConfigAdapter::legacy(
+                                encoding: EncodingConfigWithFramingAdapter::legacy(
                                     sinks::http::Encoding::Text.into(),
                                 ),
                                 request: Default::default(),

--- a/src/codecs/mod.rs
+++ b/src/codecs/mod.rs
@@ -8,5 +8,5 @@ mod encoder;
 mod ready_frames;
 
 pub use decoder::{Decoder, DecodingConfig};
-pub use encoder::{Encoder, EncodingConfig};
+pub use encoder::Encoder;
 pub use ready_frames::ReadyFrames;

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -74,7 +74,10 @@ use crate::{
 };
 
 #[cfg(feature = "codecs")]
-pub use adapter::{EncodingConfigAdapter, EncodingConfigMigrator, Transformer};
+pub use adapter::{
+    EncodingConfigAdapter, EncodingConfigMigrator, EncodingConfigWithFramingAdapter,
+    EncodingConfigWithFramingMigrator, Transformer,
+};
 pub use codec::{as_tracked_write, StandardEncodings, StandardJsonEncoding, StandardTextEncoding};
 pub use config::EncodingConfig;
 pub use fixed::EncodingConfigFixed;


### PR DESCRIPTION
This PR adds support structures needed to have both an `Encoder<()>` (no framing) and `Encoder<Framer>` (with framing), both of which emit internal logs when encoding fails.

Some context that triggered the need for this: https://github.com/vectordotdev/vector/pull/12133#discussion_r846364609.