### PR TITLE
fix(vrl): allow a single brace to be escaped

### DIFF
--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -1247,6 +1247,7 @@ fn unescape_string_literal(mut s: &str) -> String {
                 b'n' => '\n',
                 b'r' => '\r',
                 b't' => '\t',
+                b'{' => '{',
                 _ => unimplemented!("invalid escape"),
             };
 


### PR DESCRIPTION
Closes #12364 

VRL templates needs to treat `{` as an escapable character to handle escaping template delimiters - `\{{`. However if you have a string with a single `{` - `"\{"` - it wasn't properly escaping it and was panicking instead.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>