### PR TITLE
docs: Document lack of support for `credential_process` for AWS components

### DIFF
--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -234,9 +234,15 @@ If `.value` was zero, Vector would panic. This can be fixed by handling the erro
 We have migrated sources and sinks that utilize AWS to the official AWS SDK (from Rusoto).
 This comes with some benefits such as support for IMDSv2. This requires us to deprecate some config options.
 
-If you were providing a custom path to an AWS credentials file, this is no longer supported for components that have
-been migrated. It is still possible to use a credentials file, but it should be placed in the default location (`~/.aws/credentials` on Linux, OS X, and Unix; `%userprofile%\.aws\credentials` on Microsoft Windows), or
-the location should be set with an environment variable (`AWS_CONFIG_FILE` or `AWS_SHARED_CREDENTIALS_FILE`).
+The new AWS SDK lacks support for certain authentication configuration:
+
+* Vector AWS components' `auth.credential_file` option was removed as the new [SDK does not yet support it
+  it](https://github.com/awslabs/aws-sdk-rust/issues/237). It is still possible to use a credentials file, but it should
+  be placed in the default location (`~/.aws/credentials` on Linux, OS X, and Unix; `%userprofile%\.aws\credentials` on
+  Microsoft Windows), or the location should be set with an environment variable (`AWS_CONFIG_FILE` or
+  `AWS_SHARED_CREDENTIALS_FILE`).
+* Support for `credential_process` in an AWS profile was dropped as it [not yet supported by the new
+  SDK](https://github.com/awslabs/aws-sdk-rust/issues/261).
 
 Specifying a region is now also required. Make sure a region is specified in either the AWS config file, or the Vector config.
 

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -241,7 +241,7 @@ The new AWS SDK lacks support for certain authentication configuration:
   be placed in the default location (`~/.aws/credentials` on Linux, OS X, and Unix; `%userprofile%\.aws\credentials` on
   Microsoft Windows), or the location should be set with an environment variable (`AWS_CONFIG_FILE` or
   `AWS_SHARED_CREDENTIALS_FILE`).
-- Support for `credential_process` in an AWS profile was dropped as it [not yet supported by the new
+- Support for `credential_process` in an AWS profile was dropped as it is [not yet supported by the new
   SDK](https://github.com/awslabs/aws-sdk-rust/issues/261).
 
 Specifying a region is now also required. Make sure a region is specified in either the AWS config file, or the Vector config.

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -236,12 +236,12 @@ This comes with some benefits such as support for IMDSv2. This requires us to de
 
 The new AWS SDK lacks support for certain authentication configuration:
 
-* Vector AWS components' `auth.credential_file` option was removed as the new [SDK does not yet support it
+- Vector AWS components' `auth.credential_file` option was removed as the new [SDK does not yet support it
   it](https://github.com/awslabs/aws-sdk-rust/issues/237). It is still possible to use a credentials file, but it should
   be placed in the default location (`~/.aws/credentials` on Linux, OS X, and Unix; `%userprofile%\.aws\credentials` on
   Microsoft Windows), or the location should be set with an environment variable (`AWS_CONFIG_FILE` or
   `AWS_SHARED_CREDENTIALS_FILE`).
-* Support for `credential_process` in an AWS profile was dropped as it [not yet supported by the new
+- Support for `credential_process` in an AWS profile was dropped as it [not yet supported by the new
   SDK](https://github.com/awslabs/aws-sdk-rust/issues/261).
 
 Specifying a region is now also required. Make sure a region is specified in either the AWS config file, or the Vector config.

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -158,6 +158,11 @@ components: _aws: {
 				4. The [AWS credentials file](\(urls.aws_credentials_file)) (usually located at `~/.aws/credentials`).
 				5. The [IAM instance profile](\(urls.iam_instance_profile)) (only works if running on an EC2 instance with an instance profile/role).
 
+				Note that use of
+				[`credentials_process`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html)
+				in AWS credentials files is not supported as the underlying AWS SDK currently [lacks
+				support](https://github.com/awslabs/aws-sdk-rust/issues/261).
+
 				If no credentials are found, Vector's health check fails and an error is [logged](\(urls.vector_monitoring)).
 				If your AWS credentials expire, Vector will automatically search for up-to-date
 				credentials in the places (and order) described above.


### PR DESCRIPTION
Closes: #12279

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
