### PR TITLE
fix(observability): Fix overriding Vector fields in enterprise logs

### DIFF
--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -421,14 +421,12 @@ fn setup_logs_reporting(
         source: Some(format!(
             r#"
             .ddsource = "vector"
-            .vector = {{
-                "configuration_key": "{configuration_key}",
-                "configuration_version_hash": "{configuration_version_hash}",
-                "version": "{vector_version}",
-                "arch": "{build_arch}",
-                "os": "{build_os}",
-                "vendor": "{build_vendor}"
-            }}
+            .vector.configuration_key = "{configuration_key}"
+            .vector.configuration_version_hash = "{configuration_version_hash}"
+            .vector.version = "{vector_version}"
+            .vector.arch = "{build_arch}"
+            .vector.os = "{build_os}"
+            .vector.vendor = "{build_vendor}"
             {}
         "#,
             custom_logs_tags_vrl,


### PR DESCRIPTION
This PR 
- Fixes a mistake in enterprise reporting wherein the `remap` transform attached to `internal_logs` was configured to override the `.vector` section of events. This accidentally removed `component_*` fields from spans.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
