### PR TITLE
chore(tests): Avoid sharing target with host system for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -88,7 +88,6 @@ jobs:
             env:
               SPLUNK_VERSION: 7.3.9
           - test: 'splunk'
-          - test: 'shutdown'
     steps:
       - uses: actions/checkout@v3
       - run: make ci-sweep

--- a/scripts/integration/Dockerfile
+++ b/scripts/integration/Dockerfile
@@ -4,6 +4,7 @@ FROM docker.io/rust:${RUST_VERSION}-slim-bullseye
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
+    curl \
     g++ \
     libclang1-9 \
     libsasl2-dev \
@@ -13,4 +14,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN rustup run "${RUST_VERSION}" cargo install cargo-nextest --version 0.9.8
+RUN curl -LsSf https://get.nexte.st/0.9/linux | tar zxf - -C /usr/local/bin

--- a/scripts/integration/docker-compose.aws.yml
+++ b/scripts/integration/docker-compose.aws.yml
@@ -61,6 +61,7 @@ services:
       - backend
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -68,5 +69,6 @@ networks:
   backend: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.azure.yml
+++ b/scripts/integration/docker-compose.azure.yml
@@ -33,9 +33,11 @@ services:
       - local-azure-blob
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.clickhouse.yml
+++ b/scripts/integration/docker-compose.clickhouse.yml
@@ -29,9 +29,11 @@ services:
       - clickhouse
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.datadog-agent.yml
+++ b/scripts/integration/docker-compose.datadog-agent.yml
@@ -60,6 +60,7 @@ services:
       - datadog-trace-agent
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -67,5 +68,6 @@ networks:
   backend: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.datadog-logs.yml
+++ b/scripts/integration/docker-compose.datadog-logs.yml
@@ -24,9 +24,11 @@ services:
       - TEST_DATADOG_API_KEY
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.datadog-metrics.yml
+++ b/scripts/integration/docker-compose.datadog-metrics.yml
@@ -24,9 +24,11 @@ services:
       - TEST_DATADOG_API_KEY
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.datadog-traces.yml
+++ b/scripts/integration/docker-compose.datadog-traces.yml
@@ -24,9 +24,11 @@ services:
       - TEST_DATADOG_API_KEY
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.dnstap.yml
+++ b/scripts/integration/docker-compose.dnstap.yml
@@ -36,12 +36,14 @@ services:
       - RUST_BACKTRACE=1
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - /var/run/docker.sock:/var/run/docker.sock
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
       - dnstap-sockets:/run/bind/socket
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}
   dnstap-sockets: {}

--- a/scripts/integration/docker-compose.docker-logs.yml
+++ b/scripts/integration/docker-compose.docker-logs.yml
@@ -23,9 +23,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.elasticsearch.yml
+++ b/scripts/integration/docker-compose.elasticsearch.yml
@@ -64,6 +64,7 @@ services:
       - backend
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -71,5 +72,6 @@ networks:
   backend: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.eventstoredb.yml
+++ b/scripts/integration/docker-compose.eventstoredb.yml
@@ -31,9 +31,11 @@ services:
       - eventstoredb
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.fluent.yml
+++ b/scripts/integration/docker-compose.fluent.yml
@@ -23,11 +23,13 @@ services:
       - "--nocapture"
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.gcp.yml
+++ b/scripts/integration/docker-compose.gcp.yml
@@ -31,9 +31,11 @@ services:
       - gcloud-pubsub
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.humio.yml
+++ b/scripts/integration/docker-compose.humio.yml
@@ -30,9 +30,11 @@ services:
       - humio
     volumes:
       - ${PWD}:/code
-      - cargogit:/usr/local/cargo/git
-      - cargoregistry:/usr/local/cargo/registry
+      - target:/code/target
+      - cargogit:/cargo/git
+      - cargoregistry:/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.influxdb.yml
+++ b/scripts/integration/docker-compose.influxdb.yml
@@ -48,9 +48,11 @@ services:
       - INFLUXDB_V2_ADDRESS=http://influxdb-v2:8086
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.kafka.yml
+++ b/scripts/integration/docker-compose.kafka.yml
@@ -56,9 +56,11 @@ services:
       - KAFKA_HOST=kafka
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.logstash.yml
+++ b/scripts/integration/docker-compose.logstash.yml
@@ -47,9 +47,11 @@ services:
     network_mode: host
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.loki.yml
+++ b/scripts/integration/docker-compose.loki.yml
@@ -29,6 +29,7 @@ services:
       - LOKI_ADDRESS=http://loki:3100
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -36,5 +37,6 @@ networks:
   backend: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.mongodb.yml
+++ b/scripts/integration/docker-compose.mongodb.yml
@@ -66,6 +66,7 @@ services:
       - backend
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -73,5 +74,6 @@ networks:
   backend: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.nats.yml
+++ b/scripts/integration/docker-compose.nats.yml
@@ -84,6 +84,7 @@ services:
       - backend
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -91,5 +92,6 @@ networks:
   backend: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.nginx.yml
+++ b/scripts/integration/docker-compose.nginx.yml
@@ -50,6 +50,7 @@ services:
       - public
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -58,5 +59,6 @@ networks:
   proxy: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.postgres.yml
+++ b/scripts/integration/docker-compose.postgres.yml
@@ -37,11 +37,13 @@ services:
       - PG_HOST=postgres
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
       - socket:/socket
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}
   socket: {}

--- a/scripts/integration/docker-compose.prometheus.yml
+++ b/scripts/integration/docker-compose.prometheus.yml
@@ -50,9 +50,11 @@ services:
       - prometheus
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.pulsar.yml
+++ b/scripts/integration/docker-compose.pulsar.yml
@@ -31,9 +31,11 @@ services:
       - PULSAR_ADDRESS=pulsar://pulsar:6650
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.redis.yml
+++ b/scripts/integration/docker-compose.redis.yml
@@ -32,6 +32,7 @@ services:
       - backend
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
@@ -39,5 +40,6 @@ networks:
   backend: {}
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.shutdown.yml
+++ b/scripts/integration/docker-compose.shutdown.yml
@@ -56,10 +56,12 @@ services:
       - KAFKA_HOST=kafka
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}

--- a/scripts/integration/docker-compose.splunk.yml
+++ b/scripts/integration/docker-compose.splunk.yml
@@ -39,9 +39,11 @@ services:
       - SPLUNK_API_ADDRESS=https://splunk-hec:8089
     volumes:
       - ${PWD}:/code
+      - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
 
 volumes:
+  target: {}
   cargogit: {}
   cargoregistry: {}


### PR DESCRIPTION
This was causing issues as the integration tests run as `root` in Docker
and polluted the target directory of the host system so that subsequent
`cargo` operations on the host would fail due to file permissions.

I briefly went down the path of trying to continue to share the
directory and set the uid/gid appropriately but this turned out to be
non-trivial. I think having a separate volume shared by the integration
tests for `target/` seems sensible.

Also sped up the building of the integration container a bit by
installing the prebuilt `cargo nextest` binary rather than building it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
