### PR TITLE
feat(vrl): add variant enum argument to the is_json function

### DIFF
--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -765,6 +765,11 @@ bench_function! {
         args: func_args![value: r#"{"key": "value""#],
         want: Ok(false),
     }
+
+    exact_variant {
+        args: func_args![value: r#"{"key": "value""#, variant: "object"],
+        want: Ok(true),
+    }
 }
 
 bench_function! {

--- a/lib/vrl/stdlib/src/is_json.rs
+++ b/lib/vrl/stdlib/src/is_json.rs
@@ -10,6 +10,40 @@ fn is_json(value: Value) -> Resolved {
     }
 }
 
+fn is_json_with_variant(value: Value, variant: &Bytes) -> Resolved {
+    let bytes = value.try_bytes()?;
+
+    match serde_json::from_slice::<'_, serde::de::IgnoredAny>(&bytes) {
+        Err(_) => Ok(value!(false)),
+        Ok(_) => {
+            for c in bytes {
+                return match c {
+                    // Search for the first non whitespace char
+                    b' ' | b'\n' | b'\t' | b'\r' => continue,
+                    b'{' => Ok(value!(variant.as_ref() == b"object")),
+                    b'[' => Ok(value!(variant.as_ref() == b"array")),
+                    b't' | b'f' => Ok(value!(variant.as_ref() == b"bool")),
+                    b'-' | b'0'..=b'9' => Ok(value!(variant.as_ref() == b"number")),
+                    b'"' => Ok(value!(variant.as_ref() == b"string")),
+                    _ => Ok(value!(false)),
+                };
+            }
+            // Empty input value cannot be any type, not a specific variant
+            Ok(value!(false))
+        }
+    }
+}
+
+fn variants() -> Vec<Value> {
+    vec![
+        value!("object"),
+        value!("array"),
+        value!("bool"),
+        value!("number"),
+        value!("string"),
+    ]
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct IsJson;
 
@@ -19,11 +53,18 @@ impl Function for IsJson {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[Parameter {
-            keyword: "value",
-            kind: kind::BYTES,
-            required: true,
-        }]
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "variant",
+                kind: kind::BYTES,
+                required: false,
+            },
+        ]
     }
 
     fn examples(&self) -> &'static [Example] {
@@ -43,6 +84,11 @@ impl Function for IsJson {
                 source: r#"is_json("}{")"#,
                 result: Ok("false"),
             },
+            Example {
+                title: "exact_variant",
+                source: r#"is_json("{}", variant: "object")"#,
+                result: Ok("true"),
+            },
         ]
     }
 
