### PR TITLE
feat(vrl): add a max_depth parameter to the parse_json function

### DIFF
--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -1420,8 +1420,23 @@ bench_function! {
     }
 
     map_max_depth {
-        args: func_args![value: r#"{"key": "value"}"#, max_depth: 128],
+        args: func_args![value: r#"{"key": "value"}"#, max_depth: 10],
         want: Ok(value!({key: "value"})),
+    }
+
+    nested {
+        args: func_args![value: r#"{"1":{"2":{"3":{"4":{"5":{"6":"end"}}}}}}"#],
+        want: Ok(value!({"1":{"2":{"3":{"4":{"5":{"6":"end"}}}}}})),
+    }
+
+    nested_max_depth_1 {
+        args: func_args![value: r#"{"1":{"2":{"3":{"4":{"5":{"6":"end"}}}}}}"#, max_depth: 1],
+        want: Ok(value!({"1":{"2":"{\"3\":{\"4\":{\"5\":{\"6\":\"end\"}}}}"}})),
+    }
+
+    nested_max_depth_10 {
+        args: func_args![value: r#"{"1":{"2":{"3":{"4":{"5":{"6":"end"}}}}}}"#, max_depth: 10],
+        want: Ok(value!({"1":{"2":{"3":{"4":{"5":{"6":"end"}}}}}})),
     }
 }
 

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -1431,7 +1431,7 @@ bench_function! {
 
     nested_max_depth_1 {
         args: func_args![value: r#"{"1":{"2":{"3":{"4":{"5":{"6":"end"}}}}}}"#, max_depth: 1],
-        want: Ok(value!({"1":{"2":"{\"3\":{\"4\":{\"5\":{\"6\":\"end\"}}}}"}})),
+        want: Ok(value!({"1":"{\"2\":{\"3\":{\"4\":{\"5\":{\"6\":\"end\"}}}}}"})),
     }
 
     nested_max_depth_10 {

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -1418,6 +1418,11 @@ bench_function! {
         args: func_args![value: r#"{"key": "value"}"#],
         want: Ok(value!({key: "value"})),
     }
+
+    map_max_depth {
+        args: func_args![value: r#"{"key": "value"}"#, max_depth: 128],
+        want: Ok(value!({key: "value"})),
+    }
 }
 
 bench_function! {

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -177,10 +177,9 @@ impl Function for ParseJson {
         let value = arguments.required("value");
         let max_depth = arguments.optional("max_depth");
 
-        if let Some(max_depth) = max_depth {
-            Ok(Box::new(ParseJsonMaxDepthFn { value, max_depth }))
-        } else {
-            Ok(Box::new(ParseJsonFn { value }))
+        match max_depth {
+            Some(max_depth) => Ok(Box::new(ParseJsonMaxDepthFn { value, max_depth })),
+            None => Ok(Box::new(ParseJsonFn { value })),
         }
     }
 

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -1,10 +1,70 @@
+use serde_json::value::{RawValue, Value as JsonValue};
+use serde_json::{Error, Map};
+use std::collections::HashMap;
 use vrl::prelude::*;
 
-fn parse_json(value: Value) -> Resolved {
+fn parse_json(value: Value, max_depth: Option<Value>) -> Resolved {
     let bytes = value.try_bytes()?;
-    let value = serde_json::from_slice::<'_, Value>(&bytes)
-        .map_err(|e| format!("unable to parse json: {}", e))?;
-    Ok(value)
+
+    if let Some(md) = max_depth {
+        let parsed_depth = positive_int_depth(md)?;
+
+        let raw_value: Box<RawValue> = serde_json::from_slice::<_>(&bytes)
+            .map_err(|e| format!("unable to read json: {}", e))?;
+
+        let res = parse_once_with_depth(raw_value, parsed_depth)
+            .map_err(|e| format!("unable to parse json with max depth: {}", e))?;
+        Ok(Value::from(res))
+    } else {
+        let value = serde_json::from_slice::<'_, Value>(&bytes)
+            .map_err(|e| format!("unable to parse json: {}", e))?;
+        Ok(value)
+    }
+}
+
+fn positive_int_depth(value: Value) -> std::result::Result<i64, ExpressionError> {
+    let res = value.try_integer()?;
+    if !(1..=128).contains(&res) {
+        Err(ExpressionError::from(format!(
+            "max_depth value should be greater than 0 and less than 128, got {}",
+            res
+        )))
+    } else {
+        Ok(res)
+    }
+}
+
+fn parse_once_with_depth(
+    value: Box<RawValue>,
+    max_depth: i64,
+) -> std::result::Result<JsonValue, Error> {
+    if value.get().starts_with('{') {
+        if max_depth == 0 {
+            serde_json::value::to_value(value.to_string())
+        } else {
+            let map: HashMap<String, Box<RawValue>> = serde_json::from_str(value.get())?;
+
+            let mut res_map: Map<String, JsonValue> = Map::with_capacity(map.len());
+            for (k, v) in map {
+                res_map.insert(k, parse_once_with_depth(v, max_depth - 1)?);
+            }
+            Ok(serde_json::Value::from(res_map))
+        }
+    } else if value.get().starts_with('[') {
+        if max_depth == 0 {
+            serde_json::value::to_value(value.to_string())
+        } else {
+            let arr: Vec<Box<RawValue>> = serde_json::from_str(value.get())?;
+
+            let mut res_arr: Vec<JsonValue> = Vec::with_capacity(arr.len());
+            for v in arr {
+                res_arr.push(parse_once_with_depth(v, max_depth - 1)?)
+            }
+            Ok(serde_json::Value::from(res_arr))
+        }
+    } else {
+        serde_json::from_str(value.get())
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -29,11 +89,18 @@ impl Function for ParseJson {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "value",
-            kind: kind::BYTES,
-            required: true,
-        }]
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "max_depth",
+                kind: kind::INTEGER,
+                required: false,
+            },
+        ]
     }
 
     fn examples(&self) -> &'static [Example] {
@@ -75,6 +142,11 @@ impl Function for ParseJson {
                     r#"function call error for "parse_json" at (0:26): unable to parse json: key must be a string at line 1 column 3"#,
                 ),
             },
+            Example {
+                title: "max_depth",
+                source: r#"parse_json!(s'{"first_level":{"second_level":"finish"}}', max_depth: 1)"#,
+                result: Ok(r#"{"first_level":"{\"second_level\":\"finish\"}"}"#),
+            },
         ]
     }
 
@@ -85,25 +157,33 @@ impl Function for ParseJson {
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
+        let max_depth = arguments.optional("max_depth");
 
-        Ok(Box::new(ParseJsonFn { value }))
+        Ok(Box::new(ParseJsonFn { value, max_depth }))
     }
 
     fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Resolved {
         let value = args.required("value");
-        parse_json(value)
+        let max_depth = args.optional("max_depth");
+        parse_json(value, max_depth)
     }
 }
 
 #[derive(Debug, Clone)]
 struct ParseJsonFn {
     value: Box<dyn Expression>,
+    max_depth: Option<Box<dyn Expression>>,
 }
 
 impl Expression for ParseJsonFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
-        parse_json(value)
+        let max_depth = self
+            .max_depth
+            .as_ref()
+            .map(|c| c.resolve(ctx))
+            .transpose()?;
+        parse_json(value, max_depth)
     }
 
     fn type_def(&self, _: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
@@ -161,6 +241,42 @@ mod tests {
                 .add_null()
                 .add_array(Collection::from_unknown(inner_kind()))
                 .add_object(Collection::from_unknown(inner_kind())),
+        }
+
+        max_depth {
+            args: func_args![ value: r#"{"top_layer": {"layer_one": "finish", "layer_two": 2}}"#, max_depth: 1],
+            want: Ok(value!({ top_layer: r#"{"layer_one": "finish", "layer_two": 2}"# })),
+            tdef: type_def(),
+        }
+
+        max_depth_array {
+            args: func_args![ value: r#"[{"top_layer": {"next_layer": ["finish"]}}]"#, max_depth: 2],
+            want: Ok(value!([{ top_layer: r#"{"next_layer": ["finish"]}"# }])),
+            tdef: type_def(),
+        }
+
+        max_depth_exhausted {
+            args: func_args![ value: r#"{"top_layer": {"layer_one": "finish", "layer_two": 2}}"#, max_depth: 10],
+            want: Ok(value!({ top_layer: {layer_one: "finish", layer_two: 2} })),
+            tdef: type_def(),
+        }
+
+        invalid_json_with_max_depth {
+            args: func_args![ value: r#"{"field": "value"#, max_depth: 3 ],
+            want: Err("unable to read json: EOF while parsing a string at line 1 column 16"),
+            tdef: TypeDef::bytes().fallible()
+                .add_boolean()
+                .add_integer()
+                .add_float()
+                .add_null()
+                .add_array(Collection::from_unknown(inner_kind()))
+                .add_object(Collection::from_unknown(inner_kind())),
+        }
+
+        invalid_input_max_depth {
+            args: func_args![ value: r#"{"top_layer": "finish"}"#, max_depth: 129],
+            want: Err("max_depth value should be greater than 0 and less than 128, got 129"),
+            tdef: type_def(),
         }
     ];
 }

--- a/website/cue/reference/remap/functions/parse_json.cue
+++ b/website/cue/reference/remap/functions/parse_json.cue
@@ -19,6 +19,12 @@ remap: functions: parse_json: {
 			required:    true
 			type: ["string"]
 		},
+		{
+			name:        "max_depth"
+			description: "Number of layers to parse for nested JSON-formatted documents."
+			required:    false
+			type: ["integer"]
+		},
 	]
 	internal_failure_reasons: [
 		"`value` isn't a valid JSON-formatted payload",
@@ -32,6 +38,13 @@ remap: functions: parse_json: {
 				parse_json!("{\"key\": \"val\"}")
 				"""#
 			return: key: "val"
+		},
+		{
+			title: "Parse JSON with max_depth"
+			source: #"""
+				parse_json!("{\"top_level\":{\"key\": \"val\"}}", max_depth: 1)
+				"""#
+			return: top_level: "{\"key\": \"val\"}"
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/parse_json.cue
+++ b/website/cue/reference/remap/functions/parse_json.cue
@@ -21,7 +21,10 @@ remap: functions: parse_json: {
 		},
 		{
 			name:        "max_depth"
-			description: "Number of layers to parse for nested JSON-formatted documents."
+			description: """
+				Number of layers to parse for nested JSON-formatted documents.
+				The value must be in range 1..128.
+				"""
 			required:    false
 			type: ["integer"]
 		},

--- a/website/cue/reference/remap/functions/parse_json.cue
+++ b/website/cue/reference/remap/functions/parse_json.cue
@@ -20,12 +20,12 @@ remap: functions: parse_json: {
 			type: ["string"]
 		},
 		{
-			name:        "max_depth"
+			name: "max_depth"
 			description: """
 				Number of layers to parse for nested JSON-formatted documents.
 				The value must be in range 1..128.
 				"""
-			required:    false
+			required: false
 			type: ["integer"]
 		},
 	]


### PR DESCRIPTION
Add the max_depth option to the `parse_json` VRL function to partially traverse highly nested JSON-formatted messages.

These changes were tested in the Kubernetes cluster 1.21 on top of the Vector 0.20

```
$ parse_json!("{\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"finish\"}}}}}}", max_depth: 5)

{ "1": { "2": { "3": { "4": { "5": "{\"6\": \"finish\"}" } } } } }
```
```
$ parse_json!("{\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"finish\"}}}}}}", max_depth: 4)

{ "1": { "2": { "3": { "4": "{\"5\": {\"6\": \"finish\"}}" } } } }
```
```
$ parse_json!("{\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"finish\"}}}}}}", max_depth: 10)

{ "1": { "2": { "3": { "4": {"5": {"6": "finish"} } } } } }
```
```
$ parse_json!("{\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"finish\"}}}}}}", max_depth: 129)

function call error for "parse_json" at (0:95): max_depth value should be greater than 0 and less than 128, got 129
```
***
Closes #12458
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>
