### PR TITLE
chore(observability): ensure transforms are checked for component spec compliance

### DIFF
--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -82,6 +82,19 @@ pub static SOURCE_TESTS: Lazy<ComponentTests> = Lazy::new(|| ComponentTests {
         "component_sent_event_bytes_total",
     ],
 });
+
+/// The component test specification for all transforms
+pub static TRANSFORM_TESTS: Lazy<ComponentTests> = Lazy::new(|| ComponentTests {
+    events: &["EventsReceived", "EventsSent"],
+    tagged_counters: &[],
+    untagged_counters: &[
+        "component_received_events_total",
+        "component_received_event_bytes_total",
+        "component_sent_events_total",
+        "component_sent_event_bytes_total",
+    ],
+});
+
 /// The component test specification for all sinks
 pub static SINK_TESTS: Lazy<ComponentTests> = Lazy::new(|| {
     ComponentTests {
@@ -93,6 +106,7 @@ pub static SINK_TESTS: Lazy<ComponentTests> = Lazy::new(|| {
         ],
     }
 });
+
 /// The component test specification for components with multiple outputs
 pub static COMPONENT_MULTIPLE_OUTPUTS_TESTS: Lazy<ComponentTests> = Lazy::new(|| ComponentTests {
     events: &["EventsSent"],
@@ -313,6 +327,16 @@ where
         events
     })
     .await
+}
+
+pub async fn assert_transform_compliance<T>(f: impl Future<Output = T>) -> T {
+    init_test();
+
+    let result = f.await;
+
+    TRANSFORM_TESTS.assert(&[]);
+
+    result
 }
 
 /// Convenience wrapper for running sink tests

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -23,7 +23,8 @@ use vector_core::{
         BufferType, WhenFull,
     },
     internal_event::EventsSent,
