### PR TITLE
chore(vrl): internal mutability experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9022,6 +9022,7 @@ dependencies = [
  "regex",
  "serde",
  "thiserror",
+ "utf8-width",
  "value",
  "vector_common",
  "vrl-core",

--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -177,7 +177,7 @@ impl Function for FindEnrichmentTableRecords {
         }
     }
 
-    fn call_by_vm(&self, _: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let condition = args.required("condition");
         let condition = condition
             .into_object()
@@ -215,10 +215,7 @@ pub struct FindEnrichmentTableRecordsFn {
 }
 
 impl Expression for FindEnrichmentTableRecordsFn {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         let condition = self
             .condition
             .iter()

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -181,7 +181,7 @@ impl Function for GetEnrichmentTableRecord {
         }
     }
 
-    fn call_by_vm(&self, _: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let condition = args.required("condition");
         let condition = condition
             .into_object()
@@ -219,10 +219,7 @@ pub struct GetEnrichmentTableRecordFn {
 }
 
 impl Expression for GetEnrichmentTableRecordFn {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         let condition = self
             .condition
             .iter()

--- a/lib/vector-vrl-functions/src/get_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/get_metadata_field.rs
@@ -1,7 +1,7 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-fn get_metadata_field(ctx: &mut Context, key: &str) -> Result<Value> {
+fn get_metadata_field(ctx: &Context, key: &str) -> Result<Value> {
     ctx.target()
         .get_metadata(key)
         .map(|value| value.unwrap_or(Value::Null))
@@ -67,7 +67,7 @@ impl Function for GetMetadataField {
         }
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let key = args.required_any("key").downcast_ref::<String>().unwrap();
         get_metadata_field(ctx, key)
     }
@@ -81,7 +81,7 @@ struct GetMetadataFieldFn {
 impl Expression for GetMetadataFieldFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let key = &self.key;
 

--- a/lib/vector-vrl-functions/src/remove_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/remove_metadata_field.rs
@@ -1,7 +1,7 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-fn remove_metadata_field(ctx: &mut Context, key: &str) -> Result<Value> {
+fn remove_metadata_field(ctx: &Context, key: &str) -> Result<Value> {
     ctx.target_mut().remove_metadata(key)?;
     Ok(Value::Null)
 }
@@ -65,7 +65,7 @@ impl Function for RemoveMetadataField {
         }
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let key = args.required_any("key").downcast_ref::<String>().unwrap();
         remove_metadata_field(ctx, key)
     }
@@ -79,7 +79,7 @@ struct RemoveMetadataFieldFn {
 impl Expression for RemoveMetadataFieldFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let key = &self.key;
 

--- a/lib/vector-vrl-functions/src/set_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/set_metadata_field.rs
@@ -1,7 +1,7 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-fn set_metadata_field(ctx: &mut Context, key: &str, value: String) -> Result<Value> {
+fn set_metadata_field(ctx: &Context, key: &str, value: String) -> Result<Value> {
     ctx.target_mut().set_metadata(key, value)?;
     Ok(Value::Null)
 }
@@ -73,7 +73,7 @@ impl Function for SetMetadataField {
         }
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let value = value.try_bytes_utf8_lossy()?.to_string();
         let key = args.required_any("key").downcast_ref::<String>().unwrap();
@@ -91,7 +91,7 @@ struct SetMetadataFieldFn {
 impl Expression for SetMetadataFieldFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         let value = value.try_bytes_utf8_lossy()?.to_string();

--- a/lib/vector-vrl-functions/src/set_semantic_meaning.rs
+++ b/lib/vector-vrl-functions/src/set_semantic_meaning.rs
@@ -80,7 +80,7 @@ impl Function for SetSemanticMeaning {
         Ok(Box::new(SetSemanticMeaningFn))
     }
 
-    fn call_by_vm(&self, _: &mut Context, _: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _: &Context, _: &mut VmArgumentList) -> Result<Value> {
         Ok(Value::Null)
     }
 }
@@ -91,7 +91,7 @@ struct SetSemanticMeaningFn;
 impl Expression for SetSemanticMeaningFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        _: &'ctx mut Context,
+        _: &'ctx Context,
     ) -> Resolved<'value> {
         Ok(Value::Null.into())
     }

--- a/lib/vrl/compiler/src/context.rs
+++ b/lib/vrl/compiler/src/context.rs
@@ -1,16 +1,18 @@
+use std::{cell::RefCell, rc::Rc};
+
 use vector_common::TimeZone;
 
 use crate::{state::Runtime, Target};
 
 pub struct Context<'a> {
-    target: &'a mut dyn Target,
-    state: &'a mut Runtime,
+    target: Rc<RefCell<dyn Target>>,
+    state: RefCell<Runtime>,
     timezone: &'a TimeZone,
 }
 
 impl<'a> Context<'a> {
     /// Create a new [`Context`].
-    pub fn new(target: &'a mut dyn Target, state: &'a mut Runtime, timezone: &'a TimeZone) -> Self {
+    pub fn new(target: Rc<dyn Target>, state: &'a mut Runtime, timezone: &'a TimeZone) -> Self {
         Self {
             target,
             state,

--- a/lib/vrl/compiler/src/context.rs
+++ b/lib/vrl/compiler/src/context.rs
@@ -9,7 +9,7 @@ use crate::{state::Runtime, Target};
 
 pub struct Context<'a> {
     target: Rc<RefCell<dyn Target>>,
-    state: RefCell<Runtime>,
+    state: Rc<RefCell<Runtime>>,
     timezone: &'a TimeZone,
 }
 
@@ -17,7 +17,7 @@ impl<'a> Context<'a> {
     /// Create a new [`Context`].
     pub fn new(
         target: Rc<RefCell<dyn Target>>,
-        state: RefCell<Runtime>,
+        state: Rc<RefCell<Runtime>>,
         timezone: &'a TimeZone,
     ) -> Self {
         Self {

--- a/lib/vrl/compiler/src/context.rs
+++ b/lib/vrl/compiler/src/context.rs
@@ -1,4 +1,7 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+};
 
 use vector_common::TimeZone;
 
@@ -12,7 +15,11 @@ pub struct Context<'a> {
 
 impl<'a> Context<'a> {
     /// Create a new [`Context`].
-    pub fn new(target: Rc<dyn Target>, state: &'a mut Runtime, timezone: &'a TimeZone) -> Self {
+    pub fn new(
+        target: Rc<RefCell<dyn Target>>,
+        state: RefCell<Runtime>,
+        timezone: &'a TimeZone,
+    ) -> Self {
         Self {
             target,
             state,
@@ -21,23 +28,23 @@ impl<'a> Context<'a> {
     }
 
     /// Get a reference to the [`Target`].
-    pub fn target(&self) -> &dyn Target {
-        self.target
+    pub fn target(&self) -> Ref<dyn Target> {
+        self.target.borrow()
     }
 
     /// Get a mutable reference to the [`Target`].
-    pub fn target_mut(&mut self) -> &mut dyn Target {
-        self.target
+    pub fn target_mut(&self) -> RefMut<dyn Target> {
+        self.target.borrow_mut()
     }
 
     /// Get a reference to the [`runtime state`](Runtime).
-    pub fn state(&self) -> &Runtime {
-        self.state
+    pub fn state(&self) -> Ref<Runtime> {
+        self.state.borrow()
     }
 
     /// Get a mutable reference to the [`runtime state`](Runtime).
-    pub fn state_mut(&mut self) -> &mut Runtime {
-        self.state
+    pub fn state_mut(&self) -> RefMut<Runtime> {
+        self.state.borrow_mut()
     }
 
     /// Get a reference to the [`TimeZone`]

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -77,10 +77,7 @@ pub trait Expression: Send + Sync + fmt::Debug + DynClone {
     /// This method is executed at runtime.
     ///
     /// An expression is allowed to fail, which aborts the running program.
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: core::Target>(
-        &'rt self,
-        ctx: &'ctx Context,
-    ) -> Resolved<'value>;
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value>;
 
     /// Compile the expression to bytecode that can be interpreted by the VM.
     fn compile_to_vm(
@@ -239,10 +236,7 @@ impl Expr {
 }
 
 impl Expression for Expr {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         use Expr::*;
 
         match self {

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -77,9 +77,9 @@ pub trait Expression: Send + Sync + fmt::Debug + DynClone {
     /// This method is executed at runtime.
     ///
     /// An expression is allowed to fail, which aborts the running program.
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: core::Target>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value>;
 
     /// Compile the expression to bytecode that can be interpreted by the VM.
@@ -239,9 +239,9 @@ impl Expr {
 }
 
 impl Expression for Expr {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context<T>,
     ) -> Resolved<'value> {
         use Expr::*;
 

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -59,10 +59,7 @@ impl Abort {
 }
 
 impl Expression for Abort {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         let message = self
             .message
             .as_ref()

--- a/lib/vrl/compiler/src/expression/array.rs
+++ b/lib/vrl/compiler/src/expression/array.rs
@@ -29,7 +29,10 @@ impl Deref for Array {
 }
 
 impl Expression for Array {
-    fn resolve<'a, 'b: 'a, 'c: 'b>(&'b self, ctx: &'a mut Context) -> Resolved<'c> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
+        &'rt self,
+        ctx: &'ctx Context<T>,
+    ) -> Resolved<'value> {
         self.inner
             .iter()
             .map(|expr| expr.resolve(ctx).map(Cow::into_owned))

--- a/lib/vrl/compiler/src/expression/array.rs
+++ b/lib/vrl/compiler/src/expression/array.rs
@@ -29,10 +29,7 @@ impl Deref for Array {
 }
 
 impl Expression for Array {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         self.inner
             .iter()
             .map(|expr| expr.resolve(ctx).map(Cow::into_owned))

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -163,10 +163,7 @@ impl Assignment {
 
 impl Expression for Assignment {
     #[inline(always)]
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         self.variant.resolve(ctx)
     }
 
@@ -280,7 +277,7 @@ impl Target {
 
     // FIXME(Jean): Have this take `Cow`, and store the cow for variables, but
     // owned value for external targets.
-    fn insert(&self, value: Value, ctx: &mut Context) {
+    fn insert(&self, value: Value, ctx: &Context) {
         use Target::*;
 
         match self {
@@ -398,10 +395,7 @@ impl<U> Expression for Variant<Target, U>
 where
     U: Expression + Clone,
 {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         use Variant::*;
 
         let value = match self {

--- a/lib/vrl/compiler/src/expression/block.rs
+++ b/lib/vrl/compiler/src/expression/block.rs
@@ -32,10 +32,7 @@ impl Block {
 }
 
 impl Expression for Block {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         // NOTE:
         //
         // Technically, this invalidates the scoping invariant of variables

--- a/lib/vrl/compiler/src/expression/block.rs
+++ b/lib/vrl/compiler/src/expression/block.rs
@@ -32,9 +32,9 @@ impl Block {
 }
 
 impl Expression for Block {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context<T>,
     ) -> Resolved<'value> {
         // NOTE:
         //

--- a/lib/vrl/compiler/src/expression/container.rs
+++ b/lib/vrl/compiler/src/expression/container.rs
@@ -26,10 +26,7 @@ pub enum Variant {
 }
 
 impl Expression for Container {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         use Variant::*;
 
         match &self.variant {

--- a/lib/vrl/compiler/src/expression/container.rs
+++ b/lib/vrl/compiler/src/expression/container.rs
@@ -26,9 +26,9 @@ pub enum Variant {
 }
 
 impl Expression for Container {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context<T>,
     ) -> Resolved<'value> {
         use Variant::*;
 

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -570,10 +570,7 @@ impl FunctionCall {
 }
 
 impl Expression for FunctionCall {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         self.expr.resolve(ctx).map_err(|err| match err {
             #[cfg(feature = "expr-abort")]
             ExpressionError::Abort { .. } => {

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -1199,7 +1199,7 @@ mod tests {
     impl Expression for Fn {
         fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
             &'rt self,
-            _ctx: &'ctx mut Context,
+            _ctx: &'ctx Context,
         ) -> Resolved<'value> {
             todo!()
         }
@@ -1252,7 +1252,7 @@ mod tests {
 
         fn call_by_vm(
             &self,
-            _ctx: &mut Context,
+            _ctx: &Context,
             _args: &mut crate::vm::VmArgumentList,
         ) -> Result<value::Value, ExpressionError> {
             unimplemented!()

--- a/lib/vrl/compiler/src/expression/group.rs
+++ b/lib/vrl/compiler/src/expression/group.rs
@@ -20,10 +20,7 @@ impl Group {
 }
 
 impl Expression for Group {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         self.inner.resolve(ctx)
     }
 

--- a/lib/vrl/compiler/src/expression/group.rs
+++ b/lib/vrl/compiler/src/expression/group.rs
@@ -20,9 +20,9 @@ impl Group {
 }
 
 impl Expression for Group {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context<T>,
     ) -> Resolved<'value> {
         self.inner.resolve(ctx)
     }

--- a/lib/vrl/compiler/src/expression/if_statement.rs
+++ b/lib/vrl/compiler/src/expression/if_statement.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use value::Value;
 
@@ -32,10 +32,7 @@ impl IfStatement {
 }
 
 impl Expression for IfStatement {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         let predicate = self.predicate.resolve(ctx)?.try_boolean()?;
 
         match predicate {
@@ -44,7 +41,7 @@ impl Expression for IfStatement {
                 .alternative
                 .as_ref()
                 .map(|block| block.resolve(ctx))
-                .unwrap_or_else(|| Ok(Value::Null.into())),
+                .unwrap_or_else(|| Ok(Cow::Owned(Value::Null))),
         }
     }
 

--- a/lib/vrl/compiler/src/expression/literal.rs
+++ b/lib/vrl/compiler/src/expression/literal.rs
@@ -48,10 +48,7 @@ impl Literal {
 }
 
 impl Expression for Literal {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, _: &'ctx Context) -> Resolved<'value> {
         use Literal::*;
 
         Ok(match self {

--- a/lib/vrl/compiler/src/expression/literal.rs
+++ b/lib/vrl/compiler/src/expression/literal.rs
@@ -48,9 +48,9 @@ impl Literal {
 }
 
 impl Expression for Literal {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
         &'rt self,
-        _: &'ctx mut Context,
+        ctx: &'ctx Context<T>,
     ) -> Resolved<'value> {
         use Literal::*;
 

--- a/lib/vrl/compiler/src/expression/noop.rs
+++ b/lib/vrl/compiler/src/expression/noop.rs
@@ -13,10 +13,7 @@ use crate::{
 pub struct Noop;
 
 impl Expression for Noop {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        _: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, _: &'ctx Context) -> Resolved<'value> {
         Ok(Cow::Owned(Value::Null))
     }
 

--- a/lib/vrl/compiler/src/expression/noop.rs
+++ b/lib/vrl/compiler/src/expression/noop.rs
@@ -13,9 +13,9 @@ use crate::{
 pub struct Noop;
 
 impl Expression for Noop {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
         &'rt self,
-        _: &'ctx mut Context,
+        _: &'ctx Context<T>,
     ) -> Resolved<'value> {
         Ok(Cow::Owned(Value::Null))
     }

--- a/lib/vrl/compiler/src/expression/not.rs
+++ b/lib/vrl/compiler/src/expression/not.rs
@@ -46,10 +46,7 @@ impl Not {
 }
 
 impl Expression for Not {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         Ok(Value::from(!self.inner.resolve(ctx)?.try_boolean()?).into())
     }
 

--- a/lib/vrl/compiler/src/expression/object.rs
+++ b/lib/vrl/compiler/src/expression/object.rs
@@ -29,10 +29,7 @@ impl Deref for Object {
 }
 
 impl Expression for Object {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         self.inner
             .iter()
             .map(|(key, expr)| expr.resolve(ctx).map(|v| (key.to_owned(), v.into_owned())))

--- a/lib/vrl/compiler/src/expression/object.rs
+++ b/lib/vrl/compiler/src/expression/object.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt, ops::Deref};
+use std::{borrow::Cow, collections::BTreeMap, fmt, ops::Deref};
 
 use value::Value;
 
@@ -29,13 +29,16 @@ impl Deref for Object {
 }
 
 impl Expression for Object {
-    fn resolve<'a, 'b: 'a, 'c: 'b>(&'b self, ctx: &'a mut Context) -> Resolved<'c> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
+        &'rt self,
+        ctx: &'ctx Context<T>,
+    ) -> Resolved<'value> {
         self.inner
             .iter()
             .map(|(key, expr)| expr.resolve(ctx).map(|v| (key.to_owned(), v.into_owned())))
             .collect::<Result<BTreeMap<_, _>, _>>()
             .map(Value::Object)
-            .map(Into::into)
+            .map(Cow::Owned)
     }
 
     fn as_value(&self) -> Option<Value> {

--- a/lib/vrl/compiler/src/expression/predicate.rs
+++ b/lib/vrl/compiler/src/expression/predicate.rs
@@ -66,10 +66,7 @@ impl Predicate {
 }
 
 impl Expression for Predicate {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         let (last, other) = self.inner.split_last().expect("at least one expression");
 
         other

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -81,10 +81,7 @@ impl Query {
 }
 
 impl Expression for Query {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         use Target::*;
 
         let value = match &self.target {

--- a/lib/vrl/compiler/src/expression/unary.rs
+++ b/lib/vrl/compiler/src/expression/unary.rs
@@ -25,10 +25,7 @@ pub enum Variant {
 
 impl Expression for Unary {
     #[inline(always)]
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
-        &'rt self,
-        ctx: &'ctx mut Context,
-    ) -> Resolved<'value> {
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
         use Variant::*;
 
         match &self.variant {

--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -49,9 +49,9 @@ impl Variable {
 }
 
 impl Expression for Variable {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context<T>,
     ) -> Resolved<'value> {
         Ok(ctx
             .state()

--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt};
+use std::{borrow::Cow, fmt, ops::Deref};
 
 use diagnostic::{DiagnosticMessage, Label};
 use lookup::LookupBuf;
@@ -49,14 +49,14 @@ impl Variable {
 }
 
 impl Expression for Variable {
-    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx, T: crate::Target>(
-        &'rt self,
-        ctx: &'ctx Context<T>,
-    ) -> Resolved<'value> {
-        Ok(ctx
-            .state()
+    fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(&'rt self, ctx: &'ctx Context) -> Resolved<'value> {
+        let state = ctx.state();
+
+        Ok(state
+            .deref()
             .variable(&self.ident)
-            .map(Cow::Borrowed)
+            .cloned()
+            .map(Cow::Owned)
             .unwrap_or_else(|| Cow::Owned(Value::Null)))
     }
 

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -80,9 +80,9 @@ pub trait Function: Send + Sync + fmt::Debug {
     }
 
     /// This function is called by the VM.
-    fn call_by_vm<T>(
+    fn call_by_vm(
         &self,
-        _ctx: &Context<T>,
+        _ctx: &Context,
         _args: &mut VmArgumentList,
     ) -> Result<Value, ExpressionError>;
 

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -80,9 +80,9 @@ pub trait Function: Send + Sync + fmt::Debug {
     }
 
     /// This function is called by the VM.
-    fn call_by_vm(
+    fn call_by_vm<T>(
         &self,
-        _ctx: &mut Context,
+        _ctx: &Context<T>,
         _args: &mut VmArgumentList,
     ) -> Result<Value, ExpressionError>;
 

--- a/lib/vrl/compiler/src/function/closure.rs
+++ b/lib/vrl/compiler/src/function/closure.rs
@@ -1,5 +1,5 @@
-use core::{ExpressionError, Target};
-use std::{collections::BTreeMap, marker::PhantomData, ops::DerefMut};
+use core::ExpressionError;
+use std::{collections::BTreeMap, ops::DerefMut};
 
 use parser::ast::Ident;
 use value::{
@@ -141,23 +141,17 @@ impl Output {
     }
 }
 
-pub struct Runner<'a, F, T> {
+pub struct Runner<'a, F> {
     pub(crate) variables: &'a [Ident],
     pub(crate) runner: F,
-    _marker: PhantomData<T>,
 }
 
-impl<'a, F, T> Runner<'a, F, T>
+impl<'a, F> Runner<'a, F>
 where
     F: Fn(&Context) -> Result<Value, ExpressionError>,
-    T: Target,
 {
     pub fn new(variables: &'a [Ident], runner: F) -> Self {
-        Self {
-            variables,
-            runner,
-            _marker: PhantomData,
-        }
+        Self { variables, runner }
     }
 
     /// Run the closure to completion, given the provided key/value pair, and

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -1,5 +1,3 @@
-use core::Target;
-
 use lookup::LookupBuf;
 
 use crate::{

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -1,3 +1,5 @@
+use core::Target;
+
 use lookup::LookupBuf;
 
 use crate::{
@@ -34,7 +36,7 @@ impl Program {
     /// Resolve the program to its final [`Value`].
     pub fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.expressions.resolve(ctx)
     }

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -1,3 +1,4 @@
+use core::Target;
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
 use value::Value;
@@ -301,7 +302,10 @@ impl Vm {
     /// each one.
     /// The VM is stack based. When the `Return` `OpCode` is encountered the top item on the stack is popped and returned.
     /// It is expected that the final instruction is a `Return`.
-    pub fn interpret<'a>(&self, ctx: &mut Context<'a>) -> Result<Value, ExpressionError> {
+    pub fn interpret<'a, T: Target>(
+        &self,
+        ctx: &mut Context<'a, T>,
+    ) -> Result<Value, ExpressionError> {
         // Any mutable state during the run is stored here.
         let mut state: VmState = VmState::new(self);
 

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -302,10 +302,7 @@ impl Vm {
     /// each one.
     /// The VM is stack based. When the `Return` `OpCode` is encountered the top item on the stack is popped and returned.
     /// It is expected that the final instruction is a `Return`.
-    pub fn interpret<'a, T: Target>(
-        &self,
-        ctx: &mut Context<'a>,
-    ) -> Result<Value, ExpressionError> {
+    pub fn interpret<'a>(&self, ctx: &mut Context<'a>) -> Result<Value, ExpressionError> {
         // Any mutable state during the run is stored here.
         let mut state: VmState = VmState::new(self);
 

--- a/lib/vrl/compiler/src/vm/machine.rs
+++ b/lib/vrl/compiler/src/vm/machine.rs
@@ -1,4 +1,3 @@
-use core::Target;
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
 use value::Value;
@@ -302,7 +301,7 @@ impl Vm {
     /// each one.
     /// The VM is stack based. When the `Return` `OpCode` is encountered the top item on the stack is popped and returned.
     /// It is expected that the final instruction is a `Return`.
-    pub fn interpret<'a>(&self, ctx: &mut Context<'a>) -> Result<Value, ExpressionError> {
+    pub fn interpret<'a>(&self, ctx: &Context<'a>) -> Result<Value, ExpressionError> {
         // Any mutable state during the run is stored here.
         let mut state: VmState = VmState::new(self);
 
@@ -704,7 +703,7 @@ where
 /// Sets the value of the given variable to the provided value.
 #[cfg(feature = "expr-assignment")]
 fn set_variable<'a>(
-    ctx: &mut Context<'a>,
+    ctx: &Context<'a>,
     variable: &Variable,
     value: Value,
 ) -> Result<(), ExpressionError> {

--- a/lib/vrl/stdlib/src/append.rs
+++ b/lib/vrl/stdlib/src/append.rs
@@ -51,7 +51,7 @@ impl Function for Append {
         Ok(Box::new(AppendFn { value, items }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let items = args.required("items");
 
@@ -68,7 +68,7 @@ struct AppendFn {
 impl Expression for AppendFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let items = self.items.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/array.rs
+++ b/lib/vrl/stdlib/src/array.rs
@@ -57,7 +57,7 @@ impl Function for Array {
         Ok(Box::new(ArrayFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         check(&value)?;
 
@@ -73,7 +73,7 @@ struct ArrayFn {
 impl Expression for ArrayFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         check(&value)?;

--- a/lib/vrl/stdlib/src/assert.rs
+++ b/lib/vrl/stdlib/src/assert.rs
@@ -78,7 +78,7 @@ impl Function for Assert {
         Ok(Box::new(AssertFn { condition, message }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let condition = args.required("condition");
         let message = args.optional("message");
 
@@ -95,7 +95,7 @@ struct AssertFn {
 impl Expression for AssertFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let condition = self.condition.resolve(ctx)?.into_owned();
         let format = self.condition.format();

--- a/lib/vrl/stdlib/src/assert_eq.rs
+++ b/lib/vrl/stdlib/src/assert_eq.rs
@@ -86,7 +86,7 @@ impl Function for AssertEq {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let left = args.required("left");
         let right = args.required("right");
         let message = args.optional("message");
@@ -105,7 +105,7 @@ struct AssertEqFn {
 impl Expression for AssertEqFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let left = self.left.resolve(ctx)?.into_owned();
         let right = self.right.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/boolean.rs
+++ b/lib/vrl/stdlib/src/boolean.rs
@@ -57,7 +57,7 @@ impl Function for Boolean {
         Ok(Box::new(BooleanFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         check(&value)?;
 
@@ -73,7 +73,7 @@ struct BooleanFn {
 impl Expression for BooleanFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         check(&value)?;

--- a/lib/vrl/stdlib/src/ceil.rs
+++ b/lib/vrl/stdlib/src/ceil.rs
@@ -66,7 +66,7 @@ impl Function for Ceil {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let precision = args.optional("precision");
 
@@ -83,7 +83,7 @@ struct CeilFn {
 impl Expression for CeilFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let precision = self
             .precision

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -145,7 +145,7 @@ impl Function for Compact {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let recursive = args.optional("recursive");
         let null = args.optional("null");
@@ -212,7 +212,7 @@ impl CompactOptions {
 impl Expression for CompactFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let recursive = self
             .recursive

--- a/lib/vrl/stdlib/src/contains.rs
+++ b/lib/vrl/stdlib/src/contains.rs
@@ -80,7 +80,7 @@ impl Function for Contains {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value").try_bytes()?;
         let substring = args.required("substring").try_bytes()?;
         let case_sensitive = args
@@ -102,7 +102,7 @@ struct ContainsFn {
 impl Expression for ContainsFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.try_bytes()?;
         let substring = self.substring.resolve(ctx)?.try_bytes()?;

--- a/lib/vrl/stdlib/src/decode_base64.rs
+++ b/lib/vrl/stdlib/src/decode_base64.rs
@@ -67,7 +67,7 @@ impl Function for DecodeBase64 {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let charset = args.optional("charset");
 
@@ -84,7 +84,7 @@ struct DecodeBase64Fn {
 impl Expression for DecodeBase64Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let charset = self

--- a/lib/vrl/stdlib/src/decode_percent.rs
+++ b/lib/vrl/stdlib/src/decode_percent.rs
@@ -45,7 +45,7 @@ impl Function for DecodePercent {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         decode_percent(value)
@@ -60,7 +60,7 @@ struct DecodePercentFn {
 impl Expression for DecodePercentFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/decrypt.rs
+++ b/lib/vrl/stdlib/src/decrypt.rs
@@ -153,7 +153,7 @@ impl Function for Decrypt {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let ciphertext = args.required("ciphertext");
         let algorithm = args.required("algorithm");
         let key = args.required("key");
@@ -173,7 +173,7 @@ struct DecryptFn {
 impl Expression for DecryptFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let ciphertext = self.ciphertext.resolve(ctx)?.into_owned();
         let algorithm = self.algorithm.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -2,7 +2,7 @@ use ::value::Value;
 use vrl::prelude::*;
 
 #[inline]
-fn del(query: &expression::Query, ctx: &mut Context) -> Result<Value> {
+fn del(query: &expression::Query, ctx: &Context) -> Result<Value> {
     let path = query.path();
 
     if query.is_external() {
@@ -118,7 +118,7 @@ impl Function for Del {
         }
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let query = args
             .required_any("target")
             .downcast_ref::<expression::Query>()
@@ -164,7 +164,7 @@ impl Expression for DelFn {
     // see tracking issue: https://github.com/vectordotdev/vector/issues/5887
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         del(&self.query, ctx).map(Cow::Owned)
     }

--- a/lib/vrl/stdlib/src/downcase.rs
+++ b/lib/vrl/stdlib/src/downcase.rs
@@ -58,7 +58,7 @@ impl Function for Downcase {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value").try_bytes()?;
         Ok(downcase(&value).unwrap_or_else(|| Value::from(value)))
     }
@@ -72,7 +72,7 @@ struct DowncaseFn {
 impl Expression for DowncaseFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         let bytes = value.try_as_bytes()?;

--- a/lib/vrl/stdlib/src/encode_base64.rs
+++ b/lib/vrl/stdlib/src/encode_base64.rs
@@ -75,7 +75,7 @@ impl Function for EncodeBase64 {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let padding = args.optional("padding");
         let charset = args.optional("charset");
@@ -94,7 +94,7 @@ struct EncodeBase64Fn {
 impl Expression for EncodeBase64Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/encode_json.rs
+++ b/lib/vrl/stdlib/src/encode_json.rs
@@ -44,7 +44,7 @@ impl Function for EncodeJson {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         encode_json(value)
     }
@@ -58,7 +58,7 @@ struct EncodeJsonFn {
 impl Expression for EncodeJsonFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         encode_json(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -121,7 +121,7 @@ impl Function for EncodeKeyValue {
 
     fn call_by_vm(
         &self,
-        _ctx: &mut Context,
+        _ctx: &Context,
         args: &mut VmArgumentList,
     ) -> Result<Value, ExpressionError> {
         let value = args.required("value");
@@ -173,7 +173,7 @@ fn resolve_fields(fields: Value) -> Result<Vec<String>, ExpressionError> {
 impl Expression for EncodeKeyValueFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let fields = self

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -65,7 +65,7 @@ impl Function for EncodeLogfmt {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let fields = args.optional("fields_ordering");
 

--- a/lib/vrl/stdlib/src/encode_percent.rs
+++ b/lib/vrl/stdlib/src/encode_percent.rs
@@ -150,7 +150,7 @@ impl Function for EncodePercent {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let ascii_set = args
             .required_any("ascii_set")
@@ -170,7 +170,7 @@ struct EncodePercentFn {
 impl Expression for EncodePercentFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         encode_percent(value, &self.ascii_set).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/encrypt.rs
+++ b/lib/vrl/stdlib/src/encrypt.rs
@@ -213,7 +213,7 @@ impl Function for Encrypt {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let plaintext = args.required("plaintext");
         let algorithm = args.required("algorithm");
         let key = args.required("key");
@@ -233,7 +233,7 @@ struct EncryptFn {
 impl Expression for EncryptFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let plaintext = self.plaintext.resolve(ctx)?.into_owned();
         let algorithm = self.algorithm.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/ends_with.rs
+++ b/lib/vrl/stdlib/src/ends_with.rs
@@ -95,7 +95,7 @@ impl Function for EndsWith {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, arguments: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, arguments: &mut VmArgumentList) -> Result<Value> {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
         let case_sensitive = arguments
@@ -136,7 +136,7 @@ struct EndsWithFn {
 impl Expression for EndsWithFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let case_sensitive = if self.case_sensitive.resolve(ctx)?.try_boolean()? {
             Case::Sensitive

--- a/lib/vrl/stdlib/src/exists.rs
+++ b/lib/vrl/stdlib/src/exists.rs
@@ -57,7 +57,7 @@ impl Function for Exists {
         }
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let field = args
             .required_any("field")
             .downcast_ref::<expression::Query>()
@@ -83,7 +83,7 @@ pub(crate) struct ExistsFn {
     query: expression::Query,
 }
 
-fn exists(query: &expression::Query, ctx: &mut Context) -> Result<Value> {
+fn exists(query: &expression::Query, ctx: &Context) -> Result<Value> {
     let path = query.path();
 
     if query.is_external() {
@@ -115,7 +115,7 @@ fn exists(query: &expression::Query, ctx: &mut Context) -> Result<Value> {
 impl Expression for ExistsFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         exists(&self.query, ctx).map(Cow::Owned)
     }

--- a/lib/vrl/stdlib/src/find.rs
+++ b/lib/vrl/stdlib/src/find.rs
@@ -65,7 +65,7 @@ impl Function for Find {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let pattern = args.required("pattern");
         let from = args.optional("from");
@@ -119,7 +119,7 @@ impl FindFn {
 impl Expression for FindFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let pattern = self.pattern.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/flatten.rs
+++ b/lib/vrl/stdlib/src/flatten.rs
@@ -62,7 +62,7 @@ impl Function for Flatten {
         Ok(Box::new(FlattenFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         flatten(value)
     }
@@ -76,7 +76,7 @@ struct FlattenFn {
 impl Expression for FlattenFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         flatten(self.value.resolve(ctx)?.into_owned()).map(Cow::Owned)
     }

--- a/lib/vrl/stdlib/src/float.rs
+++ b/lib/vrl/stdlib/src/float.rs
@@ -57,7 +57,7 @@ impl Function for Float {
         Ok(Box::new(FloatFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         check(&value)?;
 
@@ -73,7 +73,7 @@ struct FloatFn {
 impl Expression for FloatFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         check(&value)?;

--- a/lib/vrl/stdlib/src/floor.rs
+++ b/lib/vrl/stdlib/src/floor.rs
@@ -66,7 +66,7 @@ impl Function for Floor {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let precision = args.optional("precision");
 
@@ -83,7 +83,7 @@ struct FloorFn {
 impl Expression for FloorFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let precision = self
             .precision

--- a/lib/vrl/stdlib/src/for_each.rs
+++ b/lib/vrl/stdlib/src/for_each.rs
@@ -85,7 +85,7 @@ impl Function for ForEach {
         })
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let VmFunctionClosure { variables, vm } = args.closure();
         let runner = closure::Runner::new(variables, |ctx| vm.interpret(ctx));
@@ -103,7 +103,7 @@ struct ForEachFn {
 impl Expression for ForEachFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let FunctionClosure { variables, block } = &self.closure;

--- a/lib/vrl/stdlib/src/for_each.rs
+++ b/lib/vrl/stdlib/src/for_each.rs
@@ -1,9 +1,9 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-fn for_each<T>(value: Value, ctx: &mut Context, runner: closure::Runner<T>) -> Result<Value>
+fn for_each<T>(value: Value, ctx: &Context, runner: closure::Runner<T>) -> Result<Value>
 where
-    T: Fn(&mut Context) -> Result<Value>,
+    T: Fn(&Context) -> Result<Value>,
 {
     for item in value.into_iter(false) {
         match item {

--- a/lib/vrl/stdlib/src/format_int.rs
+++ b/lib/vrl/stdlib/src/format_int.rs
@@ -80,7 +80,7 @@ impl Function for FormatInt {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let base = args.optional("base");
 
@@ -97,7 +97,7 @@ struct FormatIntFn {
 impl Expression for FormatIntFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/format_number.rs
+++ b/lib/vrl/stdlib/src/format_number.rs
@@ -141,7 +141,7 @@ impl Function for FormatNumber {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let scale = args.optional("scale");
         let decimal_separator = args.optional("decimal_separator");
@@ -162,7 +162,7 @@ struct FormatNumberFn {
 impl Expression for FormatNumberFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/format_timestamp.rs
+++ b/lib/vrl/stdlib/src/format_timestamp.rs
@@ -56,7 +56,7 @@ impl Function for FormatTimestamp {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let format = args.required("format");
 
@@ -73,7 +73,7 @@ struct FormatTimestampFn {
 impl Expression for FormatTimestampFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.format.resolve(ctx)?.into_owned();
         let ts = self.value.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/get_env_var.rs
+++ b/lib/vrl/stdlib/src/get_env_var.rs
@@ -43,7 +43,7 @@ impl Function for GetEnvVar {
         Ok(Box::new(GetEnvVarFn { name }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let name = args.required("name");
         get_env_var(name)
     }
@@ -57,7 +57,7 @@ struct GetEnvVarFn {
 impl Expression for GetEnvVarFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.name.resolve(ctx)?.into_owned();
         get_env_var(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/get_hostname.rs
+++ b/lib/vrl/stdlib/src/get_hostname.rs
@@ -32,7 +32,7 @@ impl Function for GetHostname {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, _args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, _args: &mut VmArgumentList) -> Result<Value> {
         get_hostname()
     }
 }
@@ -43,7 +43,7 @@ struct GetHostnameFn;
 impl Expression for GetHostnameFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        _: &'ctx mut Context,
+        _: &'ctx Context,
     ) -> Resolved<'value> {
         get_hostname().map(Cow::Owned)
     }

--- a/lib/vrl/stdlib/src/includes.rs
+++ b/lib/vrl/stdlib/src/includes.rs
@@ -57,7 +57,7 @@ impl Function for Includes {
         Ok(Box::new(IncludesFn { value, item }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let item = args.required("item");
 
@@ -74,7 +74,7 @@ struct IncludesFn {
 impl Expression for IncludesFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let list = self.value.resolve(ctx)?.into_owned();
         let item = self.item.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/integer.rs
+++ b/lib/vrl/stdlib/src/integer.rs
@@ -57,7 +57,7 @@ impl Function for Integer {
         Ok(Box::new(IntegerFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         check(&value)?;
 
@@ -73,7 +73,7 @@ struct IntegerFn {
 impl Expression for IntegerFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         check(&value)?;

--- a/lib/vrl/stdlib/src/ip_aton.rs
+++ b/lib/vrl/stdlib/src/ip_aton.rs
@@ -46,7 +46,7 @@ impl Function for IpAton {
         Ok(Box::new(IpAtonFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         ip_aton(value)
     }
@@ -60,7 +60,7 @@ struct IpAtonFn {
 impl Expression for IpAtonFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         ip_aton(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/ip_cidr_contains.rs
+++ b/lib/vrl/stdlib/src/ip_cidr_contains.rs
@@ -79,7 +79,7 @@ impl Function for IpCidrContains {
         Ok(Box::new(IpCidrContainsFn { cidr, value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let cidr = args.required("cidr");
         let value = args.required("value");
 
@@ -96,7 +96,7 @@ struct IpCidrContainsFn {
 impl Expression for IpCidrContainsFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let cidr = self.cidr.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -47,7 +47,7 @@ impl Function for IpNtoa {
         Ok(Box::new(IpNtoaFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         ip_ntoa(value)
     }
@@ -61,7 +61,7 @@ struct IpNtoaFn {
 impl Expression for IpNtoaFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         ip_ntoa(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/ip_ntop.rs
+++ b/lib/vrl/stdlib/src/ip_ntop.rs
@@ -61,7 +61,7 @@ impl Function for IpNtop {
         Ok(Box::new(IpNtopFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         ip_ntop(value)
     }
@@ -75,7 +75,7 @@ struct IpNtopFn {
 impl Expression for IpNtopFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         ip_ntop(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/ip_pton.rs
+++ b/lib/vrl/stdlib/src/ip_pton.rs
@@ -60,7 +60,7 @@ impl Function for IpPton {
         Ok(Box::new(IpPtonFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         ip_pton(value)
     }
@@ -74,7 +74,7 @@ struct IpPtonFn {
 impl Expression for IpPtonFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         ip_pton(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/ip_subnet.rs
+++ b/lib/vrl/stdlib/src/ip_subnet.rs
@@ -83,7 +83,7 @@ impl Function for IpSubnet {
         Ok(Box::new(IpSubnetFn { value, subnet }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let subnet = args.required("subnet");
 
@@ -100,7 +100,7 @@ struct IpSubnetFn {
 impl Expression for IpSubnetFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let mask = self.subnet.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/ip_to_ipv6.rs
+++ b/lib/vrl/stdlib/src/ip_to_ipv6.rs
@@ -49,7 +49,7 @@ impl Function for IpToIpv6 {
         Ok(Box::new(IpToIpv6Fn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         ip_to_ipv6(value)
     }
@@ -63,7 +63,7 @@ struct IpToIpv6Fn {
 impl Expression for IpToIpv6Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         ip_to_ipv6(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
+++ b/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
@@ -51,7 +51,7 @@ impl Function for Ipv6ToIpV4 {
         Ok(Box::new(Ipv6ToIpV4Fn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         ipv6_to_ipv4(value)
     }
@@ -65,7 +65,7 @@ struct Ipv6ToIpV4Fn {
 impl Expression for Ipv6ToIpV4Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         ipv6_to_ipv4(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/is_array.rs
+++ b/lib/vrl/stdlib/src/is_array.rs
@@ -47,7 +47,7 @@ impl Function for IsArray {
         Ok(Box::new(IsArrayFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_array()))
     }
 }
@@ -60,7 +60,7 @@ struct IsArrayFn {
 impl Expression for IsArrayFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_boolean.rs
+++ b/lib/vrl/stdlib/src/is_boolean.rs
@@ -47,7 +47,7 @@ impl Function for IsBoolean {
         Ok(Box::new(IsBooleanFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_boolean()))
     }
 }
@@ -60,7 +60,7 @@ struct IsBooleanFn {
 impl Expression for IsBooleanFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_empty.rs
+++ b/lib/vrl/stdlib/src/is_empty.rs
@@ -72,7 +72,7 @@ impl Function for IsEmpty {
         Ok(Box::new(IsEmptyFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         is_empty(value)
     }
@@ -86,7 +86,7 @@ struct IsEmptyFn {
 impl Expression for IsEmptyFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         is_empty(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/is_float.rs
+++ b/lib/vrl/stdlib/src/is_float.rs
@@ -47,7 +47,7 @@ impl Function for IsFloat {
         Ok(Box::new(IsFloatFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_float()))
     }
 }
@@ -60,7 +60,7 @@ struct IsFloatFn {
 impl Expression for IsFloatFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_integer.rs
+++ b/lib/vrl/stdlib/src/is_integer.rs
@@ -47,7 +47,7 @@ impl Function for IsInteger {
         Ok(Box::new(IsIntegerFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_integer()))
     }
 }
@@ -60,7 +60,7 @@ struct IsIntegerFn {
 impl Expression for IsIntegerFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_null.rs
+++ b/lib/vrl/stdlib/src/is_null.rs
@@ -47,7 +47,7 @@ impl Function for IsNull {
         Ok(Box::new(IsNullFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_null()))
     }
 }
@@ -60,7 +60,7 @@ struct IsNullFn {
 impl Expression for IsNullFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_nullish.rs
+++ b/lib/vrl/stdlib/src/is_nullish.rs
@@ -41,7 +41,7 @@ impl Function for IsNullish {
         Ok(Box::new(IsNullishFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         is_nullish(value)
     }
@@ -55,7 +55,7 @@ struct IsNullishFn {
 impl Expression for IsNullishFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         is_nullish(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/is_object.rs
+++ b/lib/vrl/stdlib/src/is_object.rs
@@ -47,7 +47,7 @@ impl Function for IsObject {
         Ok(Box::new(IsObjectFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_object()))
     }
 }
@@ -60,7 +60,7 @@ struct IsObjectFn {
 impl Expression for IsObjectFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_regex.rs
+++ b/lib/vrl/stdlib/src/is_regex.rs
@@ -47,7 +47,7 @@ impl Function for IsRegex {
         Ok(Box::new(IsRegexFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_regex()))
     }
 }
@@ -60,7 +60,7 @@ struct IsRegexFn {
 impl Expression for IsRegexFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_string.rs
+++ b/lib/vrl/stdlib/src/is_string.rs
@@ -47,7 +47,7 @@ impl Function for IsString {
         Ok(Box::new(IsStringFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_bytes()))
     }
 }
@@ -60,7 +60,7 @@ struct IsStringFn {
 impl Expression for IsStringFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/is_timestamp.rs
+++ b/lib/vrl/stdlib/src/is_timestamp.rs
@@ -47,7 +47,7 @@ impl Function for IsTimestamp {
         Ok(Box::new(IsTimestampFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         Ok(value!(args.required("value").is_timestamp()))
     }
 }
@@ -60,7 +60,7 @@ struct IsTimestampFn {
 impl Expression for IsTimestampFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         self.value
             .resolve(ctx)

--- a/lib/vrl/stdlib/src/join.rs
+++ b/lib/vrl/stdlib/src/join.rs
@@ -62,7 +62,7 @@ impl Function for Join {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let separator = args.optional("separator");
 
@@ -79,7 +79,7 @@ struct JoinFn {
 impl Expression for JoinFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let array = self.value.resolve(ctx)?.into_owned();
         let separator = self

--- a/lib/vrl/stdlib/src/length.rs
+++ b/lib/vrl/stdlib/src/length.rs
@@ -63,7 +63,7 @@ impl Function for Length {
         Ok(Box::new(LengthFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         length(value)
     }
@@ -77,7 +77,7 @@ struct LengthFn {
 impl Expression for LengthFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -146,7 +146,7 @@ impl Function for Log {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let info = args
             .required_any("level")
@@ -176,7 +176,7 @@ struct LogFn {
 impl Expression for LogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let rate_limit_secs = match &self.rate_limit_secs {

--- a/lib/vrl/stdlib/src/map_keys.rs
+++ b/lib/vrl/stdlib/src/map_keys.rs
@@ -4,11 +4,11 @@ use vrl::prelude::*;
 fn map_keys<T>(
     value: Value,
     recursive: bool,
-    ctx: &mut Context,
+    ctx: &Context,
     runner: closure::Runner<T>,
 ) -> Result<Value>
 where
-    T: Fn(&mut Context) -> Result<Value>,
+    T: Fn(&Context) -> Result<Value>,
 {
     let mut iter = value.into_iter(recursive);
 

--- a/lib/vrl/stdlib/src/map_keys.rs
+++ b/lib/vrl/stdlib/src/map_keys.rs
@@ -102,7 +102,7 @@ impl Function for MapKeys {
         })
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let recursive = args
             .optional("recursive")
@@ -127,7 +127,7 @@ struct MapKeysFn {
 impl Expression for MapKeysFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let recursive = match &self.recursive {
             None => false,

--- a/lib/vrl/stdlib/src/map_values.rs
+++ b/lib/vrl/stdlib/src/map_values.rs
@@ -101,7 +101,7 @@ impl Function for MapValues {
         })
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let recursive = args
             .optional("recursive")
@@ -126,7 +126,7 @@ struct MapValuesFn {
 impl Expression for MapValuesFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let recursive = match &self.recursive {
             None => false,

--- a/lib/vrl/stdlib/src/map_values.rs
+++ b/lib/vrl/stdlib/src/map_values.rs
@@ -4,11 +4,11 @@ use vrl::prelude::*;
 fn map_values<T>(
     value: Value,
     recursive: bool,
-    ctx: &mut Context,
+    ctx: &Context,
     runner: closure::Runner<T>,
 ) -> Result<Value>
 where
-    T: Fn(&mut Context) -> Result<Value>,
+    T: Fn(&Context) -> Result<Value>,
 {
     let mut iter = value.into_iter(recursive);
 

--- a/lib/vrl/stdlib/src/match.rs
+++ b/lib/vrl/stdlib/src/match.rs
@@ -57,7 +57,7 @@ impl Function for Match {
         Ok(Box::new(MatchFn { value, pattern }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let pattern = args.required("pattern");
 
@@ -74,7 +74,7 @@ pub(crate) struct MatchFn {
 impl Expression for MatchFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let pattern = self.pattern.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -105,7 +105,7 @@ impl Function for MatchAny {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let pattern = args
             .required_any("patterns")
@@ -125,7 +125,7 @@ struct MatchAnyFn {
 impl Expression for MatchAnyFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         match_any(value, &self.regex_set).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/match_array.rs
+++ b/lib/vrl/stdlib/src/match_array.rs
@@ -80,7 +80,7 @@ impl Function for MatchArray {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let pattern = args.required("pattern");
         let all = args.optional("all");
@@ -99,7 +99,7 @@ pub(crate) struct MatchArrayFn {
 impl Expression for MatchArrayFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let list = self.value.resolve(ctx)?.into_owned();
         let pattern = self.pattern.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/match_datadog_query.rs
+++ b/lib/vrl/stdlib/src/match_datadog_query.rs
@@ -111,7 +111,7 @@ impl Function for MatchDatadogQuery {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, arguments: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, arguments: &mut VmArgumentList) -> Result<Value> {
         let value = arguments.required("value");
         let filter = arguments
             .required_any("query")
@@ -146,7 +146,7 @@ struct MatchDatadogQueryFn {
 impl Expression for MatchDatadogQueryFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/md5.rs
+++ b/lib/vrl/stdlib/src/md5.rs
@@ -42,7 +42,7 @@ impl Function for Md5 {
         Ok(Box::new(Md5Fn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         md5(value)
     }
@@ -56,7 +56,7 @@ struct Md5Fn {
 impl Expression for Md5Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         md5(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/merge.rs
+++ b/lib/vrl/stdlib/src/merge.rs
@@ -52,7 +52,7 @@ impl Function for Merge {
         Ok(Box::new(MergeFn { to, from, deep }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, arguments: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, arguments: &mut VmArgumentList) -> Result<Value> {
         let to = arguments.required("to");
         let mut to = to.try_object()?;
         let from = arguments.required("from");
@@ -78,7 +78,7 @@ pub(crate) struct MergeFn {
 impl Expression for MergeFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let mut to_value = self.to.resolve(ctx)?.try_object()?;
         let from_value = self.from.resolve(ctx)?.try_object()?;

--- a/lib/vrl/stdlib/src/now.rs
+++ b/lib/vrl/stdlib/src/now.rs
@@ -26,7 +26,7 @@ impl Function for Now {
         Ok(Box::new(NowFn))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, _args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, _args: &mut VmArgumentList) -> Result<Value> {
         Ok(Utc::now().into())
     }
 }
@@ -37,7 +37,7 @@ struct NowFn;
 impl Expression for NowFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        _: &'ctx mut Context,
+        _: &'ctx Context,
     ) -> Resolved<'value> {
         Ok(Cow::Owned(Utc::now().into()))
     }

--- a/lib/vrl/stdlib/src/object.rs
+++ b/lib/vrl/stdlib/src/object.rs
@@ -57,7 +57,7 @@ impl Function for Object {
         Ok(Box::new(ObjectFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         check(&value)?;
 
@@ -73,7 +73,7 @@ struct ObjectFn {
 impl Expression for ObjectFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         check(&value)?;

--- a/lib/vrl/stdlib/src/only_fields.rs
+++ b/lib/vrl/stdlib/src/only_fields.rs
@@ -45,7 +45,7 @@ pub struct OnlyFieldsFn {
 impl Expression for OnlyFieldsFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let paths = self.paths.iter().map(Path::to_string).collect::<Vec<_>>();
 

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -126,7 +126,7 @@ impl Function for ParseApacheLog {
         ]
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let format = args.required_any("format").downcast_ref::<Bytes>().unwrap();
         let timestamp_format = args.optional("timestamp_format");
@@ -145,7 +145,7 @@ struct ParseApacheLogFn {
 impl Expression for ParseApacheLogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         let timestamp_format = self

--- a/lib/vrl/stdlib/src/parse_aws_alb_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_alb_log.rs
@@ -53,7 +53,7 @@ impl Function for ParseAwsAlbLog {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_aws_alb_log(value)
     }
@@ -73,7 +73,7 @@ impl ParseAwsAlbLogFn {
 impl Expression for ParseAwsAlbLogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         parse_aws_alb_log(bytes).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -88,7 +88,7 @@ impl Function for ParseAwsCloudWatchLogSubscriptionMessage {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_aws_cloudwatch_log_subscription_message(value)
     }
@@ -102,7 +102,7 @@ struct ParseAwsCloudWatchLogSubscriptionMessageFn {
 impl Expression for ParseAwsCloudWatchLogSubscriptionMessageFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         parse_aws_cloudwatch_log_subscription_message(bytes).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
@@ -87,7 +87,7 @@ impl Function for ParseAwsVpcFlowLog {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let format = args.optional("format");
 
@@ -110,7 +110,7 @@ impl ParseAwsVpcFlowLogFn {
 impl Expression for ParseAwsVpcFlowLogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let format = self

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -82,7 +82,7 @@ impl Function for ParseCommonLog {
         }]
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let timestamp_format = args.optional("timestamp_format");
 
@@ -99,7 +99,7 @@ struct ParseCommonLogFn {
 impl Expression for ParseCommonLogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         let timestamp_format = self

--- a/lib/vrl/stdlib/src/parse_csv.rs
+++ b/lib/vrl/stdlib/src/parse_csv.rs
@@ -73,7 +73,7 @@ impl Function for ParseCsv {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let delimiter = args
             .optional("delimiter")
@@ -92,7 +92,7 @@ struct ParseCsvFn {
 impl Expression for ParseCsvFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let csv_string = self.value.resolve(ctx)?.into_owned();
         let delimiter = self.delimiter.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -105,7 +105,7 @@ impl Function for ParseDuration {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let unit = args.required("unit");
 
@@ -122,7 +122,7 @@ struct ParseDurationFn {
 impl Expression for ParseDurationFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         let unit = self.unit.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/parse_glog.rs
+++ b/lib/vrl/stdlib/src/parse_glog.rs
@@ -115,7 +115,7 @@ impl Function for ParseGlog {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_glog(value)
     }
@@ -129,7 +129,7 @@ struct ParseGlogFn {
 impl Expression for ParseGlogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         parse_glog(bytes).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -162,7 +162,7 @@ impl Function for ParseGrok {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let remove_empty = args
             .optional("remove_empty")
@@ -189,7 +189,7 @@ struct ParseGrokFn {
 impl Expression for ParseGrokFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let remove_empty = self.remove_empty.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -172,7 +172,7 @@ impl Function for ParseGroks {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let bytes = value.try_bytes_utf8_lossy()?;
 
@@ -263,7 +263,7 @@ struct ParseGrokFn {
 impl Expression for ParseGrokFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let bytes = value.try_bytes_utf8_lossy()?;

--- a/lib/vrl/stdlib/src/parse_int.rs
+++ b/lib/vrl/stdlib/src/parse_int.rs
@@ -88,7 +88,7 @@ impl Function for ParseInt {
         Ok(Box::new(ParseIntFn { value, base }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let base = args.optional("base");
 
@@ -105,7 +105,7 @@ struct ParseIntFn {
 impl Expression for ParseIntFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let base = self

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -181,7 +181,7 @@ impl Function for ParseJson {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value").try_bytes()?;
         let max_depth = args.optional("max_depth");
 
@@ -201,7 +201,7 @@ struct ParseJsonFn {
 impl Expression for ParseJsonFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.try_bytes()?;
         parse_json(&value).map(Cow::Owned)
@@ -221,7 +221,7 @@ struct ParseJsonMaxDepthFn {
 impl Expression for ParseJsonMaxDepthFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.try_bytes()?;
         let max_depth = self.max_depth.resolve(ctx)?.try_integer()?;

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -163,7 +163,7 @@ impl Function for ParseKeyValue {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let bytes = args.required("value");
         let key_value_delimiter = args
             .optional("key_value_delimiter")
@@ -249,7 +249,7 @@ pub(crate) struct ParseKeyValueFn {
 impl Expression for ParseKeyValueFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         let key_value_delimiter = self.key_value_delimiter.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/parse_klog.rs
+++ b/lib/vrl/stdlib/src/parse_klog.rs
@@ -116,7 +116,7 @@ impl Function for ParseKlog {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_klog(value)
     }
@@ -130,7 +130,7 @@ struct ParseKlogFn {
 impl Expression for ParseKlogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         parse_klog(bytes).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/parse_linux_authorization.rs
+++ b/lib/vrl/stdlib/src/parse_linux_authorization.rs
@@ -45,7 +45,7 @@ impl Function for ParseLinuxAuthorization {
         Ok(Box::new(ParseSyslogFn { value }))
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         super::parse_syslog::parse_syslog(value, ctx)
     }

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -58,7 +58,7 @@ impl Function for ParseLogFmt {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let bytes = args.required("value");
 
         let key_value_delimiter = Value::from("=");

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -115,7 +115,7 @@ impl Function for ParseNginxLog {
         }
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let format = args.required_any("format").downcast_ref::<Bytes>().unwrap();
         let timestamp_format = args.optional("timestamp_format");
@@ -159,7 +159,7 @@ struct ParseNginxLogFn {
 impl Expression for ParseNginxLogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         let timestamp_format = self

--- a/lib/vrl/stdlib/src/parse_query_string.rs
+++ b/lib/vrl/stdlib/src/parse_query_string.rs
@@ -70,7 +70,7 @@ impl Function for ParseQueryString {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_query_string(value)
     }
@@ -84,7 +84,7 @@ struct ParseQueryStringFn {
 impl Expression for ParseQueryStringFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
         parse_query_string(bytes).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/parse_regex.rs
+++ b/lib/vrl/stdlib/src/parse_regex.rs
@@ -111,7 +111,7 @@ impl Function for ParseRegex {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let pattern = args
             .required_any("pattern")
             .downcast_ref::<regex::Regex>()
@@ -137,7 +137,7 @@ pub(crate) struct ParseRegexFn {
 impl Expression for ParseRegexFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let numeric_groups = self.numeric_groups.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/parse_regex_all.rs
+++ b/lib/vrl/stdlib/src/parse_regex_all.rs
@@ -116,7 +116,7 @@ impl Function for ParseRegexAll {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let pattern = args
             .required_any("pattern")
             .downcast_ref::<regex::Regex>()
@@ -142,7 +142,7 @@ pub(crate) struct ParseRegexAllFn {
 impl Expression for ParseRegexAllFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let numeric_groups = self.numeric_groups.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/parse_ruby_hash.rs
+++ b/lib/vrl/stdlib/src/parse_ruby_hash.rs
@@ -62,7 +62,7 @@ impl Function for ParseRubyHash {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_ruby_hash(value)
     }
@@ -76,7 +76,7 @@ struct ParseRubyHashFn {
 impl Expression for ParseRubyHashFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         parse_ruby_hash(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -64,7 +64,7 @@ impl Function for ParseSyslog {
         Ok(Box::new(ParseSyslogFn { value }))
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_syslog(value, ctx)
     }
@@ -78,7 +78,7 @@ pub(crate) struct ParseSyslogFn {
 impl Expression for ParseSyslogFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/parse_timestamp.rs
+++ b/lib/vrl/stdlib/src/parse_timestamp.rs
@@ -59,7 +59,7 @@ impl Function for ParseTimestamp {
         ]
     }
 
-    fn call_by_vm(&self, ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let format = args.required("format");
         parse_timestamp(value, format, ctx)
@@ -75,7 +75,7 @@ struct ParseTimestampFn {
 impl Expression for ParseTimestampFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let format = self.format.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/parse_tokens.rs
+++ b/lib/vrl/stdlib/src/parse_tokens.rs
@@ -52,7 +52,7 @@ impl Function for ParseTokens {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         parse_tokens(value)
     }
@@ -66,7 +66,7 @@ struct ParseTokensFn {
 impl Expression for ParseTokensFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         parse_tokens(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/parse_url.rs
+++ b/lib/vrl/stdlib/src/parse_url.rs
@@ -64,7 +64,7 @@ impl Function for ParseUrl {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, arguments: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, arguments: &mut VmArgumentList) -> Result<Value> {
         let value = arguments.required("value");
         let string = value.try_bytes_utf8_lossy()?;
         let default_known_ports = arguments
@@ -104,7 +104,7 @@ struct ParseUrlFn {
 impl Expression for ParseUrlFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let string = value.try_bytes_utf8_lossy()?;

--- a/lib/vrl/stdlib/src/parse_user_agent.rs
+++ b/lib/vrl/stdlib/src/parse_user_agent.rs
@@ -205,7 +205,7 @@ impl Function for ParseUserAgent {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let string = value.try_bytes_utf8_lossy()?;
         let parser = args
@@ -231,7 +231,7 @@ struct ParseUserAgentFn {
 impl Expression for ParseUserAgentFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let string = value.try_bytes_utf8_lossy()?;

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -191,7 +191,7 @@ impl Function for ParseXml {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         let options = ParseOptions {
@@ -226,7 +226,7 @@ struct ParseXmlFn {
 impl Expression for ParseXmlFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/push.rs
+++ b/lib/vrl/stdlib/src/push.rs
@@ -57,7 +57,7 @@ impl Function for Push {
         Ok(Box::new(PushFn { value, item }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let list = args.required("value");
         let item = args.required("item");
 
@@ -74,7 +74,7 @@ struct PushFn {
 impl Expression for PushFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let list = self.value.resolve(ctx)?.into_owned();
         let item = self.item.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/random_bytes.rs
+++ b/lib/vrl/stdlib/src/random_bytes.rs
@@ -61,7 +61,7 @@ impl Function for RandomBytes {
         Ok(Box::new(RandomBytesFn { length }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let length = args.required("length");
         random_bytes(length)
     }
@@ -86,7 +86,7 @@ struct RandomBytesFn {
 impl Expression for RandomBytesFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let length = self.length.resolve(ctx)?.into_owned();
         random_bytes(length).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/redact.rs
+++ b/lib/vrl/stdlib/src/redact.rs
@@ -137,7 +137,7 @@ impl Function for Redact {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let redactor = Redactor::Full;
         let filters = args
@@ -188,7 +188,7 @@ fn redact(value: Value, filters: &[Filter], redactor: &Redactor) -> Value {
 impl Expression for RedactFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let filters = &self.filters;

--- a/lib/vrl/stdlib/src/remove.rs
+++ b/lib/vrl/stdlib/src/remove.rs
@@ -158,7 +158,7 @@ impl Function for Remove {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let path = args.required("path");
         let compact = args.optional("compact").unwrap_or_else(|| value!(false));
@@ -177,7 +177,7 @@ pub(crate) struct RemoveFn {
 impl Expression for RemoveFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let path = self.path.resolve(ctx)?.into_owned();
         let compact = self.compact.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/replace.rs
+++ b/lib/vrl/stdlib/src/replace.rs
@@ -116,7 +116,7 @@ impl Function for Replace {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let pattern = args.required("pattern");
         let with = args.required("with");
@@ -137,7 +137,7 @@ struct ReplaceFn {
 impl Expression for ReplaceFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let with_value = self.with.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/reverse_dns.rs
+++ b/lib/vrl/stdlib/src/reverse_dns.rs
@@ -49,7 +49,7 @@ impl Function for ReverseDns {
         Ok(Box::new(ReverseDnsFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         reverse_dns(value)
     }
@@ -63,7 +63,7 @@ struct ReverseDnsFn {
 impl Expression for ReverseDnsFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         reverse_dns(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/round.rs
+++ b/lib/vrl/stdlib/src/round.rs
@@ -75,7 +75,7 @@ impl Function for Round {
         Ok(Box::new(RoundFn { value, precision }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let precision = args.optional("precision").unwrap_or_else(|| value!(0));
 
@@ -92,7 +92,7 @@ struct RoundFn {
 impl Expression for RoundFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let precision = self.precision.resolve(ctx)?.into_owned();
         let value = self.value.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/set.rs
+++ b/lib/vrl/stdlib/src/set.rs
@@ -133,7 +133,7 @@ impl Function for Set {
         Ok(Box::new(SetFn { value, path, data }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let path = args.required("path");
         let data = args.required("data");
@@ -152,7 +152,7 @@ pub(crate) struct SetFn {
 impl Expression for SetFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let path = self.path.resolve(ctx)?.into_owned();
         let value = self.value.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/sha1.rs
+++ b/lib/vrl/stdlib/src/sha1.rs
@@ -42,7 +42,7 @@ impl Function for Sha1 {
         Ok(Box::new(Sha1Fn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         sha1(value)
     }
@@ -56,7 +56,7 @@ struct Sha1Fn {
 impl Expression for Sha1Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         sha1(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/sha2.rs
+++ b/lib/vrl/stdlib/src/sha2.rs
@@ -102,7 +102,7 @@ impl Function for Sha2 {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let variant = args
             .required_any("variant")
@@ -122,7 +122,7 @@ struct Sha2Fn {
 impl Expression for Sha2Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let variant = &self.variant;

--- a/lib/vrl/stdlib/src/sha3.rs
+++ b/lib/vrl/stdlib/src/sha3.rs
@@ -98,7 +98,7 @@ impl Function for Sha3 {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let variant = args
             .required_any("variant")
@@ -118,7 +118,7 @@ struct Sha3Fn {
 impl Expression for Sha3Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let variant = &self.variant;

--- a/lib/vrl/stdlib/src/slice.rs
+++ b/lib/vrl/stdlib/src/slice.rs
@@ -101,7 +101,7 @@ impl Function for Slice {
         Ok(Box::new(SliceFn { value, start, end }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let start = args.required("start").try_integer()?;
         let end = args
@@ -123,7 +123,7 @@ struct SliceFn {
 impl Expression for SliceFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let start = self.start.resolve(ctx)?.try_integer()?;
         let end = match &self.end {

--- a/lib/vrl/stdlib/src/split.rs
+++ b/lib/vrl/stdlib/src/split.rs
@@ -90,7 +90,7 @@ impl Function for Split {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let pattern = args.required("pattern");
         let limit = args.optional("limit").unwrap_or_else(|| value!(999999999));
@@ -109,7 +109,7 @@ pub(crate) struct SplitFn {
 impl Expression for SplitFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let limit = self.limit.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/starts_with.rs
+++ b/lib/vrl/stdlib/src/starts_with.rs
@@ -94,7 +94,7 @@ impl Function for StartsWith {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, arguments: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, arguments: &mut VmArgumentList) -> Result<Value> {
         let value = arguments.required("value");
         let substring = arguments.required("substring");
         let case_sensitive = arguments
@@ -135,7 +135,7 @@ struct StartsWithFn {
 impl Expression for StartsWithFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let case_sensitive = if self.case_sensitive.resolve(ctx)?.try_boolean()? {
             Case::Sensitive

--- a/lib/vrl/stdlib/src/string.rs
+++ b/lib/vrl/stdlib/src/string.rs
@@ -57,7 +57,7 @@ impl Function for String {
         Ok(Box::new(StringFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, arguments: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, arguments: &mut VmArgumentList) -> Result<Value> {
         let value = arguments.required("value");
         check(&value)?;
 
@@ -73,7 +73,7 @@ struct StringFn {
 impl Expression for StringFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         check(&value)?;

--- a/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
+++ b/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
@@ -42,7 +42,7 @@ impl Function for StripAnsiEscapeCodes {
         Ok(Box::new(StripAnsiEscapeCodesFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         strip_ansi_escape_codes(value)
     }
@@ -56,7 +56,7 @@ struct StripAnsiEscapeCodesFn {
 impl Expression for StripAnsiEscapeCodesFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let bytes = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/strip_whitespace.rs
+++ b/lib/vrl/stdlib/src/strip_whitespace.rs
@@ -47,7 +47,7 @@ impl Function for StripWhitespace {
         Ok(Box::new(StripWhitespaceFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         Ok(value.try_bytes_utf8_lossy()?.trim().into())
@@ -62,7 +62,7 @@ struct StripWhitespaceFn {
 impl Expression for StripWhitespaceFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         let bytes = value.try_as_bytes()?;

--- a/lib/vrl/stdlib/src/strlen.rs
+++ b/lib/vrl/stdlib/src/strlen.rs
@@ -42,7 +42,7 @@ impl Function for Strlen {
         Ok(Box::new(StrlenFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         strlen(value)
     }
@@ -56,7 +56,7 @@ struct StrlenFn {
 impl Expression for StrlenFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/tag_types_externally.rs
+++ b/lib/vrl/stdlib/src/tag_types_externally.rs
@@ -64,7 +64,7 @@ impl Function for TagTypesExternally {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         Ok(tag_type_externally(value))
     }
@@ -78,7 +78,7 @@ struct TagTypesExternallyFn {
 impl Expression for TagTypesExternallyFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let tagged_externally = tag_type_externally(value);

--- a/lib/vrl/stdlib/src/tally.rs
+++ b/lib/vrl/stdlib/src/tally.rs
@@ -56,7 +56,7 @@ impl Function for Tally {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         tally(value)
     }
@@ -70,7 +70,7 @@ pub(crate) struct TallyFn {
 impl Expression for TallyFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         tally(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/tally_value.rs
+++ b/lib/vrl/stdlib/src/tally_value.rs
@@ -49,7 +49,7 @@ impl Function for TallyValue {
         ]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let array = args.required("array");
         let value = args.required("value");
 
@@ -66,7 +66,7 @@ pub(crate) struct TallyValueFn {
 impl Expression for TallyValueFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let array = self.array.resolve(ctx)?.into_owned();
         let value = self.value.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/timestamp.rs
+++ b/lib/vrl/stdlib/src/timestamp.rs
@@ -57,7 +57,7 @@ impl Function for Timestamp {
         Ok(Box::new(TimestampFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         check(&value)?;
 
@@ -73,7 +73,7 @@ struct TimestampFn {
 impl Expression for TimestampFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         check(&value)?;

--- a/lib/vrl/stdlib/src/to_bool.rs
+++ b/lib/vrl/stdlib/src/to_bool.rs
@@ -159,7 +159,7 @@ impl Function for ToBool {
         Ok(Box::new(ToBoolFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         to_bool(value)
@@ -174,7 +174,7 @@ struct ToBoolFn {
 impl Expression for ToBoolFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -114,7 +114,7 @@ impl Function for ToFloat {
         Ok(Box::new(ToFloatFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         to_float(value)
@@ -129,7 +129,7 @@ struct ToFloatFn {
 impl Expression for ToFloatFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/to_int.rs
+++ b/lib/vrl/stdlib/src/to_int.rs
@@ -113,7 +113,7 @@ impl Function for ToInt {
         Ok(Box::new(ToIntFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         to_int(value)
@@ -128,7 +128,7 @@ struct ToIntFn {
 impl Expression for ToIntFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/to_regex.rs
+++ b/lib/vrl/stdlib/src/to_regex.rs
@@ -45,7 +45,7 @@ impl Function for ToRegex {
         Ok(Box::new(ToRegexFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         to_regex(value)
@@ -60,7 +60,7 @@ struct ToRegexFn {
 impl Expression for ToRegexFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         to_regex(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/to_string.rs
+++ b/lib/vrl/stdlib/src/to_string.rs
@@ -104,7 +104,7 @@ impl Function for ToString {
         Ok(Box::new(ToStringFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
 
         to_string(value)
@@ -119,7 +119,7 @@ struct ToStringFn {
 impl Expression for ToStringFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/to_syslog_facility.rs
+++ b/lib/vrl/stdlib/src/to_syslog_facility.rs
@@ -78,7 +78,7 @@ impl Function for ToSyslogFacility {
         Ok(Box::new(ToSyslogFacilityFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         to_syslog_facility(value)
     }
@@ -92,7 +92,7 @@ struct ToSyslogFacilityFn {
 impl Expression for ToSyslogFacilityFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/to_syslog_level.rs
+++ b/lib/vrl/stdlib/src/to_syslog_level.rs
@@ -62,7 +62,7 @@ impl Function for ToSyslogLevel {
         Ok(Box::new(ToSyslogLevelFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         to_syslog_level(value)
     }
@@ -76,7 +76,7 @@ struct ToSyslogLevelFn {
 impl Expression for ToSyslogLevelFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
 

--- a/lib/vrl/stdlib/src/to_syslog_severity.rs
+++ b/lib/vrl/stdlib/src/to_syslog_severity.rs
@@ -62,7 +62,7 @@ impl Function for ToSyslogSeverity {
         Ok(Box::new(ToSyslogSeverityFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         to_syslog_severity(value)
     }
@@ -76,7 +76,7 @@ struct ToSyslogSeverityFn {
 impl Expression for ToSyslogSeverityFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let level = self.value.resolve(ctx)?.into_owned();
         to_syslog_severity(level).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/to_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_timestamp.rs
@@ -226,7 +226,7 @@ impl Function for ToTimestamp {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let unit = args
             .optional_any("unit")
@@ -295,7 +295,7 @@ struct ToTimestampFn {
 impl Expression for ToTimestampFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let unit = self.unit;

--- a/lib/vrl/stdlib/src/to_unix_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_unix_timestamp.rs
@@ -102,7 +102,7 @@ impl Function for ToUnixTimestamp {
         }
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let unit = args
             .optional_any("unit")
@@ -171,7 +171,7 @@ struct ToUnixTimestampFn {
 impl Expression for ToUnixTimestampFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let unit = self.unit;

--- a/lib/vrl/stdlib/src/truncate.rs
+++ b/lib/vrl/stdlib/src/truncate.rs
@@ -89,7 +89,7 @@ impl Function for Truncate {
         }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         let limit = args.required("limit");
         let ellipsis = args.optional("ellipsis").unwrap_or_else(|| value!(false));
@@ -108,7 +108,7 @@ struct TruncateFn {
 impl Expression for TruncateFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         let limit = self.limit.resolve(ctx)?.into_owned();

--- a/lib/vrl/stdlib/src/type_def.rs
+++ b/lib/vrl/stdlib/src/type_def.rs
@@ -52,7 +52,7 @@ impl Function for TypeDef {
         Ok(Box::new(TypeDefFn { type_def }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, _args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, _args: &mut VmArgumentList) -> Result<Value> {
         Err("function not supported in VM runtime.".into())
     }
 }
@@ -65,7 +65,7 @@ struct TypeDefFn {
 impl Expression for TypeDefFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        _: &'ctx mut Context,
+        _: &'ctx Context,
     ) -> Resolved<'value> {
         type_def(&self.type_def.clone()).map(Cow::Owned)
     }

--- a/lib/vrl/stdlib/src/unique.rs
+++ b/lib/vrl/stdlib/src/unique.rs
@@ -43,7 +43,7 @@ impl Function for Unique {
         }]
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value");
         unique(value)
     }
@@ -57,7 +57,7 @@ pub(crate) struct UniqueFn {
 impl Expression for UniqueFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?.into_owned();
         unique(value).map(Cow::Owned)

--- a/lib/vrl/stdlib/src/upcase.rs
+++ b/lib/vrl/stdlib/src/upcase.rs
@@ -58,7 +58,7 @@ impl Function for Upcase {
         Ok(Box::new(UpcaseFn { value }))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, args: &mut VmArgumentList) -> Result<Value> {
         let value = args.required("value").try_bytes()?;
         Ok(upcase(&value).unwrap_or_else(|| Value::from(value)))
     }
@@ -72,7 +72,7 @@ struct UpcaseFn {
 impl Expression for UpcaseFn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        ctx: &'ctx mut Context,
+        ctx: &'ctx Context,
     ) -> Resolved<'value> {
         let value = self.value.resolve(ctx)?;
         let bytes = value.try_as_bytes()?;

--- a/lib/vrl/stdlib/src/uuid_v4.rs
+++ b/lib/vrl/stdlib/src/uuid_v4.rs
@@ -32,7 +32,7 @@ impl Function for UuidV4 {
         Ok(Box::new(UuidV4Fn))
     }
 
-    fn call_by_vm(&self, _ctx: &mut Context, _args: &mut VmArgumentList) -> Result<Value> {
+    fn call_by_vm(&self, _ctx: &Context, _args: &mut VmArgumentList) -> Result<Value> {
         uuid_v4()
     }
 }
@@ -43,7 +43,7 @@ struct UuidV4Fn;
 impl Expression for UuidV4Fn {
     fn resolve<'value, 'ctx: 'value, 'rt: 'ctx>(
         &'rt self,
-        _: &'ctx mut Context,
+        _: &'ctx Context,
     ) -> Resolved<'value> {
         uuid_v4().map(Cow::Owned)
     }

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -69,15 +69,26 @@ impl Condition {
 }
 
 pub trait Conditional {
-    fn check(&self, e: &Event) -> bool;
+    /// Check if the condition succeeded or not.
+    ///
+    /// The `Ok` variant of the return type signals a positive check, while
+    /// `Err` signals the opposite.
+    ///
+    /// The [`Event`] is taken by value, to allow transforms to use it in
+    /// whatever way needed, while both the `Ok` and `Err` variants return the
+    /// event after the check.
+    ///
+    /// It is expected, but not enforced, that conditions do not modify the
+    /// event.
+    fn check(&self, e: Event) -> Result<Event, Event>;
 
     /// Provides context for a failure. This is potentially mildly expensive if
     /// it involves string building and so should be avoided in hot paths.
-    fn check_with_context(&self, e: &Event) -> Result<(), String> {
+    fn check_with_context(&self, e: Event) -> Result<Event, (Event, String)> {
         if self.check(e) {
-            Ok(())
+            Ok(e)
         } else {
-            Err("condition failed".into())
+            Err((e, "condition failed".into()))
         }
     }
 }


### PR DESCRIPTION
🚧 

This is a continuation of #12712, which changes the `Expression::resolve` trait method to return `Cow<'_, Value>`.

That PR is about ready to be merged, and sees a modest 3-4% performance gain for VRL-heavy soaks, but it's also limited in how much further gains it can provide.

The reason for this, is that our `resolve` method takes a `&mut Context`, and since the returned `Cow` has its lifetime tied to the lifetime of `Context`, there's no way for an expression to resolve multiple sub-expressions and keep references to their values, as it violates the single mutable reference rule when passing in `&mut ctx` to `resolve`.

A possible solution, I'm experimenting with here, is to pass in `&Context`, and have that type track internal mutability at runtime. I have the VRL side of things passing in this spike, but there are some complications on the integration side of Vector that I still need to work on.

Specifically, VRL now requires taking ownership of the `Target`, since it's wrapped in `Rc<RefCell<dyn Target>>`. This doesn't work with the `Condition` trait in Vector, as it only provides a reference to the event. This can be changed, but it requires a bit of work (and then there's whether this is a direction we want to take).

Additionally, the change in this PR means we can no longer return references from variable calls or external fields, because of the fact we get a `Ref<Context>`, which is an owned type, and by the time we return the `Cow`, that owned type is dropped, and the reference goes out of scope. The need to clone here _might_ still be worth it, if other expressions become significantly faster because they can now keep track of multiple references to sub-expressions.