### PR TITLE
chore: Run multiple replicas of the soaks at a workflow level

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -159,7 +159,7 @@ jobs:
             // jobs to run. For example, the first job might have the values:
             // { target: "fluent_remap_aws_firehose", replica: [1] }
             const matrix = {
-              target: target,  // run each experiment
+              target: target, replica: [1,2,3] // run each experiment
             }
 
             // export this variable to be available to other github steps
@@ -260,7 +260,7 @@ jobs:
           path: /tmp/comparison-image.tar
 
   soak:
-    name: Soak (${{ matrix.target }})
+    name: Soak (${{ matrix.target }}) - ${{ matrix.replica }}
     runs-on: [self-hosted, linux, x64, soak-asg]
     needs: [compute-soak-meta, compute-test-plan, build-image-baseline, build-image-comparison]
     strategy:
@@ -328,7 +328,7 @@ jobs:
       - name: Upload timing captures
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}
+          name: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.target }}-${{ matrix.replica }}
           path: /tmp/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.target }}/
 
       - name: Clean up machine


### PR DESCRIPTION
Now that #12348 has landed we have an autoscale runner pool to back up gaining
more replicas. We can't increase our numbers on a single machine or we'll go
past the hour turn-around time but we _can_ increase the number of parallel
replicas in the workflow.

It's not totally clear if the difference between machines will make this
experiment invalid or not.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
