### PR TITLE
docs(external docs): add note about function fallibility

### DIFF
--- a/website/cue/reference/remap/expressions.cue
+++ b/website/cue/reference/remap/expressions.cue
@@ -8,8 +8,8 @@ remap: {
 		description: string
 		return:      string
 
-		grammar?: #Grammar
-
+		grammar?:         #Grammar
+		characteristics?: remap.#Characteristics
 		examples: [remap.#Example, ...remap.#Example]
 	}
 

--- a/website/cue/reference/remap/expressions/function_call.cue
+++ b/website/cue/reference/remap/expressions/function_call.cue
@@ -107,6 +107,35 @@ remap: expressions: function_call: {
 		}
 	}
 
+	characteristics: {
+		fallibility: {
+			title: "Function Fallibility"
+			description: """
+				VRL functions can be marked as "fallible" or
+				"infallible". When a function is defined as
+				fallible, it can fail at runtime, requiring the
+				error to be handled before the program can be
+				compiled.
+
+				If a function is defined as infallible, it means
+				that **given the correct function arguments**,
+				the function can never fail at runtime, and thus
+				no error handling is needed.
+
+				Note that even if a function is defined as
+				infallible, if any of its arguments can fail at
+				runtime, the function is considered to be
+				fallible, and thus the error case needs to be
+				handled in this case.
+
+				The VRL compiler ensures all potential errors in
+				a program are handled, so there's no need to
+				worry about missing any potential runtime
+				failures.
+				"""
+		}
+	}
+
 	examples: [
 		{
 			title: "Positional function invocation"

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -1089,7 +1089,9 @@
             {{ end }}
           </div>
           {{ end }}
+        </div>
       </div>
+      {{ end }}
     </div>
     {{ end }}
   </div>

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -1057,6 +1057,39 @@
         </div>
       </div>
       {{ end }}
+
+      {{ with $v.characteristics }}
+      {{ $id := printf "%s-characteristics" ($v.title | urlize) }}
+      <div class="mt-4">
+        <span>
+          {{ partial "heading.html" (dict "text" "Characteristics" "level" 4 "id" $id) }}
+        </span>
+
+        <div class="mt-2 flex flex-col divide-y dark:divide-gray-700 border dark:border-gray-700">
+          {{ range . }}
+          <div class="py-1.5 px-3">
+            {{ partial "heading.html" (dict "text" .title "level" 5 "icon" false) }}
+
+            {{ with .description }}
+            <div class="mt-1 prose prose-sm dark:prose-dark max-w-none">
+              {{ . | markdownify }}
+            </div>
+            {{ end }}
+
+            {{ with .enum }}
+            <div class="mt-2">
+              <span>
+                Enum options
+              </span>
+
+              <div class="prose dark:prose-dark max-w-none">
+                {{ template "enum-options-table" . }}
+              </div>
+            </div>
+            {{ end }}
+          </div>
+          {{ end }}
+      </div>
     </div>
     {{ end }}
   </div>

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -621,10 +621,11 @@
 
         {{/* Badges */}}
         <span class="flex space-x-1">
+          {{ $href := "/docs/reference/vrl/expressions/#function-call-characteristics" | relURL }}
           {{ if $infallible }}
-          {{ partial "badge.html" (dict "word" "infallible" "color" "blue") }}
+          {{ partial "badge.html" (dict "word" "infallible" "color" "blue" "inline" true "href" $href) }}
           {{ else }}
-          {{ partial "badge.html" (dict "word" "fallible" "color" "yellow") }}
+          {{ partial "badge.html" (dict "word" "fallible" "color" "yellow" "inline" true "href" $href) }}
           {{ end }}
         </span>
       </span>


### PR DESCRIPTION
This PR resolves the "[Update VRL Website Documentation](https://github.com/vectordotdev/vector/blob/b530718e961b6d4a0a4ba9428fdcccb41a8a8e18/rfcs/2021-08-22-7204-vrl-error-diagnostic-improvements.md#update-vrl-website-documentation)" section of RFC https://github.com/vectordotdev/vector/pull/8894.

The PR adds a note to the "function call" expression docs, explaining how fallibility works for function calls.

closes #12903.