### PR TITLE
fix(codecs): Fix deserializing of `framing.character_delimited.delimiter` for encoding

### DIFF
--- a/lib/codecs/src/encoding/framing/character_delimited.rs
+++ b/lib/codecs/src/encoding/framing/character_delimited.rs
@@ -29,7 +29,8 @@ impl CharacterDelimitedEncoderConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct CharacterDelimitedEncoderOptions {
     /// The character that delimits byte sequences.
-    delimiter: u8,
+    #[serde(with = "vector_core::serde::ascii_char")]
+    pub delimiter: u8,
 }
 
 /// An encoder for handling bytes that are delimited by (a) chosen character(s).


### PR DESCRIPTION
Bug/fix similar to #10829, just for the encoding side.