### PR TITLE
enhancement(datadog provider): Retry forbidden requests

### DIFF
--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -151,7 +151,7 @@ async fn smoke() {
 /// there should be no outbound messages from the sink. That is, receiving from
 /// its Receiver must fail.
 async fn handles_failure_v1() {
-    let (_expected, mut rx) = start_test(ApiStatus::BadRequestv1, BatchStatus::Errored).await;
+    let (_expected, mut rx) = start_test(ApiStatus::BadRequestv1, BatchStatus::Rejected).await;
     let res = rx.try_next();
 
     assert!(matches!(res, Err(TryRecvError { .. })));
@@ -164,7 +164,7 @@ async fn handles_failure_v1() {
 /// there should be no outbound messages from the sink. That is, receiving from
 /// its Receiver must fail.
 async fn handles_failure_v2() {
-    let (_expected, mut rx) = start_test(ApiStatus::BadRequestv2, BatchStatus::Errored).await;
+    let (_expected, mut rx) = start_test(ApiStatus::BadRequestv2, BatchStatus::Rejected).await;
     let res = rx.try_next();
 
     assert!(matches!(res, Err(TryRecvError { .. })));

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -29,8 +29,8 @@ use crate::{
 enum ApiStatus {
     OKv1,
     OKv2,
-    Forbiddenv1,
-    Forbiddenv2,
+    BadRequestv1,
+    BadRequestv2,
 }
 
 fn test_server(
@@ -44,7 +44,7 @@ fn test_server(
     let status = match api_status {
         ApiStatus::OKv1 => StatusCode::OK,
         ApiStatus::OKv2 => StatusCode::ACCEPTED,
-        ApiStatus::Forbiddenv1 | ApiStatus::Forbiddenv2 => StatusCode::FORBIDDEN,
+        ApiStatus::BadRequestv1 | ApiStatus::BadRequestv2 => StatusCode::BAD_REQUEST,
     };
 
     // NOTE: we pass `Trigger` out to the caller even though this suite never
@@ -147,11 +147,11 @@ async fn smoke() {
 #[tokio::test]
 /// Assert delivery error behavior for v1 API
 ///
-/// In the event that delivery fails -- in this case because it is FORBIDDEN --
+/// In the event that delivery fails -- in this case because it is BAD_REQUEST --
 /// there should be no outbound messages from the sink. That is, receiving from
 /// its Receiver must fail.
 async fn handles_failure_v1() {
-    let (_expected, mut rx) = start_test(ApiStatus::Forbiddenv1, BatchStatus::Errored).await;
+    let (_expected, mut rx) = start_test(ApiStatus::BadRequestv1, BatchStatus::Errored).await;
     let res = rx.try_next();
 
     assert!(matches!(res, Err(TryRecvError { .. })));
@@ -160,11 +160,11 @@ async fn handles_failure_v1() {
 #[tokio::test]
 /// Assert delivery error behavior for v2 API
 ///
-/// In the event that delivery fails -- in this case because it is FORBIDDEN --
+/// In the event that delivery fails -- in this case because it is BAD_REQUEST --
 /// there should be no outbound messages from the sink. That is, receiving from
 /// its Receiver must fail.
 async fn handles_failure_v2() {
-    let (_expected, mut rx) = start_test(ApiStatus::Forbiddenv2, BatchStatus::Errored).await;
+    let (_expected, mut rx) = start_test(ApiStatus::BadRequestv2, BatchStatus::Errored).await;
     let res = rx.try_next();
 
     assert!(matches!(res, Err(TryRecvError { .. })));

--- a/src/sinks/datadog/metrics/service.rs
+++ b/src/sinks/datadog/metrics/service.rs
@@ -37,6 +37,12 @@ impl RetryLogic for DatadogMetricsRetryLogic {
         let status = response.status_code;
 
         match status {
+            // This retry logic will be expanded further, but specifically retrying unauthorized
+            // requests for now. I verified using `curl` that `403` is the respose code for this.
+            //
+            // https://github.com/vectordotdev/vector/issues/10870
+            // https://github.com/vectordotdev/vector/issues/12220
+            StatusCode::FORBIDDEN => RetryAction::Retry("forbidden".into()),
             StatusCode::TOO_MANY_REQUESTS => RetryAction::Retry("too many requests".into()),
             StatusCode::NOT_IMPLEMENTED => {
                 RetryAction::DontRetry("endpoint not implemented".into())


### PR DESCRIPTION
We intend to expand out retried requests to cover a much broader swatch
(likely all requests) as part of
https://github.com/vectordotdev/vector/issues/10870 but
https://github.com/vectordotdev/vector/issues/12220 is blocking a user
from trying out Vector so adding these ahead of time.

Closes: #12220

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
