### PR TITLE
enhancement(enterprise): Add dynamic tag configuration to enterprise section 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8230,8 +8230,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
 dependencies = [
  "lazy_static",
- "quote 1.0.18",
- "syn 1.0.92",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    fmt::{Display, Formatter},
+    fmt::{Display, Formatter}, collections::HashMap,
 };
 
 use http::Request;
@@ -76,6 +76,8 @@ pub struct Options {
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     proxy: ProxyConfig,
+
+    tags: Option<HashMap<String, String>>,
 }
 
 impl Default for Options {
@@ -92,6 +94,7 @@ impl Default for Options {
             reporting_interval_secs: default_reporting_interval_secs(),
             max_retries: default_max_retries(),
             proxy: ProxyConfig::default(),
+            tags: None,
         }
     }
 }

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -836,10 +836,12 @@ mod test {
             ("variant".to_string(), "baseline".to_string()),
         ]);
 
+        let vrl = convert_tags_to_vrl(tags, Some("tags".to_string()));
         assert_eq!(
-            convert_tags_to_vrl(tags, Some("tags".to_string())),
+            vrl,
             r#"merge(., {"tags": {"pull_request":"1234","replica":"abcd","variant":"baseline"}})"#
         );
+        assert!(vrl::compile(vrl.as_str(), vrl_stdlib::all().as_ref()).is_ok());
     }
 
     #[test]
@@ -849,10 +851,12 @@ mod test {
             ("replica".to_string(), "abcd".to_string()),
             ("variant".to_string(), "baseline".to_string()),
         ]);
+        let vrl = convert_tags_to_vrl(tags, None);
 
         assert_eq!(
-            convert_tags_to_vrl(tags, None),
+            vrl,
             r#"merge(., {"pull_request":"1234","replica":"abcd","variant":"baseline"})"#
         );
