### PR TITLE
chore(ci): use our custom runners for cross-linux + checks, and native action cancellation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   AUTOINSTALL: true
   AWS_ACCESS_KEY_ID: "dummy"
@@ -22,17 +26,6 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  cancel-previous:
-    name: Cancel redundant jobs
-    runs-on: ubuntu-20.04
-    timeout-minutes: 3
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-          all_but_latest: true # can cancel workflows scheduled later
-
   changes:
       runs-on: ubuntu-20.04
       # Set job outputs to values from filter step
@@ -171,7 +164,7 @@ jobs:
 
   cross-linux:
     name: Cross - ${{ matrix.target }}
-    runs-on: ubuntu-20.04
+    runs-on: [linux, test-runner]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -298,7 +291,7 @@ jobs:
 
   checks:
     name: Checks
-    runs-on: ubuntu-20.04
+    runs-on: [linux, test-runner]
     needs: changes
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -350,7 +350,6 @@ jobs:
     name: master-failure
     if: failure() && github.ref == 'refs/heads/master'
     needs:
-      - cancel-previous
       - changes
       - cross-linux
       - test-misc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,7 +286,7 @@ tokio-postgres = { version = "0.7.6", default-features = false, features = ["run
 tokio-tungstenite = {version = "0.15.0", default-features = false, features = ["connect"], optional = true}
 toml = { version = "0.5.9", default-features = false }
 tonic = { version = "0.7.1", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "compression"] }
-trust-dns-proto = { version = "0.21", default-features = false, features = ["dnssec"], optional = true }
+trust-dns-proto = { version = "0.21.0", default-features = false, features = ["dnssec"], optional = true }
 typetag = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 uuid = { version = "1", default-features = false, features = ["serde", "v4"] }


### PR DESCRIPTION
As stated in the title.

We should use our custom runners for the cross-linux and check job, as they compile Vector, and can benefit from more cores.

This also switches `test.yml` over to the native "cancel previous jobs" functionality of GHA in an effort to see if we can avoid using the workflow action, as it should be faster to avoid having to run it as a full-fledged step which requires a runner instance, and so on.

EDIT: Empirically, after pushing some further commits to this PR, the speed-up on the `Checks` and `Cross - *` jobs is about 3-4x, from 30-35 minutes down to 10 minutes or less.