### PR TITLE
enhancement(vrl): expand expose of constant values

### DIFF
--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -144,8 +144,8 @@ impl Expr {
     pub fn as_literal(&self, keyword: &'static str) -> Result<Value, super::function::Error> {
         let literal = match self {
             Expr::Literal(literal) => Ok(literal.clone()),
-            Expr::Variable(var) if var.value().is_some() => {
-                match var.value().unwrap().clone().into() {
+            Expr::Variable(var) if var.as_value().is_some() => {
+                match var.as_value().unwrap().into() {
                     Expr::Literal(literal) => Ok(literal),
                     expr => Err(super::function::Error::UnexpectedExpression {
                         keyword,

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -156,6 +156,13 @@ impl Expression for Assignment {
         self.variant.type_def(state)
     }
 
+    fn as_value(&self) -> Option<Value> {
+        match &self.variant {
+            Variant::Single { expr, .. } => expr.as_value(),
+            Variant::Infallible { expr, .. } => expr.as_value(),
+        }
+    }
+
     fn compile_to_vm(
         &self,
         vm: &mut crate::vm::Vm,

--- a/lib/vrl/compiler/src/expression/noop.rs
+++ b/lib/vrl/compiler/src/expression/noop.rs
@@ -19,6 +19,10 @@ impl Expression for Noop {
         TypeDef::null().infallible()
     }
 
+    fn as_value(&self) -> Option<Value> {
+        Some(Value::Null)
+    }
+
     fn compile_to_vm(
         &self,
         vm: &mut Vm,

--- a/lib/vrl/compiler/src/expression/not.rs
+++ b/lib/vrl/compiler/src/expression/not.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use diagnostic::{DiagnosticError, Label, Note, Urls};
+use value::Value;
 
 use crate::value::VrlValueConvert;
 use crate::{
@@ -53,6 +54,13 @@ impl Expression for Not {
         let fallible = self.inner.type_def(state).is_fallible();
 
         TypeDef::boolean().with_fallibility(fallible)
+    }
+
+    fn as_value(&self) -> Option<Value> {
+        self.inner.as_value().and_then(|value| match value {
+            Value::Boolean(bool) => Some((!bool).into()),
+            _ => None,
+        })
     }
 
     fn compile_to_vm(

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -104,11 +104,18 @@ impl Expression for Query {
     }
 
     fn as_value(&self) -> Option<Value> {
-        match self.target {
-            Target::Internal(ref variable) => variable
-                .value()
-                .and_then(|v| v.get_by_path(self.path()))
-                .cloned(),
+        match &self.target {
+            Target::Internal(variable) => variable
+                .as_value()
+                .and_then(|v| v.get_by_path(self.path()).cloned()),
+            Target::External => {
+                // NOTE: This one *could* be made to work, if we pass in the
+                // compiler context into `as_value`. Since `ExternalEnv` stores
+                // `assignment::Details`, which in turn has an optional `Value`
+                // attached for constant values.
+                None
+            }
+            Target::Container(expr) => expr.as_value(),
             _ => None,
         }
     }

--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -37,10 +37,6 @@ impl Variable {
         &self.ident
     }
 
-    pub fn value(&self) -> Option<&Value> {
-        self.value.as_ref()
-    }
-
     pub fn noop(ident: Ident) -> Self {
         Self { ident, value: None }
     }
@@ -61,6 +57,10 @@ impl Expression for Variable {
             .cloned()
             .map(|d| d.type_def)
             .unwrap_or_else(|| TypeDef::null().infallible())
+    }
+
+    fn as_value(&self) -> Option<Value> {
+        self.value.clone()
     }
 
     fn compile_to_vm(

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -224,8 +224,8 @@ impl ArgumentList {
         self.optional_expr(keyword)
             .map(|expr| match expr {
                 Expr::Literal(literal) => Ok(literal),
-                Expr::Variable(var) if var.value().is_some() => {
-                    match var.value().unwrap().clone().into() {
+                Expr::Variable(var) if var.as_value().is_some() => {
+                    match var.as_value().unwrap().into() {
                         Expr::Literal(literal) => Ok(literal),
                         expr => Err(Error::UnexpectedExpression {
                             keyword,

--- a/lib/vrl/tests/tests/diagnostics/if_statement_always_false.vrl
+++ b/lib/vrl/tests/tests/diagnostics/if_statement_always_false.vrl
@@ -1,0 +1,14 @@
+# result:
+#
+# error[E112]: predicate always resolves to `false`
+#   ┌─ :2:4
+#   │
+# 2 │ if false { false }
+#   │    ^^^^^
+#   │    │
+#   │    this predicate never resolves to true
+#   │    this means the code inside the block never runs
+#   │
+#   = see language documentation at https://vrl.dev
+
+if false { false }

--- a/lib/vrl/tests/tests/diagnostics/if_statement_always_true.vrl
+++ b/lib/vrl/tests/tests/diagnostics/if_statement_always_true.vrl
@@ -1,0 +1,14 @@
+# result:
+#
+# error[E113]: predicate always resolves to `true`
+#   ┌─ :2:4
+#   │
+# 2 │ if true { true }
+#   │    ^^^^
+#   │    │
+#   │    this predicate always resolves to true
+#   │    this means the conditional around this block is unnecessary
+#   │
+#   = see language documentation at https://vrl.dev
+
+if true { true }

--- a/lib/vrl/tests/tests/expressions/assignment/infallible_mixed.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/infallible_mixed.vrl
@@ -1,5 +1,5 @@
+# object: { "foo": 1 }
 # result: [{ "ok": 1.0 }, null]
 
-foo = 1
-.ok, err = 1 / foo
+.ok, err = 1 / del(.foo)
 [., err]

--- a/lib/vrl/tests/tests/expressions/assignment/infallible_mixed_path.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/infallible_mixed_path.vrl
@@ -1,5 +1,5 @@
+# object: { "foo": 1 }
 # result: [{ "ok": { "foo": [null, null, 1.0] } }, { "bar": { "baz": null } }]
 
-foo = 1
-.ok.foo[2], err.bar.baz = 1 / foo
+.ok.foo[2], err.bar.baz = 1 / del(.foo)
 [., err]

--- a/lib/vrl/tests/tests/expressions/assignment/infallible_ok_return_value.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/infallible_ok_return_value.vrl
@@ -1,4 +1,4 @@
+# object: { "foo": 1 }
 # result: 1.0
 
-foo = 1
-ok, err = 1 / foo
+ok, err = 1 / .foo

--- a/lib/vrl/tests/tests/expressions/equality/eq.vrl
+++ b/lib/vrl/tests/tests/expressions/equality/eq.vrl
@@ -1,4 +1,4 @@
+# object: { "foo": 4 }
 # result: [true, false, false, false]
 
-foo = 4
-[1 == 1, 0 == 1, "true" == true, (5 / foo ?? 0) == 0]
+[1 == 1, 0 == 1, "true" == true, (5 / .foo ?? 0) == 0]

--- a/lib/vrl/tests/tests/expressions/equality/ne.vrl
+++ b/lib/vrl/tests/tests/expressions/equality/ne.vrl
@@ -1,4 +1,5 @@
+# object: { "foo": 4 }
 # result: [false, true, true, true]
 
 foo = 4
-[1 != 1, 0 != 1, "true" != true, (5 / foo ?? 0) != 0]
+[1 != 1, 0 != 1, "true" != true, (5 / .foo ?? 0) != 0]

--- a/lib/vrl/tests/tests/expressions/if_statement/if_else.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_else.vrl
@@ -1,11 +1,12 @@
+# object: { "true": true }
 # result: ["yes", "no"]
 
-if1 = if true {
+if1 = if .true == true {
     "yes"
 } else {
     "no"
 }
 
-if2 = if false { "yes" } else { "no" }
+if2 = if .true == false { "yes" } else { "no" }
 
 [if1, if2]

--- a/lib/vrl/tests/tests/expressions/if_statement/if_elseif_else.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_elseif_else.vrl
@@ -1,10 +1,11 @@
+# object: { "true": true }
 # result: "yes 3"
 
-if false {
+if .true == false {
     "yes"
-} else if false {
+} else if .true == false {
     "yes 2"
-} else if true {
+} else if .true == true {
     "yes 3"
 } else {
     "no"

--- a/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
@@ -1,5 +1,5 @@
 # result: null
 
-if false {
+if null == true {
     "yes"
 }

--- a/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
@@ -1,5 +1,0 @@
-# result: null
-
-if null == true {
-    "yes"
-}

--- a/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
@@ -1,5 +1,5 @@
 # result: "yes"
 
-if true {
+if true == true {
     "yes"
 }

--- a/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
@@ -1,5 +1,6 @@
+# object: { "true" : true }
 # result: "yes"
 
-if true == true {
+if .true == true {
     "yes"
 }

--- a/lib/vrl/tests/tests/expressions/if_statement/nested_if_else.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/nested_if_else.vrl
@@ -1,18 +1,19 @@
+# object: { "status_code_150": 150, "status_code_250": 250, "status_code_350": 350, "status_code_450": 450, "status_code_550": 550 }
 # result: ["1xx", "2xx", "3xx", "4xx", null]
 
-status_code = 150
+status_code = int!(.status_code_150)
 a1 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
 
-status_code = 250
+status_code = int!(.status_code_250)
 a2 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
 
-status_code = 350
+status_code = int!(.status_code_350)
 a3 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
 
-status_code = 450
+status_code = int!(.status_code_450)
 a4 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
 
-status_code = 550
+status_code = int!(.status_code_550)
 a5 = if status_code < 200 { "1xx" } else if status_code < 300 { "2xx" } else if status_code < 400 { "3xx" } else if status_code < 500 { "4xx" }
 
 [a1, a2, a3, a4, a5]

--- a/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
@@ -1,34 +1,34 @@
 # result: [true, true, false, false, true, true]
 
-v1 = if true
+v1 = if true == true
 {
     true
 }
 
-v2 = if true
+v2 = if true == true
 { true }
 
-v3 = if false
+v3 = if false == true
 { true } else
 { false }
 
-v4 = if false
+v4 = if false == true
 { true } else
-if false
+if false == true
 { true } else
 { false }
 
-v5 = if false {
+v5 = if false == true {
     true
 } else
-if false {
+if false == true {
     false
 } else {
     true
 }
 
 v6 =
-    if true {
+    if true == true {
         true }
 
 [v1, v2, v3, v4, v5, v6]

--- a/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/newlines.vrl
@@ -1,34 +1,35 @@
+# object: { "true": true }
 # result: [true, true, false, false, true, true]
 
-v1 = if true == true
+v1 = if true == .true
 {
     true
 }
 
-v2 = if true == true
+v2 = if true == .true
 { true }
 
-v3 = if false == true
+v3 = if false == .true
 { true } else
 { false }
 
-v4 = if false == true
+v4 = if false == .true
 { true } else
-if false == true
+if false == .true
 { true } else
 { false }
 
-v5 = if false == true {
+v5 = if false == .true {
     true
 } else
-if false == true {
+if false == .true {
     false
 } else {
     true
 }
 
 v6 =
-    if true == true {
+    if true == .true {
         true }
 
 [v1, v2, v3, v4, v5, v6]

--- a/lib/vrl/tests/tests/internal/short_circuit.vrl
+++ b/lib/vrl/tests/tests/internal/short_circuit.vrl
@@ -1,9 +1,8 @@
-# object: { "foo": false, "bar": false, "baz": false }
-# result: { "foo": false, "bar": false, "baz": false }
+# object: { "foo": false, "bar": false, "baz": false, "qux": 1 }
+# result: { "foo": false, "bar": false, "baz": false, "qux": 1 }
 
 # The rhs condition should never trigger in these cases.
 true || (.foo = true)
 false && (.bar = true)
-foo = 1
-5 / foo ?? (.baz = true)
+5 / .qux ?? (.baz = true)
 .

--- a/website/cue/reference/releases/0.21.1.cue
+++ b/website/cue/reference/releases/0.21.1.cue
@@ -34,7 +34,7 @@ releases: "0.21.1": {
 			type: "fix"
 			scopes: ["kubernetes_logs source"]
 			description: """
-				The `kubernetes_logs` no longer panicks whenever an error is received from the Kubernetes API watch
+				The `kubernetes_logs` no longer panics whenever an error is received from the Kubernetes API watch
 				stream.
 				"""
 			pr_numbers: [12248]
@@ -79,7 +79,7 @@ releases: "0.21.1": {
 			type: "fix"
 			scopes: ["config"]
 			description: """
-				Vector no longer panicks when used with configuration options that take event paths such as `encoding.only_fields`.
+				Vector no longer panics when used with configuration options that take event paths such as `encoding.only_fields`.
 				"""
 			pr_numbers: [12306]
 		},


### PR DESCRIPTION
This PR expands the cases in which the VRL compiler knows the constant value of an expression. A constant value always starts as a literal expression, but other expressions that act on this value might propagate that value up the chain as well.

For example, given this:

```coffee
value = true
value == true
```

We know that the second (comparison operation) expression also always resolves to a constant value of `true`, so we propagate this information up the tree.

This PR doesn't cover _all_ expressions, but it tackles the low-hanging fruit.