### PR TITLE
chore(vrl): allow ignoring cue during test runs

### DIFF
--- a/lib/vrl/tests/src/docs.rs
+++ b/lib/vrl/tests/src/docs.rs
@@ -74,7 +74,11 @@ pub enum Error {
     Runtime(String),
 }
 
-pub fn tests() -> Vec<Test> {
+pub fn tests(ignore_cue: bool) -> Vec<Test> {
+    if ignore_cue {
+        return vec![];
+    }
+
     let dir = fs::canonicalize("../../../scripts").unwrap();
 
     let output = Command::new("bash")

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -51,6 +51,10 @@ pub struct Cmd {
     /// Should we use the VM to evaluate the VRL
     #[clap(short, long = "runtime", default_value_t)]
     runtime: VrlRuntime,
+
+    /// Ignore the Cue tests (to speed up run)
+    #[clap(long)]
+    ignore_cue: bool,
 }
 
 impl Cmd {
@@ -115,7 +119,7 @@ fn main() {
 
             tests.into_iter()
         })
-        .chain(docs::tests().into_iter())
+        .chain(docs::tests(cmd.ignore_cue).into_iter())
         .filter(|test| should_run(&format!("{}/{}", test.category, test.name), &cmd.pattern))
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
Small PR to allow speeding up VRL test runs during development.

ref: #12317