### PR TITLE
chore(deps): revert bump tonic from 0.6.2 to 0.7.0 (#12062)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
  "thiserror",
 ]
 
@@ -375,7 +375,7 @@ checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -413,7 +413,7 @@ checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -953,49 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags",
- "bytes 1.1.0",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa 1.0.1",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
-dependencies = [
- "async-trait",
- "bytes 1.1.0",
- "futures-util",
- "http",
- "http-body",
- "mime",
-]
-
-[[package]]
 name = "azure_core"
 version = "0.1.1"
 source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=3ca5610b959b3b6b77bb88da09f0764b605b01bc#3ca5610b959b3b6b77bb88da09f0764b605b01bc"
@@ -1186,7 +1143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3618f2e36f171327d104bbb8d94c51b15a0a87d140b8f54d320ded4b8d09b03e"
 dependencies = [
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -1301,7 +1258,7 @@ dependencies = [
  "tokio-util 0.7.0",
  "url",
  "webpki 0.22.0",
- "webpki-roots 0.22.3",
+ "webpki-roots 0.22.2",
  "winapi 0.3.9",
 ]
 
@@ -1377,7 +1334,7 @@ checksum = "4a2b3b92c135dae665a6f760205b89187638e83bed17ef3e44e83c712cf30600"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -1584,7 +1541,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -1619,7 +1576,7 @@ dependencies = [
  "indoc",
  "memchr",
  "pretty_assertions",
- "prost 0.10.0",
+ "prost 0.9.0",
  "serde",
  "serde_json",
  "smallvec",
@@ -1697,8 +1654,8 @@ checksum = "cc347c19eb5b940f396ac155822caee6662f850d97306890ac3773ed76c90c5a"
 dependencies = [
  "prost 0.9.0",
  "prost-types 0.9.0",
- "tonic 0.6.2",
- "tonic-build 0.6.2",
+ "tonic",
+ "tonic-build",
  "tracing-core 0.1.24",
 ]
 
@@ -1720,7 +1677,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.6.2",
+ "tonic",
  "tracing 0.1.33",
  "tracing-core 0.1.24",
  "tracing-subscriber",
@@ -1997,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2034,7 +1991,7 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "strsim 0.10.0",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2045,7 +2002,7 @@ checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2171,7 +2128,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2182,7 +2139,7 @@ checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2195,7 +2152,7 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "rustc_version 0.4.0",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2407,7 +2364,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2419,7 +2376,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2439,7 +2396,7 @@ checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2493,7 +2450,7 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "rustversion",
- "syn 1.0.90",
+ "syn 1.0.84",
  "synstructure",
 ]
 
@@ -2546,7 +2503,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
  "synstructure",
 ]
 
@@ -2850,7 +2807,7 @@ checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2953,7 +2910,7 @@ checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3061,7 +3018,7 @@ dependencies = [
  "quote 1.0.10",
  "serde",
  "serde_json",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3072,7 +3029,7 @@ checksum = "e56b093bfda71de1da99758b036f4cc811fd2511c8a76f75680e9ffbd2bb4251"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2 1.0.32",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3607,7 +3564,7 @@ checksum = "daa5135cb6aa90ee17b4f0a0fb2908059b0830f90fda333f12816f275b21820c"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3677,7 +3634,7 @@ checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -4246,12 +4203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,7 +4322,7 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "regex",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -4382,7 +4333,7 @@ checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -4770,7 +4721,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -5055,7 +5006,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -5396,7 +5347,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -5510,7 +5461,7 @@ checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -5521,7 +5472,7 @@ checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -5714,16 +5665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
-dependencies = [
- "proc-macro2 1.0.32",
- "syn 1.0.90",
-]
-
-[[package]]
 name = "prettytable-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5756,7 +5697,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
  "version_check",
 ]
 
@@ -5802,9 +5743,9 @@ dependencies = [
  "indexmap",
  "nom 7.1.1",
  "num_enum",
- "prost 0.10.0",
- "prost-build 0.10.0",
- "prost-types 0.10.0",
+ "prost 0.9.0",
+ "prost-build 0.9.0",
+ "prost-types 0.9.0",
  "snafu",
  "vector_common",
 ]
