### PR TITLE
chore(vrl): improve performance of `del` function

### DIFF
--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -1,32 +1,35 @@
 use ::value::Value;
 use vrl::prelude::*;
 
+#[inline]
 fn del(query: &expression::Query, ctx: &mut Context) -> Resolved {
     let path = query.path();
+
     if query.is_external() {
-        return Ok(ctx
+        Ok(ctx
             .target_mut()
             .target_remove(path, false)
             .ok()
             .flatten()
-            .unwrap_or(Value::Null));
-    }
-    if let Some(ident) = query.variable_ident() {
-        return match ctx.state_mut().variable_mut(ident) {
+            .unwrap_or(Value::Null))
+    } else if let Some(ident) = query.variable_ident() {
+        match ctx.state_mut().variable_mut(ident) {
             Some(value) => {
                 let new_value = value.get_by_path(path).cloned();
                 value.remove_by_path(path, false);
                 Ok(new_value.unwrap_or(Value::Null))
             }
             None => Ok(Value::Null),
-        };
-    }
-    if let Some(expr) = query.expression_target() {
+        }
+    } else if let Some(expr) = query.expression_target() {
         let value = expr.resolve(ctx)?;
 
-        return Ok(value.get_by_path(path).cloned().unwrap_or(Value::Null));
+        // No need to do the actual deletion, as the expression is only
+        // available as an argument to the function.
+        Ok(value.get_by_path(path).cloned().unwrap_or(Value::Null))
+    } else {
+        Ok(Value::Null)
     }
-    Ok(Value::Null)
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
This likely won't show up in the soaks, but micro-benchmarks show a ~5-10% performance gain.