### PR TITLE
enhancement!(gcp_stackdriver_logs sink, codecs): Integrate `encoding::Encoder` with `gcp_stackdriver_logs` sink

### DIFF
--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -35,6 +35,11 @@ impl JsonSerializer {
     pub const fn new() -> Self {
         Self
     }
+
+    /// Encode event as JSON.
+    pub fn encode_json(&self, event: Event) -> Result<serde_json::Value, serde_json::Error> {
+        event.try_into()
+    }
 }
 
 impl Encoder<Event> for JsonSerializer {

--- a/lib/codecs/src/encoding/format/native_json.rs
+++ b/lib/codecs/src/encoding/format/native_json.rs
@@ -23,6 +23,13 @@ impl NativeJsonSerializerConfig {
 #[derive(Debug, Clone)]
 pub struct NativeJsonSerializer;
 
+impl NativeJsonSerializer {
+    /// Encode event as native JSON.
+    pub fn encode_json(&self, event: Event) -> Result<serde_json::Value, serde_json::Error> {
+        event.try_into()
+    }
+}
+
 impl Encoder<Event> for NativeJsonSerializer {
     type Error = vector_core::Error;
 

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -241,6 +241,32 @@ pub enum Serializer {
     RawMessage(RawMessageSerializer),
 }
 
+impl Serializer {
+    /// Check if the serializer supports encoding to JSON via `Serializer::encode_json`.
+    pub fn supports_json(&self) -> bool {
+        match self {
+            Serializer::Json(_) | Serializer::NativeJson(_) => true,
+            Serializer::Native(_) | Serializer::RawMessage(_) => false,
+        }
+    }
+
+    /// Encode event as JSON.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the serializer does not support encoding to JSON. Call `Serializer::supports_json`
+    /// if you need to determine the capability to encode to JSON at runtime.
+    pub fn encode_json(&self, event: Event) -> Result<serde_json::Value, serde_json::Error> {
+        match self {
+            Serializer::Json(serializer) => serializer.encode_json(event),
+            Serializer::NativeJson(serializer) => serializer.encode_json(event),
+            Serializer::Native(_) | Serializer::RawMessage(_) => {
+                panic!("Serializer does not support JSON")
+            }
+        }
+    }
+}
+
 impl From<JsonSerializer> for Serializer {
     fn from(serializer: JsonSerializer) -> Self {
         Self::Json(serializer)

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{host_key, Encoding};
+use super::host_key;
 use crate::{
     config::{
         AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
@@ -10,9 +10,12 @@ use crate::{
             common::{
                 acknowledgements::HecClientAcknowledgementsConfig, SplunkHecDefaultBatchSettings,
             },
-            logs::config::HecLogsSinkConfig,
+            logs::config::{HecEncoding, HecEncodingMigrator, HecLogsSinkConfig},
         },
-        util::{encoding::EncodingConfig, BatchConfig, Compression, TowerRequestConfig},
+        util::{
+            encoding::{EncodingConfig, EncodingConfigAdapter},
+            BatchConfig, Compression, TowerRequestConfig,
+        },
         Healthcheck, VectorSink,
     },
     template::Template,
@@ -28,7 +31,8 @@ pub struct HumioLogsConfig {
     #[serde(alias = "host")]
     pub(super) endpoint: Option<String>,
     pub(super) source: Option<Template>,
-    pub(super) encoding: EncodingConfig<Encoding>,
+    #[serde(flatten)]
+    pub(super) encoding: EncodingConfigAdapter<EncodingConfig<HecEncoding>, HecEncodingMigrator>,
     pub(super) event_type: Option<Template>,
     #[serde(default = "host_key")]
     pub(super) host_key: String,
@@ -67,7 +71,7 @@ impl GenerateConfig for HumioLogsConfig {
             token: "${HUMIO_TOKEN}".to_owned(),
             endpoint: None,
             source: None,
-            encoding: Encoding::Json.into(),
+            encoding: EncodingConfig::from(HecEncoding::Json).into(),
             event_type: None,
             indexed_fields: vec![],
             index: None,
@@ -116,7 +120,7 @@ impl HumioLogsConfig {
             sourcetype: self.event_type.clone(),
             source: self.source.clone(),
             timestamp_nanos_key: self.timestamp_nanos_key.clone(),
-            encoding: self.encoding.clone().into_encoding(),
+            encoding: self.encoding.clone(),
             compression: self.compression,
             batch: self.batch,
             request: self.request,
@@ -295,7 +299,7 @@ mod integration_tests {
             token: token.to_string(),
             endpoint: Some(humio_address()),
             source: None,
-            encoding: Encoding::Json.into(),
+            encoding: EncodingConfig::from(HecEncoding::Json).into(),
             event_type: None,
             host_key: log_schema().host_key().to_string(),
             indexed_fields: vec![],

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -5,7 +5,7 @@ use indoc::indoc;
 use serde::{Deserialize, Serialize};
 use vector_core::{sink::StreamSink, transform::Transform};
 
-use super::{host_key, logs::HumioLogsConfig, Encoding};
+use super::{host_key, logs::HumioLogsConfig};
 use crate::{
     config::{
         AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
@@ -13,8 +13,14 @@ use crate::{
     },
     event::{Event, EventArray, EventContainer},
     sinks::{
-        splunk_hec::common::SplunkHecDefaultBatchSettings,
-        util::{encoding::EncodingConfig, BatchConfig, Compression, TowerRequestConfig},
+        splunk_hec::{
+            common::SplunkHecDefaultBatchSettings,
+            logs::config::{HecEncoding, HecEncodingMigrator},
+        },
+        util::{
+            encoding::{EncodingConfig, EncodingConfigAdapter},
+            BatchConfig, Compression, TowerRequestConfig,
+        },
         Healthcheck, VectorSink,
     },
     template::Template,
@@ -31,7 +37,8 @@ struct HumioMetricsConfig {
     #[serde(alias = "host")]
     pub(in crate::sinks::humio) endpoint: Option<String>,
     source: Option<Template>,
-    encoding: EncodingConfig<Encoding>,
+    #[serde(flatten)]
+    encoding: EncodingConfigAdapter<EncodingConfig<HecEncoding>, HecEncodingMigrator>,
     event_type: Option<Template>,
     #[serde(default = "host_key")]
     host_key: String,

--- a/src/sinks/humio/mod.rs
+++ b/src/sinks/humio/mod.rs
@@ -1,26 +1,6 @@
 pub mod logs;
 pub mod metrics;
 
-use serde::{Deserialize, Serialize};
-
-use crate::sinks::splunk_hec;
-
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone)]
-#[serde(rename_all = "snake_case")]
-enum Encoding {
-    Json,
-    Text,
-}
-
-impl From<Encoding> for splunk_hec::logs::encoder::HecLogsEncoder {
-    fn from(v: Encoding) -> Self {
-        match v {
-            Encoding::Json => splunk_hec::logs::encoder::HecLogsEncoder::Json,
-            Encoding::Text => splunk_hec::logs::encoder::HecLogsEncoder::Text,
-        }
-    }
-}
-
 fn host_key() -> String {
     crate::config::log_schema().host_key().to_string()
 }

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use codecs::{encoding::SerializerConfig, JsonSerializerConfig, RawMessageSerializerConfig};
 use futures_util::FutureExt;
 use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
@@ -7,6 +8,7 @@ use vector_core::sink::VectorSink;
 
 use super::{encoder::HecLogsEncoder, request_builder::HecLogsRequestBuilder, sink::HecLogsSink};
 use crate::{
+    codecs::Encoder,
     config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
@@ -17,8 +19,9 @@ use crate::{
             SplunkHecDefaultBatchSettings,
         },
         util::{
-            encoding::EncodingConfig, http::HttpRetryLogic, BatchConfig, Compression,
-            ServiceBuilderExt, TowerRequestConfig,
+            encoding::{EncodingConfig, EncodingConfigAdapter, EncodingConfigMigrator},
+            http::HttpRetryLogic,
+            BatchConfig, Compression, ServiceBuilderExt, TowerRequestConfig,
         },
         Healthcheck,
     },
@@ -26,8 +29,28 @@ use crate::{
     tls::TlsConfig,
 };
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HecEncoding {
+    Json,
+    Text,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HecEncodingMigrator;
+
+impl EncodingConfigMigrator for HecEncodingMigrator {
+    type Codec = HecEncoding;
+
+    fn migrate(codec: &Self::Codec) -> SerializerConfig {
+        match codec {
+            HecEncoding::Text => RawMessageSerializerConfig::new().into(),
+            HecEncoding::Json => JsonSerializerConfig::new().into(),
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
 pub struct HecLogsSinkConfig {
     // Deprecated name
     #[serde(alias = "token")]
@@ -40,7 +63,8 @@ pub struct HecLogsSinkConfig {
     pub index: Option<Template>,
     pub sourcetype: Option<Template>,
     pub source: Option<Template>,
-    pub encoding: EncodingConfig<HecLogsEncoder>,
+    #[serde(flatten)]
+    pub encoding: EncodingConfigAdapter<EncodingConfig<HecEncoding>, HecEncodingMigrator>,
     #[serde(default)]
     pub compression: Compression,
     #[serde(default)]
@@ -64,7 +88,7 @@ impl GenerateConfig for HecLogsSinkConfig {
             index: None,
             sourcetype: None,
             source: None,
-            encoding: HecLogsEncoder::Text.into(),
+            encoding: EncodingConfig::from(HecEncoding::Text).into(),
             compression: Compression::default(),
             batch: BatchConfig::default(),
             request: TowerRequestConfig::default(),
@@ -117,8 +141,15 @@ impl HecLogsSinkConfig {
             None
         };
 
+        let transformer = self.encoding.transformer();
+        let serializer = self.encoding.clone().encoding();
+        let encoder = Encoder::<()>::new(serializer);
+        let encoder = HecLogsEncoder {
+            transformer,
+            encoder,
+        };
         let request_builder = HecLogsRequestBuilder {
-            encoding: self.encoding.clone(),
+            encoder,
             compression: self.compression,
         };
 
@@ -163,7 +194,6 @@ impl HecLogsSinkConfig {
 
 // Add a compatibility alias to avoid breaking existing configs
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 struct HecSinkCompatConfig {
     #[serde(flatten)]
     config: HecLogsSinkConfig,

--- a/src/sinks/splunk_hec/logs/encoder.rs
+++ b/src/sinks/splunk_hec/logs/encoder.rs
@@ -1,26 +1,28 @@
-use std::io;
+use std::borrow::Cow;
 
-use serde::{Deserialize, Serialize};
-use vector_core::{config::log_schema, event::LogEvent};
+use bytes::BytesMut;
+use serde::Serialize;
+use tokio_util::codec::Encoder as _;
 
 use super::sink::HecProcessedEvent;
 use crate::{
+    event::{Event, LogEvent},
     internal_events::SplunkEventEncodeError,
-    sinks::util::encoding::{Encoder, EncodingConfiguration},
+    sinks::util::encoding::{Encoder, Transformer},
 };
 
 #[derive(Serialize, Debug)]
-pub enum HecEvent {
+pub enum HecEvent<'a> {
     #[serde(rename = "event")]
-    Json(LogEvent),
+    Json(serde_json::Value),
     #[serde(rename = "event")]
-    Text(String),
+    Text(Cow<'a, str>),
 }
 
 #[derive(Serialize, Debug)]
-pub struct HecData {
+pub struct HecData<'a> {
     #[serde(flatten)]
-    pub event: HecEvent,
+    pub event: HecEvent<'a>,
     pub fields: LogEvent,
     pub time: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -33,8 +35,8 @@ pub struct HecData {
     pub sourcetype: Option<String>,
 }
 
-impl HecData {
-    pub const fn new(event: HecEvent, fields: LogEvent, time: f64) -> Self {
+impl<'a> HecData<'a> {
+    pub const fn new(event: HecEvent<'a>, fields: LogEvent, time: f64) -> Self {
         Self {
             event,
             fields,
@@ -47,46 +49,10 @@ impl HecData {
     }
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum HecLogsEncoder {
-    Json,
-    Text,
-}
-
-impl Default for HecLogsEncoder {
-    fn default() -> Self {
-        HecLogsEncoder::Text
-    }
-}
-
-impl HecLogsEncoder {
-    pub fn encode_event(&self, processed_event: HecProcessedEvent) -> Option<Vec<u8>> {
-        let log = processed_event.event;
-        let metadata = processed_event.metadata;
-        let event = match self {
-            HecLogsEncoder::Json => HecEvent::Json(log),
-            HecLogsEncoder::Text => HecEvent::Text(
-                log.get(log_schema().message_key())
-                    .map(|v| v.to_string_lossy())
-                    .unwrap_or_else(|| "".to_string()),
-            ),
-        };
-
-        let mut hec_data = HecData::new(event, metadata.fields, metadata.timestamp);
-        hec_data.host = metadata.host.map(|host| host.to_string_lossy());
-        hec_data.index = metadata.index;
-        hec_data.source = metadata.source;
-        hec_data.sourcetype = metadata.sourcetype;
-
-        match serde_json::to_vec(&hec_data) {
-            Ok(value) => Some(value),
-            Err(error) => {
-                emit!(SplunkEventEncodeError { error });
-                None
-            }
-        }
-    }
+#[derive(Debug, Clone)]
+pub struct HecLogsEncoder {
+    pub transformer: Transformer,
+    pub encoder: crate::codecs::Encoder<()>,
 }
 
 impl Encoder<Vec<HecProcessedEvent>> for HecLogsEncoder {
@@ -95,30 +61,46 @@ impl Encoder<Vec<HecProcessedEvent>> for HecLogsEncoder {
         input: Vec<HecProcessedEvent>,
         writer: &mut dyn std::io::Write,
     ) -> std::io::Result<usize> {
+        let mut encoder = self.encoder.clone();
         let encoded_input: Vec<u8> = input
             .into_iter()
-            .filter_map(|e| self.encode_event(e))
+            .filter_map(|processed_event| {
+                let mut event = Event::from(processed_event.event);
+                let metadata = processed_event.metadata;
+                self.transformer.transform(&mut event);
+
+                let mut bytes = BytesMut::new();
+                let serializer = encoder.serializer();
+                let hec_event = if serializer.supports_json() {
+                    HecEvent::Json(
+                        serializer
+                            .encode_json(event)
+                            .map_err(|error| emit!(SplunkEventEncodeError { error }))
+                            .ok()?,
+                    )
+                } else {
+                    encoder.encode(event, &mut bytes).ok()?;
+                    HecEvent::Text(String::from_utf8_lossy(&bytes))
+                };
+
+                let mut hec_data = HecData::new(hec_event, metadata.fields, metadata.timestamp);
+                hec_data.host = metadata.host.map(|host| host.to_string_lossy());
+                hec_data.index = metadata.index;
+                hec_data.source = metadata.source;
+                hec_data.sourcetype = metadata.sourcetype;
+
+                match serde_json::to_vec(&hec_data) {
+                    Ok(value) => Some(value),
+                    Err(error) => {
+                        emit!(SplunkEventEncodeError { error });
+                        None
+                    }
+                }
+            })
             .flatten()
             .collect();
         let encoded_size = encoded_input.len();
         writer.write_all(encoded_input.as_slice())?;
         Ok(encoded_size)
-    }
-}
-
-impl<E> Encoder<Vec<HecProcessedEvent>> for E
-where
-    E: EncodingConfiguration,
-    E::Codec: Encoder<Vec<HecProcessedEvent>>,
-{
-    fn encode_input(
-        &self,
-        mut input: Vec<HecProcessedEvent>,
-        writer: &mut dyn io::Write,
-    ) -> io::Result<usize> {
-        for event in input.iter_mut() {
-            self.apply_rules(event);
-        }
-        self.codec().encode_input(input, writer)
     }
 }

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -12,7 +12,7 @@ use crate::{
                 acknowledgements::HecClientAcknowledgementsConfig,
                 integration_test_helpers::{get_token, splunk_api_address, splunk_hec_address},
             },
-            logs::{config::HecLogsSinkConfig, encoder::HecLogsEncoder},
+            logs::config::{HecEncoding, HecLogsSinkConfig},
         },
         util::{encoding::EncodingConfig, BatchConfig, Compression, TowerRequestConfig},
     },
@@ -94,7 +94,7 @@ async fn find_entries(messages: &[String]) -> bool {
 }
 
 async fn config(
-    encoding: impl Into<EncodingConfig<HecLogsEncoder>>,
+    encoding: impl Into<EncodingConfig<HecEncoding>>,
     indexed_fields: Vec<String>,
 ) -> HecLogsSinkConfig {
     let mut batch = BatchConfig::default();
@@ -108,7 +108,7 @@ async fn config(
         index: None,
         sourcetype: None,
         source: None,
-        encoding: encoding.into(),
+        encoding: encoding.into().into(),
         compression: Compression::None,
         batch,
         request: TowerRequestConfig::default(),
@@ -122,7 +122,7 @@ async fn config(
 async fn splunk_insert_message() {
     let cx = SinkContext::new_test();
 
-    let config = config(HecLogsEncoder::Text, vec![]).await;
+    let config = config(HecEncoding::Text, vec![]).await;
     let (sink, _) = config.build(cx).await.unwrap();
 
     let message = random_string(100);
@@ -144,7 +144,7 @@ async fn splunk_insert_message() {
 async fn splunk_insert_broken_token() {
     let cx = SinkContext::new_test();
 
-    let mut config = config(HecLogsEncoder::Text, vec![]).await;
+    let mut config = config(HecEncoding::Text, vec![]).await;
     config.default_token = "BROKEN_TOKEN".into();
     let (sink, _) = config.build(cx).await.unwrap();
 
@@ -162,7 +162,7 @@ async fn splunk_insert_broken_token() {
 async fn splunk_insert_source() {
     let cx = SinkContext::new_test();
 
-    let mut config = config(HecLogsEncoder::Text, vec![]).await;
+    let mut config = config(HecEncoding::Text, vec![]).await;
     config.source = Template::try_from("/var/log/syslog".to_string()).ok();
 
     let (sink, _) = config.build(cx).await.unwrap();
@@ -180,7 +180,7 @@ async fn splunk_insert_source() {
 async fn splunk_insert_index() {
     let cx = SinkContext::new_test();
 
-    let mut config = config(HecLogsEncoder::Text, vec![]).await;
+    let mut config = config(HecEncoding::Text, vec![]).await;
     config.index = Template::try_from("custom_index".to_string()).ok();
     let (sink, _) = config.build(cx).await.unwrap();
 
@@ -198,7 +198,7 @@ async fn splunk_index_is_interpolated() {
     let cx = SinkContext::new_test();
 
     let indexed_fields = vec!["asdf".to_string()];
-    let mut config = config(HecLogsEncoder::Json, indexed_fields).await;
+    let mut config = config(HecEncoding::Json, indexed_fields).await;
     config.index = Template::try_from("{{ index_name }}".to_string()).ok();
 
     let (sink, _) = config.build(cx).await.unwrap();
@@ -218,7 +218,7 @@ async fn splunk_index_is_interpolated() {
 async fn splunk_insert_many() {
     let cx = SinkContext::new_test();
 
-    let config = config(HecLogsEncoder::Text, vec![]).await;
+    let config = config(HecEncoding::Text, vec![]).await;
     let (sink, _) = config.build(cx).await.unwrap();
 
     let (messages, events) = random_lines_with_stream(100, 10, None);
@@ -232,7 +232,7 @@ async fn splunk_custom_fields() {
     let cx = SinkContext::new_test();
 
     let indexed_fields = vec!["asdf".into()];
-    let config = config(HecLogsEncoder::Json, indexed_fields).await;
+    let config = config(HecEncoding::Json, indexed_fields).await;
     let (sink, _) = config.build(cx).await.unwrap();
 
     let message = random_string(100);
@@ -252,7 +252,7 @@ async fn splunk_hostname() {
     let cx = SinkContext::new_test();
 
     let indexed_fields = vec!["asdf".into()];
-    let config = config(HecLogsEncoder::Json, indexed_fields).await;
+    let config = config(HecEncoding::Json, indexed_fields).await;
     let (sink, _) = config.build(cx).await.unwrap();
 
     let message = random_string(100);
@@ -275,7 +275,7 @@ async fn splunk_sourcetype() {
     let cx = SinkContext::new_test();
 
     let indexed_fields = vec!["asdf".to_string()];
-    let mut config = config(HecLogsEncoder::Json, indexed_fields).await;
+    let mut config = config(HecEncoding::Json, indexed_fields).await;
     config.sourcetype = Template::try_from("_json".to_string()).ok();
 
     let (sink, _) = config.build(cx).await.unwrap();
@@ -300,7 +300,7 @@ async fn splunk_configure_hostname() {
 
     let config = HecLogsSinkConfig {
         host_key: "roast".into(),
-        ..config(HecLogsEncoder::Json, vec!["asdf".to_string()]).await
+        ..config(HecEncoding::Json, vec!["asdf".to_string()]).await
     };
 
     let (sink, _) = config.build(cx).await.unwrap();
@@ -334,7 +334,7 @@ async fn splunk_indexer_acknowledgements() {
     let config = HecLogsSinkConfig {
         default_token: String::from(ACK_TOKEN),
         acknowledgements: acknowledgements_config,
-        ..config(HecLogsEncoder::Json, vec!["asdf".to_string()]).await
+        ..config(HecEncoding::Json, vec!["asdf".to_string()]).await
     };
     let (sink, _) = config.build(cx).await.unwrap();
 
@@ -351,7 +351,7 @@ async fn splunk_indexer_acknowledgements() {
 async fn splunk_indexer_acknowledgements_disabled_on_server() {
     let cx = SinkContext::new_test();
 
-    let config = config(HecLogsEncoder::Json, vec!["asdf".to_string()]).await;
+    let config = config(HecEncoding::Json, vec!["asdf".to_string()]).await;
     let (sink, _) = config.build(cx).await.unwrap();
 
     let (tx, mut rx) = BatchNotifier::new_with_receiver();

--- a/src/sinks/splunk_hec/logs/request_builder.rs
+++ b/src/sinks/splunk_hec/logs/request_builder.rs
@@ -6,18 +6,18 @@ use vector_core::event::{EventFinalizers, Finalizable};
 use super::{encoder::HecLogsEncoder, sink::HecProcessedEvent};
 use crate::sinks::{
     splunk_hec::common::request::HecRequest,
-    util::{encoding::EncodingConfig, Compression, RequestBuilder},
+    util::{Compression, RequestBuilder},
 };
 
 pub struct HecLogsRequestBuilder {
+    pub encoder: HecLogsEncoder,
     pub compression: Compression,
-    pub encoding: EncodingConfig<HecLogsEncoder>,
 }
 
 impl RequestBuilder<(Option<Arc<str>>, Vec<HecProcessedEvent>)> for HecLogsRequestBuilder {
     type Metadata = (usize, usize, EventFinalizers, Option<Arc<str>>);
     type Events = Vec<HecProcessedEvent>;
-    type Encoder = EncodingConfig<HecLogsEncoder>;
+    type Encoder = HecLogsEncoder;
     type Payload = Bytes;
     type Request = HecRequest;
     type Error = std::io::Error;
@@ -27,7 +27,7 @@ impl RequestBuilder<(Option<Arc<str>>, Vec<HecProcessedEvent>)> for HecLogsReque
     }
 
     fn encoder(&self) -> &Self::Encoder {
-        &self.encoding
+        &self.encoder
     }
 
     fn split_input(

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -8,12 +8,21 @@ use vector_core::{
     event::{Event, Value},
 };
 
-use super::sink::HecProcessedEvent;
+use super::{config::HecEncodingMigrator, sink::HecProcessedEvent};
 use crate::{
+    codecs::Encoder,
     config::{SinkConfig, SinkContext},
     sinks::{
-        splunk_hec::logs::{config::HecLogsSinkConfig, encoder::HecLogsEncoder, sink::process_log},
-        util::{test::build_test_server, Compression},
+        splunk_hec::logs::{
+            config::{HecEncoding, HecLogsSinkConfig},
+            encoder::HecLogsEncoder,
+            sink::process_log,
+        },
+        util::{
+            encoding::{Encoder as _, EncodingConfig, EncodingConfigAdapter},
+            test::build_test_server,
+            Compression,
+        },
     },
     template::Template,
     test_util::next_addr,
@@ -96,12 +105,27 @@ fn splunk_process_log_event() {
     assert!(metadata.fields.contains("event_field2"));
 }
 
+fn hec_encoder(encoding: HecEncoding) -> HecLogsEncoder {
+    let encoding: EncodingConfigAdapter<EncodingConfig<HecEncoding>, HecEncodingMigrator> =
+        EncodingConfig::from(encoding).into();
+    let transformer = encoding.transformer();
+    let serializer = encoding.encoding();
+    let encoder = Encoder::<()>::new(serializer);
+    HecLogsEncoder {
+        transformer,
+        encoder,
+    }
+}
+
 #[test]
 fn splunk_encode_log_event_json() {
     let processed_event = get_processed_event();
-    let encoder = HecLogsEncoder::Json;
-    let bytes = encoder.encode_event(processed_event).unwrap();
-    let hec_data = serde_json::from_slice::<HecEventJson>(&bytes[..]).unwrap();
+    let encoder = hec_encoder(HecEncoding::Json);
+    let mut bytes = Vec::new();
+    encoder
+        .encode_input(vec![processed_event], &mut bytes)
+        .unwrap();
+    let hec_data = serde_json::from_slice::<HecEventJson>(&bytes).unwrap();
     let event = hec_data.event;
 
     assert_eq!(event.get("key").unwrap(), &serde_json::Value::from("value"));
@@ -131,9 +155,12 @@ fn splunk_encode_log_event_json() {
 #[test]
 fn splunk_encode_log_event_text() {
     let processed_event = get_processed_event();
-    let encoder = HecLogsEncoder::Text;
-    let bytes = encoder.encode_event(processed_event).unwrap();
-    let hec_data = serde_json::from_slice::<HecEventText>(&bytes[..]).unwrap();
+    let encoder = hec_encoder(HecEncoding::Text);
+    let mut bytes = Vec::new();
+    encoder
+        .encode_input(vec![processed_event], &mut bytes)
+        .unwrap();
+    let hec_data = serde_json::from_slice::<HecEventText>(&bytes).unwrap();
 
     assert_eq!(hec_data.event.as_str(), "hello world");
 
@@ -158,7 +185,7 @@ async fn splunk_passthrough_token() {
         index: None,
         sourcetype: None,
         source: None,
-        encoding: HecLogsEncoder::Json.into(),
+        encoding: EncodingConfig::from(HecEncoding::Json).into(),
         compression: Compression::None,
         batch: Default::default(),
         request: Default::default(),

--- a/src/sinks/util/encoding/config.rs
+++ b/src/sinks/util/encoding/config.rs
@@ -73,7 +73,7 @@ where
     }
 }
 
-#[cfg(any(feature = "sinks-new_relic_logs", feature = "sinks-humio"))]
+#[cfg(any(feature = "sinks-new_relic_logs"))]
 impl<E> EncodingConfig<E> {
     pub(crate) fn into_encoding<X>(self) -> EncodingConfig<X>
     where

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -988,7 +988,7 @@ mod tests {
         config::{log_schema, SinkConfig, SinkContext, SourceConfig, SourceContext},
         event::Event,
         sinks::{
-            splunk_hec::logs::{config::HecLogsSinkConfig, encoder::HecLogsEncoder},
+            splunk_hec::logs::config::{HecEncoding, HecLogsSinkConfig},
             util::{encoding::EncodingConfig, BatchConfig, Compression, TowerRequestConfig},
             Healthcheck, VectorSink,
         },
@@ -1049,7 +1049,7 @@ mod tests {
 
     async fn sink(
         address: SocketAddr,
-        encoding: impl Into<EncodingConfig<HecLogsEncoder>>,
+        encoding: impl Into<EncodingConfig<HecEncoding>>,
         compression: Compression,
     ) -> (VectorSink, Healthcheck) {
         HecLogsSinkConfig {
@@ -1060,7 +1060,7 @@ mod tests {
             index: None,
             sourcetype: None,
             source: None,
-            encoding: encoding.into(),
+            encoding: encoding.into().into(),
             compression,
             batch: BatchConfig::default(),
             request: TowerRequestConfig::default(),
@@ -1074,7 +1074,7 @@ mod tests {
     }
 
     async fn start(
-        encoding: impl Into<EncodingConfig<HecLogsEncoder>>,
+        encoding: impl Into<EncodingConfig<HecEncoding>>,
         compression: Compression,
         acknowledgements: Option<HecAcknowledgementsConfig>,
     ) -> (VectorSink, impl Stream<Item = Event> + Unpin) {
@@ -1177,7 +1177,7 @@ mod tests {
     #[tokio::test]
     async fn no_compression_text_event() {
         let message = "gzip_text_event";
-        let (sink, source) = start(HecLogsEncoder::Text, Compression::None, None).await;
+        let (sink, source) = start(HecEncoding::Text, Compression::None, None).await;
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
 
@@ -1193,7 +1193,7 @@ mod tests {
     #[tokio::test]
     async fn one_simple_text_event() {
         let message = "one_simple_text_event";
-        let (sink, source) = start(HecLogsEncoder::Text, Compression::gzip_default(), None).await;
+        let (sink, source) = start(HecEncoding::Text, Compression::gzip_default(), None).await;
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
 
@@ -1209,7 +1209,7 @@ mod tests {
     #[tokio::test]
     async fn multiple_simple_text_event() {
         let n = 200;
-        let (sink, source) = start(HecLogsEncoder::Text, Compression::None, None).await;
+        let (sink, source) = start(HecEncoding::Text, Compression::None, None).await;
 
         let messages = (0..n)
             .map(|i| format!("multiple_simple_text_event_{}", i))
@@ -1230,7 +1230,7 @@ mod tests {
     #[tokio::test]
     async fn one_simple_json_event() {
         let message = "one_simple_json_event";
-        let (sink, source) = start(HecLogsEncoder::Json, Compression::gzip_default(), None).await;
+        let (sink, source) = start(HecEncoding::Json, Compression::gzip_default(), None).await;
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
 
@@ -1246,7 +1246,7 @@ mod tests {
     #[tokio::test]
     async fn multiple_simple_json_event() {
         let n = 200;
-        let (sink, source) = start(HecLogsEncoder::Json, Compression::gzip_default(), None).await;
+        let (sink, source) = start(HecEncoding::Json, Compression::gzip_default(), None).await;
 
         let messages = (0..n)
             .map(|i| format!("multiple_simple_json_event{}", i))
@@ -1266,7 +1266,7 @@ mod tests {
 
     #[tokio::test]
     async fn json_event() {
-        let (sink, source) = start(HecLogsEncoder::Json, Compression::gzip_default(), None).await;
+        let (sink, source) = start(HecEncoding::Json, Compression::gzip_default(), None).await;
 
         let mut event = Event::new_empty_log();
         event.as_mut_log().insert("greeting", "hello");
@@ -1286,7 +1286,7 @@ mod tests {
 
     #[tokio::test]
     async fn line_to_message() {
-        let (sink, source) = start(HecLogsEncoder::Json, Compression::gzip_default(), None).await;
+        let (sink, source) = start(HecEncoding::Json, Compression::gzip_default(), None).await;
 
         let mut event = Event::new_empty_log();
         event.as_mut_log().insert("line", "hello");
@@ -1512,7 +1512,7 @@ mod tests {
     async fn event_service_token_passthrough_enabled() {
         let message = "passthrough_token_enabled";
         let (source, address) = source_with(None, Some(VALID_TOKENS), None, true).await;
-        let (sink, health) = sink(address, HecLogsEncoder::Text, Compression::gzip_default()).await;
+        let (sink, health) = sink(address, HecEncoding::Text, Compression::gzip_default()).await;
         assert!(health.await.is_ok());
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
@@ -1551,7 +1551,7 @@ mod tests {
     async fn no_authorization() {
         let message = "no_authorization";
         let (source, address) = source_with(None, None, None, false).await;
-        let (sink, health) = sink(address, HecLogsEncoder::Text, Compression::gzip_default()).await;
+        let (sink, health) = sink(address, HecEncoding::Text, Compression::gzip_default()).await;
         assert!(health.await.is_ok());
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
@@ -1565,7 +1565,7 @@ mod tests {
     async fn no_authorization_token_passthrough_enabled() {
         let message = "no_authorization";
         let (source, address) = source_with(None, None, None, true).await;
-        let (sink, health) = sink(address, HecLogsEncoder::Text, Compression::gzip_default()).await;
+        let (sink, health) = sink(address, HecEncoding::Text, Compression::gzip_default()).await;
         assert!(health.await.is_ok());
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
@@ -1739,7 +1739,7 @@ mod tests {
     #[tokio::test]
     async fn host_test() {
         let message = "for the host";
-        let (sink, source) = start(HecLogsEncoder::Text, Compression::gzip_default(), None).await;
+        let (sink, source) = start(HecEncoding::Text, Compression::gzip_default(), None).await;
 
         let event = channel_n(vec![message], sink, source).await.remove(0);
 


### PR DESCRIPTION
Part of #9459.

This is a breaking change since the `encoding` is no longer optional.