### PR TITLE
Experimental PR to understand user-agent parsing costs

### DIFF
--- a/soaks/tests/http_pipelines_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole/vector.toml
@@ -111,13 +111,13 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 }
 '''
 
-[[transforms.processing.logs.transforms]]
-type = "remap"
-source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
-  .custom.http.useragent_details = details
-}
-'''
+# [[transforms.processing.logs.transforms]]
+# type = "remap"
+# source = '''
+# if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+#   .custom.http.useragent_details = details
+# }
+# '''
 
 [[transforms.processing.logs.transforms]]
 type = "remap"
@@ -1457,13 +1457,13 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 }
 '''
 
-[[transforms.processing.logs.transforms]]
-type = "remap"
-source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
-  .custom.http.useragent_details = details
-}
-'''
+# [[transforms.processing.logs.transforms]]
+# type = "remap"
+# source = '''
+# if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+#   .custom.http.useragent_details = details
+# }
+# '''
 
 [[transforms.processing.logs.transforms]]
 type = "remap"
@@ -2767,13 +2767,13 @@ if .custom.http.useragent == null {
 del(.custom.data.user_agent)
 '''
 
-[[transforms.processing.logs.transforms]]
-type = "remap"
-source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
-  .custom.http.useragent_details = details
-}
-'''
+# [[transforms.processing.logs.transforms]]
+# type = "remap"
+# source = '''
+# if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+#   .custom.http.useragent_details = details
+# }
+# '''
 
 [[transforms.processing.logs.transforms]]
 type = "remap"
@@ -3251,13 +3251,13 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 }
 '''
 
-[[transforms.processing.logs.transforms]]
-type = "remap"
-source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
-  .custom.http.useragent_details = details
-}
-'''
+# [[transforms.processing.logs.transforms]]
+# type = "remap"
+# source = '''
+# if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+#   .custom.http.useragent_details = details
+# }
+# '''
 
 [[transforms.processing.logs.transforms]]
 type = "remap"
@@ -3534,13 +3534,13 @@ if (err == null) {
 }
 '''
 
-[[transforms.processing.logs.transforms]]
-type = "remap"
-source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
-  .custom.http.useragent_details = details
-}
-'''
+# [[transforms.processing.logs.transforms]]
+# type = "remap"
+# source = '''
+# if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+#   .custom.http.useragent_details = details
+# }
+# '''
 
 [[transforms.processing.logs.transforms]]
 type = "remap"
@@ -3972,13 +3972,13 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 }
 '''
 
-[[transforms.processing.logs.transforms]]
-type = "remap"
-source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
-  .custom.http.useragent_details = details
-}
-'''
+# [[transforms.processing.logs.transforms]]
+# type = "remap"
+# source = '''
+# if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+#   .custom.http.useragent_details = details
+# }
+# '''
 
 [[transforms.processing.logs.transforms]]
 type = "remap"


### PR DESCRIPTION
We know that user agent parsing in 'enriched' mode is one of the more expensive
areas of http -> pipelines today. If user agent parsing was infinitely fast what
would throughput look like?

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
