### PR TITLE
chore(config): Rename TLS configuration structs for clarity

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -3,7 +3,7 @@ pub mod region;
 
 use crate::config::ProxyConfig;
 use crate::http::{build_proxy_connector, build_tls_connector};
-use crate::tls::{MaybeTlsSettings, TlsOptions};
+use crate::tls::{MaybeTlsSettings, TlsConfig};
 pub use auth::AwsAuthentication;
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::SdkError;
@@ -79,7 +79,7 @@ pub async fn create_client<T: ClientBuilder>(
     region: Region,
     endpoint: Option<Endpoint>,
     proxy: &ProxyConfig,
-    tls_options: &Option<TlsOptions>,
+    tls_options: &Option<TlsConfig>,
 ) -> crate::Result<T::Client> {
     let mut config_builder =
         T::create_config_builder(auth.credentials_provider(region.clone()).await?);

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -4,7 +4,7 @@ use rdkafka::{consumer::ConsumerContext, ClientConfig, ClientContext, Statistics
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
-use crate::{internal_events::KafkaStatisticsReceived, tls::TlsOptions};
+use crate::{internal_events::KafkaStatisticsReceived, tls::TlsConfig};
 
 #[derive(Debug, Snafu)]
 enum KafkaError {
@@ -42,7 +42,7 @@ pub(crate) struct KafkaSaslConfig {
 pub(crate) struct KafkaTlsConfig {
     pub(crate) enabled: Option<bool>,
     #[serde(flatten)]
-    pub(crate) options: TlsOptions,
+    pub(crate) options: TlsConfig,
 }
 
 impl KafkaAuthConfig {

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -1,4 +1,4 @@
-use crate::tls::TlsConfig;
+use crate::tls::TlsEnableableConfig;
 use nkeys::error::Error as NKeysError;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -96,7 +96,7 @@ impl NatsAuthConfig {
 pub(crate) fn from_tls_auth_config(
     connection_name: &str,
     auth_config: &Option<NatsAuthConfig>,
-    tls_config: &Option<TlsConfig>,
+    tls_config: &Option<TlsEnableableConfig>,
 ) -> Result<nats::asynk::Options, NatsConfigError> {
     let nats_options = match &auth_config {
         None => nats::asynk::Options::new(),

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     http::HttpClient,
     signal,
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -40,7 +40,7 @@ pub(crate) struct HttpConfig {
     request: RequestConfig,
     poll_interval_secs: u64,
     #[serde(flatten)]
-    tls_options: Option<TlsOptions>,
+    tls_options: Option<TlsConfig>,
     #[serde(
         default,
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
@@ -63,7 +63,7 @@ impl Default for HttpConfig {
 /// Makes an HTTP request to the provided endpoint, returning the String body.
 async fn http_request(
     url: &Url,
-    tls_options: &Option<TlsOptions>,
+    tls_options: &Option<TlsConfig>,
     headers: &IndexMap<String, String>,
     proxy: &ProxyConfig,
 ) -> std::result::Result<bytes::Bytes, &'static str> {
@@ -116,7 +116,7 @@ async fn http_request(
 /// Calls `http_request`, serializing the result to a `ConfigBuilder`.
 async fn http_request_to_config_builder(
     url: &Url,
-    tls_options: &Option<TlsOptions>,
+    tls_options: &Option<TlsConfig>,
     headers: &IndexMap<String, String>,
     proxy: &ProxyConfig,
 ) -> Result {
@@ -138,7 +138,7 @@ async fn http_request_to_config_builder(
 fn poll_http(
     poll_interval_secs: u64,
     url: Url,
-    tls_options: Option<TlsOptions>,
+    tls_options: Option<TlsConfig>,
     headers: IndexMap<String, String>,
     proxy: ProxyConfig,
 ) -> impl Stream<Item = signal::SignalTo> {

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -23,7 +23,7 @@ use crate::{
         Healthcheck, VectorSink,
     },
     template::Template,
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use aws_smithy_client::erase::DynConnector;
@@ -77,7 +77,7 @@ pub struct CloudwatchLogsSinkConfig {
     pub batch: BatchConfig<CloudwatchLogsDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     // Deprecated name. Moved to auth.
     pub assume_role: Option<String>,
     #[serde(default)]

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -33,7 +33,7 @@ use crate::{
         retries::RetryLogic,
         Compression, EncodedEvent, PartitionBuffer, PartitionInnerBuffer, TowerRequestConfig,
     },
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 #[derive(Clone)]
@@ -63,7 +63,7 @@ pub struct CloudWatchMetricsSinkConfig {
     pub batch: BatchConfig<CloudWatchMetricsDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     // Deprecated name. Moved to auth.
     assume_role: Option<String>,
     #[serde(default)]

--- a/src/sinks/aws_kinesis_firehose/config.rs
+++ b/src/sinks/aws_kinesis_firehose/config.rs
@@ -30,7 +30,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 // AWS Kinesis Firehose API accepts payloads up to 4MB or 500 events
@@ -61,7 +61,7 @@ pub struct KinesisFirehoseSinkConfig {
     pub batch: BatchConfig<KinesisFirehoseDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(default)]
     pub auth: AwsAuthentication,
     #[serde(

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -25,7 +25,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -98,7 +98,7 @@ pub struct KinesisSinkConfig {
     pub batch: BatchConfig<KinesisDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(default)]
     pub auth: AwsAuthentication,
     #[serde(

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -24,7 +24,7 @@ use crate::{
         },
         Healthcheck,
     },
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 const DEFAULT_KEY_PREFIX: &str = "date=%F/";
@@ -50,7 +50,7 @@ pub struct S3SinkConfig {
     pub batch: BatchConfig<BulkSizeBasedDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(default)]
     pub auth: AwsAuthentication,
     #[serde(
@@ -75,7 +75,7 @@ impl GenerateConfig for S3SinkConfig {
             compression: Compression::gzip_default(),
             batch: BatchConfig::default(),
             request: TowerRequestConfig::default(),
-            tls: Some(TlsOptions::default()),
+            tls: Some(TlsConfig::default()),
             auth: AwsAuthentication::default(),
             acknowledgements: Default::default(),
         })

--- a/src/sinks/aws_sqs/config.rs
+++ b/src/sinks/aws_sqs/config.rs
@@ -12,7 +12,7 @@ use crate::{
     config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
     sinks::util::{encoding::EncodingConfig, TowerRequestConfig},
     template::{Template, TemplateParseError},
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 #[derive(Debug, Snafu)]
@@ -38,7 +38,7 @@ pub struct SqsSinkConfig {
     pub message_deduplication_id: Option<String>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     // Deprecated name. Moved to auth.
     pub(super) assume_role: Option<String>,
     #[serde(default)]

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -25,7 +25,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 fn default_host() -> String {
@@ -50,7 +50,7 @@ pub struct AzureMonitorLogsConfig {
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -16,7 +16,7 @@ use crate::{
         BatchConfig, Buffer, Compression, RealtimeSizeBasedDefaultBatchSettings,
         TowerRequestConfig, UriSerde,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
@@ -41,7 +41,7 @@ pub struct ClickhouseConfig {
     pub auth: Option<Auth>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -18,7 +18,7 @@ use crate::{
         util::{http::HttpStatusRetryLogic, ServiceBuilderExt, TowerRequestConfig},
         Healthcheck, VectorSink,
     },
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -30,7 +30,7 @@ pub struct DatadogEventsConfig {
     pub site: Option<String>,
     pub default_api_key: String,
 
-    pub(super) tls: Option<TlsConfig>,
+    pub(super) tls: Option<TlsEnableableConfig>,
 
     #[serde(default)]
     pub request: TowerRequestConfig,

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -21,7 +21,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 // The Datadog API has a hard limit of 5MB for uncompressed payloads. Above this
@@ -60,7 +60,7 @@ pub(crate) struct DatadogLogsConfig {
         default
     )]
     encoding: EncodingConfigFixed<DatadogLogsJsonEncoding>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
 
     #[serde(default)]
     compression: Option<Compression>,
@@ -151,7 +151,11 @@ impl DatadogLogsConfig {
 
     pub fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
         let tls_settings = MaybeTlsSettings::from_config(
-            &Some(self.tls.clone().unwrap_or_else(TlsConfig::enabled)),
+            &Some(
+                self.tls
+                    .clone()
+                    .unwrap_or_else(TlsEnableableConfig::enabled),
+            ),
             false,
         )?;
         Ok(HttpClient::new(tls_settings, proxy)?)

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -10,7 +10,7 @@ use super::{
     service::{DatadogMetricsRetryLogic, DatadogMetricsService},
     sink::DatadogMetricsSink,
 };
-use crate::tls::{MaybeTlsSettings, TlsConfig};
+use crate::tls::{MaybeTlsSettings, TlsEnableableConfig};
 use crate::{
     common::datadog::get_base_domain,
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
@@ -117,7 +117,7 @@ pub struct DatadogMetricsConfig {
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     acknowledgements: AcknowledgementsConfig,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
 }
 
 impl_generate_config_from_default!(DatadogMetricsConfig);
@@ -198,7 +198,11 @@ impl DatadogMetricsConfig {
 
     fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
         let tls_settings = MaybeTlsSettings::from_config(
-            &Some(self.tls.clone().unwrap_or_else(TlsConfig::enabled)),
+            &Some(
+                self.tls
+                    .clone()
+                    .unwrap_or_else(TlsEnableableConfig::enabled),
+            ),
             false,
         )?;
         let client = HttpClient::new(tls_settings, proxy)?;

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -27,7 +27,7 @@ use crate::{
         },
         Healthcheck, UriParseSnafu, VectorSink,
     },
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 // The Datadog API has a hard limit of 3.2MB for uncompressed payloads.
@@ -59,7 +59,7 @@ pub struct DatadogTracesConfig {
     site: Option<String>,
     default_api_key: String,
 
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
 
     #[serde(default)]
     compression: Option<Compression>,
@@ -163,7 +163,11 @@ impl DatadogTracesConfig {
 
     pub fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
         let tls_settings = MaybeTlsSettings::from_config(
-            &Some(self.tls.clone().unwrap_or_else(TlsConfig::enabled)),
+            &Some(
+                self.tls
+                    .clone()
+                    .unwrap_or_else(TlsEnableableConfig::enabled),
+            ),
             false,
         )?;
         Ok(HttpClient::new(tls_settings, proxy)?)

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -59,7 +59,7 @@ use crate::{
         VectorSink,
     },
     template::Template,
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 const DEFAULT_COMPRESSION: Compression = Compression::gzip_default();
@@ -91,7 +91,7 @@ pub struct DatadogArchivesSinkConfig {
     pub azure_blob: Option<AzureBlobConfig>,
     #[serde(default)]
     pub gcp_cloud_storage: Option<GcsConfig>,
-    tls: Option<TlsOptions>,
+    tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -31,7 +31,7 @@ use crate::{
         Healthcheck, VectorSink,
     },
     template::Template,
-    tls::TlsOptions,
+    tls::TlsConfig,
     transforms::metric_to_log::MetricToLogConfig,
 };
 
@@ -66,7 +66,7 @@ pub struct ElasticsearchConfig {
     pub auth: Option<ElasticsearchAuth>,
     pub query: Option<HashMap<String, String>>,
     pub aws: Option<RegionOrEndpoint>,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
 
     #[serde(alias = "normal")]
     pub bulk: Option<BulkConfig>,

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -21,7 +21,7 @@ use crate::{
         HealthcheckError,
     },
     test_util::{random_events_with_stream, random_string, trace_init},
-    tls::{self, TlsOptions},
+    tls::{self, TlsConfig},
 };
 
 fn aws_server() -> String {
@@ -223,7 +223,7 @@ async fn insert_events_over_https() {
             endpoint: https_server(),
             doc_type: Some("log_lines".into()),
             compression: Compression::None,
-            tls: Some(TlsOptions {
+            tls: Some(TlsConfig {
                 ca_file: Some(tls::TEST_PEM_CA_PATH.into()),
                 ..Default::default()
             }),

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -41,7 +41,7 @@ use crate::{
         Healthcheck, VectorSink,
     },
     template::Template,
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 const NAME: &str = "gcp_cloud_storage";
@@ -66,7 +66,7 @@ pub struct GcsSinkConfig {
     request: TowerRequestConfig,
     #[serde(flatten)]
     auth: GcpAuthConfig,
-    tls: Option<TlsOptions>,
+    tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         Healthcheck, UriParseSnafu, VectorSink,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Debug, Snafu)]
@@ -62,7 +62,7 @@ pub struct PubsubConfig {
     )]
     pub encoding: EncodingConfigWithDefault<Encoding>,
 
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
 
     #[serde(
         default,

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -24,7 +24,7 @@ use crate::{
         Healthcheck, VectorSink,
     },
     template::{Template, TemplateRenderingError},
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Debug, Snafu)]
@@ -56,7 +56,7 @@ pub struct StackdriverConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
 
     #[serde(
         default,

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -41,7 +41,7 @@ pub struct StackdriverConfig {
     pub request: TowerRequestConfig,
     #[serde(default)]
     pub batch: BatchConfig<StackdriverMetricsDefaultBatchSettings>,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -35,7 +35,7 @@ use crate::{
         BatchConfig, Buffer, Compression, RealtimeSizeBasedDefaultBatchSettings,
         TowerRequestConfig, UriSerde,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Debug, Snafu)]
@@ -88,7 +88,7 @@ pub struct HttpSinkConfig {
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
     #[serde(default)]
     pub request: RequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -16,7 +16,7 @@ use crate::{
         Healthcheck, VectorSink,
     },
     template::Template,
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 const HOST: &str = "https://cloud.humio.com";
@@ -42,7 +42,7 @@ pub struct HumioLogsConfig {
     pub(super) request: TowerRequestConfig,
     #[serde(default)]
     pub(super) batch: BatchConfig<SplunkHecDefaultBatchSettings>,
-    pub(super) tls: Option<TlsOptions>,
+    pub(super) tls: Option<TlsConfig>,
     #[serde(default = "timestamp_nanos_key")]
     pub(super) timestamp_nanos_key: Option<String>,
     #[serde(

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -18,7 +18,7 @@ use crate::{
         Healthcheck, VectorSink,
     },
     template::Template,
-    tls::TlsOptions,
+    tls::TlsConfig,
     transforms::{metric_to_log::MetricToLogConfig, OutputBuffer},
 };
 
@@ -45,7 +45,7 @@ struct HumioMetricsConfig {
     request: TowerRequestConfig,
     #[serde(default)]
     batch: BatchConfig<SplunkHecDefaultBatchSettings>,
-    tls: Option<TlsOptions>,
+    tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -25,7 +25,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -58,7 +58,7 @@ pub struct InfluxDbLogsConfig {
     pub batch: BatchConfig<InfluxDbLogsDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Clone)]
@@ -68,7 +68,7 @@ pub struct InfluxDbConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     pub tags: Option<HashMap<String, String>>,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(default = "default_summary_quantiles")]
     pub quantiles: Vec<f64>,
     #[serde(
@@ -937,14 +937,14 @@ mod integration_tests {
             },
             InfluxDb1Settings, InfluxDb2Settings,
         },
-        tls::{self, TlsOptions},
+        tls::{self, TlsConfig},
     };
 
     #[tokio::test]
     async fn inserts_metrics_v1_over_https() {
         insert_metrics_v1(
             address_v1(true).as_str(),
-            Some(TlsOptions {
+            Some(TlsConfig {
                 ca_file: Some(tls::TEST_PEM_CA_PATH.into()),
                 ..Default::default()
             }),
@@ -957,7 +957,7 @@ mod integration_tests {
         insert_metrics_v1(address_v1(false).as_str(), None).await
     }
 
-    async fn insert_metrics_v1(url: &str, tls: Option<TlsOptions>) {
+    async fn insert_metrics_v1(url: &str, tls: Option<TlsConfig>) {
         crate::test_util::trace_init();
         let database = onboarding_v1(url).await;
 

--- a/src/sinks/kafka/tests.rs
+++ b/src/sinks/kafka/tests.rs
@@ -38,7 +38,7 @@ mod integration_test {
             VectorSink,
         },
         test_util::{components, random_lines_with_stream, random_string, wait_for},
-        tls::TlsOptions,
+        tls::TlsConfig,
     };
 
     fn kafka_host() -> String {
@@ -205,7 +205,7 @@ mod integration_test {
             None,
             Some(KafkaTlsConfig {
                 enabled: Some(true),
-                options: TlsOptions::test_options(),
+                options: TlsConfig::test_config(),
             }),
             KafkaCompression::None,
         )
@@ -220,7 +220,7 @@ mod integration_test {
             None,
             Some(KafkaTlsConfig {
                 enabled: Some(true),
-                options: TlsOptions::test_options(),
+                options: TlsConfig::test_config(),
             }),
             KafkaCompression::None,
         )

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -15,7 +15,7 @@ use crate::{
         VectorSink,
     },
     template::Template,
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -44,7 +44,7 @@ pub struct LokiConfig {
     #[serde(default)]
     pub batch: BatchConfig<LokiDefaultBatchSettings>,
 
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
 
     #[serde(
         default,

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -18,7 +18,7 @@ use crate::{
         StreamSink,
     },
     template::{Template, TemplateParseError},
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
 };
 
 #[derive(Debug, Snafu)]
@@ -43,7 +43,7 @@ pub struct NatsSinkConfig {
     connection_name: String,
     subject: String,
     url: String,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     auth: Option<NatsAuthConfig>,
 }
 
@@ -233,7 +233,7 @@ mod integration_tests {
     use crate::nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword};
     use crate::sinks::VectorSink;
     use crate::test_util::{random_lines_with_stream, random_string, trace_init};
-    use crate::tls::TlsOptions;
+    use crate::tls::TlsConfig;
 
     async fn publish_and_check(conf: NatsSinkConfig) -> Result<(), BuildError> {
         // Publish `N` messages to NATS.
@@ -481,9 +481,9 @@ mod integration_tests {
             connection_name: "".to_owned(),
             subject: subject.clone(),
             url: "nats://localhost:4227".to_owned(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },
@@ -533,9 +533,9 @@ mod integration_tests {
             connection_name: "".to_owned(),
             subject: subject.clone(),
             url: "nats://localhost:4228".to_owned(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     crt_file: Some("tests/data/nats_client_cert.pem".into()),
                     key_file: Some("tests/data/nats_client_key.pem".into()),
@@ -564,9 +564,9 @@ mod integration_tests {
             connection_name: "".to_owned(),
             subject: subject.clone(),
             url: "nats://localhost:4228".to_owned(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },
@@ -593,9 +593,9 @@ mod integration_tests {
             connection_name: "".to_owned(),
             subject: subject.clone(),
             url: "nats://localhost:4229".to_owned(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },
@@ -626,9 +626,9 @@ mod integration_tests {
             connection_name: "".to_owned(),
             subject: subject.clone(),
             url: "nats://localhost:4229".to_owned(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     tcp::TcpKeepaliveConfig,
     template::Template,
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
 };
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -26,7 +26,7 @@ pub(self) struct PapertrailConfig {
     endpoint: UriSerde,
     encoding: EncodingConfig<Encoding>,
     keepalive: Option<TcpKeepaliveConfig>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     send_buffer_bytes: Option<usize>,
     process: Option<Template>,
 }
@@ -65,7 +65,11 @@ impl SinkConfig for PapertrailConfig {
             .ok_or_else(|| "A port is required for endpoint".to_string())?;
 
         let address = format!("{}:{}", host, port);
-        let tls = Some(self.tls.clone().unwrap_or_else(TlsConfig::enabled));
+        let tls = Some(
+            self.tls
+                .clone()
+                .unwrap_or_else(TlsEnableableConfig::enabled),
+        );
 
         let pid = std::process::id();
         let encoding = self.encoding.clone();

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -46,7 +46,7 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 const MIN_FLUSH_PERIOD_SECS: u64 = 1;
@@ -65,7 +65,7 @@ pub struct PrometheusExporterConfig {
     pub default_namespace: Option<String>,
     #[serde(default = "default_address")]
     pub address: SocketAddr,
-    pub tls: Option<TlsConfig>,
+    pub tls: Option<TlsEnableableConfig>,
     #[serde(default = "super::default_histogram_buckets")]
     pub buckets: Vec<f64>,
     #[serde(default = "super::default_summary_quantiles")]
@@ -547,7 +547,7 @@ mod tests {
 
     #[tokio::test]
     async fn prometheus_tls() {
-        let mut tls_config = TlsConfig::test_config();
+        let mut tls_config = TlsEnableableConfig::test_config();
         tls_config.options.verify_hostname = Some(false);
         export_and_fetch_simple(Some(tls_config)).await;
     }
@@ -578,7 +578,10 @@ mod tests {
         );
     }
 
-    async fn export_and_fetch(tls_config: Option<TlsConfig>, events: Vec<Event>) -> String {
+    async fn export_and_fetch(
+        tls_config: Option<TlsEnableableConfig>,
+        events: Vec<Event>,
+    ) -> String {
         trace_init();
 
         let client_settings = MaybeTlsSettings::from_config(&tls_config, false).unwrap();
@@ -619,7 +622,7 @@ mod tests {
         String::from_utf8(bytes.to_vec()).unwrap()
     }
 
-    async fn export_and_fetch_simple(tls_config: Option<TlsConfig>) {
+    async fn export_and_fetch_simple(tls_config: Option<TlsEnableableConfig>) {
         let (name1, event1) = create_metric_gauge(None, 123.4);
         let (name2, event2) = tests::create_metric_set(None, vec!["0", "1", "2"]);
         let events = vec![event1, event2];

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -25,7 +25,7 @@ use crate::{
         },
     },
     template::Template,
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -63,7 +63,7 @@ pub struct RemoteWriteConfig {
     #[serde(default)]
     pub tenant_id: Option<Template>,
 
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
 
     pub auth: Option<Auth>,
 }
@@ -462,7 +462,7 @@ mod integration_tests {
         config::{SinkConfig, SinkContext},
         event::{metric::MetricValue, Event},
         sinks::influxdb::test_util::{cleanup_v1, format_timestamp, onboarding_v1, query_v1},
-        tls::{self, TlsOptions},
+        tls::{self, TlsConfig},
     };
 
     const HTTP_URL: &str = "http://localhost:8086";
@@ -487,7 +487,7 @@ mod integration_tests {
 
         let config = RemoteWriteConfig {
             endpoint: format!("{}/api/v1/prom/write?db={}", url, database),
-            tls: Some(TlsOptions {
+            tls: Some(TlsConfig {
                 ca_file: Some(tls::TEST_PEM_CA_PATH.into()),
                 ..Default::default()
             }),

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -13,7 +13,7 @@ use super::service::{S3Response, S3Service};
 use crate::aws::{create_client, is_retriable_error};
 use crate::aws::{AwsAuthentication, RegionOrEndpoint};
 use crate::common::s3::S3ClientBuilder;
-use crate::tls::TlsOptions;
+use crate::tls::TlsConfig;
 use crate::{
     config::ProxyConfig,
     sinks::{util::retries::RetryLogic, Healthcheck},
@@ -162,7 +162,7 @@ pub async fn create_service(
     region: &RegionOrEndpoint,
     auth: &AwsAuthentication,
     proxy: &ProxyConfig,
-    tls_options: &Option<TlsOptions>,
+    tls_options: &Option<TlsConfig>,
 ) -> crate::Result<S3Service> {
     let endpoint = region.endpoint()?;
     let region = region.region();

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -259,7 +259,9 @@ mod test {
         use tokio_stream::wrappers::IntervalStream;
 
         use crate::event::EventArray;
-        use crate::tls::{self, MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsOptions};
+        use crate::tls::{
+            self, MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsEnableableConfig,
+        };
 
         trace_init();
 
@@ -268,9 +270,9 @@ mod test {
             mode: Mode::Tcp(TcpSinkConfig::new(
                 addr.to_string(),
                 None,
-                Some(TlsConfig {
+                Some(TlsEnableableConfig {
                     enabled: Some(true),
-                    options: TlsOptions {
+                    options: TlsConfig {
                         verify_certificate: Some(false),
                         verify_hostname: Some(false),
                         ca_file: Some(tls::TEST_PEM_CRT_PATH.into()),
@@ -303,7 +305,7 @@ mod test {
         let (close_tx, close_rx) = tokio::sync::oneshot::channel::<()>();
         let mut close_rx = Some(close_rx.map(|x| x.unwrap()));
 
-        let config = Some(TlsConfig::test_config());
+        let config = Some(TlsEnableableConfig::test_config());
 
         // Only accept two connections.
         let jh2 = tokio::spawn(async move {

--- a/src/sinks/splunk_hec/common/util.rs
+++ b/src/sinks/splunk_hec/common/util.rs
@@ -17,7 +17,7 @@ use crate::{
         UriParseSnafu,
     },
     template::Template,
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -38,7 +38,7 @@ pub enum HealthcheckError {
 }
 
 pub fn create_client(
-    tls: &Option<TlsOptions>,
+    tls: &Option<TlsConfig>,
     proxy_config: &ProxyConfig,
 ) -> crate::Result<HttpClient> {
     let tls_settings = TlsSettings::from_options(tls)?;

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -23,7 +23,7 @@ use crate::{
         Healthcheck,
     },
     template::Template,
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -47,7 +47,7 @@ pub struct HecLogsSinkConfig {
     pub batch: BatchConfig<SplunkHecDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(default)]
     pub acknowledgements: HecClientAcknowledgementsConfig,
     // This settings is relevant only for the `humio_logs` sink and should be left to None everywhere else

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -22,7 +22,7 @@ use crate::{
         Healthcheck,
     },
     template::Template,
-    tls::TlsOptions,
+    tls::TlsConfig,
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -44,7 +44,7 @@ pub struct HecMetricsSinkConfig {
     pub batch: BatchConfig<SplunkHecDefaultBatchSettings>,
     #[serde(default)]
     pub request: TowerRequestConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
     #[serde(default)]
     pub acknowledgements: HecClientAcknowledgementsConfig,
 }

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -38,7 +38,7 @@ use crate::{
         Healthcheck, VectorSink,
     },
     tcp::TcpKeepaliveConfig,
-    tls::{MaybeTlsSettings, MaybeTlsStream, TlsConfig, TlsError},
+    tls::{MaybeTlsSettings, MaybeTlsStream, TlsEnableableConfig, TlsError},
 };
 
 #[derive(Debug, Snafu)]
@@ -57,7 +57,7 @@ enum TcpError {
 pub struct TcpSinkConfig {
     address: String,
     keepalive: Option<TcpKeepaliveConfig>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     send_buffer_bytes: Option<usize>,
 }
 
@@ -65,7 +65,7 @@ impl TcpSinkConfig {
     pub const fn new(
         address: String,
         keepalive: Option<TcpKeepaliveConfig>,
-        tls: Option<TlsConfig>,
+        tls: Option<TlsEnableableConfig>,
         send_buffer_bytes: Option<usize>,
     ) -> Self {
         Self {

--- a/src/sinks/vector/v1.rs
+++ b/src/sinks/vector/v1.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{GenerateConfig, SinkContext},
     sinks::{util::tcp::TcpSinkConfig, Healthcheck, VectorSink},
     tcp::TcpKeepaliveConfig,
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -17,19 +17,19 @@ use crate::{
 pub struct VectorConfig {
     address: String,
     keepalive: Option<TcpKeepaliveConfig>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     send_buffer_bytes: Option<usize>,
 }
 
 impl VectorConfig {
-    pub fn set_tls(&mut self, config: Option<TlsConfig>) {
+    pub fn set_tls(&mut self, config: Option<TlsEnableableConfig>) {
         self.tls = config;
     }
 
     pub const fn new(
         address: String,
         keepalive: Option<TcpKeepaliveConfig>,
-        tls: Option<TlsConfig>,
+        tls: Option<TlsEnableableConfig>,
         send_buffer_bytes: Option<usize>,
     ) -> Self {
         Self {

--- a/src/sinks/vector/v2/config.rs
+++ b/src/sinks/vector/v2/config.rs
@@ -23,7 +23,7 @@ use crate::{
         },
         Healthcheck, VectorSink as VectorSinkType,
     },
-    tls::{tls_connector_builder, MaybeTlsSettings, TlsConfig},
+    tls::{tls_connector_builder, MaybeTlsSettings, TlsEnableableConfig},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -37,7 +37,7 @@ pub struct VectorConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
     #[serde(default)]
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         SourceDescription,
     },
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 pub mod errors;
@@ -24,7 +24,7 @@ mod models;
 pub struct AwsKinesisFirehoseConfig {
     address: SocketAddr,
     access_key: Option<String>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     record_compression: Option<Compression>,
     #[serde(default = "default_framing_message_based")]
     framing: FramingConfig,

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -16,7 +16,7 @@ use super::util::MultilineConfig;
 use crate::aws::RegionOrEndpoint;
 use crate::aws::{create_client, ClientBuilder};
 use crate::common::sqs::SqsClientBuilder;
-use crate::tls::TlsOptions;
+use crate::tls::TlsConfig;
 use crate::{
     aws::auth::AwsAuthentication,
     config::{
@@ -70,7 +70,7 @@ struct AwsS3Config {
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
 
-    tls_options: Option<TlsOptions>,
+    tls_options: Option<TlsConfig>,
 }
 
 inventory::submit! {

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -21,7 +21,7 @@ use aws_sdk_sqs::Client as SqsClient;
 use aws_smithy_client::SdkError;
 use aws_types::region::Region;
 
-use crate::tls::TlsOptions;
+use crate::tls::TlsConfig;
 use crate::{
     config::{log_schema, AcknowledgementsConfig, SourceContext},
     event::{BatchNotifier, BatchStatus, LogEvent},
@@ -66,7 +66,7 @@ pub(super) struct Config {
 
     #[serde(default)]
     #[derivative(Default)]
-    pub(super) tls_options: Option<TlsOptions>,
+    pub(super) tls_options: Option<TlsConfig>,
 }
 
 const fn default_poll_secs() -> u32 {

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -1,7 +1,7 @@
 use crate::aws::create_client;
 use crate::codecs::DecodingConfig;
 use crate::common::sqs::SqsClientBuilder;
-use crate::tls::TlsOptions;
+use crate::tls::TlsConfig;
 use crate::{
     aws::{auth::AwsAuthentication, region::RegionOrEndpoint},
     config::{AcknowledgementsConfig, Output, SourceConfig, SourceContext},
@@ -50,7 +50,7 @@ pub struct AwsSqsConfig {
     pub decoding: DeserializerConfig,
     #[serde(default, deserialize_with = "bool_or_struct")]
     pub acknowledgements: AcknowledgementsConfig,
-    pub tls: Option<TlsOptions>,
+    pub tls: Option<TlsConfig>,
 }
 
 #[async_trait::async_trait]

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     schema,
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::{self, util::ErrorMessage},
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
 };
 
@@ -43,7 +43,7 @@ pub const TRACES: &str = "traces";
 #[derive(Deserialize, Serialize, Debug, Clone)]
 struct DatadogAgentConfig {
     address: SocketAddr,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     #[serde(default = "crate::serde::default_true")]
     store_api_key: bool,
     #[serde(default = "default_framing_message_based")]

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     internal_events::{FluentMessageDecodeError, FluentMessageReceived},
     serde::bool_or_struct,
     tcp::TcpKeepaliveConfig,
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 mod message;
@@ -28,7 +28,7 @@ use self::message::{FluentEntry, FluentMessage, FluentRecord, FluentTag, FluentT
 #[derive(Deserialize, Serialize, Debug)]
 pub struct FluentConfig {
     address: SocketListenAddr,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     keepalive: Option<TcpKeepaliveConfig>,
     receive_buffer_bytes: Option<usize>,
     #[serde(default, deserialize_with = "bool_or_struct")]

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -26,7 +26,7 @@ use crate::{
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -34,7 +34,7 @@ pub(crate) struct LogplexConfig {
     address: SocketAddr,
     #[serde(default)]
     query_parameters: Vec<String>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     auth: Option<HttpSourceAuthConfig>,
     #[serde(default = "default_framing_message_based")]
     framing: FramingConfig,

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -23,7 +23,7 @@ use crate::{
     sources::util::{
         add_query_parameters, Encoding, ErrorMessage, HttpSource, HttpSourceAuthConfig,
     },
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -35,7 +35,7 @@ pub(super) struct SimpleHttpConfig {
     headers: Vec<String>,
     #[serde(default)]
     query_parameters: Vec<String>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     auth: Option<HttpSourceAuthConfig>,
     #[serde(default = "crate::serde::default_true")]
     strict_path: bool,

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -15,7 +15,7 @@ use crate::{
     nats::{from_tls_auth_config, NatsAuthConfig, NatsConfigError},
     serde::{default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
     SourceSender,
 };
 
@@ -38,7 +38,7 @@ struct NatsSourceConfig {
     connection_name: String,
     subject: String,
     queue: Option<String>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     auth: Option<NatsAuthConfig>,
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
@@ -203,7 +203,7 @@ mod integration_tests {
     use super::*;
     use crate::nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword};
     use crate::test_util::{collect_n, random_string};
-    use crate::tls::TlsOptions;
+    use crate::tls::TlsConfig;
 
     async fn publish_and_check(conf: NatsSourceConfig) -> Result<(), BuildError> {
         let subject = conf.subject.clone();
@@ -422,9 +422,9 @@ mod integration_tests {
             queue: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },
@@ -474,9 +474,9 @@ mod integration_tests {
             queue: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     crt_file: Some("tests/data/nats_client_cert.pem".into()),
                     key_file: Some("tests/data/nats_client_key.pem".into()),
@@ -505,9 +505,9 @@ mod integration_tests {
             queue: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },
@@ -534,9 +534,9 @@ mod integration_tests {
             queue: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },
@@ -567,9 +567,9 @@ mod integration_tests {
             queue: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
-            tls: Some(TlsConfig {
+            tls: Some(TlsEnableableConfig {
                 enabled: Some(true),
-                options: TlsOptions {
+                options: TlsConfig {
                     ca_file: Some("tests/data/mkcert_rootCA.pem".into()),
                     ..Default::default()
                 },

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         BytesReceived, NginxMetricsCollectCompleted, NginxMetricsEventsReceived,
         NginxMetricsRequestError, NginxMetricsStubStatusParseError, StreamClosedError,
     },
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
 };
 
 pub mod parser;
@@ -61,7 +61,7 @@ struct NginxMetricsConfig {
     scrape_interval_secs: u64,
     #[serde(default = "default_namespace")]
     namespace: String,
-    tls: Option<TlsOptions>,
+    tls: Option<TlsConfig>,
     auth: Option<Auth>,
 }
 

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -19,7 +19,7 @@ use crate::{
         self,
         util::{decode, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     },
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
 };
 
 const SOURCE_NAME: &str = "prometheus_remote_write";
@@ -28,7 +28,7 @@ const SOURCE_NAME: &str = "prometheus_remote_write";
 struct PrometheusRemoteWriteConfig {
     address: SocketAddr,
 
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
 
     auth: Option<HttpSourceAuthConfig>,
 
@@ -152,10 +152,10 @@ mod test {
 
     #[tokio::test]
     async fn receives_metrics_over_https() {
-        receives_metrics(Some(TlsConfig::test_config())).await;
+        receives_metrics(Some(TlsEnableableConfig::test_config())).await;
     }
 
-    async fn receives_metrics(tls: Option<TlsConfig>) {
+    async fn receives_metrics(tls: Option<TlsEnableableConfig>) {
         components::init_test();
         let address = test_util::next_addr();
         let (tx, rx) = SourceSender::new_test_finalize(EventStatus::Delivered);

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     shutdown::ShutdownSignal,
     sources,
-    tls::{TlsOptions, TlsSettings},
+    tls::{TlsConfig, TlsSettings},
     SourceSender,
 };
 
@@ -53,7 +53,7 @@ struct PrometheusScrapeConfig {
     #[serde(default = "crate::serde::default_false")]
     honor_labels: bool,
     query: Option<HashMap<String, Vec<String>>>,
-    tls: Option<TlsOptions>,
+    tls: Option<TlsConfig>,
     auth: Option<Auth>,
 }
 
@@ -164,7 +164,7 @@ struct PrometheusCompatConfig {
     query: Option<HashMap<String, Vec<String>>>,
     #[serde(default = "default_scrape_interval_secs")]
     scrape_interval_secs: u64,
-    tls: Option<TlsOptions>,
+    tls: Option<TlsConfig>,
     auth: Option<Auth>,
 }
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -268,7 +268,7 @@ mod test {
             components::{self, SOURCE_TESTS, TCP_SOURCE_TAGS},
             next_addr, random_string, send_lines, send_lines_tls, wait_for_tcp,
         },
-        tls::{self, TlsConfig, TlsOptions},
+        tls::{self, TlsConfig, TlsEnableableConfig},
         SourceSender,
     };
 
@@ -400,7 +400,7 @@ mod test {
         let addr = next_addr();
 
         let mut config = TcpConfig::from_address(addr.into());
-        config.set_tls(Some(TlsConfig::test_config()));
+        config.set_tls(Some(TlsEnableableConfig::test_config()));
 
         let server = SocketConfig::from(config)
             .build(SourceContext::new_test(tx, None))
@@ -437,9 +437,9 @@ mod test {
         let addr = next_addr();
 
         let mut config = TcpConfig::from_address(addr.into());
-        config.set_tls(Some(TlsConfig {
+        config.set_tls(Some(TlsEnableableConfig {
             enabled: Some(true),
-            options: TlsOptions {
+            options: TlsConfig {
                 crt_file: Some("tests/data/Chain_with_intermediate.crt".into()),
                 key_file: Some("tests/data/Crt_from_intermediate.key".into()),
                 ..Default::default()

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -11,7 +11,7 @@ use crate::{
     serde::default_decoding,
     sources::util::{SocketListenAddr, TcpNullAcker, TcpSource},
     tcp::TcpKeepaliveConfig,
-    tls::TlsConfig,
+    tls::TlsEnableableConfig,
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -23,7 +23,7 @@ pub struct TcpConfig {
     shutdown_timeout_secs: u64,
     host_key: Option<String>,
     port_key: Option<String>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     receive_buffer_bytes: Option<usize>,
     framing: Option<FramingConfig>,
     #[serde(default = "default_decoding")]
@@ -43,7 +43,7 @@ impl TcpConfig {
         shutdown_timeout_secs: u64,
         host_key: Option<String>,
         port_key: Option<String>,
-        tls: Option<TlsConfig>,
+        tls: Option<TlsEnableableConfig>,
         receive_buffer_bytes: Option<usize>,
         framing: Option<FramingConfig>,
         decoding: DeserializerConfig,
@@ -84,7 +84,7 @@ impl TcpConfig {
         &self.host_key
     }
 
-    pub const fn tls(&self) -> &Option<TlsConfig> {
+    pub const fn tls(&self) -> &Option<TlsEnableableConfig> {
         &self.tls
     }
 
@@ -126,7 +126,7 @@ impl TcpConfig {
         self
     }
 
-    pub fn set_tls(&mut self, val: Option<TlsConfig>) -> &mut Self {
+    pub fn set_tls(&mut self, val: Option<TlsEnableableConfig>) -> &mut Self {
         self.tls = val;
         self
     }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     serde::bool_or_struct,
     source_sender::ClosedError,
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
 };
 
@@ -57,7 +57,7 @@ pub struct SplunkConfig {
     token: Option<String>,
     /// A list of tokens to accept. Omit this to accept any token
     valid_tokens: Option<Vec<String>>,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     /// Splunk HEC indexer acknowledgement settings
     #[serde(deserialize_with = "bool_or_struct")]
     acknowledgements: HecAcknowledgementsConfig,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     shutdown::ShutdownSignal,
     tcp::TcpKeepaliveConfig,
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
     udp, SourceSender,
 };
 use codecs::{
@@ -67,7 +67,7 @@ struct TcpConfig {
     address: SocketListenAddr,
     keepalive: Option<TcpKeepaliveConfig>,
     #[serde(default)]
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     #[serde(default = "default_shutdown_timeout_secs")]
     shutdown_timeout_secs: u64,
     receive_buffer_bytes: Option<usize>,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -27,7 +27,7 @@ use crate::{
     shutdown::ShutdownSignal,
     sources::util::{SocketListenAddr, TcpNullAcker, TcpSource},
     tcp::TcpKeepaliveConfig,
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
     udp, SourceSender,
 };
 
@@ -49,7 +49,7 @@ pub enum Mode {
     Tcp {
         address: SocketListenAddr,
         keepalive: Option<TcpKeepaliveConfig>,
-        tls: Option<TlsConfig>,
+        tls: Option<TlsEnableableConfig>,
         receive_buffer_bytes: Option<usize>,
         connection_limit: Option<u32>,
     },

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -25,7 +25,7 @@ use super::{
 use crate::{
     config::{AcknowledgementsConfig, SourceContext},
     internal_events::{HttpBadRequest, HttpBytesReceived, HttpEventsReceived},
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
 };
 
@@ -44,7 +44,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         address: SocketAddr,
         path: &str,
         strict_path: bool,
-        tls: &Option<TlsConfig>,
+        tls: &Option<TlsEnableableConfig>,
         auth: &Option<HttpSourceAuthConfig>,
         cx: SourceContext,
         acknowledgements: AcknowledgementsConfig,

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -17,7 +17,7 @@ use crate::{
         Source,
     },
     tcp::TcpKeepaliveConfig,
-    tls::{MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -27,7 +27,7 @@ pub(crate) struct VectorConfig {
     keepalive: Option<TcpKeepaliveConfig>,
     #[serde(default = "default_shutdown_timeout_secs")]
     shutdown_timeout_secs: u64,
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     receive_buffer_bytes: Option<usize>,
 }
 
@@ -39,7 +39,7 @@ impl VectorConfig {
     #[cfg(test)]
     #[allow(unused)] // this test function is not always used in test, breaking
                      // our cargo-hack run
-    pub fn set_tls(&mut self, config: Option<TlsConfig>) {
+    pub fn set_tls(&mut self, config: Option<TlsEnableableConfig>) {
         self.tls = config;
     }
 
@@ -162,7 +162,7 @@ mod test {
         shutdown::ShutdownSignal,
         sinks::vector::v1::VectorConfig as SinkConfig,
         test_util::{collect_ready, next_addr, trace_init, wait_for_tcp},
-        tls::{TlsConfig, TlsOptions},
+        tls::{TlsConfig, TlsEnableableConfig},
         SourceSender,
     };
 
@@ -226,14 +226,14 @@ mod test {
             addr,
             {
                 let mut config = VectorConfig::from_address(addr.into());
-                config.set_tls(Some(TlsConfig::test_config()));
+                config.set_tls(Some(TlsEnableableConfig::test_config()));
                 config
             },
             {
                 let mut config = SinkConfig::from_address(format!("localhost:{}", addr.port()));
-                config.set_tls(Some(TlsConfig {
+                config.set_tls(Some(TlsEnableableConfig {
                     enabled: Some(true),
-                    options: TlsOptions {
+                    options: TlsConfig {
                         verify_certificate: Some(false),
                         ..Default::default()
                     },

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -20,7 +20,7 @@ use crate::{
     serde::bool_or_struct,
     shutdown::ShutdownSignalToken,
     sources::{util::AfterReadExt as _, Source},
-    tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig},
+    tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
 };
 
@@ -97,7 +97,7 @@ pub struct VectorConfig {
     #[serde(default = "default_shutdown_timeout_secs")]
     pub shutdown_timeout_secs: u64,
     #[serde(default)]
-    tls: Option<TlsConfig>,
+    tls: Option<TlsEnableableConfig>,
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -19,7 +19,7 @@ mod settings;
 #[cfg(all(feature = "sources-utils-tls", feature = "listenfd"))]
 pub(crate) use incoming::{MaybeTlsIncomingStream, MaybeTlsListener};
 pub(crate) use maybe_tls::MaybeTls;
-pub use settings::{MaybeTlsSettings, TlsConfig, TlsOptions, TlsSettings};
+pub use settings::{MaybeTlsSettings, TlsConfig, TlsEnableableConfig, TlsSettings};
 #[cfg(test)]
 pub use settings::{TEST_PEM_CA_PATH, TEST_PEM_CRT_PATH, TEST_PEM_KEY_PATH};
 

--- a/src/tls/settings.rs
+++ b/src/tls/settings.rs
@@ -32,13 +32,13 @@ pub const TEST_PEM_CRT_PATH: &str = "tests/data/localhost.crt";
 pub const TEST_PEM_KEY_PATH: &str = "tests/data/localhost.key";
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct TlsConfig {
+pub struct TlsEnableableConfig {
     pub enabled: Option<bool>,
     #[serde(flatten)]
-    pub options: TlsOptions,
+    pub options: TlsConfig,
 }
 
-impl TlsConfig {
+impl TlsEnableableConfig {
     pub fn enabled() -> Self {
         Self {
             enabled: Some(true),
@@ -50,7 +50,7 @@ impl TlsConfig {
     pub fn test_config() -> Self {
         Self {
             enabled: Some(true),
-            options: TlsOptions::test_options(),
+            options: TlsConfig::test_config(),
         }
     }
 }
@@ -58,7 +58,7 @@ impl TlsConfig {
 /// Standard TLS options
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct TlsOptions {
+pub struct TlsConfig {
     pub verify_certificate: Option<bool>,
     pub verify_hostname: Option<bool>,
     #[serde(alias = "ca_path")]
@@ -70,9 +70,9 @@ pub struct TlsOptions {
     pub key_pass: Option<String>,
 }
 
-impl TlsOptions {
+impl TlsConfig {
     #[cfg(test)]
-    pub fn test_options() -> Self {
+    pub fn test_config() -> Self {
         Self {
             ca_file: Some(TEST_PEM_CA_PATH.into()),
             crt_file: Some(TEST_PEM_CRT_PATH.into()),
@@ -98,15 +98,12 @@ impl TlsSettings {
     /// Generate a filled out settings struct from the given optional
     /// option set, interpreted as client options. If `options` is
     /// `None`, the result is set to defaults (ie empty).
-    pub fn from_options(options: &Option<TlsOptions>) -> Result<Self> {
+    pub fn from_options(options: &Option<TlsConfig>) -> Result<Self> {
         Self::from_options_base(options, false)
     }
 
-    pub(super) fn from_options_base(
-        options: &Option<TlsOptions>,
-        for_server: bool,
-    ) -> Result<Self> {
-        let default = TlsOptions::default();
+    pub(super) fn from_options_base(options: &Option<TlsConfig>, for_server: bool) -> Result<Self> {
+        let default = TlsConfig::default();
         let options = options.as_ref().unwrap_or(&default);
 
         if !for_server {
@@ -190,7 +187,7 @@ impl TlsSettings {
     }
 }
 
-impl TlsOptions {
+impl TlsConfig {
     fn load_authorities(&self) -> Result<Vec<X509>> {
         match &self.ca_file {
             None => Ok(vec![]),
@@ -371,7 +368,7 @@ impl MaybeTlsSettings {
         Ok(Self::Tls(tls))
     }
 
-    pub fn tls_client(config: &Option<TlsOptions>) -> Result<Self> {
+    pub fn tls_client(config: &Option<TlsConfig>) -> Result<Self> {
         Ok(Self::Tls(TlsSettings::from_options_base(config, false)?))
     }
 
@@ -381,7 +378,7 @@ impl MaybeTlsSettings {
     /// should be interpreted as being for a TLS server, which requires
     /// an identity certificate and changes the certificate verification
     /// default to false.
-    pub fn from_config(config: &Option<TlsConfig>, for_server: bool) -> Result<Self> {
+    pub fn from_config(config: &Option<TlsEnableableConfig>, for_server: bool) -> Result<Self> {
         match config {
             None => Ok(Self::Raw(())), // No config, no TLS settings
             Some(config) => {
@@ -478,7 +475,7 @@ mod test {
 
     #[test]
     fn from_options_pkcs12() {
-        let options = TlsOptions {
+        let options = TlsConfig {
             crt_file: Some(TEST_PKCS12_PATH.into()),
             key_pass: Some("NOPASS".into()),
             ..Default::default()
@@ -491,7 +488,7 @@ mod test {
 
     #[test]
     fn from_options_pem() {
-        let options = TlsOptions {
+        let options = TlsConfig {
             crt_file: Some(TEST_PEM_CRT_PATH.into()),
             key_file: Some(TEST_PEM_KEY_PATH.into()),
             ..Default::default()
@@ -506,7 +503,7 @@ mod test {
     fn from_options_inline_pem() {
         let crt = String::from_utf8(TEST_PEM_CRT_BYTES.to_vec()).unwrap();
         let key = String::from_utf8(TEST_PEM_KEY_BYTES.to_vec()).unwrap();
-        let options = TlsOptions {
+        let options = TlsConfig {
             crt_file: Some(crt.into()),
             key_file: Some(key.into()),
             ..Default::default()
@@ -519,7 +516,7 @@ mod test {
 
     #[test]
     fn from_options_ca() {
-        let options = TlsOptions {
+        let options = TlsConfig {
             ca_file: Some(TEST_PEM_CA_PATH.into()),
             ..Default::default()
         };
@@ -533,7 +530,7 @@ mod test {
     fn from_options_inline_ca() {
         let ca =
             String::from_utf8(include_bytes!("../../tests/data/Vector_CA.crt").to_vec()).unwrap();
-        let options = TlsOptions {
+        let options = TlsConfig {
             ca_file: Some(ca.into()),
             ..Default::default()
         };
@@ -545,7 +542,7 @@ mod test {
 
     #[test]
     fn from_options_intermediate_ca() {
-        let options = TlsOptions {
+        let options = TlsConfig {
             ca_file: Some("tests/data/Chain_with_intermediate.crt".into()),
             ..Default::default()
         };
@@ -557,7 +554,7 @@ mod test {
 
     #[test]
     fn from_options_multi_ca() {
-        let options = TlsOptions {
+        let options = TlsConfig {
             ca_file: Some("tests/data/Multi_CA.crt".into()),
             ..Default::default()
         };
@@ -576,7 +573,7 @@ mod test {
 
     #[test]
     fn from_options_bad_certificate() {
-        let options = TlsOptions {
+        let options = TlsConfig {
             key_file: Some(TEST_PEM_KEY_PATH.into()),
             ..Default::default()
         };
@@ -584,7 +581,7 @@ mod test {
             .expect_err("from_options failed to check certificate");
         assert!(matches!(error, TlsError::MissingCrtKeyFile));
 
-        let options = TlsOptions {
+        let options = TlsConfig {
             crt_file: Some(TEST_PEM_CRT_PATH.into()),
             ..Default::default()
         };
@@ -634,10 +631,10 @@ mod test {
             .expect("Failed to generate settings from config")
     }
 
-    fn make_config(enabled: Option<bool>, set_crt: bool, set_key: bool) -> TlsConfig {
-        TlsConfig {
+    fn make_config(enabled: Option<bool>, set_crt: bool, set_key: bool) -> TlsEnableableConfig {
+        TlsEnableableConfig {
             enabled,
-            options: TlsOptions {
+            options: TlsConfig {
                 crt_file: set_crt.then(|| TEST_PEM_CRT_PATH.into()),
                 key_file: set_key.then(|| TEST_PEM_KEY_PATH.into()),
                 ..Default::default()


### PR DESCRIPTION
This is a purely mechanical change, renaming:

`TlsOptions` => `TlsConfig`
`TlsConfig` => `TlsEnableableConfig`

The former is the main structure containing TLS configuration
parameters. The latter adds the `enabled` flag for components
where that is not set automatically.

This was done to reduce the confusion over `TlsOptions` vs `TlsConfig` vs `TlsSettings`
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
