### PR TITLE
chore: Rename Vector development image

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -31,12 +31,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@f2a13332ac1ce8c0a71aeac48a150dbb1838ab67
         with:
-          images: timberio/ci_image
+          images: timberio/vector-dev
           flavor: |
             latest=true
           tags: type=sha, format=long
           labels: |
-            org.opencontainers.image.description=Image for Vector's CI workflows and Docker development environment
+            org.opencontainers.image.description=Image for Vector's Docker development environment
             org.opencontainers.image.source=https://github.com/vectordotdev/vector/tree/master/scripts/environment/Dockerfile
             org.opencontainers.image.title=Vector CI image
             org.opencontainers.image.url=https://github.com/vectordotdev/vector

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -38,7 +38,7 @@ jobs:
           labels: |
             org.opencontainers.image.description=Image for Vector's Docker development environment
             org.opencontainers.image.source=https://github.com/vectordotdev/vector/tree/master/scripts/environment/Dockerfile
-            org.opencontainers.image.title=Vector CI image
+            org.opencontainers.image.title=Vector development environment
             org.opencontainers.image.url=https://github.com/vectordotdev/vector
       - name: Build and push
         uses: docker/build-push-action@v2.10.0


### PR DESCRIPTION
Not actually used in CI after https://github.com/vectordotdev/vector/pull/12437

Will follow up to update the Makefile since the image needs to be
published first.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
