### PR TITLE
fix(nats source,nats sink): Unflatten `auth` configuration

### DIFF
--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -36,6 +36,7 @@ enum BuildError {
  */
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct NatsSinkConfig {
     encoding: EncodingConfig<Encoding>,
     #[serde(default = "default_name", alias = "name")]
@@ -43,7 +44,6 @@ pub struct NatsSinkConfig {
     subject: String,
     url: String,
     tls: Option<TlsConfig>,
-    #[serde(flatten)]
     auth: Option<NatsAuthConfig>,
 }
 

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -42,7 +42,6 @@ struct NatsSourceConfig {
     subject: String,
     queue: Option<String>,
     tls: Option<TlsConfig>,
-    #[serde(flatten)]
     auth: Option<NatsAuthConfig>,
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]


### PR DESCRIPTION
The `auth` configuration for the `nats` source and sink is documented as
being a sub-object but the actual config structure labelled it with a
`flatten` attribute. When combined with the lack of
`deny_unknown_fields`, this would result in silent failure to apply any
authentication to new connections for at least the sink.

Closes #12262