### PR TITLE
fix(nats sink,nats source): Fix handling of auth option naming

### DIFF
--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -230,10 +230,7 @@ mod integration_tests {
     use std::{thread, time::Duration};
 
     use super::*;
-    use crate::nats::{
-        NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthStrategy, NatsAuthToken,
-        NatsAuthUserPassword,
-    };
+    use crate::nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword};
     use crate::sinks::VectorSink;
     use crate::test_util::{random_lines_with_stream, random_string, trace_init};
     use crate::tls::TlsOptions;
@@ -322,22 +319,17 @@ mod integration_tests {
             subject: subject.clone(),
             url: "nats://127.0.0.1:4223".to_owned(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::UserPassword,
-                user_password: Some(NatsAuthUserPassword {
+            auth: Some(NatsAuthConfig::UserPassword {
+                user_password: NatsAuthUserPassword {
                     user: "natsuser".into(),
                     password: "natspass".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
-        let r = publish_and_check(conf).await;
-        assert!(
-            r.is_ok(),
-            "publish_and_check failed, expected Ok(()), got: {:?}",
-            r
-        );
+        publish_and_check(conf)
+            .await
+            .expect("publish_and_check failed");
     }
 
     #[tokio::test]
@@ -352,13 +344,11 @@ mod integration_tests {
             subject: subject.clone(),
             url: "nats://127.0.0.1:4224".to_owned(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::UserPassword,
-                user_password: Some(NatsAuthUserPassword {
+            auth: Some(NatsAuthConfig::UserPassword {
+                user_password: NatsAuthUserPassword {
                     user: "natsuser".into(),
                     password: "wrongpass".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -382,12 +372,10 @@ mod integration_tests {
             subject: subject.clone(),
             url: "nats://127.0.0.1:4224".to_owned(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::Token,
-                token: Some(NatsAuthToken {
+            auth: Some(NatsAuthConfig::Token {
+                token: NatsAuthToken {
                     value: "secret".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -411,12 +399,10 @@ mod integration_tests {
             subject: subject.clone(),
             url: "nats://127.0.0.1:4224".to_owned(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::Token,
-                token: Some(NatsAuthToken {
+            auth: Some(NatsAuthConfig::Token {
+                token: NatsAuthToken {
                     value: "wrongsecret".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -440,13 +426,11 @@ mod integration_tests {
             subject: subject.clone(),
             url: "nats://127.0.0.1:4225".to_owned(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::NKey,
-                nkey: Some(NatsAuthNKey {
+            auth: Some(NatsAuthConfig::Nkey {
+                nkey: NatsAuthNKey {
                     nkey: "UD345ZYSUJQD7PNCTWQPINYSO3VH4JBSADBSYUZOBT666DRASFRAWAWT".into(),
                     seed: "SUANIRXEZUROTXNFN3TJYMT27K7ZZVMD46FRIHF6KXKS4KGNVBS57YAFGY".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -470,13 +454,11 @@ mod integration_tests {
             subject: subject.clone(),
             url: "nats://127.0.0.1:4225".to_owned(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::NKey,
-                nkey: Some(NatsAuthNKey {
+            auth: Some(NatsAuthConfig::Nkey {
+                nkey: NatsAuthNKey {
                     nkey: "UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(),
                     seed: "SBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -618,12 +600,10 @@ mod integration_tests {
                     ..Default::default()
                 },
             }),
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::CredentialsFile,
-                credentials_file: Some(NatsAuthCredentialsFile {
+            auth: Some(NatsAuthConfig::CredentialsFile {
+                credentials_file: NatsAuthCredentialsFile {
                     path: "tests/data/nats.creds".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -653,12 +633,10 @@ mod integration_tests {
                     ..Default::default()
                 },
             }),
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::CredentialsFile,
-                credentials_file: Some(NatsAuthCredentialsFile {
+            auth: Some(NatsAuthConfig::CredentialsFile {
+                credentials_file: NatsAuthCredentialsFile {
                     path: "tests/data/nats-bad.creds".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -205,10 +205,7 @@ mod integration_tests {
     #![allow(clippy::print_stdout)] //tests
 
     use super::*;
-    use crate::nats::{
-        NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthStrategy, NatsAuthToken,
-        NatsAuthUserPassword,
-    };
+    use crate::nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword};
     use crate::test_util::{collect_n, random_string};
     use crate::tls::TlsOptions;
 
@@ -264,13 +261,11 @@ mod integration_tests {
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::UserPassword,
-                user_password: Some(NatsAuthUserPassword {
+            auth: Some(NatsAuthConfig::UserPassword {
+                user_password: NatsAuthUserPassword {
                     user: "natsuser".into(),
                     password: "natspass".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -294,13 +289,11 @@ mod integration_tests {
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::UserPassword,
-                user_password: Some(NatsAuthUserPassword {
+            auth: Some(NatsAuthConfig::UserPassword {
+                user_password: NatsAuthUserPassword {
                     user: "natsuser".into(),
                     password: "wrongpass".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -324,12 +317,10 @@ mod integration_tests {
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::Token,
-                token: Some(NatsAuthToken {
+            auth: Some(NatsAuthConfig::Token {
+                token: NatsAuthToken {
                     value: "secret".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -353,12 +344,10 @@ mod integration_tests {
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::Token,
-                token: Some(NatsAuthToken {
+            auth: Some(NatsAuthConfig::Token {
+                token: NatsAuthToken {
                     value: "wrongsecret".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -382,13 +371,11 @@ mod integration_tests {
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::NKey,
-                nkey: Some(NatsAuthNKey {
+            auth: Some(NatsAuthConfig::Nkey {
+                nkey: NatsAuthNKey {
                     nkey: "UD345ZYSUJQD7PNCTWQPINYSO3VH4JBSADBSYUZOBT666DRASFRAWAWT".into(),
                     seed: "SUANIRXEZUROTXNFN3TJYMT27K7ZZVMD46FRIHF6KXKS4KGNVBS57YAFGY".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -412,13 +399,11 @@ mod integration_tests {
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             tls: None,
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::NKey,
-                nkey: Some(NatsAuthNKey {
+            auth: Some(NatsAuthConfig::Nkey {
+                nkey: NatsAuthNKey {
                     nkey: "UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(),
                     seed: "SBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -560,12 +545,10 @@ mod integration_tests {
                     ..Default::default()
                 },
             }),
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::NKey,
-                credentials_file: Some(NatsAuthCredentialsFile {
+            auth: Some(NatsAuthConfig::CredentialsFile {
+                credentials_file: NatsAuthCredentialsFile {
                     path: "tests/data/nats.creds".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 
@@ -595,12 +578,10 @@ mod integration_tests {
                     ..Default::default()
                 },
             }),
-            auth: Some(NatsAuthConfig {
-                strategy: NatsAuthStrategy::NKey,
-                credentials_file: Some(NatsAuthCredentialsFile {
+            auth: Some(NatsAuthConfig::CredentialsFile {
+                credentials_file: NatsAuthCredentialsFile {
                     path: "tests/data/nats-bad.creds".into(),
-                }),
-                ..Default::default()
+                },
             }),
         };
 


### PR DESCRIPTION
The `user_password` and `credentials_file` authentication strategies, as specified in the documentation, are unusable due to using the `lowercase` renaming strategy, which renders them as `userpassword` and `credentialsfile`. This resolves that and simplifies the handling in the code by moving the options to a tagged enum.

Since these options were only just introduced in 0.21.0, and were buggy in this release, I would like your opinion on flattening the structure further. That is, instead of requiring

```toml
auth.strategy = "user_password"
auth.user_password.user = "me"
auth.user_password.password = "xyzzy"
```

flatten it out to something like:

```toml
auth.strategy = "user_password"
auth.username = "me"
auth.password = "xyzzy"
```

This would _technically_ be a breaking change, but since some of the strategies are unusable as is, maybe not?