### PR TITLE
fix(vrl): parse_nginx_log upstream label

### DIFF
--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -122,6 +122,7 @@ pub(crate) static REGEX_NGINX_ERROR_LOG: Lazy<Regex> = Lazy::new(|| {
         (,\s+client:\s+(?P<client>[^,]+))?              # Match any character after ', client: '
         (,\s+server:\s+(?P<server>[^,]+))?              # Match any character after ', server: '
         (,\s+request:\s+"(?P<request>[^"]+)")?          # Match any character after ', request: '
+        (,\s+upstream:\s+"(?P<upstream>[^"]+)")?        # Match any character after ', upstream: '
         (,\s+host:\s+"(?P<host>[^"]+)")?                # Match any character then ':' then any character after ', host: '
         (,\s+refer?rer:\s+"(?P<referer>[^"]+)")?        # Match any character after ', referrer: '
         \s*$                                            # Match any number of whitespaces (to be discarded).

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -338,5 +338,25 @@ mod tests {
             }),
             tdef: TypeDef::object(kind_error()).fallible(),
         }
+
+        error_line_with_upstream {
+            args: func_args![
+                value: r#"2022/04/15 08:16:13 [error] 7164#7164: *20 connect() failed (113: No route to host) while connecting to upstream, client: 10.244.0.0, server: test.local, request: "GET / HTTP/2.0", upstream: "http://127.0.0.1:80/""#,
+                format: "error"
+            ],
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2022-04-15T08:16:13Z").unwrap().into()),
+                "severity" => "error",
+                "pid" => 7164,
+                "tid" => 7164,
+                "cid" => 20,
+                "message" => "connect() failed (113: No route to host) while connecting to upstream",
+                "client" => "10.244.0.0",
+                "server" => "test.local",
+                "request" => "GET / HTTP/2.0",
+                "upstream" => "http://127.0.0.1:80/",
+            }),
+            tdef: TypeDef::object(kind_error()).fallible(),
+        }
     ];
 }


### PR DESCRIPTION
I placed the upstream capture group before the request because an example log line with host and referrer labels looks something like this:
```
2020/07/12 14:32:03 [error] 45625#45625: *10918 upstream sent too big header while reading response header from upstream, client: 139.xxx.yyy.zzz, server: www.nixcraft.com, request: “POST /app/mg/posts HTTP/2.0”, upstream: “fastcgi://unix:/run/php/php-fpm.sock:”, host: “www.nixcraft.com”, referrer: “https://www.nixcraft.com/mg/admin/index.app”
```

I also executed benchmarks but did not find any significant performance degradation.

***
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>
Closes https://github.com/vectordotdev/vector/issues/12240