### PR TITLE
fix(deps, gcp service): Use default deps for `goauth`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ prost = { version = "0.10.4", default-features = false, features = ["std"] }
 prost-types = { version = "0.10.1", default-features = false, optional = true }
 
 # GCP
-goauth = { version = "0.13.0", default-features = false, optional = true }
+goauth = { version = "0.13.0", optional = true }
 gouth = { version = "0.2.1", default-features = false, optional = true }
 smpl_jwt = { version = "0.7.1", default-features = false, optional = true }
 


### PR DESCRIPTION
Version 0.13 of the `goauth` crate added support for vendored
native-tls, and added a default feature for `default-tls` in `reqwest`.
Without these default features being enabled, goauth would default to
contacting the OAuth2 token fetch interface with HTTP instead of HTTPS,
which caused an "invalid URL" error. Re-adding the default features
fixes this behavior.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
