### PR TITLE
chore: Update component spec for BytesSent re compression

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -182,7 +182,7 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
 
 *Sinks* that send events down stream, and delete them in Vector, MUST emit
 a `BytesSent` event immediately after sending bytes to the downstream target, if
-the transmission was successful.
+the transmission was successful. The reported bytes MUST be before compression.
 
 Note that for sinks that simply expose data, but don't delete the data after
 sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.


### PR DESCRIPTION
Clarifying that the `BytesSent` event should be bytes _before_
compression to mirror the `BytesReceived` event.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
