### PR TITLE
docs(external docs): added documentation for template strings

### DIFF
--- a/website/cue/reference/remap/literals/string.cue
+++ b/website/cue/reference/remap/literals/string.cue
@@ -52,7 +52,7 @@ remap: literals: string: {
 				"\\0":       "Null"
 				"\\\"":      "Double quote"
 				"\\'":       "Single quote"
-				"\\{{":      "Double brace"
+				"\\{":       "Brace"
 			}
 		}
 		templates: {

--- a/website/cue/reference/remap/literals/string.cue
+++ b/website/cue/reference/remap/literals/string.cue
@@ -11,7 +11,8 @@ remap: literals: string: {
 
 		**Interpreted string** literals are character sequences between double quotes (`"..."`). Within the quotes,
 		any character may appear except unescaped newline and unescaped double quote. The text between the quotes forms the result
-		of the literal, with backslash escapes interpreted as defined below.
+		of the literal, with backslash escapes interpreted as defined below. Strings can be templated by enclosing
+		variables in `{{..}}`. The value of the variables are inserted into the string at that position.
 		"""
 
 	examples: [
@@ -24,6 +25,9 @@ remap: literals: string: {
 		#"""
 			"Hello, \
 			 world!"
+			"""#,
+		#"""
+			"Hello, {{ planet }}!"
 			"""#,
 		#"""
 			s'Hello, world!'
@@ -48,7 +52,18 @@ remap: literals: string: {
 				"\\0":       "Null"
 				"\\\"":      "Double quote"
 				"\\'":       "Single quote"
+				"\\{{":      "Double brace"
 			}
+		}
+		templates: {
+			title: "Templates"
+			description: """
+				Strings can be templated by enclosing a variable name with `{{..}}`. The
+				value of the variable is inserted into the string at this position at runtime.
+				The variable has to be a string. Only variables are supported, if you want to
+				insert a path from the event you must assign it to a variable first. To insert
+				a `{{` into the string it can be escaped with a `\\` escape: `\\{{..\\}}`.
+				"""
 		}
 		multiline_strings: {
 			title: "Multiline strings"

--- a/website/cue/reference/remap/literals/string.cue
+++ b/website/cue/reference/remap/literals/string.cue
@@ -60,9 +60,11 @@ remap: literals: string: {
 			description: """
 				Strings can be templated by enclosing a variable name with `{{..}}`. The
 				value of the variable is inserted into the string at this position at runtime.
-				The variable has to be a string. Only variables are supported, if you want to
-				insert a path from the event you must assign it to a variable first. To insert
-				a `{{` into the string it can be escaped with a `\\` escape: `\\{{..\\}}`.
+				Currently, the variable has to be a string. Only variables are supported, if
+				you want to insert a path from the event you must assign it to a variable
+				first. To insert a `{{` into the string it can be escaped with a `\\`
+				escape: `\\{{..\\}}`. We plan to expand this in future to allow paths and
+				format strings to enable non string variables.
 				"""
 		}
 		multiline_strings: {


### PR DESCRIPTION
ref #7117 

This adds some documentation for template strings to the [VRL reference](https://vector.dev/docs/reference/vrl/expressions/).

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>