### PR TITLE
chore(sources): Shared shutdown signals don't need `Shared`

### DIFF
--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -44,7 +44,6 @@ pub struct SqsSource {
 impl SqsSource {
     pub async fn run(self, out: SourceSender, shutdown: ShutdownSignal) -> Result<(), ()> {
         let mut task_handles = vec![];
-        let shutdown = shutdown.shared();
         let finalizer = self.acknowledgements.then(|| {
             let client = self.client.clone();
             let queue_url = self.queue_url.clone();

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -9,7 +9,6 @@ use file_source::{
 use futures::{
     future::TryFutureExt,
     stream::{Stream, StreamExt},
-    FutureExt,
 };
 use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
@@ -327,7 +326,6 @@ pub fn file_source(
     let message_start_indicator = config.message_start_indicator.clone();
     let multi_line_timeout = config.multi_line_timeout;
     let checkpoints = checkpointer.view();
-    let shutdown = shutdown.shared();
     let finalizer = acknowledgements.then(|| {
         let checkpoints = checkpointer.view();
         OrderedFinalizer::new(shutdown.clone(), move |entry: FinalizerEntry| {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -10,7 +10,7 @@ use codecs::{
     decoding::{DeserializerConfig, FramingConfig},
     StreamDecodingError,
 };
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use rdkafka::{
     config::ClientConfig,
     consumer::{Consumer, StreamConsumer},
@@ -173,7 +173,6 @@ async fn kafka_source(
     acknowledgements: bool,
 ) -> Result<(), ()> {
     let consumer = Arc::new(consumer);
-    let shutdown = shutdown.shared();
     let mut finalizer = acknowledgements.then(|| {
         let consumer = Arc::clone(&consumer);
         OrderedFinalizer::new(shutdown.clone(), move |entry: FinalizerEntry| {

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -169,7 +169,7 @@ struct SplunkSource {
 impl SplunkSource {
     fn new(config: &SplunkConfig, protocol: &'static str, cx: SourceContext) -> Self {
         let acknowledgements = cx.do_acknowledgements(&config.acknowledgements.inner);
-        let shutdown = cx.shutdown.shared();
+        let shutdown = cx.shutdown;
         let valid_tokens = config
             .valid_tokens
             .iter()

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -2,7 +2,7 @@ use std::marker::{PhantomData, Unpin};
 use std::{future::Future, pin::Pin, task::Poll};
 
 use futures::stream::{FuturesOrdered, FuturesUnordered};
-use futures::{future::Shared, FutureExt, Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use tokio::sync::mpsc;
 
 use crate::event::{BatchStatus, BatchStatusReceiver};
@@ -38,7 +38,7 @@ where
     T: Send + 'static,
     S: FuturesSet<FinalizerFuture<T>> + Default + Send + Unpin + 'static,
 {
-    pub(crate) fn new<F, Fut>(shutdown: Shared<ShutdownSignal>, apply_done: F) -> Self
+    pub(crate) fn new<F, Fut>(shutdown: ShutdownSignal, apply_done: F) -> Self
     where
         F: Fn(T) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
@@ -61,7 +61,7 @@ where
 }
 
 async fn run_finalizer<T, F: Future<Output = ()>>(
-    shutdown: Shared<ShutdownSignal>,
+    shutdown: ShutdownSignal,
     mut new_entries: mpsc::UnboundedReceiver<(BatchStatusReceiver, T)>,
     apply_done: impl Fn(T) -> F,
     mut status_receivers: impl FuturesSet<FinalizerFuture<T>> + Unpin,


### PR DESCRIPTION
The `ShutdownSignal` handles sharing of the trigger through use of an
`Arc`, and the tripwire can be cloned and waited on by multiple tasks.
As such, this does not need to be wrapped with the `Shared` future.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
