### PR TITLE
chore(enterprise): Refactor handling of enterprise configuration for components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -686,13 +686,14 @@ sinks-websocket = ["tokio-tungstenite"]
 
 # Datadog integration
 enterprise = [
+  "hex",
+  "sha2",
+  "sinks-datadog_logs",
+  "sinks-datadog_metrics",
   "sources-host_metrics",
   "sources-internal_logs",
   "sources-internal_metrics",
-  "sinks-datadog_logs",
-  "sinks-datadog_metrics",
-  "sha2",
-  "hex"
+  "transforms-remap",
 ]
 
 # Identifies that the build is a nightly build

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -15,7 +15,7 @@ use url::{ParseError, Url};
 
 use super::{
     load_source_from_paths, process_paths, ComponentKey, Config, ConfigPath, OutputId, SinkOuter,
-    SourceOuter,
+    SourceOuter, TransformOuter,
 };
 use crate::{
     common::datadog::{get_api_base_endpoint, Region},
@@ -26,13 +26,17 @@ use crate::{
         util::retries::ExponentialBackoff,
     },
     sources::{
-        host_metrics::HostMetricsConfig, internal_logs::InternalLogsConfig,
+        host_metrics::{self, HostMetricsConfig},
+        internal_logs::InternalLogsConfig,
         internal_metrics::InternalMetricsConfig,
     },
+    transforms::remap::RemapConfig,
 };
 use vector_core::config::proxy::ProxyConfig;
 
 static HOST_METRICS_KEY: &str = "#datadog_host_metrics";
+static TAG_METRICS_KEY: &str = "#datadog_tag_metrics";
+static TAG_LOGS_KEY: &str = "#datadog_tag_logs";
 static INTERNAL_METRICS_KEY: &str = "#datadog_internal_metrics";
 static INTERNAL_LOGS_KEY: &str = "#datadog_internal_logs";
 static DATADOG_METRICS_KEY: &str = "#datadog_metrics";
@@ -335,6 +339,8 @@ pub async fn try_attach(
     }
 
     let host_metrics_id = OutputId::from(ComponentKey::from(HOST_METRICS_KEY));
+    let tag_metrics_id = OutputId::from(ComponentKey::from(TAG_METRICS_KEY));
+    let tag_logs_id = OutputId::from(ComponentKey::from(TAG_LOGS_KEY));
     let internal_metrics_id = OutputId::from(ComponentKey::from(INTERNAL_METRICS_KEY));
     let internal_logs_id = OutputId::from(ComponentKey::from(INTERNAL_LOGS_KEY));
     let datadog_metrics_id = ComponentKey::from(DATADOG_METRICS_KEY);
