### PR TITLE
fix(vrl): resolve CLI issues with local scoping

### DIFF
--- a/lib/vrl/cli/src/repl.rs
+++ b/lib/vrl/cli/src/repl.rs
@@ -51,6 +51,7 @@ pub(crate) fn run(mut objects: Vec<Value>, timezone: &TimeZone, vrl_runtime: Vrl
     let error_docs_regex = Regex::new(r"^help\serror\s(\w{1,})$").unwrap();
 
     let mut external_state = state::ExternalEnv::default();
+    let mut local_state = state::LocalEnv::default();
     let mut rt = Runtime::new(state::Runtime::default());
     let mut rl = Editor::<Repl>::new();
     rl.set_helper(Some(Repl::new()));
@@ -109,12 +110,17 @@ pub(crate) fn run(mut objects: Vec<Value>, timezone: &TimeZone, vrl_runtime: Vrl
                     &mut rt,
                     command,
                     &mut external_state,
+                    std::mem::take(&mut local_state),
                     timezone,
                     vrl_runtime,
                 );
 
                 let string = match result {
-                    Ok(v) => v.to_string(),
+                    Ok((v, local)) => {
+                        let _ = std::mem::replace(&mut local_state, local);
+
+                        v.to_string()
+                    }
                     Err(v) => v.to_string(),
                 };
 
@@ -140,22 +146,23 @@ fn resolve(
     object: Option<&mut impl Target>,
     runtime: &mut Runtime,
     program: &str,
-    state: &mut state::ExternalEnv,
+    external: &mut state::ExternalEnv,
+    local: state::LocalEnv,
     timezone: &TimeZone,
     vrl_runtime: VrlRuntime,
-) -> Result<Value, String> {
+) -> Result<(Value, state::LocalEnv), String> {
     let mut empty = value!({});
     let object = match object {
         None => &mut empty as &mut dyn Target,
         Some(object) => object,
     };
 
-    let program = match vrl::compile_with_state(program, &stdlib::all(), state) {
-        Ok(program) => program,
+    let (program, local) = match vrl::compile_for_repl(program, &stdlib::all(), external, local) {
+        Ok(result) => result,
         Err(diagnostics) => return Err(Formatter::new(program, diagnostics).colored().to_string()),
     };
 
-    execute(runtime, program, object, timezone, vrl_runtime)
+    execute(runtime, program, object, timezone, vrl_runtime).map(|value| (value, local))
 }
 
 fn execute(
@@ -277,6 +284,7 @@ impl Validator for Repl {
         ctx: &mut validate::ValidationContext,
     ) -> rustyline::Result<ValidationResult> {
         let timezone = TimeZone::default();
+        let local_state = state::LocalEnv::default();
         let mut external_state = state::ExternalEnv::default();
         let mut rt = Runtime::new(state::Runtime::default());
         let target: Option<&mut Value> = None;
@@ -286,6 +294,7 @@ impl Validator for Repl {
             &mut rt,
             ctx.input(),
             &mut external_state,
+            local_state,
             &timezone,
             VrlRuntime::Ast,
         ) {

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -30,7 +30,7 @@ use state::ExternalEnv;
 use std::{fmt::Display, str::FromStr};
 pub use type_def::TypeDef;
 
-pub type Result = std::result::Result<Program, compiler::Errors>;
+pub type Result<T = Program> = std::result::Result<T, compiler::Errors>;
 
 /// The choice of available runtimes.
 #[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq)]
@@ -77,6 +77,15 @@ pub fn compile(ast: parser::Program, fns: &[Box<dyn Function>]) -> Result {
     compile_with_state(ast, fns, &mut external)
 }
 
+pub fn compile_for_repl(
+    ast: parser::Program,
+    fns: &[Box<dyn Function>],
+    local: state::LocalEnv,
+    external: &mut ExternalEnv,
+) -> Result<(Program, state::LocalEnv)> {
+    compiler::Compiler::new_with_local_state(fns, local).compile(ast, external)
+}
+
 /// Similar to [`compile`], except that it takes a pre-generated [`State`]
 /// object, allowing running multiple successive programs based on each others
 /// state.
@@ -89,7 +98,9 @@ pub fn compile_with_state(
     fns: &[Box<dyn Function>],
     state: &mut ExternalEnv,
 ) -> Result {
-    compiler::Compiler::new(fns).compile(ast, state)
+    compiler::Compiler::new(fns)
+        .compile(ast, state)
+        .map(|(program, _)| program)
 }
 
 /// re-export of commonly used parser types.

--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -32,3 +32,14 @@ pub fn compile_with_state(
 
     compiler::compile_with_state(ast, fns, state)
 }
+
+pub fn compile_for_repl(
+    source: &str,
+    fns: &[Box<dyn Function>],
+    external: &mut state::ExternalEnv,
+    local: state::LocalEnv,
+) -> compiler::Result<(Program, state::LocalEnv)> {
+    let ast = parser::parse(source).map_err(|err| vec![Box::new(err) as _])?;
+
+    compiler::compile_for_repl(ast, fns, local, external)
+}


### PR DESCRIPTION
resolves #12204.

To clarify on this comment in this issue:

> When resolving this, we should get some more comprehensive tests that verify the scoping rules.

The issue is unrelated to the scoping feature itself, instead it was caused by a happy consequent of that feature, allowing VRL to keep internal scope... internal.

However, VRL's CLI has been a hacky side-project from the start that never got a proper do-over, and it suffers from a few issues that originate from the fact that each line in the REPL is its own VRL program. Technically, two VRL programs should share zero information between them, but because of the REPLs current implementation, we have to keep sharing internal state between programs to ensure this REPL workflow:

```
$ foo = 5
$ foo
```

works, by passing information about the variable `foo` from the first program, to the second program.

All in all, I wish this wasn't needed, but for now, I've "fixed" the broken REPL by exposing internal state publicly again (and also made sure there's a reference to the REPL needing this by naming the function `compile_for_repl`, which should also hopefully dissuade people from using this function for other use-cases).