### PR TITLE
feat(OP-335): add source field when sending datadog logs for enterprise

### DIFF
--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -77,6 +77,9 @@ pub(crate) struct DatadogLogsConfig {
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     acknowledgements: AcknowledgementsConfig,
+
+    #[serde(skip)]
+    enterprise: bool,
 }
 
 impl GenerateConfig for DatadogLogsConfig {
@@ -102,6 +105,7 @@ impl DatadogLogsConfig {
             endpoint,
             site,
             region,
+            enterprise: true,
             ..Self::default()
         }
     }
@@ -152,8 +156,10 @@ impl DatadogLogsConfig {
                 self.get_uri(),
                 cx.globals.enterprise,
             ));
+        let mut encoding = self.encoding.clone();
+        encoding.codec.enterprise = self.enterprise;
         let sink = LogSinkBuilder::new(service, cx, default_api_key, batch)
-            .encoding(self.encoding.clone())
+            .encoding(encoding)
             .compression(self.compression.unwrap_or_default())
             .build();
 

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -116,6 +116,7 @@ pub struct LogSink<S> {
 pub struct DatadogLogsJsonEncoding {
     log_schema: &'static LogSchema,
     inner: StandardEncodings,
+    pub(super) enterprise: bool,
 }
 
 impl Default for DatadogLogsJsonEncoding {
@@ -123,6 +124,7 @@ impl Default for DatadogLogsJsonEncoding {
         DatadogLogsJsonEncoding {
             log_schema: log_schema(),
             inner: StandardEncodings::Json,
+            enterprise: false,
         }
     }
 }
@@ -135,6 +137,9 @@ impl Encoder<Vec<Event>> for DatadogLogsJsonEncoding {
             log.rename_key_flat(self.log_schema.host_key(), "host");
             if let Some(Value::Timestamp(ts)) = log.remove(self.log_schema.timestamp_key()) {
                 log.insert_flat("timestamp", Value::Integer(ts.timestamp_millis()));
+            }
+            if self.enterprise {
+                log.insert("source", "vector_enterprise");
             }
         }
 

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -139,7 +139,7 @@ impl Encoder<Vec<Event>> for DatadogLogsJsonEncoding {
                 log.insert_flat("timestamp", Value::Integer(ts.timestamp_millis()));
             }
             if self.enterprise {
-                log.insert("source", "vector_enterprise");
+                log.insert("ddsource", "vector_enterprise");
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Jeremie Drouet <jeremie.drouet@datadoghq.com>

When running the enterprise feature is enable, Vector sends the internal logs to Datadog and we need to identify those logs as coming from vector enterprise. This PR automagically add a field `source:vector_enterprise` to every log directly from the `codec`.

I considered adding an internal transform to add those fields (with `vrl` or `add_fields`) but the transform would add an internal weight.
I also considered creating a separate codec to add this field wrapping the existing one (and avoid the `if self.enterprise`) but this would add lots of code for a gain that might not be that important.

Closes [OP-335](https://datadoghq.atlassian.net/browse/OP-335)