### PR TITLE
fix(releasing): Don't enable & start service by default on Debian

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ extended-description-file = "target/debian-extended-description.txt"
 
 [package.metadata.deb.systemd-units]
 unit-scripts = "distribution/systemd/"
+enable = false
+start = false
 
 # libc requirements are defined by `cross`
 # https://github.com/rust-embedded/cross#supported-targets

--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -16,6 +16,7 @@ Vector's 0.22.0 release includes **breaking changes**:
 2. [`kubernetes_logs` source now requires rights to list and watch nodes](#kubernetes-logs-list-watch-nodes)
 3. [VRL now supports template strings](#vrl-template-strings)
 4. [`encode_key_value` and `encode_logfmt` quote wrapping behavior change](#encode-key-value-quote-wrapping)
+5. [The `.deb` package no longer enables and starts the Vector systemd service](#systemd-autostart)
 
 We cover them below to help you upgrade quickly:
 
@@ -165,4 +166,23 @@ With this change, the message would be encoded as:
 
 ```text
 lvl=info msg="{\"some\":\"val\"}"
+```
+
+#### [The `.deb` package no longer enables and starts the Vector systemd service] {#systemd-autostart}
+
+The [official `.deb` package](https://vector.dev/download/)
+no longer automatically enables and starts the Vector systemd service. 
+This is in line with how the RPM package behaves.
+
+To enable and start the service (after configuring it to your requirements),
+you can use `systemctl enable --now`:
+
+```
+systemctl enable --now vector
+```
+
+To just start the service without enabling it to run at system startup,
+
+```
+systemctl start vector
 ```

--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -166,22 +166,3 @@ With this change, the message would be encoded as:
 ```text
 lvl=info msg="{\"some\":\"val\"}"
 ```
-
-#### [The `.deb` package no longer enables and starts the Vector systemd service] {#systemd-autostart}
-
-The [official `.deb` package](https://vector.dev/download/)
-no longer automatically enables and starts the Vector systemd service.
-This is in line with how the RPM package behaves.
-
-To enable and start the service (after configuring it to your requirements),
-you can use `systemctl enable --now`:
-
-```
-systemctl enable --now vector
-```
-
-To just start the service without enabling it to run at system startup,
-
-```
-systemctl start vector
-```

--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -16,7 +16,6 @@ Vector's 0.22.0 release includes **breaking changes**:
 2. [`kubernetes_logs` source now requires rights to list and watch nodes](#kubernetes-logs-list-watch-nodes)
 3. [VRL now supports template strings](#vrl-template-strings)
 4. [`encode_key_value` and `encode_logfmt` quote wrapping behavior change](#encode-key-value-quote-wrapping)
-5. [The `.deb` package no longer enables and starts the Vector systemd service](#systemd-autostart)
 
 We cover them below to help you upgrade quickly:
 
@@ -171,7 +170,7 @@ lvl=info msg="{\"some\":\"val\"}"
 #### [The `.deb` package no longer enables and starts the Vector systemd service] {#systemd-autostart}
 
 The [official `.deb` package](https://vector.dev/download/)
-no longer automatically enables and starts the Vector systemd service. 
+no longer automatically enables and starts the Vector systemd service.
 This is in line with how the RPM package behaves.
 
 To enable and start the service (after configuring it to your requirements),

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -28,12 +28,12 @@ This is in line with how the RPM package behaves.
 To enable and start the service (after configuring it to your requirements),
 you can use `systemctl enable --now`:
 
-```
+```shell
 systemctl enable --now vector
 ```
 
 To just start the service without enabling it to run at system startup,
 
-```
+```shell
 systemctl start vector
 ```

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -1,0 +1,39 @@
+---
+date: "2022-06-16"
+title: "0.23 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.23.0"
+authors: ["akx", "jszwedko"]
+release: "0.23.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.23.0 release includes **breaking changes**:
+
+1. [The `.deb` package no longer enables and starts the Vector systemd service](#systemd-autostart)
+
+We cover them below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Breaking changes
+
+#### [The `.deb` package no longer enables and starts the Vector systemd service] {#systemd-autostart}
+
+The [official `.deb` package](https://vector.dev/download/)
+no longer automatically enables and starts the Vector systemd service.
+This is in line with how the RPM package behaves.
+
+To enable and start the service (after configuring it to your requirements),
+you can use `systemctl enable --now`:
+
+```
+systemctl enable --now vector
+```
+
+To just start the service without enabling it to run at system startup,
+
+```
+systemctl start vector
+```


### PR DESCRIPTION
As @hhromic pointed out in https://github.com/vectordotdev/vector/pull/12635#issuecomment-1119659572, it doesn't make much sense for th Debian package to enable and start Vector before it's configured by the sysadmin.

My PR #12635 "defangs" the default configuration to not spout out random logs to the system journal, which helps a bit, but 
the sysadmin still needs to configure, then restart Vector for their system-specific configuration to take effect.

The `enable` and `start` configuration stanzas were gleaned from https://github.com/kornelski/cargo-deb/blob/51a59b377b88fa9b419a88a515be9077c098bc23/src/manifest.rs#L83-L101 .