### PR TITLE
fix(aws provider): Make region required configuration

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -77,7 +77,7 @@ pub trait ClientBuilder {
 
 pub async fn create_client<T: ClientBuilder>(
     auth: &AwsAuthentication,
-    region: Option<Region>,
+    region: Region,
     endpoint: Option<Endpoint>,
     proxy: &ProxyConfig,
     tls_options: &Option<TlsOptions>,
@@ -88,9 +88,7 @@ pub async fn create_client<T: ClientBuilder>(
         config_builder = T::with_endpoint_resolver(config_builder, endpoint_override);
     }
 
-    if let Some(region) = region {
-        config_builder = T::with_region(config_builder, region);
-    }
+    config_builder = T::with_region(config_builder, region);
 
     let tls_settings = MaybeTlsSettings::tls_client(tls_options)?;
 

--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -7,28 +7,21 @@ use std::str::FromStr;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct RegionOrEndpoint {
-    pub region: Option<String>,
+    pub region: String,
     pub endpoint: Option<String>,
 }
 
 impl RegionOrEndpoint {
     pub const fn with_region(region: String) -> Self {
         Self {
-            region: Some(region),
+            region,
             endpoint: None,
-        }
-    }
-
-    pub fn with_endpoint(endpoint: impl Into<String>) -> Self {
-        Self {
-            region: None,
-            endpoint: Some(endpoint.into()),
         }
     }
 
     pub fn with_both(region: impl Into<String>, endpoint: impl Into<String>) -> Self {
         Self {
-            region: Some(region.into()),
+            region: region.into(),
             endpoint: Some(endpoint.into()),
         }
     }
@@ -41,7 +34,7 @@ impl RegionOrEndpoint {
         }
     }
 
-    pub fn region(&self) -> Option<Region> {
-        self.region.clone().map(Region::new)
+    pub fn region(&self) -> Region {
+        Region::new(self.region.clone())
     }
 }

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -65,7 +65,7 @@ impl<'a> InternalEvent for EndpointBytesSent<'a> {
 #[cfg(feature = "aws-core")]
 pub struct AwsBytesSent {
     pub byte_size: usize,
-    pub region: Option<aws_types::region::Region>,
+    pub region: aws_types::region::Region,
 }
 
 #[cfg(feature = "aws-core")]
@@ -77,11 +77,7 @@ impl InternalEvent for AwsBytesSent {
             byte_size = %self.byte_size,
             region = ?self.region,
         );
-        let region = self
-            .region
-            .as_ref()
-            .map(|r| r.as_ref().to_string())
-            .unwrap_or_default();
+        let region = self.region.to_string();
         counter!(
             "component_sent_bytes_total", self.byte_size as u64,
             "protocol" => "https",

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -451,7 +451,7 @@ async fn cloudwatch_healthcheck() {
 
 async fn create_client_test() -> CloudwatchLogsClient {
     let auth = AwsAuthentication::test_auth();
-    let region = Some(Region::new("localstack"));
+    let region = Region::new("localstack");
     let watchlogs_address = watchlogs_address();
     let endpoint = Some(Endpoint::immutable(
         Uri::from_str(&watchlogs_address).unwrap(),

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -159,7 +159,7 @@ impl CloudWatchMetricsSinkConfig {
     async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<CloudwatchClient> {
         let region = if cfg!(test) {
             // Moto (used for mocking AWS) doesn't recognize 'custom' as valid region name
-            Some(Region::new("us-east-1"))
+            Region::new("us-east-1")
         } else {
             self.region.region()
         };
@@ -364,7 +364,7 @@ mod tests {
     fn config() -> CloudWatchMetricsSinkConfig {
         CloudWatchMetricsSinkConfig {
             default_namespace: "vector".into(),
-            region: RegionOrEndpoint::with_endpoint("local".to_owned()),
+            region: RegionOrEndpoint::with_region("local".to_owned()),
             ..Default::default()
         }
     }
@@ -510,7 +510,7 @@ mod integration_tests {
     fn config() -> CloudWatchMetricsSinkConfig {
         CloudWatchMetricsSinkConfig {
             default_namespace: "vector".into(),
-            region: RegionOrEndpoint::with_endpoint(cloudwatch_address().as_str()),
+            region: RegionOrEndpoint::with_both("local", cloudwatch_address().as_str()),
             ..Default::default()
         }
     }

--- a/src/sinks/aws_kinesis_firehose/service.rs
+++ b/src/sinks/aws_kinesis_firehose/service.rs
@@ -16,7 +16,7 @@ use aws_sdk_firehose::{Client as KinesisFirehoseClient, Region};
 #[derive(Clone)]
 pub struct KinesisService {
     pub client: KinesisFirehoseClient,
-    pub region: Option<Region>,
+    pub region: Region,
     pub stream_name: String,
 }
 

--- a/src/sinks/aws_kinesis_firehose/tests.rs
+++ b/src/sinks/aws_kinesis_firehose/tests.rs
@@ -29,7 +29,7 @@ async fn check_batch_size() {
 
     let config = KinesisFirehoseSinkConfig {
         stream_name: String::from("test"),
-        region: RegionOrEndpoint::with_endpoint("http://localhost:4566"),
+        region: RegionOrEndpoint::with_both("local", "http://localhost:4566"),
         encoding: EncodingConfig::from(StandardEncodings::Json),
         compression: Compression::None,
         batch,
@@ -57,7 +57,7 @@ async fn check_batch_events() {
 
     let config = KinesisFirehoseSinkConfig {
         stream_name: String::from("test"),
-        region: RegionOrEndpoint::with_endpoint("http://localhost:4566"),
+        region: RegionOrEndpoint::with_both("local", "http://localhost:4566"),
         encoding: EncodingConfig::from(StandardEncodings::Json),
         compression: Compression::None,
         batch,

--- a/src/sinks/aws_kinesis_streams/service.rs
+++ b/src/sinks/aws_kinesis_streams/service.rs
@@ -19,7 +19,7 @@ use aws_types::region::Region;
 pub struct KinesisService {
     pub client: KinesisClient,
     pub stream_name: String,
-    pub region: Option<Region>,
+    pub region: Region,
 }
 
 pub struct KinesisResponse {

--- a/src/sinks/aws_sqs/integration_tests.rs
+++ b/src/sinks/aws_sqs/integration_tests.rs
@@ -27,7 +27,7 @@ async fn create_test_client() -> SqsClient {
     let proxy = ProxyConfig::default();
     create_client::<SqsClientBuilder>(
         &auth,
-        Some(Region::new("localstack")),
+        Region::new("localstack"),
         Some(Endpoint::immutable(Uri::from_str(&endpoint).unwrap())),
         &proxy,
         &None,
@@ -48,7 +48,7 @@ async fn sqs_send_message_batch() {
 
     let config = SqsSinkConfig {
         queue_url: queue_url.clone(),
-        region: RegionOrEndpoint::with_endpoint(sqs_address().as_str()),
+        region: RegionOrEndpoint::with_both("local", sqs_address().as_str()),
         encoding: Encoding::Text.into(),
         message_group_id: None,
         message_deduplication_id: None,

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -70,10 +70,7 @@ impl ElasticsearchCommon {
         let http_auth = authorization.choose_one(&uri.auth)?;
         let base_url = uri.uri.to_string().trim_end_matches('/').to_owned();
 
-        let region = match &config.aws {
-            Some(region) => region.region(),
-            None => None,
-        };
+        let region = config.aws.as_ref().map(|config| config.region());
 
         let aws_auth = match &config.auth {
             Some(ElasticsearchAuth::Basic { .. }) | None => None,

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -76,11 +76,11 @@ impl DriverResponse for S3Response {
 #[derive(Clone)]
 pub struct S3Service {
     client: S3Client,
-    region: Option<Region>,
+    region: Region,
 }
 
 impl S3Service {
-    pub const fn new(client: S3Client, region: Option<Region>) -> S3Service {
+    pub const fn new(client: S3Client, region: Region) -> S3Service {
         S3Service { client, region }
     }
 

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -148,10 +148,7 @@ impl AwsS3Config {
         multiline: Option<line_agg::Config>,
         proxy: &ProxyConfig,
     ) -> crate::Result<sqs::Ingestor> {
-        let region = self
-            .region
-            .region()
-            .ok_or(CreateSqsIngestorError::RegionMissing)?;
+        let region = self.region.region();
 
         let endpoint = self
             .region
@@ -160,7 +157,7 @@ impl AwsS3Config {
 
         let s3_client = create_client::<S3ClientBuilder>(
             &self.auth,
-            Some(region.clone()),
+            region.clone(),
             endpoint.clone(),
             proxy,
             &self.tls_options,
@@ -171,7 +168,7 @@ impl AwsS3Config {
             Some(ref sqs) => {
                 let sqs_client = create_client::<SqsClientBuilder>(
                     &self.auth,
-                    Some(region.clone()),
+                    region.clone(),
                     endpoint,
                     proxy,
                     &sqs.tls_options,
@@ -205,8 +202,6 @@ enum CreateSqsIngestorError {
     Credentials { source: crate::Error },
     #[snafu(display("Configuration for `sqs` required when strategy=sqs"))]
     ConfigMissing,
-    #[snafu(display("Region is required"))]
-    RegionMissing,
     #[snafu(display("Endpoint is invalid"))]
     InvalidEndpoint,
 }
@@ -743,7 +738,7 @@ mod integration_tests {
     async fn s3_client() -> S3Client {
         let auth = AwsAuthentication::test_auth();
         let region_endpoint = RegionOrEndpoint {
-            region: Some("us-east-1".to_owned()),
+            region: "us-east-1".to_owned(),
             endpoint: Some(s3_address()),
         };
         let proxy_config = ProxyConfig::default();
@@ -761,7 +756,7 @@ mod integration_tests {
     async fn sqs_client() -> SqsClient {
         let auth = AwsAuthentication::test_auth();
         let region_endpoint = RegionOrEndpoint {
-            region: Some("us-east-1".to_owned()),
+            region: "us-east-1".to_owned(),
             endpoint: Some(s3_address()),
         };
         let proxy_config = ProxyConfig::default();

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -54,19 +54,17 @@ components: _aws: {
 		}
 
 		endpoint: {
-			common:        false
-			description:   "Custom endpoint for use with AWS-compatible services."
-			relevant_when: "region = null"
-			required:      false
+			common:      false
+			description: "Custom endpoint for use with AWS-compatible services."
+			required:    false
 			type: string: {
 				default: null
-				examples: ["127.0.0.0:5000/path/to/service"]
+				examples: ["http://127.0.0.0:5000/path/to/service"]
 			}
 		}
 		region: {
-			description:   "The [AWS region](\(urls.aws_regions)) of the target service. If `endpoint` is provided it will override this value since the endpoint includes the region."
-			required:      true
-			relevant_when: "endpoint = null"
+			description: "The [AWS region](\(urls.aws_regions)) of the target service."
+			required:    true
 			type: string: {
 				examples: ["us-east-1"]
 			}


### PR DESCRIPTION
As of 0.21.0 where the new AWS SDK was integrated, `region`, is now
required by the client. If not provided, it fails at runtime to make
requests. Instead, make it a required configuration field.

Closes: #12311

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
