### PR TITLE
chore(new sink): add RFC for Google Chronicle sink

### DIFF
--- a/rfcs/2022-05-17-11532-chronicle-sink.md
+++ b/rfcs/2022-05-17-11532-chronicle-sink.md
@@ -136,6 +136,43 @@ removed from the event.
 
 The encoding of the message (text or json) can be set via an `encoding` field.
 
+##### Schema
+
+A UDM message has the following sections. (To keep this RFC succinct, this is
+not a comprehensive list, the full list can be found
+[here](https://cloud.google.com/chronicle/docs/reference/udm-field-list#udm_event_data_model).)
+
+- *Metadata*
+  Contains metadata about the event. The fields available for metadata can be
+  found [here](https://cloud.google.com/chronicle/docs/reference/udm-field-list#metadata).
+  Mandatory fields are `event_type` and `event_timestamp`.
+
+  The value of `event_type` has repercussions for which fields are mandatory
+  in the rest of the event. See [here](https://cloud.google.com/chronicle/docs/unified-data-model/udm-usage#required_and_optional_fields_based_on_event_type)
+  for the list. For example, if `event_type == "FILE_COPY"` then `src.file`
+  becomes mandatory. **Currently it is not possible to validate a field based
+  on the value of another field within Vector schema, so this will need to
+  be left for future improvement.
+
+- *Principal*
+  The principal is the entity that originates the event. This field is mandatory
+  and can contain any of the fields defined
+  [here](https://cloud.google.com/chronicle/docs/reference/udm-field-list#noun).
+
+- *Src*
+  The source entity being acted upon. Depending on the `event_type` this field
+  is optional. Can contain any of the fields defined
+  [here](https://cloud.google.com/chronicle/docs/reference/udm-field-list#noun).
+
+- *Target*
+  The target entity being acted upon. Depending on the `event_type` this field
+  is optional. Can contain any of the fields defined
+  [here](https://cloud.google.com/chronicle/docs/reference/udm-field-list#noun).
+
+
+
+
+
 ### Implementation
 
 Both event types require different batching strategies.
@@ -186,4 +223,8 @@ after the RFC is approved:
 
 ## Future Improvements
 
-- List any future improvements. Use this to keep your "plan of attack" scope small and project a sound design.
+- Consider sending the event data as Proto3 rather than JSON. We would likely
+  need definitive profiling data to assure ourselves that the performance
+  enhancements would be worth the extra complexity of protobufs.
+- Enhance Vector schema to enforce mandatory fields based on the value of
+  `metadata.event_type`.

--- a/rfcs/2022-05-17-11532-chronicle-sink.md
+++ b/rfcs/2022-05-17-11532-chronicle-sink.md
@@ -172,6 +172,19 @@ batching.
 Since log events are batched by `log_type` we will need to partition the
 batches on the value of the `log_type` field using a `PartitionHttpSink`.
 
+
+#### Error handling
+
+According to the Chronicle docs:
+
+> Clients should retry on 500 and 503 errors with exponential backoff. The
+> minimum delay should be 1s unless it is documented otherwise. For 429
+> errors, the client may retry with minimum 30s delay. For all other errors,
+> retry may not be applicable.
+
+I believe the current GCP sinks implement this behaviour so we can reuse the
+logic from these sinks.
+
 ## Rationale
 
 There is significant user demand for sending data into Google Chronicle.

--- a/rfcs/2022-05-17-11532-chronicle-sink.md
+++ b/rfcs/2022-05-17-11532-chronicle-sink.md
@@ -1,0 +1,189 @@
+# RFC 11532 - 2022-05-17 - Google Chronicle Sink
+
+This RFC proposes a new sink that sends data into
+[Google Chronicle](https://cloud.google.com/chronicle/docs).
+Chronicle is a Security Information and Event Managent (SIEM) platform to store,
+aggregate and search security telemetry.
+
+## Context
+
+- https://github.com/vectordotdev/vector/issues/11532
+
+## Cross cutting concerns
+
+- The schema support required for the UDM events relies on
+  [this PR](https://github.com/vectordotdev/vector/pull/11743)
+  being merged.
+
+## Scope
+
+### In scope
+
+- A sink that sends data into Google Chronicle. This includes UDM events and
+  unstructured log events.
+
+### Out of scope
+
+- Adding any explicit knowledge of SIEM events as a separate event
+  type into Vector will not be considered.
+
+## Pain
+
+## Proposal
+
+### User Experience
+
+This adds a new sink to Vector to send data into Google Chronicle.
+
+There is a choice of two different types of events that can be sent to Chronicle.
+
+Which type to send will be configured with an `event_type` configuration option.
+
+```toml
+event_type = "unstructured"
+```
+
+or
+
+```toml
+event_type = "udm"
+```
+
+#### UDM (Unified Data Model) events
+
+https://cloud.google.com/chronicle/docs/reference/ingestion-api#udmevents
+https://cloud.google.com/chronicle/docs/unified-data-model/udm-usage
+
+UDM events are events that conform to a [strict schema](https://cloud.google.com/chronicle/docs/reference/udm-field-list).
+An example event:
+
+```json
+{
+  "metadata": {
+    "event_timestamp": "2019-10-23T04:00:00.000Z",
+    "event_type": "NETWORK_HTTP",
+    "product_name": "Acme Proxy",
+    "vendor_name": "Acme"
+  },
+  "network": {
+    "http": {
+      "method": "GET",
+      "response_code": 200
+    }
+  },
+  "principal": {
+    "hostname": "host0",
+    "ip": "10.1.2.3",
+    "port": 60000
+  },
+  "target": {
+    "hostname": "www.altostrat.com",
+    "ip": "198.51.100.68",
+    "port": 443,
+    "url": "www.altostrat.com/images/logo.png"
+  }
+}
+```
+
+Events can be batched and sent in a JSON object that also includes the
+`customer_id`:
+
+```json
+{
+"customer_id": "c8c65bfa-5f2c-42d4-9189-64bb7b939f2c",
+"events": [...]
+}
+```
+
+UDM events can be sumbitted as either JSON or Proto3. We will submit using JSON
+as this fits in easier with Vectors data model. The newly developed schema
+support for Vector will be used to ensure the JSON is formed according to the
+[Chronicle requirements](https://cloud.google.com/chronicle/docs/unified-data-model/format-events-as-udm).
+
+Vector has no internal knowledge of SIEM events so it will be up to the user to
+ensure the event is well formed - either the source will receive the data in the
+correct structure, or it will be transformed into such before reaching the sink.
+
+#### Unstructured log data events
+
+Unstructured log events are events in plain text with no strict schema attached.
+
+```json
+{
+  "log_text": "26-Feb-2019 13:35:02.187 client 10.120.20.32#4238: query: altostrat.com IN A + (203.0.113.102)",
+  "ts_epoch_microseconds": 1551188102187000
+}
+```
+
+Events are batched and sent in a JSON object that includes the `customer_id` and
+a `log_type`:
+
+```json
+{
+  "customer_id": "c8c65bfa-5f2c-42d4-9189-64bb7b939f2c",
+  "log_type": "BIND_DNS",
+  "entries": [...]
+}
+```
+
+`log_type` has to be one of the values returned by the [logtypes endpoint](https://cloud.google.com/chronicle/docs/reference/ingestion-api#logtypes).
+
+If `event_type == "unstructured"` we will require another configuration field -
+`log_type` to be set. This field will be templatable.
+
+Another field `remove_log_type` allows the field used in the template to be
+removed from the event.
+
+The encoding of the message (text or json) can be set via an `encoding` field.
+
+### Implementation
+
+Both event types require different batching strategies.
+
+#### UDM
+
+UDM can use a simple `BatchedHttpSink` with a `JsonArrayBuffer` to perform the
+batching.
+
+#### Unstructured log events
+
+Since log events are batched by `log_type` we will need to partition the
+batches on the value of the `log_type` field using a `PartitionHttpSink`.
+
+## Rationale
+
+There is significant user demand for sending data into Google Chronicle.
+
+## Drawbacks
+
+Adding a new sink does place an additional maintenance burden on the team. In
+particular since Chronicle is a third party service, developing integration
+tests to ensure the sink continues to work correctly is burdensome.
+
+## Prior Art
+
+## Alternatives
+
+An option that was considered was to use the HTTP sink and and enhance it to
+allow GCP authentication. This would nearly work for UDM events, but
+unfortunately since the payload is a JSON object with a `customer_id` field
+and an array of `events`, the structure is slightly different to what is
+possible with the HTTP sink.
+
+## Outstanding Questions
+
+Should we crate one sink with an `event_type` option, or should these be two
+separate sinks?
+
+## Plan Of Attack
+
+Incremental steps to execute this change. These will be converted to issues
+after the RFC is approved:
+
+- [ ] Create the sink to work for unstructured log events.
+- [ ] Enhance the sink to work with UDM (without schema support).
+- [ ] Add schema support for UDM events.
+
+## Future Improvements
+
+- List any future improvements. Use this to keep your "plan of attack" scope small and project a sound design.

--- a/rfcs/2022-05-17-11532-chronicle-sink.md
+++ b/rfcs/2022-05-17-11532-chronicle-sink.md
@@ -128,6 +128,7 @@ a `log_type`:
 
 `log_type` has to be one of the values returned by the [logtypes endpoint](https://cloud.google.com/chronicle/docs/reference/ingestion-api#logtypes).
 
+
 If `event_type == "unstructured"` we will require another configuration field -
 `log_type` to be set. This field will be templatable.
 
@@ -169,10 +170,6 @@ not a comprehensive list, the full list can be found
   is optional. Can contain any of the fields defined
   [here](https://cloud.google.com/chronicle/docs/reference/udm-field-list#noun).
 
-
-
-
-
 ### Implementation
 
 Both event types require different batching strategies.
@@ -211,6 +208,18 @@ possible with the HTTP sink.
 
 Should we crate one sink with an `event_type` option, or should these be two
 separate sinks?
+
+The `log_types` field has to contain a value that has been returned from the
+`log_types` endpoint. It could be possible for the Sink to call this on boot
+time which would provide a list of possible values that could be validated
+before sending to chronicle. I feel it isn't worth doing this as the event
+will be validated by Chronicle anyway so we may as well rely on the error
+returned when sending an invalid `log_type`. Others may disagree. Is it worth
+performing this validation ourselves?
+
+We would need to take into account that Vector would then need rebooting
+should the `log_types` list be updated.
+
 
 ## Plan Of Attack
 

--- a/rfcs/2022-05-17-11532-chronicle-sink.md
+++ b/rfcs/2022-05-17-11532-chronicle-sink.md
@@ -1,6 +1,6 @@
 # RFC 11532 - 2022-05-17 - Google Chronicle Sink
 
-This RFC proposes a new sink that sends data into
+This RFC proposes two new sinks that send data into
 [Google Chronicle](https://cloud.google.com/chronicle/docs).
 Chronicle is a Security Information and Event Managent (SIEM) platform to store,
 aggregate and search security telemetry.
@@ -33,23 +33,11 @@ aggregate and search security telemetry.
 
 ### User Experience
 
-This adds a new sink to Vector to send data into Google Chronicle.
-
-There is a choice of two different types of events that can be sent to Chronicle.
-
-Which type to send will be configured with an `event_type` configuration option.
-
-```toml
-event_type = "unstructured"
-```
-
-or
-
-```toml
-event_type = "udm"
-```
+This adds two new sinks to Vector to send data into Google Chronicle.
 
 #### UDM (Unified Data Model) events
+
+The `gcp_chronicle_udm` sink.
 
 https://cloud.google.com/chronicle/docs/reference/ingestion-api#udmevents
 https://cloud.google.com/chronicle/docs/unified-data-model/udm-usage
@@ -106,6 +94,8 @@ correct structure, or it will be transformed into such before reaching the sink.
 
 #### Unstructured log data events
 
+The `gcp_chronicle_unstructured` sink.
+
 Unstructured log events are events in plain text with no strict schema attached.
 
 ```json
@@ -130,10 +120,8 @@ a `log_type`:
 
 
 If `event_type == "unstructured"` we will require another configuration field -
-`log_type` to be set. This field will be templatable.
-
-Another field `remove_log_type` allows the field used in the template to be
-removed from the event.
+`log_type` to be set. This field will be templatable. The field can be removed
+from the final event via `encoding.exclude_fields`.
 
 The encoding of the message (text or json) can be set via an `encoding` field.
 
@@ -206,9 +194,6 @@ possible with the HTTP sink.
 
 ## Outstanding Questions
 
-Should we crate one sink with an `event_type` option, or should these be two
-separate sinks?
-
 The `log_types` field has to contain a value that has been returned from the
 `log_types` endpoint. It could be possible for the Sink to call this on boot
 time which would provide a list of possible values that could be validated
@@ -226,8 +211,8 @@ should the `log_types` list be updated.
 Incremental steps to execute this change. These will be converted to issues
 after the RFC is approved:
 
-- [ ] Create the sink to work for unstructured log events.
-- [ ] Enhance the sink to work with UDM (without schema support).
+- [ ] Create the unstructured log events sink.
+- [ ] Create the UDM sink (without schema support).
 - [ ] Add schema support for UDM events.
 
 ## Future Improvements

--- a/rfcs/2022-05-17-11532-chronicle-sink.md
+++ b/rfcs/2022-05-17-11532-chronicle-sink.md
@@ -160,18 +160,8 @@ not a comprehensive list, the full list can be found
 
 ### Implementation
 
-Both event types require different batching strategies.
-
-#### UDM
-
-UDM can use a simple `BatchedHttpSink` with a `JsonArrayBuffer` to perform the
-batching.
-
-#### Unstructured log events
-
-Since log events are batched by `log_type` we will need to partition the
-batches on the value of the `log_type` field using a `PartitionHttpSink`.
-
+Both event types require different batching strategies. Unstructured log events
+are partitioned by `log_type`. UDM events do not require partitioning.
 
 #### Error handling
 
@@ -206,18 +196,6 @@ and an array of `events`, the structure is slightly different to what is
 possible with the HTTP sink.
 
 ## Outstanding Questions
-
-The `log_types` field has to contain a value that has been returned from the
-`log_types` endpoint. It could be possible for the Sink to call this on boot
-time which would provide a list of possible values that could be validated
-before sending to chronicle. I feel it isn't worth doing this as the event
-will be validated by Chronicle anyway so we may as well rely on the error
-returned when sending an invalid `log_type`. Others may disagree. Is it worth
-performing this validation ourselves?
-
-We would need to take into account that Vector would then need rebooting
-should the `log_types` list be updated.
-
 
 ## Plan Of Attack
 


### PR DESCRIPTION
Ref: #11532 

This RFC discussing the implementation of a new sink for [Google Chronicle](https://cloud.google.com/chronicle/docs/overview).

There are a number of complications around how to handle the sending of both unstructured log events and structured UDM events, so this RFC intends to clarify the best way to handle this.

[Readable](https://github.com/vectordotdev/vector/blob/stephen/11532_chronicle_rfc/rfcs/2022-05-17-11532-chronicle-sink.md)

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
