### PR TITLE
fix(gcp_pubsub source): Handle connection resets with fast retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,8 +3137,7 @@ dependencies = [
 [[package]]
 name = "h2"
 version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+source = "git+https://github.com/hyperium/h2.git?rev=f6aa3be6719270cd7b4094ee1940751b5f4ec88e#f6aa3be6719270cd7b4094ee1940751b5f4ec88e"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -8644,6 +8643,7 @@ dependencies = [
  "gouth",
  "governor",
  "grok",
+ "h2",
  "hash_hasher",
  "headers",
  "heim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,7 @@ futures-util = { version = "0.3.21", default-features = false }
 glob = { version = "0.3.0", default-features = false }
 governor = { version = "0.4.1", default-features = false, features = ["dashmap", "jitter", "std"], optional = true }
 grok = { version = "1.2.0", default-features = false, optional = true }
+h2 = { version = "0.3.13", default-features = false, optional = true }
 hash_hasher = { version = "2.0.0", default-features = false, optional  = true }
 headers = { version = "0.3.6", default-features = false }
 hostname = { version = "0.3.1", default-features = false }
@@ -345,6 +346,8 @@ leveldb-sys = { git = "https://github.com/vectordotdev/leveldb-sys.git", branch 
 # Removes dependency on `time` v0.1
 # https://github.com/chronotope/chrono/pull/578
 chrono = { git = "https://github.com/vectordotdev/chrono.git", branch = "no-default-time" }
+# Adds `Status::is_reset` test, remove after the next version is released.
+h2 = { git = "https://github.com/hyperium/h2.git", rev = "f6aa3be6719270cd7b4094ee1940751b5f4ec88e" }
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
@@ -477,7 +480,7 @@ sources-eventstoredb_metrics = []
 sources-exec = []
 sources-file = ["file-source"]
 sources-fluent = ["base64", "listenfd", "tokio-util/net", "rmpv", "rmp-serde", "sources-utils-tcp-keepalive", "sources-utils-tcp-socket", "sources-utils-tls", "serde_bytes"]
-sources-gcp_pubsub = ["gcp", "prost-types", "protobuf-build", "tonic"]
+sources-gcp_pubsub = ["gcp", "h2", "prost-types", "protobuf-build", "tonic"]
 sources-heroku_logs = ["sources-utils-http", "sources-utils-http-query", "sources-http"]
 sources-host_metrics = ["heim"]
 sources-http = ["sources-utils-http", "sources-utils-http-query"]

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -1,4 +1,4 @@
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{error::Error as _, pin::Pin, sync::Arc, time::Duration};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use codecs::decoding::{DeserializerConfig, FramingConfig};
@@ -207,6 +207,12 @@ struct PubsubSource {
     retry_delay: Duration,
 }
 
+enum State {
+    RetryNow,
+    RetryDelay,
+    Shutdown,
+}
+
 impl PubsubSource {
     async fn run(mut self) -> crate::Result<()> {
         let mut endpoint = Channel::from_shared(self.endpoint.clone()).context(EndpointSnafu)?;
@@ -221,9 +227,15 @@ impl PubsubSource {
             None => EmptyStream::default().boxed(),
         };
 
-        while self.run_once(&endpoint, &mut token_generator).await {
-            info!(timeout_secs = 1, "Retrying after timeout.");
-            tokio::time::sleep(self.retry_delay).await;
+        loop {
+            match self.run_once(&endpoint, &mut token_generator).await {
+                State::RetryNow => debug!("Retrying immediately."),
+                State::RetryDelay => {
+                    info!(timeout_secs = 1, "Retrying after timeout.");
+                    tokio::time::sleep(self.retry_delay).await;
+                }
+                State::Shutdown => break,
+            }
         }
 
         Ok(())
@@ -233,12 +245,12 @@ impl PubsubSource {
         &mut self,
         endpoint: &Endpoint,
         token_generator: &mut Pin<Box<dyn Stream<Item = ()> + Send>>,
-    ) -> bool {
+    ) -> State {
         let connection = match endpoint.connect().await {
             Ok(connection) => connection,
             Err(error) => {
                 emit!(GcpPubsubConnectError { error });
-                return true;
+                return State::RetryDelay;
             }
         };
 
@@ -264,12 +276,12 @@ impl PubsubSource {
         let request_stream = self.request_stream();
         debug!("Starting streaming pull.");
         let stream = tokio::select! {
-            _ = &mut self.shutdown => return false,
+            _ = &mut self.shutdown => return State::Shutdown,
             result = client.streaming_pull(request_stream) => match result {
                 Ok(stream) => stream,
                 Err(error) => {
                     emit!(GcpPubsubStreamingPullError { error });
-                    return true;
+                    return State::RetryDelay;
                 }
             }
         };
@@ -280,10 +292,10 @@ impl PubsubSource {
 
         loop {
             tokio::select! {
-                _ = &mut self.shutdown => return false,
+                _ = &mut self.shutdown => return State::Shutdown,
                 _ = &mut token_generator.next() => {
                     debug!("New authentication token generated, restarting stream.");
-                    return true;
+                    break State::RetryNow;
                 },
                 receipts = ack_stream.next() => if let Some((status, receipts)) = receipts {
                     if status == BatchStatus::Delivered {
@@ -292,16 +304,11 @@ impl PubsubSource {
                 },
                 response = stream.next() => match response {
                     Some(Ok(response)) => self.handle_response(response, &finalizer).await,
-                    Some(Err(error)) => {
-                        emit!(GcpPubsubReceiveError { error });
-                        break;
-                    }
-                    None => break,
+                    Some(Err(error)) => break translate_error(error),
+                    None => break State::RetryNow,
                 },
             }
         }
-
-        true
     }
 
     fn make_tls_config(&self) -> ClientTlsConfig {
@@ -417,6 +424,31 @@ impl PubsubSource {
             event
         })
     }
+}
+
+fn translate_error(error: tonic::Status) -> State {
+    // GCP occasionally issues a connection reset
+    // in the middle of the streaming pull. This
+    // reset is not technically an error, so we
+    // want to retry immediately, but it is
+    // reported to us as an error from the
+    // underlying library (`tonic`).
+    if is_reset(&error) {
+        debug!("Stream reset by server.");
+        State::RetryNow
+    } else {
+        emit!(GcpPubsubReceiveError { error });
+        State::RetryDelay
+    }
+}
+
+fn is_reset(error: &Status) -> bool {
+    error
+        .source()
+        .and_then(|source| source.downcast_ref::<hyper::Error>())
+        .and_then(|error| error.source())
+        .and_then(|source| source.downcast_ref::<h2::Error>())
+        .map_or(false, |error| error.is_remote() && error.is_reset())
 }
 
 #[cfg(test)]

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -231,7 +231,10 @@ impl PubsubSource {
             match self.run_once(&endpoint, &mut token_generator).await {
                 State::RetryNow => debug!("Retrying immediately."),
                 State::RetryDelay => {
-                    info!(timeout_secs = 1, "Retrying after timeout.");
+                    info!(
+                        timeout_secs = self.retry_delay.as_secs_f64(),
+                        "Retrying after timeout."
+                    );
                     tokio::time::sleep(self.retry_delay).await;
                 }
                 State::Shutdown => break,


### PR DESCRIPTION
GCP occasionally issues a connection reset in the middle of the
streaming pull. This reset is not technically an error, so we want to
retry immediately instead of waiting for a timeout and slowing down the
streaming data.

Ref #12660