### PR TITLE
chore(vrl): change `Program` from `Vec<dyn Expression>` to `Block` expression

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -48,7 +48,11 @@ impl<'a> Compiler<'a> {
         ast: parser::Program,
         external: &mut ExternalEnv,
     ) -> Result<(Program, DiagnosticList), DiagnosticList> {
-        let expressions = self.compile_root_exprs(ast, external);
+        let mut expressions = self.compile_root_exprs(ast, external);
+
+        if expressions.is_empty() {
+            expressions.push(Expr::Noop(Noop));
+        }
 
         let (errors, warnings): (Vec<_>, Vec<_>) =
             self.diagnostics.into_iter().partition(|diagnostic| {

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -48,11 +48,7 @@ impl<'a> Compiler<'a> {
         ast: parser::Program,
         external: &mut ExternalEnv,
     ) -> Result<(Program, DiagnosticList), DiagnosticList> {
-        let expressions = self
-            .compile_root_exprs(ast, external)
-            .into_iter()
-            .map(|expr| Box::new(expr) as _)
-            .collect();
+        let expressions = self.compile_root_exprs(ast, external);
 
         let (errors, warnings): (Vec<_>, Vec<_>) =
             self.diagnostics.into_iter().partition(|diagnostic| {
@@ -70,14 +66,9 @@ impl<'a> Compiler<'a> {
             target_assignments: self.external_assignments,
         };
 
-        Ok((
-            Program {
-                expressions,
-                info,
-                local_env: self.local,
-            },
-            warnings.into(),
-        ))
+        let expressions = Block::new(expressions, self.local);
+
+        Ok((Program { expressions, info }, warnings.into()))
     }
 
     fn compile_root_exprs(

--- a/lib/vrl/compiler/src/expression/block.rs
+++ b/lib/vrl/compiler/src/expression/block.rs
@@ -16,7 +16,7 @@ pub struct Block {
     /// This allows any expressions within the block to mutate the local
     /// environment, but once the block ends, the environment is reset to the
     /// state of the parent expression of the block.
-    local_env: LocalEnv,
+    pub(crate) local_env: LocalEnv,
 }
 
 impl Block {

--- a/lib/vrl/vrl/src/runtime.rs
+++ b/lib/vrl/vrl/src/runtime.rs
@@ -100,22 +100,11 @@ impl Runtime {
 
         let mut ctx = Context::new(target, &mut self.state, timezone);
 
-        let err = |err| match err {
+        program.resolve(&mut ctx).map_err(|err| match err {
             #[cfg(feature = "expr-abort")]
             ExpressionError::Abort { .. } => Terminate::Abort(err),
             err @ ExpressionError::Error { .. } => Terminate::Error(err),
-        };
-
-        match program.split_last() {
-            None => Ok(Value::Null),
-            Some((last, other)) => {
-                other
-                    .iter()
-                    .try_for_each(|expr| expr.resolve(&mut ctx).map(|_| ()).map_err(err))?;
-
-                last.resolve(&mut ctx).map_err(err)
-            }
-        }
+        })
     }
 
     pub fn compile(
@@ -127,9 +116,7 @@ impl Runtime {
         let mut local = LocalEnv::default();
         let mut vm = Vm::new(Arc::new(fns));
 
-        for expr in program.iter() {
-            expr.compile_to_vm(&mut vm, (&mut local, external))?;
-        }
+        program.compile_to_vm(&mut vm, (&mut local, external))?;
 
         vm.write_opcode(OpCode::Return);
 


### PR DESCRIPTION
This cleans up the code, and might have performance benefit as well, given that we no longer have to store a list of boxed trait objects, but store a concrete `Block` type, which itself stores a list of concrete `Expr` types.

Let's see if the soaks give it any credits, but if not, the code re-use is still worth the PR.