### PR TITLE
chore: Run only 20 replicas of each soak experiment

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -158,7 +158,7 @@ jobs:
             // jobs to run. For example, the first job might have the values:
             // { target: "fluent_remap_aws_firehose", replica: [1] }
             const matrix = {
-              target: target, replica: [1,2,3] // run each experiment
+              target: target, replica: [1,2] // run each experiment
             }
 
             // export this variable to be available to other github steps


### PR DESCRIPTION
As evidenced by
https://github.com/vectordotdev/vector/pull/12524#issuecomment-1115428258 having
30 replicas of each soak variant experiment does good things for noise. However,
we do have a relatively large compute cluster backing these soaks _and_ we still
have queued up jobs during the teams working day. It's not clear that we _need_
30 replicas, so this experiment drops to 20.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
