### PR TITLE
docs(datadog_metrics sink): Remove `default_namespace` from example

### DIFF
--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -62,7 +62,7 @@ components: sinks: datadog_metrics: {
 			common: false
 			description: """
 				Used as a namespace for metrics that don't have it.
-				A namespace will be prefixed to a metric's name with `.`.
+				A namespace will be prefixed to a metric's name separated by `.`.
 				"""
 			required: false
 			warnings: []

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -59,16 +59,16 @@ components: sinks: datadog_metrics: {
 		region:   sinks._datadog.configuration.region
 		site:     sinks._datadog.configuration.site
 		default_namespace: {
-			common: true
+			common: false
 			description: """
 				Used as a namespace for metrics that don't have it.
-				A namespace will be prefixed to a metric's name.
+				A namespace will be prefixed to a metric's name with `.`.
 				"""
 			required: false
 			warnings: []
 			type: string: {
 				default: null
-				examples: ["service"]
+				examples: ["myservice"]
 			}
 		}
 	}


### PR DESCRIPTION
By marking it as uncommon. Also made the example `mynamespace` to make
it clearer that users should change it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