+        assert!(vrl::compile(vrl.as_str(), vrl_stdlib::all().as_ref()).is_ok());
     }
 }

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -371,7 +371,7 @@ fn setup_logs_reporting(
 
     let custom_logs_tags_vrl = datadog
         .tags
-        .clone()
+        .as_ref()
         .map_or("".to_string(), |tags| convert_tags_to_vrl(tags, false));
 
     let tag_logs = RemapConfig {
@@ -439,7 +439,7 @@ fn setup_metrics_reporting(
 
     let custom_metric_tags_vrl = datadog
         .tags
-        .clone()
+        .as_ref()
         .map_or("".to_string(), |tags| convert_tags_to_vrl(tags, true));
 
     let tag_metrics = RemapConfig {
@@ -515,7 +515,7 @@ const fn default_max_retries() -> u32 {
 
 /// Converts user configured tags to VRL source code for adding tags/fields to
 /// events
-fn convert_tags_to_vrl(tags: IndexMap<String, String>, is_metric: bool) -> String {
+fn convert_tags_to_vrl(tags: &IndexMap<String, String>, is_metric: bool) -> String {
     let json_tags = serde_json::to_string(&tags).unwrap();
     if is_metric {
         format!(r#".tags = merge(.tags, {}, deep: true)"#, json_tags)
@@ -881,7 +881,7 @@ mod test {
             ("variant".to_string(), "baseline".to_string()),
         ]);
 
-        let vrl = convert_tags_to_vrl(tags, true);
+        let vrl = convert_tags_to_vrl(&tags, true);
         assert_eq!(
             vrl,
             r#".tags = merge(.tags, {"pull_request":"1234","replica":"abcd","variant":"baseline"}, deep: true)"#
@@ -904,7 +904,7 @@ mod test {
             ("replica".to_string(), "abcd".to_string()),
             ("variant".to_string(), "baseline".to_string()),
         ]);
-        let vrl = convert_tags_to_vrl(tags, false);
+        let vrl = convert_tags_to_vrl(&tags, false);
 
         assert_eq!(
             vrl,

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -859,7 +859,9 @@ mod test {
         let mut state = vrl::state::ExternalEnv::new_with_kind(Kind::object(btreemap! {
             "tags" => Kind::object(btreemap! {}),
         }));
-        assert!(vrl::compile_with_state(vrl.as_str(), vrl_stdlib::all().as_ref(), &mut state).is_ok());
+        assert!(
+            vrl::compile_with_state(vrl.as_str(), vrl_stdlib::all().as_ref(), &mut state).is_ok()
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -871,6 +871,56 @@ mod tests {
 
         assert_eq!(config1.sha256_hash(), config2.sha256_hash())
     }
+
+    #[test]
+    #[cfg(feature = "enterprise")]
+    fn enterprise_tags_ignored_sha256_hashes() {
+        let config1: ConfigBuilder = format::deserialize(
+            indoc! {r#"
+                [enterprise]
+                api_key = "api_key"
+                application_key = "application_key"
+                configuration_key = "configuration_key"
+
+                [enterprise.tags]
+                tag = "value"
+
+                [sources.internal_metrics]
+                type = "internal_metrics"
+
+                [sinks.datadog_metrics]
+                type = "datadog_metrics"
+                inputs = ["*"]
+                default_api_key = "default_api_key"
+            "#},
+            Format::Toml,
+        )
+        .unwrap();
+
+        let config2: ConfigBuilder = format::deserialize(
+            indoc! {r#"
+                [enterprise]
+                api_key = "api_key"
+                application_key = "application_key"
+                configuration_key = "configuration_key"
+
+                [enterprise.tags]
+                another_tag = "another value"
+
+                [sources.internal_metrics]
+                type = "internal_metrics"
+
+                [sinks.datadog_metrics]
+                type = "datadog_metrics"
+                inputs = ["*"]
+                default_api_key = "default_api_key"
+            "#},
+            Format::Toml,
+        )
+        .unwrap();
+
+        assert_eq!(config1.sha256_hash(), config2.sha256_hash())
+    }
 }
 
 #[cfg(all(


### PR DESCRIPTION
Closes [OP-337](https://datadoghq.atlassian.net/browse/OP-337)

This PR adds the ability to configure custom tags in the `[enterprise]` section which are then added to the metrics and logs we use for enterprise telemetry.

### Testing

Set up an environment variable in your shell: `export ENV_VAR_TAG_TEST="env var tag"`. Set up a new pipeline in Datadog. Insert the resulting `[enterprise]` section into the following configuration

```toml
[api]
enabled = true

[enterprise]
api_key = "..."
application_key = "..."
configuration_key = "..."

[enterprise.tags]
some_tag = "tag"
some_env_var_tag = "${ENV_VAR_TAG_TEST}"

[sources.in]
type = "demo_logs"
format = "syslog"

[sinks.out]
type = "blackhole"
inputs = ["*"]
```

Run the configuration: `target/debug/vector -c {path to config}`

In [Datadog Metrics Explorer](https://app.datadoghq.com/metric/explorer?from_ts=1651786660709&to_ts=1651786960709&live=true&tile_size=m&exp_agg=avg&exp_row_type=metric), query for any `pipelines` namespaced metric (e.g. `pipelines.component_received_events_total`). You should be able to slice it by the tags from `[enterprise.tags]`. ([Try this pre-configured link](https://app.datadoghq.com/metric/explorer?from_ts=1651786964978&to_ts=1651787264978&live=true&tile_size=m&exp_metric=pipelines.component_received_events_total&exp_agg=avg&exp_row_type=metric&exp_scope=some_tag%3Atag%2Csome_env_var_tag%3Aenv_var_tag))

In [Datadog Logs Explorer](https://app.datadoghq.com/logs?query=&index=%2A&from_ts=1651786441603&to_ts=1651787341603&live=true), search for logs related to your pipelines configuration with the filter: `@configuration_key:{insert your configuration key here}`. Select any log, and you should see the relevant custom tags. ([Try this pre-configured link](https://app.datadoghq.com/logs?query=%40configuration_key%3A015c9b90-cbe4-11ec-abeb-da7ad0900002%20%40some_env_var_tag%3A%22env%20var%20tag%22&event=AQAAAYCWMa8xfmau8QAAAABBWUNXTWE4MkFBREtfVHZjdUlPME9RQUc&index=%2A&from_ts=1651786406121&to_ts=1651787306121&live=true))