### PR TITLE
chore(vrl): add iteration docs

### DIFF
--- a/website/cue/reference/remap/expressions/function_call.cue
+++ b/website/cue/reference/remap/expressions/function_call.cue
@@ -95,7 +95,7 @@ remap: expressions: function_call: {
 					}
 				}
 			}
-			arguments: {
+			closure: {
 				description: """
 					The `closure` is an optional piece of code resolved by the function call. It is primarily used in functions that iterate over collections. Its syntax is as follows:
 

--- a/website/cue/reference/remap/expressions/function_call.cue
+++ b/website/cue/reference/remap/expressions/function_call.cue
@@ -15,7 +15,7 @@ remap: expressions: function_call: {
 
 	grammar: {
 		source: """
-			function ~ abort? ~ "(" ~ arguments? ~ ")"
+			function ~ abort? ~ "(" ~ arguments? ~ ")" ~ closure?
 			"""
 		definitions: {
 			function: {
@@ -94,6 +94,15 @@ remap: expressions: function_call: {
 							"""
 					}
 				}
+			}
+			arguments: {
+				description: """
+					The `closure` is an optional piece of code resolved by the function call. It is primarily used in functions that iterate over collections. Its syntax is as follows:
+
+					```coffee
+					for_each([]) -> |index, value| { ... }
+					```
+					"""
 			}
 		}
 	}

