### PR TITLE
chore(buffers): fix unconstrained generic parameter in `EventCount` impl

### DIFF
--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -84,15 +84,21 @@ pub trait EventCount {
     fn event_count(&self) -> usize;
 }
 
-impl<T> EventCount for Vec<T> {
+impl<T> EventCount for Vec<T>
+where
+    T: EventCount,
+{
     fn event_count(&self) -> usize {
-        self.len()
+        self.iter().map(EventCount::event_count).sum()
     }
 }
 
-impl<T> EventCount for &Vec<T> {
+impl<'a, T> EventCount for &'a T
+where
+    T: EventCount,
+{
     fn event_count(&self) -> usize {
-        self.len()
+        (*self).event_count()
     }
 }
 

--- a/lib/vector-common/src/byte_size_of.rs
+++ b/lib/vector-common/src/byte_size_of.rs
@@ -31,6 +31,15 @@ pub trait ByteSizeOf {
     fn allocated_bytes(&self) -> usize;
 }
 
+impl<'a, T> ByteSizeOf for &'a T
+where
+    T: ByteSizeOf,
+{
+    fn allocated_bytes(&self) -> usize {
+        (*self).size_of()
+    }
+}
+
 impl ByteSizeOf for Bytes {
     fn allocated_bytes(&self) -> usize {
         self.len()
@@ -94,15 +103,6 @@ where
 }
 
 impl<T> ByteSizeOf for &[T]
-where
-    T: ByteSizeOf,
-{
-    fn allocated_bytes(&self) -> usize {
-        self.iter().map(ByteSizeOf::size_of).sum()
-    }
-}
-
-impl<T> ByteSizeOf for &Vec<T>
 where
     T: ByteSizeOf,
 {

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -65,23 +65,7 @@ impl ByteSizeOf for Event {
     }
 }
 
-impl ByteSizeOf for &Event {
-    fn allocated_bytes(&self) -> usize {
-        match self {
-            Event::Log(log_event) => log_event.allocated_bytes(),
-            Event::Metric(metric_event) => metric_event.allocated_bytes(),
-            Event::Trace(trace_event) => trace_event.allocated_bytes(),
-        }
-    }
-}
-
 impl EventCount for Event {
-    fn event_count(&self) -> usize {
-        1
-    }
-}
-
-impl EventCount for &Event {
     fn event_count(&self) -> usize {
         1
     }

--- a/src/sinks/loki/event.rs
+++ b/src/sinks/loki/event.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, io};
 
 use bytes::Bytes;
 use serde::{ser::SerializeSeq, Serialize};
+use vector_buffers::EventCount;
 use vector_core::{
     event::{EventFinalizers, Finalizable},
     ByteSizeOf,
@@ -90,6 +91,13 @@ impl ByteSizeOf for LokiRecord {
                 res + item.0.allocated_bytes() + item.1.allocated_bytes()
             })
             + self.event.allocated_bytes()
+    }
+}
+
+impl EventCount for LokiRecord {
+    fn event_count(&self) -> usize {
+        // A Loki record is mapped one-to-one with an event.
+        1
     }
 }
 


### PR DESCRIPTION
In #12755, I incorrectly added a blanket implementation of `EventCount` for `Vec<T>`, but did not constrain `T` such that a construction such as `Vec<EventArray>` would receive the blanket implementation and, yet, return a potentially very incorrect value for event count: the length of the vector, rather than the sum of the event count of all elements.

This PR properly constrains the implementation and sums the event count of each element. Additionally, we've added blanket implementations for references to types implementing `EventCount`, as well as `ByteSizeOf`, to make things a little cleaner as well.

Fixes #12858.