### PR TITLE
chore(vrl): add syntax support for function closures

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -419,6 +419,7 @@ impl<'a> Compiler<'a> {
             ident,
             abort_on_error,
             arguments,
+            ..
         } = node.into_inner();
 
         let arguments = arguments

--- a/lib/vrl/parser/src/arbitrary.rs
+++ b/lib/vrl/parser/src/arbitrary.rs
@@ -262,6 +262,7 @@ impl<'a> ArbitraryDepth<'a> for FunctionCall {
             ident,
             abort_on_error,
             arguments,
+            closure: None,
         })
     }
 }

--- a/lib/vrl/parser/src/ast.rs
+++ b/lib/vrl/parser/src/ast.rs
@@ -77,6 +77,13 @@ impl<T> Node<T> {
 
         (span.start(), node, span.end())
     }
+
+    pub fn as_deref(&self) -> &T::Target
+    where
+        T: Deref,
+    {
+        self.as_ref().deref()
+    }
 }
 
 impl<T: fmt::Debug> fmt::Debug for Node<T> {
@@ -299,6 +306,12 @@ impl fmt::Display for Ident {
 impl fmt::Debug for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ident({})", self.0)
+    }
+}
+
+impl From<String> for Ident {
+    fn from(ident: String) -> Self {
+        Ident(ident)
     }
 }
 
@@ -748,6 +761,7 @@ impl FromStr for Opcode {
 // -----------------------------------------------------------------------------
 
 #[derive(Clone, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum Assignment {
     Single {
         target: Node<AssignmentTarget>,
@@ -954,6 +968,7 @@ pub struct FunctionCall {
     pub ident: Node<Ident>,
     pub abort_on_error: bool,
     pub arguments: Vec<Node<FunctionArgument>>,
+    pub closure: Option<Node<FunctionClosure>>,
 }
 
 impl fmt::Display for FunctionCall {
@@ -970,7 +985,14 @@ impl fmt::Display for FunctionCall {
             }
         }
 
-        f.write_str(")")
+        f.write_str(")")?;
+
+        if let Some(closure) = &self.closure {
+            f.write_str(" ")?;
+            closure.fmt(f)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -990,7 +1012,14 @@ impl fmt::Debug for FunctionCall {
             }
         }
 
-        f.write_str("))")
+        f.write_str(")")?;
+
+        if let Some(closure) = &self.closure {
+            f.write_str(" ")?;
+            closure.fmt(f)?;
+        }
+
+        f.write_str(")")
     }
 }
 
@@ -1023,6 +1052,47 @@ impl fmt::Debug for FunctionArgument {
         } else {
             write!(f, "Argument({:?})", self.expr)
         }
+    }
+}
+
+/// A closure attached to a function.
+#[derive(Clone, PartialEq)]
+pub struct FunctionClosure {
+    pub variables: Vec<Node<Ident>>,
+    pub block: Node<Block>,
+}
+
+impl fmt::Display for FunctionClosure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("-> |")?;
+
+        let mut iter = self.variables.iter().peekable();
+        while let Some(var) = iter.next() {
+            var.fmt(f)?;
+
+            if iter.peek().is_some() {
+                f.write_str(", ")?;
+            }
+        }
+
+        f.write_str("| {\n")?;
+
+        let mut iter = self.block.0.iter().peekable();
+        while let Some(expr) = iter.next() {
+            f.write_str("\t")?;
+            expr.fmt(f)?;
+            if iter.peek().is_some() {
+                f.write_str("\n")?;
+            }
+        }
+
+        f.write_str("\n}")
+    }
+}
+
+impl fmt::Debug for FunctionClosure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Closure(...)")
     }
 }
 

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -260,6 +260,7 @@ pub enum Token<S> {
     SemiColon,
     Underscore,
     Escape,
+    Arrow,
 
     Equals,
     MergeEquals,
@@ -345,6 +346,7 @@ impl<S> Token<S> {
             SemiColon => SemiColon,
             Underscore => Underscore,
             Escape => Escape,
+            Arrow => Arrow,
 
             Equals => Equals,
             MergeEquals => MergeEquals,
@@ -399,6 +401,7 @@ where
             SemiColon => "SemiColon",
             Underscore => "Underscore",
             Escape => "Escape",
+            Arrow => "Arrow",
 
             Equals => "Equals",
             MergeEquals => "MergeEquals",
@@ -591,6 +594,11 @@ impl<'input> Iterator for Lexer<'input> {
 
                     '!' if self.test_peek(|ch| ch == '!' || !is_operator(ch)) => {
                         Some(Ok(self.token(start, Bang)))
+                    }
+
+                    '-' if self.test_peek(|ch| ch == '>') => {
+                        let _ = self.bump();
+                        Some(Ok(self.token(start, Arrow)))
                     }
 
                     '#' => {
@@ -2019,6 +2027,62 @@ mod test {
                 StringSegment::Literal(" zoog".to_string(), Span::new(16, 21)),
             ]),
             string.template(Span::new(0, 22))
+        );
+    }
+
+    #[test]
+    fn function_closure_no_arg() {
+        test(
+            data("foo() -> || {}"),
+            vec![
+                ("~~~           ", FunctionCall("foo")),
+                ("   ~          ", LParen),
+                ("    ~         ", RParen),
+                ("      ~~      ", Arrow),
+                ("         ~~   ", Operator("||")),
+                ("            ~ ", LBrace),
+                ("             ~", RBrace),
+            ],
+        );
+    }
+
+    #[test]
+    fn function_closure_single_arg() {
+        test(
+            data("foo() -> |idx| { idx }"),
+            vec![
+                ("~~~                   ", FunctionCall("foo")),
+                ("   ~                  ", LParen),
+                ("    ~                 ", RParen),
+                ("      ~~              ", Arrow),
+                ("         ~            ", Operator("|")),
+                ("          ~~~         ", Identifier("idx")),
+                ("             ~        ", Operator("|")),
+                ("               ~      ", LBrace),
+                ("                 ~~~  ", Identifier("idx")),
+                ("                     ~", RBrace),
+            ],
+        );
+    }
+
+    #[test]
+    fn function_closure_args() {
+        test(
+            data("foo() -> |i, v| { v }"),
+            vec![
+                ("~~~                  ", FunctionCall("foo")),
+                ("   ~                 ", LParen),
+                ("    ~                ", RParen),
+                ("      ~~             ", Arrow),
+                ("         ~           ", Operator("|")),
+                ("          ~          ", Identifier("i")),
+                ("           ~         ", Comma),
+                ("             ~       ", Identifier("v")),
+                ("              ~      ", Operator("|")),
+                ("                ~    ", LBrace),
+                ("                  ~  ", Identifier("v")),
+                ("                    ~", RBrace),
+            ],
         );
     }
 }

