### PR TITLE
chore: Avoid forcing non-vector crates to log at INFO in soak

### DIFF
--- a/soaks/bin/soak_one.sh
+++ b/soaks/bin/soak_one.sh
@@ -138,7 +138,7 @@ do
                    --config-path "/etc/lading/lading.yaml" \
                    --global-labels "variant=${VARIANT},target=vector,experiment=${SOAK_NAME}" \
                    --capture-path "/tmp/captures/${VARIANT}.captures" \
-                   --target-environment-variables "VECTOR_THREADS=${VECTOR_CPUS},VECTOR_LOG=info" \
+                   --target-environment-variables "VECTOR_THREADS=${VECTOR_CPUS}" \
                    --target-stderr-path /tmp/captures/vector.stderr.log \
                    --target-stdout-path /tmp/captures/vector.stdout.log \
                    --experiment-duration-seconds "${TOTAL_SAMPLES}" \


### PR DESCRIPTION
In relation to #12444 we see that even our VECTOR_LOG setting causes a
non-trivial amount of logging to happen for some soaks, like
`splunk_hec_route_s3`. This commit allows vector to log at info level but does
not force sub-crates to log.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
