### PR TITLE
fix(vrl): fix if statement type definitions

### DIFF
--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -340,9 +340,15 @@ impl<'a> Compiler<'a> {
                 // );
                 self.local = result;
 
-                if let Some(details) =
-                    Details::merge_optional(original_external, external.target().cloned())
-                {
+                let merged_details =
+                    Details::merge_optional(original_external.clone(), external.target().cloned());
+                println!(
+                    "Merging original: {:?} and if={:?} to make {:?}",
+                    original_external,
+                    external.target().cloned(),
+                    merged_details
+                );
+                if let Some(details) = merged_details {
                     external.update_target(details);
                 }
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -333,10 +333,10 @@ impl<'a> Compiler<'a> {
             }
             None => {
                 // assignments must be the result of either the if block or the original value
-                self.local = self.local.clone().merge(original_locals.clone());
+                self.local = self.local.clone().merge(original_locals);
 
                 if let Some(details) =
-                    Details::merge_optional(original_external.clone(), external.target().cloned())
+                    Details::merge_optional(original_external, external.target().cloned())
                 {
                     external.update_target(details);
                 }

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -7,7 +7,7 @@ use crate::{
     expression::*,
     program::ProgramInfo,
     state::{ExternalEnv, LocalEnv},
-    Function, Program,
+    Function, Program, TypeDef,
 };
 
 pub(crate) type Diagnostics = Vec<Box<dyn DiagnosticMessage>>;
@@ -319,9 +319,11 @@ impl<'a> Compiler<'a> {
 
                 // assignments must be the result of either the if or else block, but not the original value
                 self.local = self.local.clone().merge(consequent_locals);
-                if let Some(details) =
-                    Details::merge_optional(consequent_external, external.target().cloned())
-                {
+                if let Some(details) = Details::merge_optional(
+                    consequent_external,
+                    external.target().cloned(),
+                    TypeDef::any(),
+                ) {
                     external.update_target(details);
                 }
 
@@ -335,9 +337,11 @@ impl<'a> Compiler<'a> {
                 // assignments must be the result of either the if block or the original value
                 self.local = self.local.clone().merge(original_locals);
 
-                if let Some(details) =
-                    Details::merge_optional(original_external, external.target().cloned())
-                {
+                if let Some(details) = Details::merge_optional(
+                    original_external,
+                    external.target().cloned(),
+                    TypeDef::any(),
+                ) {
                     external.update_target(details);
                 }
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -333,22 +333,11 @@ impl<'a> Compiler<'a> {
             }
             None => {
                 // assignments must be the result of either the if block or the original value
-                let result = self.local.clone().merge(original_locals.clone());
-                // println!(
-                //     "Merging original={:?} and if={:?} to make {:?}",
-                //     self.local, original_locals, result
-                // );
-                self.local = result;
+                self.local = self.local.clone().merge(original_locals.clone());
 
-                let merged_details =
-                    Details::merge_optional(original_external.clone(), external.target().cloned());
-                println!(
-                    "Merging original: {:?} and if={:?} to make {:?}",
-                    original_external,
-                    external.target().cloned(),
-                    merged_details
-                );
-                if let Some(details) = merged_details {
+                if let Some(details) =
+                    Details::merge_optional(original_external.clone(), external.target().cloned())
+                {
                     external.update_target(details);
                 }
 

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -317,7 +317,7 @@ impl<'a> Compiler<'a> {
 
                 let else_block = self.compile_block(block, external)?;
 
-                // assignments must be the result of either the if or else block, but not the original snapshot
+                // assignments must be the result of either the if or else block, but not the original value
                 self.local = self.local.clone().merge(consequent_locals);
                 if let Some(details) =
                     Details::merge_optional(consequent_external, external.target().cloned())
@@ -332,8 +332,14 @@ impl<'a> Compiler<'a> {
                 })
             }
             None => {
-                // assignments must be the result of either the if block or the original snapshot
-                self.local = self.local.clone().merge(original_locals);
+                // assignments must be the result of either the if block or the original value
+                let result = self.local.clone().merge(original_locals.clone());
+                // println!(
+                //     "Merging original={:?} and if={:?} to make {:?}",
+                //     self.local, original_locals, result
+                // );
+                self.local = result;
+
                 if let Some(details) =
                     Details::merge_optional(original_external, external.target().cloned())
                 {

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -394,6 +394,7 @@ where
                     value
                 }
                 Err(error) => {
+                    // TODO: delete me?
                     ok.insert(default.clone(), ctx);
                     let value = Value::from(error.to_string());
                     err.insert(value.clone(), ctx);

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -394,7 +394,6 @@ where
                     value
                 }
                 Err(error) => {
-                    // TODO: delete me?
                     ok.insert(default.clone(), ctx);
                     let value = Value::from(error.to_string());
                     err.insert(value.clone(), ctx);

--- a/lib/vrl/compiler/src/expression/if_statement.rs
+++ b/lib/vrl/compiler/src/expression/if_statement.rs
@@ -34,7 +34,7 @@ impl Expression for IfStatement {
         let type_def = self.consequent.type_def(state);
 
         match &self.alternative {
-            None => type_def,
+            None => type_def.add_null(),
             Some(alternative) => type_def.merge_deep(alternative.type_def(state)),
         }
     }

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -82,7 +82,7 @@ impl ExternalEnv {
                 type_def: kind.into(),
                 value: None,
             }),
-            ..Default::default()
+            custom: AnyMap::new(),
         }
     }
 

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -82,7 +82,7 @@ impl ExternalEnv {
                 type_def: kind.into(),
                 value: None,
             }),
-            custom: AnyMap::new(),
+            ..Default::default()
         }
     }
 

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -402,7 +402,7 @@ impl Details {
     pub(crate) fn merge_optional(a: Option<Self>, b: Option<Self>) -> Option<Self> {
         match (a, b) {
             (Some(a), Some(b)) => Some(a.merge(b)),
-            (Some(x), None) | (None, Some(x)) => {
+            (Some(_), None) | (None, Some(_)) => {
                 // None for details can mean "any" type
                 Some(Details {
                     type_def: TypeDef::any(),

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -399,3 +399,14 @@ pub(crate) struct Details {
     pub(crate) type_def: TypeDef,
     pub(crate) value: Option<Value>,
 }
+
+impl Details {
+    /// Returns the union of 2 possible states
+    pub(crate) fn merge(self, other: Self) -> Self {
+        // TODO: handle the value better
+        Self {
+            type_def: self.type_def.merge_deep(other.type_def),
+            value: None,
+        }
+    }
+}

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -350,21 +350,7 @@ impl TypeDef {
 
     pub fn merge(&mut self, other: Self, strategy: merge::Strategy) {
         self.fallible |= other.fallible;
-
-        // NOTE: technically we shouldn't do this, but to keep backward compatibility with the
-        // "old" `Kind` implementation, we consider a type that is marked as "any" equal to the old
-        // implementation's `unknown`, which, when merging, would discard that type.
-        //
-        // see: https://github.com/vectordotdev/vector/blob/18415050b60b08197e8135b7659390256995e844/lib/vrl/compiler/src/type_def.rs#L428-L429
-        // if !self.is_any() && other.is_any() {
-        //     // keep `self`'s `kind` definition
-        // } else if self.is_any() && !other.is_any() {
-        //     // overwrite `self`'s `kind` definition with `others`'s
-        //     self.kind = other.kind;
-        // } else {
-        // merge the two `kind`s
         self.kind.merge(other.kind, strategy);
-        // }
     }
 
     pub fn merge_overwrite(mut self, other: Self) -> Self {

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -403,10 +403,21 @@ pub(crate) struct Details {
 impl Details {
     /// Returns the union of 2 possible states
     pub(crate) fn merge(self, other: Self) -> Self {
-        // TODO: handle the value better
         Self {
             type_def: self.type_def.merge_deep(other.type_def),
-            value: None,
+            value: if self.value == other.value {
+                self.value
+            } else {
+                None
+            },
+        }
+    }
+
+    pub(crate) fn merge_optional(a: Option<Self>, b: Option<Self>) -> Option<Self> {
+        match (a, b) {
+            (Some(a), Some(b)) => Some(a.merge(b)),
+            (Some(x), None) | (None, Some(x)) => Some(x),
+            (None, None) => None,
         }
     }
 }

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -356,15 +356,15 @@ impl TypeDef {
         // implementation's `unknown`, which, when merging, would discard that type.
         //
         // see: https://github.com/vectordotdev/vector/blob/18415050b60b08197e8135b7659390256995e844/lib/vrl/compiler/src/type_def.rs#L428-L429
-        if !self.is_any() && other.is_any() {
-            // keep `self`'s `kind` definition
-        } else if self.is_any() && !other.is_any() {
-            // overwrite `self`'s `kind` definition with `others`'s
-            self.kind = other.kind;
-        } else {
-            // merge the two `kind`s
-            self.kind.merge(other.kind, strategy);
-        }
+        // if !self.is_any() && other.is_any() {
+        //     // keep `self`'s `kind` definition
+        // } else if self.is_any() && !other.is_any() {
+        //     // overwrite `self`'s `kind` definition with `others`'s
+        //     self.kind = other.kind;
+        // } else {
+        // merge the two `kind`s
+        self.kind.merge(other.kind, strategy);
+        // }
     }
 
     pub fn merge_overwrite(mut self, other: Self) -> Self {
@@ -419,5 +419,48 @@ impl Details {
             (Some(x), None) | (None, Some(x)) => Some(x),
             (None, None) => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn merge_details_same_literal() {
+        let a = Details {
+            type_def: TypeDef::integer(),
+            value: Some(Value::from(5)),
+        };
+        let b = Details {
+            type_def: TypeDef::float(),
+            value: Some(Value::from(5)),
+        };
+        assert_eq!(
+            a.merge(b),
+            Details {
+                type_def: TypeDef::integer().add_float(),
+                value: Some(Value::from(5))
+            }
+        )
+    }
+
+    #[test]
+    fn merge_details_different_literal() {
+        let a = Details {
+            type_def: TypeDef::any(),
+            value: Some(Value::from(5)),
+        };
+        let b = Details {
+            type_def: TypeDef::object(Collection::empty()),
+            value: Some(Value::from(6)),
+        };
+        assert_eq!(
+            a.merge(b),
+            Details {
+                type_def: TypeDef::any(),
+                value: None
+            }
+        )
     }
 }

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -416,7 +416,13 @@ impl Details {
     pub(crate) fn merge_optional(a: Option<Self>, b: Option<Self>) -> Option<Self> {
         match (a, b) {
             (Some(a), Some(b)) => Some(a.merge(b)),
-            (Some(x), None) | (None, Some(x)) => Some(x),
+            (Some(x), None) | (None, Some(x)) => {
+                // None for details can mean "any" type
+                Some(Details {
+                    type_def: TypeDef::any(),
+                    value: None,
+                })
+            }
             (None, None) => None,
         }
     }

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -399,16 +399,17 @@ impl Details {
         }
     }
 
-    pub(crate) fn merge_optional(a: Option<Self>, b: Option<Self>) -> Option<Self> {
+    pub(crate) fn merge_optional(
+        a: Option<Self>,
+        b: Option<Self>,
+        none_type: TypeDef,
+    ) -> Option<Self> {
         match (a, b) {
             (Some(a), Some(b)) => Some(a.merge(b)),
-            (Some(_), None) | (None, Some(_)) => {
-                // None for details can mean "any" type
-                Some(Details {
-                    type_def: TypeDef::any(),
-                    value: None,
-                })
-            }
+            (Some(_), None) | (None, Some(_)) => Some(Details {
+                type_def: none_type,
+                value: None,
+            }),
             (None, None) => None,
         }
     }

--- a/lib/vrl/stdlib/src/append.rs
+++ b/lib/vrl/stdlib/src/append.rs
@@ -69,7 +69,8 @@ impl Expression for AppendFn {
     fn type_def(&self, state: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
         self.value
             .type_def(state)
-            .merge_append(self.items.type_def(state))
+            .restrict_array()
+            .merge_append(self.items.type_def(state).restrict_array())
     }
 }
 

--- a/lib/vrl/stdlib/src/merge.rs
+++ b/lib/vrl/stdlib/src/merge.rs
@@ -74,7 +74,8 @@ impl Expression for MergeFn {
     fn type_def(&self, state: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
         self.to
             .type_def(state)
-            .merge_shallow(self.from.type_def(state))
+            .restrict_object()
+            .merge_shallow(self.from.type_def(state).restrict_object())
     }
 }
 

--- a/lib/vrl/stdlib/src/push.rs
+++ b/lib/vrl/stdlib/src/push.rs
@@ -77,8 +77,11 @@ impl Expression for PushFn {
             0.into(),
             self.item.type_def(state).into(),
         )]));
-
-        self.value.type_def(state).merge_append(item).infallible()
+        self.value
+            .type_def(state)
+            .restrict_array()
+            .merge_append(item)
+            .infallible()
     }
 }
 

--- a/lib/vrl/tests/tests/expressions/if_statement/if_else_external_assignment.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_else_external_assignment.vrl
@@ -1,0 +1,19 @@
+# result: true
+
+.a = 5
+if true {
+  .a = 0.0
+} else {
+  .a = "string"
+}
+assert!(.a == 0.0)
+assert!(type_def(.a) == {"float": true, "bytes": true})
+
+.a = 5
+if false {
+  .a = 0.0
+} else {
+  .a = "string"
+}
+assert!(.a == "string")
+assert!(type_def(.a) == {"float": true, "bytes": true})

--- a/lib/vrl/tests/tests/expressions/if_statement/if_else_local_assignment.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_else_local_assignment.vrl
@@ -1,0 +1,19 @@
+# result: true
+
+a = 5
+if true {
+  a = 0.0
+} else {
+  a = "string"
+}
+assert!(a == 0.0)
+assert!(type_def(a) == {"float": true, "bytes": true})
+
+a = 5
+if false {
+  a = 0.0
+} else {
+  a = "string"
+}
+assert!(a == "string")
+assert!(type_def(a) == {"float": true, "bytes": true})

--- a/lib/vrl/tests/tests/expressions/if_statement/if_expression.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_expression.vrl
@@ -1,0 +1,14 @@
+# result: true
+
+result = if true {
+  "string"
+}
+assert!(result == "string")
+assert!(type_def(result) == {"bytes": true, "null": true})
+
+
+result = if false {
+  "string"
+}
+assert!(result == null)
+assert!(type_def(result) == {"bytes": true, "null": true})

--- a/lib/vrl/tests/tests/expressions/if_statement/if_external_assignment.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_external_assignment.vrl
@@ -1,0 +1,15 @@
+# result: true
+
+.a = 5
+if false {
+  .a = "string"
+}
+assert!(.a == 5)
+assert!(type_def(.a) == {"integer": true, "bytes": true})
+
+.a = 5
+if true {
+  .a = "string"
+}
+assert!(.a == "string")
+assert!(type_def(.a) == {"integer": true, "bytes": true})

--- a/lib/vrl/tests/tests/expressions/if_statement/if_local_assignment.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_local_assignment.vrl
@@ -1,0 +1,15 @@
+# result: true
+
+a = 5
+if false {
+  a = "string"
+}
+assert!(a == 5)
+assert!(type_def(a) == {"integer": true, "bytes": true})
+
+a = 5
+if true {
+  a = "string"
+}
+assert!(a == "string")
+assert!(type_def(a) == {"integer": true, "bytes": true})

--- a/lib/vrl/tests/tests/expressions/if_statement/if_new_external_assignment.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_new_external_assignment.vrl
@@ -1,0 +1,7 @@
+# result: {"any": true}
+
+assert!(type_def(.a) == {"any": true})
+if false {
+  .a = "string"
+}
+type_def(.a)

--- a/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_null.vrl
@@ -1,5 +1,7 @@
-# result: null
+# result: true
 
-if false {
+result = if false {
     "yes"
 }
+assert!(result == null)
+assert!(type_def(result) == {"bytes": true, "null": true})

--- a/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
+++ b/lib/vrl/tests/tests/expressions/if_statement/if_resolves.vrl
@@ -1,5 +1,7 @@
-# result: "yes"
+# result: true
 
-if true {
+result = if true {
     "yes"
 }
+assert!(result == "yes")
+assert!(type_def(result) == {"bytes": true, "null": true})

--- a/lib/vrl/tests/tests/issues/12948_conditional_type_def_regression.vrl
+++ b/lib/vrl/tests/tests/issues/12948_conditional_type_def_regression.vrl
@@ -1,0 +1,9 @@
+# result: null
+
+if .platform == "Apache2" || .platform == "Nginx" {
+  apache2 = del(.apache2)
+  if is_null(apache2) { apache2 = {} }
+  .http = merge(object!(apache2), {})
+}
+
+

--- a/lib/vrl/tests/tests/issues/12948_conditional_type_def_regression.vrl
+++ b/lib/vrl/tests/tests/issues/12948_conditional_type_def_regression.vrl
@@ -5,5 +5,3 @@ if .platform == "Apache2" || .platform == "Nginx" {
   if is_null(apache2) { apache2 = {} }
   .http = merge(object!(apache2), {})
 }
-
-

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -12,6 +12,7 @@ badges:
 Vector's 0.23.0 release includes **breaking changes**:
 
 1. [The `.deb` package no longer enables and starts the Vector systemd service](#systemd-autostart)
+2. [VRL if statement type definitions updated](#vrl-if-statements)
 
 We cover them below to help you upgrade quickly:
 
@@ -37,3 +38,8 @@ To just start the service without enabling it to run at system startup,
 ```shell
 systemctl start vector
 ```
+
+#### [VRL if statement type definitions updated] {#vrl-merge}
+
+VRL if statements didn't properly merge type definitions for each branch. This is now fixed.
+In some cases this can cause compilation errors when upgrading if the previous code relied on the previous behavior.

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -39,7 +39,7 @@ To just start the service without enabling it to run at system startup,
 systemctl start vector
 ```
 
-#### [VRL if statement type definitions updated] {#vrl-merge}
+#### [VRL if statement type definitions updated] {#vrl-if-statements}
 
 VRL if statements didn't properly merge type definitions for each branch. This is now fixed.
 In some cases this can cause compilation errors when upgrading if the previous code relied on the previous behavior.


### PR DESCRIPTION
fixes: https://github.com/vectordotdev/vector/issues/11773
fixes: https://github.com/vectordotdev/vector/issues/12948

- This now correctly calculates the type definitions of locals and external values in if/else statements.
- The expression type of an if statement without an else clause now includes `null`. The actual value could already be null, but the type definition didn't include it.


### Examples

Just if statement (original and block type are merged)

```
$ a = 5
5

$ if false {a = "string"}
null

$ a
5

$ type_def(a)
{ "bytes": true, "integer": true }
```

If/else statement (only the if/else types are merged)

```
$ a = 5
5

$ if false {a = "string"} else {a = {}}
{  }

$ type_def(a)
{ "bytes": true, "object": {  } }
```
