### PR TITLE
chore: Apply a number of hadolint fixes to Dockerfiles

### DIFF
--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14 AS builder
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz" --strip-components=2
+RUN tar -xvf vector-0*-"$(cat /etc/apk/arch)"-unknown-linux-musl*.tar.gz --strip-components=2
 
 RUN mkdir -p /var/lib/vector
 

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM alpine:3.14 AS builder
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
+RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2"
 
 RUN mkdir -p /var/lib/vector
 
 FROM alpine:3.14
-RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
+RUN apk --no-cache add ca-certificates tzdata
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.toml /etc/vector/vector.toml

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14 AS builder
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2"
+RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz" --strip-components=2
 
 RUN mkdir -p /var/lib/vector
 

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,13 +1,15 @@
 FROM debian:bullseye-slim AS builder
 
+WORKDIR /vector
+
 COPY vector_*.deb ./
-RUN dpkg -i vector_*_$(dpkg --print-architecture).deb
+RUN dpkg -i "vector_*_$(dpkg --print-architecture).deb"
 
 RUN mkdir -p /var/lib/vector
 
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim AS builder
 WORKDIR /vector
 
 COPY vector_*.deb ./
-RUN dpkg -i "vector_*_$(dpkg --print-architecture).deb"
+RUN dpkg -i vector_*_"$(dpkg --print-architecture)".deb
 
 RUN mkdir -p /var/lib/vector
 

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian:bullseye-slim AS builder
 
+WORKDIR /vector
+
 COPY vector_*.deb ./
-RUN dpkg -i vector_*_$(dpkg --print-architecture).deb
+RUN dpkg -i "vector_*_$(dpkg --print-architecture).deb"
 
 RUN mkdir -p /var/lib/vector
 

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim AS builder
 WORKDIR /vector
 
 COPY vector_*.deb ./
-RUN dpkg -i "vector_*_$(dpkg --print-architecture).deb"
+RUN dpkg -i vector_*_"$(dpkg --print-architecture)".deb
 
 RUN mkdir -p /var/lib/vector
 

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14 AS builder
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2
+RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2"
 
 RUN mkdir -p /var/lib/vector
 

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14 AS builder
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz" --strip-components=2
+RUN tar -xvf vector-0*-"$(cat /etc/apk/arch)"-unknown-linux-musl*.tar.gz --strip-components=2
 
 RUN mkdir -p /var/lib/vector
 

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14 AS builder
 WORKDIR /vector
 
 COPY vector-*-unknown-linux-musl*.tar.gz ./
-RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz --strip-components=2"
+RUN tar -xvf "vector-0*-$(cat /etc/apk/arch)-unknown-linux-musl*.tar.gz" --strip-components=2
 
 RUN mkdir -p /var/lib/vector
 

--- a/lib/soak/Dockerfile
+++ b/lib/soak/Dockerfile
@@ -2,7 +2,7 @@
 # BUILDER
 #
 FROM docker.io/rust:1.58-buster as builder
-WORKDIR vector
+WORKDIR /vector
 ARG VECTOR_FEATURES
 # RUN apt-get -y update && apt-get -y install build-essential cmake libclang-dev libsasl2-dev
 COPY . .

--- a/scripts/environment/Dockerfile
+++ b/scripts/environment/Dockerfile
@@ -11,21 +11,19 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN echo $TZ > /etc/timezone
 
 # Setup the env
-RUN mkdir -p /git/vectordotdev/vector/scripts/environment
-ADD scripts/environment/bootstrap-ubuntu-20.04.sh /git/vectordotdev/vector/scripts/environment/
+COPY scripts/environment/bootstrap-ubuntu-20.04.sh /git/vectordotdev/vector/scripts/environment/
 RUN ./git/vectordotdev/vector/scripts/environment/bootstrap-ubuntu-20.04.sh
 
 # Setup the toolchain
 WORKDIR /git/vectordotdev/vector
