### PR TITLE
chore: Fix missing match arm in `console` sink

### DIFF
--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -62,6 +62,7 @@ impl SinkConfig for ConsoleSinkConfig {
                 None,
                 Serializer::Text(_)
                 | Serializer::Json(_)
+                | Serializer::Logfmt(_)
                 | Serializer::NativeJson(_)
                 | Serializer::RawMessage(_),
             ) => NewlineDelimitedEncoder::new().into(),


### PR DESCRIPTION
Fixes a merge conflict with #12181.