### PR TITLE
feat(kubenetes_logs): Annotate logs with node labels

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -494,9 +494,7 @@ async fn metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Set label on all nodes to check it later.
-    framework
-        .label_nodes("label5=foobazbar")
-        .await?;
+    framework.label_nodes("label5=foobazbar").await?;
 
     let test_namespace = framework
         .namespace(namespace::Config::from_namespace(

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -493,6 +493,11 @@ async fn metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
+    // Set label on all nodes to check it later.
+    framework
+        .label_nodes("label5=foobazbar")
+        .await?;
+
     let test_namespace = framework
         .namespace(namespace::Config::from_namespace(
             &namespace::make_namespace(
@@ -574,6 +579,7 @@ async fn metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(val["kubernetes"]["pod_labels"]["label2"], "world");
         assert_eq!(val["kubernetes"]["namespace_labels"]["label3"], "foobar");
         assert_eq!(val["kubernetes"]["namespace_labels"]["label4"], "fizzbuzz");
+        assert_eq!(val["kubernetes"]["node_labels"]["label5"], "foobazbar");
 
         if minor < 16 {
             assert!(val["kubernetes"]["pod_ip"].is_string());

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -168,6 +168,11 @@ impl Framework {
         pod::get_pod_on_node(&self.interface.kubectl_command, namespace, node, service).await
     }
 
+    /// Sets a label on all nodes.
+    pub async fn label_nodes(&self, label: &str) -> Result<String> {
+        pod::label_nodes(&self.interface.kubectl_command, label).await
+    }
+
     /// Return the Vector pod that is deployed on the same node as the given pod. We want to make
     /// sure we are scanning the Vector instance that is deployed with the test pod.
     pub async fn get_vector_pod_with_pod(

--- a/lib/k8s-test-framework/src/pod.rs
+++ b/lib/k8s-test-framework/src/pod.rs
@@ -55,19 +55,21 @@ where
 }
 
 /// Set label on all nodes to discover this label from the pod.
-pub async fn label_nodes<Cmd, Label>(
-    kubectl_command: Cmd,
-    label: Label,
-) -> Result<String>
+pub async fn label_nodes<Cmd, Label>(kubectl_command: Cmd, label: Label) -> Result<String>
 where
     Cmd: AsRef<OsStr>,
     Label: AsRef<OsStr>,
 {
     let mut command = Command::new(&kubectl_command);
-    command.arg("label").arg("node").arg(label).arg("--all").arg("--overwrite");
+    command
+        .arg("label")
+        .arg("node")
+        .arg(label)
+        .arg("--all")
+        .arg("--overwrite");
 
     let res = run_command_output(command).await?;
-    Ok(res.to_string())
+    Ok(res)
 }
 
 pub async fn get_pod_on_node<Cmd, NS>(

--- a/lib/k8s-test-framework/src/pod.rs
+++ b/lib/k8s-test-framework/src/pod.rs
@@ -54,6 +54,22 @@ where
     Ok(node.to_string())
 }
 
+/// Set label on all nodes to discover this label from the pod.
+pub async fn label_nodes<Cmd, Label>(
+    kubectl_command: Cmd,
+    label: Label,
+) -> Result<String>
+where
+    Cmd: AsRef<OsStr>,
+    Label: AsRef<OsStr>,
+{
+    let mut command = Command::new(&kubectl_command);
+    command.arg("label").arg("node").arg(label).arg("--all").arg("--overwrite");
+
+    let res = run_command_output(command).await?;
+    Ok(res.to_string())
+}
+
 pub async fn get_pod_on_node<Cmd, NS>(
     kubectl_command: Cmd,
     namespace: NS,

--- a/scripts/deploy-chart-test.sh
+++ b/scripts/deploy-chart-test.sh
@@ -54,7 +54,7 @@ CUSTOM_HELM_REPO_LOCAL_NAME="${CUSTOM_HELM_REPO_LOCAL_NAME:-"local_repo"}"
 split-container-image() {
   local INPUT="$1"
   CONTAINER_IMAGE_REPOSITORY="${INPUT%:*}"
-  CONTAINER_IMAGE_TAG="${INPUT#*:}"
+  CONTAINER_IMAGE_TAG="${INPUT##*:}"
 }
 
 up() {

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -98,6 +98,31 @@ impl InternalEvent for KubernetesLogsEventNamespaceAnnotationError<'_> {
 }
 
 #[derive(Debug)]
+pub(crate) struct KubernetesLogsEventNodeAnnotationError<'a> {
+    pub event: &'a Event,
+}
+
+impl InternalEvent for KubernetesLogsEventNodeAnnotationError<'_> {
+    fn emit(self) {
+        error!(
+            message = "Failed to annotate event with node metadata.",
+            event = ?self.event,
+            error_code = ANNOTATION_FAILED,
+            error_type = error_type::READER_FAILED,
+            stage = error_stage::PROCESSING,
+            rate_limit_secs = 10,
+        );
+        counter!(
+            "component_errors_total", 1,
+            "error_code" => ANNOTATION_FAILED,
+            "error_type" => error_type::READER_FAILED,
+            "stage" => error_stage::PROCESSING,
+        );
+        counter!("k8s_event_node_annotation_failures_total", 1);
+    }
+}
+
+#[derive(Debug)]
 pub struct KubernetesLogsFormatPickerEdgeCase {
     pub what: &'static str,
 }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -14,7 +14,7 @@ use file_source::{
     ReadFrom,
 };
 use futures_util::Stream;
-use k8s_openapi::api::core::v1::{Namespace, Pod};
+use k8s_openapi::api::core::v1::{Namespace, Node, Pod};
 use kube::{
     api::{Api, ListParams},
     config::{self, KubeConfigOptions},
@@ -37,7 +37,8 @@ use crate::{
     internal_events::{
         BytesReceived, FileSourceInternalEventsEmitter, KubernetesLifecycleError,
         KubernetesLogsEventAnnotationError, KubernetesLogsEventNamespaceAnnotationError,
-        KubernetesLogsEventsReceived, KubernetesLogsPodInfo, StreamClosedError,
+        KubernetesLogsEventNodeAnnotationError, KubernetesLogsEventsReceived,
+        KubernetesLogsPodInfo, StreamClosedError,
     },
     kubernetes::custom_reflector,
     shutdown::ShutdownSignal,
@@ -49,6 +50,7 @@ use crate::{
 mod k8s_paths_provider;
 mod lifecycle;
 mod namespace_metadata_annotator;
+mod node_metadata_annotator;
 mod parser;
 mod partial_events_merger;
 mod path_helpers;
@@ -56,6 +58,7 @@ mod pod_metadata_annotator;
 mod transform_utils;
 mod util;
 
+use crate::sources::kubernetes_logs::node_metadata_annotator::NodeMetadataAnnotator;
 use futures::{future::FutureExt, stream::StreamExt};
 use k8s_paths_provider::K8sPathsProvider;
 use lifecycle::Lifecycle;
@@ -101,6 +104,9 @@ pub struct Config {
 
     /// Specifies the field names for Namespace metadata annotation.
     namespace_annotation_fields: namespace_metadata_annotator::FieldsSpec,
+
+    /// Specifies the field names for Node metadata annotation.
+    node_annotation_fields: node_metadata_annotator::FieldsSpec,
 
     /// A list of glob patterns to exclude from reading the files.
     exclude_paths_glob_patterns: Vec<PathBuf>,
@@ -170,6 +176,7 @@ impl Default for Config {
             data_dir: None,
             pod_annotation_fields: pod_metadata_annotator::FieldsSpec::default(),
             namespace_annotation_fields: namespace_metadata_annotator::FieldsSpec::default(),
+            node_annotation_fields: node_metadata_annotator::FieldsSpec::default(),
             exclude_paths_glob_patterns: default_path_exclusion(),
             max_read_bytes: default_max_read_bytes(),
             max_line_bytes: default_max_line_bytes(),
@@ -217,9 +224,12 @@ struct Source {
     auto_partial_merge: bool,
     pod_fields_spec: pod_metadata_annotator::FieldsSpec,
     namespace_fields_spec: namespace_metadata_annotator::FieldsSpec,
+    node_field_spec: node_metadata_annotator::FieldsSpec,
     field_selector: String,
     label_selector: String,
     namespace_label_selector: String,
+    node_selector: String,
+    self_node_name: String,
     exclude_paths: Vec<glob::Pattern>,
     max_read_bytes: usize,
     max_line_bytes: usize,
@@ -236,10 +246,24 @@ impl Source {
         globals: &GlobalOptions,
         key: &ComponentKey,
     ) -> crate::Result<Self> {
-        let field_selector = prepare_field_selector(config)?;
+        let self_node_name = if config.self_node_name.is_empty()
+            || config.self_node_name == default_self_node_name_env_template()
+        {
+            std::env::var(SELF_NODE_NAME_ENV_KEY).map_err(|_| {
+                format!(
+                    "self_node_name config value or {} env var is not set",
+                    SELF_NODE_NAME_ENV_KEY
+                )
+            })?
+        } else {
+            config.self_node_name.clone()
+        };
+
+        let field_selector = prepare_field_selector(config, self_node_name.as_str())?;
         let label_selector = prepare_label_selector(config.extra_label_selector.as_ref());
         let namespace_label_selector =
             prepare_label_selector(config.extra_namespace_label_selector.as_ref());
+        let node_selector = prepare_node_selector(self_node_name.as_str())?;
 
         // If the user passed a custom Kubeconfig use it, otherwise
         // we attempt to load the local kubec-config, followed by the
@@ -279,9 +303,12 @@ impl Source {
             auto_partial_merge: config.auto_partial_merge,
             pod_fields_spec: config.pod_annotation_fields.clone(),
             namespace_fields_spec: config.namespace_annotation_fields.clone(),
+            node_field_spec: config.node_annotation_fields.clone(),
             field_selector,
             label_selector,
             namespace_label_selector,
+            node_selector,
+            self_node_name,
             exclude_paths,
             max_read_bytes: config.max_read_bytes,
             max_line_bytes: config.max_line_bytes,
@@ -304,9 +331,12 @@ impl Source {
             auto_partial_merge,
             pod_fields_spec,
             namespace_fields_spec,
+            node_field_spec,
             field_selector,
             label_selector,
             namespace_label_selector,
+            node_selector,
+            self_node_name,
             exclude_paths,
             max_read_bytes,
             max_line_bytes,
@@ -339,7 +369,7 @@ impl Source {
 
         // -----------------------------------------------------------------
 
-        let namespaces = Api::<Namespace>::all(client);
+        let namespaces = Api::<Namespace>::all(client.clone());
         let ns_watcher = watcher(
             namespaces,
             ListParams {
@@ -356,10 +386,26 @@ impl Source {
             delay_deletion,
         )));
 
+        // -----------------------------------------------------------------
+
+        let nodes = Api::<Node>::all(client);
+        let node_watcher = watcher(
+            nodes,
+            ListParams {
+                field_selector: Some(node_selector),
+                ..Default::default()
+            },
+        );
+        let node_store_w = reflector::store::Writer::default();
+        let node_state = node_store_w.as_reader();
+
+        tokio::spawn(custom_reflector(node_store_w, node_watcher, delay_deletion));
+
         let paths_provider =
             K8sPathsProvider::new(pod_state.clone(), ns_state.clone(), exclude_paths);
         let annotator = PodMetadataAnnotator::new(pod_state, pod_fields_spec);
         let ns_annotator = NamespaceMetadataAnnotator::new(ns_state, namespace_fields_spec);
+        let node_annotator = NodeMetadataAnnotator::new(node_state, node_field_spec);
 
         // TODO: maybe more of the parameters have to be configurable.
 
@@ -459,6 +505,12 @@ impl Source {
                     if ns_info.is_none() {
                         emit!(KubernetesLogsEventNamespaceAnnotationError { event: &event });
                     }
+                }
+
+                let node_info = node_annotator.annotate(&mut event, self_node_name.as_str());
+
+                if node_info.is_none() {
+                    emit!(KubernetesLogsEventNodeAnnotationError { event: &event });
                 }
             }
 
@@ -606,19 +658,7 @@ fn prepare_exclude_paths(config: &Config) -> crate::Result<Vec<glob::Pattern>> {
 
 // This function constructs the effective field selector to use, based on
 // the specified configuration.
-fn prepare_field_selector(config: &Config) -> crate::Result<String> {
-    let self_node_name = if config.self_node_name.is_empty()
-        || config.self_node_name == default_self_node_name_env_template()
-    {
-        std::env::var(SELF_NODE_NAME_ENV_KEY).map_err(|_| {
-            format!(
-                "self_node_name config value or {} env var is not set",
-                SELF_NODE_NAME_ENV_KEY
-            )
-        })?
-    } else {
-        config.self_node_name.clone()
-    };
+fn prepare_field_selector(config: &Config, self_node_name: &str) -> crate::Result<String> {
     info!(
         message = "Obtained Kubernetes Node name to collect logs for (self).",
         ?self_node_name
@@ -634,6 +674,11 @@ fn prepare_field_selector(config: &Config) -> crate::Result<String> {
         "{},{}",
         field_selector, config.extra_field_selector
     ))
+}
+
+// This function constructs the selector for a node to annotate entries with a node metadata.
+fn prepare_node_selector(self_node_name: &str) -> crate::Result<String> {
+    Ok(format!("metadata.name={}", self_node_name))
 }
 
 // This function constructs the effective label selector to use, based on
@@ -730,7 +775,7 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            let output = super::prepare_field_selector(&input).unwrap();
+            let output = super::prepare_field_selector(&input, "qwe").unwrap();
             assert_eq!(expected, output, "expected left, actual right");
         }
     }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -58,12 +58,12 @@ mod pod_metadata_annotator;
 mod transform_utils;
 mod util;
 
-use futures::{future::FutureExt, stream::StreamExt};
-use k8s_paths_provider::K8sPathsProvider;
-use lifecycle::Lifecycle;
 use self::namespace_metadata_annotator::NamespaceMetadataAnnotator;
 use self::node_metadata_annotator::NodeMetadataAnnotator;
 use self::pod_metadata_annotator::PodMetadataAnnotator;
+use futures::{future::FutureExt, stream::StreamExt};
+use k8s_paths_provider::K8sPathsProvider;
+use lifecycle::Lifecycle;
 
 /// The key we use for `file` field.
 const FILE_KEY: &str = "file";

--- a/src/sources/kubernetes_logs/node_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/node_metadata_annotator.rs
@@ -1,0 +1,136 @@
+//! Annotates events with node metadata.
+
+#![deny(missing_docs)]
+
+use k8s_openapi::{api::core::v1::Node, apimachinery::pkg::apis::meta::v1::ObjectMeta};
+use kube::runtime::reflector::{store::Store, ObjectRef};
+use lookup::lookup_v2::{parse_path, OwnedSegment};
+use serde::{Deserialize, Serialize};
+
+use crate::event::{Event, LogEvent};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields, default)]
+pub struct FieldsSpec {
+    pub node_labels: String,
+}
+
+impl Default for FieldsSpec {
+    fn default() -> Self {
+        Self {
+            node_labels: "kubernetes.node_labels".to_owned(),
+        }
+    }
+}
+
+/// Annotate the event with node metadata.
+pub struct NodeMetadataAnnotator {
+    node_state_reader: Store<Node>,
+    fields_spec: FieldsSpec,
+}
+
+impl NodeMetadataAnnotator {
+    /// Create a new [`NodeMetadataAnnotator`].
+    pub const fn new(node_state_reader: Store<Node>, fields_spec: FieldsSpec) -> Self {
+        Self {
+            node_state_reader,
+            fields_spec,
+        }
+    }
+}
+
+impl NodeMetadataAnnotator {
+    /// Annotates an event with the information from the [`Node::metadata`].
+    /// The event has to have a [`VECTOR_SELF_NODE_NAME`] field set.
+    pub fn annotate(&self, event: &mut Event, node: &str) -> Option<()> {
+        let log = event.as_mut_log();
+        let obj = ObjectRef::<Node>::new(node);
+        let resource = self.node_state_reader.get(&obj)?;
+        let node: &Node = resource.as_ref();
+
+        annotate_from_metadata(log, &self.fields_spec, &node.metadata);
+        Some(())
+    }
+}
+
+fn annotate_from_metadata(log: &mut LogEvent, fields_spec: &FieldsSpec, metadata: &ObjectMeta) {
+    // Calculate and cache the prefix path.
+    let prefix_path = parse_path(&fields_spec.node_labels);
+    if let Some(labels) = &metadata.labels {
+        for (key, val) in labels.iter() {
+            let mut path = prefix_path.clone().segments;
+            path.push(OwnedSegment::Field(key.clone()));
+            log.insert(&path, val.to_owned());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vector_common::assert_event_data_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_annotate_from_metadata() {
+        let cases = vec![
+            (
+                FieldsSpec::default(),
+                ObjectMeta::default(),
+                LogEvent::default(),
+            ),
+            (
+                FieldsSpec::default(),
+                ObjectMeta {
+                    name: Some("sandbox0-name".to_owned()),
+                    uid: Some("sandbox0-uid".to_owned()),
+                    labels: Some(
+                        vec![
+                            ("sandbox0-label0".to_owned(), "val0".to_owned()),
+                            ("sandbox0-label1".to_owned(), "val1".to_owned()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..ObjectMeta::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    log.insert("kubernetes.node_labels.\"sandbox0-label0\"", "val0");
+                    log.insert("kubernetes.node_labels.\"sandbox0-label1\"", "val1");
+                    log
+                },
+            ),
+            (
+                FieldsSpec {
+                    node_labels: "node_labels".to_owned(),
+                },
+                ObjectMeta {
+                    name: Some("sandbox0-name".to_owned()),
+                    uid: Some("sandbox0-uid".to_owned()),
+                    labels: Some(
+                        vec![
+                            ("sandbox0-label0".to_owned(), "val0".to_owned()),
+                            ("sandbox0-label1".to_owned(), "val1".to_owned()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..ObjectMeta::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    log.insert("node_labels.\"sandbox0-label0\"", "val0");
+                    log.insert("node_labels.\"sandbox0-label1\"", "val1");
+                    log
+                },
+            ),
+        ];
+
+        for (fields_spec, metadata, expected) in cases.into_iter() {
+            let mut log = LogEvent::default();
+            annotate_from_metadata(&mut log, &fields_spec, &metadata);
+            assert_event_data_eq!(log, expected);
+        }
+    }
+}

--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -13,8 +13,9 @@ badges:
 Vector's 0.22.0 release includes **breaking changes**:
 
 1. [`gcp_stackdriver_metrics` configuration change](#stackdriver-metrics)
-2. [VRL now supports template strings](#vrl-template-strings)
-3. [`encode_key_value` and `encode_logfmt` quote wrapping behavior change](#encode-key-value-quote-wrapping)
+2. [`kubernetes_logs` source now requires rights to list and watch nodes](#kubernetes-logs-list-watch-nodes)
+3. [VRL now supports template strings](#vrl-template-strings)
+4. [`encode_key_value` and `encode_logfmt` quote wrapping behavior change](#encode-key-value-quote-wrapping)
 
 We cover them below to help you upgrade quickly:
 
@@ -27,6 +28,33 @@ We cover them below to help you upgrade quickly:
 The `gcp_stackdriver_metrics` sink now matches the `gcp_stackdriver_logs`
 configuration, and doesn't require an additional `labels` section to add
 labels to submitted metrics.
+
+#### `kubernetes_logs` source now requires rights to list and watch nodes {#kubernetes-logs-list-watch-nodes}
+
+Logs from Kubernetes pods are now annotated with a node's labels on which a pod is running.
+
+1. For official helm-chart users, upgrade the chart to the version >= [0.10.4](https://github.com/vectordotdev/helm-charts/releases/tag/vector-0.10.4)
+   before upgrading the vector version in your cluster.
+2. For custom vector installations, modify the cluster role assigned to the vector service account to include nodes.
+   The result should look like the following snippet:
+```yaml
+# Permissions to use Kubernetes API.
+# Requires that RBAC authorization is enabled.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+      - pods
+    verbs:
+      - list
+      - watch
+```
 
 ### TOML transform example
 

--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -37,6 +37,7 @@ Logs from Kubernetes pods are now annotated with a node's labels on which a pod 
    before upgrading the vector version in your cluster.
 2. For custom vector installations, modify the cluster role assigned to the vector service account to include nodes.
    The result should look like the following snippet:
+
 ```yaml
 # Permissions to use Kubernetes API.
 # Requires that RBAC authorization is enabled.

--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -33,7 +33,7 @@ labels to submitted metrics.
 
 Logs from Kubernetes pods are now annotated with a node's labels on which a pod is running.
 
-1. For official helm-chart users, upgrade the chart to the version >= [0.10.4](https://github.com/vectordotdev/helm-charts/releases/tag/vector-0.10.4)
+1. For official helm-chart users, upgrade the chart to the version >= [0.11.0](https://github.com/vectordotdev/helm-charts/releases/tag/vector-0.11.0)
    before upgrading the vector version in your cluster.
 2. For custom vector installations, modify the cluster role assigned to the vector service account to include nodes.
    The result should look like the following snippet:

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -167,6 +167,24 @@ components: sources: kubernetes_logs: {
 				}
 			}
 		}
+		node_annotation_fields: {
+			common:      false
+			description: "Configuration for how the events are annotated with Node metadata."
+			required:    false
+			type: object: {
+				examples: []
+				options: {
+					node_labels: {
+						common:      false
+						description: "Event field for Node labels."
+						required:    false
+						type: string: {
+							default: "kubernetes.node_labels"
+						}
+					}
+				}
+			}
+		}
 		auto_partial_merge: {
 			common:      false
 			description: "Automatically merge partial messages into a single event. Partial here is in respect to messages that were split by the Kubernetes Container Runtime log driver."


### PR DESCRIPTION
This PR adds a new feature. With these changes, the vector agent will annotate all entries from kuberenetes_logs sources with node labels.

**NOTE!**: Integrations tests do not work because access rights are required to list and watch node objects. When I faced this issue, I came up with an idea. What if we make nodes (and probably namespaces) annotators lazy-loaded? It will allow users to control each Vector pod's number of watch requests. Maybe this behavior is not explicit enough. I just wanted to share the idea.
***

Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>
Closes https://github.com/vectordotdev/vector/issues/7499
