### PR TITLE
chore: Remove unnecessary `clone`s of `encoding`

### DIFF
--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -190,7 +190,7 @@ impl SinkConfig for KinesisSinkConfig {
             });
 
         let transformer = self.encoding.transformer();
-        let serializer = self.encoding.clone().encoding();
+        let serializer = self.encoding.encoding();
         let encoder = Encoder::<()>::new(serializer);
 
         let request_builder = KinesisRequestBuilder {

--- a/src/sinks/aws_sqs/request_builder.rs
+++ b/src/sinks/aws_sqs/request_builder.rs
@@ -29,9 +29,8 @@ pub(crate) struct SqsRequestBuilder {
 
 impl SqsRequestBuilder {
     pub fn new(config: SqsSinkConfig) -> crate::Result<Self> {
-        let encoding = config.encoding.clone();
-        let transformer = encoding.transformer();
-        let serializer = encoding.encoding();
+        let transformer = config.encoding.transformer();
+        let serializer = config.encoding.encoding();
         let encoder = Encoder::<()>::new(serializer);
 
         Ok(Self {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -198,9 +198,8 @@ pub struct FileSink {
 
 impl FileSink {
     pub fn new(config: &FileSinkConfig, acker: Acker) -> Self {
-        let encoding = config.encoding.clone();
-        let transformer = encoding.transformer();
-        let (framer, serializer) = encoding.encoding();
+        let transformer = config.encoding.transformer();
+        let (framer, serializer) = config.encoding.encoding();
         let framer = framer.unwrap_or_else(|| NewlineDelimitedEncoder::new().into());
         let encoder = Encoder::<Framer>::new(framer, serializer);
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -273,7 +273,7 @@ impl RequestBuilder<(String, Vec<Event>)> for RequestSettings {
 impl RequestSettings {
     fn new(config: &GcsSinkConfig) -> crate::Result<Self> {
         let transformer = config.encoding.transformer();
-        let (framer, serializer) = config.encoding.clone().encoding();
+        let (framer, serializer) = config.encoding.encoding();
         let framer = match (framer, &serializer) {
             (Some(framer), _) => framer,
             (None, Serializer::Json(_)) => CharacterDelimitedEncoder::new(b',').into(),

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -149,9 +149,8 @@ pub struct NatsSink {
 impl NatsSink {
     async fn new(config: NatsSinkConfig, acker: Acker) -> Result<Self, BuildError> {
         let connection = config.connect().await?;
-        let encoding = config.encoding.clone();
-        let transformer = encoding.transformer();
-        let serializer = encoding.encoding();
+        let transformer = config.encoding.transformer();
+        let serializer = config.encoding.encoding();
         let encoder = Encoder::<()>::new(serializer);
 
         Ok(NatsSink {

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -91,9 +91,8 @@ impl SinkConfig for PapertrailConfig {
 
         let sink_config = TcpSinkConfig::new(address, self.keepalive, tls, self.send_buffer_bytes);
 
-        let encoding = self.encoding.clone();
-        let transformer = encoding.transformer();
-        let serializer = encoding.encoding();
+        let transformer = self.encoding.transformer();
+        let serializer = self.encoding.encoding();
         let encoder = Encoder::<()>::new(serializer);
 
         sink_config.build(

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -187,9 +187,8 @@ impl RedisSinkConfig {
 
         let key = Template::try_from(self.key.clone()).context(KeyTemplateSnafu)?;
 
-        let encoding = self.encoding.clone();
-        let transformer = encoding.transformer();
-        let serializer = encoding.encoding();
+        let transformer = self.encoding.transformer();
+        let serializer = self.encoding.encoding();
         let mut encoder = Encoder::<()>::new(serializer);
 
         let method = self.list_option.map(|option| option.method);


### PR DESCRIPTION
This is some followup on the sinks that got based off a commit before 2c8749009e169f85957abcc94064aa40e4a7849b in https://github.com/vectordotdev/vector/pull/12561 landed.