### PR TITLE
fix(sources): Partial fix for negative ack handling for stream sources

### DIFF
--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -16,6 +16,8 @@ mod errors;
 pub use errors::{ClosedError, StreamSendError};
 
 pub(crate) const CHUNK_SIZE: usize = 1000;
+#[cfg(test)]
+const TEST_BUFFER_SIZE: usize = 100;
 
 #[derive(Debug)]
 pub struct Builder {
@@ -88,18 +90,42 @@ impl SourceSender {
 
     #[cfg(test)]
     pub fn new_test() -> (Self, impl Stream<Item = Event> + Unpin) {
-        let (pipe, recv) = Self::new_with_buffer(100);
+        let (pipe, recv) = Self::new_with_buffer(TEST_BUFFER_SIZE);
         let recv = recv.into_stream().flat_map(into_event_stream);
         (pipe, recv)
     }
 
     #[cfg(test)]
     pub fn new_test_finalize(status: EventStatus) -> (Self, impl Stream<Item = Event> + Unpin) {
-        let (pipe, recv) = Self::new_with_buffer(100);
+        let (pipe, recv) = Self::new_with_buffer(TEST_BUFFER_SIZE);
         // In a source test pipeline, there is no sink to acknowledge
         // events, so we have to add a map to the receiver to handle the
         // finalization.
         let recv = recv.into_stream().flat_map(move |mut events| {
+            events.for_each_event(|mut event| {
+                let metadata = event.metadata_mut();
+                metadata.update_status(status);
+                metadata.update_sources();
+            });
+            into_event_stream(events)
+        });
+        (pipe, recv)
+    }
+
+    #[cfg(test)]
+    pub fn new_test_error_after(n: usize) -> (Self, impl Stream<Item = Event> + Unpin) {
+        let (pipe, recv) = Self::new_with_buffer(TEST_BUFFER_SIZE);
+        // In a source test pipeline, there is no sink to acknowledge
+        // events, so we have to add a map to the receiver to handle the
+        // finalization.
+        let mut count: usize = 0;
+        let recv = recv.into_stream().flat_map(move |mut events| {
+            let status = if count == n {
+                EventStatus::Errored
+            } else {
+                EventStatus::Delivered
+            };
+            count += 1;
             events.for_each_event(|mut event| {
                 let metadata = event.metadata_mut();
                 metadata.update_status(status);

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1724,7 +1724,7 @@ mod tests {
             }
         }
 
-        fn acknowledgements(&self) -> bool {
+        const fn acknowledgements(&self) -> bool {
             !matches!(self, NoAcks)
         }
     }

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -103,7 +103,6 @@ where
     Fut: Future<Output = ()> + Send + 'static,
 {
     async fn run<const SOE: bool>(mut self) {
-        assert!(self.failure.is_some());
         loop {
             tokio::select! {
                 _ = self.shutdown.clone() => break,


### PR DESCRIPTION
This is a partial fix for #12109 which causes the stream sources to shutdown when they receive a negative acknowledgement. The end goal is to have them shut down only the one stream that had a nack, so another fix will be forthcoming. I have only added a test for the file source because of that. Testing for journald will require reworking its fake source, so I didn't spend much effort on that before moving on. I can work up tests for kafka and journald if that is desirable for this PR.