### PR TITLE
chore: Remove map! macro

### DIFF
--- a/lib/vrl/compiler/src/test_util.rs
+++ b/lib/vrl/compiler/src/test_util.rs
@@ -170,18 +170,6 @@ macro_rules! __prep_bench_or_test {
 }
 
 #[macro_export]
-macro_rules! map {
-    () => (
-        ::std::collections::BTreeMap::new()
-    );
-    ($($k:tt: $v:expr),+ $(,)?) => {
-        vec![$(($k.into(), $v.into())),+]
-            .into_iter()
-            .collect::<::std::collections::BTreeMap<_, _>>()
-    };
-}
-
-#[macro_export]
 macro_rules! type_def {
     (unknown) => {
         TypeDef::any()

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -336,11 +336,16 @@ mod test {
                 Default::default(),
             ),
             (
-                vec![1.into(), Value::Object(map!["field2": 2]), 2.into()],
                 vec![
                     1.into(),
-                    Value::Object(map!["field1": Value::Null,
-                                    "field2": 2]),
+                    Value::Object(BTreeMap::from([(String::from("field2"), Value::from(2))])),
+                ],
+                vec![
+                    1.into(),
+                    Value::Object(BTreeMap::from([
+                        (String::from("field1"), Value::Null),
+                        (String::from("field2"), Value::from(2)),
+                    ])),
                     2.into(),
                 ],
                 Default::default(),
@@ -383,43 +388,63 @@ mod test {
                 Default::default(),
             ),
             (
-                map!["key1": Value::from(1),
-                     "key2": Value::Object(map!["key2": Value::from(3)]),
-                     "key3": Value::from(2),
-                ],
-                map![
-                    "key1": Value::from(1),
-                    "key2": Value::Object(map!["key1": Value::Null,
-                                            "key2": Value::from(3),
-                                            "key3": Value::Null]),
-                    "key3": Value::from(2),
-                ],
+                BTreeMap::from([
+                    (String::from("key1"), Value::from(1)),
+                    (
+                        String::from("key2"),
+                        Value::Object(BTreeMap::from([(String::from("key2"), Value::from(3))])),
+                    ),
+                    (String::from("key3"), Value::from(2)),
+                ]),
+                BTreeMap::from([
+                    (String::from("key1"), Value::from(1)),
+                    (
+                        String::from("key2"),
+                        Value::Object(BTreeMap::from([
+                            (String::from("key1"), Value::Null),
+                            (String::from("key2"), Value::from(3)),
+                            (String::from("key3"), Value::Null),
+                        ])),
+                    ),
+                    (String::from("key3"), Value::from(2)),
+                ]),
                 Default::default(),
             ),
             (
-                map!["key1": Value::from(1),
-                     "key2": Value::Object(map!["key1": Value::Null,]),
-                     "key3": Value::from(2),
-                ],
-                map![
-                    "key1": Value::from(1),
-                    "key2": Value::Object(map!["key1": Value::Null,]),
-                    "key3": Value::from(2),
-                ],
+                BTreeMap::from([
+                    (String::from("key1"), Value::from(1)),
+                    (
+                        String::from("key2"),
+                        Value::Object(BTreeMap::from([(String::from("key1"), Value::Null)])),
+                    ),
+                    (String::from("key3"), Value::from(2)),
+                ]),
+                BTreeMap::from([
+                    (String::from("key1"), Value::from(1)),
+                    (
+                        String::from("key2"),
+                        Value::Object(BTreeMap::from([(String::from("key1"), Value::Null)])),
+                    ),
+                    (String::from("key3"), Value::from(2)),
+                ]),
                 CompactOptions {
                     recursive: false,
                     ..Default::default()
                 },
             ),
             (
-                map!["key1": Value::from(1),
-                     "key3": Value::from(2),
-                ],
-                map![
-                    "key1": Value::from(1),
-                    "key2": Value::Object(map!["key1": Value::Null,]),
-                    "key3": Value::from(2),
-                ],
+                BTreeMap::from([
+                    (String::from("key1"), Value::from(1)),
+                    (String::from("key3"), Value::from(2)),
+                ]),
+                BTreeMap::from([
+                    (String::from("key1"), Value::from(1)),
+                    (
+                        String::from("key2"),
+                        Value::Object(BTreeMap::from([(String::from("key1"), Value::Null)])),
+                    ),
+                    (String::from("key3"), Value::from(2)),
+                ]),
                 Default::default(),
             ),
             (
@@ -446,11 +471,8 @@ mod test {
         compact => Compact;
 
         with_map {
-            args: func_args![value: map!["key1": Value::Null,
-                                         "key2": 1,
-                                         "key3": "",
-            ]],
-            want: Ok(Value::Object(map!["key2": 1])),
+            args: func_args![value: Value::from(BTreeMap::from([(String::from("key1"), Value::Null), (String::from("key2"), Value::from(1)), (String::from("key3"), Value::from(""))]))],
+            want: Ok(Value::Object(BTreeMap::from([(String::from("key2"), Value::from(1))]))),
             tdef: TypeDef::object(Collection::any()),
         }
 
@@ -469,7 +491,7 @@ mod test {
                 },
                 nullish: true
             ],
-            want: Ok(Value::Object(map!["key2": 1])),
+            want: Ok(Value::Object(BTreeMap::from([(String::from("key2"), Value::from(1))]))),
             tdef: TypeDef::object(Collection::any()),
         }
     ];

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -337,8 +337,9 @@ mod test {
             ),
             (
                 vec![
-                    1.into(),
+                    Value::from(1),
                     Value::Object(BTreeMap::from([(String::from("field2"), Value::from(2))])),
+                    Value::from(2),
                 ],
                 vec![
                     1.into(),

--- a/lib/vrl/stdlib/src/encode_json.rs
+++ b/lib/vrl/stdlib/src/encode_json.rs
@@ -101,7 +101,7 @@ mod tests {
         }
 
         map {
-            args: func_args![value: map!["field": "value"]],
+            args: func_args![value: Value::from(BTreeMap::from([(String::from("field"), Value::from("value"))]))],
             want: Ok(r#"{"field":"value"}"#),
             tdef: TypeDef::bytes().infallible(),
         }

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -166,55 +166,46 @@ impl Expression for ParseApacheLogFn {
 }
 
 fn kind_common() -> BTreeMap<Field, Kind> {
-    map! {
-         "host": Kind::bytes() | Kind::null(),
-         "identity": Kind::bytes() | Kind::null(),
-         "user": Kind::bytes() | Kind::null(),
-         "timestamp": Kind::timestamp() | Kind::null(),
-         "message": Kind::bytes() | Kind::null(),
-         "method": Kind::bytes() | Kind::null(),
-         "path": Kind::bytes() | Kind::null(),
-         "protocol": Kind::bytes() | Kind::null(),
-         "status": Kind::integer() | Kind::null(),
-         "size": Kind::integer() | Kind::null(),
-    }
-    .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
-    .collect()
+    BTreeMap::from([
+        (Field::from("host"), Kind::bytes() | Kind::null()),
+        (Field::from("identity"), Kind::bytes() | Kind::null()),
+        (Field::from("user"), Kind::bytes() | Kind::null()),
+        (Field::from("timestamp"), Kind::timestamp() | Kind::null()),
+        (Field::from("message"), Kind::bytes() | Kind::null()),
+        (Field::from("method"), Kind::bytes() | Kind::null()),
+        (Field::from("path"), Kind::bytes() | Kind::null()),
+        (Field::from("protocol"), Kind::bytes() | Kind::null()),
+        (Field::from("status"), Kind::integer() | Kind::null()),
+        (Field::from("size"), Kind::integer() | Kind::null()),
+    ])
 }
 
 fn kind_combined() -> BTreeMap<Field, Kind> {
-    map! {
-        "host": Kind::bytes() | Kind::null(),
-        "identity": Kind::bytes() | Kind::null(),
-        "user": Kind::bytes() | Kind::null(),
-        "timestamp": Kind::timestamp() | Kind::null(),
-        "message": Kind::bytes() | Kind::null(),
-        "method": Kind::bytes() | Kind::null(),
-        "path": Kind::bytes() | Kind::null(),
-        "protocol": Kind::bytes() | Kind::null(),
-        "status": Kind::integer() | Kind::null(),
-        "size": Kind::integer() | Kind::null(),
-        "referrer": Kind::bytes() | Kind::null(),
-        "agent": Kind::bytes() | Kind::null(),
-    }
-    .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
-    .collect()
+    BTreeMap::from([
+        (Field::from("host"), Kind::bytes() | Kind::null()),
+        (Field::from("identity"), Kind::bytes() | Kind::null()),
+        (Field::from("user"), Kind::bytes() | Kind::null()),
+        (Field::from("timestamp"), Kind::timestamp() | Kind::null()),
+        (Field::from("message"), Kind::bytes() | Kind::null()),
+        (Field::from("method"), Kind::bytes() | Kind::null()),
+        (Field::from("path"), Kind::bytes() | Kind::null()),
+        (Field::from("protocol"), Kind::bytes() | Kind::null()),
+        (Field::from("status"), Kind::integer() | Kind::null()),
+        (Field::from("size"), Kind::integer() | Kind::null()),
+        (Field::from("referrer"), Kind::bytes() | Kind::null()),
+        (Field::from("agent"), Kind::bytes() | Kind::null()),
+    ])
 }
 
 fn kind_error() -> BTreeMap<Field, Kind> {
-    map! {
-         "timestamp": Kind::timestamp() | Kind::null(),
-         "module": Kind::bytes() | Kind::null(),
-         "severity": Kind::bytes() | Kind::null(),
-         "thread": Kind::bytes() | Kind::null(),
-         "port": Kind::bytes() | Kind::null(),
-         "message": Kind::bytes() | Kind::null(),
-    }
-    .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
-    .collect()
+    BTreeMap::from([
+        (Field::from("timestamp"), Kind::timestamp() | Kind::null()),
+        (Field::from("module"), Kind::bytes() | Kind::null()),
+        (Field::from("severity"), Kind::bytes() | Kind::null()),
+        (Field::from("thread"), Kind::bytes() | Kind::null()),
+        (Field::from("port"), Kind::bytes() | Kind::null()),
+        (Field::from("message"), Kind::bytes() | Kind::null()),
+    ])
 }
 
 #[cfg(test)]

--- a/lib/vrl/stdlib/src/parse_aws_alb_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_alb_log.rs
@@ -82,42 +82,57 @@ impl Expression for ParseAwsAlbLogFn {
 }
 
 fn inner_kind() -> BTreeMap<Field, Kind> {
-    map! {
-        "actions_executed": Kind::bytes() | Kind::null(),
-        "chosen_cert_arn": Kind::bytes() | Kind::null(),
-        "classification_reason": Kind::bytes() | Kind::null(),
-        "classification": Kind::bytes() | Kind::null(),
-        "client_host": Kind::bytes(),
-        "domain_name": Kind::bytes() | Kind::null(),
-        "elb_status_code": Kind::bytes(),
-        "elb": Kind::bytes(),
-        "error_reason": Kind::bytes() | Kind::null(),
-        "matched_rule_priority": Kind::bytes() | Kind::null(),
-        "received_bytes": Kind::integer(),
-        "redirect_url": Kind::bytes() | Kind::null(),
-        "request_creation_time": Kind::bytes(),
-        "request_method": Kind::bytes(),
-        "request_processing_time": Kind::float(),
-        "request_protocol": Kind::bytes(),
-        "request_url": Kind::bytes(),
-        "response_processing_time": Kind::float(),
-        "sent_bytes": Kind::integer(),
-        "ssl_cipher": Kind::bytes() | Kind::null(),
-        "ssl_protocol": Kind::bytes() | Kind::null(),
-        "target_group_arn": Kind::bytes(),
-        "target_host": Kind::bytes() | Kind::null(),
-        "target_port_list": Kind::bytes() | Kind::null(),
-        "target_processing_time": Kind::float(),
-        "target_status_code_list": Kind::bytes() | Kind::null(),
-        "target_status_code": Kind::bytes() | Kind::null(),
-        "timestamp": Kind::bytes(),
-        "trace_id": Kind::bytes(),
-        "type": Kind::bytes(),
-        "user_agent": Kind::bytes(),
-    }
-    .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
-    .collect()
+    BTreeMap::from([
+        (
+            Field::from("actions_executed"),
+            Kind::bytes() | Kind::null(),
+        ),
+        (Field::from("chosen_cert_arn"), Kind::bytes() | Kind::null()),
+        (
+            Field::from("classification_reason"),
+            Kind::bytes() | Kind::null(),
+        ),
+        (Field::from("classification"), Kind::bytes() | Kind::null()),
+        (Field::from("client_host"), Kind::bytes()),
+        (Field::from("domain_name"), Kind::bytes() | Kind::null()),
+        (Field::from("elb_status_code"), Kind::bytes()),
+        (Field::from("elb"), Kind::bytes()),
+        (Field::from("error_reason"), Kind::bytes() | Kind::null()),
+        (
+            Field::from("matched_rule_priority"),
+            Kind::bytes() | Kind::null(),
+        ),
+        (Field::from("received_bytes"), Kind::integer()),
+        (Field::from("redirect_url"), Kind::bytes() | Kind::null()),
+        (Field::from("request_creation_time"), Kind::bytes()),
+        (Field::from("request_method"), Kind::bytes()),
+        (Field::from("request_processing_time"), Kind::float()),
+        (Field::from("request_protocol"), Kind::bytes()),
+        (Field::from("request_url"), Kind::bytes()),
+        (Field::from("response_processing_time"), Kind::float()),
+        (Field::from("sent_bytes"), Kind::integer()),
+        (Field::from("ssl_cipher"), Kind::bytes() | Kind::null()),
+        (Field::from("ssl_protocol"), Kind::bytes() | Kind::null()),
+        (Field::from("target_group_arn"), Kind::bytes()),
+        (Field::from("target_host"), Kind::bytes() | Kind::null()),
+        (
+            Field::from("target_port_list"),
+            Kind::bytes() | Kind::null(),
+        ),
+        (Field::from("target_processing_time"), Kind::float()),
+        (
+            Field::from("target_status_code_list"),
+            Kind::bytes() | Kind::null(),
+        ),
+        (
+            Field::from("target_status_code"),
+            Kind::bytes() | Kind::null(),
+        ),
+        (Field::from("timestamp"), Kind::bytes()),
+        (Field::from("trace_id"), Kind::bytes()),
+        (Field::from("type"), Kind::bytes()),
+        (Field::from("user_agent"), Kind::bytes()),
+    ])
 }
 
 fn parse_log(mut input: &str) -> Result<Value> {

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -8,19 +8,36 @@ fn parse_aws_cloudwatch_log_subscription_message(bytes: Value) -> Resolved {
     let bytes = bytes.try_bytes()?;
     let message = serde_json::from_slice::<AwsCloudWatchLogsSubscriptionMessage>(&bytes)
         .map_err(|e| format!("unable to parse: {}", e))?;
-    Ok(map![
-        "owner": message.owner,
-        "message_type": message.message_type.as_str(),
-        "log_group": message.log_group,
-        "log_stream": message.log_stream,
-        "subscription_filters": message.subscription_filters,
-        "log_events": message.log_events.into_iter().map(|event| map![
-            "id": event.id,
-            "timestamp": event.timestamp,
-            "message": event.message,
-        ]).collect::<Vec<_>>(),
-    ]
-    .into())
+    let map = Value::from(BTreeMap::from([
+        (String::from("owner"), Value::from(message.owner)),
+        (
+            String::from("message_type"),
+            Value::from(message.message_type.as_str()),
+        ),
+        (String::from("log_group"), Value::from(message.log_group)),
+        (String::from("log_stream"), Value::from(message.log_stream)),
+        (
+            String::from("subscription_filters"),
+            Value::from(message.subscription_filters),
+        ),
+        (
+            String::from("log_events"),
+            Value::Array(
+                message
+                    .log_events
+                    .into_iter()
+                    .map(|event| {
+                        Value::from(BTreeMap::from([
+                            (String::from("id"), Value::from(event.id)),
+                            (String::from("timestamp"), Value::from(event.timestamp)),
+                            (String::from("message"), Value::from(event.message)),
+                        ]))
+                    })
+                    .collect::<Vec<Value>>(),
+            ),
+        ),
+    ]));
+    Ok(map)
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -111,25 +128,28 @@ impl Expression for ParseAwsCloudWatchLogSubscriptionMessageFn {
 }
 
 fn inner_kind() -> BTreeMap<Field, Kind> {
-    map! {
-        "owner": Kind::bytes(),
-        "message_type": Kind::bytes(),
-        "log_group": Kind::bytes(),
-        "log_stream": Kind::bytes(),
-        "subscription_filters": Kind::array({
-            let mut v = Collection::any();
-            v.set_unknown(Kind::bytes());
-            v
-        }),
-        "log_events": Kind::object(BTreeMap::from([
-            ("id".into(), Kind::bytes()),
-            ("timestamp".into(), Kind::timestamp()),
-            ("message".into(), Kind::bytes()),
-        ])),
-    }
-    .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
-    .collect()
+    BTreeMap::from([
+        (Field::from("owner"), Kind::bytes()),
+        (Field::from("message_type"), Kind::bytes()),
+        (Field::from("log_group"), Kind::bytes()),
+        (Field::from("log_stream"), Kind::bytes()),
+        (
+            Field::from("subscription_filters"),
+            Kind::array({
+                let mut v = Collection::any();
+                v.set_unknown(Kind::bytes());
+                v
+            }),
+        ),
+        (
+            Field::from("log_events"),
+            Kind::object(BTreeMap::from([
+                (Field::from("id"), Kind::bytes()),
+                (Field::from("timestamp"), Kind::timestamp()),
+                (Field::from("message"), Kind::bytes()),
+            ])),
+        ),
+    ])
 }
 
 #[cfg(test)]

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -191,22 +191,22 @@ mod tests {
          ]
      }
      "#],
-            want: Ok(map![
-                "owner": "071959437513",
-                "message_type": "DATA_MESSAGE",
-                "log_group": "/jesse/test",
-                "log_stream": "test",
-                "subscription_filters": vec!["Destination"],
-                "log_events": vec![map![
-                    "id": "35683658089614582423604394983260738922885519999578275840",
-                    "timestamp": Utc.timestamp(1600110569, 39000000),
-                    "message": "{\"bytes\":26780,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"157.130.216.193\",\"method\":\"PUT\",\"protocol\":\"HTTP/1.0\",\"referer\":\"https://www.principalcross-platform.io/markets/ubiquitous\",\"request\":\"/expedite/convergence\",\"source_type\":\"stdin\",\"status\":301,\"user-identifier\":\"-\"}",
-                ], map![
-                    "id": "35683658089659183914001456229543810359430816722590236673",
-                    "timestamp": Utc.timestamp(1600110569, 41000000),
-                    "message": "{\"bytes\":17707,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"109.81.244.252\",\"method\":\"GET\",\"protocol\":\"HTTP/2.0\",\"referer\":\"http://www.investormission-critical.io/24/7/vortals\",\"request\":\"/scale/functionalities/optimize\",\"source_type\":\"stdin\",\"status\":502,\"user-identifier\":\"feeney1708\"}",
-                ]],
-            ]),
+            want: Ok(Value::from(BTreeMap::from([
+                (String::from("owner"), Value::from("071959437513")),
+                (String::from("message_type"), Value::from("DATA_MESSAGE")),
+                (String::from("log_group"), Value::from("/jesse/test")),
+                (String::from("log_stream"), Value::from("test")),
+                (String::from("subscription_filters"), Value::from(vec![Value::from("Destination")])),
+                (String::from("log_events"), Value::from(vec![Value::from(BTreeMap::from([
+                    (String::from("id"), Value::from( "35683658089614582423604394983260738922885519999578275840")),
+                    (String::from("timestamp"), Value::from(Utc.timestamp(1600110569, 39000000))),
+                    (String::from("message"), Value::from("{\"bytes\":26780,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"157.130.216.193\",\"method\":\"PUT\",\"protocol\":\"HTTP/1.0\",\"referer\":\"https://www.principalcross-platform.io/markets/ubiquitous\",\"request\":\"/expedite/convergence\",\"source_type\":\"stdin\",\"status\":301,\"user-identifier\":\"-\"}")),
+                ])), Value::from(BTreeMap::from([
+                    (String::from("id"), Value::from("35683658089659183914001456229543810359430816722590236673")),
+                    (String::from("timestamp"), Value::from(Utc.timestamp(1600110569, 41000000))),
+                    (String::from("message"), Value::from("{\"bytes\":17707,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"109.81.244.252\",\"method\":\"GET\",\"protocol\":\"HTTP/2.0\",\"referer\":\"http://www.investormission-critical.io/24/7/vortals\",\"request\":\"/scale/functionalities/optimize\",\"source_type\":\"stdin\",\"status\":502,\"user-identifier\":\"feeney1708\"}")),
+                ]))])),
+                ]))),
             tdef: TypeDef::object(inner_kind()).fallible(),
         }
 

--- a/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
@@ -125,36 +125,36 @@ impl Expression for ParseAwsVpcFlowLogFn {
 }
 
 fn inner_kind() -> BTreeMap<Field, Kind> {
-    map! {
-        "account_id": Kind::integer() | Kind::null(),
-        "action": Kind::bytes() | Kind::null(),
-        "az_id": Kind::bytes() | Kind::null(),
-        "bytes": Kind::integer() | Kind::null(),
-        "dstaddr": Kind::bytes() | Kind::null(),
-        "dstport": Kind::integer() | Kind::null(),
-        "end": Kind::integer() | Kind::null(),
-        "instance_id": Kind::bytes() | Kind::null(),
-        "interface_id": Kind::bytes() | Kind::null(),
-        "log_status": Kind::bytes() | Kind::null(),
-        "packets": Kind::integer() | Kind::null(),
-        "pkt_dstaddr": Kind::bytes() | Kind::null(),
-        "pkt_srcaddr": Kind::bytes() | Kind::null(),
-        "protocol": Kind::integer() | Kind::null(),
-        "region": Kind::bytes() | Kind::null(),
-        "srcaddr": Kind::bytes() | Kind::null(),
-        "srcport": Kind::integer() | Kind::null(),
-        "start": Kind::integer() | Kind::null(),
-        "sublocation_id": Kind::bytes() | Kind::null(),
-        "sublocation_type": Kind::bytes() | Kind::null(),
-        "subnet_id": Kind::bytes() | Kind::null(),
-        "tcp_flags": Kind::integer() | Kind::null(),
-        "type": Kind::bytes() | Kind::null(),
-        "version": Kind::integer() | Kind::null(),
-        "vpc_id": Kind::bytes() | Kind::null(),
-    }
-    .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
-    .collect()
+    BTreeMap::from([
+        (Field::from("account_id"), Kind::integer() | Kind::null()),
+        (Field::from("action"), Kind::bytes() | Kind::null()),
+        (Field::from("az_id"), Kind::bytes() | Kind::null()),
+        (Field::from("bytes"), Kind::integer() | Kind::null()),
+        (Field::from("dstaddr"), Kind::bytes() | Kind::null()),
+        (Field::from("dstport"), Kind::integer() | Kind::null()),
+        (Field::from("end"), Kind::integer() | Kind::null()),
+        (Field::from("instance_id"), Kind::bytes() | Kind::null()),
+        (Field::from("interface_id"), Kind::bytes() | Kind::null()),
+        (Field::from("log_status"), Kind::bytes() | Kind::null()),
+        (Field::from("packets"), Kind::integer() | Kind::null()),
+        (Field::from("pkt_dstaddr"), Kind::bytes() | Kind::null()),
+        (Field::from("pkt_srcaddr"), Kind::bytes() | Kind::null()),
+        (Field::from("protocol"), Kind::integer() | Kind::null()),
+        (Field::from("region"), Kind::bytes() | Kind::null()),
+        (Field::from("srcaddr"), Kind::bytes() | Kind::null()),
+        (Field::from("srcport"), Kind::integer() | Kind::null()),
+        (Field::from("start"), Kind::integer() | Kind::null()),
+        (Field::from("sublocation_id"), Kind::bytes() | Kind::null()),
+        (
+            Field::from("sublocation_type"),
+            Kind::bytes() | Kind::null(),
+        ),
+        (Field::from("subnet_id"), Kind::bytes() | Kind::null()),
+        (Field::from("tcp_flags"), Kind::integer() | Kind::null()),
+        (Field::from("type"), Kind::bytes() | Kind::null()),
+        (Field::from("version"), Kind::integer() | Kind::null()),
+        (Field::from("vpc_id"), Kind::bytes() | Kind::null()),
+    ])
 }
 
 type ParseResult<T> = std::result::Result<T, String>;

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -114,21 +114,18 @@ impl Expression for ParseCommonLogFn {
 }
 
 fn inner_kind() -> BTreeMap<Field, Kind> {
-    map! {
-        "host": Kind::bytes() | Kind::null(),
-        "identity": Kind::bytes() | Kind::null(),
-        "user": Kind::bytes() | Kind::null(),
-        "timestamp": Kind::timestamp() | Kind::null(),
-        "message": Kind::bytes() | Kind::null(),
-        "method": Kind::bytes() | Kind::null(),
-        "path": Kind::bytes() | Kind::null(),
-        "protocol": Kind::bytes() | Kind::null(),
-        "status": Kind::integer() | Kind::null(),
-        "size": Kind::integer() | Kind::null(),
-    }
-    .into_iter()
-    .map(|(key, kind): (&str, _)| (key.into(), kind))
-    .collect()
+    BTreeMap::from([
+        (Field::from("host"), Kind::bytes() | Kind::null()),
+        (Field::from("identity"), Kind::bytes() | Kind::null()),
+        (Field::from("user"), Kind::bytes() | Kind::null()),
+        (Field::from("timestamp"), Kind::timestamp() | Kind::null()),
+        (Field::from("message"), Kind::bytes() | Kind::null()),
+        (Field::from("method"), Kind::bytes() | Kind::null()),
+        (Field::from("path"), Kind::bytes() | Kind::null()),
+        (Field::from("protocol"), Kind::bytes() | Kind::null()),
+        (Field::from("status"), Kind::integer() | Kind::null()),
+        (Field::from("size"), Kind::integer() | Kind::null()),
+    ])
 }
 
 #[cfg(test)]

--- a/lib/vrl/stdlib/src/uuid_v4.rs
+++ b/lib/vrl/stdlib/src/uuid_v4.rs
@@ -52,6 +52,8 @@ impl Expression for UuidV4Fn {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use ::value::Value;
     use vector_common::TimeZone;
 
@@ -65,7 +67,7 @@ mod tests {
     #[test]
     fn uuid_v4() {
         let mut state = vrl::state::Runtime::default();
-        let mut object: Value = map![].into();
+        let mut object: Value = Value::Object(BTreeMap::new());
         let tz = TimeZone::default();
         let mut ctx = Context::new(&mut object, &mut state, &tz);
         let value = UuidV4Fn.resolve(&mut ctx).unwrap();

--- a/lib/vrl/vrl/src/prelude.rs
+++ b/lib/vrl/vrl/src/prelude.rs
@@ -30,7 +30,7 @@ pub use compiler::value::{VrlValueArithmetic, VrlValueConvert};
 pub use compiler::{
     bench_function, expr,
     expression::FunctionArgument,
-    func_args, map, test_function, test_type_def, type_def, value,
+    func_args, test_function, test_type_def, type_def, value,
     vm::{VmArgumentList, VmFunctionClosure},
 };
 pub use diagnostic::DiagnosticMessage;


### PR DESCRIPTION
As discussed in #12695 one of the blockers to adjusting the `Value` type
systemtically is the difficult compiler output around our testing macros. This
commit removes one of those macros -- map! -- in favor of `BTreeMap::from` for
the most part.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
