### PR TITLE
chore(ci): Fix config for named used in the dnstap integration tests

### DIFF
--- a/tests/data/dnstap/named.conf.options.template
+++ b/tests/data/dnstap/named.conf.options.template
@@ -3,7 +3,6 @@ options {
         dnstap { all; };
         dnstap-output unix "/etc/bind/socket/dnstap.sock#";
         listen-on-v6 { none; };
-        dnssec-enable no;
         dnssec-validation no;
 };
 


### PR DESCRIPTION
The new image for bind has dropped the `dnssec-enable` setting and now
fails to run with it present.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
