### PR TITLE
chore(deps): Revert goauth from 0.13.0 back to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,9 +3051,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goauth"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8457926bf7016133268f52fb6c0a636747fa2cccd8aa5afbef7347a01ca9b4e3"
+checksum = "5a139506b3f65acaee2a2b4cb5bd51b26e0c6945d280955a9c25c026e1849537"
 dependencies = [
  "arc-swap",
  "futures 0.3.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ prost = { version = "0.10.4", default-features = false, features = ["std"] }
 prost-types = { version = "0.10.1", default-features = false, optional = true }
 
 # GCP
-goauth = { version = "0.13.0", default-features = false, optional = true }
+goauth = { version = "0.12.0", default-features = false, optional = true }
 gouth = { version = "0.2.1", default-features = false, optional = true }
 smpl_jwt = { version = "0.7.1", default-features = false, optional = true }
 

--- a/deny.toml
+++ b/deny.toml
@@ -53,4 +53,6 @@ ignore = [
 deny = [
     # https://github.com/vectordotdev/vector/issues/11257
     { name = "tokio-util", version = ">=0.6.9" },
+    # https://github.com/vectordotdev/vector/pull/12865
+    { name = "goauth", version = "=0.13.0" },
 ]


### PR DESCRIPTION
After the upgrade, GCP components are unable to authenticate:

```
2022-05-25T16:03:37.660557Z DEBUG vector::gcp: Fetching GCP authentication token. project="datadog-sandbox" iss="bruceg-pubsub-tester@datadog-sandbox.iam.gserviceaccount.com" token_uri="https://oauth2.googleapis.com/token"
2022-05-25T16:03:37.676921Z ERROR vector::topology: Configuration error. error=Sink "sink": Failed to get OAuth token: error sending request for url (https://oauth2.googleapis.com/token): error trying to connect: invalid URL, scheme is not http
```

We will need to redo the version upgrade later and fix the token fetch
handling at that point.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
