### PR TITLE
fix(transforms):  keep metrics sorted in aggregate transform

### DIFF
--- a/lib/vector-core/src/event/metric/series.rs
+++ b/lib/vector-core/src/event/metric/series.rs
@@ -6,7 +6,7 @@ use vector_common::byte_size_of::ByteSizeOf;
 
 use super::{write_list, write_word, MetricTags};
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct MetricSeries {
     #[serde(flatten)]
     pub name: MetricName,
@@ -72,7 +72,7 @@ impl ByteSizeOf for MetricSeries {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct MetricName {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -102,7 +102,6 @@ impl Aggregate {
     }
 
     fn flush_into(&mut self, output: &mut Vec<Event>) {
-        // let mut map = BTreeMap::new();
         let map = std::mem::take(&mut self.map);
         for (series, entry) in map.into_iter() {
             let metric = metric::Metric::from_parts(series, entry.0, entry.1);

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    // collections::{hash_map::Entry, HashMap},
+    collections::{btree_map::Entry, BTreeMap},
     pin::Pin,
     time::Duration,
 };
@@ -61,14 +62,14 @@ type MetricEntry = (metric::MetricData, EventMetadata);
 #[derive(Debug)]
 pub struct Aggregate {
     interval: Duration,
-    map: HashMap<metric::MetricSeries, MetricEntry>,
+    map: BTreeMap<metric::MetricSeries, MetricEntry>,
 }
 
 impl Aggregate {
     pub fn new(config: &AggregateConfig) -> crate::Result<Self> {
         Ok(Self {
             interval: Duration::from_millis(config.interval_ms),
-            map: HashMap::new(),
+            map: BTreeMap::new(),
         })
     }
 
@@ -101,7 +102,9 @@ impl Aggregate {
     }
 
     fn flush_into(&mut self, output: &mut Vec<Event>) {
-        for (series, entry) in self.map.drain() {
+        // let mut map = BTreeMap::new();
+        let map = std::mem::take(&mut self.map);
+        for (series, entry) in map.into_iter() {
             let metric = metric::Metric::from_parts(series, entry.0, entry.1);
             output.push(Event::Metric(metric));
         }


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/12275

The Datadog Agent tends to send metrics that are ordered, which means when they are batched and sent out later, HTTP compression is able to comrpess them fairly well. However, when sent through the `aggregate` transform, they are stored in a `HashMap` which randomizes the order and causes compression to perform significantly (~70%) worse. Switching the `HashMap` for a `BTreeMap` keeps the metrics sorted which allows for much better compression. In my test, Vector now compresses about 30% smaller than the data it receives from the DD Agent.