### PR TITLE
chore: Run 'comparison' soak first

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -295,12 +295,12 @@ jobs:
           rm -rf /tmp/${{ github.run_id }}-${{ github.run_attempt }}/
           mkdir -p /tmp/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.target }}/
 
-      - name: Run baseline experiment
+      - name: Run comparison experiment
         run: |
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
                                   --build-image "false" \
-                                  --variant "baseline" \
-                                  --tag ${{ needs.compute-soak-meta.outputs.baseline-tag }} \
+                                  --variant "comparison" \
+                                  --tag ${{ needs.compute-soak-meta.outputs.comparison-tag }} \
                                   --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \
                                   --memory ${{ needs.compute-soak-meta.outputs.soak-memory }} \
                                   --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \
@@ -309,13 +309,12 @@ jobs:
                                   --replicas ${{ needs.compute-soak-meta.outputs.runner-node-replicas }} \
                                   --capture-dir /tmp/${{ github.run_id }}-${{ github.run_attempt }}
 
-
-      - name: Run comparison experiment
+      - name: Run baseline experiment
         run: |
           ./soaks/bin/soak_one.sh --soak ${{ matrix.target }} \
                                   --build-image "false" \
-                                  --variant "comparison" \
-                                  --tag ${{ needs.compute-soak-meta.outputs.comparison-tag }} \
+                                  --variant "baseline" \
+                                  --tag ${{ needs.compute-soak-meta.outputs.baseline-tag }} \
                                   --cpus ${{ needs.compute-soak-meta.outputs.soak-cpus }} \
                                   --memory ${{ needs.compute-soak-meta.outputs.soak-memory }} \
                                   --vector-cpus ${{ needs.compute-soak-meta.outputs.vector-cpus }} \


### PR DESCRIPTION
Per a comment made by @JeanMertz, if the soak test is going to fail it's more
likely to fail on the comparison leg. He's right and this will save a bunch of
debug time.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
