### PR TITLE
chore(ci): Run check-component-features in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,7 +282,6 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
-      - run: cargo install cargo-hack
       - run: make check-component-features
 
   check-msrv:

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ check-all: check-scripts
 
 .PHONY: check-component-features
 check-component-features: ## Check that all component features are setup properly
-	${MAYBE_ENVIRONMENT_EXEC} cargo hack check --workspace --keep-going --each-feature --exclude-features "sources-utils-http sources-utils-http-encoding sources-utils-http-prelude sources-utils-http-query sources-utils-tcp-keepalive sources-utils-tcp-socket sources-utils-tls sources-utils-udp sources-utils-unix sinks-utils-udp" --all-targets
+	${MAYBE_ENVIRONMENT_EXEC} ./scripts/check-component-features
 
 .PHONY: check-clippy
 check-clippy: ## Check code with Clippy

--- a/scripts/check-component-features
+++ b/scripts/check-component-features
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -o errexit
+
+# Extract all feature names from Cargo.toml
+features=$(
+  sed -e '
+    1,/^\[features\]$/d;
+    /^\[/,$d;
+    /=/!d;
+    s/ *=.*$//;
+    /-utils-/d;
+    /^default$/d;
+    /^all-integration-tests$/d;
+  ' < Cargo.toml | sort
+)
+
+procs=$( nproc )
+
+# Prime the pump to build most of the artifacts
+cargo check --workspace --all-targets --no-default-features
+cargo check --workspace --all-targets --no-default-features --features default
+cargo check --workspace --all-targets --no-default-features --features all-integration-tests
+
+# The feature builds already run in parallel below, don't overload
+export CARGO_BUILD_JOBS=1
+
+exec xargs --max-procs=$procs --max-lines=1 scripts/check-one-feature <<< $features

--- a/scripts/check-component-features
+++ b/scripts/check-component-features
@@ -23,7 +23,7 @@ procs=$( nproc )
 # Prime the pump to build most of the artifacts
 cargo check --workspace --all-targets --no-default-features
 cargo check --workspace --all-targets --no-default-features --features default
-#cargo check --workspace --all-targets --no-default-features --features all-integration-tests
+cargo check --workspace --all-targets --no-default-features --features all-integration-tests
 
 # The feature builds already run in parallel below, don't overload
 export CARGO_BUILD_JOBS=1

--- a/scripts/check-component-features
+++ b/scripts/check-component-features
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
+set -o nounset
+set -o pipefail
 
 # Extract all feature names from Cargo.toml
 features=$(

--- a/scripts/check-component-features
+++ b/scripts/check-component-features
@@ -19,7 +19,7 @@ procs=$( nproc )
 # Prime the pump to build most of the artifacts
 cargo check --workspace --all-targets --no-default-features
 cargo check --workspace --all-targets --no-default-features --features default
-cargo check --workspace --all-targets --no-default-features --features all-integration-tests
+#cargo check --workspace --all-targets --no-default-features --features all-integration-tests
 
 # The feature builds already run in parallel below, don't overload
 export CARGO_BUILD_JOBS=1

--- a/scripts/check-component-features
+++ b/scripts/check-component-features
@@ -10,6 +10,8 @@ features=$(
     /^\[/,$d;
     /=/!d;
     s/ *=.*$//;
+
+    # Skip over certain features
     /-utils-/d;
     /^default$/d;
     /^all-integration-tests$/d;

--- a/scripts/check-one-feature
+++ b/scripts/check-one-feature
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -o errexit
+
+if [ $# -lt 1 ]
+then
+  echo "usage: $0 FEATURE [OPTIONS]"
+  exit 1
+fi
+
+feature=$1
+shift
+
+target=$PWD/target-feature-$feature
+log=$target/log
+
+echo "Starting feature check for $feature"
+
+mkdir -p target
+cp --archive --link target $target
+trap '
+  cat $log
+  rm --force --recursive $target
+' EXIT
+rm -f $target/debug/.cargo-lock
+
+# Redirect all the output to a temporary log to avoid crossing the
+# streams when this is run in parallel. The log gets dumped in the
+# exit cleanup handler above.
+(
+  echo "===== Feature: $feature ====="
+  cargo check --workspace --all-targets \
+	  --no-default-features \
+	  --features $feature \
+	  --target-dir $target \
+	  "$@"
+) &> $log
+
+# It would be nice to relink newer files back into `target` so
+# subsequent runs can pick them up, but that ends up confusing `cargo`
+# later in the process.

--- a/scripts/check-one-feature
+++ b/scripts/check-one-feature
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
+set -o nounset
+set -o pipefail
 
 if [ $# -lt 1 ]
 then

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -33,8 +33,6 @@ fn watchlogs_address() -> String {
     std::env::var("WATCHLOGS_ADDRESS").unwrap_or_else(|_| "http://localhost:6000".into())
 }
 
-const FOO: String = String::from("BROKEN!");
-
 #[tokio::test]
 async fn cloudwatch_insert_log_event() {
     trace_init();

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -33,6 +33,8 @@ fn watchlogs_address() -> String {
     std::env::var("WATCHLOGS_ADDRESS").unwrap_or_else(|_| "http://localhost:6000".into())
 }
 
+const FOO: String = String::from("BROKEN!");
+
 #[tokio::test]
 async fn cloudwatch_insert_log_event() {
     trace_init();

--- a/src/sources/util/http/auth.rs
+++ b/src/sources/util/http/auth.rs
@@ -42,12 +42,12 @@ impl TryFrom<Option<&HttpSourceAuthConfig>> for HttpSourceAuth {
 
 #[derive(Debug, Clone)]
 pub struct HttpSourceAuth {
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub(self) token: Option<String>,
 }
 
 impl HttpSourceAuth {
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub fn is_valid(&self, header: &Option<String>) -> Result<(), ErrorMessage> {
         use warp::http::StatusCode;
 

--- a/src/sources/util/http/error.rs
+++ b/src/sources/util/http/error.rs
@@ -15,7 +15,7 @@ pub struct ErrorMessage {
     feature = "sources-datadog_agent"
 ))]
 impl ErrorMessage {
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub fn new(code: http::StatusCode, message: String) -> Self {
         ErrorMessage {
             code: code.as_u16(),
@@ -23,7 +23,7 @@ impl ErrorMessage {
         }
     }
 
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub fn status_code(&self) -> http::StatusCode {
         http::StatusCode::from_u16(self.code).unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR)
     }

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -38,7 +38,7 @@ const fn default_shutdown_timeout_secs() -> u64 {
 impl VectorConfig {
     #[cfg(test)]
     #[allow(unused)] // this test function is not always used in test, breaking
-                     // our cargo-hack run
+                     // our check-component-features run
     pub fn set_tls(&mut self, config: Option<TlsEnableableConfig>) {
         self.tls = config;
     }


### PR DESCRIPTION
This speeds up the `check-component-features` check by running each
feature in a separate job in a separate build tree. This is possible
because cargo doesn't overwrite output files after they are created. To
take advantage of this, we first do a check on the full build and then
create a temporary build tree for each feature composed of hard links to
the individual files created during that check. This speeds up the
subsequent builds and allows them to run in parallel as they no longer
clobber each other's outputs.

This check normally takes a little under 2 hours on the CI runners (currently 16 cores). The improved process finished in well under 1 hour on a 4 core (8 vCPU) instance, and should scale close to linearly with core count. I have added a test commit that will cause this to fail to verify it works properly in the CI environment, and will revert it after the tests run.