### PR TITLE
fix(docker platform): add empty `/var/lib/vector` directory to Docker images

### DIFF
--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -5,11 +5,14 @@ WORKDIR /vector
 COPY vector-*-unknown-linux-musl*.tar.gz ./
 RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
 
+RUN mkdir -p /var/lib/vector
+
 FROM alpine:3.14
 RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
+COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -3,6 +3,8 @@ FROM debian:bullseye-slim AS builder
 COPY vector_*.deb ./
 RUN dpkg -i vector_*_$(dpkg --print-architecture).deb
 
+RUN mkdir -p /var/lib/vector
+
 FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
@@ -10,6 +12,7 @@ RUN apt-get update && apt-get install -y ca-certificates tzdata systemd && rm -r
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
 COPY --from=builder /etc/vector /etc/vector
+COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -3,11 +3,14 @@ FROM debian:bullseye-slim AS builder
 COPY vector_*.deb ./
 RUN dpkg -i vector_*_$(dpkg --print-architecture).deb
 
+RUN mkdir -p /var/lib/vector
+
 FROM gcr.io/distroless/cc-debian10
 
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
 COPY --from=builder /etc/vector /etc/vector
+COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -5,10 +5,13 @@ WORKDIR /vector
 COPY vector-*-unknown-linux-musl*.tar.gz ./
 RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
 
+RUN mkdir -p /var/lib/vector
+
 FROM gcr.io/distroless/static
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml
+COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test
 RUN ["vector", "--version"]

--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -22,6 +22,7 @@ FROM docker.io/debian:bullseye-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dede
 RUN apt-get update && apt-get dist-upgrade -y && apt-get -y install zlib1g ca-certificates
 COPY --from=lading /usr/bin/lading /usr/bin/lading
 COPY --from=builder /vector/vector /usr/bin/vector
+RUN mkdir -p /var/lib/vector
 
 # Smoke test
 RUN ["/usr/bin/lading", "--help"]

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=cache,target=/vector/target \
 FROM debian:${DEBIAN_RELEASE}-slim
 RUN apt-get update && apt-get -y install zlib1g
 COPY --from=builder /vector/vector /usr/bin/vector
+RUN mkdir -p /var/lib/vector
 
 # Smoke test
 RUN ["vector", "--version"]


### PR DESCRIPTION
After removing the `VOLUME` declarations from the Dockerfiles, the images were left without a default empty data directory, thus preventing Vector to start when a data directory is required.

Fixes #12413  🙈 