--- a/lib/vrl/parser/src/parser.lalrpop
+++ b/lib/vrl/parser/src/parser.lalrpop
@@ -50,6 +50,7 @@ extern {
         ":" => Token::Colon,
         "." => Token::Dot,
         "!" => Token::Bang,
+        "->" => Token::Arrow,
 
         "+" => Token::Operator("+"),
         "*" => Token::Operator("*"),
@@ -371,18 +372,37 @@ FunctionCall: FunctionCall = {
     <ident: Sp<"function call">> <abort_on_error: "!"?> "("
         NonterminalNewline*
         <arguments: CommaMultiline<Sp<FunctionArgument>>?>
-    ")" => {
+    ")" <closure: Sp<FunctionClosure>?> => {
         let ident = ident.map(|s| Ident(s.to_owned()));
         let abort_on_error = abort_on_error.is_some();
         let arguments = arguments.unwrap_or_default();
 
-        FunctionCall { ident, abort_on_error, arguments }
+        FunctionCall { ident, abort_on_error, arguments, closure }
     },
 };
 
 #[inline]
 FunctionArgument: FunctionArgument = {
     <ident: (<Sp<AnyIdent>> ":")?> <expr: ArithmeticExpr> => FunctionArgument { <> },
+};
+
+#[inline]
+FunctionClosure: FunctionClosure = {
+    "->" <variables: ClosureVariables> NonterminalNewline* <block: Sp<Block>> =>
+        FunctionClosure { variables, block }
+};
+
+#[inline]
+ClosureVariables: Vec<Node<Ident>> = {
+    "||" => vec![],
+    "|" <variables: CommaMultiline<ClosureVariable>?> "|" =>
+        variables.unwrap_or_default()
+};
+
+#[inline]
+ClosureVariable: Node<Ident> = {
+    Sp<Ident> => <>,
+    Sp<"_"> => <>.map(|s| Ident("".to_owned())),
 };
 
 // -----------------------------------------------------------------------------

--- a/lib/vrl/proptests/src/main.rs
+++ b/lib/vrl/proptests/src/main.rs
@@ -144,7 +144,8 @@ prop_compose! {
             arguments: params.into_iter().map(|p| node(FunctionArgument {
                 ident: None,
                 expr: node(Expr::Variable(node(p)))
-            })).collect()
+            })).collect(),
+            closure: None,
         }
     }
 }
@@ -262,6 +263,7 @@ fn expr() -> impl Strategy<Value = Expr> {
                                 })
                             })
                             .collect(),
+                        closure: None,
                     }))
                 }
             ),


### PR DESCRIPTION
This PR adds syntactic support for function closures in VRL. This will be used to allow function calls to iterate over collections in an upcoming follow-up PR.

In its current form, the syntax is supported, but unused.

ref #12317