### PR TITLE
fix(cli): Use user-provided array values in vector config --include-defaults

### DIFF
--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -105,9 +105,6 @@ mod tests {
 
         merge_json(&mut json, to_override);
 
-        assert_eq!(
-            *json.get("arr").unwrap(),
-            json!(["value3", "value4"])
-        )
+        assert_eq!(*json.get("arr").unwrap(), json!(["value3", "value4"]))
     }
 }

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -90,24 +90,24 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_array_concat() {
+    fn test_array_override() {
         let mut json = json!({
             "arr": [
                 "value1", "value2"
             ]
         });
 
-        let to_add = json!({
+        let to_override = json!({
             "arr": [
                 "value3", "value4"
             ]
         });
 
-        merge_json(&mut json, to_add);
+        merge_json(&mut json, to_override);
 
         assert_eq!(
             *json.get("arr").unwrap(),
-            json!(["value1", "value2", "value3", "value4"])
+            json!(["value3", "value4"])
         )
     }
 }

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -26,9 +26,6 @@ fn merge_json(a: &mut Value, b: Value) {
         (Value::Array(ref mut a), Value::Object(b)) => {
             a.extend([Value::Object(b)]);
         }
-        (Value::Array(ref mut a), Value::Array(b)) => {
-            a.extend(b);
-        }
         (a, b) => {
             *a = b;
         }

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -23,9 +23,6 @@ fn merge_json(a: &mut Value, b: Value) {
                 merge_json(a.entry(k).or_insert(Value::Null), v);
             }
         }
-        (Value::Array(ref mut a), Value::Object(b)) => {
-            a.extend([Value::Object(b)]);
-        }
         (a, b) => {
             *a = b;
         }


### PR DESCRIPTION
Closes #12329 

This PR adjusts `vector config --include-defaults` behavior to directly use user-provided array values rather than merge them with the related `ConfigBuilder`'s array values. This avoids duplicates.

### Example

With the following configuration,
```
[sources.source0]
type = "stdin"

[sinks.sink0]
type = "blackhole"
inputs = ["*"]
```

Running 

```
vector -c {{your config path}} config --include-defaults
```

should generate the following  (trimmed for brevity). Previously, this output would include `inputs: ["*", "*"]`.

```
{
 ...
  "sinks": {
    "sink0": {
      ...
      "inputs": [
        "*"
      ],
      ...
    }
  ...
}
```

