### PR TITLE
chore(codecs): make source output types depend on codec

### DIFF
--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use value::Kind;
 use vector_core::{
-    config::log_schema,
+    config::{log_schema, DataType},
     event::{Event, LogEvent},
     schema,
 };
@@ -23,6 +23,11 @@ impl BytesDeserializerConfig {
     /// Build the `BytesDeserializer` from this configuration.
     pub fn build(&self) -> BytesDeserializer {
         BytesDeserializer::new()
+    }
+
+    /// The data type of returned events
+    pub fn output_type(&self) -> DataType {
+        DataType::Log
     }
 
     /// The schema produced by the deserializer.

--- a/lib/codecs/src/decoding/format/json.rs
+++ b/lib/codecs/src/decoding/format/json.rs
@@ -5,7 +5,11 @@ use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use std::convert::TryInto;
 use value::Kind;
-use vector_core::{config::log_schema, event::Event, schema};
+use vector_core::{
+    config::{log_schema, DataType},
+    event::Event,
+    schema,
+};
 
 /// Config used to build a `JsonDeserializer`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -15,6 +19,11 @@ impl JsonDeserializerConfig {
     /// Build the `JsonDeserializer` from this configuration.
     pub fn build(&self) -> JsonDeserializer {
         Into::<JsonDeserializer>::into(self)
+    }
+
+    /// The data type of returned events
+    pub fn output_type(&self) -> DataType {
+        DataType::Log
     }
 
     /// The schema produced by the deserializer.

--- a/lib/codecs/src/decoding/format/native.rs
+++ b/lib/codecs/src/decoding/format/native.rs
@@ -3,6 +3,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use vector_core::{
+    config::DataType,
     event::{proto, Event, EventArray, EventContainer},
     schema,
 };
@@ -17,6 +18,11 @@ impl NativeDeserializerConfig {
     /// Build the `NativeDeserializer` from this configuration.
     pub fn build(&self) -> NativeDeserializer {
         NativeDeserializer::default()
+    }
+
+    /// The data type of returned events
+    pub fn output_type(&self) -> DataType {
+        DataType::all()
     }
 
     /// The schema produced by the deserializer.

--- a/lib/codecs/src/decoding/format/native_json.rs
+++ b/lib/codecs/src/decoding/format/native_json.rs
@@ -4,7 +4,7 @@ use smallvec::{smallvec, SmallVec};
 use value::Kind;
 
 use super::Deserializer;
-use vector_core::{event::Event, schema};
+use vector_core::{config::DataType, event::Event, schema};
 
 /// Config used to build a `NativeJsonDeserializer`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -14,6 +14,11 @@ impl NativeJsonDeserializerConfig {
     /// Build the `NativeJsonDeserializer` from this configuration.
     pub const fn build(&self) -> NativeJsonDeserializer {
         NativeJsonDeserializer
+    }
+
+    /// The data type of returned events
+    pub fn output_type(&self) -> DataType {
+        DataType::all()
     }
 
     /// The schema produced by the deserializer.

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -7,7 +7,7 @@ use value::Kind;
 
 use super::Deserializer;
 use vector_core::{
-    config::log_schema,
+    config::{log_schema, DataType},
     event::{Event, Value},
     schema,
 };
@@ -20,6 +20,11 @@ impl SyslogDeserializerConfig {
     /// Build the `SyslogDeserializer` from this configuration.
     pub const fn build(&self) -> SyslogDeserializer {
         SyslogDeserializer
+    }
+
+    /// The data type of returned events
+    pub fn output_type(&self) -> DataType {
+        DataType::Log
     }
 
     /// The schema produced by the deserializer.

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -25,7 +25,7 @@ use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::fmt::Debug;
-use vector_core::{event::Event, schema};
+use vector_core::{config::DataType, event::Event, schema};
 
 /// An error that occurred while decoding structured events from a byte stream /
 /// byte messages.
@@ -257,6 +257,18 @@ impl DeserializerConfig {
             DeserializerConfig::NativeJson => {
                 Deserializer::NativeJson(NativeJsonDeserializerConfig.build())
             }
+        }
+    }
+
+    /// The data type of returned events
+    pub fn output_type(&self) -> DataType {
+        match self {
+            DeserializerConfig::Bytes => BytesDeserializerConfig.output_type(),
+            DeserializerConfig::Json => JsonDeserializerConfig.output_type(),
+            #[cfg(feature = "syslog")]
+            DeserializerConfig::Syslog => SyslogDeserializerConfig.output_type(),
+            DeserializerConfig::Native => NativeDeserializerConfig.output_type(),
+            DeserializerConfig::NativeJson => NativeJsonDeserializerConfig.output_type(),
         }
     }
 

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -8,8 +8,8 @@ use warp::Filter;
 use crate::{
     codecs::DecodingConfig,
     config::{
-        AcknowledgementsConfig, DataType, GenerateConfig, Output, Resource, SourceConfig,
-        SourceContext, SourceDescription,
+        AcknowledgementsConfig, GenerateConfig, Output, Resource, SourceConfig, SourceContext,
+        SourceDescription,
     },
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     tls::{MaybeTlsSettings, TlsConfig},
@@ -86,7 +86,7 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -4,7 +4,7 @@ use crate::common::sqs::SqsClientBuilder;
 use crate::tls::TlsOptions;
 use crate::{
     aws::{auth::AwsAuthentication, region::RegionOrEndpoint},
-    config::{AcknowledgementsConfig, DataType, Output, SourceConfig, SourceContext},
+    config::{AcknowledgementsConfig, Output, SourceConfig, SourceContext},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::aws_sqs::source::SqsSource,
 };
@@ -77,7 +77,7 @@ impl SourceConfig for AwsSqsConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -17,7 +17,7 @@ use vector_core::ByteSizeOf;
 
 use crate::{
     codecs::{Decoder, DecodingConfig},
-    config::{log_schema, DataType, Output, SourceConfig, SourceContext, SourceDescription},
+    config::{log_schema, Output, SourceConfig, SourceContext, SourceDescription},
     internal_events::{BytesReceived, DemoLogsEventProcessed, EventsReceived, StreamClosedError},
     serde::{default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
@@ -224,7 +224,7 @@ impl SourceConfig for DemoLogsConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -27,7 +27,7 @@ use vector_core::ByteSizeOf;
 use crate::{
     async_read::VecAsyncReadExt,
     codecs::{Decoder, DecodingConfig},
-    config::{log_schema, DataType, Output, SourceConfig, SourceContext, SourceDescription},
+    config::{log_schema, Output, SourceConfig, SourceContext, SourceDescription},
     event::Event,
     internal_events::{
         ExecCommandExecuted, ExecEventsReceived, ExecFailedError, ExecTimeoutError,
@@ -222,7 +222,7 @@ impl SourceConfig for ExecConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -19,8 +19,8 @@ use warp::http::{HeaderMap, StatusCode};
 use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{
-        log_schema, AcknowledgementsConfig, DataType, GenerateConfig, Output, Resource,
-        SourceConfig, SourceContext, SourceDescription,
+        log_schema, AcknowledgementsConfig, GenerateConfig, Output, Resource, SourceConfig,
+        SourceContext, SourceDescription,
     },
     event::Event,
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
@@ -108,7 +108,7 @@ impl SourceConfig for LogplexConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -192,7 +192,12 @@ impl SourceConfig for SimpleHttpConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(
+            self.decoding
+                .as_ref()
+                .map(|d| d.output_type())
+                .unwrap_or(DataType::Log),
+        )]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -25,8 +25,7 @@ use super::util::finalizer::OrderedFinalizer;
 use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{
-        log_schema, AcknowledgementsConfig, DataType, Output, SourceConfig, SourceContext,
-        SourceDescription,
+        log_schema, AcknowledgementsConfig, Output, SourceConfig, SourceContext, SourceDescription,
     },
     event::{BatchNotifier, Event, Value},
     internal_events::{
@@ -157,7 +156,7 @@ impl SourceConfig for KafkaSourceConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -9,10 +9,7 @@ use vector_core::ByteSizeOf;
 
 use crate::{
     codecs::{Decoder, DecodingConfig},
-    config::{
-        log_schema, DataType, GenerateConfig, Output, SourceConfig, SourceContext,
-        SourceDescription,
-    },
+    config::{log_schema, GenerateConfig, Output, SourceConfig, SourceContext, SourceDescription},
     event::Event,
     internal_events::{BytesReceived, NatsEventsReceived, StreamClosedError},
     nats::{from_tls_auth_config, NatsAuthConfig, NatsConfigError},
@@ -85,7 +82,7 @@ impl SourceConfig for NatsSourceConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -1,9 +1,6 @@
 use crate::{
     codecs::{Decoder, DecodingConfig},
-    config::{
-        log_schema, DataType, GenerateConfig, Output, SourceConfig, SourceContext,
-        SourceDescription,
-    },
+    config::{log_schema, GenerateConfig, Output, SourceConfig, SourceContext, SourceDescription},
     event::Event,
     internal_events::{BytesReceived, EventsReceived, StreamClosedError},
     serde::{default_decoding, default_framing_message_based},
@@ -101,7 +98,7 @@ impl SourceConfig for RedisSourceConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -46,6 +46,17 @@ impl SocketConfig {
     pub fn make_basic_tcp_config(addr: std::net::SocketAddr) -> Self {
         tcp::TcpConfig::from_address(addr.into()).into()
     }
+
+    fn output_type(&self) -> DataType {
+        match &self.mode {
+            Mode::Tcp(config) => config.decoding().output_type(),
+            Mode::Udp(config) => config.decoding().output_type(),
+            #[cfg(unix)]
+            Mode::UnixDatagram(config) => config.decoding.output_type(),
+            #[cfg(unix)]
+            Mode::UnixStream(config) => config.decoding.output_type(),
+        }
+    }
 }
 
 impl From<tcp::TcpConfig> for SocketConfig {
@@ -186,7 +197,7 @@ impl SourceConfig for SocketConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.output_type())]
     }
 
     fn source_type(&self) -> &'static str {

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -14,9 +14,7 @@ use vector_core::ByteSizeOf;
 
 use crate::{
     codecs::DecodingConfig,
-    config::{
-        log_schema, DataType, Output, Resource, SourceConfig, SourceContext, SourceDescription,
-    },
+    config::{log_schema, Output, Resource, SourceConfig, SourceContext, SourceDescription},
     internal_events::{BytesReceived, StdinEventsReceived, StreamClosedError},
     serde::{default_decoding, default_framing_stream_based},
     shutdown::ShutdownSignal,
@@ -65,7 +63,7 @@ impl SourceConfig for StdinConfig {
     }
 
     fn outputs(&self) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+        vec![Output::default(self.decoding.output_type())]
     }
 
     fn source_type(&self) -> &'static str {


### PR DESCRIPTION
Closes #12049

This covers every source that has a `DeserializerConfig`, which I believe is the correct subset.
