### PR TITLE
chore: Use domain qualified image names in all `Dockerfile`s

### DIFF
--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 AS builder
+FROM docker.io/alpine:3.14 AS builder
 
 WORKDIR /vector
 
@@ -7,7 +7,7 @@ RUN tar -xvf vector-0*-"$(cat /etc/apk/arch)"-unknown-linux-musl*.tar.gz --strip
 
 RUN mkdir -p /var/lib/vector
 
-FROM alpine:3.14
+FROM docker.io/alpine:3.14
 RUN apk --no-cache add ca-certificates tzdata
 
 COPY --from=builder /vector/bin/* /usr/local/bin/

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim AS builder
+FROM docker.io/debian:bullseye-slim AS builder
 
 WORKDIR /vector
 
@@ -7,7 +7,7 @@ RUN dpkg -i vector_*_"$(dpkg --print-architecture)".deb
 
 RUN mkdir -p /var/lib/vector
 
-FROM debian:bullseye-slim
+FROM docker.io/debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
 

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim AS builder
+FROM docker.io/debian:bullseye-slim AS builder
 
 WORKDIR /vector
 

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 AS builder
+FROM docker.io/alpine:3.14 AS builder
 
 WORKDIR /vector
 

--- a/scripts/integration/Dockerfile
+++ b/scripts/integration/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_VERSION
-FROM rust:${RUST_VERSION}-slim-bullseye
+FROM docker.io/rust:${RUST_VERSION}-slim-bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/skaffold/docker/Dockerfile
+++ b/skaffold/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM docker.io/debian:bullseye-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/vector/target \
 #
 # TARGET
 #
-FROM debian:${DEBIAN_RELEASE}-slim
+FROM docker.io/debian:${DEBIAN_RELEASE}-slim
 RUN apt-get update && apt-get -y --no-install-recommends install zlib1g && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /vector/vector /usr/bin/vector
 RUN mkdir -p /var/lib/vector


### PR DESCRIPTION
Most of the images named in our `Dockerfile` configs assume the Docker
hub. The default podman config comes with no assumed domain names, and
so fail to run these scripts, but can run them with the qualified
docker.io domain.

I missed doing these in #12739 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