@@ -5862,16 +5803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd5316aa8f5c82add416dfbc25116b84b748a21153f512917e8143640a71bbd"
-dependencies = [
- "bytes 1.1.0",
- "prost-derive 0.10.0",
-]
-
-[[package]]
 name = "prost-build"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5910,28 +5841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328f9f29b82409216decb172d81e936415d21245befa79cd34c3f29d87d1c50b"
-dependencies = [
- "bytes 1.1.0",
- "cfg-if 1.0.0",
- "cmake",
- "heck 0.4.0",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph 0.6.0",
- "prost 0.10.0",
- "prost-types 0.10.0",
- "regex",
- "tempfile",
- "which 4.2.2",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5941,7 +5850,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -5954,20 +5863,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df35198f0777b75e9ff669737c6da5136b59dba33cf5a010a6d1cc4d56defc6f"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -5991,16 +5887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926681c118ae6e512a3ccefd4abbe5521a14f4cc1e207356d4d00c0b7f2006fd"
-dependencies = [
- "bytes 1.1.0",
- "prost 0.10.0",
-]
-
-[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6017,7 +5903,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -6508,7 +6394,7 @@ checksum = "e289706df51226e84814bf6ba1a9e1013112ae29bc7a9878f73fce360520c403"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -6953,7 +6839,7 @@ checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7005,7 +6891,7 @@ checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7052,7 +6938,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7327,7 +7213,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7417,7 +7303,7 @@ dependencies = [
  "quote 1.0.10",
  "serde",
  "serde_derive",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7433,7 +7319,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7524,7 +7410,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7548,7 +7434,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7561,7 +7447,7 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "rustversion",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7601,20 +7487,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "synstructure"
@@ -7624,7 +7504,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
  "unicode-xid 0.2.2",
 ]
 
@@ -7734,7 +7614,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7769,7 +7649,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7849,7 +7729,7 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "standback",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -7936,7 +7816,7 @@ checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -8108,6 +7988,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bytes 1.1.0",
+ "flate2",
  "futures-core",
  "futures-util",
  "h2",
@@ -8120,43 +8001,9 @@ dependencies = [
  "prost 0.9.0",
  "prost-derive 0.9.0",
  "tokio",
+ "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.8",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing 0.1.33",
- "tracing-futures 0.2.5",
-]
-
-[[package]]
-name = "tonic"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fb54bf1e446f44d870d260d99957e7d11fb9d0a0f5bd1a662ad1411cc103f9"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.13.0",
- "bytes 1.1.0",
- "flate2",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project 1.0.10",
- "prost 0.10.0",
- "prost-derive 0.10.0",
- "rustls-pemfile 0.3.0",
- "tokio",
- "tokio-rustls 0.23.3",
- "tokio-stream",
- "tokio-util 0.7.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -8173,20 +8020,7 @@ dependencies = [
  "proc-macro2 1.0.32",
  "prost-build 0.9.0",
  "quote 1.0.10",
- "syn 1.0.90",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d17087af5c80e5d5fc8ba9878e60258065a0a757e35efe7a05b7904bece1943"
-dependencies = [
- "prettyplease",
- "proc-macro2 1.0.32",
- "prost-build 0.10.0",
- "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -8224,7 +8058,6 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing 0.1.33",
@@ -8286,7 +8119,7 @@ source = "git+https://github.com/tokio-rs/tracing?rev=f470db1b0354b368f62f9ee4d7
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -8297,7 +8130,7 @@ checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -8580,7 +8413,7 @@ checksum = "78cea224ddd4282dfc40d1edabbd0c020a12e946e3a48e2c2b8f6ff167ad29fe"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -8591,7 +8424,7 @@ checksum = "a46ee5bd706ff79131be9c94e7edcb82b703c487766a114434e5790361cf08c5"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -8621,7 +8454,7 @@ checksum = "e60147782cc30833c05fba3bab1d9b5771b2685a2557672ac96fa5d154099c0e"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -8932,8 +8765,8 @@ dependencies = [
  "pretty_assertions",
  "prometheus-parser",
  "proptest",
- "prost 0.10.0",
- "prost-build 0.10.0",
+ "prost 0.9.0",
+ "prost-build 0.9.0",
  "pulsar",
  "quickcheck",
  "rand 0.8.5",
@@ -8975,8 +8808,8 @@ dependencies = [
  "tokio-test",
  "tokio-util 0.6.8",
  "toml",
- "tonic 0.7.1",
- "tonic-build 0.7.0",
+ "tonic",
+ "tonic-build",
  "tower",
  "tower-test",
  "tracing 0.1.33",
@@ -9143,9 +8976,9 @@ dependencies = [
  "pin-project 1.0.10",
  "pretty_assertions",
  "proptest",
- "prost 0.10.0",
- "prost-build 0.10.0",
- "prost-types 0.10.0",
+ "prost 0.9.0",
+ "prost-build 0.9.0",
+ "prost-types 0.9.0",
  "quickcheck",
  "rand 0.8.5",
  "rand_distr",
@@ -9468,7 +9301,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
  "wasm-bindgen-shared",
 ]
 
@@ -9502,7 +9335,7 @@ checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9583,9 +9416,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki 0.22.0",
 ]
@@ -9875,7 +9708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
 dependencies = [
  "proc-macro2 1.0.32",
- "syn 1.0.90",
+ "syn 1.0.84",
  "synstructure",
 ]
 
@@ -9896,7 +9729,7 @@ checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.90",
+ "syn 1.0.84",
  "synstructure",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ rmp-serde = { version = "1.0.0", default-features = false, optional = true }
 rmpv = { version = "1.0.0", default-features = false, features = ["with-serde"], optional = true }
 
 # Prost
-prost = { version = "0.10", default-features = false, features = ["std"]  }
+prost = { version = "0.9", default-features = false, features = ["std"] }
 
 # GCP
 goauth = { version = "0.11.1", default-features = false, optional = true }
@@ -278,7 +278,7 @@ syslog = { version = "6.0.1", default-features = false, optional = true }
 tikv-jemallocator = { version = "0.4.3", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.4", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 toml = { version = "0.5.8", default-features = false }
-tonic = { version = "0.7", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "compression"] }
+tonic = { version = "0.6", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "compression"] }
 trust-dns-proto = { version = "0.21", features = ["dnssec"], optional = true }
 typetag = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
@@ -304,8 +304,8 @@ atty = "0.2.14"
 nix = "0.23.1"
 
 [build-dependencies]
-prost-build = { version = "0.10", optional = true }
-tonic-build = { version = "0.7", default-features = false, features = ["transport", "prost", "compression"], optional = true }
+prost-build = { version = "0.9", optional = true }
+tonic-build = { version = "0.6", default-features = false, features = ["transport", "prost", "compression"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { version = "0.4", default-features = false }
 derivative = { version = "2", default-features = false }
 dyn-clone = { version = "1", default-features = false }
 memchr = { version = "2", default-features = false }
-prost = { version = "0.10", default-features = false, features = ["std"] }
+prost = { version = "0.9", default-features = false, features = ["std"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
 smallvec = { version = "1", default-features = false, features = ["union"] }

--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -12,10 +12,10 @@ license = "MPL-2.0"
 indexmap = "~1.8.1"
 nom = "7.1.1"
 num_enum = "0.5.7"
-prost = "0.10"
-prost-types = "0.10"
+prost = "0.9"
+prost-types = "0.9"
 snafu = { version = "0.7" }
 vector_common = { path = "../vector-common", features = ["btreemap"] }
 
 [build-dependencies]
-prost-build = "0.10"
+prost-build = "0.9"

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -33,8 +33,8 @@ no-proxy = { version  = "0.3.1", default-features = false, features = ["serializ
 once_cell = { version = "1.10", default-features = false }
 ordered-float = { version = "2.10.0", default-features = false }
 pin-project = { version = "1.0.10", default-features = false }
-prost = { version = "0.10", default-features = false, features = ["std"] }
-prost-types = { version = "0.10", default-features = false }
+prost = { version = "0.9", default-features = false, features = ["std"] }
+prost-types = { version = "0.9", default-features = false }
 regex = { version = "1.5.5", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0.136", default-features = false, features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", default-features = false }
@@ -60,7 +60,7 @@ vector_common = { path = "../vector-common" }
 vrl-lib = { package = "vrl", path = "../vrl/vrl", optional = true }
 
 [build-dependencies]
-prost-build = "0.10"
+prost-build = "0.9"
 
 [dev-dependencies]
 base64 = "0.13.0"


### PR DESCRIPTION
This reverts commit 74b7da00a0a7c5baf1518cb5619fb134f60d1cd8.

The prost upgrade (required by newer tonic) seems to have broken the Windows CI checks. This is testing if reverting the upgrade fixes the problem before doing more investigation.