### PR TITLE
[WIP]  Hide value::Value's BTreeMap inside an opauqe Object

### DIFF
--- a/lib/datadog/grok/src/filters/keyvalue.rs
+++ b/lib/datadog/grok/src/filters/keyvalue.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fmt::Formatter;
 
 use bytes::Bytes;
@@ -18,7 +17,7 @@ use once_cell::sync::Lazy;
 use ordered_float::NotNan;
 use regex::Regex;
 use tracing::warn;
-use value::Value;
+use value::{value::Object, Value};
 use vrl_compiler::Target;
 
 use crate::{
@@ -127,7 +126,7 @@ impl std::fmt::Display for KeyValueFilter {
 pub fn apply_filter(value: &Value, filter: &KeyValueFilter) -> Result<Value, GrokRuntimeError> {
     match value {
         Value::Bytes(bytes) => {
-            let mut result = Value::Object(BTreeMap::default());
+            let mut result = Value::Object(Object::new());
             parse(
                 String::from_utf8_lossy(bytes).as_ref(),
                 &filter.key_value_delimiter,

--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -1,11 +1,9 @@
-use std::collections::BTreeMap;
-
 use itertools::{
     FoldWhile::{Continue, Done},
     Itertools,
 };
 use tracing::warn;
-use value::Value;
+use value::{value::Object, Value};
 use vrl_compiler::Target;
 
 use crate::{
@@ -46,7 +44,7 @@ pub fn parse_grok(
 /// - FailedToApplyFilter - matches the rule, but there was a runtime error while applying on of the filters
 /// - NoMatch - this rule does not match a given string
 fn apply_grok_rule(source: &str, grok_rule: &GrokRule, remove_empty: bool) -> Result<Value, Error> {
-    let mut parsed = Value::Object(BTreeMap::new());
+    let mut parsed = Value::Object(Object::new());
 
     if let Some(ref matches) = grok_rule.pattern.match_against(source) {
         for (name, match_str) in matches.iter() {
@@ -586,62 +584,62 @@ mod tests {
             (
                 "%{data:field:array}",
                 "[1,2]",
-                Ok(Value::Array(vec!["1".into(), "2".into()])),
+                Ok(Value::Array(vec![Value::from("1"), Value::from("2")])),
             ),
             (
                 r#"%{data:field:array("\\t")}"#,
                 "[1\t2]",
-                Ok(Value::Array(vec!["1".into(), "2".into()])),
+                Ok(Value::Array(vec![Value::from("1"), Value::from("2")])),
             ),
             (
                 r#"(?m)%{data:field:array("[]","\\n")}"#,
                 "[1\n2]",
-                Ok(Value::Array(vec!["1".into(), "2".into()])),
+                Ok(Value::Array(vec![Value::from("1"), Value::from("2")])),
             ),
             (
                 r#"%{data:field:array("","-")}"#,
                 "1-2",
-                Ok(Value::Array(vec!["1".into(), "2".into()])),
+                Ok(Value::Array(vec![Value::from("1"), Value::from("2")])),
             ),
             (
                 "%{data:field:array(integer)}",
                 "[1,2]",
-                Ok(Value::Array(vec![1.into(), 2.into()])),
+                Ok(Value::Array(vec![Value::Integer(1), Value::Integer(2)])),
             ),
             (
                 r#"%{data:field:array(";", integer)}"#,
                 "[1;2]",
-                Ok(Value::Array(vec![1.into(), 2.into()])),
+                Ok(Value::Array(vec![Value::Integer(1), Value::Integer(2)])),
             ),
             (
                 r#"%{data:field:array("{}",";", integer)}"#,
                 "{1;2}",
-                Ok(Value::Array(vec![1.into(), 2.into()])),
+                Ok(Value::Array(vec![Value::Integer(1), Value::Integer(2)])),
             ),
             (
                 "%{data:field:array(number)}",
                 "[1,2]",
-                Ok(Value::Array(vec![1.into(), 2.into()])),
+                Ok(Value::Array(vec![Value::Integer(1), Value::Integer(2)])),
             ),
             (
                 "%{data:field:array(integer)}",
                 "[1,2]",
-                Ok(Value::Array(vec![1.into(), 2.into()])),
+                Ok(Value::Array(vec![Value::Integer(1), Value::Integer(2)])),
             ),
             (
                 "%{data:field:array(scale(10))}",
                 "[1,2.1]",
-                Ok(Value::Array(vec![10.into(), 21.into()])),
+                Ok(Value::Array(vec![Value::Integer(10), Value::Integer(21)])),
             ),
             (
                 r#"%{data:field:array(";", scale(10))}"#,
                 "[1;2.1]",
-                Ok(Value::Array(vec![10.into(), 21.into()])),
+                Ok(Value::Array(vec![Value::Integer(10), Value::Integer(21)])),
             ),
             (
                 r#"%{data:field:array("{}",";", scale(10))}"#,
                 "{1;2.1}",
-                Ok(Value::Array(vec![10.into(), 21.into()])),
+                Ok(Value::Array(vec![Value::Integer(10), Value::Integer(21)])),
             ),
         ]);
 
@@ -650,13 +648,13 @@ mod tests {
             (
                 r#"%{data:field:array}"#,
                 "abc",
-                Ok(Value::Object(btreemap! {})),
+                Ok(Value::Object(Object::new())),
             ),
             // failed to apply value filter(values are strings)
             (
                 r#"%{data:field:array(scale(10))}"#,
                 "[a,b]",
-                Ok(Value::Object(btreemap! {})),
+                Ok(Value::Object(Object::new())),
             ),
         ]);
     }

--- a/lib/enrichment/Cargo.toml
+++ b/lib/enrichment/Cargo.toml
@@ -10,5 +10,5 @@ arc-swap = { version = "1.4.0", default-features = false }
 dyn-clone = { version = "1.0.5", default-features = false }
 chrono = { version = "0.4.19", default-features = false }
 vector_common = { path = "../vector-common", default-features = false, features = [ "btreemap", "conversion" ] }
+value = { path = "../value", default-features = false, features = [] }
 vrl = { package = "vrl", path = "../vrl/vrl" }
-value = { package = "value", path = "../value" }

--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use ::value::Value;
+use ::value::{value::Object, Value};
 use vrl::prelude::*;
 
 use crate::{
@@ -38,7 +38,7 @@ fn find_enrichment_table_records(
             index,
         )?
         .into_iter()
-        .map(Value::Object)
+        .map(|x| Value::Object(Object::from(x.into_iter())))
         .collect();
     Ok(Value::Array(data))
 }

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeMap;
 
-use value::{kind::Collection, Kind, Value};
+use crate::{
+    vrl_util::{self, add_index, evaluate_condition, index_from_args, EnrichmentTableRecord},
+    Case, Condition, IndexHandle, TableRegistry, TableSearch,
+};
+use value::{kind::Collection, value::Object, Kind, Value};
 use vrl::{
     function::{
         ArgumentList, Compiled, CompiledArgument, Example, FunctionCompileContext, Parameter,
@@ -12,11 +16,6 @@ use vrl::{
     state,
     value::kind,
     Context, Expression, Function,
-};
-
-use crate::{
-    vrl_util::{self, add_index, evaluate_condition, index_from_args, EnrichmentTableRecord},
-    Case, Condition, IndexHandle, TableRegistry, TableSearch,
 };
 
 fn get_enrichment_table_record(
@@ -39,13 +38,15 @@ fn get_enrichment_table_record(
             }),
         })
         .transpose()?;
-    let data = enrichment_tables.find_table_row(
-        table,
-        case_sensitive,
-        condition,
-        select.as_ref().map(|select| select.as_ref()),
-        index,
-    )?;
+    let data: Object<Value> = enrichment_tables
+        .find_table_row(
+            table,
+            case_sensitive,
+            condition,
+            select.as_ref().map(|select| select.as_ref()),
+            index,
+        )
+        .map(|x| Object::from_iter(x.into_iter()))?;
 
     Ok(Value::Object(data))
 }

--- a/lib/value/src/kind/debug.rs
+++ b/lib/value/src/kind/debug.rs
@@ -1,4 +1,5 @@
 use crate::kind::Unknown;
+use crate::value::Object;
 use crate::{Kind, Value};
 use std::collections::BTreeMap;
 
@@ -6,14 +7,14 @@ impl Kind {
     /// Returns a tree representation of `Kind`, in a more human readable format.
     /// This is for debugging / development purposes only.
     #[must_use]
-    pub fn debug_info(&self) -> BTreeMap<String, Value> {
-        let mut output = BTreeMap::new();
+    pub fn debug_info(&self) -> Object<Value> {
+        let mut output = Object::new();
         insert_kind(&mut output, self, true);
         output
     }
 }
 
-fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bool) {
+fn insert_kind(tree: &mut Object<Value>, kind: &Kind, show_unknown: bool) {
     if kind.is_any() {
         insert_if_true(tree, "any", true);
     } else {
@@ -26,9 +27,9 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
         insert_if_true(tree, "null", kind.contains_null());
 
         if let Some(fields) = &kind.object {
-            let mut object_tree = BTreeMap::new();
+            let mut object_tree = Object::new();
             for (field, field_kind) in fields.known() {
-                let mut field_tree = BTreeMap::new();
+                let mut field_tree = Object::new();
                 insert_kind(&mut field_tree, field_kind, show_unknown);
                 object_tree.insert(field.name.clone(), Value::Object(field_tree));
             }
@@ -39,9 +40,9 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
         }
 
         if let Some(indices) = &kind.array {
-            let mut array_tree = BTreeMap::new();
+            let mut array_tree = Object::new();
             for (index, index_kind) in indices.known() {
-                let mut index_tree = BTreeMap::new();
+                let mut index_tree = Object::new();
                 insert_kind(&mut index_tree, index_kind, show_unknown);
                 array_tree.insert(index.to_string(), Value::Object(index_tree));
             }
@@ -53,9 +54,9 @@ fn insert_kind(tree: &mut BTreeMap<String, Value>, kind: &Kind, show_unknown: bo
     }
 }
 
-fn insert_unknown(tree: &mut BTreeMap<String, Value>, unknown: Option<&Unknown>, prefix: &str) {
+fn insert_unknown(tree: &mut Object<Value>, unknown: Option<&Unknown>, prefix: &str) {
     if let Some(unknown) = unknown {
-        let mut unknown_tree = BTreeMap::new();
+        let mut unknown_tree = Object::new();
         insert_kind(&mut unknown_tree, unknown.to_kind().as_ref(), false);
         if unknown.is_exact() {
             tree.insert(

--- a/lib/value/src/value/arbitrary.rs
+++ b/lib/value/src/value/arbitrary.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use ordered_float::NotNan;
 use quickcheck::{Arbitrary, Gen};
 
-use crate::Value;
+use crate::{value::Object, Value};
 
 const MAX_ARRAY_SIZE: usize = 4;
 const MAX_MAP_SIZE: usize = 4;
@@ -42,7 +42,7 @@ impl Arbitrary for Value {
             4 => Self::Timestamp(datetime(g)),
             5 => {
                 let mut gen = Gen::new(MAX_MAP_SIZE);
-                Self::Object(BTreeMap::arbitrary(&mut gen))
+                Self::Object(Object::from(BTreeMap::arbitrary(&mut gen).into_iter()))
             }
             6 => {
                 let mut gen = Gen::new(MAX_ARRAY_SIZE);

--- a/lib/value/src/value/convert.rs
+++ b/lib/value/src/value/convert.rs
@@ -1,13 +1,11 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
+use crate::{value::object::Object, value::regex::ValueRegex, Kind, Value};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use ordered_float::NotNan;
 use regex::Regex;
-
-use crate::value::regex::ValueRegex;
-use crate::{Kind, Value};
 
 impl Value {
     /// Returns self as `NotNan<f64>`, only if self is `Value::Float`.
@@ -18,10 +16,10 @@ impl Value {
         }
     }
 
-    /// Returns self as `BTreeMap<String, Value>`, only if self is `Value::Object`.
-    pub fn into_object(self) -> Option<BTreeMap<String, Self>> {
+    /// Returns self as `Object<Value>`, only if self is `Value::Object`.
+    pub fn into_object(self) -> Option<Object<Self>> {
         match self {
-            Value::Object(map) => Some(map),
+            Value::Object(obj) => Some(obj),
             _ => None,
         }
     }
@@ -315,7 +313,13 @@ impl From<f64> for Value {
 
 impl From<BTreeMap<String, Self>> for Value {
     fn from(value: BTreeMap<String, Self>) -> Self {
-        Self::Object(value)
+        Self::Object(Object::from(value.into_iter()))
+    }
+}
+
+impl From<Object<Self>> for Value {
+    fn from(object: Object<Self>) -> Self {
+        Self::Object(object)
     }
 }
 
@@ -327,7 +331,7 @@ impl FromIterator<Self> for Value {
 
 impl FromIterator<(String, Self)> for Value {
     fn from_iter<I: IntoIterator<Item = (String, Self)>>(iter: I) -> Self {
-        Self::Object(iter.into_iter().collect::<BTreeMap<String, Self>>())
+        Self::Object(iter.into_iter().collect::<Object<Self>>())
     }
 }
 
@@ -348,25 +352,32 @@ impl From<i64> for Value {
         Self::Integer(value)
     }
 }
-
 impl From<i32> for Value {
     fn from(value: i32) -> Self {
         Self::Integer(value as i64)
     }
 }
-
 impl From<i16> for Value {
     fn from(value: i16) -> Self {
         Self::Integer(value as i64)
     }
 }
-
 impl From<i8> for Value {
     fn from(value: i8) -> Self {
         Self::Integer(value as i64)
     }
 }
 
+impl From<u64> for Value {
+    fn from(value: u64) -> Self {
+        Self::Integer(value as i64)
+    }
+}
+impl From<u32> for Value {
+    fn from(value: u32) -> Self {
+        Self::Integer(value as i64)
+    }
+}
 impl From<u16> for Value {
     fn from(value: u16) -> Self {
         Self::Integer(value as i64)
@@ -377,11 +388,7 @@ impl From<u8> for Value {
         Self::Integer(value as i64)
     }
 }
-impl From<u32> for Value {
-    fn from(value: u32) -> Self {
-        Self::Integer(value as i64)
-    }
-}
+
 impl From<isize> for Value {
     fn from(value: isize) -> Self {
         Self::Integer(value as i64)
@@ -389,11 +396,6 @@ impl From<isize> for Value {
 }
 impl From<usize> for Value {
     fn from(value: usize) -> Self {
-        Self::Integer(value as i64)
-    }
-}
-impl From<u64> for Value {
-    fn from(value: u64) -> Self {
         Self::Integer(value as i64)
     }
 }

--- a/lib/value/src/value/display.rs
+++ b/lib/value/src/value/display.rs
@@ -51,6 +51,8 @@ mod test {
     use ordered_float::NotNan;
     use regex::Regex;
 
+    use crate::value::Object;
+
     use super::Value;
 
     #[test]
@@ -110,10 +112,8 @@ mod test {
 
     #[test]
     fn test_display_object() {
-        assert_eq!(
-            Value::Object([("foo".into(), "bar".into())].into()).to_string(),
-            r#"{ "foo": "bar" }"#
-        );
+        let obj = Value::Object(Object::from([("foo", "bar".into())]));
+        assert_eq!(obj.to_string(), r#"{ "foo": "bar" }"#);
     }
 
     #[test]

--- a/lib/value/src/value/iter.rs
+++ b/lib/value/src/value/iter.rs
@@ -1,6 +1,5 @@
+use crate::{value::object::Object, Value};
 use std::{marker::PhantomData, ops::IndexMut};
-
-use crate::Value;
 
 impl Value {
     /// Create an iterater over the `Value`.
@@ -264,7 +263,10 @@ impl From<IterData> for Value {
     fn from(iter: IterData) -> Self {
         match iter {
             IterData::Value(value) => value,
-            IterData::Object(object) => Self::Object(object.into_iter().collect()),
+            IterData::Object(object) => {
+                let obj: Object<Self> = object.into_iter().collect();
+                Self::Object(obj)
+            }
             IterData::Array(array) => Self::Array(array),
         }
     }
@@ -320,7 +322,7 @@ mod tests {
             (
                 "object non-recursive",
                 TestCase {
-                    value: Value::Object(BTreeMap::from([("foo".to_owned(), true.into())])),
+                    value: Value::Object(Object::from([("foo", true.into())])),
                     recursive: false,
                     items: vec![true.into()],
                 },
@@ -328,22 +330,13 @@ mod tests {
             (
                 "object recursive",
                 TestCase {
-                    value: BTreeMap::from([(
-                        "foo".to_owned(),
-                        BTreeMap::from([
-                            ("foo".to_owned(), true.into()),
-                            ("bar".to_owned(), "baz".into()),
-                        ])
-                        .into(),
-                    )])
-                    .into(),
+                    value: Value::Object(Object::from([(
+                        "foo",
+                        Value::Object(Object::from([("foo", true.into()), ("bar", "baz".into())])),
+                    )])),
                     recursive: true,
                     items: vec![
-                        BTreeMap::from([
-                            ("foo".to_owned(), true.into()),
-                            ("bar".to_owned(), "baz".into()),
-                        ])
-                        .into(),
+                        Value::Object(Object::from([("foo", true.into()), ("bar", "baz".into())])),
                         "baz".into(),
                         true.into(),
                     ],

--- a/lib/value/src/value/lua.rs
+++ b/lib/value/src/value/lua.rs
@@ -43,7 +43,7 @@ impl<'a> FromLua<'a> for Value {
                 } else if table_is_timestamp(&t)? {
                     table_to_timestamp(t).map(Self::Timestamp)
                 } else {
-                    <_>::from_lua(LuaValue::Table(t), lua).map(Self::Object)
+                    <_>::from_lua(LuaValue::Table(t), lua) //.map(Self::Object)
                 }
             }
             other => Err(mlua::Error::FromLuaConversionError {

--- a/lib/value/src/value/object.rs
+++ b/lib/value/src/value/object.rs
@@ -1,0 +1,168 @@
+//! Ordered associated object, mapping from string to `Value`.
+
+use std::{
+    cmp::Ordering,
+    collections::{btree_map, BTreeMap},
+    ops::{Deref, DerefMut},
+};
+
+#[cfg(feature = "serde")]
+use serde::{Serialize, Serializer};
+
+/// Wraps a string-keyed `BTreeMap`, similar to `ValueRgex` in purpose.
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct Object<V>(BTreeMap<String, V>);
+
+impl<V> Object<V> {
+    /// Create a new `Object`
+    #[must_use]
+    pub fn new() -> Self {
+        Self(BTreeMap::default())
+    }
+
+    /// Insert key->value into the object
+    #[allow(clippy::needless_pass_by_value)] // we want to match BTreeMap::insert signature
+    pub fn insert<K>(&mut self, key: K, value: V) -> Option<V>
+    where
+        K: ToString,
+    {
+        self.0.insert(key.to_string(), value)
+    }
+
+    /// Return an iterator over kv pairs
+    #[must_use]
+    #[allow(clippy::needless_lifetimes)] // unclear how to elide the explicit
+                                         // lifetimes here, clippy gives no hint
+    pub fn iter<'a>(&'a self) -> Iter<'a, String, V> {
+        Iter(self.0.iter())
+    }
+}
+
+// #[cfg(feature = "lua")]
+// impl<V> UserData for Object<V> {
+
+// }
+
+#[cfg(feature = "serde")]
+impl<V> Serialize for Object<V>
+where
+    V: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_map(&self.0)
+    }
+}
+
+/// Iteration over key/value pairs of the Object
+#[derive(Clone)]
+pub struct Iter<'a, K, V>(btree_map::Iter<'a, K, V>);
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, K, V> From<btree_map::Iter<'a, K, V>> for Iter<'a, K, V> {
+    fn from(iter: btree_map::Iter<'a, K, V>) -> Self {
+        Self(iter)
+    }
+}
+
+pub struct IntoIter<K, V>(btree_map::IntoIter<K, V>);
+
+impl<V> IntoIterator for Object<V> {
+    type Item = (String, V);
+    type IntoIter = IntoIter<String, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.0.into_iter())
+    }
+}
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<V> Default for Object<V> {
+    fn default() -> Self {
+        Self(BTreeMap::default())
+    }
+}
+
+impl<V> Deref for Object<V> {
+    type Target = BTreeMap<String, V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<V> DerefMut for Object<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K, V, const N: usize> From<[(K, V); N]> for Object<V>
+where
+    K: ToString,
+{
+    fn from(arr: [(K, V); N]) -> Self {
+        if N == 0 {
+            return Self::default();
+        }
+
+        let mut map = BTreeMap::default();
+        for (k, v) in arr {
+            map.insert(k.to_string(), v);
+        }
+        Self(map)
+    }
+}
+
+impl<V> FromIterator<(String, V)> for Object<V> {
+    fn from_iter<I: IntoIterator<Item = (String, V)>>(iter: I) -> Self {
+        let mut obj = Self::default();
+
+        for (k, v) in iter {
+            obj.0.insert(k, v);
+        }
+
+        obj
+    }
+}
+
+impl<V> From<btree_map::IntoIter<String, V>> for Object<V> {
+    fn from(iter: btree_map::IntoIter<String, V>) -> Self {
+        Self(iter.collect::<BTreeMap<_, _>>())
+    }
+}
+
+impl<V> PartialEq for Object<V>
+where
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<V> PartialOrd for Object<V>
+where
+    V: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}

--- a/lib/value/src/value/regex.rs
+++ b/lib/value/src/value/regex.rs
@@ -1,5 +1,4 @@
-//! This was copied from VRL code, to make the Vector Value more similar to the VRL value.
-//! Both copies will eventually be merged when the value types are merged
+//! Regular expression.
 
 use std::cmp::Ordering;
 use std::{

--- a/lib/value/src/value/target.rs
+++ b/lib/value/src/value/target.rs
@@ -52,8 +52,7 @@ impl Value {
     ///    # use std::collections::BTreeMap;
     ///    # use std::iter::FromIterator;
     ///
-    ///    let map = BTreeMap::from_iter(vec![("foo".to_owned(), true.into())].into_iter());
-    ///    let value = Value::Object(map);
+    ///    let value = Value::Object([("foo", true.into())].into());
     ///    let path = LookupBuf::from_str("foo").unwrap();
     ///
     ///    assert_eq!(value.get_by_path(&path), Some(&Value::Boolean(true)))
@@ -82,10 +81,7 @@ impl Value {
     /// # use std::collections::BTreeMap;
     /// # use std::iter::FromIterator;
     ///
-    /// let fields = vec![("foo".to_owned(), Value::from("bar"))];
-    /// let map = BTreeMap::from_iter(fields.into_iter());
-    ///
-    /// let mut value = Value::Object(map);
+    /// let mut value = Value::Object([("foo", Value::from("bar"))].into());
     /// let path = LookupBuf::from_str(".foo").unwrap();
     ///
     /// value.insert_by_path(&path, true.into());
@@ -110,7 +106,7 @@ impl Value {
     ///
     /// value.insert_by_path(&path, "bar".into());
     ///
-    /// let expected = Value::Array(vec![Value::Boolean(false), Value::Object([("foo".into(), "bar".into())].into())]);
+    /// let expected = Value::Array(vec![Value::Boolean(false), Value::Object([("foo", "bar".into())].into())]);
     /// assert_eq!(
     ///     value.get_by_path(&LookupBuf::root()),
     ///     Some(&expected),

--- a/lib/vector-common/src/btreemap.rs
+++ b/lib/vector-common/src/btreemap.rs
@@ -1,4 +1,23 @@
 #[macro_export]
+macro_rules! object {
+    () => (::value::value::Object::new());
+
+    // trailing comma case
+    ($($key:expr => $value:expr,)+) => (object!($($key => $value),+));
+
+    ($($key:expr => $value:expr),*) => {
+        {
+            let mut _map = ::value::value::Object::new();
+            $(
+                #[allow(clippy::let_underscore_drop)]
+                let _ = _map.insert(String::from($key), $value.into());
+            )*
+            _map
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! btreemap {
     () => (::std::collections::BTreeMap::new());
 

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -1,3 +1,4 @@
+use ::value::value::Object;
 use chrono::TimeZone;
 use ordered_float::NotNan;
 
@@ -426,7 +427,7 @@ fn decode_value(input: Value) -> Option<event::Value> {
 }
 
 fn decode_map(fields: BTreeMap<String, Value>) -> Option<event::Value> {
-    let mut accum: BTreeMap<String, event::Value> = BTreeMap::new();
+    let mut accum: Object<event::Value> = Object::new();
     for (key, value) in fields {
         match decode_value(value) {
             Some(value) => {
@@ -468,7 +469,7 @@ fn encode_value(value: event::Value) -> Value {
     }
 }
 
-fn encode_map(fields: BTreeMap<String, event::Value>) -> ValueMap {
+fn encode_map(fields: Object<event::Value>) -> ValueMap {
     ValueMap {
         fields: fields
             .into_iter()

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -5,6 +5,7 @@ use std::{
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use quickcheck::{empty_shrinker, Arbitrary, Gen};
+use value::value::Object;
 
 use crate::{
     event::{
@@ -79,7 +80,7 @@ impl Arbitrary for Event {
 impl Arbitrary for LogEvent {
     fn arbitrary(g: &mut Gen) -> Self {
         let mut gen = Gen::new(MAX_MAP_SIZE);
-        let map: BTreeMap<String, Value> = BTreeMap::arbitrary(&mut gen);
+        let map: Object<Value> = Object::from(BTreeMap::arbitrary(&mut gen).into_iter());
         let metadata: EventMetadata = EventMetadata::arbitrary(g);
         LogEvent::from_parts(map, metadata)
     }
@@ -90,6 +91,7 @@ impl Arbitrary for LogEvent {
         Box::new(
             fields
                 .shrink()
+                .map(|x| Object::from(x.into_iter()))
                 .map(move |x| LogEvent::from_parts(x, metadata.clone())),
         )
     }
@@ -106,6 +108,7 @@ impl Arbitrary for TraceEvent {
         Box::new(
             fields
                 .shrink()
+                .map(|x| Object::from(x.into_iter()))
                 .map(move |x| TraceEvent::from_parts(x, metadata.clone())),
         )
     }

--- a/lib/vector-core/src/event/test/serialization.rs
+++ b/lib/vector-core/src/event/test/serialization.rs
@@ -4,7 +4,7 @@ use prost::Message;
 use quickcheck::{QuickCheck, TestResult};
 use regex::Regex;
 use vector_buffers::encoding::Encodable;
-use vector_common::btreemap;
+use vector_common::object;
 
 use super::*;
 use crate::{config::log_schema, event::ser::EventEncodableMetadataFlags};
@@ -41,7 +41,7 @@ fn eventarray_can_go_from_raw_prost_to_encodable_and_vice_versa() {
     // LevelDB-based disk buffers being removed, or some other extenuating circumstance that must be
     // explained.
 
-    let event_fields = btreemap! {
+    let event_fields = object! {
         "key1" => "value1",
         "key2" => "value2",
         "key3" => "value3",
@@ -87,7 +87,7 @@ fn event_can_go_from_raw_prost_to_eventarray_encodable() {
     // LevelDB-based disk buffers being removed, or some other extenuating circumstance that must be
     // explained.
 
-    let event_fields = btreemap! {
+    let event_fields = object! {
         "key1" => "value1",
         "key2" => "value2",
         "key3" => "value3",

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use lookup::LookupBuf;
 use serde::{Deserialize, Serialize};
+use value::value::Object;
 use vector_buffers::EventCount;
 use vector_common::EventDataEq;
 
@@ -16,11 +17,11 @@ use crate::ByteSizeOf;
 pub struct TraceEvent(LogEvent);
 
 impl TraceEvent {
-    pub fn into_parts(self) -> (BTreeMap<String, Value>, EventMetadata) {
+    pub fn into_parts(self) -> (Object<Value>, EventMetadata) {
         self.0.into_parts()
     }
 
-    pub fn from_parts(fields: BTreeMap<String, Value>, metadata: EventMetadata) -> Self {
+    pub fn from_parts(fields: Object<Value>, metadata: EventMetadata) -> Self {
         Self(LogEvent::from_parts(fields, metadata))
     }
 
@@ -46,7 +47,7 @@ impl TraceEvent {
         Self(self.0.with_batch_notifier_option(batch))
     }
 
-    pub fn as_map(&self) -> &BTreeMap<String, Value> {
+    pub fn as_map(&self) -> &Object<Value> {
         self.0.as_map()
     }
 

--- a/lib/vector-core/src/event/util/log/mod.rs
+++ b/lib/vector-core/src/event/util/log/mod.rs
@@ -14,13 +14,12 @@ pub(self) use super::Value;
 
 #[cfg(test)]
 pub(self) mod test {
-    use std::collections::BTreeMap;
-
     use serde_json::Value as JsonValue;
+    use value::value::Object;
 
     use super::Value;
 
-    pub(crate) fn fields_from_json(json_value: JsonValue) -> BTreeMap<String, Value> {
+    pub(crate) fn fields_from_json(json_value: JsonValue) -> Object<Value> {
         match Value::from(json_value) {
             Value::Object(map) => map,
             something => panic!("Expected a map, got {:?}", something),

--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -8,6 +8,7 @@ use std::{
 
 use ::value::Value;
 use clap::Parser;
+use value::value::Object;
 use vector_common::TimeZone;
 use vrl::{
     diagnostic::Formatter,
@@ -80,7 +81,7 @@ impl Opts {
         }?;
 
         match input.as_str() {
-            "" => Ok(vec![Value::Object(BTreeMap::default())]),
+            "" => Ok(default_objects()),
             _ => input
                 .lines()
                 .map(|line| Ok(serde_to_vrl(serde_json::from_str(line)?)))
@@ -223,5 +224,5 @@ fn read<R: Read>(mut reader: R) -> Result<String, Error> {
 }
 
 fn default_objects() -> Vec<Value> {
-    vec![Value::Object(BTreeMap::new())]
+    vec![Value::Object(Object::new())]
 }

--- a/lib/vrl/compiler/src/expression/object.rs
+++ b/lib/vrl/compiler/src/expression/object.rs
@@ -1,13 +1,12 @@
-use std::{collections::BTreeMap, fmt, ops::Deref};
-
-use value::Value;
-
 use crate::{
     expression::{Expr, Resolved},
     state::{ExternalEnv, LocalEnv},
     vm::OpCode,
     Context, Expression, TypeDef,
 };
+use ::value::Value;
+use std::{collections::BTreeMap, fmt, ops::Deref};
+use value::value::Object as ValueObject;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Object {
@@ -33,7 +32,7 @@ impl Expression for Object {
         self.inner
             .iter()
             .map(|(key, expr)| expr.resolve(ctx).map(|v| (key.to_owned(), v)))
-            .collect::<Result<BTreeMap<_, _>, _>>()
+            .collect::<Result<ValueObject<_>, _>>()
             .map(Value::Object)
     }
 
@@ -41,7 +40,7 @@ impl Expression for Object {
         self.inner
             .iter()
             .map(|(key, expr)| expr.as_value().map(|v| (key.to_owned(), v)))
-            .collect::<Option<BTreeMap<_, _>>>()
+            .collect::<Option<ValueObject<_>>>()
             .map(Value::Object)
     }
 

--- a/lib/vrl/compiler/src/test_util.rs
+++ b/lib/vrl/compiler/src/test_util.rs
@@ -172,12 +172,12 @@ macro_rules! __prep_bench_or_test {
 #[macro_export]
 macro_rules! map {
     () => (
-        ::std::collections::BTreeMap::new()
+        ::value::value::Object::new()
     );
     ($($k:tt: $v:expr),+ $(,)?) => {
-        vec![$(($k.into(), $v.into())),+]
+        vec![$((String::from($k), $v.into())),+]
             .into_iter()
-            .collect::<::std::collections::BTreeMap<_, _>>()
+            .collect::<::value::value::Object<_>>()
     };
 }
 

--- a/lib/vrl/compiler/src/value/convert.rs
+++ b/lib/vrl/compiler/src/value/convert.rs
@@ -1,9 +1,8 @@
-use std::{borrow::Cow, collections::BTreeMap};
+use std::borrow::Cow;
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use value::kind::Collection;
-use value::{Value, ValueRegex};
+use value::{kind::Collection, value::Object, Value, ValueRegex};
 
 use crate::expression::{Container, Variant};
 use crate::value::{Error, Kind};
@@ -20,7 +19,7 @@ pub trait VrlValueConvert: Sized {
     fn try_regex(self) -> Result<ValueRegex, Error>;
     fn try_null(self) -> Result<(), Error>;
     fn try_array(self) -> Result<Vec<Value>, Error>;
-    fn try_object(self) -> Result<BTreeMap<String, Value>, Error>;
+    fn try_object(self) -> Result<Object<Value>, Error>;
     fn try_timestamp(self) -> Result<DateTime<Utc>, Error>;
 
     fn try_into_i64(&self) -> Result<i64, Error>;
@@ -131,7 +130,7 @@ impl VrlValueConvert for Value {
         }
     }
 
-    fn try_object(self) -> Result<BTreeMap<String, Value>, Error> {
+    fn try_object(self) -> Result<Object<Value>, Error> {
         match self {
             Value::Object(v) => Ok(v),
             _ => Err(Error::Expected {

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -1,5 +1,6 @@
-use std::{collections::BTreeMap, ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc};
 
+use value::value::Object;
 use value::Value;
 
 use super::VmFunctionClosure;
@@ -549,7 +550,7 @@ impl Vm {
                     // The next primitive on the stack is the number of fields in the object
                     // followed by key, value pairs.
                     let count = state.next_primitive()?;
-                    let mut object = BTreeMap::new();
+                    let mut object = Object::new();
 
                     for _ in 0..count {
                         let value = state.pop_stack()?;

--- a/lib/vrl/core/src/macro.rs
+++ b/lib/vrl/core/src/macro.rs
@@ -10,13 +10,13 @@ macro_rules! value {
     });
 
     ({}) => ({
-        ::value::Value::Object(::std::collections::BTreeMap::default())
+        ::value::Value::Object(::value::value::Object::new())
     });
 
     ({$($($k1:literal)? $($k2:ident)?: $v:tt),+ $(,)?}) => ({
         let map = vec![$((String::from($($k1)? $(stringify!($k2))?), $crate::value!($v))),+]
             .into_iter()
-            .collect::<::std::collections::BTreeMap<_, ::value::Value>>();
+            .collect::<::value::value::Object<::value::Value>>();
 
         ::value::Value::Object(map)
     });

--- a/lib/vrl/stdlib/src/flatten.rs
+++ b/lib/vrl/stdlib/src/flatten.rs
@@ -1,5 +1,3 @@
-use std::collections::btree_map;
-
 use ::value::Value;
 use vrl::prelude::*;
 
@@ -91,13 +89,13 @@ impl Expression for FlattenFn {
 
 /// An iterator to walk over maps allowing us to flatten nested maps to a single level.
 struct MapFlatten<'a> {
-    values: btree_map::Iter<'a, String, Value>,
+    values: ::value::value::ObjectIter<'a, String, Value>,
     inner: Option<Box<MapFlatten<'a>>>,
     parent: Option<String>,
 }
 
 impl<'a> MapFlatten<'a> {
-    fn new(values: btree_map::Iter<'a, String, Value>) -> Self {
+    fn new(values: ::value::value::ObjectIter<'a, String, Value>) -> Self {
         Self {
             values,
             inner: None,
@@ -105,7 +103,10 @@ impl<'a> MapFlatten<'a> {
         }
     }
 
-    fn new_from_parent(parent: String, values: btree_map::Iter<'a, String, Value>) -> Self {
+    fn new_from_parent(
+        parent: String,
+        values: ::value::value::ObjectIter<'a, String, Value>,
+    ) -> Self {
         Self {
             values,
             inner: None,

--- a/lib/vrl/stdlib/src/merge.rs
+++ b/lib/vrl/stdlib/src/merge.rs
@@ -64,7 +64,7 @@ impl Function for Merge {
 
         merge_maps(&mut to, &from, deep);
 
-        Ok(to.into())
+        Ok(::value::Value::Object(to))
     }
 }
 
@@ -83,7 +83,7 @@ impl Expression for MergeFn {
 
         merge_maps(&mut to_value, &from_value, deep);
 
-        Ok(to_value.into())
+        Ok(::value::Value::Object(to_value))
     }
 
     fn type_def(&self, state: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -179,7 +179,7 @@ fn kind_common() -> BTreeMap<Field, Kind> {
          "size": Kind::integer() | Kind::null(),
     }
     .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
+    .map(|(key, kind): (String, _)| (key.into(), kind))
     .collect()
 }
 
@@ -199,7 +199,7 @@ fn kind_combined() -> BTreeMap<Field, Kind> {
         "agent": Kind::bytes() | Kind::null(),
     }
     .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
+    .map(|(key, kind): (String, _)| (key.into(), kind))
     .collect()
 }
 
@@ -213,7 +213,7 @@ fn kind_error() -> BTreeMap<Field, Kind> {
          "message": Kind::bytes() | Kind::null(),
     }
     .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
+    .map(|(key, kind): (String, _)| (key.into(), kind))
     .collect()
 }
 

--- a/lib/vrl/stdlib/src/parse_aws_alb_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_alb_log.rs
@@ -116,7 +116,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
         "user_agent": Kind::bytes(),
     }
     .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
+    .map(|(key, kind): (String, _)| (key.into(), kind))
     .collect()
 }
 

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -128,7 +128,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
         ])),
     }
     .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
+    .map(|(key, kind): (String, _)| (key.into(), kind))
     .collect()
 }
 

--- a/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
@@ -153,7 +153,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
         "vpc_id": Kind::bytes() | Kind::null(),
     }
     .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
+    .map(|(key, kind): (String, _)| (key.into(), kind))
     .collect()
 }
 

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -127,7 +127,7 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
         "size": Kind::integer() | Kind::null(),
     }
     .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
+    .map(|(key, kind): (String, _)| (key.into(), kind))
     .collect()
 }
 

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use std::{fmt, sync::Arc};
 
 use ::value::Value;
 use vrl::{

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -280,7 +280,7 @@ impl Expression for ParseGrokFn {
 #[cfg(test)]
 mod test {
     use ::value::Value;
-    use vector_common::btreemap;
+    use vector_common::object;
 
     use super::*;
 
@@ -311,7 +311,7 @@ mod test {
         parsed {
             args: func_args![ value: "2020-10-02T23:22:12.223222Z info Hello world",
                               patterns: vec!["%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"]],
-            want: Ok(Value::from(btreemap! {
+            want: Ok(Value::from(object! {
                 "timestamp" => "2020-10-02T23:22:12.223222Z",
                 "level" => "info",
                 "message" => "Hello world",
@@ -322,7 +322,7 @@ mod test {
         parsed2 {
             args: func_args![ value: "2020-10-02T23:22:12.223222Z",
                               patterns: vec!["(%{TIMESTAMP_ISO8601:timestamp}|%{LOGLEVEL:level})"]],
-            want: Ok(Value::from(btreemap! {
+            want: Ok(Value::from(object! {
                 "timestamp" => "2020-10-02T23:22:12.223222Z",
                 "level" => "",
             })),
@@ -335,7 +335,7 @@ mod test {
                               remove_empty: true,
             ],
             want: Ok(Value::from(
-                btreemap! { "timestamp" => "2020-10-02T23:22:12.223222Z" },
+                object! { "timestamp" => "2020-10-02T23:22:12.223222Z" },
             )),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
@@ -355,7 +355,7 @@ mod test {
                     "_message": "%{GREEDYDATA:message}"
                 })
             ],
-            want: Ok(Value::from(btreemap! {
+            want: Ok(Value::from(object! {
                 "timestamp" => "2020-10-02T23:22:12.223222Z",
                 "level" => "info",
                 "status" => "200",
@@ -379,7 +379,7 @@ mod test {
                     "_message": "%{GREEDYDATA:message}"
                 })
             ],
-            want: Ok(Value::from(btreemap! {
+            want: Ok(Value::from(object! {
                 "timestamp" => "2020-10-02T23:22:12.223222Z",
                 "level" => "info",
                 "message" => "hello world"
@@ -410,10 +410,10 @@ mod test {
                     "_x_forwarded_for": r#"%{regex("[^\\\"]*"):http._x_forwarded_for:nullIf("-")}"#
                 })
             ],
-            want: Ok(Value::Object(btreemap! {
+            want: Ok(Value::Object(object! {
                 "date_access" => "13/Jul/2016:10:55:36",
                 "duration" => 202000000,
-                "http" => btreemap! {
+                "http" => object! {
                     "auth" => "frank",
                     "ident" => "-",
                     "method" => "GET",
@@ -424,9 +424,9 @@ mod test {
                     "useragent" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36",
                     "_x_forwarded_for" => Value::Null,
                 },
-                "network" => btreemap! {
+                "network" => object! {
                     "bytes_written" => 2326,
-                    "client" => btreemap! {
+                    "client" => object! {
                         "ip" => "127.0.0.1"
                     }
                 }

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -1,9 +1,6 @@
-use std::{
-    borrow::Cow,
-    collections::{btree_map::Entry, BTreeMap},
-};
+use std::{borrow::Cow, collections::btree_map::Entry};
 
-use ::value::Value;
+use ::value::{value::Object, Value};
 use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
 use roxmltree::{Document, Node, NodeType};
@@ -298,8 +295,8 @@ fn inner_kind() -> Kind {
 /// Process an XML node, and return a VRL `Value`.
 fn process_node<'a>(node: Node, config: &ParseXmlConfig<'a>) -> Value {
     // Helper to recurse over a `Node`s children, and build an object.
-    let recurse = |node: Node| -> BTreeMap<String, Value> {
-        let mut map = BTreeMap::new();
+    let recurse = |node: Node| -> Object<Value> {
+        let mut map = Object::new();
 
         // Expand attributes, if required.
         if config.include_attr {
@@ -368,7 +365,7 @@ fn process_node<'a>(node: Node, config: &ParseXmlConfig<'a>) -> Value {
 
                         // If the node is an element, treat it as an object.
                         if node.is_element() {
-                            let mut map = BTreeMap::new();
+                            let mut map = Object::new();
 
                             map.insert(
                                 node.tag_name().name().to_string(),

--- a/lib/vrl/stdlib/src/type_def.rs
+++ b/lib/vrl/stdlib/src/type_def.rs
@@ -9,7 +9,7 @@ fn type_def(type_def: &VrlTypeDef) -> Resolved {
         tree.insert("fallible".to_owned(), true.into());
     }
 
-    Ok(tree.into())
+    Ok(::value::Value::Object(tree))
 }
 
 /// A debug function to print the type definition of an expression at runtime.

--- a/lib/vrl/stdlib/src/uuid_v4.rs
+++ b/lib/vrl/stdlib/src/uuid_v4.rs
@@ -52,7 +52,7 @@ impl Expression for UuidV4Fn {
 
 #[cfg(test)]
 mod tests {
-    use ::value::Value;
+    use ::value::{value::Object, Value};
     use vector_common::TimeZone;
 
     use super::*;
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn uuid_v4() {
         let mut state = vrl::state::Runtime::default();
-        let mut object: Value = map![].into();
+        let mut object: Value = Value::Object(Object::new());
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut state, &tz);
         let value = UuidV4Fn.resolve(&mut ctx).unwrap();

--- a/lib/vrl/tests/src/docs.rs
+++ b/lib/vrl/tests/src/docs.rs
@@ -1,11 +1,8 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    fs,
-    process::Command,
-};
+use std::{collections::HashMap, fs, process::Command};
 
 use serde::Deserialize;
 use serde_json::{Map, Value};
+use value::value::Object;
 
 use crate::Test;
 
@@ -140,7 +137,7 @@ impl Test {
             Some(event) => {
                 serde_json::from_value::<Value>(serde_json::Value::Object(event.log)).unwrap()
             }
-            None => Value::Object(BTreeMap::default()),
+            None => Value::Object(Object::default()),
         };
 
         if returns.is_some() && output.is_some() {

--- a/lib/vrl/tests/src/test.rs
+++ b/lib/vrl/tests/src/test.rs
@@ -1,6 +1,6 @@
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{fs, path::Path};
 
-use ::value::Value;
+use ::value::{value::Object, Value};
 use vrl::function::Example;
 
 #[derive(Debug)]
@@ -76,7 +76,7 @@ impl Test {
 
         let mut error = None;
         let object = if object.is_empty() {
-            Value::Object(BTreeMap::default())
+            Value::Object(Object::default())
         } else {
             match serde_json::from_str::<'_, Value>(&object) {
                 Ok(value) => value,
@@ -102,7 +102,7 @@ impl Test {
     }
 
     pub fn from_example(func: impl ToString, example: &Example) -> Self {
-        let object = Value::Object(BTreeMap::default());
+        let object = Value::Object(Object::default());
         let result = match example.result {
             Ok(string) => string.to_owned(),
             Err(err) => err.to_string(),

--- a/src/sinks/datadog/traces/tests.rs
+++ b/src/sinks/datadog/traces/tests.rs
@@ -7,6 +7,7 @@ use hyper::StatusCode;
 use indoc::indoc;
 use ordered_float::NotNan;
 use prost::Message;
+use value::value::Object;
 use vector_core::event::{BatchNotifier, BatchStatus, Event};
 
 use crate::{
@@ -70,14 +71,14 @@ fn simple_span() -> BTreeMap<String, Value> {
         ("error".to_string(), Value::Integer(404)),
         (
             "meta".to_string(),
-            Value::Object(BTreeMap::<String, Value>::from([
+            Value::Object(Object::<Value>::from([
                 ("foo".to_string(), Value::from("bar")),
                 ("bar".to_string(), Value::from("baz")),
             ])),
         ),
         (
             "metrics".to_string(),
-            Value::Object(BTreeMap::<String, Value>::from([(
+            Value::Object(Object::<Value>::from([(
                 "a_metric".to_string(),
                 Value::Float(NotNan::new(0.577).unwrap()),
             )])),

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -1,12 +1,10 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    convert::TryFrom,
-};
+use std::{collections::HashMap, convert::TryFrom};
 
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use tower::ServiceBuilder;
+use value::value::Object;
 
 use crate::aws::RegionOrEndpoint;
 use crate::{
@@ -195,7 +193,7 @@ impl DataStreamConfig {
         }
         let map = log.as_map_mut();
         if let Some(value) = map.remove(timestamp_key) {
-            map.insert(DATA_STREAM_TIMESTAMP_KEY.into(), value);
+            map.insert(String::from(DATA_STREAM_TIMESTAMP_KEY), value);
         }
     }
 
@@ -250,7 +248,7 @@ impl DataStreamConfig {
         let existing = log
             .as_map_mut()
             .entry("data_stream".into())
-            .or_insert_with(|| Value::Object(BTreeMap::new()))
+            .or_insert_with(|| Value::Object(Object::new()))
             .as_object_mut_unwrap();
         if let Some(dtype) = dtype {
             existing

--- a/src/sinks/kafka/request_builder.rs
+++ b/src/sinks/kafka/request_builder.rs
@@ -78,7 +78,7 @@ fn get_headers(event: &Event, headers_key: &Option<String>) -> Option<OwnedHeade
                 match headers {
                     Value::Object(headers_map) => {
                         let mut owned_headers = OwnedHeaders::new_with_capacity(headers_map.len());
-                        for (key, value) in headers_map {
+                        for (key, value) in headers_map.iter() {
                             if let Value::Bytes(value_bytes) = value {
                                 owned_headers = owned_headers.add(key, value_bytes.as_ref());
                             } else {

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, convert::TryInto};
 use chrono::{serde::ts_seconds, DateTime, TimeZone, Utc};
 use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
+use value::value::Object;
 use vector_core::event::Value;
 
 /// Fluent msgpack messages can be encoded in one of three ways, each with and
@@ -186,7 +187,7 @@ impl From<FluentValue> for Value {
                 )
             }
             rmpv::Value::Ext(code, bytes) => {
-                let mut fields = BTreeMap::new();
+                let mut fields = Object::new();
                 fields.insert(
                     String::from("msgpack_extension_code"),
                     Value::Integer(code.into()),
@@ -221,10 +222,9 @@ impl From<FluentTimestamp> for Value {
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
-
     use approx::assert_relative_eq;
     use quickcheck::quickcheck;
+    use value::value::Object;
     use vector_core::event::Value;
 
     use crate::sources::fluent::message::FluentValue;
@@ -306,7 +306,7 @@ mod test {
             let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.clone().into_iter().map(|(k,v)| (key_fn(k), val_fn(v))).collect();
             let actual = rmpv::Value::Map(actual_inner);
 
-            let mut expected_inner = BTreeMap::new();
+            let mut expected_inner = Object::new();
             for (k,v) in input.into_iter() {
                 expected_inner.insert(k, Value::Integer(v));
             }
@@ -327,7 +327,7 @@ mod test {
             let actual_inner: Vec<(rmpv::Value, rmpv::Value)> = input.into_iter().map(|(k,v)| (key_fn(k), val_fn(v))).collect();
             let actual = rmpv::Value::Map(actual_inner);
 
-            let expected = Value::Object(BTreeMap::new());
+            let expected = Value::Object(Object::new());
 
             assert_eq!(Value::from(FluentValue(actual)), expected);
       }
@@ -342,7 +342,7 @@ mod test {
         fn from_ext(code: i8, bytes: Vec<u8>) -> () {
             let actual = rmpv::Value::Ext(code, bytes.clone());
 
-            let mut inner = BTreeMap::new();
+            let mut inner = Object::new();
             inner.insert("msgpack_extension_code".to_string(), Value::Integer(code.into()));
             inner.insert("bytes".to_string(), Value::Bytes(bytes.into()));
             let expected = Value::Object(inner);

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -314,18 +314,14 @@ fn enrich_syslog_event(event: &mut Event, host_key: &str, default_host: Option<B
 
 #[cfg(test)]
 mod test {
-    use std::{
-        collections::{BTreeMap, HashMap},
-        fmt,
-        str::FromStr,
-    };
+    use std::{collections::HashMap, fmt, str::FromStr};
 
     use chrono::prelude::*;
     use codecs::decoding::format::Deserializer;
     use rand::{thread_rng, Rng};
     use tokio::time::{sleep, Duration, Instant};
     use tokio_util::codec::BytesCodec;
-    use value::Value;
+    use value::{value::Object, Value};
     use vector_common::assert_event_data_eq;
     use vector_core::config::ComponentKey;
 
@@ -1051,7 +1047,7 @@ mod test {
         }
     }
 
-    fn structured_data_from_fields(fields: BTreeMap<String, Value>) -> StructuredData {
+    fn structured_data_from_fields(fields: Object<Value>) -> StructuredData {
         let mut structured_data = StructuredData::default();
 
         for (key, value) in fields.into_iter() {


### PR DESCRIPTION
This commit adjusts our Value type so that it does not expose that the `Object`
field is backed by a BTreeMap. The intention is to allow us to experiment with
different representations of the map. As this commit demonstrates changing that
type was a non-trivial lift, meaning we couldn't get quick experiments going to
try this or that idea out.

It has been my intention to make the changes here as mechanical in nature as
possible. However, careful review is still warranted as I followed the compiler
in its feedback but, well, there was a lot of it and I might have gotten
confused.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>