### PR TITLE
fix(ci): ensure the example folder is validated with namespacing

### DIFF
--- a/config/examples/namespacing/sinks/es_cluster.toml
+++ b/config/examples/namespacing/sinks/es_cluster.toml
@@ -1,5 +1,5 @@
 # Send structured data to a short-term storage
 inputs       = ["apache_sample"]            # only take sampled data
 type         = "elasticsearch"
-host         = "http://79.12.221.222:9200"   # local or external host
-index        = "vector-%Y-%m-%d"             # daily indices
+endpoint     = "http://79.12.221.222:9200"   # local or external host
+bulk.index   = "vector-%Y-%m-%d"             # daily indices

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 #
 #   Ensures that all examples are valid
 
-for config in ./config/**/*.toml ; do
-  cargo run -- validate --deny-warnings --no-environment "$config"
+for config in ./config/examples/* ; do
+  if [ -d "$config" ]; then
+    cargo run -- validate --deny-warnings --no-environment --config-dir "$config"
+  else
+    cargo run -- validate --deny-warnings --no-environment "$config"
+  fi
 done


### PR DESCRIPTION
For now, each `toml` file in the `config/examples` folder were validated individually. Therefore, the `namespacing` folder was not properly validated.
With this fix, every file/folder in the `config/examples` is validated as a single file or as a config folder.

Closes OP-148