### PR TITLE
chore: Update the mold linker to 1.2 from 1.1

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -120,7 +120,7 @@ apt clean
 
 # Install mold, because the system linker wastes a bunch of time.
 TEMP=$(mktemp -d)
-MOLD_VERSION=1.2.0
+MOLD_VERSION=1.2.1
 MOLD_TARGET=mold-${MOLD_VERSION}-x86_64-linux
 curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${MOLD_TARGET}.tar.gz" \
      --output "$TEMP/${MOLD_TARGET}.tar.gz"

--- a/soaks/Dockerfile.builder
+++ b/soaks/Dockerfile.builder
@@ -6,7 +6,7 @@ RUN apt-get update && \
 		rm -rf /var/lib/apt/lists/*
 
 # Build mold, a fast linker
-RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.1.1 && make -j"$(nproc)" && make install
+RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.2.1 && make -j"$(nproc)" && make install
 
 # Smoke test
 RUN ["/usr/local/bin/mold", "--version"]

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -8,7 +8,7 @@ ARG FEATURES=api,api-client,sources-datadog_agent,sources-fluent,sources-host_me
 #
 FROM docker.io/rust:${RUST_VERSION}-${DEBIAN_RELEASE} as builder
 RUN apt-get update && apt-get -y --no-install-recommends install build-essential git clang cmake libclang-dev libsasl2-dev libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev zlib1g
-RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.1.1 && make -j"$(nproc)" && make install
+RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.2.1 && make -j"$(nproc)" && make install
 
 WORKDIR /vector
 COPY . .
@@ -32,4 +32,3 @@ RUN mkdir -p /var/lib/vector
 RUN ["vector", "--version"]
 
 ENTRYPOINT ["/usr/bin/vector"]
-


### PR DESCRIPTION
The mold project has steadily worked toward their goal of linking chromium in 1
second. We benefit from this work too.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
