### PR TITLE
chore(core): remove runtime lookup parsing for `keyvalue` filter in `parse_groks`

### DIFF
--- a/lib/datadog/grok/src/filters/keyvalue.rs
+++ b/lib/datadog/grok/src/filters/keyvalue.rs
@@ -143,9 +143,8 @@ pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, Gro
                     || matches!(&v, Value::Bytes(b) if b.is_empty())
                     || k.trim().is_empty())
                 {
-                    let lookup: LookupBuf = Lookup::from_str(&k)
-                        .unwrap_or_else(|_| Lookup::from(&k))
-                        .into();
+
+                    let lookup: LookupBuf = Lookup::from(&k).into();
                     result.target_insert(&lookup, v).unwrap_or_else(
                         |error| warn!(message = "Error updating field value", field = %lookup, %error)
                     );

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -857,10 +857,8 @@ mod tests {
                 "%{data::keyvalue}",
                 "db.name=my_db,db.operation=insert",
                 Ok(Value::from(btreemap! {
-                    "db" => btreemap! {
-                        "name" => "my_db",
-                        "operation" => "insert",
-                    }
+                    "db.name" => "my_db",
+                    "db.operation" => "insert",
                 })),
             ),
         ]);


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/12402

This is technically a breaking change. Previously the key was parsed as if it was a VRL path, and if that failed it would fall back to treating it as a single segment. VRL path parsing should generally only be used on values that are provided by the user so
the nesting / character escaping can be provided. Since this key comes from the log content, we decided to treat is as just a single path segment. This also makes this change significantly smaller since it doesn't require switching to the new lookup parsing. There will likely be a small perf improvement once it is switched to the new lookup code, but I expect this will get us >95% of the improvement already.