### PR TITLE
fix(gcp_pubsub source): Handle connection errors by retrying

### DIFF
--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -229,10 +229,7 @@ impl PubsubSource {
         let request_stream = self.request_stream();
         let stream = tokio::select! {
             _ = &mut self.shutdown => return Ok(false),
-            result = client.streaming_pull(request_stream) => match result {
-                    Err(source) => return Err(PubsubError::Pull { source }.into()),
-                    Ok(stream) => stream,
-                }
+            result = client.streaming_pull(request_stream) => result.context(PullSnafu)?,
         };
         let mut stream = stream.into_inner();
 


### PR DESCRIPTION
While the `gcp_pubsub` source catches errors, it does not actually try to reconnect when it encounters one that drops the connection. This fixes that.

Closes #12608 