### PR TITLE
fix(vrl): update type definition of parent scopes when needed

### DIFF
--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -23,6 +23,17 @@ impl LocalEnv {
     pub(crate) fn insert_variable(&mut self, ident: Ident, details: assignment::Details) {
         self.bindings.insert(ident, details);
     }
+
+    /// Merge state present in both `self` and `other`.
+    pub(crate) fn merge_mutations(mut self, other: Self) -> Self {
+        for (ident, other_details) in other.bindings.into_iter() {
+            if let Some(self_details) = self.bindings.get_mut(&ident) {
+                *self_details = other_details;
+            }
+        }
+
+        self
+    }
 }
 
 /// A lexical scope within the program.

--- a/lib/vrl/tests/tests/expressions/block/scoping.vrl
+++ b/lib/vrl/tests/tests/expressions/block/scoping.vrl
@@ -1,11 +1,11 @@
-# result: [5, 7, 6]
+# result: [5, 7, "FOO"]
 
 foo = 5
 result = [foo]
 
 {
   # overwrite existing variable
-  foo = 6
+  foo = "foo"
 
   # instantiate new variable
   bar = 7
@@ -19,5 +19,6 @@ result = [foo]
 # result = push(result, bar)
 
 # variable is overwritten in inner scope
-push(result, foo)
-
+#
+# `upcase` proves type definition is also changed
+push(result, upcase(foo))


### PR DESCRIPTION
This PR fixes type definition tracking of lexical scopes. Lexical scopes were introduced in #12017, but due to an oversight, changes in the type definition of parent variables within blocks weren't correctly propagated back up the chain.

Essentially, given this:

```coffee
foo = 1
{ foo = "bar" }
upcase(foo)
```

Would fail, stating that `foo` in `upcase(foo)` is an integer, while the nested scope on line 2 changed it to a string.

It's worth pointing out that this _only_ affected changes in type definitions, the variables themselves would still be mutated as expected at runtime, e.g. this works even without this PR:

```coffee
foo = 1
{ foo = foo + 1 }
foo # 2
```

fixes #12381