### PR TITLE
chore(sources): Convert the finalizer framework to output a stream

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -72,6 +72,11 @@ where
     PP: PathsProvider,
     E: FileSourceInternalEvents,
 {
+    // The first `shutdown_data` signal here is to stop this file
+    // server from outputting new data; the second
+    // `shutdown_checkpointer` is for finishing the background
+    // checkpoint writer task, which has to wait for all
+    // acknowledgements to be completed.
     pub fn run<C, S1, S2>(
         self,
         mut chans: C,
@@ -83,9 +88,7 @@ where
         C: Sink<Vec<Line>> + Unpin,
         <C as Sink<Vec<Line>>>::Error: std::error::Error,
         S1: Future + Unpin + Send + 'static,
-        <S1 as Future>::Output: Clone + Send + Sync,
         S2: Future + Unpin + Send + 'static,
-        <S2 as Future>::Output: Clone + Send + Sync,
     {
         let mut fingerprint_buffer = Vec::new();
 

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -5,7 +5,7 @@ use aws_sdk_sqs::{
     Client as SqsClient,
 };
 use chrono::{DateTime, TimeZone, Utc};
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use tokio::{pin, select, time::Duration};
 
 use crate::{
@@ -38,11 +38,15 @@ impl SqsSource {
     pub async fn run(self, out: SourceSender, shutdown: ShutdownSignal) -> Result<(), ()> {
         let mut task_handles = vec![];
         let finalizer = self.acknowledgements.then(|| {
+            let (finalizer, mut ack_stream) = Finalizer::new(shutdown.clone());
             let client = self.client.clone();
             let queue_url = self.queue_url.clone();
-            Arc::new(Finalizer::new(shutdown.clone(), move |receipts_to_ack| {
-                delete_messages(client.clone(), receipts_to_ack, queue_url.clone())
-            }))
+            tokio::spawn(async move {
+                while let Some(receipts_to_ack) = ack_stream.next().await {
+                    delete_messages(client.clone(), receipts_to_ack, queue_url.clone()).await;
+                }
+            });
+            Arc::new(finalizer)
         });
 
         for _ in 0..self.concurrency {
@@ -51,11 +55,12 @@ impl SqsSource {
             let mut out = out.clone();
             let finalizer = finalizer.clone();
             task_handles.push(tokio::spawn(async move {
+                let finalizer = finalizer.as_ref();
                 pin!(shutdown);
                 loop {
                     select! {
                         _ = &mut shutdown => break,
-                        _ = source.run_once(&mut out, finalizer.clone()) => {},
+                        _ = source.run_once(&mut out, finalizer) => {},
                     }
                 }
             }));
@@ -73,7 +78,7 @@ impl SqsSource {
         Ok(())
     }
 
-    async fn run_once(&self, out: &mut SourceSender, finalizer: Option<Arc<Finalizer>>) {
+    async fn run_once(&self, out: &mut SourceSender, finalizer: Option<&Arc<Finalizer>>) {
         let result = self
             .client
             .receive_message()

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -324,7 +324,14 @@ pub fn file_source(
     let multi_line_timeout = config.multi_line_timeout;
 
     let (finalizer, shutdown_checkpointer) = if acknowledgements {
+        // The shutdown sent in to the finalizer is the global
+        // shutdown handle used to tell it to stop accepting new batch
+        // statuses and just wait for the remaining acks to come in.
         let (finalizer, mut ack_stream) = OrderedFinalizer::<FinalizerEntry>::new(shutdown.clone());
+        // We set up a separate shutdown signal to tie together the
+        // finalizer and the checkpoint writer task in the file
+        // server, to make it continue to write out updated
+        // checkpoints until all the acks have come in.
         let (send_shutdown, shutdown2) = oneshot::channel::<()>();
         let checkpoints = checkpointer.view();
         tokio::spawn(async move {
@@ -337,6 +344,8 @@ pub fn file_source(
         });
         (Some(finalizer), shutdown2.map(|_| ()).boxed())
     } else {
+        // When not dealing with end-to-end acknowledgements, just
+        // clone the global shutdown to stop the checkpoint writer.
         (None, shutdown.clone().map(|_| ()).boxed())
     };
 

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -70,7 +70,8 @@ where
     /// stream of acknowledged identifiers. In the case the finalizer
     /// is not to be used, a special empty stream is returned that is
     /// always pending and so never wakes.
-    pub fn maybe_new(
+    #[cfg(any(feature = "sources-gcp_pubsub", feature = "sources-kafka"))]
+    pub(crate) fn maybe_new(
         maybe: bool,
         shutdown: ShutdownSignal,
     ) -> (

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -1,16 +1,18 @@
 use std::marker::{PhantomData, Unpin};
-use std::{future::Future, pin::Pin, task::Poll};
+use std::{future::Future, pin::Pin, task::Context, task::Poll};
 
 use futures::stream::{FuturesOrdered, FuturesUnordered};
 use futures::{FutureExt, Stream, StreamExt};
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::event::{BatchStatus, BatchStatusReceiver};
 use crate::shutdown::ShutdownSignal;
 
-/// The `OrderedFinalizer` framework marks events from a source as
-/// done in a single background task *in the order they are received
-/// from the source*, using `FinalizerSet`.
+/// The `OrderedFinalizer` framework produces a stream of acknowledged
+/// event batch identifiers from a source in a single background task
+/// *in the order they are received from the source*, using
+/// `FinalizerSet`.
 #[cfg(any(
     feature = "sources-file",
     feature = "sources-journald",
@@ -18,9 +20,10 @@ use crate::shutdown::ShutdownSignal;
 ))]
 pub(crate) type OrderedFinalizer<T> = FinalizerSet<T, FuturesOrdered<FinalizerFuture<T>>>;
 
-/// The `UnorderedFinalizer` framework marks events from a source as
-/// done in a single background task *in the order the finalization
-/// happens on the event batches*, using `FinalizerSet`.
+/// The `UnorderedFinalizer` framework produces a stream of
+/// acknowledged event batch identifiers from a source in a single
+/// background task *in the order that finalization happens on the
+/// event batches*, using `FinalizerSet`.
 #[cfg(any(
     feature = "sources-aws_sqs",
     feature = "sources-splunk_hec",
@@ -28,12 +31,16 @@ pub(crate) type OrderedFinalizer<T> = FinalizerSet<T, FuturesOrdered<FinalizerFu
 ))]
 pub(crate) type UnorderedFinalizer<T> = FinalizerSet<T, FuturesUnordered<FinalizerFuture<T>>>;
 
-/// The `FinalizerSet` framework here is a mechanism for marking
-/// events from a source as done in a single background task. The type
-/// `T` is the source-specific data associated with each entry to be
-/// used to complete the finalization.
+/// The `FinalizerSet` framework here is a mechanism for creating a
+/// stream of acknowledged (finalized) event batch identifiers from a
+/// source as done in a single background task. It does this by
+/// pushing the batch status receiver along with an identifier into
+/// either a `FuturesOrdered` or `FuturesUnordered`, waiting on the
+/// stream of acknowledgements that comes out, extracting just the
+/// identifier and sending that into the returned stream. The type `T`
+/// is the source-specific data associated with each entry.
 pub(crate) struct FinalizerSet<T, S> {
-    sender: Option<mpsc::UnboundedSender<(BatchStatusReceiver, T)>>,
+    sender: Option<UnboundedSender<(BatchStatusReceiver, T)>>,
     _phantom: PhantomData<S>,
 }
 
@@ -42,16 +49,39 @@ where
     T: Send + 'static,
     S: FuturesSet<FinalizerFuture<T>> + Default + Send + Unpin + 'static,
 {
-    pub(crate) fn new<F, Fut>(shutdown: ShutdownSignal, apply_done: F) -> Self
-    where
-        F: Fn(T) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = ()> + Send + 'static,
-    {
-        let (sender, receiver) = mpsc::unbounded_channel();
-        tokio::spawn(run_finalizer(shutdown, receiver, apply_done, S::default()));
-        Self {
-            sender: Some(sender),
-            _phantom: Default::default(),
+    /// Produce a finalizer set along with the output stream of
+    /// received acknowledged batch identifiers.
+    pub(crate) fn new(
+        shutdown: ShutdownSignal,
+    ) -> (Self, impl Stream<Item = T> + Send + Unpin + 'static) {
+        let (todo_tx, todo_rx) = mpsc::unbounded_channel();
+        let (done_tx, done_rx) = mpsc::unbounded_channel();
+        tokio::spawn(run_finalizer(shutdown, todo_rx, done_tx, S::default()));
+        (
+            Self {
+                sender: Some(todo_tx),
+                _phantom: Default::default(),
+            },
+            UnboundedReceiverStream::new(done_rx),
+        )
+    }
+
+    /// This returns an optional finalizer set along with a generic
+    /// stream of acknowledged identifiers. In the case the finalizer
+    /// is not to be used, a special empty stream is returned that is
+    /// always pending and so never wakes.
+    pub fn maybe_new(
+        maybe: bool,
+        shutdown: ShutdownSignal,
+    ) -> (
+        Option<Self>,
+        Pin<Box<dyn Stream<Item = T> + Send + 'static>>,
+    ) {
+        if maybe {
+            let (finalizer, stream) = Self::new(shutdown);
+            (Some(finalizer), stream.boxed())
+        } else {
+            (None, EmptyStream(Default::default()).boxed())
         }
     }
 
@@ -64,15 +94,25 @@ where
     }
 }
 
-async fn run_finalizer<T, F: Future<Output = ()>>(
+async fn run_finalizer<T>(
     shutdown: ShutdownSignal,
-    mut new_entries: mpsc::UnboundedReceiver<(BatchStatusReceiver, T)>,
-    apply_done: impl Fn(T) -> F,
+    mut new_entries: UnboundedReceiver<(BatchStatusReceiver, T)>,
+    done_entries: UnboundedSender<T>,
     mut status_receivers: impl FuturesSet<FinalizerFuture<T>> + Unpin,
 ) {
     loop {
         tokio::select! {
             _ = shutdown.clone() => break,
+            // We could eliminate this `new_entries` channel by just
+            // pushing new entries directly into the
+            // `status_receivers` except for two problems: 1. The
+            // `status_receivers` needs to be `mut` for both pushing
+            // entries in and polling the stream, and the locking
+            // required to solve that could cause long lock pauses,
+            // and 2. The `OrderedFutures`/`UnorderedFutures` types
+            // produce an unending stream of `None` when they are
+            // empty, and there is no async way to wait for them to
+            // not be empty.
             new_entry = new_entries.recv() => match new_entry {
                 Some((receiver, entry)) => {
                     status_receivers.push(FinalizerFuture {
@@ -83,8 +123,11 @@ async fn run_finalizer<T, F: Future<Output = ()>>(
                 None => break,
             },
             finished = status_receivers.next(), if !status_receivers.is_empty() => match finished {
-                Some((status, entry)) => if status == BatchStatus::Delivered {
-                    apply_done(entry).await;
+                Some((status, entry)) => if status == BatchStatus::Delivered && done_entries.send(entry).is_err() {
+                    // The receiver went away before shutdown, so
+                    // just close up shop as there is nothing more
+                    // we can do here.
+                    return;
                 }
                 // The is_empty guard above prevents this from being reachable.
                 None => unreachable!(),
@@ -95,11 +138,10 @@ async fn run_finalizer<T, F: Future<Output = ()>>(
     // closed. Wait for the last statuses to come in before indicating
     // we are done.
     while let Some((status, entry)) = status_receivers.next().await {
-        if status == BatchStatus::Delivered {
-            apply_done(entry).await;
+        if status == BatchStatus::Delivered && done_entries.send(entry).is_err() {
+            break;
         }
     }
-    drop(shutdown);
 }
 
 pub(crate) trait FuturesSet<Fut: Future>: Stream<Item = Fut::Output> {
@@ -140,5 +182,20 @@ impl<T> Future for FinalizerFuture<T> {
         // The use of this above in a `Futures{Ordered|Unordered|`
         // will only take this once before dropping the future.
         Poll::Ready((status, self.entry.take().unwrap_or_else(|| unreachable!())))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct EmptyStream<T>(PhantomData<T>);
+
+impl<T> Stream for EmptyStream<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
     }
 }

--- a/src/sources/util/finalizer.rs
+++ b/src/sources/util/finalizer.rs
@@ -114,7 +114,7 @@ where
     fn poll_next(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
         if !*this.is_shutdown {
-            if let Poll::Ready(_) = this.shutdown.poll_unpin(ctx) {
+            if this.shutdown.poll_unpin(ctx).is_ready() {
                 *this.is_shutdown = true
             }
             // Only poll for new entries until shutdown is flagged.


### PR DESCRIPTION
The `FinalizerSet` is used by several sources to asynchronously process
acknowledgement responses. It is currently written to take a async closure
that is called when an batch is acknowledged, but this requires sharing
data into the closure, complicating program flow for some sources.

This change rewrites it to output a stream of acknowledged identifiers,
which is then either handled in the main loop in the source or in a 
separate task as needed. This rewrite also avoids the need for an
additional task in the finalizer framework moving that out into only
the sources that require background handling (as opposed to `select`
on the stream).

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