@@ -342,15 +348,43 @@ pub async fn try_attach(
 
     // Create internal sources for host and internal metrics. We're using distinct sources here and
     // not attempting to reuse existing ones, to configure according to enterprise requirements.
-    let mut host_metrics =
-        HostMetricsConfig::enterprise(config_version, &datadog.configuration_key);
-    let mut internal_metrics =
-        InternalMetricsConfig::enterprise(config_version, &datadog.configuration_key);
-    let internal_logs = InternalLogsConfig::enterprise(config_version, &datadog.configuration_key);
+    let host_metrics = HostMetricsConfig {
+        namespace: host_metrics::Namespace::from(Some("pipelines".to_owned())),
+        scrape_interval_secs: datadog.reporting_interval_secs,
+        ..Default::default()
+    };
 
-    // Override default scrape intervals.
-    host_metrics.scrape_interval_secs(datadog.reporting_interval_secs);
-    internal_metrics.scrape_interval_secs(datadog.reporting_interval_secs);
+    let internal_metrics = InternalMetricsConfig {
+        namespace: Some("pipelines".to_owned()),
+        scrape_interval_secs: datadog.reporting_interval_secs,
+        ..Default::default()
+    };
+
+    let internal_logs = InternalLogsConfig {
+        ..Default::default()
+    };
+
+    let tag_metrics = RemapConfig {
+        source: Some(format!(
+            r#"
+            tags.version = "{}"
+            tags.configuration_key = "{}"
+        "#,
+            &config_version, &datadog.configuration_key,
+        )),
+        ..Default::default()
+    };
+
+    let tag_logs = RemapConfig {
+        source: Some(format!(
+            r#"
+            version = "{}"
+            configuration_key = "{}"
+        "#,
+            &config_version, &datadog.configuration_key,
+        )),
+        ..Default::default()
+    };
 
     config.sources.insert(
         host_metrics_id.component.clone(),
@@ -365,33 +399,41 @@ pub async fn try_attach(
         SourceOuter::new(internal_logs),
     );
 
-    // Create a Datadog metrics sink to consume and emit internal + host metrics.
-    let datadog_metrics = DatadogMetricsConfig::enterprise(
-        api_key.clone(),
-        datadog.endpoint.clone(),
-        datadog.site.clone(),
-        datadog.region,
+    config.transforms.insert(
+        tag_metrics_id.component.clone(),
+        TransformOuter::new(vec![host_metrics_id, internal_metrics_id], tag_metrics),
     );
+    config.transforms.insert(
+        tag_logs_id.component.clone(),
+        TransformOuter::new(vec![internal_logs_id], tag_logs),
+    );
+
+    // Create a Datadog metrics sink to consume and emit internal + host metrics.
+    let datadog_metrics = DatadogMetricsConfig {
+        default_api_key: api_key.clone().into(),
+        endpoint: datadog.endpoint.clone(),
+        site: datadog.site.clone(),
+        region: datadog.region,
+        ..Default::default()
+    };
 
     config.sinks.insert(
         datadog_metrics_id,
-        SinkOuter::new(
-            vec![host_metrics_id, internal_metrics_id],
-            Box::new(datadog_metrics),
-        ),
+        SinkOuter::new(vec![tag_metrics_id], Box::new(datadog_metrics)),
     );
 
     // Create a Datadog logs sink to consume and emit internal logs.
-    let datadog_logs = DatadogLogsConfig::enterprise(
-        api_key,
-        datadog.endpoint.clone(),
-        datadog.site.clone(),
-        datadog.region,
-    );
+    let datadog_logs = DatadogLogsConfig {
+        default_api_key: api_key.clone().into(),
+        endpoint: datadog.endpoint.clone(),
+        site: datadog.site.clone(),
+        region: datadog.region,
+        ..Default::default()
+    };
 
     config.sinks.insert(
         datadog_logs_id,
-        SinkOuter::new(vec![internal_logs_id], Box::new(datadog_logs)),
+        SinkOuter::new(vec![tag_logs_id], Box::new(datadog_logs)),
     );
 
     Ok(())

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -410,7 +410,7 @@ pub async fn try_attach(
 
     // Create a Datadog metrics sink to consume and emit internal + host metrics.
     let datadog_metrics = DatadogMetricsConfig {
-        default_api_key: api_key.clone().into(),
+        default_api_key: api_key.clone(),
         endpoint: datadog.endpoint.clone(),
         site: datadog.site.clone(),
         region: datadog.region,
@@ -424,7 +424,7 @@ pub async fn try_attach(
 
     // Create a Datadog logs sink to consume and emit internal logs.
     let datadog_logs = DatadogLogsConfig {
-        default_api_key: api_key.clone().into(),
+        default_api_key: api_key.clone(),
         endpoint: datadog.endpoint.clone(),
         site: datadog.site.clone(),
         region: datadog.region,

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -367,8 +367,8 @@ pub async fn try_attach(
     let tag_metrics = RemapConfig {
         source: Some(format!(
             r#"
-            tags.version = "{}"
-            tags.configuration_key = "{}"
+            .tags.version = "{}"
+            .tags.configuration_key = "{}"
         "#,
             &config_version, &datadog.configuration_key,
         )),
@@ -378,8 +378,8 @@ pub async fn try_attach(
     let tag_logs = RemapConfig {
         source: Some(format!(
             r#"
-            version = "{}"
-            configuration_key = "{}"
+            .version = "{}"
+            .configuration_key = "{}"
         "#,
             &config_version, &datadog.configuration_key,
         )),

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -16,6 +16,7 @@ pub struct TransformOuter<T> {
 }
 
 impl<T> TransformOuter<T> {
+    #[cfg(feature = "enterprise")]
     pub(super) fn new(inputs: Vec<T>, transform: impl TransformConfig + 'static) -> Self {
         TransformOuter {
             inputs,

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -16,6 +16,13 @@ pub struct TransformOuter<T> {
 }
 
 impl<T> TransformOuter<T> {
+    pub(super) fn new(inputs: Vec<T>, transform: impl TransformConfig + 'static) -> Self {
+        TransformOuter {
+            inputs,
+            inner: Box::new(transform),
+        }
+    }
+
     pub(super) fn map_inputs<U>(self, f: impl Fn(&T) -> U) -> TransformOuter<U> {
         let inputs = self.inputs.iter().map(f).collect();
         self.with_inputs(inputs)

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -50,33 +50,33 @@ impl SinkBatchSettings for DatadogLogsDefaultBatchSettings {
 pub(crate) struct DatadogLogsConfig {
     pub(crate) endpoint: Option<String>,
     // Deprecated, replaced by the site option
-    region: Option<Region>,
-    site: Option<String>,
+    pub region: Option<Region>,
+    pub site: Option<String>,
     // Deprecated name
     #[serde(alias = "api_key")]
-    default_api_key: String,
+    pub default_api_key: String,
     #[serde(
         skip_serializing_if = "crate::serde::skip_serializing_if_default",
         default
     )]
-    encoding: EncodingConfigFixed<DatadogLogsJsonEncoding>,
-    tls: Option<TlsEnableableConfig>,
+    pub encoding: EncodingConfigFixed<DatadogLogsJsonEncoding>,
+    pub tls: Option<TlsEnableableConfig>,
 
     #[serde(default)]
-    compression: Option<Compression>,
+    pub compression: Option<Compression>,
 
     #[serde(default)]
-    batch: BatchConfig<DatadogLogsDefaultBatchSettings>,
+    pub batch: BatchConfig<DatadogLogsDefaultBatchSettings>,
 
     #[serde(default)]
-    request: TowerRequestConfig,
+    pub request: TowerRequestConfig,
 
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
-    acknowledgements: AcknowledgementsConfig,
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for DatadogLogsConfig {
@@ -89,23 +89,6 @@ impl GenerateConfig for DatadogLogsConfig {
 }
 
 impl DatadogLogsConfig {
-    /// Creates a default [`DatadogLogsConfig`] with the given API key.
-    #[cfg(feature = "enterprise")]
-    pub fn enterprise<T: Into<String>>(
-        api_key: T,
-        endpoint: Option<String>,
-        site: Option<String>,
-        region: Option<Region>,
-    ) -> Self {
-        Self {
-            default_api_key: api_key.into(),
-            endpoint,
-            site,
-            region,
-            ..Self::default()
-        }
-    }
-
     // TODO: We should probably hoist this type of base URI generation so that all DD sinks can
     // utilize it, since it all follows the same pattern.
     fn get_uri(&self) -> http::Uri {

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -106,7 +106,7 @@ pub struct DatadogMetricsConfig {
     pub site: Option<String>,
     // Deprecated name
     #[serde(alias = "api_key")]
-    default_api_key: String,
+    pub default_api_key: String,
     #[serde(default)]
     pub batch: BatchConfig<DatadogMetricsDefaultBatchSettings>,
     #[serde(default)]

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -116,8 +116,8 @@ pub struct DatadogMetricsConfig {
         deserialize_with = "crate::serde::bool_or_struct",
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
-    acknowledgements: AcknowledgementsConfig,
-    tls: Option<TlsEnableableConfig>,
+    pub acknowledgements: AcknowledgementsConfig,
+    pub tls: Option<TlsEnableableConfig>,
 }
 
 impl_generate_config_from_default!(DatadogMetricsConfig);
@@ -147,22 +147,6 @@ impl SinkConfig for DatadogMetricsConfig {
 }
 
 impl DatadogMetricsConfig {
-    /// Creates a [`DatadogMetricsConfig`] with enterprise reporting settings.
-    pub fn enterprise<T: Into<String>>(
-        api_key: T,
-        endpoint: Option<String>,
-        site: Option<String>,
-        region: Option<Region>,
-    ) -> Self {
-        Self {
-            default_api_key: api_key.into(),
-            endpoint,
-            site,
-            region,
-            ..Self::default()
-        }
-    }
-
     /// Gets the base URI of the Datadog agent API.
     ///
     /// Per the Datadog agent convention, we should include a unique identifier as part of the

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -23,7 +23,7 @@ const MICROSECONDS: f64 = 1.0 / 1_000_000.0;
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
 #[serde(default)]
-pub(super) struct CGroupsConfig {
+pub(crate) struct CGroupsConfig {
     #[derivative(Default(value = "100"))]
     levels: usize,
     pub(super) base: Option<PathBuf>,

--- a/src/sources/host_metrics/disk.rs
+++ b/src/sources/host_metrics/disk.rs
@@ -8,7 +8,7 @@ use super::{filter_result, FilterList, HostMetrics};
 use crate::event::metric::Metric;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub(super) struct DiskConfig {
+pub struct DiskConfig {
     #[serde(default)]
     devices: FilterList,
 }

--- a/src/sources/host_metrics/filesystem.rs
+++ b/src/sources/host_metrics/filesystem.rs
@@ -10,7 +10,7 @@ use super::{filter_result, FilterList, HostMetrics};
 use crate::event::metric::Metric;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub(super) struct FilesystemConfig {
+pub struct FilesystemConfig {
     #[serde(default)]
     devices: FilterList,
     #[serde(default)]

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -34,7 +34,7 @@ mod network;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
-enum Collector {
+pub enum Collector {
     #[cfg(target_os = "linux")]
     CGroups,
     Cpu,
@@ -53,7 +53,7 @@ pub(self) struct FilterList {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct Namespace(Option<String>);
+pub struct Namespace(Option<String>);
 
 impl Default for Namespace {
     fn default() -> Self {
@@ -61,29 +61,31 @@ impl Default for Namespace {
     }
 }
 
+impl From<Option<String>> for Namespace {
+    fn from(s: Option<String>) -> Self {
+        Namespace(s)
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HostMetricsConfig {
     #[serde(default = "default_scrape_interval")]
-    scrape_interval_secs: f64,
+    pub scrape_interval_secs: f64,
 
-    collectors: Option<Vec<Collector>>,
+    pub collectors: Option<Vec<Collector>>,
     #[serde(default)]
-    namespace: Namespace,
-    #[serde(skip)]
-    version: Option<String>,
-    #[serde(skip)]
-    configuration_key: Option<String>,
+    pub namespace: Namespace,
 
     #[cfg(target_os = "linux")]
     #[serde(default)]
-    cgroups: cgroups::CGroupsConfig,
+    pub cgroups: cgroups::CGroupsConfig,
     #[serde(default)]
-    disk: disk::DiskConfig,
+    pub disk: disk::DiskConfig,
     #[serde(default)]
-    filesystem: filesystem::FilesystemConfig,
+    pub filesystem: filesystem::FilesystemConfig,
     #[serde(default)]
-    network: network::NetworkConfig,
+    pub network: network::NetworkConfig,
 }
 
 const fn default_scrape_interval() -> f64 {
@@ -122,16 +124,6 @@ impl SourceConfig for HostMetricsConfig {
 }
 
 impl HostMetricsConfig {
-    /// Return a host metrics config with enterprise reporting defaults.
-    pub fn enterprise(version: impl Into<String>, configuration_key: impl Into<String>) -> Self {
-        Self {
-            namespace: Namespace(Some("pipelines".to_owned())),
-            version: Some(version.into()),
-            configuration_key: Some(configuration_key.into()),
-            ..Self::default()
-        }
-    }
-
     /// Set the interval to collect internal metrics.
     pub fn scrape_interval_secs(&mut self, value: f64) {
         self.scrape_interval_secs = value;
@@ -194,8 +186,6 @@ impl HostMetrics {
 
     async fn capture_metrics(&self) -> Vec<Metric> {
         let hostname = crate::get_hostname();
-        let version = self.config.version.clone();
-        let configuration_key = self.config.configuration_key.clone();
 
         let mut metrics = Vec::new();
         #[cfg(target_os = "linux")]
@@ -229,16 +219,16 @@ impl HostMetrics {
                 metric.insert_tag("host".into(), hostname.into());
             }
         }
-        if let Some(version) = &version {
-            for metric in &mut metrics {
-                metric.insert_tag("version".to_owned(), version.clone());
-            }
-        }
-        if let Some(configuration_key) = &configuration_key {
-            for metric in &mut metrics {
-                metric.insert_tag("configuration_key".to_owned(), configuration_key.clone());
-            }
-        }
+        //if let Some(version) = &version {
+        //for metric in &mut metrics {
+        //metric.insert_tag("version".to_owned(), version.clone());
+        //}
+        //}
+        //if let Some(configuration_key) = &configuration_key {
+        //for metric in &mut metrics {
+        //metric.insert_tag("configuration_key".to_owned(), configuration_key.clone());
+        //}
+        //}
         emit!(EventsReceived {
             count: metrics.len(),
             byte_size: metrics.size_of(),

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -219,16 +219,6 @@ impl HostMetrics {
                 metric.insert_tag("host".into(), hostname.into());
             }
         }
-        //if let Some(version) = &version {
-        //for metric in &mut metrics {
-        //metric.insert_tag("version".to_owned(), version.clone());
-        //}
-        //}
-        //if let Some(configuration_key) = &configuration_key {
-        //for metric in &mut metrics {
-        //metric.insert_tag("configuration_key".to_owned(), configuration_key.clone());
-        //}
-        //}
         emit!(EventsReceived {
             count: metrics.len(),
             byte_size: metrics.size_of(),

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -79,7 +79,7 @@ pub struct HostMetricsConfig {
 
     #[cfg(target_os = "linux")]
     #[serde(default)]
-    pub cgroups: cgroups::CGroupsConfig,
+    pub(crate) cgroups: cgroups::CGroupsConfig,
     #[serde(default)]
     pub disk: disk::DiskConfig,
     #[serde(default)]

--- a/src/sources/host_metrics/network.rs
+++ b/src/sources/host_metrics/network.rs
@@ -12,7 +12,7 @@ use super::{filter_result, FilterList, HostMetrics};
 use crate::event::metric::Metric;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub(super) struct NetworkConfig {
+pub struct NetworkConfig {
     #[serde(default)]
     devices: FilterList,
 }

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -17,26 +17,12 @@ use crate::{
 #[serde(deny_unknown_fields, default)]
 pub struct InternalMetricsConfig {
     #[derivative(Default(value = "2.0"))]
-    scrape_interval_secs: f64,
-    tags: TagsConfig,
-    namespace: Option<String>,
-    #[serde(skip)]
-    version: Option<String>,
-    #[serde(skip)]
-    configuration_key: Option<String>,
+    pub scrape_interval_secs: f64,
+    pub tags: TagsConfig,
+    pub namespace: Option<String>,
 }
 
 impl InternalMetricsConfig {
-    /// Return an internal metrics config with enterprise reporting defaults.
-    pub fn enterprise(version: impl Into<String>, configuration_key: impl Into<String>) -> Self {
-        Self {
-            namespace: Some("pipelines".to_owned()),
-            version: Some(version.into()),
-            configuration_key: Some(configuration_key.into()),
-            ..Self::default()
-        }
-    }
-
     /// Set the interval to collect internal metrics.
     pub fn scrape_interval_secs(&mut self, value: f64) {
         self.scrape_interval_secs = value;
@@ -68,8 +54,6 @@ impl SourceConfig for InternalMetricsConfig {
         }
         let interval = time::Duration::from_secs_f64(self.scrape_interval_secs);
         let namespace = self.namespace.clone();
-        let version = self.version.clone();
-        let configuration_key = self.configuration_key.clone();
 
         let host_key = self
             .tags
@@ -84,8 +68,6 @@ impl SourceConfig for InternalMetricsConfig {
         Ok(Box::pin(
             InternalMetrics {
                 namespace,
-                version,
-                configuration_key,
                 host_key,
                 pid_key,
                 controller: Controller::get()?,
@@ -112,8 +94,6 @@ impl SourceConfig for InternalMetricsConfig {
 
 struct InternalMetrics<'a> {
     namespace: Option<String>,
-    version: Option<String>,
-    configuration_key: Option<String>,
     host_key: Option<String>,
     pid_key: Option<String>,
     controller: &'a Controller,
@@ -140,14 +120,6 @@ impl<'a> InternalMetrics<'a> {
                 // if an explicit namespace is provided to this source.
                 if let Some(namespace) = &self.namespace {
                     metric = metric.with_namespace(Some(namespace));
-                }
-
-                // Version and configuration key are reported in enterprise.
-                if let Some(version) = &self.version {
-                    metric.insert_tag("version".to_owned(), version.clone());
-                }
-                if let Some(configuration_key) = &self.configuration_key {
-                    metric.insert_tag("configuration_key".to_owned(), configuration_key.clone());
                 }
 
                 if let Some(host_key) = &self.host_key {


### PR DESCRIPTION
Pushing this up for thoughts.

While reviewing #12584 I realized that the logic for reporting to Datadog when the `enterprise` flag was enabled extended further throughout the code base than I expected.

This refactoring moves the logic that was conditionally adding the enterprise config version and key from the Vector components themselves into the internal topology via `remap` transforms.

Pros:

* Removes the config version and key from config structs, eliminating the possibility that a user might set them directly
* Encapsulates the enterprise logic more succinctly in `src/config/enterprise.rs`

Cons:

* Adds more components to the internal topology that is spun up when the `enterprise` flag is set
* Makes more component config fields `pub`. I actually think this is fine as I view the config structs _as_ the interface for creating a component. An alternative here would be to lean on deserialization of config snippets to instantiate the components.

There is one more spot where there is specialized logic for enterprise in `datadog_logs`:

https://github.com/vectordotdev/vector/blob/290fbd4f0849e1b9b8496dd1afd050a6ba7dc4d6/src/sinks/datadog/logs/service.rs#L144-L148

I left it for now, but wouldn't mind seeing this extracted as well. It would just require a bit more refactoring to allow this header to be set dynamically based on configuration options. This one, at least, is tied back to the global option and so wouldn't be settable in user defined config.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
