### PR TITLE
feat(sink): Add Axiom sink

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -197,6 +197,7 @@ scopes:
   - aws_kinesis_streams sink # Anything `aws_kinesis_streams` sink related
   - aws_s3 sink # Anything `aws_s3` sink related
   - aws_sqs sink # Anything `aws_sqs` sink related
+  - axiom sink # Anything `axiom` sink related
   - azure_blob sink # Anything `azure_blob` sink related
   - azure_monitor_logs sink # Anything `azure_monitor_logs` sink related
   - blackhole sink # Anything `blackhole` sink related

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -56,6 +56,7 @@ jobs:
       matrix:
         include:
           - test: 'aws'
+          - test: 'axiom'
           - test: 'azure'
           - test: 'clickhouse'
           - test: 'datadog-agent'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -608,6 +608,7 @@ sinks-logs = [
   "sinks-aws_kinesis_streams",
   "sinks-aws_s3",
   "sinks-aws_sqs",
+  "sinks-axiom",
   "sinks-azure_blob",
   "sinks-azure_monitor_logs",
   "sinks-blackhole",
@@ -660,6 +661,7 @@ sinks-aws_kinesis_firehose = ["aws-core", "dep:aws-sdk-firehose"]
 sinks-aws_kinesis_streams = ["aws-core", "dep:aws-sdk-kinesis"]
 sinks-aws_s3 = ["dep:base64", "dep:md-5", "aws-core", "dep:aws-sdk-s3"]
 sinks-aws_sqs = ["aws-core", "dep:aws-sdk-sqs"]
+sinks-axiom = ["sinks-elasticsearch"]
 sinks-azure_blob = ["dep:azure_core", "dep:azure_identity", "dep:azure_storage", "dep:azure_storage_blobs"]
 sinks-azure_monitor_logs = []
 sinks-blackhole = []
@@ -714,6 +716,7 @@ nightly = []
 # Testing-related features
 all-integration-tests = [
   "aws-integration-tests",
+  "axiom-integration-tests",
   "azure-integration-tests",
   "clickhouse-integration-tests",
   "datadog-agent-integration-tests",
@@ -766,6 +769,7 @@ aws-kinesis-firehose-integration-tests = ["sinks-aws_kinesis_firehose", "dep:aws
 aws-kinesis-streams-integration-tests = ["sinks-aws_kinesis_streams"]
 aws-s3-integration-tests = ["sinks-aws_s3", "sources-aws_s3"]
 aws-sqs-integration-tests = ["sinks-aws_sqs", "sources-aws_sqs"]
+axiom-integration-tests = ["sinks-axiom"]
 azure-blob-integration-tests = ["sinks-azure_blob"]
 clickhouse-integration-tests = ["sinks-clickhouse"]
 datadog-agent-integration-tests = ["sources-datadog_agent"]

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ test-behavior: test-behavior-transforms test-behavior-formats test-behavior-conf
 
 .PHONY: test-integration
 test-integration: ## Runs all integration tests
-test-integration: test-integration-aws test-integration-azure test-integration-clickhouse test-integration-docker-logs test-integration-elasticsearch
+test-integration: test-integration-aws test-integration-axiom test-integration-azure test-integration-clickhouse test-integration-docker-logs test-integration-elasticsearch
 test-integration: test-integration-azure test-integration-clickhouse test-integration-docker-logs test-integration-elasticsearch
 test-integration: test-integration-eventstoredb test-integration-fluent test-integration-gcp test-integration-humio test-integration-influxdb
 test-integration: test-integration-kafka test-integration-logstash test-integration-loki test-integration-mongodb test-integration-nats

--- a/scripts/integration/docker-compose.axiom.yml
+++ b/scripts/integration/docker-compose.axiom.yml
@@ -1,0 +1,62 @@
+version: "3"
+
+services:
+  postgres: 
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_USER: axiom
+      POSTGRES_PASSWORD: axiom
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  axiom-db:
+    image: axiomhq/axiom-db:${AXIOM_VERSION:-1.20.1}
+    restart: unless-stopped
+    environment:
+      AXIOM_STORAGE: "file:///data"
+      AXIOM_POSTGRES_URL: "postgres://axiom:axiom@postgres?sslmode=disable&connect_timeout=5"
+    depends_on:
+      - postgres
+  axiom-core:
+    image: axiomhq/axiom-core:${AXIOM_VERSION:-1.20.1}
+    restart: unless-stopped
+    environment:
+      AXIOM_POSTGRES_URL: "postgres://axiom:axiom@postgres?sslmode=disable&connect_timeout=5"
+      AXIOM_DB_URL: "http://axiom-db:80"
+      AXIOM_HTTP_PORT: "80"
+    depends_on:
+      - axiom-db
+    ports:
+      - 8081:80
+  runner:
+    build:
+      context: ${PWD}
+      dockerfile: scripts/integration/Dockerfile
+      args:
+        - RUST_VERSION=${RUST_VERSION}
+    working_dir: /code
+    command:
+      - "cargo"
+      - "nextest"
+      - "run"
+      - "--no-fail-fast"
+      - "--no-default-features"
+      - "--features"
+      - "axiom-integration-tests"
+      - "--lib"
+      - "sinks::axiom::"
+      - "--"
+      - "--nocapture"
+    environment:
+      - AXIOM_URL=http://axiom-core
+    depends_on:
+      - axiom-core
+      - axiom-db
+    volumes:
+      - ${PWD}:/code
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
+
+volumes:
+  cargogit: {}
+  cargoregistry: {}
+  postgres_data: {}

--- a/scripts/integration/docker-compose.axiom.yml
+++ b/scripts/integration/docker-compose.axiom.yml
@@ -21,7 +21,7 @@ services:
     restart: unless-stopped
     environment:
       AXIOM_POSTGRES_URL: "postgres://axiom:axiom@postgres?sslmode=disable&connect_timeout=5"
-      AXIOM_DB_URL: "http://axiom-db:80"
+      AXIOM_DB_URL: "http://axiom-db:8080"
       AXIOM_HTTP_PORT: "80"
     depends_on:
       - axiom-db

--- a/scripts/integration/docker-compose.axiom.yml
+++ b/scripts/integration/docker-compose.axiom.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
   axiom-db:
-    image: axiomhq/axiom-db:${AXIOM_VERSION:-1.20.1}
+    image: axiomhq/axiom-db:latest
     restart: unless-stopped
     environment:
       AXIOM_STORAGE: "file:///data"
@@ -17,7 +17,7 @@ services:
     depends_on:
       - postgres
   axiom-core:
-    image: axiomhq/axiom-core:${AXIOM_VERSION:-1.20.1}
+    image: axiomhq/axiom-core:latest
     restart: unless-stopped
     environment:
       AXIOM_POSTGRES_URL: "postgres://axiom:axiom@postgres?sslmode=disable&connect_timeout=5"

--- a/scripts/integration/docker-compose.axiom.yml
+++ b/scripts/integration/docker-compose.axiom.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  postgres: 
+  postgres:
     image: postgres:13-alpine
     environment:
       POSTGRES_USER: axiom

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -117,11 +117,11 @@ mod test {
 #[cfg(feature = "axiom-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
-    use chrono::{DateTime, Utc};
+    use chrono::{DateTime, Duration, Utc};
     use futures::stream;
     use http::StatusCode;
     use std::env;
-    use tokio::time::{sleep, Duration};
+    use tokio::time;
     use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};
 
     use super::*;
@@ -136,23 +136,21 @@ mod integration_tests {
 
     #[tokio::test]
     async fn axiom_logs_put_data() {
-        let url = env::var("AXIOM_URL").unwrap();
-
-        let client = reqwest::Client::builder().build().unwrap();
-
         // Wait until deployment is ready
         wait_for_duration(
             || async {
-                client
-                    .get(url.clone())
-                    .send()
+                let url = env::var("AXIOM_URL").unwrap();
+                reqwest::get(url)
                     .await
                     .map(|res| res.status() == StatusCode::OK)
                     .unwrap_or(false)
             },
-            Duration::from_secs(30),
+            time::Duration::from_secs(30),
         )
         .await;
+
+        let client = reqwest::Client::new();
+        let url = env::var("AXIOM_URL").unwrap();
 
         // Axiom credentials
         let email = "info@axiom.co".to_string();

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     config::{
-        log_schema, AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext,
-        SinkDescription,
+        log_schema, AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig,
+        SinkContext, SinkDescription,
     },
     sinks::{
         elasticsearch::{ElasticsearchAuth, ElasticsearchConfig},
@@ -90,7 +90,7 @@ impl SinkConfig for AxiomConfig {
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        Input::new(DataType::Metric | DataType::Log)
     }
 
     fn sink_type(&self) -> &'static str {

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -181,8 +181,6 @@ mod integration_tests {
             .json(&login_payload)
             .send()
             .await
-            .unwrap()
-            .error_for_status()
             .unwrap();
         let session_cookie = if login_res.status() == StatusCode::OK {
             Some(
@@ -217,7 +215,7 @@ mod integration_tests {
             Some(cookie) => cookie,
             None => {
                 // Try to initialize the deployment
-                let res = client
+                client
                     .post(format!("{}/auth/init", url))
                     .json(&auth_init_payload)
                     .send()
@@ -225,7 +223,6 @@ mod integration_tests {
                     .unwrap()
                     .error_for_status()
                     .unwrap();
-                assert_eq!(StatusCode::OK, res.status());
 
                 // Try again to log in and get the session cookie
                 let login_res = client

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -58,7 +58,7 @@ impl GenerateConfig for AxiomConfig {
 impl SinkConfig for AxiomConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let mut request = self.request.clone();
-        self.request.headers.insert(
+        request.headers.insert(
             "X-Axiom-Org-Id".to_string(),
             self.org_id.clone().unwrap_or_default(),
         );
@@ -67,6 +67,12 @@ impl SinkConfig for AxiomConfig {
             "timestamp-field".to_string(),
             log_schema().timestamp_key().to_string(),
         );
+
+        // Axiom has a custom high-performance database that can be ingested
+        // into using our HTTP endpoints, including one compatible with the
+        // Elasticsearch Bulk API.
+        // This configuration wraps the Elasticsearch config to minimize the
+        // amount of code.
         let elasticsearch_config = ElasticsearchConfig {
             endpoint: self.build_endpoint(),
             compression: self.compression,
@@ -79,6 +85,7 @@ impl SinkConfig for AxiomConfig {
             request,
             ..Default::default()
         };
+
         elasticsearch_config.build(cx).await
     }
 

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -1,0 +1,397 @@
+use std::collections::HashMap;
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::{
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
+    },
+    sinks::{
+        elasticsearch::{ElasticsearchAuth, ElasticsearchConfig},
+        util::{http::RequestConfig, Compression},
+        Healthcheck, VectorSink,
+    },
+    tls::TlsConfig,
+};
+
+static CLOUD_URL: &str = "https://cloud.axiom.co";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(self) struct AxiomConfig {
+    url: Option<String>,
+    org_id: Option<String>,
+    token: String,
+    dataset: String,
+
+    #[serde(default)]
+    compression: Compression,
+    tls: Option<TlsConfig>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
+}
+
+inventory::submit! {
+    SinkDescription::new::<AxiomConfig>("axiom")
+}
+
+impl GenerateConfig for AxiomConfig {
+    fn generate_config() -> toml::Value {
+        toml::from_str(
+            r#"token = "${AXIOM_TOKEN}"
+            dataset = "my-dataset"
+            url = "${AXIOM_URL}"
+            org_id = "${AXIOM_ORG_ID}""#,
+        )
+        .unwrap()
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "axiom")]
+impl SinkConfig for AxiomConfig {
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let mut headers = IndexMap::with_capacity(1);
+        headers.insert(
+            "X-Axiom-Org-Id".to_string(),
+            self.org_id.clone().unwrap_or_default(),
+        );
+        let mut query = HashMap::with_capacity(1);
+        query.insert("timestamp-field".to_string(), "timestamp".to_string());
+        let elasticsearch_config = ElasticsearchConfig {
+            endpoint: self.build_endpoint(),
+            compression: self.compression,
+            auth: Some(ElasticsearchAuth::Basic {
+                user: "axiom".to_string(),
+                password: self.token.clone(),
+            }),
+            query: Some(query),
+            tls: self.tls.clone(),
+            request: RequestConfig {
+                headers,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let config = elasticsearch_config.build(cx).await?;
+        Ok(config)
+    }
+
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn sink_type(&self) -> &'static str {
+        "axiom"
+    }
+
+    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+        Some(&self.acknowledgements)
+    }
+}
+
+impl AxiomConfig {
+    fn build_endpoint(&self) -> String {
+        let url = if let Some(url) = self.url.as_ref() {
+            url.clone()
+        } else {
+            CLOUD_URL.to_string()
+        };
+
+        format!("{}/api/v1/datasets/{}/elastic", url, self.dataset)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<super::AxiomConfig>();
+    }
+}
+
+#[cfg(feature = "axiom-integration-tests")]
+#[cfg(test)]
+mod integration_tests {
+    use chrono::{DateTime, Duration, Utc};
+    use futures::stream;
+    use http::StatusCode;
+    use std::env;
+    use tokio::time::sleep;
+    use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};
+
+    use super::*;
+    use crate::{
+        config::SinkContext,
+        sinks::axiom::AxiomConfig,
+        test_util::components::{run_and_assert_sink_compliance, HTTP_SINK_TAGS},
+    };
+
+    #[tokio::test]
+    async fn axiom_logs_put_data() {
+        let url = env::var("AXIOM_URL").unwrap();
+
+        let client = reqwest::Client::builder().build().unwrap();
+
+        // Wait until deployment is ready
+        let sleep_duration = Duration::milliseconds(1000).to_std().unwrap();
+        for _ in 0..30 {
+            if let Ok(res) = client.get(url.clone()).send().await {
+                if res.status() == StatusCode::OK {
+                    break;
+                }
+            }
+
+            sleep(sleep_duration).await;
+        }
+
+        // Axiom credentials
+        let email = "info@axiom.co".to_string();
+        let password = "vector-is-cool".to_string();
+
+        // Is the deployment already set up? Try to login and get the session
+        // cookie.
+        #[derive(Serialize)]
+        struct LoginRequest {
+            email: String,
+            password: String,
+        }
+        let login_payload = LoginRequest {
+            email: email.clone(),
+            password: password.clone(),
+        };
+        let login_url = format!("{}/auth/signin/credentials", url);
+        let login_res = client
+            .post(&login_url)
+            .json(&login_payload)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+        let session_cookie = if login_res.status() == StatusCode::OK {
+            Some(
+                login_res
+                    .headers()
+                    .get("set-cookie")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            )
+        } else {
+            None
+        };
+
+        // If the deployment is not yet setup, set it up and login to get the
+        // session cookie.
+        #[derive(Serialize)]
+        struct AuthInitRequest {
+            org: String,
+            name: String,
+            email: String,
+            password: String,
+        }
+        let auth_init_payload = AuthInitRequest {
+            org: "vector".to_string(),
+            name: "Vector".to_string(),
+            email: email.clone(),
+            password: password.clone(),
+        };
+        let session_cookie = match session_cookie {
+            Some(cookie) => cookie,
+            None => {
+                // Try to initialize the deployment
+                let res = client
+                    .post(format!("{}/auth/init", url))
+                    .json(&auth_init_payload)
+                    .send()
+                    .await
+                    .unwrap()
+                    .error_for_status()
+                    .unwrap();
+                assert_eq!(StatusCode::OK, res.status());
+
+                // Try again to log in and get the session cookie
+                let login_res = client
+                    .post(&login_url)
+                    .json(&login_payload)
+                    .send()
+                    .await
+                    .unwrap()
+                    .error_for_status()
+                    .unwrap();
+                let cookie_string = login_res
+                    .headers()
+                    .get("set-cookie")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+                cookie_string.split(';').next().unwrap().to_string()
+            }
+        };
+
+        // Create a token
+        #[derive(Serialize)]
+        struct CreateTokenRequest {
+            id: String,
+            name: String,
+        }
+
+        #[derive(Deserialize)]
+        struct CreateTokenResponse {
+            id: String,
+        }
+
+        let create_token_payload = CreateTokenRequest {
+            id: "new".to_string(),
+            name: "Vector Test Token".to_string(),
+        };
+        let create_token_res: CreateTokenResponse = client
+            .post(format!("{}/api/v1/tokens/personal", url))
+            .header("Cookie", session_cookie.clone())
+            .json(&create_token_payload)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+
+        // Get the created token
+        #[derive(Deserialize)]
+        struct TokenResponse {
+            token: String,
+        }
+        let token_res: TokenResponse = client
+            .get(format!(
+                "{}/api/v1/tokens/personal/{}/token",
+                url, create_token_res.id
+            ))
+            .header("Cookie", session_cookie)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let token = token_res.token;
+
+        #[derive(Serialize)]
+        struct CreateDatasetRequest {
+            name: String,
+            description: String,
+        }
+        let dataset = "vector-test".to_string();
+        let create_dataset_payload = CreateDatasetRequest {
+            name: dataset.clone(),
+            description: "Vector Test Dataset".to_string(),
+        };
+        let create_dataset_res = client
+            .post(format!("{}/api/v1/datasets", url))
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&create_dataset_payload)
+            .send()
+            .await
+            .unwrap();
+        match create_dataset_res.status() {
+            StatusCode::OK => Ok(()),                                  // Created
+            StatusCode::CONFLICT => Ok(()),                            // Dataset already exists
+            _ => create_dataset_res.error_for_status().map(|_res| ()), // Error
+        }
+        .unwrap();
+
+        let cx = SinkContext::new_test();
+
+        let config = AxiomConfig {
+            url: Some(url.clone()),
+            token: token.clone(),
+            dataset: dataset.clone(),
+            ..Default::default()
+        };
+
+        let (sink, _) = config.build(cx).await.unwrap();
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+
+        let mut event1 = LogEvent::from("message_1").with_batch_notifier(&batch);
+        event1.insert("host", "aws.cloud.eur");
+        event1.insert("source_type", "file");
+
+        let mut event2 = LogEvent::from("message_2").with_batch_notifier(&batch);
+        event2.insert("host", "aws.cloud.eur");
+        event2.insert("source_type", "file");
+
+        drop(batch);
+
+        let events = vec![Event::Log(event1), Event::Log(event2)];
+
+        run_and_assert_sink_compliance(sink, stream::iter(events), &HTTP_SINK_TAGS).await;
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+        #[derive(Serialize)]
+        struct QueryRequest {
+            apl: String,
+            #[serde(rename = "endTime")]
+            end_time: DateTime<Utc>,
+            #[serde(rename = "startTime")]
+            start_time: DateTime<Utc>,
+            // ...
+        }
+
+        #[derive(Deserialize, Debug)]
+        struct QueryResponseMatch {
+            data: serde_json::Value,
+            // ...
+        }
+
+        #[derive(Deserialize, Debug)]
+        struct QueryResponse {
+            matches: Vec<QueryResponseMatch>,
+            // ...
+        }
+
+        let query_req = QueryRequest {
+            apl: format!("['{}'] | order by _time desc | limit 2", dataset),
+            start_time: Utc::now() - Duration::minutes(10),
+            end_time: Utc::now() + Duration::minutes(10),
+        };
+        let query_res: QueryResponse = client
+            .post(format!("{}/api/v1/datasets/_apl?format=legacy", url))
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&query_req)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+
+        assert_eq!(2, query_res.matches.len());
+
+        let fst = match query_res.matches[0].data {
+            serde_json::Value::Object(ref obj) => obj,
+            _ => panic!("Unexpected value, expected object"),
+        };
+        // Note that we order descending, so message_2 comes first
+        assert_eq!("message_2", fst.get("message").unwrap().as_str().unwrap());
+
+        let snd = match query_res.matches[1].data {
+            serde_json::Value::Object(ref obj) => obj,
+            _ => panic!("Unexpected value, expected object"),
+        };
+        assert_eq!("message_1", snd.get("message").unwrap().as_str().unwrap());
+    }
+}

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -15,6 +15,8 @@ pub mod aws_kinesis_streams;
 pub mod aws_s3;
 #[cfg(feature = "sinks-aws_sqs")]
 pub mod aws_sqs;
+#[cfg(feature = "sinks-axiom")]
+pub mod axiom;
 #[cfg(feature = "sinks-azure_blob")]
 pub mod azure_blob;
 #[cfg(any(feature = "sinks-azure_blob", feature = "sinks-datadog_archives"))]

--- a/website/content/en/docs/reference/configuration/sinks/axiom.md
+++ b/website/content/en/docs/reference/configuration/sinks/axiom.md
@@ -3,7 +3,7 @@ title: Axiom
 description: Deliver log events to [Axiom](https://axiom.co)
 kind: sink
 layout: component
-tags: ["axiom", "component", "sink", "logs"]
+tags: ["axiom", "component", "sink", "logs", "metrics"]
 ---
 
 {{/*

--- a/website/content/en/docs/reference/configuration/sinks/axiom.md
+++ b/website/content/en/docs/reference/configuration/sinks/axiom.md
@@ -1,0 +1,14 @@
+---
+title: Axiom
+description: Deliver log events to [Axiom](https://axiom.co)
+kind: sink
+layout: component
+tags: ["axiom", "component", "sink", "logs"]
+---
+
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -108,8 +108,8 @@ components: sinks: axiom: {
 
 	input: {
 		logs:    true
-		metrics: null
-		traces:  true
+		metrics: true
+		traces:  null
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -1,0 +1,123 @@
+package metadata
+
+components: sinks: axiom: {
+	title: "Axiom"
+
+	classes: {
+		commonly_used: false
+		delivery:      "at_least_once"
+		development:   "beta"
+		egress_method: "batch"
+		service_providers: ["Axiom"]
+		stateful: false
+	}
+
+	features: {
+		acknowledgements: true
+		healthcheck: enabled: true
+		send: {
+			batch: {
+				enabled:      true
+				common:       false
+				max_events:   1000
+				max_bytes:    1_048_576
+				timeout_secs: 1.0
+			}
+			compression: {
+				enabled: true
+				default: "gzip"
+				algorithms: ["none", "gzip"]
+				levels: ["none", "fast", "default", "best", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+			}
+			encoding: {
+				enabled: true
+				codec: enabled: false
+			}
+			proxy: enabled: true
+			request: {
+				enabled: true
+				headers: true
+			}
+			tls: {
+				enabled:                true
+				can_verify_certificate: true
+				can_verify_hostname:    true
+				enabled_default:        false
+			}
+			to: {
+				service: services.axiom
+
+				interface: {
+					socket: {
+						api: {
+							title: "Axiom API"
+							url:   urls.axiom
+						}
+						direction: "outgoing"
+						protocols: ["http"]
+						ssl: "required"
+					}
+				}
+			}
+		}
+	}
+
+	support: {
+		requirements: []
+		warnings: []
+		notices: []
+	}
+
+	configuration: {
+		token: {
+			description: "Your Axiom token"
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["xxxx", "${AXIOM_TOKEN}"]
+				syntax: "literal"
+			}
+		}
+		dataset: {
+			description: "Your Axiom dataset"
+			required:    true
+			warnings: []
+			type: string: {
+				examples: ["vector.dev"]
+				syntax: "literal"
+			}
+		}
+		url: {
+			description: "Your Axiom URL (only required if not Axiom Cloud)"
+			required:    false
+			warnings: []
+			type: string: {
+				examples: ["https://cloud.axiom.co", "${AXIOM_URL}"]
+				syntax: "literal"
+			}
+		}
+		org_id: {
+			description: "Your Axiom Org ID (only required for personal tokens)"
+			required:    false
+			warnings: []
+			type: string: {
+				examples: ["xxxx", "${AXIOM_ORG_ID}"]
+				syntax: "literal"
+			}
+		}
+	}
+
+	input: {
+		logs: true
+		metrics: null
+	}
+
+	telemetry: metrics: {
+		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
+		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
+		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
+	}
+}

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -86,30 +86,30 @@ components: sinks: axiom: {
 			description: "Your Axiom URL (only required if not Axiom Cloud)"
 			common:      false
 			required:    false
-			warnings:    []
+			warnings: []
 			type: string: {
 				examples: ["https://cloud.axiom.co", "${AXIOM_URL}"]
-				syntax: "literal"
-			  default:     ""
+				syntax:  "literal"
+				default: ""
 			}
 		}
 		org_id: {
 			description: "Your Axiom Org ID (only required for personal tokens)"
 			common:      false
 			required:    false
-			warnings:    []
+			warnings: []
 			type: string: {
 				examples: ["xxxx", "${AXIOM_ORG_ID}"]
-				syntax: "literal"
-			  default:     ""
+				syntax:  "literal"
+				default: ""
 			}
 		}
 	}
 
 	input: {
-		logs: true
+		logs:    true
 		metrics: null
-		traces: true
+		traces:  true
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -23,12 +23,7 @@ components: sinks: axiom: {
 				max_bytes:    1_048_576
 				timeout_secs: 1.0
 			}
-			compression: {
-				enabled: true
-				default: "gzip"
-				algorithms: ["none", "gzip"]
-				levels: ["none", "fast", "default", "best", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-			}
+			compression: enabled: false
 			encoding: {
 				enabled: true
 				codec: enabled: false
@@ -89,20 +84,24 @@ components: sinks: axiom: {
 		}
 		url: {
 			description: "Your Axiom URL (only required if not Axiom Cloud)"
+			common:      false
 			required:    false
-			warnings: []
+			warnings:    []
 			type: string: {
 				examples: ["https://cloud.axiom.co", "${AXIOM_URL}"]
 				syntax: "literal"
+			  default:     ""
 			}
 		}
 		org_id: {
 			description: "Your Axiom Org ID (only required for personal tokens)"
+			common:      false
 			required:    false
-			warnings: []
+			warnings:    []
 			type: string: {
 				examples: ["xxxx", "${AXIOM_ORG_ID}"]
 				syntax: "literal"
+			  default:     ""
 			}
 		}
 	}
@@ -110,6 +109,18 @@ components: sinks: axiom: {
 	input: {
 		logs: true
 		metrics: null
+		traces: true
+	}
+
+	how_it_works: {
+		setup: {
+			title: "Setup"
+			body:  """
+				1. Register for a free account at [cloud.axiom.co](\(urls.axiom_cloud))
+
+				2. Once registered, create a new dataset and create an API token for it
+				"""
+		}
 	}
 
 	telemetry: metrics: {

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -107,9 +107,16 @@ components: sinks: axiom: {
 	}
 
 	input: {
-		logs:    true
-		metrics: true
-		traces:  null
+		logs: true
+		metrics: {
+			counter:      true
+			distribution: true
+			gauge:        true
+			histogram:    true
+			set:          true
+			summary:      true
+		}
+		traces: false
 	}
 
 	how_it_works: {

--- a/website/cue/reference/services/axiom.cue
+++ b/website/cue/reference/services/axiom.cue
@@ -1,0 +1,10 @@
+package metadata
+
+services: axiom: {
+	name:     "Axiom"
+	thing:    "a \(name) dataset"
+	url:      urls.axiom
+	versions: null
+
+	description: "Stop choosing between your data and your costs with [Axiom](\(urls.axiom))’s serverless log management solution."
+}

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -81,6 +81,7 @@ urls: {
 	aws_sqs_create:                               "\(aws_docs)/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-create-queue.html"
 	aws_sqs_message_deduplication_id:             "\(aws_docs)/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html"
 	aws_vpc_flow_logs:                            "\(aws_docs)/vpc/latest/userguide/flow-logs.html"
+	axiom:                                        "https://axiom.co"
 	azure_blob:                                   "https://azure.microsoft.com/en-us/services/storage/blobs/"
 	azure_blob_endpoints:                         "https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api"
 	azure_monitor:                                "https://azure.microsoft.com/en-us/services/monitor/"

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -82,6 +82,7 @@ urls: {
 	aws_sqs_message_deduplication_id:             "\(aws_docs)/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html"
 	aws_vpc_flow_logs:                            "\(aws_docs)/vpc/latest/userguide/flow-logs.html"
 	axiom:                                        "https://axiom.co"
+	axiom_cloud:                                  "https://cloud.axiom.co"
 	azure_blob:                                   "https://azure.microsoft.com/en-us/services/storage/blobs/"
 	azure_blob_endpoints:                         "https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api"
 	azure_monitor:                                "https://azure.microsoft.com/en-us/services/monitor/"

--- a/website/data/redirects.yaml
+++ b/website/data/redirects.yaml
@@ -9,6 +9,7 @@ sinks:
 - aws_kinesis_firehose
 - aws_kinesis_streams
 - aws_s3
+- axiom
 - azure_monitor_logs
 - clickhouse
 - datadog_logs


### PR DESCRIPTION
This adds a sink for [Axiom](https://axiom.co). Axiom has support for the bulk API, so this sink is wrapping the `elasticsearch` sink as discussed in https://github.com/vectordotdev/vector/issues/12882.

Here's an example configuration using Axiom Cloud and an API token:
```toml
[sinks.axiom]
inputs = ["whatever"]
type = "axiom"
token = "xaat-1234"
dataset = "vector-dev"
```

Support for configuring the timestamp field on Axioms bulk API is underway and will be deployed + released this week. Until then, the timestamp in Axiom will be the ingestion timestamp and each event will have a `timestamp` key, so I guess it makes sense to wait with merging until that is live (I will comment as soon as that is the case).

## Questions
1. Does the `axiom.cue` file look sane to you? Can I preview the generated docs somehow locally?
2. How are you handling upgrades for test environments? Should we open a PR each time we release a new version?

Closes https://github.com/vectordotdev/vector/issues/12882