### PR TITLE
feat(vrl): New function is_json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9094,6 +9094,7 @@ dependencies = [
  "regex",
  "roxmltree",
  "rust_decimal",
+ "serde",
  "serde_json",
  "sha-1 0.10.0",
  "sha2 0.10.2",

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -33,6 +33,7 @@ once_cell = { version = "1.10", optional = true }
 rand = { version = "0.8.5", optional = true }
 regex = { version = "1", optional = true }
 rust_decimal = { version = "1", optional = true }
+serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
@@ -114,6 +115,7 @@ default = [
     "is_empty",
     "is_float",
     "is_integer",
+    "is_json",
     "is_null",
     "is_nullish",
     "is_object",
@@ -249,6 +251,7 @@ is_boolean = []
 is_empty = []
 is_float = []
 is_integer = []
+is_json = ["serde_json", "value/json"]
 is_null = []
 is_nullish = []
 is_object = []

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = { version = "1.10", optional = true }
 rand = { version = "0.8.5", optional = true }
 regex = { version = "1", optional = true }
 rust_decimal = { version = "1", optional = true }
-serde = { version = "1", default-features = false, features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
@@ -251,7 +251,7 @@ is_boolean = []
 is_empty = []
 is_float = []
 is_integer = []
-is_json = ["serde_json", "value/json"]
+is_json = ["serde", "serde_json", "value/json"]
 is_null = []
 is_nullish = []
 is_object = []

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -57,6 +57,7 @@ criterion_group!(
               is_empty,
               is_float,
               is_integer,
+              is_json,
               is_null,
               is_nullish,
               is_object,
@@ -748,6 +749,20 @@ bench_function! {
 
     object {
         args: func_args![value: value!({"foo": "bar"})],
+        want: Ok(false),
+    }
+}
+
+bench_function! {
+    is_json => vrl_stdlib::IsJson;
+
+    map {
+        args: func_args![value: r#"{"key": "value"}"#],
+        want: Ok(true),
+    }
+
+    invalid_map {
+        args: func_args![value: r#"{"key": "value""#],
         want: Ok(false),
     }
 }

--- a/lib/vrl/stdlib/src/is_json.rs
+++ b/lib/vrl/stdlib/src/is_json.rs
@@ -31,12 +31,12 @@ impl Function for IsJson {
             Example {
                 title: "object",
                 source: r#"is_json("{}")"#,
-                result: Ok("false"),
+                result: Ok("true"),
             },
             Example {
                 title: "string",
                 source: r#"is_json(s'"test"')"#,
-                result: Ok("false"),
+                result: Ok("true"),
             },
             Example {
                 title: "invalid",

--- a/lib/vrl/stdlib/src/is_json.rs
+++ b/lib/vrl/stdlib/src/is_json.rs
@@ -1,0 +1,106 @@
+use ::value::Value;
+use vrl::prelude::*;
+
+fn is_json(value: Value) -> Resolved {
+    let bytes = value.try_bytes()?;
+
+    match serde_json::from_slice::<'_, serde::de::IgnoredAny>(&bytes) {
+        Ok(_) => Ok(value!(true)),
+        Err(_) => Ok(value!(false)),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct IsJson;
+
+impl Function for IsJson {
+    fn identifier(&self) -> &'static str {
+        "is_json"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "object",
+                source: r#"is_json("{}")"#,
+                result: Ok("false"),
+            },
+            Example {
+                title: "string",
+                source: r#"is_json(s'"test"')"#,
+                result: Ok("false"),
+            },
+            Example {
+                title: "invalid",
+                source: r#"is_json("}{")"#,
+                result: Ok("false"),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        _ctx: &mut FunctionCompileContext,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        Ok(Box::new(IsJsonFn { value }))
+    }
+
+    fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Resolved {
+        is_json(args.required("value"))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct IsJsonFn {
+    value: Box<dyn Expression>,
+}
+
+impl Expression for IsJsonFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        is_json(value)
+    }
+
+    fn type_def(&self, _: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
+        TypeDef::boolean().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        is_json => IsJson;
+
+        object {
+            args: func_args![value: r#"{}"#],
+            want: Ok(value!(true)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        string {
+            args: func_args![value: r#""test""#],
+            want: Ok(value!(true)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        invalid {
+            args: func_args![value: r#"}{"#],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+    ];
+}

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -101,6 +101,8 @@ mod is_empty;
 mod is_float;
 #[cfg(feature = "is_integer")]
 mod is_integer;
+#[cfg(feature = "is_json")]
+mod is_json;
 #[cfg(feature = "is_null")]
 mod is_null;
 #[cfg(feature = "is_nullish")]
@@ -372,6 +374,8 @@ pub use is_empty::IsEmpty;
 pub use is_float::IsFloat;
 #[cfg(feature = "is_integer")]
 pub use is_integer::IsInteger;
+#[cfg(feature = "is_json")]
+pub use is_json::IsJson;
 #[cfg(feature = "is_null")]
 pub use is_null::IsNull;
 #[cfg(feature = "is_nullish")]
@@ -642,6 +646,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(IsFloat),
         #[cfg(feature = "is_integer")]
         Box::new(IsInteger),
+        #[cfg(feature = "is_json")]
+        Box::new(IsJson),
         #[cfg(feature = "is_null")]
         Box::new(IsNull),
         #[cfg(feature = "is_nullish")]

--- a/website/cue/reference/remap/functions/is_json.cue
+++ b/website/cue/reference/remap/functions/is_json.cue
@@ -1,0 +1,42 @@
+package metadata
+
+remap: functions: is_json: {
+	category: "Type"
+	description: """
+		Check if the string is a valid JSON document.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: #"The value to check"#
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["boolean"]
+		rules: [
+			#"Returns `true` if `value` is a valid JSON document."#,
+			#"Returns `false` if `value` is not JSON-formatted."#,
+		]
+	}
+
+	examples: [
+		{
+			title: "Valid JSON object"
+			source: """
+				is_json("{}")
+				"""
+			return: true
+		},
+		{
+			title: "Non-valid value"
+			source: """
+				is_json("{")
+				"""
+			return: false
+		},
+	]
+}


### PR DESCRIPTION
This PR adds a new function - `is_json`. 
It validates that a provided string is a valid JSON-formatted document.

It is better than checking the error from the `parse_json` method because `is_json` discards all deserialized data (see [serde](https://docs.serde.rs/serde/index.html)::[de](https://docs.serde.rs/serde/de/index.html)::[IgnoredAny](https://docs.serde.rs/serde/de/struct.IgnoredAny.html#)).

Benchmark results:

`is_json`
```
vrl_stdlib/functions/is_json/map                                                                            
                        time:   [65.001 ns 65.946 ns 66.930 ns]
                        thrpt:  [14.941 Melem/s 15.164 Melem/s 15.384 Melem/s]
vrl_stdlib/functions/is_json/invalid_map                                                                            
                        time:   [141.29 ns 143.05 ns 144.90 ns]
                        thrpt:  [6.9011 Melem/s 6.9906 Melem/s 7.0775 Melem/s]
```

`parse_json` implementation with checking an error
```
vrl_stdlib/functions/is_json/map                                                                            
                        time:   [396.72 ns 402.32 ns 408.12 ns]
                        thrpt:  [2.4503 Melem/s 2.4856 Melem/s 2.5207 Melem/s]
vrl_stdlib/functions/is_json/invalid_map                                                                             
                        time:   [540.15 ns 547.25 ns 554.87 ns]
                        thrpt:  [1.8022 Melem/s 1.8273 Melem/s 1.8513 Melem/s]
```

***

Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>
Closes #8123