-    ByteSizeOf, schema::Definition,
+    schema::Definition,
+    ByteSizeOf,
 };
 
 use super::{
@@ -510,7 +511,11 @@ struct TransformNode {
 }
 
 impl TransformNode {
-    pub fn from_parts(key: ComponentKey, transform: &TransformOuter<OutputId>, schema_definition: &Definition) -> Self {
+    pub fn from_parts(
+        key: ComponentKey,
+        transform: &TransformOuter<OutputId>,
+        schema_definition: &Definition,
+    ) -> Self {
         Self {
             key,
             typetag: transform.inner.transform_type(),

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -23,7 +23,7 @@ use vector_core::{
         BufferType, WhenFull,
     },
     internal_event::EventsSent,
-    ByteSizeOf,
+    ByteSizeOf, schema::Definition,
 };
 
 use super::{
@@ -35,7 +35,7 @@ use super::{
 use crate::{
     config::{
         ComponentKey, DataType, Input, Output, OutputId, ProxyConfig, SinkContext, SourceContext,
-        TransformContext,
+        TransformContext, TransformOuter,
     },
     event::{EventArray, EventContainer},
     internal_events::EventsReceived,
@@ -298,14 +298,7 @@ pub async fn build_pieces(
             merged_schema_definition: merged_definition.clone(),
         };
 
-        let node = TransformNode {
-            key: key.clone(),
-            typetag: transform.inner.transform_type(),
-            inputs: transform.inputs.clone(),
-            input_details: transform.inner.input(),
-            outputs: transform.inner.outputs(&merged_definition),
-            enable_concurrency: transform.inner.enable_concurrency(),
-        };
+        let node = TransformNode::from_parts(key.clone(), transform, &merged_definition);
 
         let transform = match transform.inner.build(&context).await {
             Err(error) => {
@@ -514,6 +507,19 @@ struct TransformNode {
     input_details: Input,
     outputs: Vec<Output>,
     enable_concurrency: bool,
+}
+
+impl TransformNode {
+    pub fn from_parts(key: ComponentKey, transform: &TransformOuter<OutputId>, schema_definition: &Definition) -> Self {
+        Self {
+            key,
+            typetag: transform.inner.transform_type(),
+            inputs: transform.inputs.clone(),
+            input_details: transform.inner.input(),
+            outputs: transform.inner.outputs(schema_definition),
+            enable_concurrency: transform.inner.enable_concurrency(),
+        }
+    }
 }
 
 fn build_transform(

--- a/src/topology/test/compliance.rs
+++ b/src/topology/test/compliance.rs
@@ -1,20 +1,43 @@
-use std::pin::Pin;
+use std::{pin::Pin, sync::Mutex};
 
 use async_trait::async_trait;
-use futures_util::{future::ready, Stream};
-use vector_core::{transform::{FunctionTransform, OutputBuffer, TransformConfig, Transform, TransformContext, SyncTransform, TaskTransform, TransformOutputsBuf}, event::Event, schema::Definition, config::{Output, Input, DataType}};
+use futures_util::{stream::BoxStream, Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot::{channel, Receiver, Sender};
+use vector_buffers::Acker;
+use vector_core::{
+    config::{AcknowledgementsConfig, DataType, Input, Output},
+    event::{Event, EventArray, EventContainer},
+    schema::Definition,
+    sink::{StreamSink, VectorSink},
+    source::Source,
+    transform::{
+        FunctionTransform, OutputBuffer, TaskTransform, Transform, TransformConfig,
+        TransformContext,
+    },
+};
 
+use crate::{
+    config::{ConfigBuilder, SinkConfig, SinkContext, SourceConfig, SourceContext},
+    sinks::Healthcheck,
+    test_util::{components::assert_transform_compliance, start_topology},
+    topology::RunningTopology,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 enum TransformType {
-	Function,
-	Sync,
-	Task,
+    Function,
+    Synchronous,
+    Task,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct NoopTransformConfig {
-	transform_type: TransformType,
+    transform_type: TransformType,
 }
 
 #[async_trait]
+#[typetag::serde(name = "noop")]
 impl TransformConfig for NoopTransformConfig {
     fn input(&self) -> Input {
         Input::all()
@@ -28,12 +51,109 @@ impl TransformConfig for NoopTransformConfig {
         "noop"
     }
 
-	async fn build(&self, globals: &TransformContext) -> crate::Result<Transform> {
+    async fn build(&self, _: &TransformContext) -> crate::Result<Transform> {
         match self.transform_type {
-			TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform))),
-			TransformType::Sync => Ok(Transform::Synchronous(Box::new(NoopTransform))),
-			TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform))),
-		}
+            TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform))),
+            TransformType::Synchronous => Ok(Transform::Synchronous(Box::new(NoopTransform))),
+            TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform))),
+        }
+    }
+}
+
+impl From<TransformType> for NoopTransformConfig {
+    fn from(transform_type: TransformType) -> Self {
+        Self { transform_type }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OneshotSourceConfig {
+    #[serde(skip)]
+    event: Option<Event>,
+}
+
+#[async_trait]
+#[typetag::serde(name = "oneshot")]
+impl SourceConfig for OneshotSourceConfig {
+    fn outputs(&self) -> Vec<Output> {
+        vec![Output::default(DataType::all())]
+    }
+
+    fn source_type(&self) -> &'static str {
+        "oneshot"
+    }
+
+    fn can_acknowledge(&self) -> bool {
+        false
+    }
+
+    async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
+        let event = self.event.clone();
+        let mut out = cx.out;
+        let shutdown = cx.shutdown;
+        Ok(Box::pin(async move {
+            let event = event.expect("event must not be none");
+            out.send_event(event).await.unwrap();
+            shutdown.await;
+            Ok(())
+        }))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OneshotSinkConfig {
+    #[serde(skip)]
+    tx: Mutex<Option<Sender<EventArray>>>,
+}
+
+#[async_trait]
+#[typetag::serde(name = "oneshot")]
+impl SinkConfig for OneshotSinkConfig {
+    fn input(&self) -> Input {
+        Input::all()
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "oneshot"
+    }
+
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        None
+    }
+
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let tx = {
+            let mut guard = self.tx.lock().expect("who cares if the lock is poisoned");
+            guard.take()
+        };
+        let sink = Box::new(OneshotSink {
+            acker: cx.acker,
+            tx,
+        });
+
+        let healthcheck = Box::pin(async { Ok(()) });
+
+        Ok((VectorSink::Stream(sink), healthcheck))
+    }
+}
+
+struct OneshotSink {
+    acker: Acker,
+    tx: Option<Sender<EventArray>>,
+}
+
+#[async_trait]
+impl StreamSink<EventArray> for OneshotSink {
+    async fn run(mut self: Box<Self>, mut input: BoxStream<'_, EventArray>) -> Result<(), ()> {
+        let tx = self.tx.take().expect("cannot take rx more than once");
+        let events = input
+            .next()
+            .await
+            .expect("must always get an item in oneshot sink");
+        self.acker.ack(events.len());
+        let _ = tx.send(events);
+
+        Ok(())
     }
 }
 
@@ -41,35 +161,102 @@ impl TransformConfig for NoopTransformConfig {
 struct NoopTransform;
 
 impl FunctionTransform for NoopTransform {
-    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         output.push(event);
     }
 }
 
 impl<T> TaskTransform<T> for NoopTransform
 where
-	T: EventContainer,
+    T: EventContainer + 'static,
 {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn futures_util::Stream<Item = T> + Send>>,
     ) -> Pin<Box<dyn Stream<Item = T> + Send>> {
-        let mut inner = self;
         Box::pin(task)
     }
 }
 
-#[tokio::test]
-async fn test_function_transform() {
+async fn create_topology(
+    event: Event,
+    transform_type: TransformType,
+) -> (RunningTopology, Receiver<EventArray>) {
+    let mut builder = ConfigBuilder::default();
 
+    let (tx, rx) = channel();
+
+    builder.add_source("in", OneshotSourceConfig { event: Some(event) });
+    builder.add_transform(
+        "transform",
+        &["in"],
+        NoopTransformConfig::from(transform_type),
+    );
+    builder.add_sink(
+        "out",
+        &["transform"],
+        OneshotSinkConfig {
+            tx: Mutex::new(Some(tx)),
+        },
+    );
+
+    let config = builder.build().expect("building config should not fail");
+    let (topology, _) = start_topology(config, false).await;
+
+    (topology, rx)
 }
 
 #[tokio::test]
-async fn test_sync_transform() {
+async fn test_function_transform_single_event() {
+    assert_transform_compliance(async {
+        let original_event = Event::from("function transform being tested");
 
+        let (topology, rx) = create_topology(original_event.clone(), TransformType::Function).await;
+        topology.stop().await;
+
+        let events = rx.await.expect("must get back event from rx");
+        let mut events = events.into_events().collect::<Vec<_>>();
+        assert_eq!(events.len(), 1);
+
+        let event = events.remove(0);
+        assert_eq!(original_event, event);
+    })
+    .await;
 }
 
 #[tokio::test]
-async fn test_task_transform() {
+async fn test_sync_transform_single_event() {
+    assert_transform_compliance(async {
+        let original_event = Event::from("function transform being tested");
 
+        let (topology, rx) =
+            create_topology(original_event.clone(), TransformType::Synchronous).await;
+        topology.stop().await;
+
+        let events = rx.await.expect("must get back event from rx");
+        let mut events = events.into_events().collect::<Vec<_>>();
+        assert_eq!(events.len(), 1);
+
+        let event = events.remove(0);
+        assert_eq!(original_event, event);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_task_transform_single_event() {
+    assert_transform_compliance(async {
+        let original_event = Event::from("function transform being tested");
+
+        let (topology, rx) = create_topology(original_event.clone(), TransformType::Task).await;
+        topology.stop().await;
+
+        let events = rx.await.expect("must get back event from rx");
+        let mut events = events.into_events().collect::<Vec<_>>();
+        assert_eq!(events.len(), 1);
+
+        let event = events.remove(0);
+        assert_eq!(original_event, event);
+    })
+    .await;
 }

--- a/src/topology/test/compliance.rs
+++ b/src/topology/test/compliance.rs
@@ -1,0 +1,75 @@
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures_util::{future::ready, Stream};
+use vector_core::{transform::{FunctionTransform, OutputBuffer, TransformConfig, Transform, TransformContext, SyncTransform, TaskTransform, TransformOutputsBuf}, event::Event, schema::Definition, config::{Output, Input, DataType}};
+
+enum TransformType {
+	Function,
+	Sync,
+	Task,
+}
+
+struct NoopTransformConfig {
+	transform_type: TransformType,
+}
+
+#[async_trait]
+impl TransformConfig for NoopTransformConfig {
+    fn input(&self) -> Input {
+        Input::all()
+    }
+
+    fn outputs(&self, _: &Definition) -> Vec<Output> {
+        vec![Output::default(DataType::all())]
+    }
+
+    fn transform_type(&self) -> &'static str {
+        "noop"
+    }
+
+	async fn build(&self, globals: &TransformContext) -> crate::Result<Transform> {
+        match self.transform_type {
+			TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform))),
+			TransformType::Sync => Ok(Transform::Synchronous(Box::new(NoopTransform))),
+			TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform))),
+		}
+    }
+}
+
+#[derive(Clone)]
+struct NoopTransform;
+
+impl FunctionTransform for NoopTransform {
+    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
+        output.push(event);
+    }
+}
+
+impl<T> TaskTransform<T> for NoopTransform
+where
+	T: EventContainer,
+{
+    fn transform(
+        self: Box<Self>,
+        task: Pin<Box<dyn futures_util::Stream<Item = T> + Send>>,
+    ) -> Pin<Box<dyn Stream<Item = T> + Send>> {
+        let mut inner = self;
+        Box::pin(task)
+    }
+}
+
+#[tokio::test]
+async fn test_function_transform() {
+
+}
+
+#[tokio::test]
+async fn test_sync_transform() {
+
+}
+
+#[tokio::test]
+async fn test_task_transform() {
+
+}

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -1,16 +1,14 @@
 #[cfg(all(
