### PR TITLE
allow parsing values as a symbol

### DIFF
--- a/lib/vrl/stdlib/src/parse_ruby_hash.rs
+++ b/lib/vrl/stdlib/src/parse_ruby_hash.rs
@@ -252,7 +252,7 @@ fn parse_value<'a, E: HashParseError<&'a str>>(input: &'a str) -> IResult<&'a st
             parse_nil,
             parse_hash,
             parse_array,
-            map(parse_colon_key, |x| Value::from(x)),
+            map(parse_colon_key, Value::from),
             map(parse_bytes, Value::Bytes),
             map(double, |value| Value::Float(NotNan::new(value).unwrap())),
             map(parse_boolean, Value::Boolean),

--- a/lib/vrl/stdlib/src/parse_ruby_hash.rs
+++ b/lib/vrl/stdlib/src/parse_ruby_hash.rs
@@ -252,6 +252,7 @@ fn parse_value<'a, E: HashParseError<&'a str>>(input: &'a str) -> IResult<&'a st
             parse_nil,
             parse_hash,
             parse_array,
+            map(parse_colon_key, |x| Value::from(x)),
             map(parse_bytes, Value::Bytes),
             map(double, |value| Value::Float(NotNan::new(value).unwrap())),
             map(parse_boolean, Value::Boolean),
@@ -291,6 +292,16 @@ mod tests {
     #[test]
     fn test_parse_arrow_empty_array() {
         parse("{ :array => [] }").unwrap();
+    }
+
+    #[test]
+    fn test_parse_symbol_value() {
+        let result = parse(r#"{ "key" => :foo }"#).unwrap();
+        assert!(result.is_object());
+        let result = result.as_object().unwrap();
+        let value = result.get("key").unwrap();
+        assert!(value.is_bytes());
+        assert_eq!(value.as_bytes().unwrap(), ":foo");
     }
 
     #[test]


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/12489

`parse_ruby_hash` can now parse hashes that contain a symbol as the value, such as `{ "key" => :foo }`