### PR TITLE
chore(ci): Correct concurrency options for test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   AUTOINSTALL: true


### PR DESCRIPTION
This makes two changes:

* Doesn't cancel workflow runs on `master`. I think we don't want to
  cancel in-flight workflows on `maser` as it can make it more difficult
  to see when breakages are introduced.
* Adds the workflow name to the concurrency group. Without this, Github
  Actions will cancel all workflows in the group regardless of name.
  This didn't manifest as an issue yet because we are only using
  `concurrency` in one workflow so far.

Addresses comments on https://github.com/vectordotdev/vector/pull/12669 .

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
