### PR TITLE
chore(vrl): improve collection "kind" display

### DIFF
--- a/lib/value/src/kind.rs
+++ b/lib/value/src/kind.rs
@@ -47,6 +47,16 @@ impl std::fmt::Display for Kind {
             return f.write_str("any");
         }
 
+        // For collections, we expand to a more descriptive representation only
+        // if the type can only be this collection.
+        if self.is_exact() {
+            if let Some(object) = &self.object {
+                return object.fmt(f);
+            } else if let Some(array) = &self.array {
+                return array.fmt(f);
+            }
+        }
+
         let mut kinds = vec![];
 
         if self.contains_bytes() {


### PR DESCRIPTION
This improves the `Display` implementation of `value::Kind`, in preparation of iteration support in VRL.

ref #12317