### PR TITLE
chore(enterprise): Add option to disable enterprise logs reporting

### DIFF
--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -342,20 +342,10 @@ pub async fn try_attach(
         }
     }
 
-    setup_metrics_reporting(
-        config,
-        &datadog,
-        api_key.clone(),
-        config_version.clone(),
-    );
+    setup_metrics_reporting(config, &datadog, api_key.clone(), config_version.clone());
 
     if datadog.enable_logs_reporting {
-        setup_logs_reporting(
-            config,
-            &datadog,
-            api_key,
-            config_version,
-        );
+        setup_logs_reporting(config, &datadog, api_key, config_version);
     }
 
     Ok(())
@@ -450,7 +440,7 @@ fn setup_metrics_reporting(
 
     // Create a Datadog metrics sink to consume and emit internal + host metrics.
     let datadog_metrics = DatadogMetricsConfig {
-        default_api_key: api_key.clone(),
+        default_api_key: api_key,
         endpoint: datadog.endpoint.clone(),
         site: datadog.site.clone(),
         region: datadog.region,

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -51,6 +51,9 @@ pub struct Options {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
+    #[serde(default = "default_enable_logs_reporting")]
+    pub enable_logs_reporting: bool,
+
     #[serde(default = "default_exit_on_fatal_error")]
     pub exit_on_fatal_error: bool,
 
@@ -82,6 +85,7 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             enabled: default_enabled(),
+            enable_logs_reporting: default_enable_logs_reporting(),
             exit_on_fatal_error: default_exit_on_fatal_error(),
             site: None,
             region: None,
@@ -245,7 +249,7 @@ pub async fn try_attach(
     mut signal_rx: SignalRx,
 ) -> Result<(), PipelinesError> {
     // Only valid if a [enterprise] section is present in config.
-    let datadog = match config.enterprise.as_ref() {
+    let datadog = match config.enterprise.clone() {
         Some(datadog) => datadog,
         _ => return Err(PipelinesError::Disabled),
     };
@@ -268,7 +272,7 @@ pub async fn try_attach(
     );
 
     // Get the configuration version. In DD Pipelines, this is referred to as the 'config hash'.
-    let config_version = config.version.as_ref().expect("Config should be versioned");
+    let config_version = config.version.clone().expect("Config should be versioned");
 
     // Get the Vector version. This is reported to Pipelines along with a config hash.
     let vector_version = crate::get_version();
@@ -284,7 +288,7 @@ pub async fn try_attach(
     // Set the relevant fields needed to report a config to Datadog. This is a struct rather than
     // exploding as func arguments to avoid confusion with multiple &str fields.
     let fields = PipelinesStrFields {
-        config_version,
+        config_version: config_version.as_ref(),
         vector_version: &vector_version,
     };
 
@@ -338,40 +342,36 @@ pub async fn try_attach(
         }
     }
 
-    let host_metrics_id = OutputId::from(ComponentKey::from(HOST_METRICS_KEY));
-    let tag_metrics_id = OutputId::from(ComponentKey::from(TAG_METRICS_KEY));
+    setup_metrics_reporting(
+        config,
+        &datadog,
+        api_key.clone(),
+        config_version.clone(),
+    );
+
+    if datadog.enable_logs_reporting {
+        setup_logs_reporting(
+            config,
+            &datadog,
+            api_key,
+            config_version,
+        );
+    }
+
+    Ok(())
+}
+
+fn setup_logs_reporting(
+    config: &mut Config,
+    datadog: &Options,
+    api_key: String,
+    config_version: String,
+) {
     let tag_logs_id = OutputId::from(ComponentKey::from(TAG_LOGS_KEY));
-    let internal_metrics_id = OutputId::from(ComponentKey::from(INTERNAL_METRICS_KEY));
     let internal_logs_id = OutputId::from(ComponentKey::from(INTERNAL_LOGS_KEY));
-    let datadog_metrics_id = ComponentKey::from(DATADOG_METRICS_KEY);
     let datadog_logs_id = ComponentKey::from(DATADOG_LOGS_KEY);
 
-    // Create internal sources for host and internal metrics. We're using distinct sources here and
-    // not attempting to reuse existing ones, to configure according to enterprise requirements.
-    let host_metrics = HostMetricsConfig {
-        namespace: host_metrics::Namespace::from(Some("pipelines".to_owned())),
-        scrape_interval_secs: datadog.reporting_interval_secs,
-        ..Default::default()
-    };
-
-    let internal_metrics = InternalMetricsConfig {
-        namespace: Some("pipelines".to_owned()),
-        scrape_interval_secs: datadog.reporting_interval_secs,
-        ..Default::default()
-    };
-
     let internal_logs = InternalLogsConfig {
-        ..Default::default()
-    };
-
-    let tag_metrics = RemapConfig {
-        source: Some(format!(
-            r#"
-            .tags.version = "{}"
-            .tags.configuration_key = "{}"
-        "#,
-            &config_version, &datadog.configuration_key,
-        )),
         ..Default::default()
     };
 
@@ -387,27 +387,66 @@ pub async fn try_attach(
         ..Default::default()
     };
 
-    config.sources.insert(
-        host_metrics_id.component.clone(),
-        SourceOuter::new(host_metrics),
-    );
-    config.sources.insert(
-        internal_metrics_id.component.clone(),
-        SourceOuter::new(internal_metrics),
-    );
+    // Create a Datadog logs sink to consume and emit internal logs.
+    let datadog_logs = DatadogLogsConfig {
+        default_api_key: api_key,
+        endpoint: datadog.endpoint.clone(),
+        site: datadog.site.clone(),
+        region: datadog.region,
+        ..Default::default()
+    };
+
     config.sources.insert(
         internal_logs_id.component.clone(),
         SourceOuter::new(internal_logs),
     );
 
     config.transforms.insert(
-        tag_metrics_id.component.clone(),
-        TransformOuter::new(vec![host_metrics_id, internal_metrics_id], tag_metrics),
-    );
-    config.transforms.insert(
         tag_logs_id.component.clone(),
         TransformOuter::new(vec![internal_logs_id], tag_logs),
     );
+
+    config.sinks.insert(
+        datadog_logs_id,
+        SinkOuter::new(vec![tag_logs_id], Box::new(datadog_logs)),
+    );
+}
+
+fn setup_metrics_reporting(
+    config: &mut Config,
+    datadog: &Options,
+    api_key: String,
+    config_version: String,
+) {
+    let host_metrics_id = OutputId::from(ComponentKey::from(HOST_METRICS_KEY));
+    let tag_metrics_id = OutputId::from(ComponentKey::from(TAG_METRICS_KEY));
+    let internal_metrics_id = OutputId::from(ComponentKey::from(INTERNAL_METRICS_KEY));
+    let datadog_metrics_id = ComponentKey::from(DATADOG_METRICS_KEY);
+
+    // Create internal sources for host and internal metrics. We're using distinct sources here and
+    // not attempting to reuse existing ones, to configure according to enterprise requirements.
+    let host_metrics = HostMetricsConfig {
+        namespace: host_metrics::Namespace::from(Some("pipelines".to_owned())),
+        scrape_interval_secs: datadog.reporting_interval_secs,
+        ..Default::default()
+    };
+
+    let internal_metrics = InternalMetricsConfig {
+        namespace: Some("pipelines".to_owned()),
+        scrape_interval_secs: datadog.reporting_interval_secs,
+        ..Default::default()
+    };
+
+    let tag_metrics = RemapConfig {
+        source: Some(format!(
+            r#"
+            .tags.version = "{}"
+            .tags.configuration_key = "{}"
+        "#,
+            &config_version, &datadog.configuration_key,
+        )),
+        ..Default::default()
+    };
 
     // Create a Datadog metrics sink to consume and emit internal + host metrics.
     let datadog_metrics = DatadogMetricsConfig {
@@ -418,30 +457,33 @@ pub async fn try_attach(
         ..Default::default()
     };
 
+    config.sources.insert(
+        host_metrics_id.component.clone(),
+        SourceOuter::new(host_metrics),
+    );
+    config.sources.insert(
+        internal_metrics_id.component.clone(),
+        SourceOuter::new(internal_metrics),
+    );
+
+    config.transforms.insert(
+        tag_metrics_id.component.clone(),
+        TransformOuter::new(vec![host_metrics_id, internal_metrics_id], tag_metrics),
+    );
+
     config.sinks.insert(
         datadog_metrics_id,
         SinkOuter::new(vec![tag_metrics_id], Box::new(datadog_metrics)),
     );
-
-    // Create a Datadog logs sink to consume and emit internal logs.
-    let datadog_logs = DatadogLogsConfig {
-        default_api_key: api_key.clone(),
-        endpoint: datadog.endpoint.clone(),
-        site: datadog.site.clone(),
-        region: datadog.region,
-        ..Default::default()
-    };
-
-    config.sinks.insert(
-        datadog_logs_id,
-        SinkOuter::new(vec![tag_logs_id], Box::new(datadog_logs)),
-    );
-
-    Ok(())
 }
 
 /// By default, the Datadog feature is enabled.
 const fn default_enabled() -> bool {
+    true
+}
+
+/// By default, internal logs are reported to Datadog.
+const fn default_enable_logs_reporting() -> bool {
     true
 }
 


### PR DESCRIPTION
Closes [OP-354](https://datadoghq.atlassian.net/browse/OP-354)

This PR adds an `enable_logs_reporting` option to enable/disable enterprise log reporting (default `true`).
- Also a small refactoring to break out the enterprise component setups into their own functions

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
