### PR TITLE
enhancement(journald source): Handle acknowledgements asynchronously

### DIFF
--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -624,7 +624,7 @@ impl Finalizer {
         shutdown: Shared<ShutdownSignal>,
     ) -> Self {
         if acknowledgements {
-            Self::Async(OrderedFinalizer::new(shutdown.clone(), move |cursor| {
+            Self::Async(OrderedFinalizer::new(shutdown, move |cursor| {
                 let checkpointer = checkpointer.clone();
                 async move {
                     checkpointer.lock().await.set(cursor).await;
@@ -723,7 +723,7 @@ impl SharedCheckpointer {
         Self(Arc::new(Mutex::new(c)))
     }
 
-    async fn lock<'a>(&'a self) -> MutexGuard<'a, StatefulCheckpointer> {
+    async fn lock(&self) -> MutexGuard<'_, StatefulCheckpointer> {
         self.0.lock().await
     }
 }

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -11,7 +11,11 @@ use crate::shutdown::ShutdownSignal;
 /// The `OrderedFinalizer` framework marks events from a source as
 /// done in a single background task *in the order they are received
 /// from the source*, using `FinalizerSet`.
-#[cfg(any(feature = "sources-file", feature = "sources-kafka",))]
+#[cfg(any(
+    feature = "sources-file",
+    feature = "sources-journald",
+    feature = "sources-kafka",
+))]
 pub(crate) type OrderedFinalizer<T> = FinalizerSet<T, FuturesOrdered<FinalizerFuture<T>>>;
 
 /// The `UnorderedFinalizer` framework marks events from a source as

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -4,6 +4,7 @@ mod encoding_config;
 #[cfg(any(
     feature = "sources-aws_sqs",
     feature = "sources-file",
+    feature = "sources-journald",
     feature = "sources-kafka",
     feature = "sources-splunk_hec"
 ))]


### PR DESCRIPTION
The journald source, as written, handles end-to-end acknowledgements
synchronously. That is, it does not read any more data until the current
batch is acknowledged. This change moves it into line with the other two
stream sources (file and kafka) by processing acknowledgements
asynchronously using the `OrderedFinalizer` framework.