### PR TITLE
chore: Adjust global allocator logic switch to be uniform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -782,7 +782,7 @@ splunk-integration-tests = ["sinks-splunk_hec"]
 dnstap-integration-tests = ["sources-dnstap"]
 disable-resolv-conf = []
 shutdown-tests = ["api", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-log_to_metric", "transforms-lua", "transforms-remap", "unix"]
-cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file"]
+cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file", "tikv-jemallocator"]
 vector-api-tests = [
   "sources-demo_logs",
   "transforms-log_to_metric",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,6 +344,7 @@ leveldb-sys = { git = "https://github.com/vectordotdev/leveldb-sys.git", branch 
 chrono = { git = "https://github.com/vectordotdev/chrono.git", branch = "no-default-time" }
 
 [features]
+jemalloc = ["tikv-jemallocator"]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
 default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka/gssapi-vendored", "vrl-cli", "enterprise"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
@@ -374,7 +375,7 @@ target-powerpc64le-unknown-linux-gnu = ["api", "api-client", "enrichment-tables"
 target-powerpc-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "vrl-cli", "enterprise"]
 
 # Enables features that work only on systems providing `cfg(unix)`
-unix = ["tikv-jemallocator"]
+unix = ["jemalloc"]
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,
 # transforms and sinks should depend on this feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -783,7 +783,7 @@ splunk-integration-tests = ["sinks-splunk_hec"]
 dnstap-integration-tests = ["sources-dnstap"]
 disable-resolv-conf = []
 shutdown-tests = ["api", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-log_to_metric", "transforms-lua", "transforms-remap", "unix"]
-cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file", "tikv-jemallocator"]
+cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file"]
 vector-api-tests = [
   "sources-demo_logs",
   "transforms-log_to_metric",

--- a/lib/vrl/tests/Cargo.toml
+++ b/lib/vrl/tests/Cargo.toml
@@ -21,9 +21,9 @@ regex = "1"
 serde = "1"
 serde_json = "1"
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["fmt"] }
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.4.3" }
+tikv-jemallocator = { version = "0.4.3", default-features = false, optional = true }
 
 [features]
 default = []
+unix = ["jemalloc"]
+jemalloc = ["tikv-jemallocator"]

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -17,7 +17,7 @@ use vrl::VrlRuntime;
 use vrl::{diagnostic::Formatter, state, Runtime, Terminate, Value};
 use vrl_tests::{docs, Test};
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern crate tracing;
 #[macro_use]
 extern crate derivative;
 
-#[cfg(feature = "tikv-jemallocator")]
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern crate tracing;
 #[macro_use]
 extern crate derivative;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
We have two places in Vector where we change which global allocator is in use,
`src/lib.rs` and then in a VRL tool. This commit adjusts the logic of both sites to be
uniform.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
