### PR TITLE
chore(codecs): Implement `StandardEncodingsMigrator`

### DIFF
--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -78,6 +78,8 @@ pub use adapter::{
     EncodingConfigAdapter, EncodingConfigMigrator, EncodingConfigWithFramingAdapter,
     EncodingConfigWithFramingMigrator, Transformer,
 };
+#[cfg(feature = "codecs")]
+pub use codec::StandardEncodingsMigrator;
 pub use codec::{as_tracked_write, StandardEncodings, StandardJsonEncoding, StandardTextEncoding};
 pub use config::EncodingConfig;
 pub use fixed::EncodingConfigFixed;

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -78,9 +78,9 @@ pub use adapter::{
     EncodingConfigAdapter, EncodingConfigMigrator, EncodingConfigWithFramingAdapter,
     EncodingConfigWithFramingMigrator, Transformer,
 };
-#[cfg(feature = "codecs")]
-pub use codec::StandardEncodingsMigrator;
 pub use codec::{as_tracked_write, StandardEncodings, StandardJsonEncoding, StandardTextEncoding};
+#[cfg(feature = "codecs")]
+pub use codec::{StandardEncodingsMigrator, StandardEncodingsWithFramingMigrator};
 pub use config::EncodingConfig;
 pub use fixed::EncodingConfigFixed;
 use lookup::lookup_v2::{parse_path, OwnedPath};


### PR DESCRIPTION
Context: https://github.com/vectordotdev/vector/pull/12136#discussion_r846248439 / https://github.com/vectordotdev/vector/pull/12133#discussion_r846354046.