### PR TITLE
chore: Allow clippy lint for stderr output in VRL

### DIFF
--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -125,6 +125,7 @@ fn run(opts: &Opts) -> Result<(), Error> {
             Error::Parse(Formatter::new(&source, diagnostics).colored().to_string())
         })?;
 
+        #[allow(clippy::print_stderr)]
         if opts.print_warnings {
             let warnings = Formatter::new(&source, warnings).colored().to_string();
             eprintln!("{warnings}")


### PR DESCRIPTION
This was added recently. Still trying to track down why CI didn't flag it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
