### PR TITLE
docs: Fix links to default configurations in target spec

### DIFF
--- a/docs/specs/target.md
+++ b/docs/specs/target.md
@@ -172,8 +172,8 @@ targets as there is little added benefit.
 
 [agent_architecture]: https://vector.dev/docs/setup/going-to-prod/arch/agent/
 [aggregator_architecture]: https://vector.dev/docs/setup/going-to-prod/arch/aggregator/
-[default_agent_configuration]: https://github.com/vectordotdev/vector/blob/target-specification/config/agent/vector.yaml
-[default_aggregator_configuration]: https://vector.dev/docs/reference/configuration/default/aggregator.yaml
+[default_agent_configuration]: https://github.com/vectordotdev/vector/blob/master/config/agent/vector.yaml
+[default_aggregator_configuration]: https://github.com/vectordotdev/vector/blob/master/config/aggregator/vector.yaml
 [hardening]: https://vector.dev/docs/setup/going-to-prod/hardening/
 [high_availability]: https://vector.dev/docs/setup/going-to-prod/high-availability/
 [reduce_decisions]: https://github.com/vectordotdev/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md#be-opinionated--reduce-decisions


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