@@ -53,11 +99,48 @@ impl Function for IsJson {
         mut arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        Ok(Box::new(IsJsonFn { value }))
+        let variant = arguments.optional_enum("variant", &variants())?;
+
+        match variant {
+            Some(raw_variant) => {
+                let variant = raw_variant.try_bytes().expect("variant not bytes");
+                Ok(Box::new(IsJsonVariantsFn { value, variant }))
+            }
+            None => Ok(Box::new(IsJsonFn { value })),
+        }
+    }
+
+    fn compile_argument(
+        &self,
+        _args: &[(&'static str, Option<FunctionArgument>)],
+        _ctx: &mut FunctionCompileContext,
+        name: &str,
+        expr: Option<&expression::Expr>,
+    ) -> CompiledArgument {
+        match (name, expr) {
+            ("variant", Some(expr)) => {
+                let variant = expr
+                    .as_enum("variant", variants())?
+                    .try_bytes()
+                    .expect("variant not bytes");
+
+                Ok(Some(Box::new(variant) as _))
+            }
+            _ => Ok(None),
+        }
     }
 
     fn call_by_vm(&self, _ctx: &mut Context, args: &mut VmArgumentList) -> Resolved {
-        is_json(args.required("value"))
+        let value = args.required("value");
+        let variant = args.optional_any("variant");
+
+        match variant {
+            Some(variant) => {
+                let variant = variant.downcast_ref::<Bytes>().unwrap();
+                is_json_with_variant(value, variant)
+            }
+            None => is_json(value),
+        }
     }
 }
 
@@ -70,6 +153,25 @@ impl Expression for IsJsonFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         is_json(value)
+    }
+
+    fn type_def(&self, _: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
+        TypeDef::boolean().infallible()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct IsJsonVariantsFn {
+    value: Box<dyn Expression>,
+    variant: Bytes,
+}
+
+impl Expression for IsJsonVariantsFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let variant = &self.variant;
+
+        is_json_with_variant(value, variant)
     }
 
     fn type_def(&self, _: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
@@ -102,5 +204,34 @@ mod tests {
             tdef: TypeDef::boolean().infallible(),
         }
 
+        exact_variant {
+            args: func_args![value: r#"{}"#, variant: "object"],
+            want: Ok(value!(true)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        exact_variant_invalid {
+            args: func_args![value: r#"123"#, variant: "object"],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        variant_with_spaces {
+            args: func_args![value: r#"   []"#, variant: "array"],
+            want: Ok(value!(true)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        invalid_variant {
+            args: func_args![value: r#"[]"#, variant: "invalid-variant"],
+            want: Err(r#"invalid enum variant""#),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        invalid_variant_type {
+            args: func_args![value: r#"[]"#, variant: 100],
+            want: Err(r#"invalid enum variant""#),
+            tdef: TypeDef::boolean().infallible(),
+        }
     ];
 }

--- a/lib/vrl/stdlib/src/is_json.rs
+++ b/lib/vrl/stdlib/src/is_json.rs
@@ -103,7 +103,7 @@ impl Function for IsJson {
 
         match variant {
             Some(raw_variant) => {
-                let variant = raw_variant.try_bytes().expect("variant not bytes");
+                let variant = raw_variant.try_bytes()?;
                 Ok(Box::new(IsJsonVariantsFn { value, variant }))
             }
             None => Ok(Box::new(IsJsonFn { value })),
@@ -121,8 +121,7 @@ impl Function for IsJson {
             ("variant", Some(expr)) => {
                 let variant = expr
                     .as_enum("variant", variants())?
-                    .try_bytes()
-                    .expect("variant not bytes");
+                    .try_bytes()?;
 
                 Ok(Some(Box::new(variant) as _))
             }

--- a/website/cue/reference/remap/functions/is_json.cue
+++ b/website/cue/reference/remap/functions/is_json.cue
@@ -15,7 +15,7 @@ remap: functions: is_json: {
 		},
 		{
 			name:        "variant"
-			description: "The variant of the JSON type to explicitly check it."
+			description: "The variant of the JSON type to explicitly check for."
 			enum: {
 				"object": "JSON object - {}"
 				"array":  "JSON array - []"

--- a/website/cue/reference/remap/functions/is_json.cue
+++ b/website/cue/reference/remap/functions/is_json.cue
@@ -13,6 +13,19 @@ remap: functions: is_json: {
 			required:    true
 			type: ["string"]
 		},
+		{
+			name:        "variant"
+			description: "The variant of the JSON type to explicitly check it."
+			enum: {
+				"object": "JSON object - {}"
+				"array":  "JSON array - []"
+				"string": "JSON-formatted string values wrapped with quote marks"
+				"number": "Integer or float numbers"
+				"bool":   "True or false"
+			}
+			required: false
+			type: ["string"]
+		},
 	]
 	internal_failure_reasons: []
 	return: {
@@ -35,6 +48,20 @@ remap: functions: is_json: {
 			title: "Non-valid value"
 			source: """
 				is_json("{")
+				"""
+			return: false
+		},
+		{
+			title: "Exact variant"
+			source: """
+				is_json("{}", variant: "object")
+				"""
+			return: true
+		},
+		{
+			title: "Non-valid exact variant"
+			source: """
+				is_json("{}", variant: "array")
 				"""
 			return: false
 		},

--- a/website/cue/reference/remap/functions/is_json.cue
+++ b/website/cue/reference/remap/functions/is_json.cue
@@ -22,6 +22,7 @@ remap: functions: is_json: {
 				"string": "JSON-formatted string values wrapped with quote marks"
 				"number": "Integer or float numbers"
 				"bool":   "True or false"
+				"null":   "Exact null value"
 			}
 			required: false
 			type: ["string"]


### PR DESCRIPTION
This is an implementation of the idea from the linked issue. 
***
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>
Close https://github.com/vectordotdev/vector/issues/12763