### PR TITLE
chore: Clarify error boundaries in instrumentation spec

### DIFF
--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -15,6 +15,7 @@ interpreted as described in [RFC 2119].
     - [BufferCreated](#buffercreated)
     - [BufferEventsReceived](#buffereventsreceived)
     - [BufferEventsSent](#buffereventssent)
+    - [BufferError](#buffererror)
     - [BufferEventsDropped](#buffereventsdropped)
 
 <!-- /MarkdownTOC -->
@@ -74,12 +75,25 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
   * MUST decrement the `buffer_events` gauge by the defined `count`
   * MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
 
+#### BufferError
+
+**Extends the [Error event].**
+
+*All buffers* MUST emit error events in accordance with the [Error event]
+requirements.
+
+This specification does not list a standard set of errors that components must
+implement since errors are specific to the buffer and operation.
+
 #### BufferEventsDropped
 
 **Extends the [EventsDropped event].**
 
-*All buffers* that can drop events MUST emit a `BufferEventsDropped`
-event in accordance with the [EventsDropped event] requirements.
+*All buffers* that can drop events MUST emit a `BufferEventsDropped` event in
+accordance with the [EventsDropped event] requirements. Because buffers cannot
+unintentionally drop data, the `intentional` properly is not requiers and all
+dropped data should be considered unintentional.
 
+[Error event]: instrumentation.md#Error
 [EventsDropped event]: instrumentation.md#EventsDropped
 [Instrumentation Specification]: instrumentation.md

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -76,11 +76,10 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
 
 #### BufferEventsDropped
 
-*All buffers* MUST emit an `BufferEventsDropped` event after dropping one or more Vector events.
+**Extends the [EventsDropped event].**
 
-* Properties
-  * `count` - the number of dropped events
-* Metric
-  * MUST increment the `buffer_discarded_events_total` counter by the defined `count`
+*All buffers* that can drop events MUST emit a `BufferEventsDropped`
+event in accordance with the [EventsDropped event] requirements.
 
+[EventsDropped event]: instrumentation.md#EventsDropped
 [Instrumentation Specification]: instrumentation.md

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -8,7 +8,14 @@ interpreted as described in [RFC 2119].
 
 <!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
 
-1. [Instrumentation](#instrumentation)
+- [Scope](#scope)
+- [Instrumentation](#instrumentation)
+  - [Terms And Definitions](#terms-and-definitions)
+  - [Events](#events)
+    - [BufferCreated](#buffercreated)
+    - [BufferEventsReceived](#buffereventsreceived)
+    - [BufferEventsSent](#buffereventssent)
+    - [EventsDropped](#eventsdropped)
 
 <!-- /MarkdownTOC -->
 
@@ -18,7 +25,10 @@ This specification addresses direct buffer development and does not cover aspect
 
 ## Instrumentation
 
-Vector buffers MUST be instrumented for optimal observability and monitoring. This is required to drive various interfaces that Vector users depend on to manage Vector installations in mission critical production environments. This section extends the [Instrumentation Specification].
+**This section extends the [Instrumentation Specification] and should be read
+first.**
+
+Vector buffers MUST be instrumented for optimal observability and monitoring.
 
 ### Terms And Definitions
 
@@ -27,7 +37,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
 
 ### Events
 
-#### `BufferCreated`
+#### BufferCreated
 
 *All buffers* MUST emit a `BufferCreated` event upon creation. To avoid stale metrics, this event MUST be regularly emitted at an interval.
 
@@ -38,7 +48,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST emit the `buffer_max_event_size` gauge (in-memory buffers) if the defined `max_size_events` value is present
   * MUST emit the `buffer_max_byte_size` gauge (disk buffers) if the defined `max_size_bytes` value is present
 
-#### `BufferEventsReceived`
+#### BufferEventsReceived
 
 *All buffers* MUST emit a `BufferEventsReceived` event after receiving one or more Vector events. *All buffers* MUST emit a `BufferEventsReceived` event upon startup if there are existing events in the buffer.
 
@@ -51,7 +61,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST increment the `buffer_events` gauge by the defined `count`
   * MUST increment the `buffer_byte_size` gauge by the defined `byte_size`
 
-#### `BufferEventsSent`
+#### BufferEventsSent
 
 *All buffers* MUST emit a `BufferEventsSent` event after sending one or more Vector events.
 
@@ -64,7 +74,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring. Th
   * MUST decrement the `buffer_events` gauge by the defined `count`
   * MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
 
-#### `EventsDropped`
+#### EventsDropped
 
 *All buffers* MUST emit an `EventsDropped` event after dropping one or more Vector events.
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -26,7 +26,7 @@ This specification addresses direct buffer development and does not cover aspect
 
 ## Instrumentation
 
-**This section extends the [Instrumentation Specification] and should be read
+**This section extends the [Instrumentation Specification], which should be read
 first.**
 
 Vector buffers MUST be instrumented for optimal observability and monitoring.

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -15,7 +15,7 @@ interpreted as described in [RFC 2119].
     - [BufferCreated](#buffercreated)
     - [BufferEventsReceived](#buffereventsreceived)
     - [BufferEventsSent](#buffereventssent)
-    - [EventsDropped](#eventsdropped)
+    - [BufferEventsDropped](#buffereventsdropped)
 
 <!-- /MarkdownTOC -->
 
@@ -74,7 +74,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
   * MUST decrement the `buffer_events` gauge by the defined `count`
   * MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
 
-#### EventsDropped
+#### BufferEventsDropped
 
 *All buffers* MUST emit an `EventsDropped` event after dropping one or more Vector events.
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -76,7 +76,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
 
 #### BufferEventsDropped
 
-*All buffers* MUST emit an `EventsDropped` event after dropping one or more Vector events.
+*All buffers* MUST emit an `BufferEventsDropped` event after dropping one or more Vector events.
 
 * Properties
   * `count` - the number of dropped events

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -90,9 +90,7 @@ implement since errors are specific to the buffer and operation.
 **Extends the [EventsDropped event].**
 
 *All buffers* that can drop events MUST emit a `BufferEventsDropped` event in
-accordance with the [EventsDropped event] requirements. Because buffers cannot
-unintentionally drop data, the `intentional` properly is not requiers and all
-dropped data should be considered unintentional.
+accordance with the [EventsDropped event] requirements.
 
 [Error event]: instrumentation.md#Error
 [EventsDropped event]: instrumentation.md#EventsDropped

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -89,7 +89,7 @@ Vector components MUST be instrumented for optimal observability and monitoring.
 
 ### Events
 
-This section lists all required and optional events that a component MUST emit.
+This section lists all required events that a component MUST emit. Additionally, additional events are listed that a component is RECOMMENDED to emit, but remain OPTIONAL.
 It is expected that components will emit custom events beyond those listed here
 that reflect component specific behavior. There is leeway in the implementation
 of these events:

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -79,7 +79,7 @@ configuration.
 When a component makes a connection to a downstream target, it SHOULD
 expose either an `endpoint` option that takes a `string` representing a
 single endpoint, or an `endpoints` option that takes an array of strings
-representing multiple endpoints. If a component uses multuiple options to
+representing multiple endpoints. If a component uses multiple options to
 automatically build the endpoint, then the `endpoint(s)` option MUST
 override that process.
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -209,6 +209,8 @@ implement since errors are specific to the component.
 
 * Properties
   * `message` - A human readable error message.
+  * `recoverable` - If the error is recoverable or not. This dictates the log
+    level and which metrics get incremented.
   * `error_code` - An error code for the failure, if applicable.
     * SHOULD only be specified if it adds additional information beyond
       `error_type`.
@@ -227,8 +229,9 @@ implement since errors are specific to the component.
     event fields. However, they MUST still be included in the emitted
     logs and metrics, as specified below, as if they were present.
 * Metrics
-  * MUST increment the `component_errors_total` counter by 1 with the defined
-    properties, except `message` as metric tags.
+  * MUST increment the `component_errors_total` counter by 1 if `recoverable`
+    is `false`. It should include the defined properties as tags, except for
+    `message` and `recoverable`.
   * MUST increment the `component_discarded_events_total` counter by the number
     of Vector events discarded if the error resulted in discarding (dropping)
     acknowledged events.
@@ -239,8 +242,9 @@ implement since errors are specific to the component.
       in the sink dropping the events, and thus acknowledging them. Retried
       events MUST not be included in the metric.
 * Logs
-  * MUST log a message at the `error` level with the defined properties
-    as key-value pairs. It SHOULD be rate limited to 10 seconds.
+  * MUST log a message at the `error` if `recoverable` is `false`, otherwise
+    it should log at the `warn` level. It MUST include the defined properties
+    as key-value pairs and it SHOULD be rate limited to 10 seconds.
 
 #### ComponentEventsDropped
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -89,10 +89,11 @@ Vector components MUST be instrumented for optimal observability and monitoring.
 
 ### Events
 
-This section lists all required events that a component MUST emit. Additional events are
-It is expected that components will emit custom events beyond those listed here
-that reflect component specific behavior. There is leeway in the implementation
-of these events:
+This section lists all required events that a component MUST emit. Additional events
+are listed that a component is RECOMMENDED to emit, but remain OPTIONAL. It is
+expected that components will emit custom events beyond those listed here that
+reflect component specific behavior. There is leeway in the implementation of these
+events:
 
 * Events MAY be augmented with additional component-specific context. For
   example, the `socket` source adds a `mode` attribute as additional context.

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -83,8 +83,7 @@ representing multiple endpoints.
 
 ## Instrumentation
 
-**This section extends the [Instrumentation Specification] and should be read
-first.**
+**Extends the [Instrumentation Specification].**
 
 Vector components MUST be instrumented for optimal observability and monitoring.
 
@@ -205,68 +204,20 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
 
 #### ComponentError
 
-*All components* MUST emit error events in accordance with the
-[Instrumentation Specification].
+**Extends the [Error event].**
+
+*All components* MUST emit error events in accordance with the [Error event]
+requirements.
 
 This specification does not list a standard set of errors that components must
 implement since errors are specific to the component.
 
-* Properties
-  * `message` - A human readable error message.
-  * `recoverable` - If the error is recoverable or not. This dictates the log
-    level and which metrics get incremented.
-  * `error_code` - An error code for the failure, if applicable.
-    * SHOULD only be specified if it adds additional information beyond
-      `error_type`.
-    * The values for `error_code` for a given error event MUST be a bounded set
-      with relatively low cardinality because it will be used as a metric tag.
-      Examples would be syscall error code. Examples of values that should not
-      be used are raw error messages from `serde` as these are highly variable
-      depending on the input. Instead, these errors should be converted to an
-      error code like `invalid_json`.
-  * `error_type` - The type of error condition. MUST be one of the types listed
-    in the `error_type` enum list in the cue docs.
-  * `stage` - The stage at which the error occurred. MUST be one of `receiving`,
-    `processing`, or `sending`.
-  * If any of the above properties are implicit to the specific error
-    type, they MAY be omitted from being represented explicitly in the
-    event fields. However, they MUST still be included in the emitted
-    logs and metrics, as specified below, as if they were present.
-* Metrics
-  * If `recoverable` is `false`, MUST increment the `component_errors_total`
-    counter by 1.
-  * MUST increment the `component_discarded_events_total` counter by the number
-    of Vector events discarded if the error resulted in discarding (dropping)
-    acknowledged events.
-    * For sources, only increment this metric if incoming events were consumed
-      (and acknowledged if applicable) and discarded. The metric MUST not
-      include events that will be re-ingested.
-    * For sinks, this means only incrementing this metric if the error resulted
-      in the sink dropping the events, and thus acknowledging them. Retried
-      events MUST not be included in the metric.
-  * MUST include the defined properties as tags, except for `message` and
-    `recoverable`.
-* Logs
-  * If `recoverable` is `false`, MUST log a message at the `error` level.
-    Otherwise, if `recoverable` is `true`, MUST log a message at the `warn`
-    level.
-  * MUST include the defined properties as key-value pairs.
-  * SHOULD be rate limited to 10 seconds.
-
 #### ComponentEventsDropped
 
-*All components* that can drop events, **unrelated to an error**, MUST emit a
-`ComponentEventsDropped` event. Otherwise, if an event is dropped due to an
-error, then the error event itself MUST emit the appropriate logs and metrics
-as described in the [ComponentError](#ComponentError) section.
+**Extends the [EventsDropped event].**
 
-* Metrics
-  * MUST increment the `component_discarded_events_total` counter by the number
-    of Vector events discarded.
-* Logs
-  * MUST log a `Bytes sent.` message at the `trace` level with the
-    defined properties as key-value pairs.
-  * MUST NOT be rate limited.
+*All components* that can drop events MUST emit a `ComponentEventsDropped`
+event in accordance with the [EventsDropped event] requirements.
 
 ## Health checks
 
@@ -283,6 +234,8 @@ AWS's status.
 See the [development documentation][health checks] for more context guidance.
 
 [Configuration Specification]: configuration.md
+[Error event]: instrumentation.md#Error
+[EventsDropped event]: instrumentation.md#EventsDropped
 [high user experience expectations]: https://github.com/vectordotdev/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md
 [health checks]: ../DEVELOPING.md#sink-healthchecks
 [Instrumentation Specification]: instrumentation.md

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -107,7 +107,7 @@ of these events:
 
 #### ComponentBytesReceived
 
-*Sources* MUST emit a `BytesReceived` event immediately after receiving, decompressing
+*Sources* MUST emit a `ComponentBytesReceived` event immediately after receiving, decompressing
 and filtering bytes from the upstream source and before the creation of a Vector event.
 
 * Properties

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -89,7 +89,7 @@ Vector components MUST be instrumented for optimal observability and monitoring.
 
 ### Events
 
-This section lists all required events that a component MUST emit. Additionally, additional events are listed that a component is RECOMMENDED to emit, but remain OPTIONAL.
+This section lists all required events that a component MUST emit. Additional events are
 It is expected that components will emit custom events beyond those listed here
 that reflect component specific behavior. There is leeway in the implementation
 of these events:

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -76,10 +76,12 @@ configuration.
 
 #### `endpoint(s)`
 
-When a component makes a connection to a downstream target, it MUST
+When a component makes a connection to a downstream target, it SHOULD
 expose either an `endpoint` option that takes a `string` representing a
 single endpoint, or an `endpoints` option that takes an array of strings
-representing multiple endpoints.
+representing multiple endpoints. If a component uses multuiple options to
+automatically build the endpoint, then the `endpoint(s)` option MUST
+override that process.
 
 ## Instrumentation
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -176,7 +176,7 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
 #### ComponentBytesSent
 
 *Sinks* that send events down stream, and delete them in Vector, MUST emit
-a `BytesSent` event immediately after sending bytes to the downstream target, if
+a `ComponentBytesSent` event immediately after sending bytes to the downstream target, if
 the transmission was successful. The reported bytes MUST be before compression.
 
 Note that for sinks that simply expose data, but don't delete the data after

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -20,10 +20,10 @@ interpreted as described in [RFC 2119].
     - [`endpoint(s)`](#endpoints)
 - [Instrumentation](#instrumentation)
   - [Events](#events)
-    - [BytesReceived](#bytesreceived)
-    - [EventsReceived](#eventsreceived)
-    - [EventsSent](#eventssent)
-    - [BytesSent](#bytessent)
+    - [ComponentBytesReceived](#componentbytesreceived)
+    - [ComponentEventsReceived](#componenteventsreceived)
+    - [ComponentEventsSent](#componenteventssent)
+    - [ComponentBytesSent](#componentbytessent)
     - [Error](#error)
 - [Health checks](#health-checks)
 
@@ -104,7 +104,7 @@ of these events:
   individual events. For example, emitting the `EventsReceived` event for 10
   events MUST increment the `component_received_events_total` counter by 10.
 
-#### BytesReceived
+#### ComponentBytesReceived
 
 *Sources* MUST emit a `BytesReceived` event immediately after receiving, decompressing
 and filtering bytes from the upstream source and before the creation of a Vector event.
@@ -128,7 +128,7 @@ and filtering bytes from the upstream source and before the creation of a Vector
   * MUST log a `Bytes received.` message at the `trace` level with the
     defined properties as key-value pairs. It MUST NOT be rate limited.
 
-#### EventsReceived
+#### ComponentEventsReceived
 
 *All components* MUST emit an `EventsReceived` event immediately after creating
 or receiving one or more Vector events.
@@ -145,7 +145,7 @@ or receiving one or more Vector events.
   * MUST log a `Events received.` message at the `trace` level with the
     defined properties as key-value pairs. It MUST NOT be rate limited.
 
-#### EventsSent
+#### ComponentEventsSent
 
 *All components* that send events down stream, and delete them in Vector, MUST
 emit an `EventsSent` event immediately after sending, if the transmission was
@@ -169,7 +169,7 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
   * MUST log a `Events sent.` message at the `trace` level with the
     defined properties as key-value pairs. It MUST NOT be rate limited.
 
-#### BytesSent
+#### ComponentBytesSent
 
 *Sinks* that send events down stream, and delete them in Vector, MUST emit
 a `BytesSent` event immediately after sending bytes to the downstream target, if

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -229,8 +229,8 @@ implement since errors are specific to the component.
     event fields. However, they MUST still be included in the emitted
     logs and metrics, as specified below, as if they were present.
 * Metrics
-  * MUST increment the `component_errors_total` counter by 1 if `recoverable`
-    is `false`. It should include the defined properties as tags, except for
+  * If `recoverable` is `false`, MUST increment the `component_errors_total`
+    counter by 1. It should include the defined properties as tags, except for
     `message` and `recoverable`.
   * MUST increment the `component_discarded_events_total` counter by the number
     of Vector events discarded if the error resulted in discarding (dropping)
@@ -242,9 +242,11 @@ implement since errors are specific to the component.
       in the sink dropping the events, and thus acknowledging them. Retried
       events MUST not be included in the metric.
 * Logs
-  * MUST log a message at the `error` if `recoverable` is `false`, otherwise
-    it should log at the `warn` level. It MUST include the defined properties
-    as key-value pairs and it SHOULD be rate limited to 10 seconds.
+  * If `recoverable` is `false`, MUST log a message at the `error` level.
+    Otherwise, if `recoverable` is `true`, MUST log a message at the `warn`
+    level.
+  * MUST include the defined properties as key-value pairs.
+  * SHOULD be rate limited to 10 seconds.
 
 #### ComponentEventsDropped
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -234,8 +234,7 @@ implement since errors are specific to the component.
     logs and metrics, as specified below, as if they were present.
 * Metrics
   * If `recoverable` is `false`, MUST increment the `component_errors_total`
-    counter by 1. It should include the defined properties as tags, except for
-    `message` and `recoverable`.
+    counter by 1.
   * MUST increment the `component_discarded_events_total` counter by the number
     of Vector events discarded if the error resulted in discarding (dropping)
     acknowledged events.
@@ -245,6 +244,8 @@ implement since errors are specific to the component.
     * For sinks, this means only incrementing this metric if the error resulted
       in the sink dropping the events, and thus acknowledging them. Retried
       events MUST not be included in the metric.
+  * MUST include the defined properties as tags, except for `message` and
+    `recoverable`.
 * Logs
   * If `recoverable` is `false`, MUST log a message at the `error` level.
     Otherwise, if `recoverable` is `true`, MUST log a message at the `warn`

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -24,7 +24,7 @@ interpreted as described in [RFC 2119].
     - [ComponentEventsReceived](#componenteventsreceived)
     - [ComponentEventsSent](#componenteventssent)
     - [ComponentBytesSent](#componentbytessent)
-    - [Error](#error)
+    - [ComponentError](#componenterror)
 - [Health checks](#health-checks)
 
 <!-- /MarkdownTOC -->
@@ -198,7 +198,7 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
   * MUST log a `Bytes sent.` message at the `trace` level with the
     defined properties as key-value pairs. It MUST NOT be rate limited.
 
-#### Error
+#### ComponentError
 
 *All components* MUST emit error events in accordance with the
 [Instrumentation Specification].

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -131,7 +131,7 @@ and filtering bytes from the upstream source and before the creation of a Vector
 
 #### ComponentEventsReceived
 
-*All components* MUST emit an `EventsReceived` event immediately after creating
+*All components* MUST emit an `ComponentEventsReceived` event immediately after creating
 or receiving one or more Vector events.
 
 * Properties

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -151,7 +151,7 @@ or receiving one or more Vector events.
 #### ComponentEventsSent
 
 *All components* that send events down stream, and delete them in Vector, MUST
-emit an `EventsSent` event immediately after sending, if the transmission was
+emit an `ComponentEventsSent` event immediately after sending, if the transmission was
 successful.
 
 Note that for sinks that simply expose data, but don't delete the data after

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -127,7 +127,8 @@ and filtering bytes from the upstream source and before the creation of a Vector
     the defined properties as metric tags.
 * Logs
   * MUST log a `Bytes received.` message at the `trace` level with the
-    defined properties as key-value pairs. It MUST NOT be rate limited.
+    defined properties as key-value pairs.
+  * MUST NOT be rate limited.
 
 #### ComponentEventsReceived
 
@@ -144,7 +145,8 @@ or receiving one or more Vector events.
     `byte_size` property with the other properties as metric tags.
 * Logs
   * MUST log a `Events received.` message at the `trace` level with the
-    defined properties as key-value pairs. It MUST NOT be rate limited.
+    defined properties as key-value pairs.
+  * MUST NOT be rate limited.
 
 #### ComponentEventsSent
 
@@ -168,7 +170,8 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
     in JSON representation.
 * Logs
   * MUST log a `Events sent.` message at the `trace` level with the
-    defined properties as key-value pairs. It MUST NOT be rate limited.
+    defined properties as key-value pairs.
+  * MUST NOT be rate limited.
 
 #### ComponentBytesSent
 
@@ -197,7 +200,8 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
     defined properties as metric tags.
 * Logs
   * MUST log a `Bytes sent.` message at the `trace` level with the
-    defined properties as key-value pairs. It MUST NOT be rate limited.
+    defined properties as key-value pairs.
+  * MUST NOT be rate limited.
 
 #### ComponentError
 
@@ -260,7 +264,8 @@ as described in the [ComponentError](#ComponentError) section.
     of Vector events discarded.
 * Logs
   * MUST log a `Bytes sent.` message at the `trace` level with the
-    defined properties as key-value pairs. It MUST NOT be rate limited.
+    defined properties as key-value pairs.
+  * MUST NOT be rate limited.
 
 ## Health checks
 

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -9,24 +9,23 @@ interpreted as described in [RFC 2119].
 
 <!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
 
-1. [Introduction](#introduction)
-1. [Scope](#scope)
-1. [How to read this document](#how-to-read-this-document)
-1. [Naming](#naming)
-   1. [Source and sink naming](#source-and-sink-naming)
-   1. [Transform naming](#transform-naming)
-1. [Configuration](#configuration)
-   1. [Options](#options)
-      1. [`endpoint(s)`](#endpoints)
-1. [Instrumentation](#instrumentation)
-   1. [Batching](#batching)
-   1. [Events](#events)
-      1. [BytesReceived](#bytesreceived)
-      1. [EventsReceived](#eventsrecevied)
-      1. [EventsSent](#eventssent)
-      1. [BytesSent](#bytessent)
-      1. [Error](#error)
-1. [Health checks](#health-checks)
+- [Introduction](#introduction)
+- [Scope](#scope)
+- [How to read this document](#how-to-read-this-document)
+- [Naming](#naming)
+  - [Source and sink naming](#source-and-sink-naming)
+  - [Transform naming](#transform-naming)
+- [Configuration](#configuration)
+  - [Options](#options)
+    - [`endpoint(s)`](#endpoints)
+- [Instrumentation](#instrumentation)
+  - [Events](#events)
+    - [BytesReceived](#bytesreceived)
+    - [EventsReceived](#eventsreceived)
+    - [EventsSent](#eventssent)
+    - [BytesSent](#bytessent)
+    - [Error](#error)
+- [Health checks](#health-checks)
 
 <!-- /MarkdownTOC -->
 
@@ -83,25 +82,17 @@ representing multiple endpoints.
 
 ## Instrumentation
 
+**This section extends the [Instrumentation Specification] and should be read
+first.**
+
 Vector components MUST be instrumented for optimal observability and monitoring.
-This is required to drive various interfaces that Vector users depend on to
-manage Vector installations in mission critical production environments. This
-section extends the [Instrumentation Specification].
-
-### Batching
-
-For performance reasons, components SHOULD instrument batches of Vector events
-as opposed to individual Vector events. [Pull request #8383] demonstrated
-meaningful performance improvements as a result of this strategy.
 
 ### Events
 
-Vector implements an event driven pattern ([RFC 2064]) for internal
-instrumentation. This section lists all required and optional events that a
-component must emit. It is expected that components will emit custom events
-beyond those listed here that reflect component specific behavior.
-
-There is leeway in the implementation of these events:
+This section lists all required and optional events that a component MUST emit.
+It is expected that components will emit custom events beyond those listed here
+that reflect component specific behavior. There is leeway in the implementation
+of these events:
 
 * Events MAY be augmented with additional component-specific context. For
   example, the `socket` source adds a `mode` attribute as additional context.
@@ -209,10 +200,8 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
 
 #### Error
 
-*All components* MUST emit error events when an error occurs, and errors MUST be
-named with an `Error` suffix. For example, the `socket` source emits a
-`SocketReceiveError` representing any error that occurs while receiving data off
-of the socket.
+*All components* MUST emit error events in accordance with the
+[Instrumentation Specification].
 
 This specification does not list a standard set of errors that components must
 implement since errors are specific to the component.
@@ -272,6 +261,4 @@ See the [development documentation][health checks] for more context guidance.
 [health checks]: ../DEVELOPING.md#sink-healthchecks
 [Instrumentation Specification]: instrumentation.md
 [logical boundaries of components]: ../USER_EXPERIENCE_DESIGN.md#logical-boundaries
-[Pull request #8383]: https://github.com/vectordotdev/vector/pull/8383/
-[RFC 2064]: https://github.com/vectordotdev/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
 [RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -15,6 +15,8 @@ interpreted as described in [RFC 2119].
 - [Emission](#emission)
   - [Batching](#batching)
   - [Errors](#errors)
+    - [Warning level](#warning-level)
+    - [Error level](#error-level)
   - [Events](#events)
 
 <!-- /MarkdownTOC -->
@@ -66,13 +68,29 @@ instrumentation SHOULD be batched whenever possible:
 
 ### Errors
 
-Errors MUST emit when they require user attention. If an error does not require
-user attention, usually because it will resolve itself, then it should emit as
-a warning. This reduces error noise and provides a clean signal for operators
-to understand if Vector is healthy and operating properly:
+As described in the [events](#events) section, all errors must emit as events
+to drive log and metric emission. Because errors can be transient and
+recoverable, errors MUST be able to log at warning and error levels:
 
-*  Retryable errors MUST emit as an error when the retry count is >= 3, the
-   first and second retry MUST emit as warnings.
+* MUST emit at the [error level](#error-level) if the error requires user
+  attention, otherwise the error MUST emit at the [warning level](#warning-level)
+  * Retryable errors only require user attention when the retry count is >= 3
+
+#### Warning level
+
+When an error event emits at the warning level it does not require user
+attention and, therefore, MUST do the following:
+
+* MUST log a message at the `warning` level
+* MUST NOT increment the `component_errors_total`
+
+#### Error level
+
+When an error event emits at the error level it requires user attention and,
+therefore, MUST do the following:
+
+* MUST log a message at the `error` level
+* MUST increment the `component_errors_total` by 1
 
 ### Events
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -72,9 +72,9 @@ instrumentation SHOULD be batched whenever possible:
 Instrumentation SHOULD be event-driven ([RFC 2064]), where individual events
 serve as the vehicle for internal telemetry, driving the emission of metrics
 and logs. This organizes Vector's telemetry, making it easier to manage and 
-catalogue. On rare occassions, metrics and logs can emit directly but MUST be
-reserved for ocassions where it is impossible to emit Vector's events. For
-example, emitting metrics in a library that cannot import Vector's events.
+catalogue. Metrics and logs SHOULD NOT be emitted directly except for where it
+is otherwise impossible to emit Vector's events, such as in an external crate
+that cannot import Vector's events.
 
 #### Error
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -59,11 +59,13 @@ Vector broadly follows the [Prometheus metric naming standards]:
 
 ### Batching
 
-For performance reasons, as demonstrated in pull request #8383],
+For performance reasons, as demonstrated in [pull request #8383],
 instrumentation SHOULD be batched whenever possible:
 
-* Vector process batches of events ([RFC 9480]) and telemtry SHOULD emit for
-  the entire batch, not each individual event.
+* Telemtry SHOULD emit for entire event batches, not each individual event.
+  [RFC 9480] describes Vector's batching strategy.
+* Benchmarking SHOULD prove that batching produces performance benefits.
+  [Issue 10658] could eliminate the need to batch for performance improvements.
 
 ### Events
 
@@ -144,8 +146,9 @@ emission of this event, meeting the following requirements:
 
 [camelcase]: https://en.wikipedia.org/wiki/Camel_case
 [`EventsDropped`]: #EventsDropped
+[Issue 10658]: https://github.com/vectordotdev/vector/issues/10658
 [Prometheus metric naming standards]: https://prometheus.io/docs/practices/naming/
-[Pull request #8383]: https://github.com/vectordotdev/vector/pull/8383/
+[pull request #8383]: https://github.com/vectordotdev/vector/pull/8383/
 [RFC 2064]: https://github.com/vectordotdev/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
 [RFC 9480]: https://github.com/vectordotdev/vector/blob/master/rfcs/2021-10-22-9480-processing-arrays-of-events.md
 [single base unit]: https://en.wikipedia.org/wiki/SI_base_unit

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -74,7 +74,7 @@ MUST meet different requirements:
   be retried and recovered. For example, a failed HTTP request can be retired
   and recovered.
   * MUST log a message at the `warning` level
-  * MUST NOT increment the any error-related metrics
+  * MUST NOT increment any error-related metrics
 * An error MUST NOT be marked as recoverable if the operation that produced can
   not be retried. For example, a failed HTTP request that will *not* be retried.
   * MUST log a message at the `error` level

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -117,7 +117,7 @@ not:
   * SHOULD be rate limited to 10 seconds.
 * Events
   * MUST emit an [`EventsDropped`] event if the error results in dropping events,
-    or the error itself MUST meeting the `EventsDropped` requirements.
+or the error itself MUST meet the `EventsDropped` requirements.
 
 #### EventsDropped
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -78,15 +78,9 @@ that cannot import Vector's events.
 
 #### Error
 
-An `<Name>Error` event MUST be emitted when an error occurs. Errors that are
-retriable and possible recoverable MUST be distinguished from errors that are
-not:
+An `<Name>Error` event MUST be emitted when an error occurs.
 
 * Properties
-  * `retriable` - If the operation that produced the error is retriable. This
-    indicates that the error operation might recover and determines if this
-    error should be a warning or an error when emitting logs and metrics. For
-    example, a failed HTTP request that will be retried.
   * `error_code` - An error code for the failure, if applicable.
     * SHOULD only be specified if it adds additional information beyond
       `error_type`.
@@ -104,24 +98,27 @@ not:
     logs and metrics, as specified below, as if they were present.
 * Metrics
   * MUST include the defined properties as tags.
-  * If `retriable` is `true`, MUST increment `<namespace>_warnings_total` metric.
-  * If `retriable` is `false`, MUST increment `<namespace>_errors_total` metric.
+  * MUST increment `<namespace>_errors_total` metric.
 * Logs
   * MUST log a descriptive, user friendly error message that sufficiently
     describes the error.
-  * MUST include the defined properties as key-value pairs, except `message`.
-  * If `retriable` is `true`, MUST log a message at the `warning` level.
-  * If `retriable` is `false`, MUST log a message at the `error` level.
+  * MUST include the defined properties as key-value pairs.
+  * MUST log a message at the `error` level.
   * SHOULD be rate limited to 10 seconds.
 * Events
-  * MUST emit an [`EventsDropped`] event if the error results in dropping events,
-or the error itself MUST meet the `EventsDropped` requirements.
+  * MUST emit an [`EventsDropped`] event if the error results in dropping
+    events, or the error event itself MUST meet the `EventsDropped`
+    requirements.
 
 #### EventsDropped
 
-An `<Namespace>EventsDropped` event must be emitted when events are dropped.
+An `<Namespace>EventsDropped` event MUST be emitted when events are dropped.
 If events are dropped due to an error, then the error event should drive the
-emission of this event, meeting the following requirements:
+emission of this event, meeting the below requirements.
+
+**You MUST NOT emit this event for retriable operations that can recover and
+do not result in data loss. For example, a failed HTTP request in a sink that
+will be retried does not result in data loss if the retry succeeds.** 
 
 * Properties
   * `intentional` - Distinguishes if the events were dropped intentionally. For

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -66,12 +66,13 @@ instrumentation SHOULD be batched whenever possible:
 
 ### Errors
 
-Errors MUST only emit when they are not recoverable and require user
-attention. This reduces error noise and provides a clean signal for operators
+Errors MUST emit when they require user attention. If an error does not require
+user attention, usually because it will resolve itself, then it should emit as
+a warning. This reduces error noise and provides a clean signal for operators
 to understand if Vector is healthy and operating properly:
 
-* Transmission errors MUST emit as warnings if the transmission will be retried
-  and errors if not.
+*  Retryable errors MUST emit as an error when the retry count is >= 3, the
+   first and second retry MUST emit as warnings.
 
 ### Events
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -133,9 +133,11 @@ not result in data loss if the retry succeeds.**
     number of events discarded.
   * MUST include the listed properties as tags except the `reason` property.
 * Logs
-  * MUST log a `<count> events <intentional> dropped: <reason>` message.
+  * MUST log a `Events dropped` message.
+  * MUST include the defined properties as key-value pairs.
   * If `intentional` is `true`, MUST log at the `debug` level.
   * If `intentional` is `false`, MUST log at the `error` level.
+  * SHOULD NOT be rate limited.
 
 
 [camelcase]: https://en.wikipedia.org/wiki/Camel_case

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -117,24 +117,23 @@ If events are dropped due to an error, then the error event should drive the
 emission of this event, meeting the below requirements.
 
 **You MUST NOT emit this event for retriable operations that can recover and
-do not result in data loss. For example, a failed HTTP request in a sink that
-will be retried does not result in data loss if the retry succeeds.** 
+prevent data loss. For example, a failed HTTP request that will be retried does
+not result in data loss if the retry succeeds.** 
 
 * Properties
+  * `count` - The number of events dropped
   * `intentional` - Distinguishes if the events were dropped intentionally. For
     example, events dropped in the `filter` transform are intentionally dropped,
     while events dropped due to an error in the `remap` transform are
     unintentionally dropped.
+  * `reason` - A short, user-friendly reason that describes why the events were
+    dropped.
 * Metrics
   * MUST increment the `<namespace>_discarded_events_total` counter by the
     number of events discarded.
-  * MUST NOT increment this metric if retrying the operation will preserve the
-    event, such as retrying delivery in sinks.
-  * MUST include the `intentional` property as a tag.
+  * MUST include the listed properties as tags except the `reason` property.
 * Logs
-  * MUST log a `<count> events [un]intentionally dropped due to <reason>`
-    message. `<reason>` MUST be a descriptive, user-friendly message that helps
-    the user understand why their data was dropped.
+  * MUST log a `<count> events <intentional> dropped: <reason>` message.
   * If `intentional` is `true`, MUST log at the `debug` level.
   * If `intentional` is `false`, MUST log at the `error` level.
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -15,8 +15,6 @@ interpreted as described in [RFC 2119].
 - [Emission](#emission)
   - [Batching](#batching)
   - [Errors](#errors)
-    - [Warning level](#warning-level)
-    - [Error level](#error-level)
   - [Events](#events)
 
 <!-- /MarkdownTOC -->
@@ -69,31 +67,17 @@ instrumentation SHOULD be batched whenever possible:
 ### Errors
 
 As described in the [events](#events) section, all errors must emit as events
-to drive log and metric emission. Because errors can be transient and
-recoverable, errors MUST be able to log at warning and error levels to
-distinguish these types of errors:
+to drive log and metric emission. Errors that are transient and recoverable
+MUST meet different requirements:
 
-* MUST emit at the [error level](#error-level) if the error requires user
-  attention, otherwise the error MUST emit at the [warning level](#warning-level)
-  * Retryable errors, such a HTTP request errors, MUST emit at the warning
-    level if the request will be retried, otherwise it MUST emit at the error
-    level.
-
-#### Warning level
-
-When an error event emits at the warning level it does not require user
-attention and, therefore, MUST do the following:
-
-* MUST log a message at the `warning` level
-* MUST NOT increment the any error-related metrics
-
-#### Error level
-
-When an error event emits at the error level it requires user attention and,
-therefore, MUST do the following:
-
-* MUST log a message at the `error` level
-* MUST increment error-related metrics
+* An error MUST be marked as recoverable if the operation that produced it can
+  be retried. For example, a failed HTTP request that will be retried.
+  * MUST log a message at the `warning` level
+  * MUST NOT increment the any error-related metrics
+* An error MUST NOT be marked as recoverable if the operation that produced can
+  not be retried. For example, a failed HTTP request that will *not* be retried.
+  * MUST log a message at the `error` level
+  * MUST increment error-related metrics to alert the user
 
 ### Events
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -71,7 +71,8 @@ to drive log and metric emission. Errors that are transient and recoverable
 MUST meet different requirements:
 
 * An error MUST be marked as recoverable if the operation that produced it can
-  be retried. For example, a failed HTTP request that will be retried.
+  be retried and recovered. For example, a failed HTTP request can be retired
+  and recovered.
   * MUST log a message at the `warning` level
   * MUST NOT increment the any error-related metrics
 * An error MUST NOT be marked as recoverable if the operation that produced can

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -53,7 +53,7 @@ Vector broadly follows the [Prometheus metric naming standards]:
   * `name` - is one or more words that describes the measurement (e.g., `memory_rss`, `requests`)
   * `unit` - MUST be a single [base unit] in plural form, if applicable (e.g., `seconds`, `bytes`)
   * Counters MUST end with `total` (e.g., `disk_written_bytes_total`, `http_requests_total`)
-* SHOULD be broad in purpose and use use tags to differentiate characteristics of the measurement (e.g., `host_cpu_seconds_total{cpu="0",mode="idle"}`)
+* SHOULD be broad in purpose and use tags to differentiate characteristics of the measurement (e.g., `host_cpu_seconds_total{cpu="0",mode="idle"}`)
 
 ## Emission
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -70,11 +70,14 @@ instrumentation SHOULD be batched whenever possible:
 
 As described in the [events](#events) section, all errors must emit as events
 to drive log and metric emission. Because errors can be transient and
-recoverable, errors MUST be able to log at warning and error levels:
+recoverable, errors MUST be able to log at warning and error levels to
+distinguish these types of errors:
 
 * MUST emit at the [error level](#error-level) if the error requires user
   attention, otherwise the error MUST emit at the [warning level](#warning-level)
-  * Retryable errors only require user attention when the retry count is >= 3
+  * Retryable errors, such a retryable HTTP requests, MUST emit at the warning
+    level since these errors could recover. Secondary signals, such as back
+    pressure will alert the user.
 
 #### Warning level
 
@@ -82,7 +85,7 @@ When an error event emits at the warning level it does not require user
 attention and, therefore, MUST do the following:
 
 * MUST log a message at the `warning` level
-* MUST NOT increment the `component_errors_total`
+* MUST NOT increment the any error-related metrics
 
 #### Error level
 
@@ -90,7 +93,7 @@ When an error event emits at the error level it requires user attention and,
 therefore, MUST do the following:
 
 * MUST log a message at the `error` level
-* MUST increment the `component_errors_total` by 1
+* MUST increment error-related metrics
 
 ### Events
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -60,7 +60,7 @@ Vector broadly follows the [Prometheus metric naming standards]:
 
 ### Batching
 
-For performance reasons, as demonstrated in ppull request #8383],
+For performance reasons, as demonstrated in pull request #8383],
 instrumentation SHOULD be batched whenever possible:
 
 * Vector process batches of events ([RFC 9480]) and telemtry SHOULD emit for

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -49,8 +49,8 @@ Vector broadly follows the [Prometheus metric naming standards]:
 * MUST be in [snakecase] format
 * MUST follow the `<namespace>_<name>_<unit>_[total]` template
   * `namespace` - the internal domain that the metric belongs to (e.g., `component`, `buffer`, `topology`)
-  * `name` is one or more words that describes the measurement (e.g., `memory_rss`, `requests`)
-  * `unit` MUST be a single [base unit] in plural form, if applicable (e.g., `seconds`, `bytes`)
+  * `name` - is one or more words that describes the measurement (e.g., `memory_rss`, `requests`)
+  * `unit` - MUST be a single [base unit] in plural form, if applicable (e.g., `seconds`, `bytes`)
   * Counters MUST end with `total` (e.g., `disk_written_bytes_total`, `http_requests_total`)
 * SHOULD be broad in purpose and use use tags to differentiate characteristics of the measurement (e.g., `host_cpu_seconds_total{cpu="0",mode="idle"}`)
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -24,8 +24,8 @@ interpreted as described in [RFC 2119].
 
 Vector's telemetry drives various interfaces that operators depend on to manage
 mission critical Vector deployments. Therefore, Vector's telemetry should be
-high quality and treated as a first class feautre in the development of Vector.
-This document strives to guide developers into achieving this.
+high quality and treated as a first class feature in the development of Vector.
+This document strives to guide developers towards achieving this.
 
 ## Naming
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -98,8 +98,6 @@ not:
       error code like `invalid_json`.
   * `error_type` - The type of error condition. MUST be one of the types listed
     in the `error_type` enum list in the cue docs.
-  * `stage` - The stage at which the error occurred. MUST be one of `receiving`,
-    `processing`, or `sending`.
   * If any of the above properties are implicit to the specific error
     type, they MAY be omitted from being represented explicitly in the
     event fields. However, they MUST still be included in the emitted

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -75,9 +75,9 @@ distinguish these types of errors:
 
 * MUST emit at the [error level](#error-level) if the error requires user
   attention, otherwise the error MUST emit at the [warning level](#warning-level)
-  * Retryable errors, such a retryable HTTP requests, MUST emit at the warning
-    level since these errors could recover. Secondary signals, such as back
-    pressure will alert the user.
+  * Retryable errors, such a HTTP request errors, MUST emit at the warning
+    level if the request will be retried, otherwise it MUST emit at the error
+    level.
 
 #### Warning level
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -8,34 +8,84 @@ interpreted as described in [RFC 2119].
 
 <!-- MarkdownTOC autolink="true" style="ordered" indent="   " -->
 
-1. [Introduction](#introduction)
-1. [Naming](#naming)
-   1. [Metric naming](#metric-naming)
+- [Introduction](#introduction)
+- [Naming](#naming)
+  - [Event naming](#event-naming)
+  - [Metric naming](#metric-naming)
+- [Emission](#emission)
+  - [Batching](#batching)
+  - [Errors](#errors)
+  - [Events](#events)
 
 <!-- /MarkdownTOC -->
 
 ## Introduction
 
-Vector's runtime behavior is expressed through user-defined configuration files
-intended to be written directly by users. Therefore, the quality of Vector's
-configuration largely affects Vector's user experience. This document aims to
-make Vector's configuration as high quality as possible in order to achieve a
-[best in class user experience][user_experience].
+Vector's telemetry drives various interfaces that operators depend on to manage
+mission critical Vector deployments. Therefore, Vector's telemetry should be
+high quality and treated as a first class feautre in the development of Vector.
+This document strives to guide developers into achieving this.
 
 ## Naming
 
+### Event naming
+
+Vector implements an event-driven instrumentation pattern ([RFC 2064]) and
+event names MUST adhere to the following rules:
+
+* MUST only contain ASCII alphanumeric and lowercase characters
+* MUST be in [camelcase] format
+* MUST follow the `<Namespace><Noun><Verb>[Error]` template
+  * `Namespace` - the internal domain the event belongs to (e.g., `Component`, `Buffer`, `Topology`)
+  * `Noun` - the subject of the event (e.g., `Bytes`, `Events`)
+  * `Verb` - the past tense verb describing when the event occured (e.g., `Received`, `Sent`, `Processes`)
+  * `[Error]` - if the event is an error it MUST end with `Error`
+
 ### Metric naming
 
-For metric naming, Vector broadly follows the
-[Prometheus metric naming standards]. Hence, a metric name:
+Vector broadly follows the [Prometheus metric naming standards]:
 
-* MUST only contain ASCII alphanumeric, lowercase, and underscores
+* MUST only contain ASCII alphanumeric, lowercase, and underscore characters
+* MUST be in [snakecase] format
 * MUST follow the `<namespace>_<name>_<unit>_[total]` template
-  * `namespace` represents a broad category of metrics (e.g., `component`, `buffer`, `topology`)
+  * `namespace` - the internal domain that the metric belongs to (e.g., `component`, `buffer`, `topology`)
   * `name` is one or more words that describes the measurement (e.g., `memory_rss`, `requests`)
   * `unit` MUST be a single [base unit] in plural form, if applicable (e.g., `seconds`, `bytes`)
   * Counters MUST end with `total` (e.g., `disk_written_bytes_total`, `http_requests_total`)
 * SHOULD be broad in purpose and use use tags to differentiate characteristics of the measurement (e.g., `host_cpu_seconds_total{cpu="0",mode="idle"}`)
 
+## Emission
+
+### Batching
+
+For performance reasons, as demonstrated in ppull request #8383],
+instrumentation SHOULD be batched whenever possible:
+
+* Vector process batches of events ([RFC 9480]) and telemtry SHOULD emit for
+  the entire batch, not each individual event.
+
+### Errors
+
+Errors MUST only emit when they are not recoverable and require user
+attention. This reduces error noise and provides a clean signal for operators
+to understand if Vector is healthy and operating properly:
+
+* Transmission errors MUST emit as warnings if the transmission will be retried
+  and errors if not.
+
+### Events
+
+Instrumentation SHOULD be event-driven ([RFC 2064]), where individual events
+serve as the vehicle for internal telemtry, driving the emission of metrics
+and logs. This organizes Vector's telemetry, making it easier to manage and 
+catalogue. On rare occassions, metrics and logs can emit directly but MUST be
+reserved for ocassions where it is impossible to emit Vector's events. For
+example, emitting metrics in a library that cannot import Vector's events.
+
+[camelcase]: https://en.wikipedia.org/wiki/Camel_case
 [Prometheus metric naming standards]: https://prometheus.io/docs/practices/naming/
+[Pull request #8383]: https://github.com/vectordotdev/vector/pull/8383/
+[RFC 2064]: https://github.com/vectordotdev/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
+[RFC 9480]: https://github.com/vectordotdev/vector/blob/master/rfcs/2021-10-22-9480-processing-arrays-of-events.md
 [single base unit]: https://en.wikipedia.org/wiki/SI_base_unit
+[snakecase]: https://en.wikipedia.org/wiki/Snake_case

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -124,10 +124,10 @@ If events are dropped due to an error, then the error event should drive the
 emission of this event, meeting the following requirements:
 
 * Properties
-  * MUST include the `intentional` property to distinguish if the events were
-    dropped intentionally. For example, events dropped in the `filter` transform
-    are intentionally dropped, while events dropped due to an error in the `remap`
-    transform are unintentionally dropped.
+  * `intentional` - Distinguishes if the events were dropped intentionally. For
+    example, events dropped in the `filter` transform are intentionally dropped,
+    while events dropped due to an error in the `remap` transform are
+    unintentionally dropped.
 * Metrics
   * MUST increment the `<namespace>_discarded_events_total` counter by the
     number of events discarded.
@@ -135,7 +135,9 @@ emission of this event, meeting the following requirements:
     event, such as retrying delivery in sinks.
   * MUST include the `intentional` property as a tag.
 * Logs
-  * MUST log a `<count> events [un]intentionally dropped.` message.
+  * MUST log a `<count> events [un]intentionally dropped due to <reason>`
+    message. `<reason>` MUST be a descriptive, user-friendly message that helps
+    the user understand why their data was dropped.
   * If `intentional` is `true`, MUST log at the `debug` level.
   * If `intentional` is `false`, MUST log at the `error` level.
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -70,7 +70,7 @@ instrumentation SHOULD be batched whenever possible:
 ### Events
 
 Instrumentation SHOULD be event-driven ([RFC 2064]), where individual events
-serve as the vehicle for internal telemtry, driving the emission of metrics
+serve as the vehicle for internal telemetry, driving the emission of metrics
 and logs. This organizes Vector's telemetry, making it easier to manage and 
 catalogue. On rare occassions, metrics and logs can emit directly but MUST be
 reserved for ocassions where it is impossible to emit Vector's events. For

--- a/lib/vector-buffers/src/buffer_usage_data.rs
+++ b/lib/vector-buffers/src/buffer_usage_data.rs
@@ -11,7 +11,7 @@ use tracing::{Instrument, Span};
 use vector_common::internal_event::emit;
 
 use crate::{
-    internal_events::{BufferCreated, BufferEventsReceived, BufferEventsSent, EventsDropped},
+    internal_events::{BufferCreated, BufferEventsReceived, BufferEventsSent, BufferEventsDropped},
     spawn_named, WhenFull,
 };
 
@@ -230,7 +230,7 @@ impl BufferUsage {
                     });
 
                     if let Some(dropped_event_data) = &stage.dropped_event_data {
-                        emit(EventsDropped {
+                        emit(BufferEventsDropped {
                             idx: stage.idx,
                             count: dropped_event_data.count.swap(0, Ordering::Relaxed),
                             byte_size: dropped_event_data.size.swap(0, Ordering::Relaxed),

--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -33,13 +33,13 @@ impl InternalEvent for BufferEventsSent {
     }
 }
 
-pub struct EventsDropped {
+pub struct BufferEventsDropped {
     pub idx: usize,
     pub count: u64,
     pub byte_size: u64,
 }
 
-impl InternalEvent for EventsDropped {
+impl InternalEvent for BufferEventsDropped {
     #[allow(clippy::cast_precision_loss)]
     fn emit(self) {
         counter!("buffer_discarded_events_total", self.count, "stage" => self.idx.to_string());


### PR DESCRIPTION
I'm working on a brief covering Vector's health and noticed we need tighter definitions around errors. Specifically, only emitting errors at the error level if they require user attention. This improves the signal to noise ratio for operators trying to understand the health of their Vector instances.