### PR TITLE
chore(vrl): optimize performance for void root expressions

### DIFF
--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -121,9 +121,10 @@ fn run(opts: &Opts) -> Result<(), Error> {
     } else {
         let objects = opts.read_into_objects()?;
         let source = opts.read_program()?;
-        let (program, warnings) = vrl::compile(&source, &stdlib::all()).map_err(|diagnostics| {
-            Error::Parse(Formatter::new(&source, diagnostics).colored().to_string())
-        })?;
+        let (program, warnings) = vrl::compile(&source, &stdlib::all(), vrl::Options::default())
+            .map_err(|diagnostics| {
+                Error::Parse(Formatter::new(&source, diagnostics).colored().to_string())
+            })?;
 
         #[allow(clippy::print_stderr)]
         if opts.print_warnings {

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -48,10 +48,21 @@ impl<'a> Compiler<'a> {
         ast: parser::Program,
         external: &mut ExternalEnv,
     ) -> Result<(Program, DiagnosticList), DiagnosticList> {
+        let expression_count = ast.len();
+
         let expressions = self
             .compile_root_exprs(ast, external)
             .into_iter()
-            .map(|expr| Box::new(expr) as _)
+            .enumerate()
+            .map(|(i, expr)| {
+                // For all root expressions, except the last one, the result value
+                // is voided.
+                if i < expression_count {
+                    Box::new(VoidExpr(expr)) as _
+                } else {
+                    Box::new(expr) as _
+                }
+            })
             .collect();
 
         let (errors, warnings): (Vec<_>, Vec<_>) =

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -90,6 +90,15 @@ impl Expression for VoidExpr {
     }
 
     #[inline(always)]
+    fn compile_to_vm(
+        &self,
+        vm: &mut vm::Vm,
+        state: (&mut LocalEnv, &mut ExternalEnv),
+    ) -> Result<(), String> {
+        self.0.compile_to_vm(vm, state)
+    }
+
+    #[inline(always)]
     fn type_def(&self, state: (&LocalEnv, &ExternalEnv)) -> TypeDef {
         self.0.type_def(state)
     }

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -20,7 +20,7 @@ pub mod vm;
 pub use crate::value::Value;
 use ::serde::{Deserialize, Serialize};
 pub use context::Context;
-pub use core::{value, ExpressionError, Resolved, Target};
+pub use core::{value, ExpressionError, Resolved, Target, Void};
 use diagnostic::DiagnosticList;
 pub(crate) use diagnostic::Span;
 pub use expression::Expression;

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -72,10 +72,28 @@ impl Display for VrlRuntime {
     }
 }
 
+pub struct Options {
+    /// If set to `true`, the compiler is allowed to void the return value of
+    /// the  final expression.
+    ///
+    /// This can improve runtime performance in situations where the caller of
+    /// the program has no interest in the return value of the program.
+    ///
+    /// Defaults to `false`.
+    pub void_return: bool,
+}
+
+#[allow(clippy::derivable_impls /* be explicit */)]
+impl Default for Options {
+    fn default() -> Self {
+        Self { void_return: false }
+    }
+}
+
 /// Compile a given program [`ast`](parser::Program) into the final [`Program`].
-pub fn compile(ast: parser::Program, fns: &[Box<dyn Function>]) -> Result {
+pub fn compile(ast: parser::Program, fns: &[Box<dyn Function>], options: Options) -> Result {
     let mut external = ExternalEnv::default();
-    compile_with_state(ast, fns, &mut external)
+    compile_with_state(ast, fns, options, &mut external)
 }
 
 pub fn compile_for_repl(
@@ -99,9 +117,10 @@ pub fn compile_for_repl(
 pub fn compile_with_state(
     ast: parser::Program,
     fns: &[Box<dyn Function>],
+    options: Options,
     state: &mut ExternalEnv,
 ) -> Result {
-    compiler::Compiler::new(fns).compile(ast, state)
+    compiler::Compiler::new(fns, options).compile(ast, state)
 }
 
 /// re-export of commonly used parser types.

--- a/lib/vrl/core/src/expression.rs
+++ b/lib/vrl/core/src/expression.rs
@@ -2,6 +2,7 @@ use diagnostic::{DiagnosticMessage, Label, Note};
 use value::Value;
 
 pub type Resolved = Result<Value, ExpressionError>;
+pub type Void = Result<(), ExpressionError>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ExpressionError {

--- a/lib/vrl/core/src/lib.rs
+++ b/lib/vrl/core/src/lib.rs
@@ -9,6 +9,6 @@ mod expression;
 mod r#macro;
 mod target;
 
-pub use expression::{ExpressionError, Resolved};
+pub use expression::{ExpressionError, Resolved, Void};
 pub use target::Target;
 pub use value::Value;

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -190,7 +190,12 @@ fn main() {
         state.set_external_context(test_enrichment.clone());
 
         let compile_start = Instant::now();
-        let program = vrl::compile_with_state(&test.source, &functions, &mut state);
+        let program = vrl::compile_with_state(
+            &test.source,
+            &functions,
+            vrl::Options::default(),
+            &mut state,
+        );
         let compile_end = compile_start.elapsed();
 
         let want = test.result.clone();

--- a/lib/vrl/vrl/benches/runtime.rs
+++ b/lib/vrl/vrl/benches/runtime.rs
@@ -45,7 +45,7 @@ fn benchmark_kind_display(c: &mut Criterion) {
         let runtime = Runtime::new(state);
         let tz = TimeZone::default();
         let functions = vrl_stdlib::all();
-        let (program, _) = vrl::compile(source.code, &functions).unwrap();
+        let (program, _) = vrl::compile(source.code, &functions, vrl::Options::default()).unwrap();
         let mut external_env = state::ExternalEnv::default();
         let vm = runtime
             .compile(functions, &program, &mut external_env)

--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -10,28 +10,29 @@ pub mod prelude;
 mod runtime;
 
 pub use compiler::{
-    function, state, value, vm::Vm, Context, Expression, Function, Program, ProgramInfo, Target,
-    Value, VrlRuntime,
+    function, state, value, vm::Vm, Context, Expression, Function, Options, Program, ProgramInfo,
+    Target, Value, VrlRuntime,
 };
 pub use diagnostic;
 pub use runtime::{Runtime, RuntimeResult, Terminate};
 
 /// Compile a given source into the final [`Program`].
-pub fn compile(source: &str, fns: &[Box<dyn Function>]) -> compiler::Result {
+pub fn compile(source: &str, fns: &[Box<dyn Function>], options: Options) -> compiler::Result {
     let mut state = state::ExternalEnv::default();
 
-    compile_with_state(source, fns, &mut state)
+    compile_with_state(source, fns, options, &mut state)
 }
 
 pub fn compile_with_state(
     source: &str,
     fns: &[Box<dyn Function>],
+    options: Options,
     state: &mut state::ExternalEnv,
 ) -> compiler::Result {
     let ast = parser::parse(source)
         .map_err(|err| diagnostic::DiagnosticList::from(vec![Box::new(err) as Box<_>]))?;
 
-    compiler::compile_with_state(ast, fns, state)
+    compiler::compile_with_state(ast, fns, options, state)
 }
 
 pub fn compile_for_repl(

--- a/lib/vrl/vrl/src/prelude.rs
+++ b/lib/vrl/vrl/src/prelude.rs
@@ -6,7 +6,7 @@ pub use compiler::{expression, state, value::kind};
 pub use compiler::{
     function::{closure, FunctionClosure},
     value::{Collection, Field, Index, IterItem, Kind},
-    Context, Expression, ExpressionError, Function, Resolved, Target, TypeDef, Value,
+    Context, Expression, ExpressionError, Function, Resolved, Target, TypeDef, Value, Void,
 };
 
 pub type Result<T> = std::result::Result<T, ExpressionError>;

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -53,12 +53,20 @@ impl ConditionConfig for VrlConfig {
         let mut state = vrl::state::ExternalEnv::default();
         state.set_external_context(enrichment_tables.clone());
 
-        let (program, warnings) = vrl::compile_with_state(&self.source, &functions, &mut state)
-            .map_err(|diagnostics| {
-                Formatter::new(&self.source, diagnostics)
-                    .colored()
-                    .to_string()
-            })?;
+        let options = vrl::Options {
+            // The return value of the program is used to determime the outcome
+            // of the condition, so it's important this value is returned as-is.
+            void_return: false,
+        };
+
+        let (program, warnings) =
+            vrl::compile_with_state(&self.source, &functions, options, &mut state).map_err(
+                |diagnostics| {
+                    Formatter::new(&self.source, diagnostics)
+                        .colored()
+                        .to_string()
+                },
+            )?;
 
         if !warnings.is_empty() {
             let warnings = Formatter::new(&self.source, warnings).colored().to_string();

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -892,9 +892,13 @@ mod test {
         let mut state = vrl::state::ExternalEnv::new_with_kind(Kind::object(btreemap! {
             "tags" => Kind::object(btreemap! {}),
         }));
-        assert!(
-            vrl::compile_with_state(vrl.as_str(), vrl_stdlib::all().as_ref(), &mut state).is_ok()
-        );
+        assert!(vrl::compile_with_state(
+            vrl.as_str(),
+            vrl_stdlib::all().as_ref(),
+            vrl::Options::default(),
+            &mut state
+        )
+        .is_ok());
     }
 
     #[test]
@@ -910,6 +914,11 @@ mod test {
             vrl,
             r#". = merge(., {"pull_request":"1234","replica":"abcd","variant":"baseline"}, deep: true)"#
         );
-        assert!(vrl::compile(vrl.as_str(), vrl_stdlib::all().as_ref()).is_ok());
+        assert!(vrl::compile(
+            vrl.as_str(),
+            vrl_stdlib::all().as_ref(),
+            vrl::Options::default()
+        )
+        .is_ok());
     }
 }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -79,7 +79,15 @@ impl RemapConfig {
         let mut state = vrl::state::ExternalEnv::new_with_kind(merged_schema_definition.into());
         state.set_external_context(enrichment_tables);
 
-        vrl::compile_with_state(&source, &functions, &mut state)
+        let options = vrl::Options {
+            // We do not care about the return `Value` of a VRL program in this
+            // transform (we only care about the mutated `Event`), so we allow
+            // the compiler to perform optimizations which might change the
+            // final return value.
+            void_return: true,
+        };
+
+        vrl::compile_with_state(&source, &functions, options, &mut state)
             .map_err(|diagnostics| {
                 Formatter::new(&source, diagnostics)
                     .colored()


### PR DESCRIPTION
This PR adds another optimization to the compiler.

The compiler is now allowed to drop the return value of an expression, as long as that return value is unused in the final result of the program.

While there are more opportunities to forgo return values, this PR allows it in two situations:

- If it's a root-level expression that is _not_ used as the final expression (because the result of the final expression of a VRL program, is what's returned by the runtime).
- If it's the final root-level expression _and_ `void_return` is enabled by the caller of the compiler. This is a new option, which allows the caller to signal to the compiler that they are uninterested in the return value of the program at runtime. This is specifically used in the `remap` transform, which doesn't use the return value of a program, but only runs the program to allow mutating the event.

To allow for void return values, a new `Expression::resolve_void` method is added to the trait, which returns `Result<(), Error>`, as opposed to `resolve`, which returns `Result<Value, Error>`. By default, this new method calls `resolve`, but then drops the returned value, which makes it safe to use, in that whatever type implements `Expression` will have its `resolve` method called, and thus whatever the type does at runtime is guaranteed to stay the same.

However, to get any performance benefits, `Expression` implementations must provide a custom implementation for `resolve_void`, to avoid any additional work previously needed to return the `Value` type.

For starters, in this PR, the `assignment` expression and `del` function add support for this new trait method. Meaning, those two expressions no longer clone values to support returning the `Value` type, when `resolve_void` is called.

This _should_ cause a small, but welcome performance gain for fairly common programs, such as:

```coffee
del(.foo)
del(.bar)
.baz = "hello"
```

In the above example, three clones are removed at runtime, when this program runs in the `remap` transform.