### PR TITLE
docs: update link to releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Vector**][docs.installation].
 ### Resources
 
 * [**Community**][urls.vector_community] - [chat][urls.vector_chat], [calendar][urls.vector_calendar], [@vectordotdev][urls.vector_twitter]
-* [**Releases**][urls.vector_releases] - [latest][urls.vector_releases]
+* [**Releases**][urls.vector_releases]
 * [**Roadmap**][urls.vector_roadmap] - [vote on new features][urls.vote_feature]
 * **Policies** - [Code of Conduct][urls.vector_code_of_conduct], [Privacy][urls.vector_privacy_policy], [Releases][urls.vector_releases_policy], [Security][urls.vector_security_policy], [Versioning][urls.vector_versioning_policy]
 
@@ -219,7 +219,7 @@ Vector is an end-to-end, unified, open data platform.
 [urls.vector_community]: https://vector.dev/community/
 [urls.vector_privacy_policy]: https://github.com/vectordotdev/vector/blob/master/PRIVACY.md
 [urls.vector_release_policy]: https://github.com/vectordotdev/vector/blob/master/RELEASING.md
-[urls.vector_releases]: https://vector.dev/releases/latest/
+[urls.vector_releases]: https://vector.dev/releases/
 [urls.vector_releases_policy]: https://github.com/vectordotdev/vector/blob/master/RELEASES.md
 [urls.vector_roadmap]: https://roadmap.vector.dev
 [urls.vector_security_policy]: https://github.com/vectordotdev/vector/security/policy


### PR DESCRIPTION
The current link referes to `latest` which 404's.
Also, remove the `latest` reference since releases are ordered by newest first and, consequently, a visit to said page would show the latest.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
