### PR TITLE
chore: Update uap-rs to 0.6.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8386,8 +8386,7 @@ dependencies = [
 [[package]]
 name = "uaparser"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ce30305c85c8234dbea6fab090a21d53000a368df718d1aa11422a4a540971"
+source = "git+https://github.com/blt/uap-rs?branch=stringless_defaults#1698af0b636161fb35aaf6050116b1a983ff16ea"
 dependencies = [
  "derive_more",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8385,8 +8385,9 @@ dependencies = [
 
 [[package]]
 name = "uaparser"
-version = "0.5.1"
-source = "git+https://github.com/blt/uap-rs?branch=stringless_defaults#1698af0b636161fb35aaf6050116b1a983ff16ea"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d705ae455d32248d299de9af5316a79ce9dc502c0b533aaeaf5f1c2fc02cc5"
 dependencies = [
  "derive_more",
  "lazy_static",

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -44,7 +44,7 @@ url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 roxmltree = { version = "0.14.1", optional = true }
 woothee = { version = "0.13.0", optional = true }
-uaparser = { git = "https://github.com/blt/uap-rs", branch = "stringless_defaults", optional = true }
+uaparser = { version = "0.6.0", default-features = false, optional = true }
 utf8-width = { version = "0.1.6", optional = true }
 
 # Cryptography

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -44,7 +44,7 @@ url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 roxmltree = { version = "0.14.1", optional = true }
 woothee = { version = "0.13.0", optional = true }
-uaparser = { version = "0.5.1", optional = true }
+uaparser = { git = "https://github.com/blt/uap-rs", branch = "stringless_defaults", optional = true }
 utf8-width = { version = "0.1.6", optional = true }
 
 # Cryptography

--- a/lib/vrl/stdlib/src/parse_user_agent.rs
+++ b/lib/vrl/stdlib/src/parse_user_agent.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, fmt, str::FromStr, sync::Arc};
+use std::{
+    borrow::{Borrow, Cow},
+    fmt,
+    str::FromStr,
+    sync::Arc,
+};
 
 use ::value::Value;
 use once_cell::sync::Lazy;
@@ -596,11 +601,11 @@ impl Parser for WootheeParser {
 
 impl Parser for UAParser {
     fn parse_user_agent(&self, user_agent: &str) -> UserAgent {
-        fn unknown_to_none(s: impl Into<Option<String>>) -> Option<String> {
-            let s = s.into()?;
-            match s.as_str() {
+        #[inline]
+        fn unknown_to_none(s: Option<Cow<'_, str>>) -> Option<String> {
+            match s?.borrow() {
                 "" | "Other" => None,
-                _ => Some(s),
+                v => Some(v.to_owned()),
             }
         }
 
@@ -608,14 +613,14 @@ impl Parser for UAParser {
 
         UserAgent {
             browser: Browser {
-                family: unknown_to_none(ua.user_agent.family),
+                family: unknown_to_none(Some(ua.user_agent.family)),
                 major: unknown_to_none(ua.user_agent.major),
                 minor: unknown_to_none(ua.user_agent.minor),
                 patch: unknown_to_none(ua.user_agent.patch),
                 ..Default::default()
             },
             os: Os {
-                family: unknown_to_none(ua.os.family),
+                family: unknown_to_none(Some(ua.os.family)),
                 major: unknown_to_none(ua.os.major),
                 minor: unknown_to_none(ua.os.minor),
                 patch: unknown_to_none(ua.os.patch),
@@ -623,7 +628,7 @@ impl Parser for UAParser {
                 ..Default::default()
             },
             device: Device {
-                family: unknown_to_none(ua.device.family),
+                family: unknown_to_none(Some(ua.device.family)),
                 brand: unknown_to_none(ua.device.brand),
                 model: unknown_to_none(ua.device.model),
                 ..Default::default()


### PR DESCRIPTION
I've found that the uaparser we use for "extended" parsing of user agents makes
a number of small allocations internally. I've got an experimental branch of
that project that prefers the use of `Cow` instead; this commit targets that
branch. I can measure a micro improvement in the benchmarks of uaparser but it's
unclear if this change will positively impact vector. Notably, even though
uaparser is returning a `Cow` this library then causes the small string to go
through an allocation, since our types are `String` on the VRL side.

Work here was incorporated upstream via https://github.com/davidarmstronglewis/uap-rs/pull/12. 

REF #12267

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
