### PR TITLE
fix(config): ignore directories starting with a dot

### DIFF
--- a/src/config/loading/loader.rs
+++ b/src/config/loading/loader.rs
@@ -91,7 +91,15 @@ pub(super) mod process {
                         if entry.is_file() {
                             files.push(entry);
                         } else if entry.is_dir() {
-                            folders.push(entry);
+                            // do not load directories when the directory starts with a '.'
+                            if !entry
+                                .file_name()
+                                .and_then(|name| name.to_str())
+                                .map(|name| name.starts_with('.'))
+                                .unwrap_or(false)
+                            {
+                                folders.push(entry);
+                            }
                         }
                     }
                     Err(err) => {


### PR DESCRIPTION
Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

The issue https://github.com/vectordotdev/vector/issues/12042 reflected an issue when loading 

When loading the configuration in k8s, as @nicarim mentioned, some `..2022_04_15_06_27_41.1541743324` are created in the container, containing the exact same configuration. Which result in loading and merging the configuration in a `Table` structure as follow.

```
{".": Table({"entry_filter_supported": Table({"inputs": Array([String("kubernetes_logs")]), "reroute_dropped": Boolean(true), "source": String("supported_containers = [\"minimal-poc\"]"), "type": String("remap")})}), "..2022_04_15_06_27_41": Table({"entry_filter_supported": Table({"inputs": Array([String("kubernetes_logs")]), "reroute_dropped": Boolean(true), "source": String("supported_containers = [\"minimal-poc\"]"), "type": String("remap")})}), "entry_filter_supported": Table({"inputs": Array([String("kubernetes_logs")]), "reroute_dropped": Boolean(true), "source": String("supported_containers = [\"minimal-poc\"]"), "type": String("remap")})
```

Considering hidden folders (starting with a `.`) should not be loaded by vector, just avoiding those `..2022_04_15_06_27_41.1541743324` directories to be consider fixes the problem.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
