### PR TITLE
enhancement(vrl): improve precision of fallible expression diagnostic

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -26,6 +26,13 @@ pub(crate) struct Compiler<'a> {
     /// This list allows us to avoid printing "undefined variable" compilation
     /// errors when the reason for it being undefined is another compiler error.
     skip_missing_query_target: Vec<(QueryTarget, LookupBuf)>,
+
+    /// Track which expression in a chain of expressions is fallible.
+    ///
+    /// It is possible for this state to switch from `None`, to `Some(T)` and
+    /// back to `None`, if the parent expression of a fallible expression
+    /// nullifies the fallibility of that expression.
+    fallible_expression_error: Option<FallibleInfo>,
 }
 
 impl<'a> Compiler<'a> {
@@ -39,6 +46,7 @@ impl<'a> Compiler<'a> {
             external_queries: vec![],
             external_assignments: vec![],
             skip_missing_query_target: vec![],
+            fallible_expression_error: None,
         }
     }
 
@@ -92,24 +100,23 @@ impl<'a> Compiler<'a> {
 
         nodes
             .into_iter()
-            .filter_map(|node| {
-                let span = node.span();
+            .filter_map(|node| match node.into_inner() {
+                Expr(expr) => {
+                    self.fallible_expression_error = None;
 
-                match node.into_inner() {
-                    Expr(expr) => {
-                        let expr = self.compile_expr(expr, external)?;
-                        if expr.type_def((&self.local, external)).is_fallible() {
-                            use crate::expression::Error;
-                            let err = Error::Fallible { span };
-                            self.diagnostics.push(Box::new(err));
-                        }
+                    let expr = self.compile_expr(expr, external)?;
 
-                        Some(expr)
+                    if let Some(info) = self.fallible_expression_error.take() {
+                        let error = crate::expression::Error::Fallible { span: info.span };
+
+                        self.diagnostics.push(Box::new(error) as _);
                     }
-                    Error(err) => {
-                        self.handle_parser_error(err);
-                        None
-                    }
+
+                    Some(expr)
+                }
+                Error(err) => {
+                    self.handle_parser_error(err);
+                    None
                 }
             })
             .collect()
@@ -129,7 +136,9 @@ impl<'a> Compiler<'a> {
     fn compile_expr(&mut self, node: Node<ast::Expr>, external: &mut ExternalEnv) -> Option<Expr> {
         use ast::Expr::*;
 
-        match node.into_inner() {
+        let span = node.span();
+
+        let expr = match node.into_inner() {
             Literal(node) => self.compile_literal(node, external),
             Container(node) => self.compile_container(node, external).map(Into::into),
             IfStatement(node) => self.compile_if_statement(node, external).map(Into::into),
@@ -140,7 +149,19 @@ impl<'a> Compiler<'a> {
             Variable(node) => self.compile_variable(node, external).map(Into::into),
             Unary(node) => self.compile_unary(node, external).map(Into::into),
             Abort(node) => self.compile_abort(node, external).map(Into::into),
+        }?;
+
+        // If the previously compiled expression is fallible, _and_ we are
+        // currently not tracking any existing fallible expression in the chain
+        // of expressions, then this is the first expression within that chain
+        // that can cause the entire chain to be fallible.
+        if expr.type_def((&self.local, external)).is_fallible()
+            && self.fallible_expression_error.is_none()
+        {
+            self.fallible_expression_error = Some(FallibleInfo { span });
         }
+
+        Some(expr)
     }
 
     #[cfg(feature = "expr-literal")]
@@ -345,16 +366,25 @@ impl<'a> Compiler<'a> {
         Some(Predicate::new(
             Node::new(span, exprs),
             (&self.local, external),
+            self.fallible_expression_error,
         ))
     }
 
     #[cfg(feature = "expr-op")]
     fn compile_op(&mut self, node: Node<ast::Op>, external: &mut ExternalEnv) -> Option<Op> {
+        use parser::ast::Opcode;
+
         let op = node.into_inner();
         let ast::Op(lhs, opcode, rhs) = op;
 
         let lhs_span = lhs.span();
         let lhs = Node::new(lhs_span, self.compile_expr(*lhs, external)?);
+
+        // If we're using error-coalescing, we need to negate any tracked
+        // fallibility error state for the lhs expression.
+        if opcode.inner() == &Opcode::Err {
+            self.fallible_expression_error = None;
+        }
 
         let rhs_span = rhs.span();
         let rhs = Node::new(rhs_span, self.compile_expr(*rhs, external)?);
@@ -431,7 +461,7 @@ impl<'a> Compiler<'a> {
             Infallible { ok, err, op, expr } => {
                 let span = expr.span();
 
-                match op {
+                let node = match op {
                     AssignmentOp::Assign => {
                         let expr = self
                             .compile_expr(*expr, external)
@@ -461,13 +491,25 @@ impl<'a> Compiler<'a> {
 
                         Node::new(span, node)
                     }
-                }
+                };
+
+                // If the RHS expression is marked as fallible, the "infallible"
+                // assignment nullifies this fallibility, and thus no error
+                // should be emitted.
+                self.fallible_expression_error = None;
+
+                node
             }
         };
 
-        let assignment = Assignment::new(node, &mut self.local, external)
-            .map_err(|err| self.diagnostics.push(Box::new(err)))
-            .ok()?;
+        let assignment = Assignment::new(
+            node,
+            &mut self.local,
+            external,
+            self.fallible_expression_error,
+        )
+        .map_err(|err| self.diagnostics.push(Box::new(err)))
+        .ok()?;
 
         // Track any potential external target assignments within the program.
         //

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -463,6 +463,12 @@ pub enum Error {
     Missing { span: Span, feature: &'static str },
 }
 
+/// Details about a fallible expression in a chain of expressions.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FallibleInfo {
+    pub(crate) span: Span,
+}
+
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
         use Error::*;

--- a/lib/vrl/tests/tests/internal/fallible_op1.vrl
+++ b/lib/vrl/tests/tests/internal/fallible_op1.vrl
@@ -1,13 +1,13 @@
 # object: { "foo": "bar" }
 # result:
 # error[E100]: unhandled error
-#   ┌─ :2:1
+#   ┌─ :2:20
 #   │
 # 2 │ (.foo == "this" || match(.bar, r''))
-#   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#   │ │
-#   │ expression can result in runtime error
-#   │ handle the error case to ensure runtime success
+#   │                    ^^^^^^^^^^^^^^^^
+#   │                    │
+#   │                    expression can result in runtime error
+#   │                    handle the error case to ensure runtime success
 #   │
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
 #   = learn more about error code 100 at https://errors.vrl.dev/100

--- a/lib/vrl/tests/tests/internal/fallible_op2.vrl
+++ b/lib/vrl/tests/tests/internal/fallible_op2.vrl
@@ -1,13 +1,13 @@
 # object: { "foo": "bar" }
 # result:
 # error[E100]: unhandled error
-#   ┌─ :2:1
+#   ┌─ :2:2
 #   │
 # 2 │ (match(.bar, r'') || .foo == "this")
-#   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#   │ │
-#   │ expression can result in runtime error
-#   │ handle the error case to ensure runtime success
+#   │  ^^^^^^^^^^^^^^^^
+#   │  │
+#   │  expression can result in runtime error
+#   │  handle the error case to ensure runtime success
 #   │
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
 #   = learn more about error code 100 at https://errors.vrl.dev/100

--- a/lib/vrl/tests/tests/issues/6469_fallible_operations_marked_as_infallible.vrl
+++ b/lib/vrl/tests/tests/issues/6469_fallible_operations_marked_as_infallible.vrl
@@ -1,13 +1,13 @@
 # result:
 #
 # error[E100]: unhandled error
-#   ┌─ :2:1
+#   ┌─ :2:5
 #   │
 # 2 │ 5 + to_int(.foo)
-#   │ ^^^^^^^^^^^^^^^^
-#   │ │
-#   │ expression can result in runtime error
-#   │ handle the error case to ensure runtime success
+#   │     ^^^^^^^^^^^^
+#   │     │
+#   │     expression can result in runtime error
+#   │     handle the error case to ensure runtime success
 #   │
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
 #   = learn more about error code 100 at https://errors.vrl.dev/100

--- a/lib/vrl/tests/tests/rfcs/7204/remove-generic-fallible-error.vrl
+++ b/lib/vrl/tests/tests/rfcs/7204/remove-generic-fallible-error.vrl
@@ -1,0 +1,50 @@
+# result:
+#
+# error[E100]: unhandled error
+#   ┌─ :2:1
+#   │
+# 2 │ to_string(.foo)
+#   │ ^^^^^^^^^^^^^^^
+#   │ │
+#   │ expression can result in runtime error
+#   │ handle the error case to ensure runtime success
+#   │
+#   = see documentation about error handling at https://errors.vrl.dev/#handling
+#   = learn more about error code 100 at https://errors.vrl.dev/100
+#   = see language documentation at https://vrl.dev
+#
+# error[E103]: unhandled fallible assignment
+#   ┌─ :4:15
+#   │
+# 4 │ if (parsed  = parse_grok(.message, "%{GREEDYDATA:parsed}"); parsed != null) {
+#   │     --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#   │     │         │
+#   │     │         this expression is fallible
+#   │     │         update the expression to be infallible
+#   │     or change this to an infallible assignment:
+#   │     parsed, err = parse_grok(.message, "%{GREEDYDATA:parsed}")
+#   │
+#   = see documentation about error handling at https://errors.vrl.dev/#handling
+#   = learn more about error code 103 at https://errors.vrl.dev/103
+#   = see language documentation at https://vrl.dev
+#
+# error[E100]: unhandled error
+#   ┌─ :8:1
+#   │
+# 8 │ "foo" + .bar + .baz[1]
+#   │ ^^^^^^^^^^^^^^^^^^^^^^
+#   │ │
+#   │ expression can result in runtime error
+#   │ handle the error case to ensure runtime success
+#   │
+#   = see documentation about error handling at https://errors.vrl.dev/#handling
+#   = learn more about error code 100 at https://errors.vrl.dev/100
+#   = see language documentation at https://vrl.dev
+
+to_string(.foo)
+
+if (parsed  = parse_grok(.message, "%{GREEDYDATA:parsed}"); parsed != null) {
+  merge(., parsed)
+}
+
+"foo" + .bar + .baz[1]

--- a/lib/vrl/tests/tests/rfcs/7204/remove-generic-fallible-error.vrl
+++ b/lib/vrl/tests/tests/rfcs/7204/remove-generic-fallible-error.vrl
@@ -13,26 +13,23 @@
 #   = learn more about error code 100 at https://errors.vrl.dev/100
 #   = see language documentation at https://vrl.dev
 #
-# error[E103]: unhandled fallible assignment
-#   ┌─ :4:15
+# error[E111]: fallible predicate
+#   ┌─ :4:4
 #   │
-# 4 │ if (parsed  = parse_grok(.message, "%{GREEDYDATA:parsed}"); parsed != null) {
-#   │     --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#   │     │         │
-#   │     │         this expression is fallible
-#   │     │         update the expression to be infallible
-#   │     or change this to an infallible assignment:
-#   │     parsed, err = parse_grok(.message, "%{GREEDYDATA:parsed}")
+# 4 │ if parse_grok(.message, "%{GREEDYDATA:parsed}") != null {
+#   │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#   │    │
+#   │    this predicate can result in runtime error
+#   │    handle the error case to ensure runtime success
 #   │
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
-#   = learn more about error code 103 at https://errors.vrl.dev/103
 #   = see language documentation at https://vrl.dev
 #
 # error[E100]: unhandled error
 #   ┌─ :8:1
 #   │
 # 8 │ "foo" + .bar + .baz[1]
-#   │ ^^^^^^^^^^^^^^^^^^^^^^
+#   │ ^^^^^^^^^^^^
 #   │ │
 #   │ expression can result in runtime error
 #   │ handle the error case to ensure runtime success
@@ -40,11 +37,26 @@
 #   = see documentation about error handling at https://errors.vrl.dev/#handling
 #   = learn more about error code 100 at https://errors.vrl.dev/100
 #   = see language documentation at https://vrl.dev
+#
+# error[E100]: unhandled error
+#    ┌─ :10:5
+#    │
+# 10 │ 5 + to_int(.foo)
+#    │     ^^^^^^^^^^^^
+#    │     │
+#    │     expression can result in runtime error
+#    │     handle the error case to ensure runtime success
+#    │
+#    = see documentation about error handling at https://errors.vrl.dev/#handling
+#    = learn more about error code 100 at https://errors.vrl.dev/100
+#    = see language documentation at https://vrl.dev
 
 to_string(.foo)
 
-if (parsed  = parse_grok(.message, "%{GREEDYDATA:parsed}"); parsed != null) {
-  merge(., parsed)
+if parse_grok(.message, "%{GREEDYDATA:parsed}") != null {
+  true
 }
 
 "foo" + .bar + .baz[1]
+
+5 + to_int(.foo)


### PR DESCRIPTION
This PR resolves the "[Remove Generic "Expression Can Result in Runtime Error" Diagnostic](https://github.com/vectordotdev/vector/blob/b530718e961b6d4a0a4ba9428fdcccb41a8a8e18/rfcs/2021-08-22-7204-vrl-error-diagnostic-improvements.md#remove-generic-expression-can-result-in-runtime-error-diagnostic)" section of RFC https://github.com/vectordotdev/vector/pull/8894.

There's a test that showcases the different diagnostic messages, such as:

```
error[E100]: unhandled error
   ┌─ :10:5
   │
10 │ 5 + to_int(.foo)
   │     ^^^^^^^^^^^^
   │     │
   │     expression can result in runtime error
   │     handle the error case to ensure runtime success
   │
   = see documentation about error handling at https://errors.vrl.dev/#handling
   = learn more about error code 100 at https://errors.vrl.dev/100
   = see language documentation at https://vrl.dev

```

Previously, the diagnostic would highlight the entire root expression, making it more difficult to understand what expression needs to be made infallible.

There's still more we can do here, such as making the errors more specific to each type of fallible expression, but that's outside the scope of the RFC.