### PR TITLE
fix(config): Deny unknown options in TLS settings

### DIFF
--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -57,6 +57,7 @@ impl TlsConfig {
 
 /// Standard TLS options
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TlsOptions {
     pub verify_certificate: Option<bool>,
     pub verify_hostname: Option<bool>,


### PR DESCRIPTION
The standard TLS options structure was missing the
`deny_unknown_fields`, leading to the ability to set (for example)
`tls.enabled = true` on components that have no support for that flag

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
