### PR TITLE
chore(vrl): improve performance of `Target` impl for `Event`

### DIFF
--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -36,6 +36,14 @@ impl Inner {
     fn invalidate(&self) {
         self.size_cache.store(None);
     }
+
+    fn as_value(&self) -> &Value {
+        &self.fields
+    }
+
+    fn as_value_mut(&mut self) -> &mut Value {
+        &mut self.fields
+    }
 }
 
 impl ByteSizeOf for Inner {
@@ -113,6 +121,14 @@ pub struct LogEvent {
 }
 
 impl LogEvent {
+    pub fn value(&self) -> &Value {
+        self.inner.as_ref().as_value()
+    }
+
+    pub fn value_mut(&mut self) -> &mut Value {
+        Arc::make_mut(&mut self.inner).as_value_mut()
+    }
+
     pub fn metadata(&self) -> &EventMetadata {
         &self.metadata
     }

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -24,6 +24,14 @@ impl TraceEvent {
         Self(LogEvent::from_parts(fields, metadata))
     }
 
+    pub fn value(&self) -> &Value {
+        self.0.value()
+    }
+
+    pub fn value_mut(&mut self) -> &mut Value {
+        self.0.value_mut()
+    }
+
     pub fn metadata(&self) -> &EventMetadata {
         self.0.metadata()
     }


### PR DESCRIPTION
This PR changes the `Target` impl for `Event` to use the more efficient path lookup/removal/insertion logic that has existed in VRL's `Value` impl for a long time.

Now that the "value unification" work is done, I was able to switch over to those efficient implementations without much effort. This should get us another nice bump in performance.