### PR TITLE
fix(vrl): Unwrap logged messages from quote marks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,7 +1775,7 @@ dependencies = [
  "tonic",
  "tracing 0.1.34",
  "tracing-core 0.1.26",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -2185,7 +2185,7 @@ dependencies = [
  "strum_macros 0.24.0",
  "thiserror",
  "tracing 0.1.34",
- "tracing-test",
+ "tracing-test 0.2.1",
  "value",
  "vector_common",
  "vrl-compiler",
@@ -4290,6 +4290,15 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -4445,7 +4454,7 @@ dependencies = [
  "once_cell",
  "tracing 0.1.34",
  "tracing-core 0.1.26",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -8165,7 +8174,7 @@ checksum = "12de1a8c6bcfee614305e836308b596bbac831137a04c61f7e5b0b0bf2cfeaf6"
 dependencies = [
  "tracing 0.1.34",
  "tracing-core 0.1.26",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -8198,7 +8207,7 @@ dependencies = [
  "mock_instant",
  "tracing 0.1.34",
  "tracing-core 0.1.26",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -8224,13 +8233,35 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers 0.0.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing 0.1.34",
+ "tracing-core 0.1.26",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
  "lazy_static",
- "matchers",
+ "matchers 0.1.0",
  "regex",
  "serde",
  "serde_json",
@@ -8245,14 +8276,37 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b48778c2d401c6a7fcf38a0e3c55dc8e8e753cbd381044a8cdb6fd69a29f53"
+dependencies = [
+ "lazy_static",
+ "tracing-core 0.1.26",
+ "tracing-subscriber 0.2.25",
+ "tracing-test-macro 0.1.0",
+]
+
+[[package]]
+name = "tracing-test"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb7bda2e93bbc9c5b247034acc6a4b3d04f033a3d4b8fc1cb87d4d1c7c7ebd7"
 dependencies = [
  "lazy_static",
  "tracing-core 0.1.26",
- "tracing-subscriber",
- "tracing-test-macro",
+ "tracing-subscriber 0.3.11",
+ "tracing-test-macro 0.2.1",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
+dependencies = [
+ "lazy_static",
+ "quote 1.0.18",
+ "syn 1.0.92",
 ]
 
 [[package]]
@@ -8824,7 +8878,7 @@ dependencies = [
  "tracing-core 0.1.26",
  "tracing-futures 0.2.5",
  "tracing-limit",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
  "tracing-tower",
  "trust-dns-proto",
  "tui",
@@ -8941,7 +8995,7 @@ dependencies = [
  "tokio-util 0.7.0",
  "tracing 0.1.34",
  "tracing-fluent-assertions",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
  "vector_common",
 ]
 
@@ -9035,7 +9089,7 @@ dependencies = [
  "tracing 0.1.34",
  "tracing-core 0.1.26",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
  "twox-hash",
  "typetag",
  "url",
@@ -9190,6 +9244,7 @@ dependencies = [
  "strip-ansi-escapes",
  "syslog_loose",
  "tracing 0.1.34",
+ "tracing-test 0.1.0",
  "uaparser",
  "url",
  "utf8-width",
@@ -9215,7 +9270,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tikv-jemallocator",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.11",
  "vector_common",
  "vrl",
  "vrl-stdlib",

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -40,7 +40,6 @@ sha-3 = { package = "sha3", version = "0.9", optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
 syslog_loose = { version = "0.16", optional = true }
 tracing = { version = "0.1", optional = true }
-tracing-test = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 roxmltree = { version = "0.14.1", optional = true }
@@ -62,6 +61,7 @@ ofb = { version = "0.6.1", optional = true }
 anyhow = "1"
 chrono-tz = "0.6"
 criterion = "0.3"
+tracing-test = "0.1"
 value = { path = "../../value", features = ["test"]}
 vector_common = { path = "../../vector-common", default-features = false, features = ["btreemap"] }
 
@@ -256,7 +256,7 @@ is_string = []
 is_timestamp = ["chrono"]
 join = []
 length = []
-log = ["tracing", "tracing-test"]
+log = ["tracing", "value/json"]
 map_keys = []
 map_values = []
 match = ["regex"]

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -40,6 +40,7 @@ sha-3 = { package = "sha3", version = "0.9", optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
 syslog_loose = { version = "0.16", optional = true }
 tracing = { version = "0.1", optional = true }
+tracing-test = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 roxmltree = { version = "0.14.1", optional = true }
@@ -255,7 +256,7 @@ is_string = []
 is_timestamp = ["chrono"]
 join = []
 length = []
-log = ["tracing"]
+log = ["tracing", "tracing-test"]
 map_keys = []
 map_values = []
 match = ["regex"]

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -8,21 +8,22 @@ fn log(
     span: vrl::diagnostic::Span,
 ) -> Resolved {
     let rate_limit_secs = rate_limit_secs.try_integer()?;
+    let res = value.to_string_lossy();
     match level.as_ref() {
         b"trace" => {
-            trace!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
+            trace!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
         }
         b"debug" => {
-            debug!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
+            debug!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
         }
         b"warn" => {
-            warn!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
+            warn!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
         }
         b"error" => {
-            error!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
+            error!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
         }
         _ => {
-            info!(message = %value, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
+            info!(message = %res, internal_log_rate_secs = rate_limit_secs, vrl_position = span.start())
         }
     }
     Ok(Value::Null)
@@ -192,6 +193,7 @@ impl Expression for LogFn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_test::traced_test;
 
     test_function![
         log => Log;
@@ -204,4 +206,20 @@ mod tests {
             tdef: TypeDef::null().infallible(),
         }
     ];
+
+    #[traced_test]
+    #[test]
+    fn output_quotes() {
+        // Check that a message is logged without additional quotes
+        log(
+            value!(1),
+            &Bytes::from("warn"),
+            value!("simple test message"),
+            Default::default(),
+        )
+        .unwrap();
+
+        assert!(!logs_contain("\"simple test message\""));
+        assert!(logs_contain("simple test message"));
+    }
 }


### PR DESCRIPTION
Encode the message before printing it.
```
2022-03-25T17:27:46.307945Z  INFO transform{component_kind="transform" component_id=log component_type=remap component_name=log}: vrl_stdlib::log: a simple message internal_log_rate_secs=1 vrl_position=0
```
```
{"timestamp":"2022-03-25T17:42:51.540297Z","level":"INFO","message":"a \"simple\" message","internal_log_rate_secs":1,"vrl_position":0,"target":"vrl_stdlib::log","span":{"component_id":"log","component_kind":"transform","component_name":"log","component_type":"remap","name":"transform"},"spans":[{"component_id":"log","component_kind":"transform","component_name":"log","component_type":"remap","name":"transform"}]}
```

***
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>
Related to the first point of this issue https://github.com/vectordotdev/vector/issues/11989


