### PR TITLE
enhancement(geoip transform): Bring up to parity with Logstash geoip filter

### DIFF
--- a/src/transforms/geoip.rs
+++ b/src/transforms/geoip.rs
@@ -21,6 +21,8 @@ pub struct GeoipConfig {
     pub database: String,
     #[serde(default = "default_geoip_target_field")]
     pub target: String,
+    #[serde(default = "default_locale")]
+    pub locale: String,
 }
 
 #[derive(Derivative, Clone)]
@@ -31,10 +33,20 @@ pub struct Geoip {
     pub database: String,
     pub source: String,
     pub target: String,
+    pub locale: String,
 }
 
 fn default_geoip_target_field() -> String {
     "geoip".to_string()
+}
+
+// valid locales are: “de”, "en", “es”, “fr”, “ja”, “pt-BR”, “ru”, and “zh-CN”
+//
+// https://dev.maxmind.com/geoip/docs/databases/city-and-country?lang=en
+//
+// TODO try to determine the system locale and use that as default if it matches a valid locale?
+fn default_locale() -> String {
+    "en".to_string()
 }
 
 inventory::submit! {
@@ -47,6 +59,7 @@ impl GenerateConfig for GeoipConfig {
             database: "/path/to/GeoLite2-City.mmdb".to_string(),
             source: "ip address".to_owned(),
             target: default_geoip_target_field(),
+            locale: "en".to_owned(),
         })
         .unwrap()
     }
@@ -60,6 +73,7 @@ impl TransformConfig for GeoipConfig {
             self.database.clone(),
             self.source.clone(),
             self.target.clone(),
+            self.locale.clone(),
         )?))
     }
 
