### PR TITLE
chore(vrl): remove `Value` clone in `Value::target_remove`

### DIFF
--- a/lib/vrl/core/src/target.rs
+++ b/lib/vrl/core/src/target.rs
@@ -86,10 +86,7 @@ impl Target for Value {
     }
 
     fn target_remove(&mut self, path: &LookupBuf, compact: bool) -> Result<Option<Value>, String> {
-        let value = self.target_get(path)?.cloned();
-        self.remove_by_path(path, compact);
-
-        Ok(value)
+        Ok(self.remove_by_path(path, compact))
     }
 }
 


### PR DESCRIPTION
This PR removes a clone happening in `Value::target_remove`. I doubt it'll have a meaningful impact, but from an API perspective this implementation makes more sense, so it's good to get this merged regardless.