### PR TITLE
fix(gcp service): Improve token refresh handling

### DIFF
--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -31,23 +31,23 @@ pub static PUBSUB_ADDRESS: Lazy<String> = Lazy::new(|| {
 pub enum GcpError {
     #[snafu(display("This requires one of api_key or credentials_path to be defined"))]
     MissingAuth,
-    #[snafu(display("Invalid GCP credentials"))]
+    #[snafu(display("Invalid GCP credentials: {}", source))]
     InvalidCredentials { source: GoErr },
     #[snafu(display("Healthcheck endpoint forbidden"))]
     HealthcheckForbidden,
-    #[snafu(display("Invalid RSA key in GCP credentials"))]
+    #[snafu(display("Invalid RSA key in GCP credentials: {}", source))]
     InvalidRsaKey { source: GoErr },
-    #[snafu(display("Failed to get OAuth token"))]
+    #[snafu(display("Failed to get OAuth token: {}", source))]
     GetToken { source: GoErr },
-    #[snafu(display("Failed to get OAuth token text"))]
+    #[snafu(display("Failed to get OAuth token text: {}", source))]
     GetTokenBytes { source: hyper::Error },
-    #[snafu(display("Failed to get implicit GCP token"))]
+    #[snafu(display("Failed to get implicit GCP token: {}", source))]
     GetImplicitToken { source: HttpError },
-    #[snafu(display("Failed to parse OAuth token JSON"))]
+    #[snafu(display("Failed to parse OAuth token JSON: {}", source))]
     TokenFromJson { source: TokenErr },
-    #[snafu(display("Failed to parse OAuth token JSON text"))]
+    #[snafu(display("Failed to parse OAuth token JSON text: {}", source))]
     TokenJsonFromStr { source: serde_json::Error },
-    #[snafu(display("Failed to build HTTP client"))]
+    #[snafu(display("Failed to build HTTP client: {}", source))]
     BuildHttpClient { source: HttpError },
 }
 

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -32,9 +32,9 @@ pub enum GcpError {
     #[snafu(display("This requires one of api_key or credentials_path to be defined"))]
     MissingAuth,
     #[snafu(display("Invalid GCP credentials"))]
-    InvalidCredentials0,
-    #[snafu(display("Invalid GCP credentials"))]
-    InvalidCredentials1 { source: GoErr },
+    InvalidCredentials { source: GoErr },
+    #[snafu(display("Healthcheck endpoint forbidden"))]
+    HealthcheckForbidden,
     #[snafu(display("Invalid RSA key in GCP credentials"))]
     InvalidRsaKey { source: GoErr },
     #[snafu(display("Failed to get OAuth token"))]
@@ -78,7 +78,7 @@ pub struct GcpCredentials {
 
 impl GcpCredentials {
     async fn from_file(path: &str, scope: Scope) -> crate::Result<Self> {
-        let creds = Credentials::from_file(path).context(InvalidCredentials1Snafu)?;
+        let creds = Credentials::from_file(path).context(InvalidCredentialsSnafu)?;
         let jwt = make_jwt(&creds, &scope)?;
         let token = goauth::get_token(&jwt, &creds)
             .await

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -10,6 +10,7 @@ use http::header::{HeaderName, HeaderValue};
 use indoc::indoc;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
+use snafu::Snafu;
 use tower::ServiceBuilder;
 use uuid::Uuid;
 use vector_core::{event::Finalizable, ByteSizeOf};
@@ -25,8 +26,7 @@ use crate::{
     sinks::{
         gcs_common::{
             config::{
-                build_healthcheck, GcsPredefinedAcl, GcsRetryLogic, GcsStorageClass,
-                KeyPrefixTemplateSnafu, BASE_URL,
+                build_healthcheck, GcsPredefinedAcl, GcsRetryLogic, GcsStorageClass, BASE_URL,
             },
             service::{GcsMetadata, GcsRequest, GcsRequestSettings, GcsService},
             sink::GcsSink,
@@ -40,9 +40,16 @@ use crate::{
         },
         Healthcheck, VectorSink,
     },
-    template::Template,
+    template::{Template, TemplateParseError},
     tls::{TlsConfig, TlsSettings},
 };
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum GcsHealthcheckError {
+    #[snafu(display("key_prefix template parse error: {}", source))]
+    KeyPrefixTemplate { source: TemplateParseError },
+}
 
 const NAME: &str = "gcp_cloud_storage";
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -230,7 +230,7 @@ async fn healthcheck(
     }
 
     let response = client.send(request).await?;
-    healthcheck_response(creds, HealthcheckError::TopicNotFound.into())(response)
+    healthcheck_response(response, creds, HealthcheckError::TopicNotFound.into())
 }
 
 #[cfg(test)]

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -311,7 +311,11 @@ async fn healthcheck(client: HttpClient, sink: StackdriverSink) -> crate::Result
     let request = sink.build_request(vec![]).await?.map(Body::from);
 
     let response = client.send(request).await?;
-    healthcheck_response(sink.creds.clone(), HealthcheckError::NotFound.into())(response)
+    healthcheck_response(
+        response,
+        sink.creds.clone(),
+        HealthcheckError::NotFound.into(),
+    )
 }
 
 impl StackdriverConfig {

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -12,7 +12,6 @@ use crate::{
         util::retries::{RetryAction, RetryLogic},
         Healthcheck, HealthcheckError,
     },
-    template::TemplateParseError,
 };
 
 pub const BASE_URL: &str = "https://storage.googleapis.com/";
@@ -47,17 +46,6 @@ pub enum GcsError {
     BucketNotFound { bucket: String },
 }
 
-#[derive(Debug, Snafu)]
-#[snafu(visibility(pub))]
-pub enum GcsHealthcheckError {
-    #[snafu(display("Invalid credentials"))]
-    InvalidCredentials,
-    #[snafu(display("Unknown bucket: {:?}", bucket))]
-    UnknownBucket { bucket: String },
-    #[snafu(display("key_prefix template parse error: {}", source))]
-    KeyPrefixTemplate { source: TemplateParseError },
-}
-
 pub fn build_healthcheck(
     bucket: String,
     client: HttpClient,
@@ -75,7 +63,7 @@ pub fn build_healthcheck(
         let not_found_error = GcsError::BucketNotFound { bucket }.into();
 
         let response = client.send(request).await?;
-        healthcheck_response(creds, not_found_error)(response)
+        healthcheck_response(response, creds, not_found_error)
     };
 
     Ok(healthcheck.boxed())
@@ -83,22 +71,20 @@ pub fn build_healthcheck(
 
 // Use this to map a healthcheck response, as it handles setting up the renewal task.
 pub fn healthcheck_response(
+    response: http::Response<hyper::Body>,
     creds: Option<GcpCredentials>,
     not_found_error: crate::Error,
-) -> impl FnOnce(http::Response<hyper::Body>) -> crate::Result<()> {
-    move |response| match response.status() {
-        StatusCode::OK => {
-            // If there are credentials configured, the
-            // generated OAuth token needs to be periodically
-            // regenerated. Since the health check runs at
-            // startup, after a successful health check is a
-            // good place to create the regeneration task.
-            if let Some(creds) = creds {
-                creds.spawn_regenerate_token();
-            }
-            Ok(())
-        }
-        StatusCode::FORBIDDEN => Err(GcpError::InvalidCredentials0.into()),
+) -> crate::Result<()> {
+    // If there are credentials configured, the generated OAuth
+    // token needs to be periodically regenerated. Since the
+    // health check runs at startup, after a health check is a
+    // good place to create the regeneration task.
+    if let Some(creds) = creds {
+        creds.spawn_regenerate_token();
+    }
+    match response.status() {
+        StatusCode::OK => Ok(()),
+        StatusCode::FORBIDDEN => Err(GcpError::HealthcheckForbidden.into()),
         StatusCode::NOT_FOUND => Err(not_found_error),
         status => Err(HealthcheckError::UnexpectedStatus { status }.into()),
     }

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -243,8 +243,7 @@ impl PubsubSource {
                                 "Invalid token text returned by GCP",
                             )
                         })?;
-                    req.metadata_mut()
-                        .insert("authorization", authorization.clone());
+                    req.metadata_mut().insert("authorization", authorization);
                 }
                 Ok(req)
             },


### PR DESCRIPTION
GCP access tokens need to be refreshed periodically. This task was
set up to be started up after a successful healthcheck. However, the
healthcheck can fail for reasons that don't prevent the sink from
running (ex credentials are only permitted to write, not read), so start
the background task unconditionally after the healthcheck runs.

This patch also simplifies the calling convention for
`healthcheck_response`.

Closes #12625

The second commit adds support for refreshing auth tokens in the `gcp_pubsub` source.