### PR TITLE
chore(ci): Run check-component-features in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,7 +279,6 @@ jobs:
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
-      - run: cargo install cargo-hack
       - run: make check-component-features
 
   check-msrv:

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ check-all: check-scripts
 
 .PHONY: check-component-features
 check-component-features: ## Check that all component features are setup properly
-	${MAYBE_ENVIRONMENT_EXEC} cargo hack check --workspace --keep-going --each-feature --exclude-features "sources-utils-http sources-utils-http-encoding sources-utils-http-prelude sources-utils-http-query sources-utils-tcp-keepalive sources-utils-tcp-socket sources-utils-tls sources-utils-udp sources-utils-unix sinks-utils-udp" --all-targets
+	${MAYBE_ENVIRONMENT_EXEC} ./scripts/check-component-features
 
 .PHONY: check-clippy
 check-clippy: ## Check code with Clippy

--- a/scripts/check-component-features
+++ b/scripts/check-component-features
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Extract all feature names from Cargo.toml
+features=$(
+  sed -e '
+    1,/^\[features\]$/d;
+    /^\[/,$d;
+    /=/!d;
+    s/ *=.*$//;
+
+    # Skip over certain features
+    /-utils-/d;
+    /^default$/d;
+    /^all-integration-tests$/d;
+  ' < Cargo.toml | sort
+)
+
+# Prime the pump to build most of the artifacts
+cargo check --workspace --all-targets --no-default-features
+cargo check --workspace --all-targets --no-default-features --features default
+cargo check --workspace --all-targets --no-default-features --features all-integration-tests
+
+# The feature builds already run in parallel below, don't overload
+export CARGO_BUILD_JOBS=1
+
+exec parallel --verbose --retries 2 scripts/check-one-feature {} ::: $features

--- a/scripts/check-one-feature
+++ b/scripts/check-one-feature
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# -lt 1 ]
+then
+  echo "usage: $0 FEATURE [OPTIONS]"
+  exit 1
+fi
+
+feature=$1
+shift
+
+if [ ! -d target ]
+then
+  echo $0: 'Run `cargo check` first to prime the `target` directory.'
+  exit 1
+fi
+
+target=$PWD/target-feature-$feature
+log=$target/.logfile
+trap 'rm --force --recursive $target' EXIT
+
+cp --archive --link target $target
+rm --force $target/debug/.cargo-lock
+
+echo "===== Feature: $feature ====="
+if cargo check --workspace --all-targets \
+	--no-default-features \
+	--features $feature \
+	--target-dir $target \
+	"$@" >$log 2>&1
+then
+  # If the run was successful, just output the `Finished` line
+  # to prevent cluttering the logs.
+  exit=0
+  fgrep --word-regexp Finished $log
+else
+  exit=$?
+  cat $log
+fi
+
+exit $exit
+
+# It would be nice to relink newer files back into `target` so
+# subsequent runs can pick them up, but that ends up confusing `cargo`
+# later in the process.

--- a/src/sources/util/http/auth.rs
+++ b/src/sources/util/http/auth.rs
@@ -42,12 +42,12 @@ impl TryFrom<Option<&HttpSourceAuthConfig>> for HttpSourceAuth {
 
 #[derive(Debug, Clone)]
 pub struct HttpSourceAuth {
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub(self) token: Option<String>,
 }
 
 impl HttpSourceAuth {
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub fn is_valid(&self, header: &Option<String>) -> Result<(), ErrorMessage> {
         use warp::http::StatusCode;
 

--- a/src/sources/util/http/error.rs
+++ b/src/sources/util/http/error.rs
@@ -15,7 +15,7 @@ pub struct ErrorMessage {
     feature = "sources-datadog_agent"
 ))]
 impl ErrorMessage {
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub fn new(code: http::StatusCode, message: String) -> Self {
         ErrorMessage {
             code: code.as_u16(),
@@ -23,7 +23,7 @@ impl ErrorMessage {
         }
     }
 
-    #[allow(unused)] // triggered by cargo-hack
+    #[allow(unused)] // triggered by check-component-features
     pub fn status_code(&self) -> http::StatusCode {
         http::StatusCode::from_u16(self.code).unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR)
     }

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -39,7 +39,7 @@ const fn default_shutdown_timeout_secs() -> u64 {
 impl VectorConfig {
     #[cfg(test)]
     #[allow(unused)] // this test function is not always used in test, breaking
-                     // our cargo-hack run
+                     // our check-component-features run
     pub fn set_tls(&mut self, config: Option<TlsEnableableConfig>) {
         self.tls = config;
     }


### PR DESCRIPTION
This speeds up the `check-component-features` check by running each
feature in a separate job in a separate build tree. This is possible
because cargo doesn't overwrite output files after they are created. To
take advantage of this, we first do a check on the full build and then
create a temporary build tree for each feature composed of hard links to
the individual files created during that check. This speeds up the
subsequent builds and allows them to run in parallel as they no longer
clobber each other's outputs.

This is an improved version of #12465 using `parallel` and a few other tweaks to fix deficiencies of that setup.