### PR TITLE
fix(vrl): fix Collection::merge to use unknown value

### DIFF
--- a/lib/value/src/kind/collection.rs
+++ b/lib/value/src/kind/collection.rs
@@ -213,21 +213,40 @@ impl<T: Ord> Collection<T> {
     /// - If a field exists in both collections, their `Kind`s are merged, or the `other` fields
     ///   are used (depending on the configured [`Strategy`](merge::Strategy)).
     ///
-    /// - If a field exists in one but not the other, the field is used.
+    /// - If a field exists in one but not the other, the field is merged with the "unknown"
+    ///   of the other if it exists, or just the field is used otherwise.
     ///
     /// For *unknown fields or indices*:
     ///
     /// - Both `Unknown`s are merged, similar to merging two `Kind`s.
     pub fn merge(&mut self, mut other: Self, strategy: merge::Strategy) {
-        self.known
-            .iter_mut()
-            .for_each(|(key, self_kind)| match other.known.remove(key) {
-                Some(other_kind) if strategy.depth.is_shallow() => *self_kind = other_kind,
-                Some(other_kind) => self_kind.merge(other_kind, strategy),
-                _ => {}
-            });
+        for (key, self_kind) in &mut self.known {
+            if let Some(other_kind) = other.known.remove(key) {
+                if strategy.depth.is_shallow() {
+                    *self_kind = other_kind;
+                } else {
+                    self_kind.merge(other_kind, strategy);
+                }
+            } else if let Some(other_unknown) = other.unknown() {
+                if strategy.depth.is_shallow() {
+                    *self_kind = other_unknown.to_kind().into_owned();
+                } else {
+                    self_kind.merge(other_unknown.to_kind().into_owned(), strategy);
+                }
+            }
+        }
 
-        self.known.extend(other.known);
+        let self_unknown_kind = self.unknown().map(|unknown| unknown.to_kind().into_owned());
+        if let Some(self_unknown_kind) = self_unknown_kind {
+            for (key, mut other_kind) in other.known {
+                if !strategy.depth.is_shallow() {
+                    other_kind.merge(self_unknown_kind.clone(), strategy);
+                }
+                self.known_mut().insert(key, other_kind);
+            }
+        } else {
+            self.known.extend(other.known);
+        }
 
         match (self.unknown.as_mut(), other.unknown) {
             (None, Some(rhs)) => self.unknown = Some(rhs),

--- a/lib/value/src/kind/merge.rs
+++ b/lib/value/src/kind/merge.rs
@@ -164,6 +164,23 @@ mod tests {
             },
         ) in HashMap::from([
             (
+                "any object",
+                TestCase {
+                    this: Kind::object(Collection::any()),
+                    other: Kind::object(BTreeMap::from([("x".into(), Kind::integer())])),
+                    strategy: Strategy {
+                        depth: Depth::Deep,
+                        indices: Indices::Keep,
+                    },
+                    merged: {
+                        let mut collection =
+                            Collection::from(BTreeMap::from([("x".into(), Kind::any())]));
+                        collection.set_unknown(Kind::any());
+                        Kind::object(collection)
+                    },
+                },
+            ),
+            (
                 "primitives shallow",
                 TestCase {
                     this: Kind::bytes(),

--- a/lib/value/src/kind/merge.rs
+++ b/lib/value/src/kind/merge.rs
@@ -164,7 +164,7 @@ mod tests {
             },
         ) in HashMap::from([
             (
-                "any object",
+                "object field with unknown",
                 TestCase {
                     this: Kind::object(Collection::any()),
                     other: Kind::object(BTreeMap::from([("x".into(), Kind::integer())])),


### PR DESCRIPTION
The `Collection::merge` function didn't look at unknown values when merging the known values.
So an `any` merged with an object with a field of a specific type _should_ still return `any`, but it didn't.

This was mostly hidden from users since there was a backwards compatibility oddness around how `any` was handled in merges, but it was still possible and now changes in https://github.com/vectordotdev/vector/pull/12954 make it more likely to hit it.