### PR TITLE
chore: Mark `Write::write` as disallowed

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,6 @@ cognitive-complexity-threshold = 75
 
 # for `disallowed_method`:
 # https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_method
-disallowed-methods = []
+disallowed-methods = [
+  { path = "std::io::Write::write", reason = "This doesn't handle short writes, use `write_all` instead." },
+]

--- a/src/sinks/util/compressor.rs
+++ b/src/sinks/util/compressor.rs
@@ -34,6 +34,7 @@ impl From<Compression> for Writer {
 
 impl io::Write for Writer {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        #[allow(clippy::disallowed_method)] // Caller handles the result of `write`.
         match self {
             Writer::Plain(inner_buf) => inner_buf.write(buf),
             Writer::Gzip(writer) => writer.write(buf),
@@ -118,6 +119,7 @@ impl Compressor {
 
 impl io::Write for Compressor {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        #[allow(clippy::disallowed_method)] // Caller handles the result of `write`.
         self.inner.write(buf)
     }
 

--- a/src/sinks/util/encoding/codec.rs
+++ b/src/sinks/util/encoding/codec.rs
@@ -271,6 +271,7 @@ where
 
     impl<'inner> io::Write for Tracked<'inner> {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            #[allow(clippy::disallowed_method)] // We pass on the result of `write` to the caller.
             let n = self.inner.write(buf)?;
             self.count += n;
             Ok(n)


### PR DESCRIPTION
We have had a few bugs related to the use of the base `Write::write`
method instead of `write_all`. This marks that function as disallowed
and carves out a small number of specific exceptions where we handle it
properly.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
