### PR TITLE
docs: Add note about type def improvements in 0.22 upgrade guide

### DIFF
--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -16,6 +16,7 @@ Vector's 0.22.0 release includes **breaking changes**:
 2. [`kubernetes_logs` source now requires rights to list and watch nodes](#kubernetes-logs-list-watch-nodes)
 3. [VRL now supports template strings](#vrl-template-strings)
 4. [`encode_key_value` and `encode_logfmt` quote wrapping behavior change](#encode-key-value-quote-wrapping)
+5. [VRL now supports updating type definition of parent scopes](#vrl-parent-scope-type)
 
 We cover them below to help you upgrade quickly:
 
@@ -165,4 +166,25 @@ With this change, the message would be encoded as:
 
 ```text
 lvl=info msg="{\"some\":\"val\"}"
+```
+#### VRL now supports updating type definition of parent scopes {#vrl-parent-scope-type}
+
+VRL will now update type definitions in parent scopes when they are mutated in
+a child scope. This is more easily explained with examples.
+
+Prior to this release the following script requires type assertions.
+
+```coffee
+foo = 1
+{ foo = "bar" }
+upcase(string!(foo))
+```
+
+With this release the compiler will know that `foo` has been mutated to a String
+inside the child scope, and the script can be simplified to:
+
+```coffee
+foo = 1
+{ foo = "bar" }
+upcase(foo)
 ```


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
