### PR TITLE
docs: Add Attributes note to datadog_logs sink

### DIFF
--- a/website/cue/reference/components/sinks/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/datadog_logs.cue
@@ -76,4 +76,14 @@ components: sinks: datadog_logs: {
 		metrics: null
 		traces:  false
 	}
+
+	how_it_works: {
+		attributes: {
+			title: "Attributes"
+			body: """
+				Datadog's logs API has special handling for the following fields: `ddsource`, `ddtags`, `hostname`, `message`, and `service`.
+				If your event contains any of these fields they will be used as described by the [API reference](https://docs.datadoghq.com/api/latest/logs/#send-logs).
+				"""
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #7259

This will be easier for users as schema work lands and we can determine any mapping internally.

I'm not entirely happy with how this is presented, and there's not a better link to the Body section of the API reference - however, I don't know how much of DD's documentation I want to copy into our docs and possibly drift from the source of truth.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
