### PR TITLE
chore: Create `Output::with_port`

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -118,21 +118,21 @@ impl Output {
         }
     }
 
-    /// Set the schema definition for this output.
+    /// Set the schema definition for this `Output`.
     #[must_use]
     pub fn with_schema_definition(mut self, schema_definition: schema::Definition) -> Self {
         self.log_schema_definition = Some(schema_definition);
         self
     }
-}
 
-impl<T: Into<String>> From<(T, DataType)> for Output {
-    fn from((name, ty): (T, DataType)) -> Self {
-        Self {
-            port: Some(name.into()),
-            ty,
-            log_schema_definition: None,
-        }
+    /// Set the port name for this `Output`.
+    #[must_use]
+    pub fn with_port<S>(mut self, name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.port = Some(name.into());
+        self
     }
 }
 

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -127,10 +127,7 @@ impl Output {
 
     /// Set the port name for this `Output`.
     #[must_use]
-    pub fn with_port<S>(mut self, name: S) -> Self
-    where
-        S: Into<String>,
-    {
+    pub fn with_port(mut self, name: impl Into<String>) -> Self {
         self.port = Some(name.into());
         self
     }

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -397,7 +397,9 @@ mod test {
         fn add_transform_output(&mut self, id: &str, name: &str, ty: DataType) {
             let id = id.into();
             match self.nodes.get_mut(&id) {
-                Some(Node::Transform { outputs, .. }) => outputs.push(Output::from((name, ty))),
+                Some(Node::Transform { outputs, .. }) => {
+                    outputs.push(Output::default(ty).with_port(name))
+                }
                 _ => panic!("invalid transform"),
             }
         }
@@ -631,7 +633,7 @@ mod test {
                 in_ty: DataType::all(),
                 outputs: vec![
                     Output::default(DataType::all()),
-                    Output::from(("bar", DataType::all())),
+                    Output::default(DataType::all()).with_port("bar"),
                 ],
             },
         );
@@ -649,7 +651,7 @@ mod test {
                 in_ty: DataType::all(),
                 outputs: vec![
                     Output::default(DataType::all()),
-                    Output::from(("errors", DataType::all())),
+                    Output::default(DataType::all()).with_port("errors"),
                 ],
             },
         );

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -177,9 +177,11 @@ impl SourceConfig for DatadogAgentConfig {
 
         if self.multiple_outputs {
             vec![
-                Output::from((METRICS, DataType::Metric)),
-                Output::from((LOGS, DataType::Log)).with_schema_definition(definition),
-                Output::from((TRACES, DataType::Trace)),
+                Output::default(DataType::Metric).with_port(METRICS),
+                Output::default(DataType::Log)
+                    .with_schema_definition(definition)
+                    .with_port(LOGS),
+                Output::default(DataType::Trace).with_port(TRACES),
             ]
         } else {
             vec![Output::default(DataType::all()).with_schema_definition(definition)]

--- a/src/transforms/pipelines/config.rs
+++ b/src/transforms/pipelines/config.rs
@@ -77,7 +77,7 @@ impl PipelineConfig {
             );
             result.outputs.push((
                 filter_name.clone(),
-                vec![Output::from((UNMATCHED_ROUTE, DataType::all()))],
+                vec![Output::default(DataType::all()).with_port(UNMATCHED_ROUTE)],
             ));
             vec![filter_name.port("success")]
         } else {

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -180,7 +180,7 @@ impl TransformConfig for PipelinesConfig {
             // the default route of the type router should always be redirected
             outputs: vec![(
                 router_name.clone(),
-                vec![Output::from((UNMATCHED_ROUTE, DataType::all()))],
+                vec![Output::default(DataType::all()).with_port(UNMATCHED_ROUTE)],
             )],
         };
         let mut conditions = IndexMap::new();

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -170,7 +170,9 @@ impl TransformConfig for RemapConfig {
         if self.reroute_dropped {
             vec![
                 default_output,
-                Output::from((DROPPED, DataType::all())).with_schema_definition(dropped_definition),
+                Output::default(DataType::all())
+                    .with_schema_definition(dropped_definition)
+                    .with_port(DROPPED),
             ]
         } else {
             vec![default_output]

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -1280,7 +1280,7 @@ mod tests {
         let mut outputs = TransformOutputsBuf::new_with_capacity(
             vec![
                 Output::default(DataType::all()),
-                Output::from((DROPPED, DataType::all())),
+                Output::default(DataType::all()).with_port(DROPPED),
             ],
             1,
         );
@@ -1307,7 +1307,7 @@ mod tests {
         let mut outputs = TransformOutputsBuf::new_with_capacity(
             vec![
                 Output::default(DataType::all()),
-                Output::from((DROPPED, DataType::all())),
+                Output::default(DataType::all()).with_port(DROPPED),
             ],
             1,
         );

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -243,7 +243,9 @@ mod test {
         let mut outputs = TransformOutputsBuf::new_with_capacity(
             output_names
                 .iter()
-                .map(|output_name| Output::from((output_name.to_owned(), DataType::all())))
+                .map(|output_name| {
+                    Output::default(DataType::all()).with_port(output_name.to_owned())
+                })
                 .collect(),
             1,
         );
@@ -282,7 +284,9 @@ mod test {
         let mut outputs = TransformOutputsBuf::new_with_capacity(
             output_names
                 .iter()
-                .map(|output_name| Output::from((output_name.to_owned(), DataType::all())))
+                .map(|output_name| {
+                    Output::default(DataType::all()).with_port(output_name.to_owned())
+                })
                 .collect(),
             1,
         );
@@ -320,7 +324,9 @@ mod test {
         let mut outputs = TransformOutputsBuf::new_with_capacity(
             output_names
                 .iter()
-                .map(|output_name| Output::from((output_name.to_owned(), DataType::all())))
+                .map(|output_name| {
+                    Output::default(DataType::all()).with_port(output_name.to_owned())
+                })
                 .collect(),
             1,
         );

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -113,9 +113,9 @@ impl TransformConfig for RouteConfig {
         let mut result: Vec<Output> = self
             .route
             .keys()
-            .map(|output_name| Output::from((output_name, DataType::all())))
+            .map(|output_name| Output::default(DataType::all()).with_port(output_name))
             .collect();
-        result.push(Output::from((UNMATCHED_ROUTE, DataType::all())));
+        result.push(Output::default(DataType::all()).with_port(UNMATCHED_ROUTE));
         result
     }
 


### PR DESCRIPTION
This commit removes the `From<(Into<String>, DataType)>` conversion on `Output`
in favor of a builder-ish style function, similar to what already existed on
this type with `with_schema_definition`.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
