### PR TITLE
chore(ci): Install protoc from Google instead of apt on Ubuntu

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -37,7 +37,6 @@ apt install --yes \
     nodejs \
     npm \
     pkg-config \
-    protobuf-compiler \
     python3-pip \
     rename \
     rpm \
@@ -102,6 +101,17 @@ if ! [ -x "$(command -v docker)" ]; then
     # ubuntu user doesn't exist in scripts/environment/Dockerfile which runs this
     usermod --append --groups docker ubuntu || true
 fi
+
+# Protoc. No guard because we want to override Ubuntu's old version in
+# case it is already installed by a dependency.
+PROTOC_VERSION=3.19.4
+PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \
+     --output $TEMP/$PROTOC_ZIP
+unzip $TEMP/$PROTOC_ZIP bin/protoc
+# .cargo/bin is in $PATH ahead of anything else, so this will make it
+# override any system-installed protoc
+mv bin/protoc $HOME/.cargo/bin
 
 # Apt cleanup
 apt clean


### PR DESCRIPTION
The version of the protobuf compiler on Ubuntu is pretty ancient, so
download the pre-compiled version from Google that matches the version
that is vendored in the `prost-build` crate.

This should _hopefully_ resolve the `dnstap` integration test failures.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
