### PR TITLE
chore: Use 'fast' user-agent parsing by default

### DIFF
--- a/soaks/tests/http_pipelines_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole/vector.toml
@@ -114,7 +114,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -1460,7 +1460,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -2770,7 +2770,7 @@ del(.custom.data.user_agent)
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -3254,7 +3254,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -3537,7 +3537,7 @@ if (err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -3975,7 +3975,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''

--- a/soaks/tests/http_pipelines_blackhole_acks/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole_acks/vector.toml
@@ -115,7 +115,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -1461,7 +1461,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -2771,7 +2771,7 @@ del(.custom.data.user_agent)
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -3255,7 +3255,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -3538,7 +3538,7 @@ if (err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''
@@ -3976,7 +3976,7 @@ if (details, err = parse_url(.custom.http.url); err == null) {
 [[transforms.processing.logs.transforms]]
 type = "remap"
 source = '''
-if (details, err = parse_user_agent(.custom.http.useragent, mode: "enriched"); err == null) {
+if (details, err = parse_user_agent(.custom.http.useragent, mode: "fast"); err == null) {
   .custom.http.useragent_details = details
 }
 '''


### PR DESCRIPTION
Per findings in #12267 the enriched mode of parsing user agents is very
expensive. It is not clear, however, if users will actually, in practice, make
use of enriched mode or if 'fast' is sufficient. As such, we've decided to focus
on 'fast' for the time being.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
