### PR TITLE
chore: Use ndjson encoding, not parse_json

### DIFF
--- a/soaks/tests/http_pipelines_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole/vector.toml
@@ -10,7 +10,7 @@ type = "internal_metrics"
 [sources.logs]
 type = "http"
 address = "0.0.0.0:8282"
-encoding = "text"
+encoding = "ndjson"
 
 ##
 ## Transforms
@@ -20,7 +20,6 @@ encoding = "text"
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_json(.message)
 if starts_with(strip_whitespace!(.message), "{") {
   custom, err = parse_json(.message)
   if (err == null) {

--- a/soaks/tests/http_pipelines_blackhole_acks/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole_acks/vector.toml
@@ -10,7 +10,7 @@ type = "internal_metrics"
 [sources.logs]
 type = "http"
 address = "0.0.0.0:8282"
-encoding = "text"
+encoding = "ndjson"
 acknowledgements = true
 
 ##
@@ -21,7 +21,6 @@ acknowledgements = true
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_json(.message)
 if starts_with(strip_whitespace!(.message), "{") {
   custom, err = parse_json(.message)
   if (err == null) {

--- a/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
@@ -10,7 +10,7 @@ type = "internal_metrics"
 [sources.logs]
 type = "http"
 address = "0.0.0.0:8282"
-encoding = "text"
+encoding = "ndjson"
 
 ##
 ## Transforms
@@ -20,7 +20,6 @@ encoding = "text"
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_json(.message)
 .custom = {}
 '''
 


### PR DESCRIPTION
One of the major difficulties underlying #10144 is an inability for Vector to
saturate its cores. Exactly why is not totally clear, but we _are_ bottlenecking
right at the top in our soak tests by parsing json in VRL rather than using the
encoding feature of the source.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
