### PR TITLE
fix(config): Continue polling http config after error

### DIFF
--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -151,7 +151,7 @@ fn poll_http(
 
             match http_request_to_config_builder(&url, &tls_options, &headers, &proxy).await {
                 Ok(config_builder) => yield signal::SignalTo::ReloadFromConfigBuilder(config_builder),
-                Err(_) => return,
+                Err(_) => {},
             };
 
             info!(


### PR DESCRIPTION
Fixes #12579.

Small fix to continue the polling loop after encountering an error fetching the http config.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
