### PR TITLE
chore(vrl): improve performance of `block` expression

### DIFF
--- a/lib/vrl/compiler/src/expression/block.rs
+++ b/lib/vrl/compiler/src/expression/block.rs
@@ -42,11 +42,13 @@ impl Expression for Block {
         //
         // This also means we don't need to make any changes to the VM runtime,
         // as it uses the same compiler as this AST runtime.
-        self.inner
+        let (last, other) = self.inner.split_last().expect("at least one expression");
+
+        other
             .iter()
-            .map(|expr| expr.resolve(ctx))
-            .collect::<Result<Vec<_>, _>>()
-            .map(|mut v| v.pop().unwrap_or(Value::Null))
+            .try_for_each(|expr| expr.resolve(ctx).map(|_| ()))?;
+
+        last.resolve(ctx)
     }
 
     fn type_def(&self, (_, external): (&LocalEnv, &ExternalEnv)) -> TypeDef {


### PR DESCRIPTION
This changes the implementation of the `block` expression to be more efficient. This has an impact on other expression types as well, as the `Block` type is used to store a list of expressions internal to other public expression types (such as if-statements, groups, etc).

The micro benches show an average improvement of ~20%. Given the simplicity of the change, it's worth a merge, but I'd be curious if any of this shows up in one of our soaks (although from perusing our soaks, I suspect we don't have any that have sufficiently complex VRL programs to show a big impact).