### PR TITLE
fix(releasing): Don't emit random logs on Debian

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ maintainer-scripts = "distribution/debian/scripts/"
 conf-files = ["/etc/vector/vector.toml", "/etc/default/vector"]
 assets = [
   ["target/release/vector", "/usr/bin/", "755"],
-  ["config/vector.toml", "/etc/vector/vector.toml", "644"],
+  ["config/vector.empty.toml", "/etc/vector/vector.toml", "644"],
   ["config/examples/*", "/etc/vector/examples/", "644"],
   ["distribution/systemd/vector.service", "/lib/systemd/system/vector.service", "644"],
   ["distribution/systemd/vector.default", "/etc/default/vector", "600"]

--- a/config/vector.empty.toml
+++ b/config/vector.empty.toml
@@ -1,0 +1,25 @@
+#                                    __   __  __
+#                                    \ \ / / / /
+#                                     \ V / / /
+#                                      \_/  \/
+#
+#                                    V E C T O R
+#                                   Configuration
+#
+# ------------------------------------------------------------------------------
+# Website: https://vector.dev
+# Docs: https://vector.dev/docs
+# Chat: https://chat.vector.dev
+# ------------------------------------------------------------------------------
+
+# Change this to use a non-default directory for Vector data storage:
+# data_dir = "/var/lib/vector"
+
+# Vector's GraphQL API (disabled by default)
+# Uncomment to try it out with the `vector top` command or
+# in your browser at http://localhost:8686
+#[api]
+#enabled = true
+#address = "127.0.0.1:8686"
+
+# Add your sources, transforms, and sinks here.


### PR DESCRIPTION
As #11721 explains, the Vector service is automatically enabled on Debian, making installing the package start spouting out random log entries into stdout, and stdout is wired to the journal.

This makes Vector start filling up the system journal with messages like

```
41.143.198.229 - ahmadajmi [27/Apr/2022:16:33:08 +0000] "DELETE /observability/metrics/production HTTP/1.0" 200 6765
```
which can be a bit intimidating.

This PR changes the default Debian configuration file to one with no sources or sinks defined.

Fixes #11721

