### PR TITLE
feat(vrl): allow compiler to emit non-fatal errors

### DIFF
--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -208,7 +208,8 @@ fn benchmark_remap(c: &mut Criterion) {
                 drop_on_abort: true,
                     ..Default::default()
             }, &Default::default())
-            .unwrap().0,
+            .unwrap()
+            .0,
         );
 
         let mut event = Event::from("coerce me");

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -62,7 +62,8 @@ fn benchmark_remap(c: &mut Criterion) {
                 },
                 &Default::default(),
             )
-            .unwrap(),
+            .unwrap()
+            .0,
         );
 
         let event = {
@@ -131,7 +132,8 @@ fn benchmark_remap(c: &mut Criterion) {
                 },
                 &Default::default(),
             )
-            .unwrap(),
+            .unwrap()
+            .0,
         );
 
         let event = {
@@ -206,7 +208,7 @@ fn benchmark_remap(c: &mut Criterion) {
                 drop_on_abort: true,
                     ..Default::default()
             }, &Default::default())
-            .unwrap(),
+            .unwrap().0,
         );
 
         let mut event = Event::from("coerce me");

--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -94,7 +94,7 @@ impl Function for FindEnrichmentTableRecords {
     ) -> Compiled {
         let registry = ctx
             .get_external_context_mut::<TableRegistry>()
-            .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticError>)?;
+            .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticMessage>)?;
 
         let tables = registry
             .table_ids()
