### PR TITLE
fix(vrl): remember local state after compilation error in REPL

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -44,7 +44,7 @@ impl<'a> Compiler<'a> {
         mut self,
         ast: parser::Program,
         external: &mut ExternalEnv,
-    ) -> Result<(Program, LocalEnv), Errors> {
+    ) -> Result<Program, Errors> {
         let expressions = self
             .compile_root_exprs(ast, external)
             .into_iter()
@@ -55,13 +55,12 @@ impl<'a> Compiler<'a> {
             return Err(self.errors);
         }
 
-        let program = Program {
+        Ok(Program {
             expressions,
             fallible: self.fallible,
             abortable: self.abortable,
-        };
-
-        Ok((program, self.local))
+            local_env: self.local,
+        })
     }
 
     fn compile_root_exprs(

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -82,7 +82,7 @@ pub fn compile_for_repl(
     fns: &[Box<dyn Function>],
     local: state::LocalEnv,
     external: &mut ExternalEnv,
-) -> Result<(Program, state::LocalEnv)> {
+) -> Result<Program> {
     compiler::Compiler::new_with_local_state(fns, local).compile(ast, external)
 }
 
@@ -98,9 +98,7 @@ pub fn compile_with_state(
     fns: &[Box<dyn Function>],
     state: &mut ExternalEnv,
 ) -> Result {
-    compiler::Compiler::new(fns)
-        .compile(ast, state)
-        .map(|(program, _)| program)
+    compiler::Compiler::new(fns).compile(ast, state)
 }
 
 /// re-export of commonly used parser types.

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -1,12 +1,21 @@
 use std::{iter::IntoIterator, ops::Deref};
 
-use crate::Expression;
+use crate::{state::LocalEnv, Expression};
 
 #[derive(Debug, Clone)]
 pub struct Program {
     pub(crate) expressions: Vec<Box<dyn Expression>>,
     pub(crate) fallible: bool,
     pub(crate) abortable: bool,
+
+    /// A copy of the local environment at program compilation.
+    ///
+    /// Can be used to instantiate a new program with the same local state as
+    /// the previous program.
+    ///
+    /// Specifically, this is used by the VRL REPL to incrementally compile
+    /// a program as each line is compiled.
+    pub(crate) local_env: LocalEnv,
 }
 
 impl Program {
@@ -24,6 +33,12 @@ impl Program {
     /// statement in the source.
     pub fn can_abort(&self) -> bool {
         self.abortable
+    }
+
+    /// Get a reference to the final local environment of the compiler that
+    /// compiled the current program.
+    pub fn local_env(&self) -> &LocalEnv {
+        &self.local_env
     }
 }
 

--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -38,7 +38,7 @@ pub fn compile_for_repl(
     fns: &[Box<dyn Function>],
     external: &mut state::ExternalEnv,
     local: state::LocalEnv,
-) -> compiler::Result<(Program, state::LocalEnv)> {
+) -> compiler::Result<Program> {
     let ast = parser::parse(source).map_err(|err| vec![Box::new(err) as _])?;
 
     compiler::compile_for_repl(ast, fns, local, external)


### PR DESCRIPTION
The introduction of [local variable scoping](https://github.com/vectordotdev/vector/pull/12017) caused the VRL REPL to break. This was partially fixed in #12210, but the local state would still be dropped if the compiler returned an error in the REPL.

This PR solves that issue.

Closes #12400.