@@ -83,12 +97,18 @@ const ASN_DATABASE_TYPE: &str = "GeoLite2-ASN";
 const ISP_DATABASE_TYPE: &str = "GeoIP2-ISP";
 
 impl Geoip {
-    pub fn new(database: String, source: String, target: String) -> crate::Result<Self> {
+    pub fn new(
+        database: String,
+        source: String,
+        target: String,
+        locale: String,
+    ) -> crate::Result<Self> {
         Ok(Geoip {
             dbreader: Arc::new(maxminddb::Reader::open_readfile(database.clone())?),
             database,
             source,
             target,
+            locale,
         })
     }
 
@@ -111,10 +131,14 @@ struct City<'a> {
     city_name: &'a str,
     continent_code: &'a str,
     country_code: &'a str,
+    country_name: &'a str,
     timezone: &'a str,
     latitude: String,  // converted from f64 as per original design
     longitude: String, // converted from f64 as per original design
     postal_code: &'a str,
+    region_code: &'a str,
+    region_name: &'a str,
+    metro_code: Option<u16>,
 }
 
 impl FunctionTransform for Geoip {
@@ -155,25 +179,51 @@ impl FunctionTransform for Geoip {
                             city.continent_code = continent_code;
                         }
 
-                        if let Some(country_code) = data.country.and_then(|cy| cy.iso_code) {
-                            city.country_code = country_code;
-                        };
+                        if let Some(country) = data.country {
+                            if let Some(country_code) = country.iso_code {
+                                city.country_code = country_code;
+                            }
+                            if let Some(country_name) = country
+                                .names
+                                .as_ref()
+                                .and_then(|names| names.get(&*self.locale))
+                            {
+                                city.country_name = country_name;
+                            }
+                        }
 
-                        if let Some(time_zone) = data.location.clone().and_then(|loc| loc.time_zone)
+                        if let Some(location) = data.location {
+                            if let Some(time_zone) = location.time_zone {
+                                city.timezone = time_zone;
+                            }
+                            if let Some(latitude) = location.latitude {
+                                city.latitude = latitude.to_string();
+                            }
+
+                            if let Some(longitude) = location.longitude {
+                                city.longitude = longitude.to_string();
+                            }
+
+                            city.metro_code = location.metro_code
+                        }
+
+                        // last subdivision is most specific per https://github.com/maxmind/GeoIP2-java/blob/39385c6ce645374039450f57208b886cf87ade47/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java#L96-L107
+                        if let Some(subdivision) = data.subdivisions.as_ref().and_then(|s| s.last())
                         {
-                            city.timezone = time_zone;
+                            if let Some(name) = subdivision
+                                .names
+                                .as_ref()
+                                .and_then(|names| names.get(&*self.locale))
+                            {
+                                city.region_name = name;
+                            }
+
+                            if let Some(iso_code) = subdivision.iso_code {
+                                city.region_code = iso_code
+                            }
                         }
 
-                        if let Some(latitude) = data.location.clone().and_then(|loc| loc.latitude) {
-                            city.latitude = latitude.to_string();
-                        }
-
-                        if let Some(longitude) = data.location.clone().and_then(|loc| loc.longitude)
-                        {
-                            city.longitude = longitude.to_string();
-                        }
-
-                        if let Some(postal_code) = data.postal.clone().and_then(|p| p.code) {
+                        if let Some(postal_code) = data.postal.and_then(|p| p.code) {
                             city.postal_code = postal_code;
                         }
                     }
@@ -234,10 +284,14 @@ mod tests {
         exp_geoip_attr.insert("city_name", "Boxford");
         exp_geoip_attr.insert("country_code", "GB");
         exp_geoip_attr.insert("continent_code", "EU");
+        exp_geoip_attr.insert("country_name", "United Kingdom");
+        exp_geoip_attr.insert("region_code", "WBK");
+        exp_geoip_attr.insert("region_name", "West Berkshire");
         exp_geoip_attr.insert("timezone", "Europe/London");
         exp_geoip_attr.insert("latitude", "51.75");
         exp_geoip_attr.insert("longitude", "-1.25");
         exp_geoip_attr.insert("postal_code", "OX1");
+        exp_geoip_attr.insert("metro_code", "<null>");
 
         for field in exp_geoip_attr.keys() {
             let k = format!("geo.{}", field).to_string();
@@ -260,11 +314,17 @@ mod tests {
         let mut exp_geoip_attr = HashMap::new();
         exp_geoip_attr.insert("city_name", "");
         exp_geoip_attr.insert("country_code", "BT");
+        exp_geoip_attr.insert("country_name", "Bhutan");
         exp_geoip_attr.insert("continent_code", "AS");
+        exp_geoip_attr.insert("region_code", "");
+        exp_geoip_attr.insert("region_name", "");
         exp_geoip_attr.insert("timezone", "Asia/Thimphu");
         exp_geoip_attr.insert("latitude", "27.5");
         exp_geoip_attr.insert("longitude", "90.5");
         exp_geoip_attr.insert("postal_code", "");
+        exp_geoip_attr.insert("metro_code", "<null>");
+
+        dbg!(&new_event);
 
         for field in exp_geoip_attr.keys() {
             let k = format!("geo.{}", field).to_string();
@@ -287,11 +347,16 @@ mod tests {
         let mut exp_geoip_attr = HashMap::new();
         exp_geoip_attr.insert("city_name", "");
         exp_geoip_attr.insert("country_code", "");
+        exp_geoip_attr.insert("country_name", "");
+        exp_geoip_attr.insert("continent_code", "");
+        exp_geoip_attr.insert("region_code", "");
+        exp_geoip_attr.insert("region_name", "");
         exp_geoip_attr.insert("continent_code", "");
         exp_geoip_attr.insert("timezone", "");
         exp_geoip_attr.insert("latitude", "");
         exp_geoip_attr.insert("longitude", "");
         exp_geoip_attr.insert("postal_code", "");
+        exp_geoip_attr.insert("metro_code", "<null>");
 
         for field in exp_geoip_attr.keys() {
             let k = format!("geo.{}", field).to_string();
@@ -390,6 +455,7 @@ mod tests {
             database.to_string(),
             "remote_addr".to_string(),
             "geo".to_string(),
+            "en".to_string(),
         )
         .unwrap();
         let result = transform_one(&mut augment, event).unwrap();

--- a/website/cue/reference/components/transforms/geoip.cue
+++ b/website/cue/reference/components/transforms/geoip.cue
@@ -59,6 +59,15 @@ components: transforms: geoip: {
 				examples: ["geoip", "parent.child"]
 			}
 		}
+		locale: {
+			description: "The locale to use to lookup the country name and region name for the city database. See [Locations Files](https://dev.maxmind.com/geoip/docs/databases/city-and-country?lang=en)"
+			required:    false
+			common:      false
+			type: string: {
+				default: "en"
+				examples: ["de", "en", "es", "fr", "ja", "pt-BR", "ru", "zh-CN"]
+			}
+		}
 	}
 
 	input: {


### PR DESCRIPTION
This brings the `geoip` tranfsorm to parity with what the logstash geoip
filter returns. Note that the data doesn't match the same shape, but is
convertable to logstash's schema by mapping fields VRL.

There is a bunch more in the database we could enrich here, but I stuck
with what logstash currently supports since this was the user need.

I tried to withold rewriting the world here, but noticed some othe
oddities with this transform which is probably due to its age:

* It always inserts all fields into the log event (typically as empty
  strings) even if the fields aren't returned by the database. I think
  ideally it would either: not insert fields it couldn't find, or insert
  them with `null` values as I did here for the added `metro_code`
* `latitude` and longitude` are inserted as strings despite being f64s
* The transform builds up a temporary struct that is then converted into
  a JSON value to be inserted into the log event. I think just using
  a BTreeMap here would make more sense.

We have an issue to integrate this with VRL
(https://github.com/vectordotdev/vector/issues/9283). I think we should
avoid these issues there where since it is reasonable to make
a backwards incompatible change as users will need to opt in to cut over
to using it.

Ref: https://github.com/logstash-plugins/logstash-filter-geoip

Closes: #12800

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
