### PR TITLE
fix(aws provider): Disable retries

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -10,6 +10,7 @@ use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::SdkError;
 use aws_smithy_http::endpoint::Endpoint;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 use aws_types::region::Region;
 use once_cell::sync::OnceCell;
@@ -79,6 +80,11 @@ pub trait ClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder;
 
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder;
+
     fn client_from_conf_conn(builder: Self::ConfigBuilder, connector: DynConnector)
         -> Self::Client;
 }
@@ -122,6 +128,8 @@ pub async fn create_client<T: ClientBuilder>(
     };
 
     config_builder = T::with_sleep_impl(config_builder, Arc::new(TokioSleep));
+    // we disable retries because we have our own retry layer wired together with ARC to backoff
+    config_builder = T::with_retry_config(config_builder, RetryConfig::new().with_max_attempts(1));
 
     Ok(T::client_from_conf_conn(config_builder, connector))
 }

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -129,7 +129,7 @@ pub async fn create_client<T: ClientBuilder>(
 
     config_builder = T::with_sleep_impl(config_builder, Arc::new(TokioSleep));
     // we disable retries because we have our own retry layer wired together with ARC to backoff
-    config_builder = T::with_retry_config(config_builder, RetryConfig::new().with_max_attempts(1));
+    config_builder = T::with_retry_config(config_builder, RetryConfig::disabled());
 
     Ok(T::client_from_conf_conn(config_builder, connector))
 }

--- a/src/common/s3.rs
+++ b/src/common/s3.rs
@@ -2,6 +2,7 @@ use crate::aws::ClientBuilder;
 use aws_sdk_s3::{Endpoint, Region};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 use std::sync::Arc;
 
@@ -33,6 +34,13 @@ impl ClientBuilder for S3ClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder {
         builder.sleep_impl(sleep_impl)
+    }
+
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder {
+        builder.retry_config(retry_config)
     }
 
     fn client_from_conf_conn(

--- a/src/common/sqs.rs
+++ b/src/common/sqs.rs
@@ -2,6 +2,7 @@ use crate::aws::ClientBuilder;
 use aws_sdk_sqs::{Endpoint, Region};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 use std::sync::Arc;
 
@@ -33,6 +34,13 @@ impl ClientBuilder for SqsClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder {
         builder.sleep_impl(sleep_impl)
+    }
+
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder {
+        builder.retry_config(retry_config)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -29,6 +29,7 @@ use crate::{
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 
 pub struct CloudwatchLogsClientBuilder;
@@ -59,6 +60,13 @@ impl ClientBuilder for CloudwatchLogsClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder {
         builder.sleep_impl(sleep_impl)
+    }
+
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder {
+        builder.retry_config(retry_config)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -11,6 +11,7 @@ use aws_sdk_cloudwatch::types::SdkError;
 use aws_sdk_cloudwatch::{Client as CloudwatchClient, Endpoint, Region};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::{future, future::BoxFuture, stream, FutureExt, SinkExt};
 use serde::{Deserialize, Serialize};
@@ -112,6 +113,13 @@ impl ClientBuilder for CloudwatchMetricsClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder {
         builder.sleep_impl(sleep_impl)
+    }
+
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder {
+        builder.retry_config(retry_config)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_kinesis_firehose/config.rs
+++ b/src/sinks/aws_kinesis_firehose/config.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use aws_sdk_firehose::{Client as KinesisFirehoseClient, Endpoint, Region};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
@@ -138,6 +139,13 @@ impl ClientBuilder for KinesisFirehoseClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder {
         builder.sleep_impl(sleep_impl)
+    }
+
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder {
+        builder.retry_config(retry_config)
     }
 
     fn client_from_conf_conn(

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use aws_sdk_kinesis::{Client as KinesisClient, Endpoint, Region};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
@@ -76,6 +77,13 @@ impl ClientBuilder for KinesisClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder {
         builder.sleep_impl(sleep_impl)
+    }
+
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder {
+        builder.retry_config(retry_config)
     }
 
     fn client_from_conf_conn(

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -7,6 +7,7 @@ use aws_sdk_s3::types::ByteStream;
 use aws_sdk_s3::{Endpoint, Region};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::retry::RetryConfig;
 use aws_types::credentials::SharedCredentialsProvider;
 use futures::stream;
 use futures::{stream::StreamExt, TryStreamExt};
@@ -109,6 +110,13 @@ impl ClientBuilder for S3ClientBuilder {
         sleep_impl: Arc<dyn AsyncSleep>,
     ) -> Self::ConfigBuilder {
         builder.sleep_impl(sleep_impl)
+    }
+
+    fn with_retry_config(
+        builder: Self::ConfigBuilder,
+        retry_config: RetryConfig,
+    ) -> Self::ConfigBuilder {
+        builder.retry_config(retry_config)
     }
 
     fn client_from_conf_conn(


### PR DESCRIPTION
We have our own retry layer wired up with ARC so we disable AWS's retries.

This also appears to match the AWS component's previous behavior with
rusoto (see https://github.com/rusoto/rusoto/issues/234 and discussion).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