--- a/website/cue/reference/remap/functions/for_each.cue
+++ b/website/cue/reference/remap/functions/for_each.cue
@@ -9,7 +9,7 @@ remap: functions: for_each: {
 		If you have a need for recursive iteration using `for_each`,
 		which can't be solved using the `map_keys` or `map_values`
 		enumeration functions (which *do* support recursion), then
-		please let us know!
+		[please let us know](\(urls.new_feature_request))!
 
 		The function uses the "function closure syntax" to allow reading
 		the key/value or index/value combination for each item in the

--- a/website/cue/reference/remap/functions/for_each.cue
+++ b/website/cue/reference/remap/functions/for_each.cue
@@ -1,8 +1,8 @@
 package metadata
 
 remap: functions: for_each: {
-	category: "Enumerate"
-	description: #"""
+	category:    "Enumerate"
+	description: """
 		Iterate over a collection.
 
 		This function currently *does not* support recursive iteration.
@@ -22,7 +22,7 @@ remap: functions: for_each: {
 		unavailable outside of the block.
 
 		Check out the examples below to learn about the closure syntax.
-		"""#
+		"""
 
 	arguments: [
 		{

--- a/website/cue/reference/remap/functions/for_each.cue
+++ b/website/cue/reference/remap/functions/for_each.cue
@@ -4,6 +4,24 @@ remap: functions: for_each: {
 	category: "Enumerate"
 	description: #"""
 		Iterate over a collection.
+
+		This function currently *does not* support recursive iteration.
+		If you have a need for recursive iteration using `for_each`,
+		which can't be solved using the `map_keys` or `map_values`
+		enumeration functions (which *do* support recursion), then
+		please let us know!
+
+		The function uses the "function closure syntax" to allow reading
+		the key/value or index/value combination for each item in the
+		collection.
+
+		The same scoping rules apply to closure blocks as they do for
+		regular blocks, meaning, any variable defined in parent scopes
+		are accessible, and mutations to those variables are preserved,
+		but any new variables instantiated in the closure block are
+		unavailable outside of the block.
+
+		Check out the examples below to learn about the closure syntax.
 		"""#
 
 	arguments: [
@@ -12,12 +30,6 @@ remap: functions: for_each: {
 			description: "The array or object to iterate."
 			required:    true
 			type: ["array", "object"]
-		},
-		{
-			name:        "recursive"
-			description: "Whether to recursively iterate the collection."
-			required:    false
-			type: ["boolean"]
 		},
 	]
 	internal_failure_reasons: []
@@ -31,17 +43,17 @@ remap: functions: for_each: {
 				tags: ["foo", "bar", "foo", "baz"]
 			}
 			source: #"""
-				.tally = {}
+				tally = {}
 				for_each(array!(.tags)) -> |_index, value| {
 				    # Get the current tally for the `value`, or
 				    # set to `0`.
-				    count = int(get!(.tally, [value])) ?? 0
+				    count = int(get!(tally, [value])) ?? 0
 				
 				    # Increment the tally for the value by `1`.
-				    .tally = set!(.tally, [value], count + 1)
+				    tally = set!(tally, [value], count + 1)
 				}
 				
-				.tally
+				tally
 				"""#
 			return: {"foo": 2, "bar": 1, "baz": 1}
 		},

--- a/website/cue/reference/remap/functions/for_each.cue
+++ b/website/cue/reference/remap/functions/for_each.cue
@@ -1,0 +1,49 @@
+package metadata
+
+remap: functions: for_each: {
+	category: "Enumerate"
+	description: #"""
+		Iterate over a collection.
+		"""#
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The array or object to iterate."
+			required:    true
+			type: ["array", "object"]
+		},
+		{
+			name:        "recursive"
+			description: "Whether to recursively iterate the collection."
+			required:    false
+			type: ["boolean"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["null"]
+	}
+	examples: [
+		{
+			title: "Tally elements"
+			input: log: {
+				tags: ["foo", "bar", "foo", "baz"]
+			}
+			source: #"""
+				.tally = {}
+				for_each(array!(.tags)) -> |_index, value| {
+				    # Get the current tally for the `value`, or
+				    # set to `0`.
+				    count = int(get!(.tally, [value])) ?? 0
+				
+				    # Increment the tally for the value by `1`.
+				    .tally = set!(.tally, [value], count + 1)
+				}
+				
+				.tally
+				"""#
+			return: {"foo": 2, "bar": 1, "baz": 1}
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/map_keys.cue
+++ b/website/cue/reference/remap/functions/map_keys.cue
@@ -1,34 +1,70 @@
 package metadata
 
-remap: functions: map_values: {
+remap: functions: map_keys: {
 	category: "Enumerate"
 	description: #"""
-		Map the values within a collection.
+		Map the keys within an object.
+
+		If `recursive` is enabled, the function iterates into nested
+		objects, using the following rules:
+
+		1. Iteration starts at the root.
+		2. For every nested object type:
+		   - First return the key of the object type itself.
+		   - Then recurse into the object, and loop back to item (1)
+		     in this list.
+		   - Any mutation done on a nested object *before* recursing into
+		     it, are preserved.
+		3. For every nested array type:
+		   - First return the key of the array type itself
+		   - Then find all objects within the array, and apply item (2)
+		     to each individual object.
+
+		Practically speaking, the above rules mean that `map_keys` with
+		`recursive` enabled will find *all* keys in the target,
+		regardless of whether nested objects are nested inside arrays.
+
+		The function uses the "function closure syntax" to allow reading
+		the key for each item in the object.
+
+		The same scoping rules apply to closure blocks as they do for
+		regular blocks, meaning, any variable defined in parent scopes
+		are accessible, and mutations to those variables are preserved,
+		but any new variables instantiated in the closure block are
+		unavailable outside of the block.
+
+		Check out the examples below to learn about the closure syntax.
 		"""#
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The array or object to iterate."
+			description: "The object to iterate."
 			required:    true
-			type: ["array", "object"]
+			type: ["object"]
+		},
+		{
+			name:        "recursive"
+			description: "Whether to recursively iterate the collection."
+			required:    false
+			type: ["boolean"]
 		},
 	]
 	internal_failure_reasons: []
 	return: {
-		types: ["array", "object"]
+		types: ["object"]
 	}
 	examples: [
 		{
-			title: "Upcase values"
+			title: "Upcase keys"
 			input: log: {
 				foo: "foo"
 				bar: "bar"
 			}
 			source: #"""
-				map_values(.) -> |value| { upcase!(value) }
+				map_keys(.) -> |key| { upcase(key) }
 				"""#
-			return: {"foo": "FOO", "bar": "BAR"}
+			return: {"FOO": "foo", "BAR": "bar"}
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/map_keys.cue
+++ b/website/cue/reference/remap/functions/map_keys.cue
@@ -1,0 +1,34 @@
+package metadata
+
+remap: functions: map_values: {
+	category: "Enumerate"
+	description: #"""
+		Map the values within a collection.
+		"""#
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The array or object to iterate."
+			required:    true
+			type: ["array", "object"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["array", "object"]
+	}
+	examples: [
+		{
+			title: "Upcase values"
+			input: log: {
+				foo: "foo"
+				bar: "bar"
+			}
+			source: #"""
+				map_values(.) -> |value| { upcase!(value) }
+				"""#
+			return: {"foo": "FOO", "bar": "BAR"}
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/map_keys.cue
+++ b/website/cue/reference/remap/functions/map_keys.cue
@@ -47,6 +47,7 @@ remap: functions: map_keys: {
 			name:        "recursive"
 			description: "Whether to recursively iterate the collection."
 			required:    false
+			default:     false
 			type: ["boolean"]
 		},
 	]

--- a/website/cue/reference/remap/functions/map_values.cue
+++ b/website/cue/reference/remap/functions/map_values.cue
@@ -3,32 +3,60 @@ package metadata
 remap: functions: map_keys: {
 	category: "Enumerate"
 	description: #"""
-		Map the keys within an object.
+		Map the values within a collection.
+
+		If `recursive` is enabled, the function iterates into nested
+		collections, using the following rules:
+
+		1. Iteration starts at the root.
+		2. For every nested collection type:
+		   - First return the collection type itself.
+		   - Then recurse into the collection, and loop back to item (1)
+		     in the list
+		   - Any mutation done on a collection *before* recursing into it,
+		     are preserved.
+
+		The function uses the "function closure syntax" to allow mutating
+		the value for each item in the collection.
+
+		The same scoping rules apply to closure blocks as they do for
+		regular blocks, meaning, any variable defined in parent scopes
+		are accessible, and mutations to those variables are preserved,
+		but any new variables instantiated in the closure block are
+		unavailable outside of the block.
+
+		Check out the examples below to learn about the closure syntax.
 		"""#
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The object to iterate."
+			description: "The object or array to iterate."
 			required:    true
-			type: ["object"]
+			type: ["array", "object"]
+		},
+		{
+			name:        "recursive"
+			description: "Whether to recursively iterate the collection."
+			required:    false
+			type: ["boolean"]
 		},
 	]
 	internal_failure_reasons: []
 	return: {
-		types: ["object"]
+		types: ["array", "object"]
 	}
 	examples: [
 		{
-			title: "Upcase keys"
+			title: "Upcase values"
 			input: log: {
 				foo: "foo"
 				bar: "bar"
 			}
 			source: #"""
-				map_keys(.) -> |key| { upcase(key) }
+				map_values(.) -> |value| { upcase!(value) }
 				"""#
-			return: {"FOO": "foo", "BAR": "bar"}
+			return: {"foo": "FOO", "bar": "BAR"}
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/map_values.cue
+++ b/website/cue/reference/remap/functions/map_values.cue
@@ -39,6 +39,7 @@ remap: functions: map_keys: {
 			name:        "recursive"
 			description: "Whether to recursively iterate the collection."
 			required:    false
+			default:     false
 			type: ["boolean"]
 		},
 	]

--- a/website/cue/reference/remap/functions/map_values.cue
+++ b/website/cue/reference/remap/functions/map_values.cue
@@ -1,6 +1,6 @@
 package metadata
 
-remap: functions: map_keys: {
+remap: functions: map_values: {
 	category: "Enumerate"
 	description: #"""
 		Map the values within a collection.

--- a/website/cue/reference/remap/functions/map_values.cue
+++ b/website/cue/reference/remap/functions/map_values.cue
@@ -1,0 +1,34 @@
+package metadata
+
+remap: functions: map_keys: {
+	category: "Enumerate"
+	description: #"""
+		Map the keys within an object.
+		"""#
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The object to iterate."
+			required:    true
+			type: ["object"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["object"]
+	}
+	examples: [
+		{
+			title: "Upcase keys"
+			input: log: {
+				foo: "foo"
+				bar: "bar"
+			}
+			source: #"""
+				map_keys(.) -> |key| { upcase(key) }
+				"""#
+			return: {"FOO": "foo", "BAR": "bar"}
+		},
+	]
+}


### PR DESCRIPTION
This PR finalizes the initial version of VRL iteration support by adding docs for the initial three functions:

- `for_each`
- `map_keys`
- `map_values`

There's no special section on "iteration" yet, as I wasn't sure what to put there. Specifically, how iteration behaves depends on independent function implementations and there's no special iteration syntax (there _is_ special function-closure syntax, but I'm unsure how useful it is to document that, as it serves no purpose yet for non-iteration functions).

Curious to hear what others think.

closes #12317 🎉.