### PR TITLE
docs: fix typo in 0.21.1 release note

### DIFF
--- a/website/cue/reference/releases/0.21.1.cue
+++ b/website/cue/reference/releases/0.21.1.cue
@@ -34,7 +34,7 @@ releases: "0.21.1": {
 			type: "fix"
 			scopes: ["kubernetes_logs source"]
 			description: """
-				The `kubernetes_logs` no longer panicks whenever an error is received from the Kubernetes API watch
+				The `kubernetes_logs` no longer panics whenever an error is received from the Kubernetes API watch
 				stream.
 				"""
 			pr_numbers: [12248]
@@ -79,7 +79,7 @@ releases: "0.21.1": {
 			type: "fix"
 			scopes: ["config"]
 			description: """
-				Vector no longer panicks when used with configuration options that take event paths such as `encoding.only_fields`.
+				Vector no longer panics when used with configuration options that take event paths such as `encoding.only_fields`.
 				"""
 			pr_numbers: [12306]
 		},


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Make "panics" consistent with others.