### PR TITLE
feat(function transform): add "function transform" spike

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -533,6 +533,7 @@ transforms-logs = [
   "transforms-dedupe",
   "transforms-field_filter",
   "transforms-filter",
+  "transforms-function",
   "transforms-geoip",
   "transforms-grok_parser",
   "transforms-json_parser",
@@ -558,6 +559,7 @@ transforms-metrics = [
   "transforms-add_tags",
   "transforms-aggregate",
   "transforms-filter",
+  "transforms-function",
   "transforms-log_to_metric",
   "transforms-lua",
   "transforms-metric_to_log",
@@ -579,6 +581,7 @@ transforms-concat = []
 transforms-dedupe = ["lru"]
 transforms-field_filter = []
 transforms-filter = []
+transforms-function = ["transforms-remap"]
 transforms-geoip = ["maxminddb"]
 transforms-grok_parser = ["grok"]
 transforms-json_parser = []
@@ -809,6 +812,7 @@ vector-unit-test-tests = [
   "transforms-remap",
   "transforms-route",
   "transforms-filter",
+  "transforms-function",
   "transforms-reduce",
   "transforms-add_tags",
   "transforms-log_to_metric",
@@ -846,7 +850,7 @@ language-benches = ["sinks-socket", "sources-socket", "transforms-add_fields", "
 statistic-benches = []
 metrics-benches = ["sinks-socket", "sources-socket"]
 remap-benches = ["transforms-add_fields", "transforms-coercer", "transforms-json_parser", "transforms-remap"]
-transform-benches = ["transforms-filter", "transforms-dedupe", "transforms-reduce", "transforms-route"]
+transform-benches = ["transforms-filter", "transforms-dedupe", "transforms-reduce", "transforms-route", "transforms-function"]
 codecs-benches = []
 loki-benches = ["sinks-loki"]
 enrichment-tables-benches = ["enrichment-tables-file"]

--- a/src/transforms/function.rs
+++ b/src/transforms/function.rs
@@ -1,0 +1,235 @@
+use crate::{
+    config::{
+        DataType, GenerateConfig, Input, Output, TransformConfig, TransformContext,
+        TransformDescription,
+    },
+    schema,
+    transforms::{remap::RemapConfig, Transform},
+};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use toml::value::Value as TomlValue;
+use value::Value;
+use vector_common::TimeZone;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionConfig {
+    /// The name of the VRL function to call.
+    pub function: String,
+
+    /// An optional list of arguments to pass to the function.
+    ///
+    /// If left empty, no arguments are passed in, or if a single argument is
+    /// expected, the `.` query expression is provided to the first argument.
+    pub arguments: Arguments,
+    pub failure: FailureConfig,
+
+    /// The field to assign the result of the function to.
+    ///
+    /// If undefined, the event root is used.
+    pub target_field: Option<String>,
+
+    /// Optional time zone configuration to use.
+    #[serde(default)]
+    pub timezone: TimeZone,
+}
+
+/// Function arguments.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields, untagged)]
+pub enum Arguments {
+    /// A list of unnamed (positional) function arguments.
+    Array(Vec<TomlValue>),
+
+    /// A list of named function arguments.
+    Object(IndexMap<String, TomlValue>),
+}
+
+/// The failure mode configuration.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FailureConfig {
+    /// The log level at which to log the runtime error.
+    ///
+    /// Can be set to `LogLevel::None` to disable logging.
+    ///
+    /// Defaults to `LogLevel::Error`.
+    #[serde(default = "default_log_level")]
+    pub log: LogLevel,
+
+    /// The result of a runtime failure of the function call.
+    pub mode: FailureMode,
+}
+
+const fn default_log_level() -> LogLevel {
+    LogLevel::Error
+}
+
+/// The level of a log message.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
+pub enum LogLevel {
+    /// No log level, equivalent to not emitting the log.
+    None,
+
+    /// Debug level.
+    Debug,
+
+    /// Info level.
+    Info,
+
+    /// Warn level.
+    Warn,
+
+    /// Error level.
+    Error,
+}
+
+/// The result of a runtime failure.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
+pub enum FailureMode {
+    /// The provided static value is used if the function fails at runtime.
+    Static(TomlValue),
+
+    /// The (unmodified) event is re-routed to the provided component if the
+    /// function fails at runtime.
+    Reroute,
+
+    /// The event is dropped if the function fails at runtime.
+    Drop,
+}
+
+inventory::submit! {
+    TransformDescription::new::<FunctionConfig>("function")
+}
+
+impl GenerateConfig for FunctionConfig {
+    fn generate_config() -> toml::Value {
+        toml::from_str(indoc::indoc! {r#"
+            function = "parse_json"
+
+            [[arguments]]
+            value = "."
+
+            [[failure]]
+            log = "error"
+            mode = "drop"
+        "#})
+        .unwrap()
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "function")]
+impl TransformConfig for FunctionConfig {
+    async fn build(&self, ctx: &TransformContext) -> crate::Result<Transform> {
+        vrl_stdlib::all()
+            .into_iter()
+            .find(|func| func.identifier() == &self.function)
+            .ok_or_else(|| BuildError::UnknownFunction {
+                ident: self.function.clone(),
+                maybe: "TODO".to_owned(),
+            })?;
+
+        let arguments = match self.arguments.clone() {
+            Arguments::Array(args) => args.into_iter().map(|arg| (None, arg)).collect::<Vec<_>>(),
+            Arguments::Object(args) => args
+                .into_iter()
+                .map(|(ident, arg)| (Some(ident), arg))
+                .collect::<Vec<_>>(),
+        };
+
+        let arguments = arguments
+            .into_iter()
+            .map(|(ident, arg)| {
+                let mut buf = String::new();
+
+                if let Some(ident) = ident {
+                    buf.push_str(&format!("{ident}: "))
+                }
+
+                match Value::try_from(arg).map_err(|err| BuildError::InvalidArgument {
+                    parameter: "TODO",
+                    error: err.to_string(),
+                })? {
+                    Value::Bytes(v) => {
+                        let v = String::from_utf8_lossy(&v);
+
+                        // TODO: document / or find alternative approach
+                        if v.starts_with(".") {
+                            buf.push_str(&v);
+                        } else {
+                            buf.push('"');
+                            buf.push_str(&v);
+                            buf.push('"');
+                        }
+                    }
+                    v => buf.push_str(&v.to_string()),
+                };
+
+                Ok(buf)
+            })
+            .collect::<Result<Vec<_>, BuildError>>()?
+            .join(", ");
+
+        let target = self.target_field.clone().unwrap_or_else(|| ".".to_owned());
+
+        let mut source = format!("{target} = {}", &self.function);
+
+        if !matches!(self.failure.mode, FailureMode::Static(_)) {
+            source.push('!');
+        }
+
+        source.push_str(&format!("({arguments})"));
+
+        if let FailureMode::Static(value) = &self.failure.mode {
+            source.push_str(&format!(" ?? {}", value.to_string()));
+        }
+
+        let remap = RemapConfig {
+            source: Some(source),
+            file: None,
+            timezone: self.timezone.clone(),
+            drop_on_error: !matches!(self.failure.mode, FailureMode::Static(_)),
+            drop_on_abort: false,
+            reroute_dropped: matches!(self.failure.mode, FailureMode::Reroute),
+            runtime: vrl::VrlRuntime::Ast,
+        };
+
+        remap.build(ctx).await
+    }
+
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
+        vec![Output::default(DataType::Log)]
+    }
+
+    fn transform_type(&self) -> &'static str {
+        "function"
+    }
+}
+
+#[derive(Debug, Snafu)]
+pub enum BuildError {
+    #[snafu(display("provided function `{}` is unknown, did you mean `{}`?", ident, maybe))]
+    UnknownFunction {
+        ident: String,
+        maybe: String,
+    },
+
+    #[snafu(display("invalid argument `{}`: {}", parameter, error))]
+    InvalidArgument {
+        parameter: &'static str,
+        error: String,
+    },
+
+    // TODO
+    Compilation {
+        error: String,
+    },
+}

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -22,6 +22,8 @@ pub mod dedupe;
 pub mod field_filter;
 #[cfg(feature = "transforms-filter")]
 pub mod filter;
+#[cfg(feature = "transforms-function")]
+pub mod function;
 #[cfg(feature = "transforms-geoip")]
 pub mod geoip;
 #[cfg(feature = "transforms-grok_parser")]


### PR DESCRIPTION
This is a proof-of-concept transform that allows you to call VRL functions without having to write actual VRL.

It's fairly basic, in that it allows you to specify:

- the function name
- a list of arguments
- what should happen if the function fails at runtime

And then generates a valid VRL program, and delegates everything else to the existing `remap` transform.

This is suboptimal, since we lose control over how to handle events once we pass them to the remap transform, and it also likely costs us a bit of performance, but it _is_ the easiest implementation to "get something going".

Here's an example config:

```toml
[transforms.parse_json]
type = "function"
function = "parse_json"
target_field = "."
arguments = { value = "." }
failure.mode = "drop"
``` 

Or, the shorthand version:

```toml
[transforms.parse_json]
type = "function"
function = "parse_json"
``` 

The equivalent `remap` transform would be:

```toml
[transforms.parse_json]
type = "remap"
source = ". = parse_json!(.)"
drop_on_error = true
``` 

A few additional notes worth considering:

- Arguments are provided as TOML values, and then converted to VRL values. This works, but can fall down in some cases. In the above example, I use `value: "."`, to mean "root path query", not "a string with a dot". This is inferred by checking if the string starts with a `.` and then converting that string into a query. This is hacky, but I assume will cover 99% of the use-cases people have. We can still provide a work-around for when you actually want to use a static string starting with a dot. It also means that (currently) you can't provide a regex value, but here too there are many ways to make this work (e.g. `value: { type = "regex", value = "(foo)?bar" }`, I simply haven't tried any of them yet.
- When you don't provide any arguments, I'd like either one of three things to happen:
  1. If the function takes no arguments, it runs as-is
  2. If the function has a single _required_ argument, the first argument is automatically inferred as `.` (e.g. root path query)
  3. Any other case results in a misconfiguration failure
- Error handling isn't great yet, as it'll simply show the `remap` transform errors, which shows an actual VRL program source as its output, which might confuse someone who has no idea what VRL is, and simply wants this function-call in Vector to work. 
- A previous PoC generated the program through the AST, but it felt overly cumbersome for no apparent gains over generating the source as a string.
- Another attempt before that tried to generate a single `Expression` and `resolve` that, but — at least currently — the VRL compiler isn't set-up to do that, which results in awkward implementation details, and a lot of duplicated work that the compiler already handles for you internally if you compile a regular program. It _would_ give us the most flexibility, but it would be a bigger task than I wanted to tackle for this initial PoC.