### PR TITLE
chore(vrl): improve performance of `assignment` expression

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -436,10 +436,7 @@ impl<'a> Compiler<'a> {
         // potential external optimizations.
         for target in assignment.targets() {
             if let assignment::Target::External(path) = target {
-                match path {
-                    Some(path) => self.external_assignments.push(path),
-                    None => self.external_assignments.push(LookupBuf::root()),
-                }
+                self.external_assignments.push(path);
             }
         }
 

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -153,7 +153,7 @@ impl Expression for Query {
             }
             Target::Internal(variable) => {
                 vm.write_opcode(OpCode::GetPath);
-                vm::Variable::Internal(variable.ident().clone(), Some(self.path.clone()))
+                vm::Variable::Internal(variable.ident().clone(), self.path.clone())
             }
             Target::FunctionCall(call) => {
                 // Write the code to call the function.

--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use diagnostic::{DiagnosticMessage, Label};
+use lookup::LookupBuf;
 use value::Value;
 
 use crate::{
@@ -72,7 +73,7 @@ impl Expression for Variable {
         vm.write_opcode(OpCode::GetPath);
 
         // Store the required path in the targets list, write its index to the vm.
-        let variable = vm::Variable::Internal(self.ident().clone(), None);
+        let variable = vm::Variable::Internal(self.ident().clone(), LookupBuf::root());
         let target = vm.get_target(&variable);
         vm.write_primitive(target);
 

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -510,11 +510,11 @@ impl Vm {
                         }
                         Variable::Internal(ident, path) => {
                             let value = match ctx.state().variable(ident) {
-                                Some(value) => match path {
-                                    Some(path) => {
+                                Some(value) => match path.is_root() {
+                                    false => {
                                         value.get_by_path(path).cloned().unwrap_or(Value::Null)
                                     }
-                                    None => value.clone(),
+                                    true => value.clone(),
                                 },
                                 None => Value::Null,
                             };
@@ -680,9 +680,9 @@ fn set_variable<'a>(
 ) -> Result<(), ExpressionError> {
     match variable {
         Variable::Internal(ident, path) => {
-            let path = match path {
-                Some(path) => path,
-                None => {
+            let path = match path.is_root() {
+                false => path,
+                true => {
                     ctx.state_mut().insert_variable(ident.clone(), value);
                     return Ok(());
                 }

--- a/lib/vrl/compiler/src/vm/variable.rs
+++ b/lib/vrl/compiler/src/vm/variable.rs
@@ -5,7 +5,7 @@ use crate::expression::assignment::Target;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Variable {
-    Internal(crate::parser::Ident, Option<LookupBuf>),
+    Internal(crate::parser::Ident, LookupBuf),
     External(LookupBuf),
     Stack(LookupBuf),
     None,
@@ -15,8 +15,7 @@ pub enum Variable {
 impl From<&Target> for Variable {
     fn from(target: &Target) -> Self {
         match target {
-            Target::External(Some(path)) => Variable::External(path.clone()),
-            Target::External(None) => Variable::External(LookupBuf::root()),
+            Target::External(path) => Variable::External(path.clone()),
             Target::Noop => Variable::None,
             Target::Internal(ident, path) => Variable::Internal(ident.clone(), path.clone()),
         }

--- a/lib/vrl/vrl/src/runtime.rs
+++ b/lib/vrl/vrl/src/runtime.rs
@@ -52,6 +52,11 @@ impl Runtime {
     pub fn new(state: state::Runtime) -> Self {
         Self {
             state,
+
+            // `LookupBuf` uses a `VecDeque` internally, which always allocates, even
+            // when it's empty (for `LookupBuf::root()`), so we do the
+            // allocation on initialization of the runtime, instead of on every
+            // `resolve` run.
             root_lookup: LookupBuf::root(),
         }
     }


### PR DESCRIPTION
In flamegraphs, I noticed a not-insignificant amount of time was spent on `LookupBuf::root()`. I thought this was strange, since `LookupBuf` is merely a wrapper type around `VecDeque`, and the root is represented as an empty queue.

I was under the impression an empty queue (`VecDeque::new()`) wouldn't allocate, but [I was wrong](https://github.com/rust-lang/rust/blob/0cd939e36c0696aad44a213566c9b152f0437020/library/alloc/src/collections/vec_deque/mod.rs#L547-L549). Even if we used `VecDeque::with_capacity(0)`, it [would still allocate](https://github.com/rust-lang/rust/blob/0cd939e36c0696aad44a213566c9b152f0437020/library/alloc/src/collections/vec_deque/mod.rs#L561-L567).

This PR memoizes root lookups by storing them at compile-time.

Let's see if it has an impact on the soaks, but at least it'll clean up the code a bit, as it is somewhat odd to consider a root lookup as `None`, but any other as `Some(Lookup)`.

_note, I wanted to cause as little churn as possible, so I opted to use `match path.is_root()`, where before `match path` was used, instead of rewriting to `if path.is_root() { } else {}`_