### PR TITLE
chore: Remove non-erratic soaks, declared erratic

### DIFF
--- a/.github/workflows/manual_soak.yml
+++ b/.github/workflows/manual_soak.yml
@@ -92,7 +92,7 @@ jobs:
           export SOAK_MEMORY="30g"
           export VECTOR_CPUS="4"
           export COEFFICIENT_OF_VARIATION="0.3"
-          export ERRATIC_SOAKS="http_pipelines_blackhole,http_pipelines_blackhole_acks,http_to_http_acks,http_datadog_filter_blackhole"
+          export ERRATIC_SOAKS="http_to_http_acks"
 
           echo "soak cpus total: ${SOAK_CPUS}"
           echo "soak memory total: ${SOAK_MEMORY}"

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -120,7 +120,7 @@ jobs:
           export SOAK_MEMORY="30g"
           export VECTOR_CPUS="4"
           export COEFFICIENT_OF_VARIATION="0.3"
-          export ERRATIC_SOAKS="http_pipelines_blackhole,http_pipelines_blackhole_acks,http_to_http_acks,http_datadog_filter_blackhole"
+          export ERRATIC_SOAKS="http_to_http_acks"
 
           echo "soak cpus total: ${SOAK_CPUS}"
           echo "soak memory total: ${SOAK_MEMORY}"


### PR DESCRIPTION
Looking at a recent soak run
(https://github.com/vectordotdev/vector/pull/12747#issuecomment-1128771074),
all but `http_to_http_acks`, are not detected as erratic, but are marked
as such.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
