### PR TITLE
introduce new `ProgramInfo` type

### DIFF
--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -198,6 +198,10 @@ impl LogEvent {
         self.inner.fields.get_by_path(path)
     }
 
+    pub fn lookup_mut(&mut self, path: &LookupBuf) -> Option<&mut Value> {
+        self.fields_mut().get_by_path_mut(path)
+    }
+
     pub fn get_by_meaning(&self, meaning: impl AsRef<str>) -> Option<&Value> {
         self.metadata()
             .schema_definition()

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -58,6 +58,10 @@ impl TraceEvent {
         self.0.lookup(path)
     }
 
+    pub fn lookup_mut(&mut self, path: &LookupBuf) -> Option<&mut Value> {
+        self.0.lookup_mut(path)
+    }
+
     pub fn get_flat(&self, key: impl AsRef<str>) -> Option<&Value> {
         self.0.as_map().get(key.as_ref())
     }

--- a/lib/vrl/core/src/target.rs
+++ b/lib/vrl/core/src/target.rs
@@ -44,6 +44,12 @@ pub trait Target: std::fmt::Debug {
     /// See [`Target::insert`] for more details.
     fn target_get(&self, path: &LookupBuf) -> Result<Option<&Value>, String>;
 
+    /// Get a mutable reference to the value for a given path, or `None` if no
+    /// value is found.
+    ///
+    /// See [`Target::insert`] for more details.
+    fn target_get_mut(&mut self, path: &LookupBuf) -> Result<Option<&mut Value>, String>;
+
     /// Remove the given path from the object.
     ///
     /// Returns the removed object, if any.
@@ -73,6 +79,10 @@ impl Target for Value {
 
     fn target_get(&self, path: &LookupBuf) -> Result<Option<&Value>, String> {
         Ok(self.get_by_path(path))
+    }
+
+    fn target_get_mut(&mut self, path: &LookupBuf) -> Result<Option<&mut Value>, String> {
+        Ok(self.get_by_path_mut(path))
     }
 
     fn target_remove(&mut self, path: &LookupBuf, compact: bool) -> Result<Option<Value>, String> {


### PR DESCRIPTION
Following up on #12546, this PR adds a new `Target::target_get_mut` method. It is unused as of now, but will be used in the future as we work towards using references in VRL as opposed to owned values.