### PR TITLE
feat(kubernetes_logs source): Include pod_namespace tag on emitted metrics

### DIFF
--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -9,6 +9,7 @@ pub struct KubernetesLogsEventsReceived<'a> {
     pub file: &'a str,
     pub byte_size: usize,
     pub pod_name: Option<&'a str>,
+    pub pod_namespace: Option<&'a str>,
 }
 
 impl InternalEvent for KubernetesLogsEventsReceived<'_> {
@@ -19,13 +20,13 @@ impl InternalEvent for KubernetesLogsEventsReceived<'_> {
             byte_size = %self.byte_size,
             file = %self.file,
         );
-        match self.pod_name {
-            Some(name) => {
-                counter!("component_received_events_total", 1, "pod_name" => name.to_owned());
-                counter!("component_received_event_bytes_total", self.byte_size as u64, "pod_name" => name.to_owned());
-                counter!("events_in_total", 1, "pod_name" => name.to_owned());
+        match (self.pod_name, self.pod_name) {
+            (Some(name), Some(namespace)) => {
+                counter!("component_received_events_total", 1, "pod_name" => name.to_owned(), "pod_namespace" => namespace.to_owned());
+                counter!("component_received_event_bytes_total", self.byte_size as u64, "pod_name" => name.to_owned(), "pod_namespace" => namespace.to_owned());
+                counter!("events_in_total", 1, "pod_name" => name.to_owned(), "pod_namespace" => namespace.to_owned());
             }
-            None => {
+            (Some(_), None) | (None, Some(_)) | (None, None) => {
                 counter!("component_received_events_total", 1);
                 counter!(
                     "component_received_event_bytes_total",

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -27,12 +27,12 @@ impl InternalEvent for KubernetesLogsEventsReceived<'_> {
         );
         match self.pod_info {
             Some(pod_info) => {
-                let pod_namespace = pod_info.namespace.to_owned();
-                let pod_name = pod_info.name.to_owned();
+                let pod_name = pod_info.name;
+                let pod_namespace = pod_info.namespace;
 
                 counter!("component_received_events_total", 1, "pod_name" => pod_name.clone(), "pod_namespace" => pod_namespace.clone());
                 counter!("component_received_event_bytes_total", self.byte_size as u64, "pod_name" => pod_name.clone(), "pod_namespace" => pod_namespace.clone());
-                counter!("events_in_total", 1, "pod_name" => pod_name.clone(), "pod_namespace" => pod_namespace.clone());
+                counter!("events_in_total", 1, "pod_name" => pod_name, "pod_namespace" => pod_namespace);
             }
             None => {
                 counter!("component_received_events_total", 1);

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     internal_events::{
         BytesReceived, FileSourceInternalEventsEmitter, KubernetesLifecycleError,
         KubernetesLogsEventAnnotationError, KubernetesLogsEventNamespaceAnnotationError,
-        KubernetesLogsEventsReceived, StreamClosedError,
+        KubernetesLogsEventsReceived, KubernetesLogsPodInfo, StreamClosedError,
     },
     kubernetes::custom_reflector,
     shutdown::ShutdownSignal,
@@ -416,8 +416,10 @@ impl Source {
             emit!(KubernetesLogsEventsReceived {
                 file: &line.filename,
                 byte_size: event.size_of(),
-                pod_name: file_info.as_ref().map(|info| info.pod_name),
-                pod_namespace: file_info.as_ref().map(|info| info.pod_namespace),
+                pod_info: file_info.as_ref().map(|info| KubernetesLogsPodInfo {
+                    name: info.pod_name.to_owned(),
+                    namespace: info.pod_namespace.to_owned(),
+                }),
             });
 
             if file_info.is_none() {

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -417,6 +417,7 @@ impl Source {
                 file: &line.filename,
                 byte_size: event.size_of(),
                 pod_name: file_info.as_ref().map(|info| info.pod_name),
+                pod_namespace: file_info.as_ref().map(|info| info.pod_namespace),
             });
 
             if file_info.is_none() {


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #12401

There may be a more elegant way to handle the conditional logic in the
internal_event, but this keeps the behavior similar to the original code while
adding the `pod_namespace` tag to metrics.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
