### PR TITLE
fix(topology): don't panic when checking inputs for new component during reload

### DIFF
--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -49,10 +49,10 @@ pub const SOURCETYPE: &str = "splunk_sourcetype";
 /// Accepts HTTP requests.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields, default)]
-pub(self) struct SplunkConfig {
+pub struct SplunkConfig {
     /// Local address on which to listen
     #[serde(default = "default_socket_address")]
-    address: SocketAddr,
+    pub address: SocketAddr,
     /// Splunk HEC token. Deprecated - use `valid_tokens` instead
     token: Option<String>,
     /// A list of tokens to accept. Omit this to accept any token

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -643,8 +643,9 @@ impl RunningTopology {
         let trans_inputs = self.config.transforms.get(key).map(|t| &t.inputs);
         let old_inputs = sink_inputs
             .or(trans_inputs)
-            .unwrap()
+            .cloned()
             .iter()
+            .flatten()
             .cloned()
             .collect::<HashSet<_>>();
 

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -17,7 +17,6 @@ mod source_finished;
     feature = "sinks-prometheus",
     feature = "transforms-log_to_metric",
     feature = "sinks-socket",
-    feature = "leveldb"
 ))]
 mod reload;
 


### PR DESCRIPTION
As stated in the title, this fixes the issue in #12273 where a panic would occur when new components were added to a running Vector process via the normal "watch a config directory for changes" reload logic.

I also did a little work to get some topology tests running again, so there's some unrelated changes to make the tests work again in service of being able to run the actually-new test I added when fixing the true issue.