### PR TITLE
fix(vrl): return correct type def for root path

### DIFF
--- a/lib/vrl/compiler/src/test_util.rs
+++ b/lib/vrl/compiler/src/test_util.rs
@@ -212,6 +212,6 @@ macro_rules! type_def {
     }};
 
     (array) => {
-        TypeDef::array(::std::collections::BTreeMap::default())
+        TypeDef::array(value::kind::Collection::any())
     };
 }


### PR DESCRIPTION
This PR fixes the type definition returned by `.` in VRL (and the `parse_xml` function).

Specifically, there's a nuanced difference between these two:

```rust
Kind::object(BTreeMap::default())
Kind::object(Collection::any())
```

The former initializes an object kind that has zero known fields, and no unknown fields (e.g. it's an object that is known to be empty).

The latter does the same, but the unknown fields are set to "any" (e.g. it's an object with no known fields, and any number and kind of unknown fields, or an object for which there is no type information for the inner elements).

This was used correctly in 99% of the cases, except (crucially) in these two places.

ref #12317