### PR TITLE
enhancement(codecs, sinks): Extend sink input type to encoder input type

### DIFF
--- a/src/sinks/aws_sqs/config.rs
+++ b/src/sinks/aws_sqs/config.rs
@@ -104,7 +104,7 @@ impl SinkConfig for SqsSinkConfig {
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        Input::new(self.encoding.config().input_type())
     }
 
     fn sink_type(&self) -> &'static str {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -173,7 +173,7 @@ impl SinkConfig for FileSinkConfig {
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        Input::new(self.encoding.config().1.input_type())
     }
 
     fn sink_type(&self) -> &'static str {

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -145,7 +145,7 @@ impl SinkConfig for GcsSinkConfig {
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        Input::new(self.encoding.config().1.input_type())
     }
 
     fn sink_type(&self) -> &'static str {

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -106,7 +106,7 @@ impl SinkConfig for NatsSinkConfig {
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        Input::new(self.encoding.config().input_type())
     }
 
     fn sink_type(&self) -> &'static str {

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -109,7 +109,7 @@ impl SinkConfig for PapertrailConfig {
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        Input::new(self.encoding.config().input_type())
     }
 
     fn sink_type(&self) -> &'static str {

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -162,7 +162,7 @@ impl SinkConfig for RedisSinkConfig {
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        Input::new(self.encoding.config().input_type())
     }
 
     fn sink_type(&self) -> &'static str {


### PR DESCRIPTION
This is a followup to #12561 for the sinks that got based off an older branch.