### PR TITLE
docs(external docs): Fix config example on monitoring page

### DIFF
--- a/website/content/en/docs/administration/monitoring.md
+++ b/website/content/en/docs/administration/monitoring.md
@@ -95,7 +95,7 @@ however you wish. Here's an example configuration that delivers Vector's metrics
 [sources.vector_metrics]
 type = "internal_metrics"
 
-[sources.prometheus]
+[sinks.prometheus]
 type = ["prometheus_remote_write"]
 endpoint = ["https://localhost:8087/"]
 inputs = ["vector_metrics"]


### PR DESCRIPTION
In the metrics integration example it was pointing to prometheus source but should be sink.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
