### PR TITLE
chore(vrl): update `Target::target_get` to return reference to `Value`

### DIFF
--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -80,7 +80,11 @@ fn apply_grok_rule(source: &str, grok_rule: &GrokRule, remove_empty: bool) -> Re
                         // ignore empty strings if necessary
                         Value::Bytes(b) if remove_empty && b.is_empty() => {}
                         // otherwise just apply VRL lookup insert logic
-                        _ => match parsed.target_get(field).expect("field does not exist") {
+                        _ => match parsed
+                            .target_get(field)
+                            .expect("field does not exist")
+                            .cloned()
+                        {
                             Some(Value::Array(mut values)) => values.push(value),
                             Some(v) => {
                                 parsed.target_insert(field, Value::Array(vec![v, value])).unwrap_or_else(

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -6,6 +6,7 @@ use parser::ast::{self, AssignmentOp, Node};
 
 use crate::{
     expression::*,
+    program::ProgramInfo,
     state::{ExternalEnv, LocalEnv},
     Function, Program, Value,
 };
@@ -60,11 +61,17 @@ impl<'a> Compiler<'a> {
             return Err(errors.into());
         }
 
+        let info = ProgramInfo {
+            fallible: self.fallible,
+            abortable: self.abortable,
+            target_queries: vec![],
+            target_assignments: vec![],
+        };
+
         Ok((
             Program {
                 expressions,
-                fallible: self.fallible,
-                abortable: self.abortable,
+                info,
                 local_env: self.local,
             },
             warnings.into(),

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use diagnostic::{DiagnosticList, DiagnosticMessage, Severity};
+use lookup::LookupBuf;
 use ordered_float::NotNan;
 use parser::ast::{self, AssignmentOp, Node};
 
@@ -19,6 +20,8 @@ pub(crate) struct Compiler<'a> {
     fallible: bool,
     abortable: bool,
     local: LocalEnv,
+    external_queries: Vec<LookupBuf>,
+    external_assignments: Vec<LookupBuf>,
 }
 
 impl<'a> Compiler<'a> {
@@ -29,6 +32,8 @@ impl<'a> Compiler<'a> {
             fallible: false,
             abortable: false,
             local: LocalEnv::default(),
+            external_queries: vec![],
+            external_assignments: vec![],
         }
     }
 
@@ -64,8 +69,8 @@ impl<'a> Compiler<'a> {
         let info = ProgramInfo {
             fallible: self.fallible,
             abortable: self.abortable,
-            target_queries: vec![],
-            target_assignments: vec![],
+            target_queries: self.external_queries,
+            target_assignments: self.external_assignments,
         };
 
         Ok((
@@ -398,17 +403,41 @@ impl<'a> Compiler<'a> {
             }
         };
 
-        Assignment::new(node, &mut self.local, external).unwrap_or_else(|err| {
+        let assignment = Assignment::new(node, &mut self.local, external).unwrap_or_else(|err| {
             self.diagnostics.push(Box::new(err));
             Assignment::noop()
-        })
+        });
+
+        // Track any potential external target assignments within the program.
+        //
+        // This data is exposed to the caller of the compiler, to allow any
+        // potential external optimizations.
+        for target in assignment.targets() {
+            if let assignment::Target::External(path) = target {
+                match path {
+                    Some(path) => self.external_assignments.push(path),
+                    None => self.external_assignments.push(LookupBuf::root()),
+                }
+            }
+        }
+
+        assignment
     }
 
     fn compile_query(&mut self, node: Node<ast::Query>, external: &mut ExternalEnv) -> Query {
         let ast::Query { target, path } = node.into_inner();
+        let path = path.into_inner();
         let target = self.compile_query_target(target, external);
 
-        Query::new(target, path.into_inner())
+        // Track any potential external target queries within the program.
+        //
+        // This data is exposed to the caller of the compiler, to allow any
+        // potential external optimizations.
+        if let Target::External = target {
+            self.external_queries.push(path.clone())
+        }
+
+        Query::new(target, path)
     }
 
     fn compile_query_target(

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -145,6 +145,23 @@ impl Assignment {
 
         Self { variant }
     }
+
+    /// Get a list of targets for this assignment.
+    ///
+    /// For regular assignments, this contains a single target, for infallible
+    /// assignments, it'll contain both the `ok` and `err` target.
+    pub(crate) fn targets(&self) -> Vec<Target> {
+        let mut targets = vec![];
+
+        match &self.variant {
+            Variant::Single { target, .. } => targets.push(target.clone()),
+            Variant::Infallible { ok, err, .. } => {
+                targets.append(&mut vec![ok.clone(), err.clone()])
+            }
+        }
+
+        targets
+    }
 }
 
 impl Expression for Assignment {

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -90,6 +90,7 @@ impl Expression for Query {
                     .target_get(&self.path)
                     .ok()
                     .flatten()
+                    .cloned()
                     .unwrap_or(Value::Null))
             }
             Internal(variable) => variable.resolve(ctx)?,
@@ -100,6 +101,7 @@ impl Expression for Query {
         Ok(crate::Target::target_get(&value, &self.path)
             .ok()
             .flatten()
+            .cloned()
             .unwrap_or(Value::Null))
     }
 

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -26,7 +26,7 @@ pub(crate) use diagnostic::Span;
 pub use expression::Expression;
 pub use function::{Function, Parameter};
 pub use paste::paste;
-pub use program::Program;
+pub use program::{Program, ProgramInfo};
 use state::ExternalEnv;
 use std::{fmt::Display, str::FromStr};
 pub use type_def::TypeDef;

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -448,7 +448,11 @@ impl Vm {
 
                     match &variable {
                         Variable::External(path) => {
-                            let value = ctx.target().target_get(path)?.unwrap_or(Value::Null);
+                            let value = ctx
+                                .target()
+                                .target_get(path)?
+                                .cloned()
+                                .unwrap_or(Value::Null);
                             state.stack.push(value);
                         }
                         Variable::Internal(ident, path) => {

--- a/lib/vrl/core/src/target.rs
+++ b/lib/vrl/core/src/target.rs
@@ -42,7 +42,7 @@ pub trait Target: std::fmt::Debug {
     /// Get a value for a given path, or `None` if no value is found.
     ///
     /// See [`Target::insert`] for more details.
-    fn target_get(&self, path: &LookupBuf) -> Result<Option<Value>, String>;
+    fn target_get(&self, path: &LookupBuf) -> Result<Option<&Value>, String>;
 
     /// Remove the given path from the object.
     ///
@@ -71,12 +71,12 @@ impl Target for Value {
         Ok(())
     }
 
-    fn target_get(&self, path: &LookupBuf) -> Result<Option<Value>, String> {
-        Ok(self.get_by_path(path).cloned())
+    fn target_get(&self, path: &LookupBuf) -> Result<Option<&Value>, String> {
+        Ok(self.get_by_path(path))
     }
 
     fn target_remove(&mut self, path: &LookupBuf, compact: bool) -> Result<Option<Value>, String> {
-        let value = self.target_get(path)?;
+        let value = self.target_get(path)?.cloned();
         self.remove_by_path(path, compact);
 
         Ok(value)

--- a/lib/vrl/stdlib/src/get.rs
+++ b/lib/vrl/stdlib/src/get.rs
@@ -34,7 +34,7 @@ fn get(value: Value, path: Value) -> Resolved {
             .into())
         }
     };
-    Ok(value.target_get(&path)?.unwrap_or(Value::Null))
+    Ok(value.target_get(&path)?.cloned().unwrap_or(Value::Null))
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -10,8 +10,8 @@ pub mod prelude;
 mod runtime;
 
 pub use compiler::{
-    function, state, value, vm::Vm, Context, Expression, Function, Program, Target, Value,
-    VrlRuntime,
+    function, state, value, vm::Vm, Context, Expression, Function, Program, ProgramInfo, Target,
+    Value, VrlRuntime,
 };
 pub use diagnostic;
 pub use runtime::{Runtime, RuntimeResult, Terminate};

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -69,6 +69,7 @@ impl ConditionConfig for VrlConfig {
             VrlRuntime::Vm => {
                 let vm = Arc::new(Runtime::default().compile(functions, &program, &mut state)?);
                 Ok(Condition::VrlVm(VrlVm {
+                    program,
                     source: self.source.clone(),
                     vm,
                 }))
@@ -103,7 +104,7 @@ impl Vrl {
         // program wants to mutate its events.
         //
         // see: https://github.com/vectordotdev/vector/issues/4744
-        let mut target = VrlImmutableTarget::new(event);
+        let mut target = VrlImmutableTarget::new(event, self.program.info());
         // TODO: use timezone from remap config
         let timezone = TimeZone::default();
 
@@ -164,6 +165,7 @@ impl Conditional for Vrl {
 
 #[derive(Debug, Clone)]
 pub struct VrlVm {
+    pub(super) program: Program,
     pub(super) source: String,
     pub(super) vm: Arc<Vm>,
 }
@@ -182,7 +184,7 @@ impl VrlVm {
         // program wants to mutate its events.
         //
         // see: https://github.com/vectordotdev/vector/issues/4744
-        let mut target = VrlImmutableTarget::new(event);
+        let mut target = VrlImmutableTarget::new(event, self.program.info());
         // TODO: use timezone from remap config
         let timezone = TimeZone::default();
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -421,7 +421,7 @@ where
             None
         };
 
-        let mut target: VrlTarget = event.into();
+        let mut target = VrlTarget::new(event, self.program.info());
         let result = self.run_vrl(&mut target);
 
         match result {

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -413,8 +413,8 @@ where
         // the event to the `dropped` output.
         let forward_on_error = !self.drop_on_error || self.reroute_dropped;
         let forward_on_abort = !self.drop_on_abort || self.reroute_dropped;
-        let original_event = if (self.program.can_fail() && forward_on_error)
-            || (self.program.can_abort() && forward_on_abort)
+        let original_event = if (self.program.info().fallible && forward_on_error)
+            || (self.program.info().abortable && forward_on_abort)
         {
             Some(event.clone())
         } else {


### PR DESCRIPTION
This changes the `Target` trait (which interfaces between VRL and Vector) to update `target_get` to no longer return an owned `Value`, but a reference to it.

For now, this change doesn't imply any performance changes, as the cloning is pushed to the edge (e.g. `foo.target_get().cloned()`), away from the trait definition. This does open up future avenues to try and improve VRL performance by reducing the need to clone values inside events.

There's a bunch of extra work that was needed for this to work with the `Metric` type, as that is the only type that doesn't store its internal representation as a `Value` (instead using regular primitives such as `f64`, etc). This meant there's no owned `Value` type to reference.

To solve this, `VrlTarget` (and `VrlImmutableTarget`) now pre-compile an owned `Value`. To try and be as efficient as possible in doing this, VRL's compiler now has a new `ProgramInfo` type which allows the caller to query for any useful information to optimize VRL runtime performance. In this case, the info type contains details about which fields in an event are queries (or assigned), which in turn allows `VrlTarget` to only pre-compute the fields that are likely to be accessed by the program.

Note that this list is not a _guaranteed_ list of paths that will be accessed, but instead a list of potentially accessed paths, depending on runtime behaviour w.r.t. if-statements, etc.

If a path is accessed dynamically (through the `get` function), the pre-compute logic is handed a "root" path, which in effect means the entire event structure needs to be pre-computed. There are more efficient ways to tackle this (e.g. tracking exactly _which_ nested collections within the event are accessed dynamically, and only pre-compute those collections), but it's "good enough" to start.

Also note that all of this logic is meant to keep the VRL-for-metrics use-case working, but since this is by-far the least-used feature of VRL, it's also not that important — at least to start — to keep/achieve the best performance here. What matters most is improving performance for VRL-for-logs use-case.