### PR TITLE
feat(vrl): warning on if-statement predicate that always/never succeeds

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -289,7 +289,11 @@ impl<'a> Compiler<'a> {
             Many(nodes) => self.compile_exprs(nodes, external),
         };
 
-        Predicate::new(Node::new(span, exprs), (&self.local, external))
+        Predicate::new(
+            Node::new(span, exprs),
+            (&self.local, external),
+            &mut self.diagnostics,
+        )
     }
 
     fn compile_op(&mut self, node: Node<ast::Op>, external: &mut ExternalEnv) -> Op {

--- a/lib/vrl/compiler/src/expression/predicate.rs
+++ b/lib/vrl/compiler/src/expression/predicate.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
 use crate::{
+    compiler::Diagnostics,
     expression::{Expr, Resolved},
     parser::Node,
     state::{ExternalEnv, LocalEnv},
@@ -18,12 +19,28 @@ pub struct Predicate {
 }
 
 impl Predicate {
-    pub fn new(node: Node<Vec<Expr>>, state: (&LocalEnv, &ExternalEnv)) -> Result {
+    pub fn new(
+        node: Node<Vec<Expr>>,
+        state: (&LocalEnv, &ExternalEnv),
+        warnings: &mut Diagnostics,
+    ) -> Result {
         let (span, exprs) = node.take();
-        let type_def = exprs
+        let (type_def, value) = exprs
             .last()
-            .map(|expr| expr.type_def(state))
-            .unwrap_or_else(TypeDef::null);
+            .map(|expr| (expr.type_def(state), expr.as_value()))
+            .unwrap_or_else(|| (TypeDef::null(), None));
+
+        match value {
+            Some(Value::Boolean(true)) => warnings.push(Box::new(Error {
+                variant: ErrorVariant::AlwaysTrue,
+                span,
+            })),
+            Some(Value::Boolean(false)) => warnings.push(Box::new(Error {
+                variant: ErrorVariant::AlwaysFalse,
+                span,
+            })),
+            _ => {}
+        }
 
         if type_def.is_fallible() {
             return Err(Error {
@@ -142,6 +159,10 @@ pub(crate) enum ErrorVariant {
     NonBoolean(Kind),
     #[error("fallible predicate")]
     Fallible,
+    #[error("predicate always resolves to `true`")]
+    AlwaysTrue,
+    #[error("predicate always resolves to `false`")]
+    AlwaysFalse,
 }
 
 impl fmt::Display for Error {
@@ -163,6 +184,8 @@ impl DiagnosticMessage for Error {
         match &self.variant {
             NonBoolean(..) => 102,
             Fallible => 111,
+            AlwaysFalse => 112,
+            AlwaysTrue => 113,
         }
     }
 
@@ -177,6 +200,17 @@ impl DiagnosticMessage for Error {
             Fallible => vec![
                 Label::primary("this predicate can result in runtime error", self.span),
                 Label::context("handle the error case to ensure runtime success", self.span),
+            ],
+            AlwaysFalse => vec![
+                Label::primary("this predicate never resolves to true", self.span),
+                Label::context("this means the code inside the block never runs", self.span),
+            ],
+            AlwaysTrue => vec![
+                Label::primary("this predicate always resolves to true", self.span),
+                Label::context(
+                    "this means the conditional around this block is unnecessary",
+                    self.span,
+                ),
             ],
         }
     }
@@ -193,6 +227,17 @@ impl DiagnosticMessage for Error {
                 ),
             ],
             Fallible => vec![Note::SeeErrorDocs],
+            _ => vec![],
+        }
+    }
+
+    fn severity(&self) -> diagnostic::Severity {
+        use diagnostic::Severity;
+        use ErrorVariant::*;
+
+        match &self.variant {
+            AlwaysTrue | AlwaysFalse => Severity::Warning,
+            _ => Severity::Error,
         }
     }
 }

--- a/lib/vrl/tests/tests/diagnostics/if_statement_always_false.vrl
+++ b/lib/vrl/tests/tests/diagnostics/if_statement_always_false.vrl
@@ -1,0 +1,14 @@
+# result:
+#
+# warning[E112]: predicate always resolves to `false`
+#   ┌─ :2:4
+#   │
+# 2 │ if false { false }
+#   │    ^^^^^
+#   │    │
+#   │    this predicate never resolves to true
+#   │    this means the code inside the block never runs
+#   │
+#   = see language documentation at https://vrl.dev
+
+if false { false }

--- a/lib/vrl/tests/tests/diagnostics/if_statement_always_true.vrl
+++ b/lib/vrl/tests/tests/diagnostics/if_statement_always_true.vrl
@@ -1,0 +1,14 @@
+# result:
+#
+# warning[E113]: predicate always resolves to `true`
+#   ┌─ :2:4
+#   │
+# 2 │ if true { true }
+#   │    ^^^^
+#   │    │
+#   │    this predicate always resolves to true
+#   │    this means the conditional around this block is unnecessary
+#   │
+#   = see language documentation at https://vrl.dev
+
+if true { true }

--- a/lib/vrl/tests/tests/expressions/if_statement/if_else.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_else.vrl
@@ -1,11 +1,12 @@
+# object: { "true": true }
 # result: ["yes", "no"]
 
-if1 = if true {
+if1 = if .true == true {
     "yes"
 } else {
     "no"
 }
 
-if2 = if false { "yes" } else { "no" }
+if2 = if .true == false { "yes" } else { "no" }
 
 [if1, if2]

--- a/lib/vrl/tests/tests/expressions/if_statement/if_elseif_else.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_elseif_else.vrl
@@ -1,10 +1,11 @@
+# object: { "true": true }
 # result: "yes 3"
 
-if false {
+if .true == false {
     "yes"
-} else if false {
+} else if .true == false {
     "yes 2"
-} else if true {
+} else if .true == true {
     "yes 3"
 } else {
     "no"

--- a/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
@@ -1,5 +1,5 @@
 # result: null
 
-if false {
+if null == true {
     "yes"
 }

--- a/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
@@ -1,5 +1,5 @@
 # result: "yes"
 
-if true {
+if true == true {
     "yes"
 }

--- a/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
@@ -1,34 +1,34 @@
 # result: [true, true, false, false, true, true]
 
-v1 = if true
+v1 = if true == true
 {
     true
 }
 
-v2 = if true
+v2 = if true == true
 { true }
 
-v3 = if false
+v3 = if false == true
 { true } else
 { false }
 
-v4 = if false
+v4 = if false == true
 { true } else
-if false
+if false == true
 { true } else
 { false }
 
-v5 = if false {
+v5 = if false == true {
     true
 } else
-if false {
+if false == true {
     false
 } else {
     true
 }
 
 v6 =
-    if true {
+    if true == true {
         true }
 
 [v1, v2, v3, v4, v5, v6]

--- a/website/cue/reference/remap/expressions/if.cue
+++ b/website/cue/reference/remap/expressions/if.cue
@@ -30,8 +30,9 @@ remap: expressions: if: {
 	examples: [
 		{
 			title: "True if expression"
+			input: log: foo: true
 			source: #"""
-				if true {
+				if .foo == true {
 					"Hello, World!"
 				}
 				"""#
@@ -39,18 +40,20 @@ remap: expressions: if: {
 		},
 		{
 			title: "False if expression"
+			input: log: foo: false
 			source: #"""
-				if false {
+				if .foo == true {
 					# not evaluated
-					null
+					"Hello, World!"
 				}
 				"""#
 			return: null
 		},
 		{
 			title: "If/else expression"
+			input: log: foo: false
 			source: #"""
-				if false {
+				if .foo == true {
 					# not evaluated
 					null
 				} else {
@@ -61,11 +64,12 @@ remap: expressions: if: {
 		},
 		{
 			title: "If/else if/else expression"
+			input: log: foo: true
 			source: #"""
-				if false {
+				if .foo == false {
 					# not evaluated
 					null
-				} else if false {
+				} else if .foo == false {
 					# not evaluated
 					null
 				} else {


### PR DESCRIPTION
This PR adds two new compilation warnings to VRL, both related to if-statement predicates.

If a predicate is known to always resolve to true or false at runtime, the compiler will reject the predicate, as this is either (1) unnecessarily complicated code for the `true` case (e.g. wrapping the code in an if-statement adds nothing of value to the program, but does increase the cognitive burden on readers). 

And (2) it is likely a bug introduced by the operator, as a predicate that always resolves to `false` means the code in the block never resolves at runtime.

As you can see in the diagnostic fixes, the compiler doesn't yet detect cases such as `if true == true`, but those will be tackled in a separate PR.