### PR TITLE
docs: note change in option behavior in 0.21.0 highlights

### DIFF
--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -26,6 +26,7 @@ Vector's 0.21.0 release includes **breaking changes**:
 11. [`kubernetes_logs` source rewritten to use `kube-rs`](#kubernetes-logs)
 12. [Published docker images no longer create implicit volumes](#docker-volume)
 13. [VRL now includes lexical scoping for blocks](#vrl-lexical-scoping)
+14. [CLI options: delimiters and wildcards](#cli-option-changes)
 
 And **deprecations**:
 
@@ -339,6 +340,22 @@ count1 = 1
 
 count1 # returns ”3”
 count2 # returns a compile-time error, because ”count2” was defined in a nested block
+```
+
+#### CLI options: delimiters and wildcards {#cli-option-changes}
+
+When using CLI options that can take multiple values, the provided values must
+be comma separated. For example:
+
+```shell
+vector --config foo.toml,bar.toml
+```
+
+Additionally when passing values that contain wildcards (`*`), these values
+must be quoted. For example:
+
+```shell
+vector --config "*.toml"
 ```
 
 ### Iteration Sneak Preview


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #12257 by documenting the change in behavior

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
