### PR TITLE
enhancement(aws_cloudwatch_logs sink): add `json/emf` support

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -83,7 +83,7 @@ pub trait ClientBuilder {
 }
 
 pub async fn create_smithy_client<T: ClientBuilder>(
-    region: Region, 
+    region: Region,
     proxy: &ProxyConfig,
     tls_options: &Option<TlsConfig>,
     is_sink: bool,
@@ -148,8 +148,8 @@ pub async fn create_client<T: ClientBuilder>(
 
     let config = config_builder.build();
 
-    let client = create_smithy_client::<T>(
-        region, proxy, tls_options, is_sink, retry_config).await?;
+    let client =
+        create_smithy_client::<T>(region, proxy, tls_options, is_sink, retry_config).await?;
 
     Ok(T::build(client, &config))
 }

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
 
 use crate::{
-    aws::{create_client, create_smithy_client, AwsAuthentication, ClientBuilder, RegionOrEndpoint},
+    aws::{
+        create_client, create_smithy_client, AwsAuthentication, ClientBuilder, RegionOrEndpoint,
+    },
     codecs::Encoder,
     config::{
         log_schema, AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig,
@@ -21,9 +23,8 @@ use crate::{
             encoding::{
                 EncodingConfig, EncodingConfigAdapter, StandardEncodings, StandardEncodingsMigrator,
             },
-            http::{RequestConfig},
-            BatchConfig, Compression, ServiceBuilderExt, SinkBatchSettings,
-            TowerRequestConfig,
+            http::RequestConfig,
+            BatchConfig, Compression, ServiceBuilderExt, SinkBatchSettings, TowerRequestConfig,
         },
         Healthcheck, VectorSink,
     },
@@ -90,7 +91,10 @@ impl CloudwatchLogsSinkConfig {
         .await
     }
 
-    pub async fn create_smithy_client(&self, proxy: &ProxyConfig) -> crate::Result<aws_smithy_client::Client> {
+    pub async fn create_smithy_client(
+        &self,
+        proxy: &ProxyConfig,
+    ) -> crate::Result<aws_smithy_client::Client> {
         let region = match self.region.region() {
             Some(region) => Ok(region),
             None => aws_config::default_provider::region::default_provider()
@@ -111,10 +115,13 @@ impl CloudwatchLogsSinkConfig {
 
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_cloudwatch_logs")]
-impl SinkConfig for CloudwatchLogsSinkConfig{
+impl SinkConfig for CloudwatchLogsSinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let batcher_settings = self.batch.into_batcher_settings()?;
-        let request_settings = self.request.tower.unwrap_with(&TowerRequestConfig::default());
+        let request_settings = self
+            .request
+            .tower
+            .unwrap_with(&TowerRequestConfig::default());
         let client = self.create_client(cx.proxy()).await?;
         let smithy_client = self.create_smithy_client(cx.proxy()).await?;
         let svc = ServiceBuilder::new()

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -1,4 +1,3 @@
-use aws_config::meta::region::ProvideRegion;
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use aws_smithy_types::retry::RetryConfig;
 use futures::FutureExt;
@@ -7,7 +6,8 @@ use tower::ServiceBuilder;
 
 use crate::{
     aws::{
-        create_client, create_smithy_client, AwsAuthentication, ClientBuilder, RegionOrEndpoint,
+        create_client, create_smithy_client, resolve_region, AwsAuthentication, ClientBuilder,
+        RegionOrEndpoint,
     },
     codecs::Encoder,
     config::{
@@ -95,13 +95,7 @@ impl CloudwatchLogsSinkConfig {
         &self,
         proxy: &ProxyConfig,
     ) -> crate::Result<aws_smithy_client::Client> {
-        let region = match self.region.region() {
-            Some(region) => Ok(region),
-            None => aws_config::default_provider::region::default_provider()
-                .region()
-                .await
-                .ok_or("Could not determine region from Vector configuration or default providers"),
-        }?;
+        let region = resolve_region(self.region.region()).await?;
         create_smithy_client::<CloudwatchLogsClientBuilder>(
             region,
             proxy,
@@ -129,7 +123,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             .service(CloudwatchLogsPartitionSvc::new(
                 self.clone(),
                 client.clone(),
-                std::sync::Arc::new(smithy_client).clone(),
+                std::sync::Arc::new(smithy_client),
             ));
         let transformer = self.encoding.transformer();
         let serializer = self.encoding.clone().encoding();

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -8,11 +8,15 @@ use aws_sdk_cloudwatchlogs::error::{
     CreateLogGroupError, CreateLogGroupErrorKind, CreateLogStreamError, CreateLogStreamErrorKind,
     DescribeLogStreamsError, DescribeLogStreamsErrorKind, PutLogEventsError,
 };
+use aws_sdk_cloudwatchlogs::operation::PutLogEvents;
+
 use aws_sdk_cloudwatchlogs::model::InputLogEvent;
 use aws_sdk_cloudwatchlogs::output::{DescribeLogStreamsOutput, PutLogEventsOutput};
 use aws_sdk_cloudwatchlogs::types::SdkError;
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
+use aws_smithy_http::operation::{Operation, Request};
 use futures::{future::BoxFuture, ready, FutureExt};
+use indexmap::IndexMap;
 use tokio::sync::oneshot;
 
 use crate::sinks::aws_cloudwatch_logs::service::CloudwatchError;
@@ -28,8 +32,11 @@ pub struct CloudwatchFuture {
 
 struct Client {
     client: CloudwatchLogsClient,
+    smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
+    aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>,
     stream_name: String,
     group_name: String,
+    headers: IndexMap<String, String>,
 }
 
 type ClientResult<T, E> = BoxFuture<'static, Result<T, SdkError<E>>>;
@@ -46,6 +53,9 @@ impl CloudwatchFuture {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         client: CloudwatchLogsClient,
+        smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
+        aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>,
+        headers: IndexMap<String, String>,
         stream_name: String,
         group_name: String,
         create_missing_group: bool,
@@ -56,8 +66,10 @@ impl CloudwatchFuture {
     ) -> Self {
         let client = Client {
             client,
+            smithy_client,
             stream_name,
             group_name,
+            headers,
         };
 
         let state = if let Some(token) = token {
@@ -212,18 +224,42 @@ impl Client {
         sequence_token: Option<String>,
         log_events: Vec<InputLogEvent>,
     ) -> ClientResult<PutLogEventsOutput, PutLogEventsError> {
-        let client = self.client.clone();
+        let client = self.smithy_client.clone();
+        let cw_client = self.client.clone();
         let group_name = self.group_name.clone();
         let stream_name = self.stream_name.clone();
+        let headers = self.headers.clone();
         Box::pin(async move {
-            client
-                .put_log_events()
-                .set_log_events(Some(log_events))
-                .set_sequence_token(sequence_token)
-                .log_group_name(group_name)
-                .log_stream_name(stream_name)
-                .send()
-                .await
+            // #12760 this is a relatively convoluted way of changing the headers of a request
+            // about to be sent. https://github.com/awslabs/aws-sdk-rust/issues/537 should
+            // eventually make this better.
+            let op = PutLogEvents::builder()
+            .set_log_events(Some(log_events))
+            .set_sequence_token(sequence_token)
+            .log_group_name(group_name)
+            .log_stream_name(stream_name)
+            .build()
+            .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?
+            .make_operation(cw_client.conf())
+            .await
+            .map_err(|err| {
+                aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
+            })?;
+            
+            let (req, parts) = op.into_request_response();
+            let (mut body, props) = req.into_parts();
+            for(header, value) in headers.iter() {
+                let owned_header = header.clone();
+                let owned_value = value.clone();
+                body.headers_mut().insert(
+                    http::header::HeaderName::from_bytes(owned_header.as_bytes()).map_err(|err| {
+                        aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
+                    })?,
+                    http::HeaderValue::from_str(owned_value.as_str()).map_err(|err| {
+                        aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
+                    })?);
+            }
+            client.call(Operation::from_parts(Request::from_parts(body, props), parts)).await
         })
     }
 

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -32,6 +32,10 @@ pub struct CloudwatchFuture {
 
 struct Client {
     client: CloudwatchLogsClient,
+    // we store a separate smithy_client to set request headers for PutLogEvents since the regular
+    // client cannot set headers
+    //
+    // https://github.com/awslabs/aws-sdk-rust/issues/537
     smithy_client: std::sync::Arc<
         aws_smithy_client::Client<
             aws_smithy_client::erase::DynConnector,

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -32,8 +32,12 @@ pub struct CloudwatchFuture {
 
 struct Client {
     client: CloudwatchLogsClient,
-    smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
-    aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>,
+    smithy_client: std::sync::Arc<
+        aws_smithy_client::Client<
+            aws_smithy_client::erase::DynConnector,
+            aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>,
+        >,
+    >,
     stream_name: String,
     group_name: String,
     headers: IndexMap<String, String>,
@@ -53,8 +57,12 @@ impl CloudwatchFuture {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         client: CloudwatchLogsClient,
-        smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
-        aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>,
+        smithy_client: std::sync::Arc<
+            aws_smithy_client::Client<
+                aws_smithy_client::erase::DynConnector,
+                aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>,
+            >,
+        >,
         headers: IndexMap<String, String>,
         stream_name: String,
         group_name: String,
@@ -234,32 +242,38 @@ impl Client {
             // about to be sent. https://github.com/awslabs/aws-sdk-rust/issues/537 should
             // eventually make this better.
             let op = PutLogEvents::builder()
-            .set_log_events(Some(log_events))
-            .set_sequence_token(sequence_token)
-            .log_group_name(group_name)
-            .log_stream_name(stream_name)
-            .build()
-            .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?
-            .make_operation(cw_client.conf())
-            .await
-            .map_err(|err| {
-                aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
-            })?;
-            
+                .set_log_events(Some(log_events))
+                .set_sequence_token(sequence_token)
+                .log_group_name(group_name)
+                .log_stream_name(stream_name)
+                .build()
+                .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?
+                .make_operation(cw_client.conf())
+                .await
+                .map_err(|err| {
+                    aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
+                })?;
+
             let (req, parts) = op.into_request_response();
             let (mut body, props) = req.into_parts();
-            for(header, value) in headers.iter() {
+            for (header, value) in headers.iter() {
                 let owned_header = header.clone();
                 let owned_value = value.clone();
                 body.headers_mut().insert(
-                    http::header::HeaderName::from_bytes(owned_header.as_bytes()).map_err(|err| {
-                        aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
-                    })?,
+                    http::header::HeaderName::from_bytes(owned_header.as_bytes()).map_err(
+                        |err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()),
+                    )?,
                     http::HeaderValue::from_str(owned_value.as_str()).map_err(|err| {
                         aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
-                    })?);
+                    })?,
+                );
             }
-            client.call(Operation::from_parts(Request::from_parts(body, props), parts)).await
+            client
+                .call(Operation::from_parts(
+                    Request::from_parts(body, props),
+                    parts,
+                ))
+                .await
         })
     }
 

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -123,6 +123,10 @@ impl CloudwatchLogsPartitionSvc {
     pub fn new(
         config: CloudwatchLogsSinkConfig,
         client: CloudwatchLogsClient,
+        // we store a separate smithy_client to set request headers for PutLogEvents since the regular
+        // client cannot set headers
+        //
+        // https://github.com/awslabs/aws-sdk-rust/issues/537
         smithy_client: std::sync::Arc<
             aws_smithy_client::Client<
                 aws_smithy_client::erase::DynConnector,

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -120,10 +120,20 @@ impl DriverResponse for CloudwatchResponse {
 }
 
 impl CloudwatchLogsPartitionSvc {
-    pub fn new(config: CloudwatchLogsSinkConfig, client: CloudwatchLogsClient,
-    smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
-    aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>) -> Self {
-        let request_settings = config.request.tower.unwrap_with(&TowerRequestConfig::default());
+    pub fn new(
+        config: CloudwatchLogsSinkConfig,
+        client: CloudwatchLogsClient,
+        smithy_client: std::sync::Arc<
+            aws_smithy_client::Client<
+                aws_smithy_client::erase::DynConnector,
+                aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>,
+            >,
+        >,
+    ) -> Self {
+        let request_settings = config
+            .request
+            .tower
+            .unwrap_with(&TowerRequestConfig::default());
 
         Self {
             config,
@@ -201,8 +211,12 @@ impl CloudwatchLogsSvc {
         config: CloudwatchLogsSinkConfig,
         key: &CloudwatchKey,
         client: CloudwatchLogsClient,
-        smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
-        aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>,
+        smithy_client: std::sync::Arc<
+            aws_smithy_client::Client<
+                aws_smithy_client::erase::DynConnector,
+                aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>,
+            >,
+        >,
     ) -> Self {
         let group_name = key.group.clone();
         let stream_name = key.stream.clone();
@@ -311,8 +325,12 @@ impl Service<Vec<InputLogEvent>> for CloudwatchLogsSvc {
 
 pub struct CloudwatchLogsSvc {
     client: CloudwatchLogsClient,
-    smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
-    aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>,
+    smithy_client: std::sync::Arc<
+        aws_smithy_client::Client<
+            aws_smithy_client::erase::DynConnector,
+            aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>,
+        >,
+    >,
     headers: IndexMap<String, String>,
     stream_name: String,
     group_name: String,
@@ -334,6 +352,10 @@ pub struct CloudwatchLogsPartitionSvc {
     clients: HashMap<CloudwatchKey, Svc>,
     request_settings: TowerRequestSettings,
     client: CloudwatchLogsClient,
-    smithy_client: std::sync::Arc<aws_smithy_client::Client<aws_smithy_client::erase::DynConnector,
-    aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>>>,
+    smithy_client: std::sync::Arc<
+        aws_smithy_client::Client<
+            aws_smithy_client::erase::DynConnector,
+            aws_smithy_client::erase::DynMiddleware<aws_smithy_client::erase::DynConnector>,
+        >,
+    >,
 }

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -39,7 +39,7 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 			proxy: enabled: true
 			request: {
 				enabled: true
-				headers: false
+				headers: true
 			}
 			tls: {
 				enabled:                true


### PR DESCRIPTION
Made it possible to pass in arbitrary request headers such that we can
set the "json/emf" header when the logs uploaded by this sink are
actually in the Amazon CloudWatch EMF format: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure

Closes #12760