### PR TITLE
enhancement(influxdb sink, codecs): Integrate `encoding::Encoder` with `influxdb` sink

### DIFF
--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -170,10 +170,12 @@ struct InfluxDbLogsEncoder {
 }
 
 impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
-    fn encode_event(&mut self, mut event: Event) -> Option<BytesMut> {
-        self.transformer.transform(&mut event);
+    fn encode_event(&mut self, event: Event) -> Option<BytesMut> {
         let mut event = event.into_log();
         event.insert("metric_type", "logs".to_string());
+        let mut event = Event::from(event);
+        self.transformer.transform(&mut event);
+        let mut event = event.into_log();
 
         // Timestamp
         let timestamp = encode_timestamp(match event.remove(log_schema().timestamp_key()) {

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -19,7 +19,7 @@ use crate::{
             InfluxDb1Settings, InfluxDb2Settings, ProtocolVersion,
         },
         util::{
-            encoding::{EncodingConfig, EncodingConfigWithDefault, EncodingConfiguration},
+            encoding::Transformer,
             http::{BatchedHttpSink, HttpEventEncoder, HttpSink},
             BatchConfig, Buffer, Compression, SinkBatchSettings, TowerRequestConfig,
         },
@@ -53,7 +53,7 @@ pub struct InfluxDbLogsConfig {
         skip_serializing_if = "crate::serde::skip_serializing_if_default",
         default
     )]
-    pub encoding: EncodingConfigWithDefault<Encoding>,
+    pub encoding: Transformer,
     #[serde(default)]
     pub batch: BatchConfig<InfluxDbLogsDefaultBatchSettings>,
     #[serde(default)]
@@ -74,15 +74,7 @@ struct InfluxDbLogsSink {
     protocol_version: ProtocolVersion,
     measurement: String,
     tags: HashSet<String>,
-    encoding: EncodingConfig<Encoding>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
-#[serde(rename_all = "snake_case")]
-#[derivative(Default)]
-pub enum Encoding {
-    #[derivative(Default)]
-    Default,
+    transformer: Transformer,
 }
 
 inventory::submit! {
@@ -141,7 +133,7 @@ impl SinkConfig for InfluxDbLogsConfig {
             protocol_version,
             measurement,
             tags,
-            encoding: self.encoding.clone().into(),
+            transformer: self.encoding.clone(),
         };
 
         let sink = BatchedHttpSink::new(
@@ -174,14 +166,14 @@ struct InfluxDbLogsEncoder {
     protocol_version: ProtocolVersion,
     measurement: String,
     tags: HashSet<String>,
-    encoding: EncodingConfig<Encoding>,
+    transformer: Transformer,
 }
 
 impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
-    fn encode_event(&mut self, event: Event) -> Option<BytesMut> {
+    fn encode_event(&mut self, mut event: Event) -> Option<BytesMut> {
+        self.transformer.transform(&mut event);
         let mut event = event.into_log();
         event.insert("metric_type", "logs".to_string());
-        self.encoding.apply_rules(&mut event);
 
         // Timestamp
         let timestamp = encode_timestamp(match event.remove(log_schema().timestamp_key()) {
@@ -228,7 +220,7 @@ impl HttpSink for InfluxDbLogsSink {
             protocol_version: self.protocol_version,
             measurement: self.measurement.clone(),
             tags: self.tags.clone(),
-            encoding: self.encoding.clone(),
+            transformer: self.transformer.clone(),
         }
     }
 
@@ -345,7 +337,9 @@ mod tests {
             "vector",
             ["metric_type", "host"].to_vec(),
         );
-        sink.encoding.except_fields = Some(vec!["host".into()]);
+        sink.transformer
+            .set_except_fields(Some(vec!["host".into()]))
+            .unwrap();
         let mut encoder = sink.build_encoder();
 
         let bytes = encoder.encode_event(event.clone()).unwrap();
@@ -357,7 +351,9 @@ mod tests {
         assert_fields(line_protocol.2.to_string(), ["message=\"hello\""].to_vec());
         assert_eq!("1542182950000000011\n", line_protocol.3);
 
-        sink.encoding.except_fields = Some(vec!["metric_type".into()]);
+        sink.transformer
+            .set_except_fields(Some(vec!["metric_type".into()]))
+            .unwrap();
         let mut encoder = sink.build_encoder();
         let bytes = encoder.encode_event(event.clone()).unwrap();
         let string = std::str::from_utf8(&bytes).unwrap();
@@ -732,7 +728,7 @@ mod tests {
             protocol_version,
             measurement,
             tags,
-            encoding: EncodingConfigWithDefault::default().into(),
+            transformer: Default::default(),
         }
     }
 }

--- a/src/sinks/util/encoding/adapter.rs
+++ b/src/sinks/util/encoding/adapter.rs
@@ -90,16 +90,18 @@ where
     /// Build a `Transformer` that applies the encoding rules to an event before serialization.
     pub fn transformer(&self) -> Transformer {
         match self {
-            Self::Encoding(config) => Transformer {
+            Self::Encoding(config) => TransformerInner {
                 only_fields: config.encoding.only_fields.clone(),
                 except_fields: config.encoding.except_fields.clone(),
                 timestamp_format: config.encoding.timestamp_format,
-            },
-            Self::LegacyEncodingConfig(config) => Transformer {
+            }
+            .into(),
+            Self::LegacyEncodingConfig(config) => TransformerInner {
                 only_fields: config.encoding.only_fields().clone(),
                 except_fields: config.encoding.except_fields().clone(),
                 timestamp_format: *config.encoding.timestamp_format(),
-            },
+            }
+            .into(),
         }
     }
 
@@ -203,16 +205,18 @@ where
     /// Build a `Transformer` that applies the encoding rules to an event before serialization.
     pub fn transformer(&self) -> Transformer {
         match self {
-            Self::Encoding(config) => Transformer {
+            Self::Encoding(config) => TransformerInner {
                 only_fields: config.encoding.only_fields.clone(),
                 except_fields: config.encoding.except_fields.clone(),
                 timestamp_format: config.encoding.timestamp_format,
-            },
-            Self::LegacyEncodingConfig(config) => Transformer {
+            }
+            .into(),
+            Self::LegacyEncodingConfig(config) => TransformerInner {
                 only_fields: config.encoding.only_fields().clone(),
                 except_fields: config.encoding.except_fields().clone(),
                 timestamp_format: *config.encoding.timestamp_format(),
-            },
+            }
+            .into(),
         }
     }
 
@@ -286,18 +290,50 @@ pub struct EncodingWithTransformationConfig {
     timestamp_format: Option<TimestampFormat>,
 }
 
-#[derive(Debug, Clone, Default)]
 /// Transformations to prepare an event for serialization.
-pub struct Transformer {
-    only_fields: Option<Vec<OwnedPath>>,
-    except_fields: Option<Vec<String>>,
-    timestamp_format: Option<TimestampFormat>,
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct Transformer(TransformerInner);
+
+impl<'de> Deserialize<'de> for Transformer {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let transformer: TransformerInner = Deserialize::deserialize(deserializer)?;
+        validate_fields(
+            transformer.only_fields.as_deref(),
+            transformer.except_fields.as_deref(),
+        )
+        .map_err(serde::de::Error::custom)?;
+        Ok(Self(transformer))
+    }
 }
 
 impl Transformer {
     /// Prepare an event for serialization by the given transformation rules.
     pub fn transform(&self, event: &mut Event) {
         self.apply_rules(event);
+    }
+
+    /// Set the `except_fields` value.
+    ///
+    /// Returns `Err` if the new `except_fields` fail validation, i.e. are not mutually exclusive
+    /// with `only_fields`.
+    pub fn set_except_fields(&mut self, except_fields: Option<Vec<String>>) -> crate::Result<()> {
+        let transformer = TransformerInner {
+            only_fields: self.0.only_fields.clone(),
+            except_fields,
+            timestamp_format: self.0.timestamp_format,
+        };
+
+        validate_fields(
+            transformer.only_fields.as_deref(),
+            transformer.except_fields.as_deref(),
+        )?;
+
+        self.0 = transformer;
+
+        Ok(())
     }
 }
 
@@ -313,16 +349,32 @@ impl EncodingConfiguration for Transformer {
     }
 
     fn only_fields(&self) -> &Option<Vec<OwnedPath>> {
-        &self.only_fields
+        &self.0.only_fields
     }
 
     fn except_fields(&self) -> &Option<Vec<String>> {
-        &self.except_fields
+        &self.0.except_fields
     }
 
     fn timestamp_format(&self) -> &Option<TimestampFormat> {
-        &self.timestamp_format
+        &self.0.timestamp_format
     }
+}
+
+impl From<TransformerInner> for Transformer {
+    fn from(inner: TransformerInner) -> Self {
+        Self(inner)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+struct TransformerInner {
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    only_fields: Option<Vec<OwnedPath>>,
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    except_fields: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    timestamp_format: Option<TimestampFormat>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Part of #9459.

Technically, this doesn't use `Encoder`, but only the new simplified `Transformer`.