### PR TITLE
fix(aws provider): Allow configuring the load timeout for AWS credentials

### DIFF
--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -116,7 +116,7 @@ mod tests {
     fn parsing_default_with_load_timeout() {
         let config = toml::from_str::<ComponentConfig>(
             r#"
-            load_timeout_secs = 10
+            auth.load_timeout_secs = 10
         "#,
         )
         .unwrap();

--- a/src/sinks/aws_kinesis_firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis_firehose/integration_tests.rs
@@ -78,7 +78,9 @@ async fn firehose_put_records() {
     components::SINK_TESTS.assert(&AWS_SINK_TAGS);
 
     let config = ElasticsearchConfig {
-        auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {})),
+        auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
+            load_timeout_secs: Some(5),
+        })),
         endpoint: elasticsearch_address(),
         bulk: Some(BulkConfig {
             index: Some(stream.clone()),

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -241,7 +241,9 @@ async fn insert_events_on_aws() {
 
     run_insert_tests(
         ElasticsearchConfig {
-            auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {})),
+            auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
+                load_timeout_secs: Some(5),
+            })),
             endpoint: aws_server(),
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
             ..config()
@@ -258,7 +260,9 @@ async fn insert_events_on_aws_with_compression() {
 
     run_insert_tests(
         ElasticsearchConfig {
-            auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {})),
+            auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
+                load_timeout_secs: Some(5),
+            })),
             endpoint: aws_server(),
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
             compression: Compression::gzip_default(),

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -39,6 +39,17 @@ components: _aws: {
 							examples: ["arn:aws:iam::123456789098:role/my_role"]
 						}
 					}
+					load_timeout_secs: {
+						category:    "Auth"
+						common:      false
+						description: "The timeout for loading credentials. Relevant when the default credentials chain is used or `assume_role`."
+						required:    false
+						type: uint: {
+							unit:    "seconds"
+							default: 5
+							examples: [30]
+						}
+					}
 					profile: {
 						category:    "Auth"
 						common:      false


### PR DESCRIPTION
Technically an enhancement, but it allows working around a regression in
behavior (the default changing from 30s to 5s as part of the SDK
upgrade) so marking as a fix.

Closes: #12421

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
