### PR TITLE
fix(aws_s3 source): handle spaces in filenames

### DIFF
--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -428,6 +428,25 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn s3_process_message_spaces() {
+        trace_init();
+
+        let key = "key with spaces".to_string();
+        let logs: Vec<String> = random_lines(100).take(10).collect();
+
+        test_event(
+            Some(key),
+            None,
+            None,
+            None,
+            logs.join("\n").into_bytes(),
+            logs,
+            Delivered,
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn s3_process_message_special_characters() {
         trace_init();
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -692,7 +692,7 @@ pub struct S3Bucket {
     pub name: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct S3Object {
     // S3ObjectKeys are URL encoded
@@ -736,4 +736,23 @@ mod urlencoded_string {
             &utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).collect::<String>(),
         )
     }
+}
+
+#[test]
+fn test_key_deserialize() {
+    let value = serde_json::from_str(r#"{"key": "noog+nork"}"#).unwrap();
+    assert_eq!(
+        S3Object {
+            key: "noog nork".to_string(),
+        },
+        value
+    );
+
+    let value = serde_json::from_str(r#"{"key": "noog%2bnork"}"#).unwrap();
+    assert_eq!(
+        S3Object {
+            key: "noog+nork".to_string(),
+        },
+        value
+    );
 }

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -710,10 +710,16 @@ mod urlencoded_string {
     {
         use serde::de::Error;
 
-        serde::de::Deserialize::deserialize(deserializer).and_then(|s| {
-            percent_decode(s)
-                .decode_utf8()
-                .map(Into::into)
+        serde::de::Deserialize::deserialize(deserializer).and_then(|s: &[u8]| {
+            let decoded = if s.iter().any(|c| *c == b'+') {
+                // AWS encodes spaces as `+` rather than `%20`, so we first need to handle this.
+                let s = s.iter().map(|c| if *c == b'+' { b' ' } else { *c }).collect::<Vec<_>>();
+                percent_decode(&s).decode_utf8().map(Into::into)
+            } else {
+                percent_decode(s).decode_utf8().map(Into::into)
+            };
+
+            decoded
                 .map_err(|err| {
                     D::Error::custom(format!("error url decoding S3 object key: {}", err))
                 })

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -713,16 +713,18 @@ mod urlencoded_string {
         serde::de::Deserialize::deserialize(deserializer).and_then(|s: &[u8]| {
             let decoded = if s.iter().any(|c| *c == b'+') {
                 // AWS encodes spaces as `+` rather than `%20`, so we first need to handle this.
-                let s = s.iter().map(|c| if *c == b'+' { b' ' } else { *c }).collect::<Vec<_>>();
+                let s = s
+                    .iter()
+                    .map(|c| if *c == b'+' { b' ' } else { *c })
+                    .collect::<Vec<_>>();
                 percent_decode(&s).decode_utf8().map(Into::into)
             } else {
                 percent_decode(s).decode_utf8().map(Into::into)
             };
 
-            decoded
-                .map_err(|err| {
-                    D::Error::custom(format!("error url decoding S3 object key: {}", err))
-                })
+            decoded.map_err(|err| {
+                D::Error::custom(format!("error url decoding S3 object key: {}", err))
+            })
         })
     }
 


### PR DESCRIPTION
Closes #12498 

AWS escapes spaces in the filename with `+`, however the source was only percent decoding, assuming `%20` was the encoding for spaces.

This checks if there is a `+` in the name and replaces it with a space. We can be confident that all `+` will be representing spaces, since any actual `+` in the filename do get encoded to `%2b`.

Signed-off-by: Stephen Wakely <stephen.wakely@datadoghq.com>
