### PR TITLE
chore: Drop global `allow(clippy::too_many_arguments)`

### DIFF
--- a/src/api/schema/components/mod.rs
+++ b/src/api/schema/components/mod.rs
@@ -105,6 +105,7 @@ impl sort::SortableByField<ComponentsSortFieldName> for Component {
 #[derive(Default)]
 pub struct ComponentsQuery;
 
+#[allow(clippy::too_many_arguments)]
 #[Object]
 impl ComponentsQuery {
     /// Configured components (sources/transforms/sinks)

--- a/src/api/schema/metrics/source/file.rs
+++ b/src/api/schema/metrics/source/file.rs
@@ -195,6 +195,7 @@ impl CustomFilter<FileSourceMetricFile<'_>> for FileSourceMetricsFilesFilter {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 #[Object]
 impl FileSourceMetrics {
     /// File metrics

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -488,16 +488,9 @@ fn build_predicates(
     let mut errors = Vec::new();
 
     for (target_pred, arg) in map {
-        if target_pred
-            .rfind('.')
-            .and_then(|i| {
-                if i > 0 && i < target_pred.len() - 1 {
-                    Some(i)
-                } else {
-                    None
-                }
-            })
-            .map(|i| {
+        match target_pred.rfind('.')
+        {
+            Some(i) if i > 0 && i < target_pred.len() - 1 => {
                 let mut target = target_pred.clone();
                 let pred = target.split_off(i + 1);
                 target.truncate(target.len() - 1);
@@ -506,11 +499,11 @@ fn build_predicates(
                         predicates.insert(format!("{}: {:?}", target_pred, arg), pred);
                     }
                     Err(err) => errors.push(err),
-                };
-            })
-            .is_none()
-        {
-            errors.push(format!("predicate not found in check_fields value '{}', format must be <target>.<predicate>", target_pred));
+                }
+            }
+            _ => errors.push(format!(
+                "predicate not found in check_fields value '{target_pred}', format must be <target>.<predicate>"
+            )),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::float_cmp)]
 #![allow(clippy::match_wild_err_arm)]
 #![allow(clippy::new_ret_no_self)]
-#![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_arg)]
 #![deny(clippy::clone_on_ref_ptr)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 #![deny(unused_comparisons)]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::float_cmp)]
-#![allow(clippy::blocks_in_if_conditions)]
 #![allow(clippy::match_wild_err_arm)]
 #![allow(clippy::new_ret_no_self)]
 #![allow(clippy::too_many_arguments)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::match_wild_err_arm)]
 #![allow(clippy::new_ret_no_self)]
 #![allow(clippy::too_many_arguments)]
-#![allow(clippy::trivial_regex)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_arg)]
 #![deny(clippy::clone_on_ref_ptr)]

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -43,7 +43,8 @@ enum State {
 
 impl CloudwatchFuture {
     /// Panics if events.is_empty()
-    pub fn new(
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
         client: CloudwatchLogsClient,
         stream_name: String,
         group_name: String,

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -52,11 +52,9 @@ where
 
         let builder_limit = NonZeroUsize::new(64);
         let sink = input
-            .map(|event| (event.size_of(), event.into_log()))
-            .map(move |(event_byte_size, log)| {
+            .map(move |event| {
                 process_log(
-                    log,
-                    event_byte_size,
+                    event,
                     sourcetype,
                     source,
                     index,
@@ -131,8 +129,7 @@ impl ByteSizeOf for HecLogsProcessedEventMetadata {
 pub type HecProcessedEvent = ProcessedEvent<LogEvent, HecLogsProcessedEventMetadata>;
 
 pub fn process_log(
-    mut log: LogEvent,
-    event_byte_size: usize,
+    event: Event,
     sourcetype: Option<&Template>,
     source: Option<&Template>,
     index: Option<&Template>,
@@ -140,6 +137,9 @@ pub fn process_log(
     indexed_fields: &[String],
     timestamp_nanos_key: Option<&str>,
 ) -> HecProcessedEvent {
+    let event_byte_size = event.size_of();
+    let mut log = event.into_log();
+
     let sourcetype =
         sourcetype.and_then(|sourcetype| render_template_string(sourcetype, &log, "sourcetype"));
 

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -58,7 +58,6 @@ fn get_processed_event() -> HecProcessedEvent {
         log_schema().timestamp_key(),
         Utc.timestamp_nanos(1638366107111456123),
     );
-    let event_byte_size = event.size_of();
 
     let sourcetype = Template::try_from("{{ event_sourcetype }}".to_string()).ok();
     let source = Template::try_from("{{ event_source }}".to_string()).ok();
@@ -67,8 +66,7 @@ fn get_processed_event() -> HecProcessedEvent {
     let timestamp_nanos_key = Some(String::from("ts_nanos_key"));
 
     process_log(
-        event.into_log(),
-        event_byte_size,
+        event,
         sourcetype.as_ref(),
         source.as_ref(),
         index.as_ref(),

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -76,7 +76,6 @@ fn get_processed_event() -> HecProcessedEvent {
         indexed_fields.as_slice(),
         timestamp_nanos_key.as_deref(),
     )
-    .unwrap()
 }
 
 fn get_event_with_token(msg: &str, token: &str) -> Event {

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -6,7 +6,6 @@ use serde::Deserialize;
 use vector_core::{
     config::log_schema,
     event::{Event, Value},
-    ByteSizeOf,
 };
 
 use super::sink::HecProcessedEvent;

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -263,6 +263,7 @@ mod tests {
         crate::test_util::test_generate_config::<SimpleHttpConfig>();
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn source<'a>(
         headers: Vec<String>,
         query_parameters: Vec<String>,

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -142,12 +142,8 @@ impl SourceConfig for KafkaSourceConfig {
         let acknowledgements = cx.do_acknowledgements(&self.acknowledgements);
 
         Ok(Box::pin(kafka_source(
+            self.clone(),
             consumer,
-            self.key_field.clone(),
-            self.topic_key.clone(),
-            self.partition_key.clone(),
-            self.offset_key.clone(),
-            self.headers_key.clone(),
             decoder,
             cx.shutdown,
             cx.out,
@@ -169,12 +165,8 @@ impl SourceConfig for KafkaSourceConfig {
 }
 
 async fn kafka_source(
+    config: KafkaSourceConfig,
     consumer: StreamConsumer<KafkaStatisticsContext>,
-    key_field: String,
-    topic_key: String,
-    partition_key: String,
-    offset_key: String,
-    headers_key: String,
     decoder: Decoder,
     shutdown: ShutdownSignal,
     mut out: SourceSender,
@@ -244,11 +236,11 @@ async fn kafka_source(
                 let msg_partition = msg.partition();
                 let msg_offset = msg.offset();
 
-                let key_field = &key_field;
-                let topic_key = &topic_key;
-                let partition_key = &partition_key;
-                let offset_key = &offset_key;
-                let headers_key = &headers_key;
+                let key_field = config.key_field.as_str();
+                let topic_key = config.topic_key.as_str();
+                let partition_key = config.partition_key.as_str();
+                let offset_key = config.offset_key.as_str();
+                let headers_key = config.headers_key.as_str();
 
                 let payload = Cursor::new(Bytes::copy_from_slice(payload));
 
@@ -266,11 +258,11 @@ async fn kafka_source(
                                     if let Event::Log(ref mut log) = event {
                                         log.insert(schema.source_type_key(), Bytes::from("kafka"));
                                         log.insert(schema.timestamp_key(), timestamp);
-                                        log.insert(key_field.as_str(), msg_key.clone());
-                                        log.insert(topic_key.as_str(), Value::from(msg_topic.clone()));
-                                        log.insert(partition_key.as_str(), Value::from(msg_partition));
-                                        log.insert(offset_key.as_str(), Value::from(msg_offset));
-                                        log.insert(headers_key.as_str(), Value::from(headers_map.clone()));
+                                        log.insert(key_field, msg_key.clone());
+                                        log.insert(topic_key, Value::from(msg_topic.clone()));
+                                        log.insert(partition_key, Value::from(msg_partition));
+                                        log.insert(offset_key, Value::from(msg_offset));
+                                        log.insert(headers_key, Value::from(headers_map.clone()));
                                     }
 
                                     yield event;
@@ -521,13 +513,10 @@ mod integration_test {
 
         let (trigger_shutdown, shutdown, shutdown_done) = ShutdownSignal::new_wired();
         let (tx, rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let consumer = create_consumer(&config).unwrap();
         tokio::spawn(kafka_source(
-            create_consumer(&config).unwrap(),
-            config.key_field,
-            config.topic_key,
-            config.partition_key,
-            config.offset_key,
-            config.headers_key,
+            config,
+            consumer,
             crate::codecs::Decoder::default(),
             shutdown,
             tx,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -123,14 +123,10 @@ impl SourceConfig for PrometheusScrapeConfig {
             .collect::<Result<Vec<http::Uri>, sources::BuildError>>()?;
         let tls = TlsSettings::from_options(&self.tls)?;
         Ok(prometheus(
+            self.clone(),
             urls,
-            self.instance_tag.clone(),
-            self.endpoint_tag.clone(),
-            self.honor_labels,
             tls,
-            self.auth.clone(),
             cx.proxy.clone(),
-            self.scrape_interval_secs,
             cx.shutdown,
             cx.out,
         ))
@@ -221,192 +217,179 @@ struct EndpointInfo {
 }
 
 fn prometheus(
+    config: PrometheusScrapeConfig,
     urls: Vec<http::Uri>,
-    instance_tag: Option<String>,
-    endpoint_tag: Option<String>,
-    honor_labels: bool,
     tls: TlsSettings,
-    auth: Option<Auth>,
     proxy: ProxyConfig,
-    interval: u64,
     shutdown: ShutdownSignal,
     mut out: SourceSender,
 ) -> sources::Source {
     Box::pin(async move {
-        let mut stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(interval)))
-            .take_until(shutdown)
-            .map(move |_| stream::iter(urls.clone()))
-            .flatten()
-            .map(move |url| {
-                let client =
-                    HttpClient::new(tls.clone(), &proxy).expect("Building HTTP client failed");
+        let mut stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(
+            config.scrape_interval_secs,
+        )))
+        .take_until(shutdown)
+        .map(move |_| stream::iter(urls.clone()))
+        .flatten()
+        .map(move |url| {
+            let client = HttpClient::new(tls.clone(), &proxy).expect("Building HTTP client failed");
 
-                let mut request = Request::get(&url)
-                    .body(Body::empty())
-                    .expect("error creating request");
-                if let Some(auth) = &auth {
-                    auth.apply(&mut request);
-                }
+            let mut request = Request::get(&url)
+                .body(Body::empty())
+                .expect("error creating request");
+            if let Some(auth) = &config.auth {
+                auth.apply(&mut request);
+            }
 
-                let instance_info = instance_tag.as_ref().map(|tag| {
-                    let instance = format!(
-                        "{}:{}",
-                        url.host().unwrap_or_default(),
-                        url.port_u16().unwrap_or_else(|| match url.scheme() {
-                            Some(scheme) if scheme == &http::uri::Scheme::HTTP => 80,
-                            Some(scheme) if scheme == &http::uri::Scheme::HTTPS => 443,
-                            _ => 0,
-                        })
-                    );
-                    InstanceInfo {
-                        tag: tag.to_string(),
-                        instance,
-                        honor_label: honor_labels,
-                    }
-                });
-                let endpoint_info = endpoint_tag.as_ref().map(|tag| EndpointInfo {
+            let instance_info = config.instance_tag.as_ref().map(|tag| {
+                let instance = format!(
+                    "{}:{}",
+                    url.host().unwrap_or_default(),
+                    url.port_u16().unwrap_or_else(|| match url.scheme() {
+                        Some(scheme) if scheme == &http::uri::Scheme::HTTP => 80,
+                        Some(scheme) if scheme == &http::uri::Scheme::HTTPS => 443,
+                        _ => 0,
+                    })
+                );
+                InstanceInfo {
                     tag: tag.to_string(),
-                    endpoint: url.to_string(),
-                    honor_label: honor_labels,
-                });
+                    instance,
+                    honor_label: config.honor_labels,
+                }
+            });
+            let endpoint_info = config.endpoint_tag.as_ref().map(|tag| EndpointInfo {
+                tag: tag.to_string(),
+                endpoint: url.to_string(),
+                honor_label: config.honor_labels,
+            });
 
-                let start = Instant::now();
-                client
-                    .send(request)
-                    .map_err(crate::Error::from)
-                    .and_then(|response| async move {
-                        let (header, body) = response.into_parts();
-                        let body = hyper::body::to_bytes(body).await?;
-                        emit!(BytesReceived {
-                            byte_size: body.len(),
-                            protocol: "http"
-                        });
-                        Ok((header, body))
-                    })
-                    .into_stream()
-                    .filter_map(move |response| {
-                        let instance_info = instance_info.clone();
-                        let endpoint_info = endpoint_info.clone();
+            let start = Instant::now();
+            client
+                .send(request)
+                .map_err(crate::Error::from)
+                .and_then(|response| async move {
+                    let (header, body) = response.into_parts();
+                    let body = hyper::body::to_bytes(body).await?;
+                    emit!(BytesReceived {
+                        byte_size: body.len(),
+                        protocol: "http"
+                    });
+                    Ok((header, body))
+                })
+                .into_stream()
+                .filter_map(move |response| {
+                    let instance_info = instance_info.clone();
+                    let endpoint_info = endpoint_info.clone();
 
-                        ready(match response {
-                            Ok((header, body)) if header.status == hyper::StatusCode::OK => {
-                                emit!(PrometheusRequestCompleted {
-                                    start,
-                                    end: Instant::now()
-                                });
+                    ready(match response {
+                        Ok((header, body)) if header.status == hyper::StatusCode::OK => {
+                            emit!(PrometheusRequestCompleted {
+                                start,
+                                end: Instant::now()
+                            });
 
-                                let body = String::from_utf8_lossy(&body);
+                            let body = String::from_utf8_lossy(&body);
 
-                                match parser::parse_text(&body) {
-                                    Ok(events) => {
-                                        emit!(PrometheusEventsReceived {
-                                            byte_size: events.size_of(),
-                                            count: events.len(),
-                                            uri: url.clone()
-                                        });
-                                        Some(stream::iter(events).map(move |mut event| {
-                                            let metric = event.as_mut_metric();
-                                            if let Some(InstanceInfo {
-                                                tag,
-                                                instance,
-                                                honor_label,
-                                            }) = &instance_info
-                                            {
-                                                match (honor_label, metric.tag_value(tag)) {
-                                                    (false, Some(old_instance)) => {
-                                                        metric.insert_tag(
-                                                            format!("exported_{}", tag),
-                                                            old_instance,
-                                                        );
-                                                        metric.insert_tag(
-                                                            tag.clone(),
-                                                            instance.clone(),
-                                                        );
-                                                    }
-                                                    (true, Some(_)) => {}
-                                                    (_, None) => {
-                                                        metric.insert_tag(
-                                                            tag.clone(),
-                                                            instance.clone(),
-                                                        );
-                                                    }
+                            match parser::parse_text(&body) {
+                                Ok(events) => {
+                                    emit!(PrometheusEventsReceived {
+                                        byte_size: events.size_of(),
+                                        count: events.len(),
+                                        uri: url.clone()
+                                    });
+                                    Some(stream::iter(events).map(move |mut event| {
+                                        let metric = event.as_mut_metric();
+                                        if let Some(InstanceInfo {
+                                            tag,
+                                            instance,
+                                            honor_label,
+                                        }) = &instance_info
+                                        {
+                                            match (honor_label, metric.tag_value(tag)) {
+                                                (false, Some(old_instance)) => {
+                                                    metric.insert_tag(
+                                                        format!("exported_{}", tag),
+                                                        old_instance,
+                                                    );
+                                                    metric
+                                                        .insert_tag(tag.clone(), instance.clone());
+                                                }
+                                                (true, Some(_)) => {}
+                                                (_, None) => {
+                                                    metric
+                                                        .insert_tag(tag.clone(), instance.clone());
                                                 }
                                             }
-                                            if let Some(EndpointInfo {
-                                                tag,
-                                                endpoint,
-                                                honor_label,
-                                            }) = &endpoint_info
-                                            {
-                                                match (honor_label, metric.tag_value(tag)) {
-                                                    (false, Some(old_endpoint)) => {
-                                                        metric.insert_tag(
-                                                            format!("exported_{}", tag),
-                                                            old_endpoint,
-                                                        );
-                                                        metric.insert_tag(
-                                                            tag.clone(),
-                                                            endpoint.clone(),
-                                                        );
-                                                    }
-                                                    (true, Some(_)) => {}
-                                                    (_, None) => {
-                                                        metric.insert_tag(
-                                                            tag.clone(),
-                                                            endpoint.clone(),
-                                                        );
-                                                    }
-                                                }
-                                            }
-                                            event
-                                        }))
-                                    }
-                                    Err(error) => {
-                                        if url.path() == "/" {
-                                            // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
-                                            warn!(
-                                                message = PARSE_ERROR_NO_PATH,
-                                                endpoint = %url,
-                                            );
                                         }
-                                        emit!(PrometheusParseError {
-                                            error,
-                                            url: url.clone(),
-                                            body,
-                                        });
-                                        None
+                                        if let Some(EndpointInfo {
+                                            tag,
+                                            endpoint,
+                                            honor_label,
+                                        }) = &endpoint_info
+                                        {
+                                            match (honor_label, metric.tag_value(tag)) {
+                                                (false, Some(old_endpoint)) => {
+                                                    metric.insert_tag(
+                                                        format!("exported_{}", tag),
+                                                        old_endpoint,
+                                                    );
+                                                    metric
+                                                        .insert_tag(tag.clone(), endpoint.clone());
+                                                }
+                                                (true, Some(_)) => {}
+                                                (_, None) => {
+                                                    metric
+                                                        .insert_tag(tag.clone(), endpoint.clone());
+                                                }
+                                            }
+                                        }
+                                        event
+                                    }))
+                                }
+                                Err(error) => {
+                                    if url.path() == "/" {
+                                        // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
+                                        warn!(
+                                            message = PARSE_ERROR_NO_PATH,
+                                            endpoint = %url,
+                                        );
                                     }
+                                    emit!(PrometheusParseError {
+                                        error,
+                                        url: url.clone(),
+                                        body,
+                                    });
+                                    None
                                 }
                             }
-                            Ok((header, _)) => {
-                                if header.status == hyper::StatusCode::NOT_FOUND
-                                    && url.path() == "/"
-                                {
-                                    // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
-                                    warn!(
-                                        message = NOT_FOUND_NO_PATH,
-                                        endpoint = %url,
-                                    );
-                                }
-                                emit!(PrometheusHttpResponseError {
-                                    code: header.status,
-                                    url: url.clone(),
-                                });
-                                None
+                        }
+                        Ok((header, _)) => {
+                            if header.status == hyper::StatusCode::NOT_FOUND && url.path() == "/" {
+                                // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
+                                warn!(
+                                    message = NOT_FOUND_NO_PATH,
+                                    endpoint = %url,
+                                );
                             }
-                            Err(error) => {
-                                emit!(PrometheusHttpError {
-                                    error,
-                                    url: url.clone(),
-                                });
-                                None
-                            }
-                        })
+                            emit!(PrometheusHttpResponseError {
+                                code: header.status,
+                                url: url.clone(),
+                            });
+                            None
+                        }
+                        Err(error) => {
+                            emit!(PrometheusHttpError {
+                                error,
+                                url: url.clone(),
+                            });
+                            None
+                        }
                     })
-                    .flatten()
-            })
-            .flatten()
-            .boxed();
+                })
+                .flatten()
+        })
+        .flatten()
+        .boxed();
 
         match out.send_event_stream(&mut stream).await {
             Ok(()) => {

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -129,7 +129,8 @@ impl SourceConfig for PrometheusScrapeConfig {
             cx.proxy.clone(),
             cx.shutdown,
             cx.out,
-        ))
+        )
+        .boxed())
     }
 
     fn outputs(&self) -> Vec<Output> {
@@ -216,193 +217,187 @@ struct EndpointInfo {
     honor_label: bool,
 }
 
-fn prometheus(
+async fn prometheus(
     config: PrometheusScrapeConfig,
     urls: Vec<http::Uri>,
     tls: TlsSettings,
     proxy: ProxyConfig,
     shutdown: ShutdownSignal,
     mut out: SourceSender,
-) -> sources::Source {
-    Box::pin(async move {
-        let mut stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(
-            config.scrape_interval_secs,
-        )))
-        .take_until(shutdown)
-        .map(move |_| stream::iter(urls.clone()))
-        .flatten()
-        .map(move |url| {
-            let client = HttpClient::new(tls.clone(), &proxy).expect("Building HTTP client failed");
+) -> Result<(), ()> {
+    let mut stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(
+        config.scrape_interval_secs,
+    )))
+    .take_until(shutdown)
+    .map(move |_| stream::iter(urls.clone()))
+    .flatten()
+    .map(move |url| {
+        let client = HttpClient::new(tls.clone(), &proxy).expect("Building HTTP client failed");
 
-            let mut request = Request::get(&url)
-                .body(Body::empty())
-                .expect("error creating request");
-            if let Some(auth) = &config.auth {
-                auth.apply(&mut request);
-            }
-
-            let instance_info = config.instance_tag.as_ref().map(|tag| {
-                let instance = format!(
-                    "{}:{}",
-                    url.host().unwrap_or_default(),
-                    url.port_u16().unwrap_or_else(|| match url.scheme() {
-                        Some(scheme) if scheme == &http::uri::Scheme::HTTP => 80,
-                        Some(scheme) if scheme == &http::uri::Scheme::HTTPS => 443,
-                        _ => 0,
-                    })
-                );
-                InstanceInfo {
-                    tag: tag.to_string(),
-                    instance,
-                    honor_label: config.honor_labels,
-                }
-            });
-            let endpoint_info = config.endpoint_tag.as_ref().map(|tag| EndpointInfo {
-                tag: tag.to_string(),
-                endpoint: url.to_string(),
-                honor_label: config.honor_labels,
-            });
-
-            let start = Instant::now();
-            client
-                .send(request)
-                .map_err(crate::Error::from)
-                .and_then(|response| async move {
-                    let (header, body) = response.into_parts();
-                    let body = hyper::body::to_bytes(body).await?;
-                    emit!(BytesReceived {
-                        byte_size: body.len(),
-                        protocol: "http"
-                    });
-                    Ok((header, body))
-                })
-                .into_stream()
-                .filter_map(move |response| {
-                    let instance_info = instance_info.clone();
-                    let endpoint_info = endpoint_info.clone();
-
-                    ready(match response {
-                        Ok((header, body)) if header.status == hyper::StatusCode::OK => {
-                            emit!(PrometheusRequestCompleted {
-                                start,
-                                end: Instant::now()
-                            });
-
-                            let body = String::from_utf8_lossy(&body);
-
-                            match parser::parse_text(&body) {
-                                Ok(events) => {
-                                    emit!(PrometheusEventsReceived {
-                                        byte_size: events.size_of(),
-                                        count: events.len(),
-                                        uri: url.clone()
-                                    });
-                                    Some(stream::iter(events).map(move |mut event| {
-                                        let metric = event.as_mut_metric();
-                                        if let Some(InstanceInfo {
-                                            tag,
-                                            instance,
-                                            honor_label,
-                                        }) = &instance_info
-                                        {
-                                            match (honor_label, metric.tag_value(tag)) {
-                                                (false, Some(old_instance)) => {
-                                                    metric.insert_tag(
-                                                        format!("exported_{}", tag),
-                                                        old_instance,
-                                                    );
-                                                    metric
-                                                        .insert_tag(tag.clone(), instance.clone());
-                                                }
-                                                (true, Some(_)) => {}
-                                                (_, None) => {
-                                                    metric
-                                                        .insert_tag(tag.clone(), instance.clone());
-                                                }
-                                            }
-                                        }
-                                        if let Some(EndpointInfo {
-                                            tag,
-                                            endpoint,
-                                            honor_label,
-                                        }) = &endpoint_info
-                                        {
-                                            match (honor_label, metric.tag_value(tag)) {
-                                                (false, Some(old_endpoint)) => {
-                                                    metric.insert_tag(
-                                                        format!("exported_{}", tag),
-                                                        old_endpoint,
-                                                    );
-                                                    metric
-                                                        .insert_tag(tag.clone(), endpoint.clone());
-                                                }
-                                                (true, Some(_)) => {}
-                                                (_, None) => {
-                                                    metric
-                                                        .insert_tag(tag.clone(), endpoint.clone());
-                                                }
-                                            }
-                                        }
-                                        event
-                                    }))
-                                }
-                                Err(error) => {
-                                    if url.path() == "/" {
-                                        // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
-                                        warn!(
-                                            message = PARSE_ERROR_NO_PATH,
-                                            endpoint = %url,
-                                        );
-                                    }
-                                    emit!(PrometheusParseError {
-                                        error,
-                                        url: url.clone(),
-                                        body,
-                                    });
-                                    None
-                                }
-                            }
-                        }
-                        Ok((header, _)) => {
-                            if header.status == hyper::StatusCode::NOT_FOUND && url.path() == "/" {
-                                // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
-                                warn!(
-                                    message = NOT_FOUND_NO_PATH,
-                                    endpoint = %url,
-                                );
-                            }
-                            emit!(PrometheusHttpResponseError {
-                                code: header.status,
-                                url: url.clone(),
-                            });
-                            None
-                        }
-                        Err(error) => {
-                            emit!(PrometheusHttpError {
-                                error,
-                                url: url.clone(),
-                            });
-                            None
-                        }
-                    })
-                })
-                .flatten()
-        })
-        .flatten()
-        .boxed();
-
-        match out.send_event_stream(&mut stream).await {
-            Ok(()) => {
-                info!("Finished sending.");
-                Ok(())
-            }
-            Err(error) => {
-                let (count, _) = stream.size_hint();
-                emit!(StreamClosedError { error, count });
-                Err(())
-            }
+        let mut request = Request::get(&url)
+            .body(Body::empty())
+            .expect("error creating request");
+        if let Some(auth) = &config.auth {
+            auth.apply(&mut request);
         }
+
+        let instance_info = config.instance_tag.as_ref().map(|tag| {
+            let instance = format!(
+                "{}:{}",
+                url.host().unwrap_or_default(),
+                url.port_u16().unwrap_or_else(|| match url.scheme() {
+                    Some(scheme) if scheme == &http::uri::Scheme::HTTP => 80,
+                    Some(scheme) if scheme == &http::uri::Scheme::HTTPS => 443,
+                    _ => 0,
+                })
+            );
+            InstanceInfo {
+                tag: tag.to_string(),
+                instance,
+                honor_label: config.honor_labels,
+            }
+        });
+        let endpoint_info = config.endpoint_tag.as_ref().map(|tag| EndpointInfo {
+            tag: tag.to_string(),
+            endpoint: url.to_string(),
+            honor_label: config.honor_labels,
+        });
+
+        let start = Instant::now();
+        client
+            .send(request)
+            .map_err(crate::Error::from)
+            .and_then(|response| async move {
+                let (header, body) = response.into_parts();
+                let body = hyper::body::to_bytes(body).await?;
+                emit!(BytesReceived {
+                    byte_size: body.len(),
+                    protocol: "http"
+                });
+                Ok((header, body))
+            })
+            .into_stream()
+            .filter_map(move |response| {
+                let instance_info = instance_info.clone();
+                let endpoint_info = endpoint_info.clone();
+
+                ready(match response {
+                    Ok((header, body)) if header.status == hyper::StatusCode::OK => {
+                        emit!(PrometheusRequestCompleted {
+                            start,
+                            end: Instant::now()
+                        });
+
+                        let body = String::from_utf8_lossy(&body);
+
+                        match parser::parse_text(&body) {
+                            Ok(events) => {
+                                emit!(PrometheusEventsReceived {
+                                    byte_size: events.size_of(),
+                                    count: events.len(),
+                                    uri: url.clone()
+                                });
+                                Some(stream::iter(events).map(move |mut event| {
+                                    let metric = event.as_mut_metric();
+                                    if let Some(InstanceInfo {
+                                        tag,
+                                        instance,
+                                        honor_label,
+                                    }) = &instance_info
+                                    {
+                                        match (honor_label, metric.tag_value(tag)) {
+                                            (false, Some(old_instance)) => {
+                                                metric.insert_tag(
+                                                    format!("exported_{}", tag),
+                                                    old_instance,
+                                                );
+                                                metric.insert_tag(tag.clone(), instance.clone());
+                                            }
+                                            (true, Some(_)) => {}
+                                            (_, None) => {
+                                                metric.insert_tag(tag.clone(), instance.clone());
+                                            }
+                                        }
+                                    }
+                                    if let Some(EndpointInfo {
+                                        tag,
+                                        endpoint,
+                                        honor_label,
+                                    }) = &endpoint_info
+                                    {
+                                        match (honor_label, metric.tag_value(tag)) {
+                                            (false, Some(old_endpoint)) => {
+                                                metric.insert_tag(
+                                                    format!("exported_{}", tag),
+                                                    old_endpoint,
+                                                );
+                                                metric.insert_tag(tag.clone(), endpoint.clone());
+                                            }
+                                            (true, Some(_)) => {}
+                                            (_, None) => {
+                                                metric.insert_tag(tag.clone(), endpoint.clone());
+                                            }
+                                        }
+                                    }
+                                    event
+                                }))
+                            }
+                            Err(error) => {
+                                if url.path() == "/" {
+                                    // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
+                                    warn!(
+                                        message = PARSE_ERROR_NO_PATH,
+                                        endpoint = %url,
+                                    );
+                                }
+                                emit!(PrometheusParseError {
+                                    error,
+                                    url: url.clone(),
+                                    body,
+                                });
+                                None
+                            }
+                        }
+                    }
+                    Ok((header, _)) => {
+                        if header.status == hyper::StatusCode::NOT_FOUND && url.path() == "/" {
+                            // https://github.com/vectordotdev/vector/pull/3801#issuecomment-700723178
+                            warn!(
+                                message = NOT_FOUND_NO_PATH,
+                                endpoint = %url,
+                            );
+                        }
+                        emit!(PrometheusHttpResponseError {
+                            code: header.status,
+                            url: url.clone(),
+                        });
+                        None
+                    }
+                    Err(error) => {
+                        emit!(PrometheusHttpError {
+                            error,
+                            url: url.clone(),
+                        });
+                        None
+                    }
+                })
+            })
+            .flatten()
     })
+    .flatten()
+    .boxed();
+
+    match out.send_event_stream(&mut stream).await {
+        Ok(()) => {
+            info!("Finished sending.");
+            Ok(())
+        }
+        Err(error) => {
+            let (count, _) = stream.size_hint();
+            emit!(StreamClosedError { error, count });
+            Err(())
+        }
+    }
 }
 
 #[cfg(all(test, feature = "sinks-prometheus"))]

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -131,16 +131,7 @@ impl SourceConfig for SocketConfig {
                 let decoder =
                     DecodingConfig::new(config.framing().clone(), config.decoding().clone())
                         .build();
-                Ok(udp::udp(
-                    config.address(),
-                    config.max_length(),
-                    host_key,
-                    config.port_key().clone(),
-                    config.receive_buffer_bytes(),
-                    decoder,
-                    cx.shutdown,
-                    cx.out,
-                ))
+                Ok(udp::udp(config, host_key, decoder, cx.shutdown, cx.out))
             }
             #[cfg(unix)]
             Mode::UnixDatagram(config) => {

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -36,34 +36,6 @@ const fn default_shutdown_timeout_secs() -> u64 {
 }
 
 impl TcpConfig {
-    pub const fn new(
-        address: SocketListenAddr,
-        keepalive: Option<TcpKeepaliveConfig>,
-        max_length: Option<usize>,
-        shutdown_timeout_secs: u64,
-        host_key: Option<String>,
-        port_key: Option<String>,
-        tls: Option<TlsEnableableConfig>,
-        receive_buffer_bytes: Option<usize>,
-        framing: Option<FramingConfig>,
-        decoding: DeserializerConfig,
-        connection_limit: Option<u32>,
-    ) -> Self {
-        Self {
-            address,
-            keepalive,
-            max_length,
-            shutdown_timeout_secs,
-            host_key,
-            port_key,
-            tls,
-            receive_buffer_bytes,
-            framing,
-            decoding,
-            connection_limit,
-        }
-    }
-
     pub fn from_address(address: SocketListenAddr) -> Self {
         Self {
             address,

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -39,6 +39,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         path: &str,
     ) -> Result<Vec<Event>, ErrorMessage>;
 
+    #[allow(clippy::too_many_arguments)]
     fn run(
         self,
         address: SocketAddr,

--- a/src/sources/util/tcp/mod.rs
+++ b/src/sources/util/tcp/mod.rs
@@ -115,6 +115,7 @@ where
 
     fn build_acker(&self, item: &[Self::Item]) -> Self::Acker;
 
+    #[allow(clippy::too_many_arguments)]
     fn run(
         self,
         addr: SocketListenAddr,
@@ -226,6 +227,7 @@ where
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_stream<T>(
     mut shutdown_signal: ShutdownSignal,
     mut socket: MaybeTlsIncomingStream<TcpStream>,

--- a/src/transforms/key_value_parser.rs
+++ b/src/transforms/key_value_parser.rs
@@ -205,6 +205,7 @@ mod tests {
         transforms::OutputBuffer,
     };
 
+    #[allow(clippy::too_many_arguments)]
     async fn parse_log(
         text: &str,
         separator: Option<String>,

--- a/src/transforms/regex_parser.rs
+++ b/src/transforms/regex_parser.rs
@@ -194,28 +194,6 @@ impl RegexParser {
         let types =
             parse_check_conversion_map(&config.types, names, config.timezone.unwrap_or(timezone))?;
 
-        Ok(Transform::function(RegexParser::new(
-            regexset,
-            patterns,
-            field,
-            config.drop_field,
-            config.drop_failed,
-            config.target_field.clone(),
-            config.overwrite_target,
-            types,
-        )))
-    }
-
-    pub fn new(
-        regexset: RegexSet,
-        patterns: Vec<Regex>,
-        field: String,
-        mut drop_field: bool,
-        drop_failed: bool,
-        target_field: Option<String>,
-        overwrite_target: bool,
-        types: HashMap<String, Conversion>,
-    ) -> Self {
         // Build a buffer of the regex capture locations and names to avoid
         // repeated allocations.
         let patterns: Vec<CompiledRegex> = patterns
@@ -224,21 +202,22 @@ impl RegexParser {
             .collect();
 
         // Pre-calculate if the source field name should be dropped.
-        drop_field = drop_field
+        let drop_field = config.drop_field
             && !patterns
                 .iter()
                 .flat_map(|p| &p.capture_names)
                 .any(|(_, f, _)| *f == field);
 
-        Self {
+        let parser = Self {
             regexset,
             patterns,
             field,
             drop_field,
-            drop_failed,
-            target_field,
-            overwrite_target,
-        }
+            drop_failed: config.drop_failed,
+            target_field: config.target_field.clone(),
+            overwrite_target: config.overwrite_target,
+        };
+        Ok(Transform::function(parser))
     }
 }
 


### PR DESCRIPTION
This removes the global allow for the `too_many_arguments` clippy lint. I reworked several of the places that were throwing this lint, but just added a localized allow where reworking it was too annoying or non-critical (ie tests). I dropped a couple other clippy allows too that were trivial to remove.

As a bonus, it removes a little better than 100 lines of code. 🎉