### PR TITLE
chore(observability): Add vector version and target triple info to enterprise logs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -143,6 +143,12 @@ fn main() {
     let target_arch = tracker
         .get_env_var("CARGO_CFG_TARGET_ARCH")
         .expect("Cargo-provided environment variables should always exist!");
+    let target_os = tracker
+        .get_env_var("CARGO_CFG_TARGET_OS")
+        .expect("Cargo-provided environment variables should always exist!");
+    let target_vendor = tracker
+        .get_env_var("CARGO_CFG_TARGET_VENDOR")
+        .expect("Cargo-provided environment variables should always exist!");
     let debug = tracker
         .get_env_var("DEBUG")
         .expect("Cargo-provided environment variables should always exist!");
@@ -170,6 +176,16 @@ fn main() {
         "TARGET_ARCH",
         "The target architecture being compiled for. (e.g. x86_64)",
         target_arch,
+    );
+    constants.add_required_constant(
+        "TARGET_OS",
+        "The target OS being compiled for. (e.g. macos)",
+        target_os,
+    );
+    constants.add_required_constant(
+        "TARGET_VENDOR",
+        "The target vendor being compiled for. (e.g. apple)",
+        target_vendor,
     );
     constants.add_required_constant("DEBUG", "Level of debug info for Vector.", debug);
     constants.add_optional_constant(

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -20,6 +20,7 @@ use super::{
     SourceOuter, TransformOuter,
 };
 use crate::{
+    built_info,
     common::datadog::{get_api_base_endpoint, Region},
     http::{HttpClient, HttpError},
     signal::{SignalRx, SignalTo},
@@ -380,9 +381,19 @@ fn setup_logs_reporting(
             .version = "{}"
             .configuration_key = "{}"
             .ddsource = "vector"
+            .vector_version = "{}"
+            .arch = "{}"
+            .os = "{}"
+            .vendor = "{}"
             {}
         "#,
-            &config_version, &datadog.configuration_key, custom_logs_tags_vrl,
+            &config_version,
+            &datadog.configuration_key,
+            crate::vector_version(),
+            built_info::TARGET_ARCH,
+            built_info::TARGET_OS,
+            built_info::TARGET_VENDOR,
+            custom_logs_tags_vrl,
         )),
         ..Default::default()
     };


### PR DESCRIPTION
Closes [OP-385](https://datadoghq.atlassian.net/browse/OP-385)

This PR adds additional log fields to enterprise logging for easier debugging: `vector_version`, `arch`, `os`, `vendor`.

### Example

Inspecting logs in Datadog, you'll see relevant fields.
<img width="693" alt="Screen Shot 2022-05-18 at 3 15 40 PM" src="https://user-images.githubusercontent.com/43912346/169139474-0ea5b628-6d93-4f86-947d-9b5a71a7ac7d.png">


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
