### PR TITLE
chore: Remove simple `btreemap! {}` instances

### DIFF
--- a/lib/datadog/grok/src/parse_grok.rs
+++ b/lib/datadog/grok/src/parse_grok.rs
@@ -131,7 +131,7 @@ mod tests {
                 "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
                     .to_string(),
             ],
-            btreemap! {},
+            BTreeMap::new(),
         )
         .expect("couldn't parse rules");
         let parsed = parse_grok(
@@ -239,7 +239,7 @@ mod tests {
 
     fn test_grok_pattern(tests: Vec<(&str, &str, Result<Value, Error>)>) {
         for (filter, k, v) in tests {
-            let rules = parse_grok_rules(&[filter.to_string()], btreemap! {})
+            let rules = parse_grok_rules(&[filter.to_string()], BTreeMap::new())
                 .expect("couldn't parse rules");
             let parsed = parse_grok(k, &rules, false);
 
@@ -258,7 +258,7 @@ mod tests {
 
     fn test_full_grok(tests: Vec<(&str, &str, Result<Value, Error>)>) {
         for (filter, k, v) in tests {
-            let rules = parse_grok_rules(&[filter.to_string()], btreemap! {})
+            let rules = parse_grok_rules(&[filter.to_string()], BTreeMap::new())
                 .expect("couldn't parse rules");
             let parsed = parse_grok(k, &rules, false);
 
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn fails_on_unknown_pattern_definition() {
         assert_eq!(
-            parse_grok_rules(&["%{unknown}".to_string()], btreemap! {})
+            parse_grok_rules(&["%{unknown}".to_string()], BTreeMap::new())
                 .unwrap_err()
                 .to_string(),
             r#"failed to parse grok expression '\A%{unknown}\z': The given pattern definition name "unknown" could not be found in the definition map"#
@@ -279,9 +279,12 @@ mod tests {
     #[test]
     fn fails_on_unknown_filter() {
         assert_eq!(
-            parse_grok_rules(&["%{data:field:unknownFilter}".to_string()], btreemap! {})
-                .unwrap_err()
-                .to_string(),
+            parse_grok_rules(
+                &["%{data:field:unknownFilter}".to_string()],
+                BTreeMap::new()
+            )
+            .unwrap_err()
+            .to_string(),
             r#"unknown filter 'unknownFilter'"#
         );
     }
@@ -289,7 +292,7 @@ mod tests {
     #[test]
     fn fails_on_invalid_matcher_parameter() {
         assert_eq!(
-            parse_grok_rules(&["%{regex(1):field}".to_string()], btreemap! {})
+            parse_grok_rules(&["%{regex(1):field}".to_string()], BTreeMap::new())
                 .unwrap_err()
                 .to_string(),
             r#"invalid arguments for the function 'regex'"#
@@ -299,7 +302,7 @@ mod tests {
     #[test]
     fn fails_on_invalid_filter_parameter() {
         assert_eq!(
-            parse_grok_rules(&["%{data:field:scale()}".to_string()], btreemap! {})
+            parse_grok_rules(&["%{data:field:scale()}".to_string()], BTreeMap::new())
                 .unwrap_err()
                 .to_string(),
             r#"invalid arguments for the function 'scale'"#
@@ -365,7 +368,7 @@ mod tests {
             (
                 "%{data::json}",
                 r#"not a json"#,
-                Ok(Value::from(btreemap! {})),
+                Ok(Value::from(BTreeMap::new())),
             ),
         ]);
     }
@@ -376,7 +379,7 @@ mod tests {
         test_full_grok(vec![(
             "%{notSpace:field1:integer} %{data:field2:json}",
             r#"not_a_number not a json"#,
-            Ok(Value::from(btreemap! {})),
+            Ok(Value::from(BTreeMap::new())),
         )]);
     }
 
@@ -387,7 +390,7 @@ mod tests {
                 "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
                     .to_string(),
             ],
-            btreemap! {},
+            BTreeMap::new(),
         )
         .expect("couldn't parse rules");
         let error = parse_grok("an ungrokkable message", &rules, false).unwrap_err();
@@ -402,7 +405,7 @@ mod tests {
                 r#"%{integer:nested.field} %{notSpace:nested.field:uppercase} %{notSpace:nested.field:nullIf("-")}"#
                     .to_string(),
             ],
-            btreemap! {},
+            BTreeMap::new(),
         )
             .expect("couldn't parse rules");
         let parsed = parse_grok("1 info message", &rules, false).unwrap();
@@ -556,15 +559,18 @@ mod tests {
 
         // check error handling
         assert_eq!(
-            parse_grok_rules(&[r#"%{date("ABC:XYZ"):field}"#.to_string()], btreemap! {})
-                .unwrap_err()
-                .to_string(),
+            parse_grok_rules(
+                &[r#"%{date("ABC:XYZ"):field}"#.to_string()],
+                BTreeMap::new()
+            )
+            .unwrap_err()
+            .to_string(),
             r#"invalid arguments for the function 'date'"#
         );
         assert_eq!(
             parse_grok_rules(
                 &[r#"%{date("EEE MMM dd HH:mm:ss yyyy", "unknown timezone"):field}"#.to_string()],
-                btreemap! {},
+                BTreeMap::new(),
             )
             .unwrap_err()
             .to_string(),
@@ -642,13 +648,13 @@ mod tests {
             (
                 r#"%{data:field:array}"#,
                 "abc",
-                Ok(Value::Object(btreemap! {})),
+                Ok(Value::Object(BTreeMap::new())),
             ),
             // failed to apply value filter(values are strings)
             (
                 r#"%{data:field:array(scale(10))}"#,
                 "[a,b]",
-                Ok(Value::Object(btreemap! {})),
+                Ok(Value::Object(BTreeMap::new())),
             ),
         ]);
     }
@@ -762,7 +768,7 @@ mod tests {
             (
                 "%{data::keyvalue}",
                 "key:=valueStr",
-                Ok(Value::from(btreemap! {})),
+                Ok(Value::from(BTreeMap::new())),
             ),
             // empty key or null
             (
@@ -784,7 +790,7 @@ mod tests {
             (
                 "%{data::keyvalue}",
                 "=,=value",
-                Ok(Value::from(btreemap! {})),
+                Ok(Value::from(BTreeMap::new())),
             ),
             // type inference
             (
@@ -814,17 +820,17 @@ mod tests {
             (
                 "%{data::keyvalue}",
                 "key = valueStr",
-                Ok(Value::from(btreemap! {})),
+                Ok(Value::from(BTreeMap::new())),
             ),
             (
                 "%{data::keyvalue}",
                 "key= valueStr",
-                Ok(Value::from(btreemap! {})),
+                Ok(Value::from(BTreeMap::new())),
             ),
             (
                 "%{data::keyvalue}",
                 "key =valueStr",
-                Ok(Value::from(btreemap! {})),
+                Ok(Value::from(BTreeMap::new())),
             ),
             (
                 r#"%{data::keyvalue(":")}"#,

--- a/lib/datadog/grok/src/parse_grok_rules.rs
+++ b/lib/datadog/grok/src/parse_grok_rules.rs
@@ -432,7 +432,7 @@ mod tests {
     fn supports_escaped_quotes() {
         let rules = parse_grok_rules(
             &[r#"%{notSpace:field:nullIf("with \"escaped\" quotes")}"#.to_string()],
-            btreemap! {},
+            BTreeMap::new(),
         )
         .expect("couldn't parse rules");
         assert!(matches!(

--- a/lib/prometheus-parser/src/line.rs
+++ b/lib/prometheus-parser/src/line.rs
@@ -587,17 +587,17 @@ mod test {
         let input = wrap("{}");
         let (left, r) = Metric::parse_labels(&input).unwrap();
         assert_eq!(left, tail);
-        assert_eq!(r, btreemap! {});
+        assert_eq!(r, BTreeMap::new());
 
         let input = wrap(r#"{name="value"}"#);
         let (left, r) = Metric::parse_labels(&input).unwrap();
         assert_eq!(left, tail);
-        assert_eq!(r, btreemap! { "name" => "value" });
+        assert_eq!(r, BTreeMap::from([("name", "value")]));
 
         let input = wrap(r#"{name="value",}"#);
         let (left, r) = Metric::parse_labels(&input).unwrap();
         assert_eq!(left, tail);
-        assert_eq!(r, btreemap! { "name" => "value" });
+        assert_eq!(r, BTreeMap::from([("name", "value")]));
 
         let input = wrap(r#"{ name = "" ,b="a=b" , a="},", _c = "\""}"#);
         let (left, r) = Metric::parse_labels(&input).unwrap();
@@ -610,7 +610,7 @@ mod test {
         let input = wrap("100");
         let (left, r) = Metric::parse_labels(&input).unwrap();
         assert_eq!(left, "100".to_owned() + tail);
-        assert_eq!(r, btreemap! {});
+        assert_eq!(r, BTreeMap::new());
 
         // We don't allow these values
 

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -637,7 +637,7 @@ mod test {
         use vector_common::btreemap;
 
         let cases = vec![
-            (btreemap! {}, vec![], Ok(Some(btreemap! {}.into()))),
+            (BTreeMap::new(), vec![], Ok(Some(BTreeMap::new().into()))),
             (
                 btreemap! { "foo" => "bar" },
                 vec![],
@@ -831,7 +831,7 @@ mod test {
                 btreemap! { "foo" => "bar" },
                 vec![SegmentBuf::from("foo")],
                 false,
-                Some(btreemap! {}.into()),
+                Some(BTreeMap::new().into()),
             ),
             (
                 btreemap! { "foo" => "bar" },
@@ -840,19 +840,19 @@ mod test {
                     FieldBuf::from("foo"),
                 ])],
                 false,
-                Some(btreemap! {}.into()),
+                Some(BTreeMap::new().into()),
             ),
             (
                 btreemap! { "foo" => "bar", "baz" => "qux" },
                 vec![],
                 false,
-                Some(btreemap! {}.into()),
+                Some(BTreeMap::new().into()),
             ),
             (
                 btreemap! { "foo" => "bar", "baz" => "qux" },
                 vec![],
                 true,
-                Some(btreemap! {}.into()),
+                Some(BTreeMap::new().into()),
             ),
             (
                 btreemap! { "foo" => vec![0] },
@@ -864,7 +864,7 @@ mod test {
                 btreemap! { "foo" => vec![0] },
                 vec![SegmentBuf::from("foo"), SegmentBuf::from(0)],
                 true,
-                Some(btreemap! {}.into()),
+                Some(BTreeMap::new().into()),
             ),
             (
                 btreemap! {

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -340,7 +340,7 @@ mod tests {
             args: func_args![value: "- - - - - - -",
                              format: "common",
             ],
-            want: Ok(btreemap! {}),
+            want: Ok(BTreeMap::new()),
             tdef: TypeDef::object(kind_common()).fallible(),
             tz: vector_common::TimeZone::default(),
         }
@@ -349,7 +349,7 @@ mod tests {
             args: func_args![value: r#"- - - [-] "-" - -"#,
                              format: "common",
             ],
-            want: Ok(btreemap! {}),
+            want: Ok(BTreeMap::new()),
             tdef: TypeDef::object(kind_common()).fallible(),
             tz: vector_common::TimeZone::default(),
         }

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -157,13 +157,13 @@ mod tests {
 
         log_line_valid_empty {
             args: func_args![value: "- - - - - - -"],
-            want: Ok(btreemap! {}),
+            want: Ok(BTreeMap::new()),
             tdef: TypeDef::object(inner_kind()).fallible(),
         }
 
         log_line_valid_empty_variant {
             args: func_args![value: r#"- - - [-] "-" - -"#],
-            want: Ok(btreemap! {}),
+            want: Ok(BTreeMap::new()),
             tdef: TypeDef::object(inner_kind()).fallible(),
         }
 

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -623,7 +623,7 @@ async fn report_serialized_config_to_datadog<'a>(
 
 #[cfg(all(test, feature = "enterprise-tests"))]
 mod test {
-    use std::{io::Write, path::PathBuf, str::FromStr, thread};
+    use std::{collections::BTreeMap, io::Write, path::PathBuf, str::FromStr, thread};
 
     use http::StatusCode;
     use indexmap::IndexMap;
@@ -889,7 +889,7 @@ mod test {
         // .tags is an object and merge() is thus a safe operation (mimicking
         // the environment this code will actually run in).
         let mut state = vrl::state::ExternalEnv::new_with_kind(Kind::object(btreemap! {
-            "tags" => Kind::object(btreemap! {}),
+            "tags" => Kind::object(BTreeMap::new()),
         }));
         assert!(
             vrl::compile_with_state(vrl.as_str(), vrl_stdlib::all().as_ref(), &mut state).is_ok()

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -442,7 +442,7 @@ mod integration_tests {
     async fn oneshot() {
         assert_source_compliance(&SOURCE_TAGS, async {
             let (tester, mut rx, shutdown) = setup(EventStatus::Delivered).await;
-            let test_data = tester.send_test_events(99, btreemap![]).await;
+            let test_data = tester.send_test_events(99, BTreeMap::new()).await;
             receive_events(&mut rx, test_data).await;
             tester.shutdown_check(shutdown).await;
         })
@@ -456,7 +456,7 @@ mod integration_tests {
         tester.shutdown(shutdown).await; // Not shutdown_check because this emits nothing
 
         assert!(rx.next().await.is_none());
-        tester.send_test_events(1, btreemap![]).await;
+        tester.send_test_events(1, BTreeMap::new()).await;
         assert!(rx.next().await.is_none());
         assert_eq!(tester.pull_count(1).await, 1);
     }
@@ -466,13 +466,13 @@ mod integration_tests {
         assert_source_compliance(&SOURCE_TAGS, async {
             let (tester, mut rx, shutdown) = setup(EventStatus::Delivered).await;
 
-            let test_data = tester.send_test_events(1, btreemap![]).await;
+            let test_data = tester.send_test_events(1, BTreeMap::new()).await;
             receive_events(&mut rx, test_data).await;
 
             tester.shutdown_check(shutdown).await;
 
             assert!(rx.next().await.is_none());
-            tester.send_test_events(1, btreemap![]).await;
+            tester.send_test_events(1, BTreeMap::new()).await;
             assert!(rx.next().await.is_none());
             // The following assert is there to test that the source isn't
             // pulling anything out of the subscription after it reports
@@ -489,7 +489,7 @@ mod integration_tests {
         assert_source_compliance(&SOURCE_TAGS, async {
             let (tester, mut rx, shutdown) = setup(EventStatus::Delivered).await;
             for _ in 0..10 {
-                let test_data = tester.send_test_events(9, btreemap![]).await;
+                let test_data = tester.send_test_events(9, BTreeMap::new()).await;
                 receive_events(&mut rx, test_data).await;
             }
             tester.shutdown_check(shutdown).await;
@@ -518,7 +518,7 @@ mod integration_tests {
         assert_source_compliance(&SOURCE_TAGS, async {
             let (tester, mut rx, shutdown) = setup(EventStatus::Delivered).await;
 
-            let test_data = tester.send_test_events(1, btreemap![]).await;
+            let test_data = tester.send_test_events(1, BTreeMap::new()).await;
             receive_events(&mut rx, test_data).await;
 
             tester.shutdown_check(shutdown).await;
@@ -544,7 +544,7 @@ mod integration_tests {
         assert_source_compliance(&SOURCE_TAGS, async {
             let (tester, mut rx, shutdown) = setup(EventStatus::Rejected).await;
 
-            let test_data = tester.send_test_events(1, btreemap![]).await;
+            let test_data = tester.send_test_events(1, BTreeMap::new()).await;
             receive_events(&mut rx, test_data).await;
 
             tester.shutdown(shutdown).await;

--- a/src/sources/host_metrics/memory.rs
+++ b/src/sources/host_metrics/memory.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use chrono::Utc;
 #[cfg(target_os = "linux")]
 use heim::memory::os::linux::MemoryExt;
@@ -6,7 +8,6 @@ use heim::memory::os::macos::MemoryExt;
 #[cfg(not(target_os = "windows"))]
 use heim::memory::os::SwapExt;
 use heim::units::information::byte;
-use vector_common::btreemap;
 
 use super::HostMetrics;
 use crate::event::metric::Metric;
@@ -21,68 +22,68 @@ impl HostMetrics {
                         "memory_total_bytes",
                         timestamp,
                         memory.total().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     self.gauge(
                         "memory_free_bytes",
                         timestamp,
                         memory.free().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     self.gauge(
                         "memory_available_bytes",
                         timestamp,
                         memory.available().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(any(target_os = "linux", target_os = "macos"))]
                     self.gauge(
                         "memory_active_bytes",
                         timestamp,
                         memory.active().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(target_os = "linux")]
                     self.gauge(
                         "memory_buffers_bytes",
                         timestamp,
                         memory.buffers().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(target_os = "linux")]
                     self.gauge(
                         "memory_cached_bytes",
                         timestamp,
                         memory.cached().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(target_os = "linux")]
                     self.gauge(
                         "memory_shared_bytes",
                         timestamp,
                         memory.shared().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(target_os = "linux")]
                     self.gauge(
                         "memory_used_bytes",
                         timestamp,
                         memory.used().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(target_os = "macos")]
                     self.gauge(
                         "memory_inactive_bytes",
                         timestamp,
                         memory.inactive().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(target_os = "macos")]
                     self.gauge(
                         "memory_wired_bytes",
                         timestamp,
                         memory.wire().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                 ]
             }
@@ -102,33 +103,33 @@ impl HostMetrics {
                         "memory_swap_free_bytes",
                         timestamp,
                         swap.free().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     self.gauge(
                         "memory_swap_total_bytes",
                         timestamp,
                         swap.total().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     self.gauge(
                         "memory_swap_used_bytes",
                         timestamp,
                         swap.used().get::<byte>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(not(target_os = "windows"))]
                     self.counter(
                         "memory_swapped_in_bytes_total",
                         timestamp,
                         swap.sin().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     #[cfg(not(target_os = "windows"))]
                     self.counter(
                         "memory_swapped_out_bytes_total",
                         timestamp,
                         swap.sout().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                 ]
             }

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -12,8 +12,6 @@ use serde::{
 };
 use tokio::time;
 use tokio_stream::wrappers::IntervalStream;
-#[cfg(unix)]
-use vector_common::btreemap;
 use vector_core::ByteSizeOf;
 
 use crate::{
@@ -236,19 +234,19 @@ impl HostMetrics {
                         "load1",
                         timestamp,
                         loadavg.0.get::<ratio>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     self.gauge(
                         "load5",
                         timestamp,
                         loadavg.1.get::<ratio>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                     self.gauge(
                         "load15",
                         timestamp,
                         loadavg.2.get::<ratio>() as f64,
-                        btreemap! {},
+                        BTreeMap::new(),
                     ),
                 ]
             }

--- a/src/template.rs
+++ b/src/template.rs
@@ -240,8 +240,9 @@ impl Serialize for Template {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use chrono::TimeZone;
-    use vector_common::btreemap;
 
     use super::*;
     use crate::event::{Event, MetricKind, MetricValue};
@@ -439,9 +440,10 @@ mod tests {
     #[test]
     fn render_metric_with_tags() {
         let template = Template::try_from("name={{name}} component={{tags.component}}").unwrap();
-        let metric = sample_metric().with_tags(Some(
-            btreemap! { "test" => "true", "component" => "template" },
-        ));
+        let metric = sample_metric().with_tags(Some(BTreeMap::from([
+            (String::from("test"), String::from("true")),
+            (String::from("component"), String::from("template")),
+        ])));
         assert_eq!(
             Ok(Bytes::from("name=a-counter component=template")),
             template.render(&metric)

--- a/src/transforms/add_tags.rs
+++ b/src/transforms/add_tags.rs
@@ -99,6 +99,8 @@ impl FunctionTransform for AddTags {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use vector_common::btreemap;
 
     use super::*;
@@ -143,7 +145,10 @@ mod tests {
             MetricKind::Absolute,
             MetricValue::Gauge { value: 10.0 },
         )
-        .with_tags(Some(btreemap! {"region" => "us-east-1"}));
+        .with_tags(Some(BTreeMap::from([(
+            String::from("region"),
+            String::from("us-east-1"),
+        )])));
         let expected = metric.clone();
 
         let map = vec![("region".to_string(), "overridden".to_string())]


### PR DESCRIPTION
This commit relates to #12717 and is a removal, almost entirely, of simple,
empty `BTreeMap` instances. This leaves non-trivial conversions to do, about 300
in all.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