-ADD scripts/environment/prepare.sh /git/vectordotdev/vector/scripts/environment/
-ADD scripts/environment/setup-helm.sh /git/vectordotdev/vector/scripts/environment/
-ADD scripts/environment/release-flags.sh /git/vectordotdev/vector/scripts/environment/
-ADD scripts/Gemfile scripts/Gemfile.lock \
+COPY scripts/environment/prepare.sh /git/vectordotdev/vector/scripts/environment/
+COPY scripts/environment/setup-helm.sh /git/vectordotdev/vector/scripts/environment/
+COPY scripts/environment/release-flags.sh /git/vectordotdev/vector/scripts/environment/
+COPY scripts/Gemfile scripts/Gemfile.lock \
     /git/vectordotdev/vector/scripts/
-ADD rust-toolchain.toml \
+COPY rust-toolchain.toml \
     /git/vectordotdev/vector/
-RUN ./scripts/environment/prepare.sh
-RUN ./scripts/environment/setup-helm.sh
+RUN ./scripts/environment/prepare.sh && ./scripts/environment/setup-helm.sh
 
 # Declare volumes
 VOLUME /vector
@@ -33,6 +31,6 @@ VOLUME /vector/target
 VOLUME /root/.cargo
 
 # Prepare for use
-ADD ./scripts/environment/entrypoint.sh /
+COPY ./scripts/environment/entrypoint.sh /
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "bash" ]

--- a/scripts/integration/Dockerfile
+++ b/scripts/integration/Dockerfile
@@ -2,7 +2,7 @@ ARG RUST_VERSION
 FROM rust:${RUST_VERSION}-slim-bullseye
 
 RUN apt-get update \
-  && apt-get install -y g++ cmake pkg-config libclang1-9 llvm-9 libsasl2-dev libssl-dev zlib1g-dev \
+  && apt-get install -y --no-install-recommends g++ cmake pkg-config libclang1-9 llvm-9 libsasl2-dev libssl-dev zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN rustup run ${RUST_VERSION} cargo install cargo-nextest --version 0.9.8
+RUN rustup run "${RUST_VERSION}" cargo install cargo-nextest --version 0.9.8

--- a/skaffold/docker/Dockerfile
+++ b/skaffold/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-slim
 
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
   ca-certificates \
   tzdata \
   patchelf \

--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -2,7 +2,7 @@
 # VECTOR BUILDER
 #
 FROM ghcr.io/vectordotdev/vector/soak-builder@sha256:c51a7091de2caebaa690e17f37dbfed4d4059dcdf5114a5596e8ca9b5ef494f3 as builder
-WORKDIR vector
+WORKDIR /vector
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -19,7 +19,7 @@ FROM ghcr.io/blt/lading@sha256:1d2f7d3145c06df976bb9c06ad04c70de5b603598b3c4a85e
 # TARGET
 #
 FROM docker.io/debian:bullseye-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dedea30abcd8f584b23d583ec6dadc7
-RUN apt-get update && apt-get dist-upgrade -y && apt-get -y install zlib1g ca-certificates
+RUN apt-get update && apt-get dist-upgrade -y && apt-get -y --no-install-recommends install zlib1g ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=lading /usr/bin/lading /usr/bin/lading
 COPY --from=builder /vector/vector /usr/bin/vector
 RUN mkdir -p /var/lib/vector

