### PR TITLE
chore: Update lading

### DIFF
--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # LADING
 #
-FROM ghcr.io/blt/lading@sha256:1d2f7d3145c06df976bb9c06ad04c70de5b603598b3c4a85eaa565fa33f63343 as lading
+FROM ghcr.io/blt/lading@sha256:587d014a76906c01edae8782ca10e8c0cbb87195d9d4d892db650f12857f0c04 as lading
 
 #
 # TARGET


### PR DESCRIPTION
This update includes two new interesting features in lading itself:

* the 'observer' is now able to collect CPU, memory data about Vector
* the 'inspector' can run out-of-band performance analysis, like `perf record`

The observer is flagged on automatically, the inspector has to be
configured. Assuming this update works out alright it should be possible then to
tackle #10447

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
