### PR TITLE
chore: Remove some instances of btreemap! macro

### DIFF
--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -521,7 +521,6 @@ impl std::fmt::Debug for File {
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
-    use vector_common::btreemap;
 
     use super::*;
 
@@ -624,10 +623,10 @@ mod tests {
         };
 
         assert_eq!(
-            Ok(btreemap! {
-                "field1" => "zirp",
-                "field2" => "zurp",
-            }),
+            Ok(BTreeMap::from([
+                (String::from("field1"), Value::from("zirp")),
+                (String::from("field2"), Value::from("zurp")),
+            ])),
             file.find_table_row(Case::Sensitive, &[condition], None, None)
         );
     }
@@ -692,10 +691,10 @@ mod tests {
         };
 
         assert_eq!(
-            Ok(btreemap! {
-                "field1" => "zirp",
-                "field2" => "zurp",
-            }),
+            Ok(BTreeMap::from([
+                (String::from("field1"), Value::from("zirp")),
+                (String::from("field2"), Value::from("zurp")),
+            ])),
             file.find_table_row(Case::Sensitive, &[condition], None, Some(handle))
         );
     }
@@ -717,14 +716,14 @@ mod tests {
 
         assert_eq!(
             Ok(vec![
-                btreemap! {
-                    "field1" => "zip",
-                    "field2" => "zup",
-                },
-                btreemap! {
-                    "field1" => "zip",
-                    "field2" => "zoop",
-                }
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field2"), Value::from("zup")),
+                ]),
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field2"), Value::from("zoop")),
+                ]),
             ]),
             file.find_table_rows(
                 Case::Sensitive,
@@ -777,14 +776,14 @@ mod tests {
 
         assert_eq!(
             Ok(vec![
-                btreemap! {
-                    "field1" => "zip",
-                    "field3" => "zoop",
-                },
-                btreemap! {
-                    "field1" => "zip",
-                    "field3" => "zibble",
-                }
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field3"), Value::from("zoop")),
+                ]),
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field3"), Value::from("zibble")),
+                ]),
             ]),
             file.find_table_rows(
                 Case::Sensitive,
@@ -812,14 +811,14 @@ mod tests {
 
         assert_eq!(
             Ok(vec![
-                btreemap! {
-                    "field1" => "zip",
-                    "field2" => "zup",
-                },
-                btreemap! {
-                    "field1" => "zip",
-                    "field2" => "zoop",
-                }
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field2"), Value::from("zup")),
+                ]),
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field2"), Value::from("zoop")),
+                ]),
             ]),
             file.find_table_rows(
                 Case::Insensitive,
@@ -834,14 +833,14 @@ mod tests {
 
         assert_eq!(
             Ok(vec![
-                btreemap! {
-                    "field1" => "zip",
-                    "field2" => "zup",
-                },
-                btreemap! {
-                    "field1" => "zip",
-                    "field2" => "zoop",
-                }
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field2"), Value::from("zup")),
+                ]),
+                BTreeMap::from([
+                    (String::from("field1"), Value::from("zip")),
+                    (String::from("field2"), Value::from("zoop")),
+                ]),
             ]),
             file.find_table_rows(
                 Case::Insensitive,
@@ -888,10 +887,13 @@ mod tests {
         ];
 
         assert_eq!(
-            Ok(btreemap! {
-                "field1" => "zip",
-                "field2" => Value::Timestamp(chrono::Utc.ymd(2016, 12, 7).and_hms(0, 0, 0)),
-            }),
+            Ok(BTreeMap::from([
+                (String::from("field1"), Value::from("zip")),
+                (
+                    String::from("field2"),
+                    Value::Timestamp(chrono::Utc.ymd(2016, 12, 7).and_hms(0, 0, 0))
+                )
+            ])),
             file.find_table_row(Case::Sensitive, &conditions, None, Some(handle))
         );
     }

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -327,11 +327,12 @@ pub enum TimestampFormat {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use codecs::{
         CharacterDelimitedEncoder, JsonSerializer, NewlineDelimitedEncoder, RawMessageSerializer,
     };
     use indoc::indoc;
-    use vector_common::btreemap;
 
     use super::*;
     use crate::{config::log_schema, sinks::util::encoding::Transformer};
@@ -446,7 +447,7 @@ mod tests {
             log.insert("e[1]", 1);
             log.insert("\"f.z\"", 1);
             log.insert("\"g.z\"", 1);
-            log.insert("h", btreemap! {});
+            log.insert("h", BTreeMap::new());
             log.insert("i", Vec::<Value>::new());
         }
         config.encoding.apply_rules(&mut event);
@@ -537,9 +538,10 @@ mod tests {
         let mut writer = Vec::new();
         let written = encoding
             .encode_input(
-                vec![Event::from(btreemap! {
-                    "key" => "value"
-                })],
+                vec![Event::from(BTreeMap::from([(
+                    String::from("key"),
+                    Value::from("value"),
+                )]))],
                 &mut writer,
             )
             .unwrap();
@@ -562,15 +564,18 @@ mod tests {
         let written = encoding
             .encode_input(
                 vec![
-                    Event::from(btreemap! {
-                        "key" => "value1"
-                    }),
-                    Event::from(btreemap! {
-                        "key" => "value2"
-                    }),
-                    Event::from(btreemap! {
-                        "key" => "value3"
-                    }),
+                    Event::from(BTreeMap::from([(
+                        String::from("key"),
+                        Value::from("value1"),
+                    )])),
+                    Event::from(BTreeMap::from([(
+                        String::from("key"),
+                        Value::from("value2"),
+                    )])),
+                    Event::from(BTreeMap::from([(
+                        String::from("key"),
+                        Value::from("value3"),
+                    )])),
                 ],
                 &mut writer,
             )
@@ -613,9 +618,10 @@ mod tests {
         let mut writer = Vec::new();
         let written = encoding
             .encode_input(
-                vec![Event::from(btreemap! {
-                    "key" => "value"
-                })],
+                vec![Event::from(BTreeMap::from([(
+                    String::from("key"),
+                    Value::from("value"),
+                )]))],
                 &mut writer,
             )
             .unwrap();
@@ -638,15 +644,18 @@ mod tests {
         let written = encoding
             .encode_input(
                 vec![
-                    Event::from(btreemap! {
-                        "key" => "value1"
-                    }),
-                    Event::from(btreemap! {
-                        "key" => "value2"
-                    }),
-                    Event::from(btreemap! {
-                        "key" => "value3"
-                    }),
+                    Event::from(BTreeMap::from([(
+                        String::from("key"),
+                        Value::from("value1"),
+                    )])),
+                    Event::from(BTreeMap::from([(
+                        String::from("key"),
+                        Value::from("value2"),
+                    )])),
+                    Event::from(BTreeMap::from([(
+                        String::from("key"),
+                        Value::from("value3"),
+                    )])),
                 ],
                 &mut writer,
             )
@@ -669,9 +678,10 @@ mod tests {
         let mut writer = Vec::new();
         let written = encoding
             .encode_input(
-                Event::from(btreemap! {
-                    "key" => "value"
-                }),
+                Event::from(BTreeMap::from([(
+                    String::from("key"),
+                    Value::from("value"),
+                )])),
                 &mut writer,
             )
             .unwrap();
@@ -690,9 +700,10 @@ mod tests {
         let mut writer = Vec::new();
         let written = encoding
             .encode_input(
-                Event::from(btreemap! {
-                    "message" => "value"
-                }),
+                Event::from(BTreeMap::from([(
+                    String::from("message"),
+                    Value::from("value"),
+                )])),
                 &mut writer,
             )
             .unwrap();

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -453,12 +453,13 @@ mod tests {
     use bytes::BytesMut;
     use chrono::{DateTime, Utc};
     use rmp_serde::Serializer;
+    use std::collections::BTreeMap;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         time::{error::Elapsed, timeout, Duration},
     };
     use tokio_util::codec::Decoder;
-    use vector_common::{assert_event_data_eq, btreemap};
+    use vector_common::assert_event_data_eq;
     use vector_core::event::Value;
 
     use super::{message::FluentMessageOptions, *};
@@ -491,11 +492,18 @@ mod tests {
             101, 115, 115, 97, 103, 101, 163, 98, 97, 114,
         ];
 
-        let expected = Event::from(btreemap! {
-            "message" => "bar",
-            "tag" => "tag.name",
-            "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z").unwrap().into()),
-        });
+        let expected = Event::from(BTreeMap::from([
+            (String::from("message"), Value::from("bar")),
+            (String::from("tag"), Value::from("tag.name")),
+            (
+                String::from("timestamp"),
+                Value::Timestamp(
+                    DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z")
+                        .unwrap()
+                        .into(),
+                ),
+            ),
+        ]));
         let got = decode_all(message.clone()).unwrap();
         assert_event_data_eq!(got.0[0], expected);
         assert_eq!(got.1, message.len());
@@ -514,11 +522,18 @@ mod tests {
             101, 115, 115, 97, 103, 101, 163, 98, 97, 114, 129, 164, 115, 105, 122, 101, 1,
         ];
 
-        let expected = Event::from(btreemap! {
-            "message" => "bar",
-            "tag" => "tag.name",
-            "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z").unwrap().into()),
-        });
+        let expected = Event::from(BTreeMap::from([
+            (String::from("message"), Value::from("bar")),
+            (String::from("tag"), Value::from("tag.name")),
+            (
+                String::from("timestamp"),
+                Value::Timestamp(
+                    DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z")
+                        .unwrap()
+                        .into(),
+                ),
+            ),
+        ]));
         let got = decode_all(message.clone()).unwrap();
         assert_eq!(got.1, message.len());
         assert_event_data_eq!(got.0[0], expected);
@@ -542,21 +557,42 @@ mod tests {
         ];
 
         let expected = vec![
-            Event::from(btreemap! {
-                "message" => "foo",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "bar",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "baz",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z").unwrap().into()),
-            }),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("foo")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("bar")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("baz")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
         ];
 
         let got = decode_all(message.clone()).unwrap();
@@ -587,21 +623,42 @@ mod tests {
         ];
 
         let expected = vec![
-            Event::from(btreemap! {
-                "message" => "foo",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "bar",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "baz",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z").unwrap().into()),
-            }),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("foo")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("bar")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("baz")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
         ];
 
         let got = decode_all(message.clone()).unwrap();
@@ -633,21 +690,42 @@ mod tests {
         ];
 
         let expected = vec![
-            Event::from(btreemap! {
-                "message" => "foo",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "bar",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "baz",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z").unwrap().into()),
-            }),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("foo")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("bar")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("baz")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
         ];
 
         let got = decode_all(message.clone()).unwrap();
@@ -680,21 +758,42 @@ mod tests {
         ];
 
         let expected = vec![
-            Event::from(btreemap! {
-                "message" => "foo",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "bar",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z").unwrap().into()),
-            }),
-            Event::from(btreemap! {
-                "message" => "baz",
-                "tag" => "tag.name",
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z").unwrap().into()),
-            }),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("foo")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:04Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("bar")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:05Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
+            Event::from(BTreeMap::from([
+                (String::from("message"), Value::from("baz")),
+                (String::from("tag"), Value::from("tag.name")),
+                (
+                    String::from("timestamp"),
+                    Value::Timestamp(
+                        DateTime::parse_from_rfc3339("2015-09-07T01:23:06Z")
+                            .unwrap()
+                            .into(),
+                    ),
+                ),
+            ])),
         ];
 
         let got = decode_all(message.clone()).unwrap();

--- a/src/sources/host_metrics/cpu.rs
+++ b/src/sources/host_metrics/cpu.rs
@@ -1,9 +1,10 @@
+use std::collections::BTreeMap;
+
 use chrono::Utc;
 use futures::{stream, StreamExt};
 #[cfg(target_os = "linux")]
 use heim::cpu::os::linux::CpuTimeExt;
 use heim::units::time::second;
-use vector_common::btreemap;
 
 use super::{filter_result, HostMetrics};
 use crate::event::metric::Metric;
@@ -24,26 +25,38 @@ impl HostMetrics {
                                     name,
                                     timestamp,
                                     times.idle().get::<second>(),
-                                    btreemap! { "mode" => "idle", "cpu" => index.to_string() },
+                                    BTreeMap::from([
+                                        (String::from("mode"), String::from("idle")),
+                                        (String::from("cpu"), index.to_string()),
+                                    ]),
                                 ),
                                 #[cfg(target_os = "linux")]
                                 self.counter(
                                     name,
                                     timestamp,
                                     times.nice().get::<second>(),
-                                    btreemap! { "mode" => "nice", "cpu" => index.to_string() },
+                                    BTreeMap::from([
+                                        (String::from("mode"), String::from("nice")),
+                                        (String::from("cpu"), index.to_string()),
+                                    ]),
                                 ),
                                 self.counter(
                                     name,
                                     timestamp,
                                     times.system().get::<second>(),
-                                    btreemap! { "mode" => "system", "cpu" => index.to_string() },
+                                    BTreeMap::from([
+                                        (String::from("mode"), String::from("system")),
+                                        (String::from("cpu"), index.to_string()),
+                                    ]),
                                 ),
                                 self.counter(
                                     name,
                                     timestamp,
                                     times.user().get::<second>(),
-                                    btreemap! { "mode" => "user", "cpu" => index.to_string() },
+                                    BTreeMap::from([
+                                        (String::from("mode"), String::from("user")),
+                                        (String::from("cpu"), index.to_string()),
+                                    ]),
                                 ),
                             ]
                             .into_iter(),

--- a/src/sources/host_metrics/network.rs
+++ b/src/sources/host_metrics/network.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use chrono::Utc;
 use futures::{stream, StreamExt};
 #[cfg(target_os = "linux")]
@@ -6,7 +8,6 @@ use heim::net::os::linux::IoCountersExt;
 use heim::net::os::windows::IoCountersExt;
 use heim::units::information::byte;
 use serde::{Deserialize, Serialize};
-use vector_common::btreemap;
 
 use super::{filter_result, FilterList, HostMetrics};
 use crate::event::metric::Metric;
@@ -45,45 +46,66 @@ impl HostMetrics {
                                     "network_receive_bytes_total",
                                     timestamp,
                                     counter.bytes_recv().get::<byte>() as f64,
-                                    btreemap! { "device" => interface },
+                                    BTreeMap::from([(
+                                        String::from("device"),
+                                        interface.to_string(),
+                                    )]),
                                 ),
                                 self.counter(
                                     "network_receive_errs_total",
                                     timestamp,
                                     counter.errors_recv() as f64,
-                                    btreemap! { "device" => interface },
+                                    BTreeMap::from([(
+                                        String::from("device"),
+                                        interface.to_string(),
+                                    )]),
                                 ),
                                 self.counter(
                                     "network_receive_packets_total",
                                     timestamp,
                                     counter.packets_recv() as f64,
-                                    btreemap! { "device" => interface },
+                                    BTreeMap::from([(
+                                        String::from("device"),
+                                        interface.to_string(),
+                                    )]),
                                 ),
                                 self.counter(
                                     "network_transmit_bytes_total",
                                     timestamp,
                                     counter.bytes_sent().get::<byte>() as f64,
-                                    btreemap! { "device" => interface },
+                                    BTreeMap::from([(
+                                        String::from("device"),
+                                        interface.to_string(),
+                                    )]),
                                 ),
                                 self.counter(
                                     "network_transmit_errs_total",
                                     timestamp,
                                     counter.errors_sent() as f64,
-                                    btreemap! { "device" => interface },
+                                    BTreeMap::from([(
+                                        String::from("device"),
+                                        interface.to_string(),
+                                    )]),
                                 ),
                                 #[cfg(any(target_os = "linux", target_os = "windows"))]
                                 self.counter(
                                     "network_transmit_packets_drop_total",
                                     timestamp,
                                     counter.drop_sent() as f64,
-                                    btreemap! { "device" => interface },
+                                    BTreeMap::from([(
+                                        String::from("device"),
+                                        interface.to_string(),
+                                    )]),
                                 ),
                                 #[cfg(any(target_os = "linux", target_os = "windows"))]
                                 self.counter(
                                     "network_transmit_packets_total",
                                     timestamp,
                                     counter.packets_sent() as f64,
-                                    btreemap! { "device" => interface },
+                                    BTreeMap::from([(
+                                        String::from("device"),
+                                        interface.to_string(),
+                                    )]),
                                 ),
                             ]
                             .into_iter(),

--- a/src/transforms/remove_tags.rs
+++ b/src/transforms/remove_tags.rs
@@ -74,7 +74,7 @@ impl FunctionTransform for RemoveTags {
 
 #[cfg(test)]
 mod tests {
-    use vector_common::btreemap;
+    use std::collections::BTreeMap;
 
     use super::*;
     use crate::{
@@ -94,14 +94,15 @@ mod tests {
             MetricKind::Incremental,
             MetricValue::Counter { value: 10.0 },
         )
-        .with_tags(Some(btreemap! {
-            "env" => "production",
-            "region" => "us-east-1",
-            "host" => "127.0.0.1",
-        }));
-        let expected = metric
-            .clone()
-            .with_tags(Some(btreemap! {"env" => "production"}));
+        .with_tags(Some(BTreeMap::from([
+            (String::from("env"), String::from("production")),
+            (String::from("region"), String::from("us-east-1")),
+            (String::from("host"), String::from("127.0.0.1")),
+        ])));
+        let expected = metric.clone().with_tags(Some(BTreeMap::from([(
+            String::from("env"),
+            String::from("production"),
+        )])));
 
         let mut transform = RemoveTags::new(vec!["region".into(), "host".into()]);
         let metric = transform_one(&mut transform, metric.into())
@@ -118,7 +119,10 @@ mod tests {
             MetricKind::Incremental,
             MetricValue::Counter { value: 10.0 },
         )
-        .with_tags(Some(btreemap! {"env" => "production"}));
+        .with_tags(Some(BTreeMap::from([(
+            String::from("env"),
+            String::from("production"),
+        )])));
         let expected = metric.clone().with_tags(None);
 
         let mut transform = RemoveTags::new(vec!["env".into()]);


### PR DESCRIPTION
Simliar to #12716 and with reference to #12695 this commit removes some
instances of the btreemap! macro in favor of `BTreeMap::from`. There are many
such instances of this macro and they're not easy to mechanically replace, so
this commit will be followed by others as time allows.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
