### PR TITLE
feat(sinks, codecs): Add `Native`/`NativeJson` encodings to `SerializerConfig` enum

### DIFF
--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -157,6 +157,10 @@ impl tokio_util::codec::Encoder<()> for Framer {
 pub enum SerializerConfig {
     /// Configures the `JsonSerializer`.
     Json,
+    /// Configures the `NativeSerializer`.
+    Native,
+    /// Configures the `NativeJsonSerializer`.
+    NativeJson,
     /// Configures the `RawMessageSerializer`.
     RawMessage,
 }
@@ -178,6 +182,10 @@ impl SerializerConfig {
     pub const fn build(&self) -> Serializer {
         match self {
             SerializerConfig::Json => Serializer::Json(JsonSerializerConfig.build()),
+            SerializerConfig::Native => Serializer::Native(NativeSerializerConfig.build()),
+            SerializerConfig::NativeJson => {
+                Serializer::NativeJson(NativeJsonSerializerConfig.build())
+            }
             SerializerConfig::RawMessage => {
                 Serializer::RawMessage(RawMessageSerializerConfig.build())
             }
@@ -188,6 +196,8 @@ impl SerializerConfig {
     pub fn schema_requirement(&self) -> schema::Requirement {
         match self {
             SerializerConfig::Json => JsonSerializerConfig.schema_requirement(),
+            SerializerConfig::Native => NativeSerializerConfig.schema_requirement(),
+            SerializerConfig::NativeJson => NativeJsonSerializerConfig.schema_requirement(),
             SerializerConfig::RawMessage => RawMessageSerializerConfig.schema_requirement(),
         }
     }
@@ -198,6 +208,10 @@ impl SerializerConfig {
 pub enum Serializer {
     /// Uses a `JsonSerializer` for serialization.
     Json(JsonSerializer),
+    /// Uses a `NativeSerializer` for serialization.
+    Native(NativeSerializer),
+    /// Uses a `NativeJsonSerializer` for serialization.
+    NativeJson(NativeJsonSerializer),
     /// Uses a `RawMessageSerializer` for serialization.
     RawMessage(RawMessageSerializer),
 }
@@ -205,10 +219,12 @@ pub enum Serializer {
 impl tokio_util::codec::Encoder<Event> for Serializer {
     type Error = vector_core::Error;
 
-    fn encode(&mut self, item: Event, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, event: Event, buffer: &mut BytesMut) -> Result<(), Self::Error> {
         match self {
-            Serializer::Json(serializer) => serializer.encode(item, dst),
-            Serializer::RawMessage(serializer) => serializer.encode(item, dst),
+            Serializer::Json(serializer) => serializer.encode(event, buffer),
+            Serializer::Native(serializer) => serializer.encode(event, buffer),
+            Serializer::NativeJson(serializer) => serializer.encode(event, buffer),
+            Serializer::RawMessage(serializer) => serializer.encode(event, buffer),
         }
     }
 }


### PR DESCRIPTION
This is a follow-up to #11929 to make the `Native`/`NativeJson` codecs configurable for sinks that use the new `Encoder`.