### PR TITLE
fix(codecs): Improve deserialization of `EncodingConfigAdapter` / fix overriding `framing`

### DIFF
--- a/lib/codecs/src/encoding/framing/character_delimited.rs
+++ b/lib/codecs/src/encoding/framing/character_delimited.rs
@@ -26,7 +26,7 @@ impl CharacterDelimitedEncoderConfig {
 }
 
 /// Options for building a `CharacterDelimitedEncoder`.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CharacterDelimitedEncoderOptions {
     /// The character that delimits byte sequences.
     #[serde(with = "vector_core::serde::ascii_char")]

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -49,7 +49,7 @@ impl From<std::io::Error> for Error {
 // Unfortunately, copying options of the nested enum variants is necessary
 // since `serde` doesn't allow `flatten`ing these:
 // https://github.com/serde-rs/serde/issues/1402.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum FramingConfig {
     /// Configures the `BytesEncoder`.

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -80,12 +80,12 @@ impl ClientBuilder for CloudwatchLogsClientBuilder {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct CloudwatchLogsSinkConfig {
     pub group_name: Template,
     pub stream_name: Template,
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
-    #[serde(flatten)]
     pub encoding:
         EncodingConfigAdapter<EncodingConfig<StandardEncodings>, StandardEncodingsMigrator>,
     pub create_missing_group: Option<bool>,

--- a/src/sinks/aws_kinesis_firehose/config.rs
+++ b/src/sinks/aws_kinesis_firehose/config.rs
@@ -51,11 +51,11 @@ impl SinkBatchSettings for KinesisFirehoseDefaultBatchSettings {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct KinesisFirehoseSinkConfig {
     pub stream_name: String,
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
-    #[serde(flatten)]
     pub encoding:
         EncodingConfigAdapter<EncodingConfig<StandardEncodings>, StandardEncodingsMigrator>,
     #[serde(default)]

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -104,12 +104,12 @@ impl SinkBatchSettings for KinesisDefaultBatchSettings {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct KinesisSinkConfig {
     pub stream_name: String,
     pub partition_key_field: Option<String>,
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
-    #[serde(flatten)]
     pub encoding:
         EncodingConfigAdapter<EncodingConfig<StandardEncodings>, StandardEncodingsMigrator>,
     #[serde(default)]

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -36,6 +36,7 @@ const DEFAULT_FILENAME_TIME_FORMAT: &str = "%s";
 const DEFAULT_FILENAME_APPEND_UUID: bool = true;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct S3SinkConfig {
     pub bucket: String,
     pub key_prefix: Option<String>,

--- a/src/sinks/aws_sqs/config.rs
+++ b/src/sinks/aws_sqs/config.rs
@@ -46,11 +46,11 @@ impl EncodingConfigMigrator for EncodingMigrator {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct SqsSinkConfig {
     pub queue_url: String,
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
-    #[serde(flatten)]
     pub encoding: EncodingConfigAdapter<EncodingConfig<Encoding>, EncodingMigrator>,
     pub message_group_id: Option<String>,
     pub message_deduplication_id: Option<String>,

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct AzureBlobSinkConfig {
     pub connection_string: String,
     pub(super) container_name: String,

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -61,6 +61,7 @@ impl EncodingConfigWithFramingMigrator for EncodingMigrator {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct FileSinkConfig {
     pub path: Template,
     pub idle_timeout_secs: Option<u64>,

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -62,6 +62,7 @@ pub enum GcsHealthcheckError {
 const NAME: &str = "gcp_cloud_storage";
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct GcsSinkConfig {
     bucket: String,
     acl: Option<GcsPredefinedAcl>,

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -74,6 +74,7 @@ impl EncodingConfigWithFramingMigrator for Migrator {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct HttpSinkConfig {
     pub uri: UriSerde,
     pub method: Option<HttpMethod>,

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -23,11 +23,11 @@ use crate::{
 pub(crate) const QUEUED_MIN_MESSAGES: u64 = 100000;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct KafkaSinkConfig {
     pub bootstrap_servers: String,
     pub topic: String,
     pub key_field: Option<String>,
-    #[serde(flatten)]
     pub(crate) encoding:
         EncodingConfigAdapter<EncodingConfig<StandardEncodings>, StandardEncodingsMigrator>,
     /// These batching options will **not** override librdkafka_options values.

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -54,8 +54,8 @@ impl EncodingConfigMigrator for EncodingMigrator {
  */
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct NatsSinkConfig {
-    #[serde(flatten)]
     encoding: EncodingConfigAdapter<EncodingConfig<Encoding>, EncodingMigrator>,
     #[serde(default = "default_name", alias = "name")]
     connection_name: String,

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -36,9 +36,9 @@ impl EncodingConfigMigrator for EncodingMigrator {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub(self) struct PapertrailConfig {
     endpoint: UriSerde,
-    #[serde(flatten)]
     encoding: EncodingConfigAdapter<EncodingConfig<Encoding>, EncodingMigrator>,
     keepalive: Option<TcpKeepaliveConfig>,
     tls: Option<TlsEnableableConfig>,

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -108,8 +108,8 @@ impl EncodingConfigMigrator for EncodingMigrator {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RedisSinkConfig {
-    #[serde(flatten)]
     encoding: EncodingConfigAdapter<EncodingConfig<Encoding>, EncodingMigrator>,
     #[serde(default)]
     data_type: DataTypeConfig,

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -38,6 +38,8 @@ impl EncodingConfigWithFramingMigrator for Migrator {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+// `#[serde(deny_unknown_fields)]` doesn't work when flattening internally tagged enums, see
+// https://github.com/serde-rs/serde/issues/1358.
 pub struct SocketSinkConfig {
     #[serde(flatten)]
     pub mode: Mode,

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -167,7 +167,11 @@ components: sinks: [Name=string]: {
 		if features.send != _|_ {
 			if features.send.encoding.enabled {
 				encoding: {
-					description: "Configures the encoding specific sink behavior."
+					description: """
+						Configures the encoding specific sink behavior.
+
+						Note: When data in `encoding` is malformed, currently only a very generic error "data did not match any variant of untagged enum EncodingConfig" is reported. Follow this [issue](\(urls.vector_encoding_config_improve_error_message)) to track progress on improving these error messages.
+						"""
 					required:    features.send.encoding.codec.enabled
 					if !features.send.encoding.codec.enabled {common: true}
 					type: object: {

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -515,6 +515,7 @@ urls: {
 	vector_docs:                                              "/docs/"
 	vector_download:                                          "/releases/latest/download/"
 	vector_download_nightly:                                  "/releases/nightly/download/"
+	vector_encoding_config_improve_error_message:             "\(vector_repo)/issues/12162"
 	vector_enriching_transforms:                              "/components/?functions%5B%5D=enrich"
 	vector_file_source:                                       "/docs/reference/configuration/sources/file/"
 	vector_exec_source:                                       "/docs/reference/configuration/sources/exec"


### PR DESCRIPTION
Closes #12473.

The error messages are improved in so far that sinks will reject unknown fields again and missing `framing` and `encoding` fields are mentioned explicitly.

Unfortunately, deserializing the `encoding` field itself will still give vague error messages due to https://github.com/serde-rs/serde/pull/1544 (some more details in #12162).

Additionally, this PR fixes a bug where the `framing` config could not be overridden when a legacy codec was used.