### PR TITLE
chore: Mark `vector config` as experimental

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,7 +179,7 @@ pub enum SubCommand {
     /// Generate a Vector configuration containing a list of components.
     Generate(generate::Opts),
 
-    /// Output a provided Vector configuration file/dir as a single JSON object, useful for checking in to version control.
+    /// (experimental) Output a provided Vector configuration file/dir as a single JSON object, useful for checking in to version control.
     Config(config::Opts),
 
     /// List available components, then exit.


### PR DESCRIPTION
This wasn't intended to be publicly released but I don't see a great way
to hide it from `-h` output without some significant refactoring.
Instead, just mark as experimental.

We'll want a bit more QA around this subcommand before marking it
stable. For example, it lacks support for the normal `--config` flags or
an output format.

Fixes: #12325 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