-    test,
     feature = "sinks-blackhole",
     feature = "sources-stdin",
     feature = "transforms-json_parser"
 ))]
 mod transient_state;
 
-#[cfg(all(test, feature = "sinks-console", feature = "sources-demo_logs"))]
+#[cfg(all(feature = "sinks-console", feature = "sources-demo_logs"))]
 mod source_finished;
 
 #[cfg(all(
-    test,
     feature = "sinks-console",
     feature = "sources-splunk_hec",
     feature = "sources-demo_logs",
@@ -20,8 +18,8 @@ mod source_finished;
 ))]
 mod reload;
 
-#[cfg(all(test, feature = "sinks-console", feature = "sources-socket"))]
+#[cfg(all(feature = "sinks-console", feature = "sources-socket"))]
 mod doesnt_reload;
 
-#[cfg(test)]
 mod backpressure;
+mod compliance;


### PR DESCRIPTION
This PR is a follow-up to #12572 which checks transforms for their adherence to the component specification.

Admittedly, this one is sort of a gimme because the topology itself handles emitting these events for all transforms, and transforms only emit their relevant events -- events for dropping events if the transform can drop events, and so on -- so we're able to test a much smaller surface here while ensuring all transforms will "adhere" to the component specification.

This PR is based on the branch for #12572 which is not yet merged (yet) and so I'll point it to base off of master once that happens.