### PR TITLE
enhancement(observability): report internal logs to Datadog for enterprise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -674,7 +674,9 @@ sinks-vector = ["sinks-utils-udp", "tonic", "protobuf-build"]
 # Datadog integration
 enterprise = [
   "sources-host_metrics",
+  "sources-internal_logs",
   "sources-internal_metrics",
+  "sinks-datadog_logs",
   "sinks-datadog_metrics",
   "sha2",
   "hex"

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -338,7 +338,7 @@ pub async fn try_attach(
 
     // Create a Datadog metrics sink to consume and emit internal + host metrics.
     let datadog_metrics = DatadogMetricsConfig::enterprise(
-        api_key,
+        api_key.clone(),
         datadog.endpoint.clone(),
         datadog.site.clone(),
         datadog.region,
@@ -353,7 +353,12 @@ pub async fn try_attach(
     );
 
     // Create a Datadog logs sink to consume and emit internal logs.
-    let datadog_logs = DatadogLogsConfig::from_api_key(api_key);
+    let datadog_logs = DatadogLogsConfig::enterprise(
+        api_key,
+        datadog.endpoint.clone(),
+        datadog.site.clone(),
+        datadog.region,
+    );
 
     config.sinks.insert(
         datadog_logs_id,

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -45,7 +45,7 @@ impl SinkBatchSettings for DatadogLogsDefaultBatchSettings {
     const TIMEOUT_SECS: f64 = BATCH_DEFAULT_TIMEOUT_SECS;
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct DatadogLogsConfig {
     pub(crate) endpoint: Option<String>,
@@ -89,6 +89,15 @@ impl GenerateConfig for DatadogLogsConfig {
 }
 
 impl DatadogLogsConfig {
+    /// Creates a default [`DatadogLogsConfig`] with the given API key.
+    #[cfg(feature = "enterprise")]
+    pub fn from_api_key<T: Into<String>>(api_key: T) -> Self {
+        Self {
+            default_api_key: api_key.into(),
+            ..Self::default()
+        }
+    }
+
     // TODO: We should probably hoist this type of base URI generation so that all DD sinks can
     // utilize it, since it all follows the same pattern.
     fn get_uri(&self) -> http::Uri {

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -91,9 +91,17 @@ impl GenerateConfig for DatadogLogsConfig {
 impl DatadogLogsConfig {
     /// Creates a default [`DatadogLogsConfig`] with the given API key.
     #[cfg(feature = "enterprise")]
-    pub fn from_api_key<T: Into<String>>(api_key: T) -> Self {
+    pub fn enterprise<T: Into<String>>(
+        api_key: T,
+        endpoint: Option<String>,
+        site: Option<String>,
+        region: Option<Region>,
+    ) -> Self {
         Self {
             default_api_key: api_key.into(),
+            endpoint,
+            site,
+            region,
             ..Self::default()
         }
     }

--- a/src/sinks/datadog/logs/mod.rs
+++ b/src/sinks/datadog/logs/mod.rs
@@ -28,7 +28,8 @@ mod config;
 mod service;
 mod sink;
 
-use crate::{config::SinkDescription, sinks::datadog::logs::config::DatadogLogsConfig};
+use crate::config::SinkDescription;
+pub(crate) use config::DatadogLogsConfig;
 
 inventory::submit! {
     SinkDescription::new::<DatadogLogsConfig>("datadog_logs")

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -30,7 +30,7 @@ inventory::submit! {
 impl_generate_config_from_default!(InternalLogsConfig);
 
 impl InternalLogsConfig {
-    /// Return an internal metrics config with enterprise reporting defaults.
+    /// Return an internal logs config with enterprise reporting defaults.
     pub fn enterprise(version: impl Into<String>, configuration_key: impl Into<String>) -> Self {
         Self {
             version: Some(version.into()),

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -17,6 +17,10 @@ use crate::{
 pub struct InternalLogsConfig {
     host_key: Option<String>,
     pid_key: Option<String>,
+    #[serde(skip)]
+    configuration_key: Option<String>,
+    #[serde(skip)]
+    version: Option<String>,
 }
 
 inventory::submit! {
@@ -24,6 +28,17 @@ inventory::submit! {
 }
 
 impl_generate_config_from_default!(InternalLogsConfig);
+
+impl InternalLogsConfig {
+    /// Return an internal metrics config with enterprise reporting defaults.
+    pub fn enterprise(version: impl Into<String>, configuration_key: impl Into<String>) -> Self {
+        Self {
+            version: Some(version.into()),
+            configuration_key: Some(configuration_key.into()),
+            ..Self::default()
+        }
+    }
+}
 
 #[async_trait::async_trait]
 #[typetag::serde(name = "internal_logs")]
@@ -36,7 +51,14 @@ impl SourceConfig for InternalLogsConfig {
             .to_owned();
         let pid_key = self.pid_key.as_deref().unwrap_or("pid").to_owned();
 
-        Ok(Box::pin(run(host_key, pid_key, cx.out, cx.shutdown)))
+        Ok(Box::pin(run(
+            host_key,
+            pid_key,
+            cx.out,
+            cx.shutdown,
+            self.configuration_key.to_owned(),
+            self.version.to_owned(),
+        )))
     }
 
     fn outputs(&self) -> Vec<Output> {
@@ -57,6 +79,8 @@ async fn run(
     pid_key: String,
     mut out: SourceSender,
     shutdown: ShutdownSignal,
+    configuration_key: Option<String>,
+    version: Option<String>,
 ) -> Result<(), ()> {
     let hostname = crate::get_hostname();
     let pid = std::process::id();
@@ -89,6 +113,12 @@ async fn run(
         log.insert(pid_key.as_str(), pid);
         log.try_insert(log_schema().source_type_key(), Bytes::from("internal_logs"));
         log.try_insert(log_schema().timestamp_key(), Utc::now());
+        if let Some(ref config_key) = configuration_key {
+            log.try_insert("configuration_key", Bytes::from(config_key.clone()));
+        }
+        if let Some(ref version) = version {
+            log.try_insert("version", Bytes::from(version.clone()));
+        }
         if let Err(error) = out.send_event(Event::from(log)).await {
             // this wont trigger any infinite loop considering it stops the component
             emit!(StreamClosedError { error, count: 1 });


### PR DESCRIPTION
Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>

This PR creates an internal sink to report the internal logs to Datadog when the enterprise feature is enabled.

Closes OP-245

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
