### PR TITLE
chore: Move soak build jobs back to scoped runners

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -140,9 +140,7 @@ jobs:
 
   build-image-baseline:
     name: Build baseline 'soak-vector' container
-    # separate soak builder group seems to not pick up jobs
-    # runs-on: [linux, soak, soak-builder]
-    runs-on: [linux, test]
+    runs-on: [linux, soak, soak-builder]
     needs: [compute-soak-meta]
     steps:
       - uses: colpal/actions-clean@v1
@@ -187,9 +185,7 @@ jobs:
 
   build-image-comparison:
     name: Build comparison 'soak-vector' container
-    # separate soak builder group seems to not pick up jobs
-    # runs-on: [linux, soak, soak-builder]
-    runs-on: [linux, test]
+    runs-on: [linux, soak, soak-builder]
     needs: [compute-soak-meta]
     steps:
       - uses: colpal/actions-clean@v1


### PR DESCRIPTION
This reverts commit 0a946cf7719de3a45b7e17723a638e8dab5a8309.

We'd moved these due to an Azure outage that has since recovered.