--- a/soaks/Dockerfile.builder
+++ b/soaks/Dockerfile.builder
@@ -6,9 +6,7 @@ RUN apt-get update && \
 		rm -rf /var/lib/apt/lists/*
 
 # Build mold, a fast linker
-RUN git clone https://github.com/rui314/mold.git
-WORKDIR /mold
-RUN git checkout v1.1.1 && make -j"$(nproc)" && make install
+RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.1.1 && make -j"$(nproc)" && make install
 
 # Smoke test
 RUN ["/usr/local/bin/mold", "--version"]

--- a/soaks/Dockerfile.builder
+++ b/soaks/Dockerfile.builder
@@ -1,11 +1,14 @@
 FROM docker.io/rust:1.58-bullseye@sha256:e4979d36d5d30838126ea5ef05eb59c4c25ede7f064985e676feb21402d0661b as builder
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
-    apt-get -y install build-essential git clang cmake libclang-dev \
-    libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g
+    apt-get -y --no-install-recommends install build-essential git clang cmake libclang-dev \
+    libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g && \
+		rm -rf /var/lib/apt/lists/*
 
 # Build mold, a fast linker
-RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.1.1 && make -j$(nproc) && make install
+RUN git clone https://github.com/rui314/mold.git
+WORKDIR /mold
+RUN git checkout v1.1.1 && make -j"$(nproc)" && make install
 
 # Smoke test
 RUN ["/usr/local/bin/mold", "--version"]

--- a/tests/data/dnstap/Dockerfile
+++ b/tests/data/dnstap/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/debian:bullseye
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
   && apt-get -y --no-install-recommends install apt-utils apt-transport-https lsb-release ca-certificates curl wget \
-  && wget -O /etc/apt/trusted.gpg.d/bind.gpg https://packages.sury.org/bind/apt.gpg \
+  && wget -q -O /etc/apt/trusted.gpg.d/bind.gpg https://packages.sury.org/bind/apt.gpg \
   && sh -c 'echo "deb https://packages.sury.org/bind/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/bind.list' \
   && apt-get update \
   && apt-get -y --no-install-recommends install bind9 bind9utils dnsutils \

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -7,9 +7,10 @@ ARG FEATURES=api,api-client,sources-datadog_agent,sources-fluent,sources-host_me
 # VECTOR BUILDER
 #
 FROM docker.io/rust:${RUST_VERSION}-${DEBIAN_RELEASE} as builder
-RUN apt-get update && apt-get -y install build-essential git clang cmake libclang-dev libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g
+RUN apt-get update && apt-get -y --no-install-recommends install build-essential git clang cmake libclang-dev libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g
 RUN git clone https://github.com/rui314/mold.git
-RUN cd mold && git checkout v1.1.1 && make -j$(nproc) && make install && rm -rf mold
+WORKDIR /mold
+RUN git checkout v1.1.1 && make -j"$(nproc)" && make install
 
 WORKDIR /vector
 COPY . .
@@ -25,7 +26,7 @@ RUN --mount=type=cache,target=/vector/target \
 # TARGET
 #
 FROM debian:${DEBIAN_RELEASE}-slim
-RUN apt-get update && apt-get -y install zlib1g
+RUN apt-get update && apt-get -y --no-install-recommends install zlib1g && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /vector/vector /usr/bin/vector
 RUN mkdir -p /var/lib/vector
 

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -8,9 +8,7 @@ ARG FEATURES=api,api-client,sources-datadog_agent,sources-fluent,sources-host_me
 #
 FROM docker.io/rust:${RUST_VERSION}-${DEBIAN_RELEASE} as builder
 RUN apt-get update && apt-get -y --no-install-recommends install build-essential git clang cmake libclang-dev libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g
-RUN git clone https://github.com/rui314/mold.git
-WORKDIR /mold
-RUN git checkout v1.1.1 && make -j"$(nproc)" && make install
+RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.1.1 && make -j"$(nproc)" && make install
 
 WORKDIR /vector
 COPY . .


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

[hadolint](https://github.com/hadolint/hadolint)

Unfixed lints (mostly since we don't/haven't pinned things anywhere):

```shell
fd Dockerfile | xargs hadolint
./distribution/docker/alpine/Dockerfile:11 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
./distribution/docker/debian/Dockerfile:12 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./distribution/docker/distroless-libc/Dockerfile:10 DL3006 warning: Always tag the version of an image explicitly
./distribution/docker/distroless-static/Dockerfile:10 DL3006 warning: Always tag the version of an image explicitly
./lib/soak/Dockerfile:14 DL3006 warning: Always tag the version of an image explicitly
./scripts/integration/Dockerfile:4 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./skaffold/docker/Dockerfile:3 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./soaks/Dockerfile:22 DL3005 error: Do not use apt-get dist-upgrade
./soaks/Dockerfile:22 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./soaks/Dockerfile:28 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
./soaks/Dockerfile:29 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
./soaks/Dockerfile.builder:2 DL3005 error: Do not use apt-get dist-upgrade
./soaks/Dockerfile.builder:2 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./tests/data/dnstap/Dockerfile:4 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./tilt/Dockerfile:10 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./tilt/Dockerfile:29 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
./tilt/Dockerfile:34 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
