### PR TITLE
chore: Fix clippy flag application again

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-[build]
+[target.'cfg(all())']
 rustflags = [
   "-Dclippy::print_stdout",
   "-Dclippy::print_stderr",

--- a/src/test_util/http.rs
+++ b/src/test_util/http.rs
@@ -37,7 +37,7 @@ where
 
     tokio::spawn(async move {
         if let Err(e) = server.await {
-            eprintln!("blackhole HTTP server error: {}", e);
+            error!("blackhole HTTP server error: {:?}", e);
         }
     });
 


### PR DESCRIPTION
The `rustflags` from all matching `target.<cfg>.rustflags` and
`target.<triple>.rustflags` are applied, but `build.rustflags` is
handled separately, and so is only applied when no `target` block
matches. This changes the `[build]` block to a target that applies to
all.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