@@ -149,9 +149,10 @@ impl Function for FindEnrichmentTableRecords {
     ) -> CompiledArgument {
         match (name, expr) {
             ("table", Some(expr)) => {
-                let registry = ctx
-                    .get_external_context_mut::<TableRegistry>()
-                    .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticError>)?;
+                let registry =
+                    ctx.get_external_context_mut::<TableRegistry>()
+                        .ok_or(Box::new(vrl_util::Error::TablesNotLoaded)
+                            as Box<dyn DiagnosticMessage>)?;
 
                 let tables = registry
                     .table_ids()

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -86,7 +86,7 @@ impl Function for GetEnrichmentTableRecord {
     ) -> Compiled {
         let registry = ctx
             .get_external_context_mut::<TableRegistry>()
-            .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticError>)?;
+            .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticMessage>)?;
 
         let tables = registry
             .table_ids()
@@ -141,9 +141,10 @@ impl Function for GetEnrichmentTableRecord {
     ) -> CompiledArgument {
         match (name, expr) {
             ("table", Some(expr)) => {
-                let registry = ctx
-                    .get_external_context_mut::<TableRegistry>()
-                    .ok_or(Box::new(vrl_util::Error::TablesNotLoaded) as Box<dyn DiagnosticError>)?;
+                let registry =
+                    ctx.get_external_context_mut::<TableRegistry>()
+                        .ok_or(Box::new(vrl_util::Error::TablesNotLoaded)
+                            as Box<dyn DiagnosticMessage>)?;
 
                 let tables = registry
                     .table_ids()

--- a/lib/enrichment/src/vrl_util.rs
+++ b/lib/enrichment/src/vrl_util.rs
@@ -23,7 +23,7 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         111
     }
@@ -84,7 +84,7 @@ pub(crate) fn add_index(
 }
 
 /// Takes a static boolean argument and return the value it resolves to.
-fn arg_to_bool(arg: &FunctionArgument) -> std::result::Result<bool, Box<dyn DiagnosticError>> {
+fn arg_to_bool(arg: &FunctionArgument) -> std::result::Result<bool, Box<dyn DiagnosticMessage>> {
     arg.expr()
         .as_value()
         .as_ref()
@@ -102,7 +102,7 @@ fn arg_to_bool(arg: &FunctionArgument) -> std::result::Result<bool, Box<dyn Diag
 }
 
 /// Takes a function argument (expected to be a static boolean) and returns a `Case`.
-fn arg_to_case(arg: &FunctionArgument) -> std::result::Result<Case, Box<dyn DiagnosticError>> {
+fn arg_to_case(arg: &FunctionArgument) -> std::result::Result<Case, Box<dyn DiagnosticMessage>> {
     if arg_to_bool(arg)? {
         Ok(Case::Sensitive)
     } else {
@@ -123,7 +123,7 @@ pub(crate) fn index_from_args(
     table: String,
     registry: &mut TableRegistry,
     args: &[(&'static str, Option<FunctionArgument>)],
-) -> std::result::Result<EnrichmentTableRecord, Box<dyn DiagnosticError>> {
+) -> std::result::Result<EnrichmentTableRecord, Box<dyn DiagnosticMessage>> {
     let case_sensitive = args
         .iter()
         .find(|(name, _)| *name == "case_sensitive")

--- a/lib/vector-vrl-functions/src/set_semantic_meaning.rs
+++ b/lib/vector-vrl-functions/src/set_semantic_meaning.rs
@@ -69,7 +69,7 @@ impl Function for SetSemanticMeaning {
             return Err(Box::new(ExpressionError::from(format!(
                 "meaning must be set on an external field: {}",
                 query
-            ))) as Box<dyn DiagnosticError>);
+            ))) as Box<dyn DiagnosticMessage>);
         }
 
         if let Some(list) = ctx.get_external_context_mut::<MeaningList>() {

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -52,12 +52,9 @@ impl<'a> Compiler<'a> {
             .collect();
 
         let (errors, warnings): (Vec<_>, Vec<_>) =
-            self.diagnostics
-                .into_iter()
-                .partition(|diagnostic| match diagnostic.severity() {
-                    Severity::Bug | Severity::Error => true,
-                    _ => false,
-                });
+            self.diagnostics.into_iter().partition(|diagnostic| {
+                matches!(diagnostic.severity(), Severity::Bug | Severity::Error)
+            });
 
         if !errors.is_empty() {
             return Err(errors.into());

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
-use diagnostic::DiagnosticError;
+use diagnostic::DiagnosticMessage;
 use ordered_float::NotNan;
 use parser::ast::{self, AssignmentOp, Node};
 
@@ -10,11 +10,11 @@ use crate::{
     Function, Program, Value,
 };
 
-pub(crate) type Errors = Vec<Box<dyn DiagnosticError>>;
+pub(crate) type Diagnostics = Vec<Box<dyn DiagnosticMessage>>;
 
 pub(crate) struct Compiler<'a> {
     fns: &'a [Box<dyn Function>],
-    errors: Errors,
+    errors: Diagnostics,
     fallible: bool,
     abortable: bool,
     local: LocalEnv,
@@ -44,7 +44,7 @@ impl<'a> Compiler<'a> {
         mut self,
         ast: parser::Program,
         external: &mut ExternalEnv,
-    ) -> Result<Program, Errors> {
+    ) -> Result<Program, Diagnostics> {
         let expressions = self
             .compile_root_exprs(ast, external)
             .into_iter()

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use diagnostic::{DiagnosticError, Label, Note};
+use diagnostic::{DiagnosticMessage, Label, Note};
 use dyn_clone::{clone_trait_object, DynClone};
 
 use crate::{
@@ -394,7 +394,7 @@ pub enum Error {
     Fallible { span: Span },
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use Error::*;
 

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use diagnostic::{DiagnosticError, Label, Note, Urls};
+use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 use parser::ast::Node;
 
 use crate::{
@@ -137,7 +137,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use ErrorVariant::*;
 

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryFrom, fmt};
 
-use diagnostic::{DiagnosticError, Label, Note};
+use diagnostic::{DiagnosticMessage, Label, Note};
 use lookup::LookupBuf;
 
 use crate::{
@@ -520,7 +520,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use ErrorVariant::*;
 

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -1,7 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use anymap::AnyMap;
-use diagnostic::{DiagnosticError, Label, Note, Urls};
+use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
 use crate::{
     expression::{levenstein, ExpressionError, FunctionArgument, Noop},
@@ -535,7 +535,7 @@ pub enum Error {
     #[error("function compilation error: error[E{}] {}", error.code(), error)]
     Compilation {
         call_span: Span,
-        error: Box<dyn DiagnosticError>,
+        error: Box<dyn DiagnosticMessage>,
     },
 
     #[error("can't abort infallible function")]
@@ -559,7 +559,7 @@ pub enum Error {
     UpdateState { call_span: Span, error: String },
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use Error::*;
 

--- a/lib/vrl/compiler/src/expression/literal.rs
+++ b/lib/vrl/compiler/src/expression/literal.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, convert::TryFrom, fmt};
 
 use bytes::Bytes;
 use chrono::{DateTime, SecondsFormat, Utc};
-use diagnostic::{DiagnosticError, Label, Note, Urls};
+use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 use ordered_float::NotNan;
 use regex::Regex;
 use value::ValueRegex;
@@ -281,7 +281,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use ErrorVariant::*;
 

--- a/lib/vrl/compiler/src/expression/not.rs
+++ b/lib/vrl/compiler/src/expression/not.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use diagnostic::{DiagnosticError, Label, Note, Urls};
+use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
 use crate::value::VrlValueConvert;
 use crate::{
@@ -101,7 +101,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use ErrorVariant::*;
 

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use diagnostic::{DiagnosticError, Label, Note, Span, Urls};
+use diagnostic::{DiagnosticMessage, Label, Note, Span, Urls};
 
 use crate::state::{ExternalEnv, LocalEnv};
 use crate::value::VrlValueArithmetic;
@@ -406,7 +406,7 @@ pub enum Error {
     Expr(#[from] expression::Error),
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use Error::*;
 

--- a/lib/vrl/compiler/src/expression/predicate.rs
+++ b/lib/vrl/compiler/src/expression/predicate.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use diagnostic::{DiagnosticError, Label, Note, Urls};
+use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
 use crate::{
     expression::{Expr, Resolved},
@@ -156,7 +156,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use ErrorVariant::*;
 

--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use diagnostic::{DiagnosticError, Label};
+use diagnostic::{DiagnosticMessage, Label};
 
 use crate::{
     expression::{levenstein, Resolved},
@@ -120,7 +120,7 @@ impl std::error::Error for Error {
     }
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use ErrorVariant::*;
 

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anymap::AnyMap;
-use diagnostic::{DiagnosticError, Label, Note};
+use diagnostic::{DiagnosticMessage, Label, Note};
 use value::kind::Collection;
 
 use crate::{
@@ -18,9 +18,9 @@ use crate::{
     Context, ExpressionError, Span, Value,
 };
 
-pub type Compiled = Result<Box<dyn Expression>, Box<dyn DiagnosticError>>;
+pub type Compiled = Result<Box<dyn Expression>, Box<dyn DiagnosticMessage>>;
 pub type CompiledArgument =
-    Result<Option<Box<dyn std::any::Any + Send + Sync>>, Box<dyn DiagnosticError>>;
+    Result<Option<Box<dyn std::any::Any + Send + Sync>>, Box<dyn DiagnosticMessage>>;
 
 pub trait Function: Send + Sync + fmt::Debug {
     /// The identifier by which the function can be called.
@@ -74,7 +74,7 @@ pub trait Function: Send + Sync + fmt::Debug {
         _ctx: &mut FunctionCompileContext,
         _name: &str,
         _expr: Option<&Expr>,
-    ) -> Result<Option<Box<dyn std::any::Any + Send + Sync>>, Box<dyn DiagnosticError>> {
+    ) -> Result<Option<Box<dyn std::any::Any + Send + Sync>>, Box<dyn DiagnosticMessage>> {
         Ok(None)
     }
 
@@ -462,7 +462,7 @@ pub enum Error {
     },
 }
 
-impl diagnostic::DiagnosticError for Error {
+impl diagnostic::DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use Error::*;
 
@@ -542,7 +542,7 @@ impl diagnostic::DiagnosticError for Error {
     }
 }
 
-impl From<Error> for Box<dyn diagnostic::DiagnosticError> {
+impl From<Error> for Box<dyn diagnostic::DiagnosticMessage> {
     fn from(error: Error) -> Self {
         Box::new(error) as _
     }

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -21,6 +21,7 @@ pub use crate::value::Value;
 use ::serde::{Deserialize, Serialize};
 pub use context::Context;
 pub use core::{value, ExpressionError, Resolved, Target};
+use diagnostic::DiagnosticList;
 pub(crate) use diagnostic::Span;
 pub use expression::Expression;
 pub use function::{Function, Parameter};
@@ -30,7 +31,7 @@ use state::ExternalEnv;
 use std::{fmt::Display, str::FromStr};
 pub use type_def::TypeDef;
 
-pub type Result<T = Program> = std::result::Result<T, compiler::Diagnostics>;
+pub type Result<T = (Program, DiagnosticList)> = std::result::Result<T, DiagnosticList>;
 
 /// The choice of available runtimes.
 #[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq)]
@@ -83,7 +84,9 @@ pub fn compile_for_repl(
     local: state::LocalEnv,
     external: &mut ExternalEnv,
 ) -> Result<Program> {
-    compiler::Compiler::new_with_local_state(fns, local).compile(ast, external)
+    compiler::Compiler::new_with_local_state(fns, local)
+        .compile(ast, external)
+        .map(|(program, _)| program)
 }
 
 /// Similar to [`compile`], except that it takes a pre-generated [`State`]

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -30,7 +30,7 @@ use state::ExternalEnv;
 use std::{fmt::Display, str::FromStr};
 pub use type_def::TypeDef;
 
-pub type Result<T = Program> = std::result::Result<T, compiler::Errors>;
+pub type Result<T = Program> = std::result::Result<T, compiler::Diagnostics>;
 
 /// The choice of available runtimes.
 #[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq)]

--- a/lib/vrl/compiler/src/value/error.rs
+++ b/lib/vrl/compiler/src/value/error.rs
@@ -1,4 +1,4 @@
-use diagnostic::DiagnosticError;
+use diagnostic::DiagnosticMessage;
 
 use super::Kind;
 use crate::ExpressionError;
@@ -57,7 +57,7 @@ pub enum Error {
     Merge(Kind, Kind),
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use Error::*;
 

--- a/lib/vrl/compiler/src/vm/argument_list.rs
+++ b/lib/vrl/compiler/src/vm/argument_list.rs
@@ -1,4 +1,4 @@
-use diagnostic::DiagnosticError;
+use diagnostic::DiagnosticMessage;
 
 use crate::{
     expression::{Expr, FunctionArgument},
@@ -122,7 +122,7 @@ impl<'a> VmArgumentList<'a> {
 
 /// Keeps clippy happy.
 type CompiledArguments =
-    Result<BTreeMap<&'static str, Box<dyn Any + Send + Sync>>, Box<dyn DiagnosticError>>;
+    Result<BTreeMap<&'static str, Box<dyn Any + Send + Sync>>, Box<dyn DiagnosticMessage>>;
 
 /// Compiles the function arguments with the given argument list.
 /// This is used by the stdlib unit tests.

--- a/lib/vrl/core/src/expression.rs
+++ b/lib/vrl/core/src/expression.rs
@@ -1,4 +1,4 @@
-use diagnostic::{DiagnosticError, Label, Note, Span};
+use diagnostic::{DiagnosticMessage, Label, Note, Span};
 use value::Value;
 
 pub type Resolved = Result<Value, ExpressionError>;
@@ -28,7 +28,7 @@ impl std::error::Error for ExpressionError {
     }
 }
 
-impl DiagnosticError for ExpressionError {
+impl DiagnosticMessage for ExpressionError {
     fn code(&self) -> usize {
         0
     }

--- a/lib/vrl/diagnostic/src/diagnostic.rs
+++ b/lib/vrl/diagnostic/src/diagnostic.rs
@@ -106,13 +106,13 @@ impl Diagnostic {
 }
 
 impl From<Box<dyn DiagnosticMessage>> for Diagnostic {
-    fn from(error: Box<dyn DiagnosticMessage>) -> Self {
+    fn from(message: Box<dyn DiagnosticMessage>) -> Self {
         Self {
-            severity: Severity::Error,
-            code: error.code(),
-            message: error.message(),
-            labels: error.labels(),
-            notes: error.notes(),
+            severity: message.severity(),
+            code: message.code(),
+            message: message.message(),
+            labels: message.labels(),
+            notes: message.notes(),
         }
     }
 }

--- a/lib/vrl/diagnostic/src/diagnostic.rs
+++ b/lib/vrl/diagnostic/src/diagnostic.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use codespan_reporting::diagnostic;
 
-use crate::{DiagnosticError, Label, Note, Severity, Span};
+use crate::{DiagnosticMessage, Label, Note, Severity, Span};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Diagnostic {
@@ -105,8 +105,8 @@ impl Diagnostic {
     }
 }
 
-impl From<Box<dyn DiagnosticError>> for Diagnostic {
-    fn from(error: Box<dyn DiagnosticError>) -> Self {
+impl From<Box<dyn DiagnosticMessage>> for Diagnostic {
+    fn from(error: Box<dyn DiagnosticMessage>) -> Self {
         Self {
             severity: Severity::Error,
             code: error.code(),

--- a/lib/vrl/diagnostic/src/formatter.rs
+++ b/lib/vrl/diagnostic/src/formatter.rs
@@ -26,6 +26,10 @@ impl<'a> Formatter<'a> {
     pub fn enable_colors(&mut self, color: bool) {
         self.color = color
     }
+
+    pub fn diagnostics(&self) -> &DiagnosticList {
+        &self.diagnostics
+    }
 }
 
 impl<'a> fmt::Display for Formatter<'a> {

--- a/lib/vrl/diagnostic/src/lib.rs
+++ b/lib/vrl/diagnostic/src/lib.rs
@@ -41,6 +41,13 @@ pub trait DiagnosticMessage: std::error::Error {
     fn notes(&self) -> Vec<Note> {
         vec![]
     }
+
+    /// The severity of the message.
+    ///
+    /// Defaults to `error`.
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
 }
 
 pub struct Urls;

--- a/lib/vrl/diagnostic/src/lib.rs
+++ b/lib/vrl/diagnostic/src/lib.rs
@@ -18,7 +18,7 @@ const VRL_FUNCS_ROOT_URL: &str = "https://functions.vrl.dev";
 
 /// A trait that can be implemented by error types to provide diagnostic
 /// information about the given error.
-pub trait DiagnosticError: std::error::Error {
+pub trait DiagnosticMessage: std::error::Error {
     fn code(&self) -> usize;
 
     /// The subject message of the error.

--- a/lib/vrl/parser/src/lex.rs
+++ b/lib/vrl/parser/src/lex.rs
@@ -1,6 +1,6 @@
 use std::{fmt, iter::Peekable, str::CharIndices};
 
-use diagnostic::{DiagnosticError, Label, Span};
+use diagnostic::{DiagnosticMessage, Label, Span};
 use ordered_float::NotNan;
 
 use crate::template_string::{StringSegment, TemplateString};
@@ -45,7 +45,7 @@ pub enum Error {
     UnexpectedParseError(String),
 }
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use Error::*;
 

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -64,7 +64,7 @@ impl Function for MatchAny {
 
             let re = value
                 .try_regex()
-                .map_err(|e| Box::new(e) as Box<dyn DiagnosticError>)?;
+                .map_err(|e| Box::new(e) as Box<dyn DiagnosticMessage>)?;
             re_strings.push(re.to_string());
         }
 
@@ -93,7 +93,7 @@ impl Function for MatchAny {
                 for value in patterns {
                     let re = value
                         .try_regex()
-                        .map_err(|e| Box::new(e) as Box<dyn DiagnosticError>)?;
+                        .map_err(|e| Box::new(e) as Box<dyn DiagnosticMessage>)?;
                     re_strings.push(re.to_string());
                 }
 

--- a/lib/vrl/stdlib/src/match_datadog_query.rs
+++ b/lib/vrl/stdlib/src/match_datadog_query.rs
@@ -60,7 +60,7 @@ impl Function for MatchDatadogQuery {
 
         // Compile the Datadog search query to AST.
         let node = parse(&query).map_err(|e| {
-            Box::new(ExpressionError::from(e.to_string())) as Box<dyn DiagnosticError>
+            Box::new(ExpressionError::from(e.to_string())) as Box<dyn DiagnosticMessage>
         })?;
 
         // Build the matcher function that accepts a VRL event value. This will parse the `node`
@@ -94,7 +94,7 @@ impl Function for MatchDatadogQuery {
 
                 // Compile the Datadog search query to AST.
                 let node = parse(&query).map_err(|e| {
-                    Box::new(ExpressionError::from(e.to_string())) as Box<dyn DiagnosticError>
+                    Box::new(ExpressionError::from(e.to_string())) as Box<dyn DiagnosticMessage>
                 })?;
 
                 // Build the matcher function that accepts a VRL event value. This will parse the `node`

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -39,7 +39,7 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         109
     }
@@ -119,10 +119,10 @@ impl Function for ParseGrok {
             .into_owned();
 
         let mut grok = grok::Grok::with_patterns();
-        let pattern = Arc::new(
-            grok.compile(&pattern, true)
-                .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticError>)?,
-        );
+        let pattern =
+            Arc::new(grok.compile(&pattern, true).map_err(|e| {
+                Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
+            })?);
 
         let remove_empty = arguments
             .optional("remove_empty")
@@ -152,7 +152,7 @@ impl Function for ParseGrok {
 
                 let mut grok = grok::Grok::with_patterns();
                 let pattern = Arc::new(grok.compile(&pattern, true).map_err(|e| {
-                    Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticError>
+                    Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
                 })?);
 
                 Ok(Some(Box::new(pattern) as _))

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-impl DiagnosticError for Error {
+impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         109
     }
@@ -163,7 +163,7 @@ impl Function for ParseGroks {
                 // We use a datadog library here because it is a superset of grok.
                 let grok_rules =
                     parse_grok_rules::parse_grok_rules(&patterns, aliases).map_err(|e| {
-                        Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticError>
+                        Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
                     })?;
 
                 Ok(Some(Box::new(grok_rules) as _))
@@ -239,7 +239,7 @@ impl Function for ParseGroks {
 
         // we use a datadog library here because it is a superset of grok
         let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
-            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticError>)?;
+            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
 
         let remove_empty = arguments
             .optional("remove_empty")

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
             .unwrap_or_default();
 
         match program {
-            Ok(program) => {
+            Ok((program, warnings)) if warnings.is_empty() => {
                 let run_start = Instant::now();
                 let result = run_vrl(
                     runtime,
@@ -310,7 +310,7 @@ fn main() {
                     }
                 }
             }
-            Err(diagnostics) => {
+            Ok((_, diagnostics)) | Err(diagnostics) => {
                 let mut failed = false;
                 let mut formatter = Formatter::new(&test.source, diagnostics);
                 if !test.skip {

--- a/lib/vrl/vrl/benches/runtime.rs
+++ b/lib/vrl/vrl/benches/runtime.rs
@@ -45,7 +45,7 @@ fn benchmark_kind_display(c: &mut Criterion) {
         let runtime = Runtime::new(state);
         let tz = TimeZone::default();
         let functions = vrl_stdlib::all();
-        let program = vrl::compile(source.code, &functions).unwrap();
+        let (program, _) = vrl::compile(source.code, &functions).unwrap();
         let mut external_env = state::ExternalEnv::default();
         let vm = runtime
             .compile(functions, &program, &mut external_env)

--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -28,7 +28,8 @@ pub fn compile_with_state(
     fns: &[Box<dyn Function>],
     state: &mut state::ExternalEnv,
 ) -> compiler::Result {
-    let ast = parser::parse(source).map_err(|err| vec![Box::new(err) as _])?;
+    let ast = parser::parse(source)
+        .map_err(|err| diagnostic::DiagnosticList::from(vec![Box::new(err) as Box<_>]))?;
 
     compiler::compile_with_state(ast, fns, state)
 }
@@ -39,7 +40,8 @@ pub fn compile_for_repl(
     external: &mut state::ExternalEnv,
     local: state::LocalEnv,
 ) -> compiler::Result<Program> {
-    let ast = parser::parse(source).map_err(|err| vec![Box::new(err) as _])?;
+    let ast = parser::parse(source)
+        .map_err(|err| diagnostic::DiagnosticList::from(vec![Box::new(err) as Box<_>]))?;
 
     compiler::compile_for_repl(ast, fns, local, external)
 }

--- a/lib/vrl/vrl/src/prelude.rs
+++ b/lib/vrl/vrl/src/prelude.rs
@@ -29,7 +29,7 @@ pub use compiler::{
     bench_function, expr, expression::FunctionArgument, func_args, map, test_function,
     test_type_def, type_def, value, vm::VmArgumentList,
 };
-pub use diagnostic::DiagnosticError;
+pub use diagnostic::DiagnosticMessage;
 pub use indoc::indoc;
 pub use ordered_float::NotNan;
 

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -53,7 +53,7 @@ impl ConditionConfig for VrlConfig {
         let mut state = vrl::state::ExternalEnv::default();
         state.set_external_context(enrichment_tables.clone());
 
-        let program = vrl::compile_with_state(&self.source, &functions, &mut state).map_err(
+        let (program, _) = vrl::compile_with_state(&self.source, &functions, &mut state).map_err(
             |diagnostics| {
                 Formatter::new(&self.source, diagnostics)
                     .colored()

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -128,7 +128,7 @@ impl Conditional for Vrl {
                 let err = Formatter::new(
                     &self.source,
                     vrl::diagnostic::Diagnostic::from(
-                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticError>
+                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticMessage>
                     ),
                 )
                 .colored()
@@ -139,7 +139,7 @@ impl Conditional for Vrl {
                 let err = Formatter::new(
                     &self.source,
                     vrl::diagnostic::Diagnostic::from(
-                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticError>
+                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticMessage>
                     ),
                 )
                 .colored()
@@ -207,7 +207,7 @@ impl Conditional for VrlVm {
                 let err = Formatter::new(
                     &self.source,
                     vrl::diagnostic::Diagnostic::from(
-                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticError>
+                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticMessage>
                     ),
                 )
                 .colored()
@@ -218,7 +218,7 @@ impl Conditional for VrlVm {
                 let err = Formatter::new(
                     &self.source,
                     vrl::diagnostic::Diagnostic::from(
-                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticError>
+                        Box::new(err) as Box<dyn vrl::diagnostic::DiagnosticMessage>
                     ),
                 )
                 .colored()

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -12,7 +12,7 @@ use value::Kind;
 use vector_common::TimeZone;
 use vrl::{
     diagnostic::{Formatter, Note},
-    prelude::{DiagnosticError, ExpressionError},
+    prelude::{DiagnosticMessage, ExpressionError},
     Program, Runtime, Terminate, Vm, VrlRuntime,
 };
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -123,7 +123,7 @@ impl TransformConfig for RemapConfig {
         // for printing warnings (including potentially emiting metrics),
         // instead of individual transforms.
         if !warnings.is_empty() {
-            eprintln!("{warnings}");
+            warn!(message = "VRL compilation warning.", %warnings);
         }
 
         Ok(transform)

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -53,6 +53,7 @@ impl RemapConfig {
         merged_schema_definition: schema::Definition,
     ) -> Result<(
         vrl::Program,
+        String,
         Vec<Box<dyn vrl::Function>>,
         vrl::state::ExternalEnv,
     )> {
@@ -85,7 +86,14 @@ impl RemapConfig {
                     .to_string()
                     .into()
             })
-            .map(|program| (program, functions, state))
+            .map(|(program, diagnostics)| {
+                (
+                    program,
+                    Formatter::new(&source, diagnostics).to_string(),
+                    functions,
+                    state,
+                )
+            })
     }
 }
 
@@ -99,16 +107,18 @@ impl_generate_config_from_default!(RemapConfig);
 #[typetag::serde(name = "remap")]
 impl TransformConfig for RemapConfig {
     async fn build(&self, context: &TransformContext) -> Result<Transform> {
-        match self.runtime {
+        let (transform, _) = match self.runtime {
             VrlRuntime::Ast => {
-                let remap = Remap::new_ast(self.clone(), context)?;
-                Ok(Transform::synchronous(remap))
+                let (remap, warnings) = Remap::new_ast(self.clone(), context)?;
+                (Transform::synchronous(remap), warnings)
             }
             VrlRuntime::Vm => {
-                let remap = Remap::new_vm(self.clone(), context)?;
-                Ok(Transform::synchronous(remap))
+                let (remap, warnings) = Remap::new_vm(self.clone(), context)?;
+                (Transform::synchronous(remap), warnings)
             }
-        }
+        };
+
+        Ok(transform)
     }
 
     fn input(&self) -> Input {
@@ -127,7 +137,7 @@ impl TransformConfig for RemapConfig {
                 merged_definition.clone(),
             )
             .ok()
-            .and_then(|(_, _, state)| state.target_kind().cloned())
+            .and_then(|(_, _, _, state)| state.target_kind().cloned())
             .and_then(Kind::into_object)
             .map(Into::into)
             .unwrap_or_else(schema::Definition::empty);
@@ -246,8 +256,11 @@ impl VrlRunner for AstRunner {
 }
 
 impl Remap<VmRunner> {
-    pub fn new_vm(config: RemapConfig, context: &TransformContext) -> crate::Result<Self> {
-        let (program, functions, mut state) = config.compile_vrl_program(
+    pub fn new_vm(
+        config: RemapConfig,
+        context: &TransformContext,
+    ) -> crate::Result<(Self, String)> {
+        let (program, warnings, functions, mut state) = config.compile_vrl_program(
             context.enrichment_tables.clone(),
             context.merged_schema_definition.clone(),
         )?;
@@ -259,13 +272,16 @@ impl Remap<VmRunner> {
             vm: Arc::new(vm),
         };
 
-        Self::new(config, context, program, runner)
+        Self::new(config, context, program, runner).map(|remap| (remap, warnings))
     }
 }
 
 impl Remap<AstRunner> {
-    pub fn new_ast(config: RemapConfig, context: &TransformContext) -> crate::Result<Self> {
-        let (program, _, _) = config.compile_vrl_program(
+    pub fn new_ast(
+        config: RemapConfig,
+        context: &TransformContext,
+    ) -> crate::Result<(Self, String)> {
+        let (program, warnings, _, _) = config.compile_vrl_program(
             context.enrichment_tables.clone(),
             context.merged_schema_definition.clone(),
         )?;
@@ -273,7 +289,7 @@ impl Remap<AstRunner> {
         let runtime = Runtime::default();
         let runner = AstRunner { runtime };
 
-        Self::new(config, context, program, runner)
+        Self::new(config, context, program, runner).map(|remap| (remap, warnings))
     }
 }
 
@@ -520,6 +536,7 @@ mod tests {
         ]);
 
         Remap::new_ast(config, &TransformContext::new_test(schema_definitions))
+            .map(|(remap, _)| remap)
     }
 
     #[test]
@@ -935,7 +952,7 @@ mod tests {
             ),
             ..Default::default()
         };
-        let mut tform = Remap::new_ast(conf, &context).unwrap();
+        let mut tform = Remap::new_ast(conf, &context).unwrap().0;
 
         let output = transform_one_fallible(&mut tform, happy).unwrap();
         let log = output.as_log();
@@ -1068,7 +1085,7 @@ mod tests {
             key: Some(ComponentKey::from("remapper")),
             ..Default::default()
         };
-        let mut tform = Remap::new_ast(conf, &context).unwrap();
+        let mut tform = Remap::new_ast(conf, &context).unwrap().0;
 
         let output =
             transform_one_fallible(&mut tform, error_trigger_assert_custom_message).unwrap_err();
@@ -1127,7 +1144,7 @@ mod tests {
             key: Some(ComponentKey::from("remapper")),
             ..Default::default()
         };
-        let mut tform = Remap::new_ast(conf, &context).unwrap();
+        let mut tform = Remap::new_ast(conf, &context).unwrap().0;
 
         let output = transform_one_fallible(&mut tform, error).unwrap_err();
         let log = output.as_log();
@@ -1194,7 +1211,7 @@ mod tests {
             key: Some(ComponentKey::from("remapper")),
             ..Default::default()
         };
-        let mut tform = Remap::new_ast(conf, &context).unwrap();
+        let mut tform = Remap::new_ast(conf, &context).unwrap().0;
 
         let output = transform_one_fallible(&mut tform, happy).unwrap();
         let log = output.as_log();


### PR DESCRIPTION
This PR allows the VRL compiler to emit non-fatal errors during program compilation. These errors are reported by Vector, but do not stop it from booting.

The plumbing for this has existed in VRL since the beginning, but I ripped out support for warnings in the public API a while back, as we had no use for it at the time, but this is/has changed recently.

This isn't used anywhere yet, but will allow us to add more fine-grained diagnostic messages to VRL that shouldn't necessarily prevent Vector from booting, but might be of concern to the operator. We might also in the future allow configuring the VRL compiler to abort compilation for diagnostic messages lower than the default `error` severity.

Warnings aren't emitted in the VRL REPL currently, as I suspect some of those warnings might become a nuisance. We can re-evaluate this decision in the near future.