### PR TITLE
fix(internal_metrics source): Fix setting of host/pid tags

### DIFF
--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -71,20 +71,16 @@ impl SourceConfig for InternalMetricsConfig {
         let version = self.version.clone();
         let configuration_key = self.configuration_key.clone();
 
-        let host_key = self.tags.host_key.as_deref().and_then(|tag| {
-            if tag.is_empty() {
-                None
-            } else {
-                Some(tag.to_owned())
-            }
-        });
-        let pid_key = self.tags.pid_key.as_deref().and_then(|tag| {
-            if tag.is_empty() {
-                None
-            } else {
-                Some(tag.to_owned())
-            }
-        });
+        let host_key = self
+            .tags
+            .host_key
+            .as_deref()
+            .and_then(|tag| (!tag.is_empty()).then(|| tag.to_owned()));
+        let pid_key = self
+            .tags
+            .pid_key
+            .as_deref()
+            .and_then(|tag| (!tag.is_empty()).then(|| tag.to_owned()));
         Ok(Box::pin(run(
             namespace,
             version,

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -68,10 +68,12 @@ components: sources: internal_metrics: {
 						description: """
 				The key name added to each event representing the current host. This can also be globally set via the
 				[global `host_key` option](\(urls.vector_configuration)/global-options#log_schema.host_key).
+
+				Set to "" to suppress this key.
 				"""
 						required:    false
 						type: string: {
-							default: null
+							default: "host"
 						}
 					}
 					pid_key: {
@@ -79,10 +81,12 @@ components: sources: internal_metrics: {
 						common:   false
 						description: """
 					The key name added to each event representing the current process ID.
+
+					Set to "" to suppress this key.
 					"""
 						required: false
 						type: string: {
-							default: null
+							default: "pid"
 						}
 					}
 				}

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -68,12 +68,10 @@ components: sources: internal_metrics: {
 						description: """
 				The key name added to each event representing the current host. This can also be globally set via the
 				[global `host_key` option](\(urls.vector_configuration)/global-options#log_schema.host_key).
-
-				Set to "" to suppress this key.
 				"""
 						required:    false
 						type: string: {
-							default: "host"
+							default: null
 						}
 					}
 					pid_key: {
@@ -81,12 +79,10 @@ components: sources: internal_metrics: {
 						common:   false
 						description: """
 					The key name added to each event representing the current process ID.
-
-					Set to "" to suppress this key.
 					"""
 						required: false
 						type: string: {
-							default: "pid"
+							default: null
 						}
 					}
 				}


### PR DESCRIPTION
The current implementation is incorrect as it only adds the tags if the
tag is specified in the config (not matching the documentation) but then
also ignores the provided key value.

Given we aren't currently setting a default for this, I opt'd to update
the docs to reflect that since this seemed less disruptive than adding
the tags by default for everyone.

**EDIT**: extracted docs updates to https://github.com/vectordotdev/vector/pull/12321

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
