### PR TITLE
fix(datadog_agent source): Submit source to inventory

### DIFF
--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{
         log_schema, AcknowledgementsConfig, DataType, GenerateConfig, Output, Resource,
-        SourceConfig, SourceContext,
+        SourceConfig, SourceContext, SourceDescription,
     },
     event::Event,
     internal_events::{HttpBytesReceived, HttpDecompressError, StreamClosedError},
@@ -79,6 +79,10 @@ impl GenerateConfig for DatadogAgentConfig {
         })
         .unwrap()
     }
+}
+
+inventory::submit! {
+    SourceDescription::new::<DatadogAgentConfig>("datadog_agent")
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
So that things like `vector generate datadog_agent` work.

Fixes: #12469

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
