### PR TITLE
docs(config): mention ytt as another available templating tool

### DIFF
--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -243,8 +243,8 @@ environment variable example.
 ### Formats
 
 Vector supports [TOML], [YAML], and [JSON] to ensure that Vector fits into your
-workflow. A side benefit of supporting JSON is that it enables you to use
-JSON-outputting data templating languages like [Jsonnet] and [Cue].
+workflow. A side benefit of supporting YAML and JSON is that they enable you to use
+data templating languages such as [ytt], [Jsonnet] and [Cue].
 
 #### Location
 
@@ -394,3 +394,4 @@ inputs = ["app*", "system_logs"]
 [jsonnet]: https://jsonnet.org
 [toml]: https://github.com/toml-lang/toml
 [yaml]: https://yaml.org
+[ytt]: https://carvel.dev/ytt/

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -360,8 +360,8 @@ configuration: {
 			title: "Formats"
 			body:  """
 				Vector supports [TOML](\(urls.toml)), [YAML](\(urls.yaml)), and [JSON](\(urls.json)) to
-				ensure Vector fits into your workflow. A side benefit of supporting JSON is the
-				enablement of data templating languages like [Jsonnet](\(urls.jsonnet)) and
+				ensure Vector fits into your workflow. A side benefit of supporting YAML and JSON is that they
+				enable you to use data templating languages such as [ytt](\(urls.ytt)), [Jsonnet](\(urls.jsonnet)) and
 				[Cue](\(urls.cue)).
 				"""
 		}

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -622,6 +622,7 @@ urls: {
 	windows_service:                                          "https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-service"
 	woothee:                                                  "https://github.com/woothee/woothee"
 	yaml:                                                     "https://yaml.org/"
+	ytt:                                                      "https://carvel.dev/ytt/"
 	yum:                                                      "\(wikipedia)/wiki/Yum_(software)"
 	zlib:                                                     "https://www.zlib.net"
 	zstd:                                                     "https://zstd.net"


### PR DESCRIPTION
This small PR adds a mention for [ytt](https://carvel.dev/ytt/) as another data templating tool, in this case for YAML configurations.
In a nutshell, ytt is to YAML what Jsonnet is to JSON.

In our team we use ytt with success and I think is fair to mention it as an alternative to Jsonnet+JSON for YAML users like us.