### PR TITLE
fix: add sleep_impl to AWS SDK client builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8602,6 +8602,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "aws-sigv4",
+ "aws-smithy-async",
  "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,9 +150,11 @@ aws-sdk-elasticsearch = {version = "0.10.1", optional = true }
 aws-sdk-firehose = { version = "0.10.1", optional = true }
 aws-sdk-kinesis = { version = "0.10.1", optional = true }
 aws-sigv4 = { version = "0.10.1", optional = true }
-aws-smithy-types = { version = "0.40.2", optional = true }
+aws-smithy-async = { version = "0.40.2", optional = true }
 aws-smithy-client = { version = "0.40.2", optional = true }
 aws-smithy-http = { version = "0.40.2", optional = true }
+aws-smithy-types = { version = "0.40.2", optional = true }
+
 
 # Azure
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "3ca5610b959b3b6b77bb88da09f0764b605b01bc", default-features = false, features = ["enable_reqwest"], optional = true }
@@ -397,9 +399,10 @@ api-client = [
 aws-core = [
   "aws-config",
   "aws-types",
-  "aws-smithy-types",
+  "aws-smithy-async",
   "aws-smithy-client",
-  "aws-smithy-http"
+  "aws-smithy-http",
+  "aws-smithy-types"
 ]
 
 # Anything that requires Protocol Buffers.

--- a/src/common/s3.rs
+++ b/src/common/s3.rs
@@ -1,7 +1,9 @@
 use crate::aws::ClientBuilder;
 use aws_sdk_s3::{Endpoint, Region};
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::SharedCredentialsProvider;
+use std::sync::Arc;
 
 pub(crate) struct S3ClientBuilder {}
 
@@ -24,6 +26,13 @@ impl ClientBuilder for S3ClientBuilder {
 
     fn with_region(builder: Self::ConfigBuilder, region: Region) -> Self::ConfigBuilder {
         builder.region(region)
+    }
+
+    fn with_sleep_impl(
+        builder: Self::ConfigBuilder,
+        sleep_impl: Arc<dyn AsyncSleep>,
+    ) -> Self::ConfigBuilder {
+        builder.sleep_impl(sleep_impl)
     }
 
     fn client_from_conf_conn(

--- a/src/common/sqs.rs
+++ b/src/common/sqs.rs
@@ -1,7 +1,9 @@
 use crate::aws::ClientBuilder;
 use aws_sdk_sqs::{Endpoint, Region};
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::SharedCredentialsProvider;
+use std::sync::Arc;
 
 pub(crate) struct SqsClientBuilder;
 
@@ -24,6 +26,13 @@ impl ClientBuilder for SqsClientBuilder {
 
     fn with_region(builder: Self::ConfigBuilder, region: Region) -> Self::ConfigBuilder {
         builder.region(region)
+    }
+
+    fn with_sleep_impl(
+        builder: Self::ConfigBuilder,
+        sleep_impl: Arc<dyn AsyncSleep>,
+    ) -> Self::ConfigBuilder {
+        builder.sleep_impl(sleep_impl)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -1,4 +1,5 @@
 use aws_sdk_cloudwatchlogs::{Endpoint, Region};
+use std::sync::Arc;
 use tower::ServiceBuilder;
 
 use futures::FutureExt;
@@ -26,6 +27,7 @@ use crate::{
     tls::TlsConfig,
 };
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::SharedCredentialsProvider;
 
@@ -50,6 +52,13 @@ impl ClientBuilder for CloudwatchLogsClientBuilder {
 
     fn with_region(builder: Self::ConfigBuilder, region: Region) -> Self::ConfigBuilder {
         builder.region(region)
+    }
+
+    fn with_sleep_impl(
+        builder: Self::ConfigBuilder,
+        sleep_impl: Arc<dyn AsyncSleep>,
+    ) -> Self::ConfigBuilder {
+        builder.sleep_impl(sleep_impl)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::{
     collections::BTreeMap,
     task::{Context, Poll},
@@ -8,6 +9,7 @@ use aws_sdk_cloudwatch::model::{Dimension, MetricDatum};
 use aws_sdk_cloudwatch::types::DateTime as AwsDateTime;
 use aws_sdk_cloudwatch::types::SdkError;
 use aws_sdk_cloudwatch::{Client as CloudwatchClient, Endpoint, Region};
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::{future, future::BoxFuture, stream, FutureExt, SinkExt};
@@ -103,6 +105,13 @@ impl ClientBuilder for CloudwatchMetricsClientBuilder {
 
     fn with_region(builder: Self::ConfigBuilder, region: Region) -> Self::ConfigBuilder {
         builder.region(region)
+    }
+
+    fn with_sleep_impl(
+        builder: Self::ConfigBuilder,
+        sleep_impl: Arc<dyn AsyncSleep>,
+    ) -> Self::ConfigBuilder {
+        builder.sleep_impl(sleep_impl)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_kinesis_firehose/config.rs
+++ b/src/sinks/aws_kinesis_firehose/config.rs
@@ -2,8 +2,10 @@ use aws_sdk_firehose::error::{
     DescribeDeliveryStreamError, PutRecordBatchError, PutRecordBatchErrorKind,
 };
 use aws_sdk_firehose::types::SdkError;
+use std::sync::Arc;
 
 use aws_sdk_firehose::{Client as KinesisFirehoseClient, Endpoint, Region};
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::FutureExt;
@@ -129,6 +131,13 @@ impl ClientBuilder for KinesisFirehoseClientBuilder {
 
     fn with_region(builder: Self::ConfigBuilder, region: Region) -> Self::ConfigBuilder {
         builder.region(region)
+    }
+
+    fn with_sleep_impl(
+        builder: Self::ConfigBuilder,
+        sleep_impl: Arc<dyn AsyncSleep>,
+    ) -> Self::ConfigBuilder {
+        builder.sleep_impl(sleep_impl)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -1,7 +1,9 @@
 use aws_sdk_kinesis::error::{DescribeStreamError, PutRecordsError, PutRecordsErrorKind};
 use aws_sdk_kinesis::types::SdkError;
+use std::sync::Arc;
 
 use aws_sdk_kinesis::{Client as KinesisClient, Endpoint, Region};
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::FutureExt;
@@ -67,6 +69,13 @@ impl ClientBuilder for KinesisClientBuilder {
 
     fn with_region(builder: Self::ConfigBuilder, region: Region) -> Self::ConfigBuilder {
         builder.region(region)
+    }
+
+    fn with_sleep_impl(
+        builder: Self::ConfigBuilder,
+        sleep_impl: Arc<dyn AsyncSleep>,
+    ) -> Self::ConfigBuilder {
+        builder.sleep_impl(sleep_impl)
     }
 
     fn client_from_conf_conn(

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -1,9 +1,11 @@
 use std::convert::TryInto;
 use std::io::ErrorKind;
+use std::sync::Arc;
 
 use async_compression::tokio::bufread;
 use aws_sdk_s3::types::ByteStream;
 use aws_sdk_s3::{Endpoint, Region};
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::stream;
@@ -100,6 +102,13 @@ impl ClientBuilder for S3ClientBuilder {
 
     fn with_region(builder: Self::ConfigBuilder, region: Region) -> Self::ConfigBuilder {
         builder.region(region)
+    }
+
+    fn with_sleep_impl(
+        builder: Self::ConfigBuilder,
+        sleep_impl: Arc<dyn AsyncSleep>,
+    ) -> Self::ConfigBuilder {
+        builder.sleep_impl(sleep_impl)
     }
 
     fn client_from_conf_conn(


### PR DESCRIPTION
closes #12459 

This sets `sleep_impl` on all AWS client builders, using Tokio's `sleep` implementation.