### PR TITLE
chore: Introduce http_remap_blackhole

### DIFF
--- a/soaks/tests/http_remap_blackhole/README.md
+++ b/soaks/tests/http_remap_blackhole/README.md
@@ -1,0 +1,4 @@
+# HTTP -> Remap -> Blackhole
+
+This soak tests http source feeding into the blackhole sink through a
+non-trivial remap transform. It is a straight pipe otherwise.

--- a/soaks/tests/http_remap_blackhole/lading.yaml
+++ b/soaks/tests/http_remap_blackhole/lading.yaml
@@ -1,0 +1,12 @@
+generator:
+  http:
+    seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+    headers:
+      dd-api-key: "DEADBEEF"
+    target_uri: "http://localhost:8282/v1/input"
+    bytes_per_second: "500 Mb"
+    parallel_connections: 10
+    method:
+      post:
+        variant: "datadog_log"
+        maximum_prebuild_cache_size_bytes: "256 Mb"

--- a/soaks/tests/http_remap_blackhole/vector.toml
+++ b/soaks/tests/http_remap_blackhole/vector.toml
@@ -1,0 +1,49 @@
+data_dir = "/var/lib/vector"
+
+##
+## Sources
+##
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sources.http]
+type = "http"
+address = "0.0.0.0:8282"
+encoding = "ndjson"
+
+##
+## Transforms
+##
+
+[transforms.remap]
+type = "remap"
+inputs = ["http"]
+source = '''
+.hostname = "vector"
+
+if .status == "warning" {
+  .thing = upcase(.hostname)
+} else if .status == "notice" {
+  .thung = downcase(.hostname)
+} else {
+  .nong = upcase(.hostname)
+}
+
+.matches = { "name": .message, "num": "2" }
+.origin, .err = .hostname + "/" + .matches.name + "/" + .matches.num
+'''
+
+##
+## Sinks
+##
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+address = "0.0.0.0:9090"
+
+[sinks.blackhole]
+type = "blackhole"
+print_interval_secs = 0
+inputs = ["remap"]


### PR DESCRIPTION
This commit is a peer to #12597. We've seen a marked improvement in throughput
in that PR. While we believe this may be an artifact we do want to confirm that
there is not a substantial difference between http and datadog_agent sources.

The soak introduced here is intended to be comparable to
datadog_agent_remap_blackhole.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
