### PR TITLE
Remove Itertools from lib/datadog/grok

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,7 +2144,6 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "criterion",
- "itertools",
  "lalrpop",
  "lalrpop-util",
  "lookup",

--- a/lib/datadog/grok/Cargo.toml
+++ b/lib/datadog/grok/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs" # LALRPOP preprocessing
 bytes = { version = "1.1.0", default-features = false }
 chrono = { version = "0.4.19", default-features = false }
 chrono-tz = { version = "0.6.1", default-features = false }
-itertools = { version = "0.10.3", default-features = false }
 lalrpop-util = { version = "0.19", default-features = false }
 nom = { version = "7.1.1", default-features = false, features = ["std"] }
 once_cell = { version = "1.10", default-features = false, features = ["std"] }


### PR DESCRIPTION
This commit removes the use of itertools fold_while from datadog
grok. parse_grok is a hot spot in http->pipelines and the stack trace is quite
high in this area. I've aimed to slim the stack down some with this change; I do
not expect it to be appreciably different in terms of throughput performance.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
