### PR TITLE
fix(socket source): Avoid creating unix sockets too early

### DIFF
--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -1119,7 +1119,7 @@ mod test {
                 Ok(meta) => {
                     match meta.permissions().mode() {
                         // S_IFSOCK   0140000   socket
-                        0o140421 => ready(true),
+                        0o140555 => ready(true),
                         perm => {
                             println!("socket has different permissions: {:?}", perm);
                             ready(false)

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -232,7 +232,6 @@ impl SourceConfig for SocketConfig {
 mod test {
     use std::{
         collections::HashMap,
-        future::ready,
         net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -254,7 +253,9 @@ mod test {
     #[cfg(unix)]
     use {
         super::{unix::UnixConfig, Mode},
+        crate::test_util::wait_for,
         futures::{SinkExt, Stream},
+        std::future::ready,
         std::os::unix::fs::PermissionsExt,
         std::path::PathBuf,
         tokio::{
@@ -276,7 +277,7 @@ mod test {
         test_util::{
             collect_n, collect_n_limited,
             components::{assert_source_compliance, SOCKET_HIGH_CARDINALITY_PUSH_SOURCE_TAGS},
-            next_addr, random_string, send_lines, send_lines_tls, wait_for, wait_for_tcp,
+            next_addr, random_string, send_lines, send_lines_tls, wait_for_tcp,
         },
         tls::{self, TlsConfig, TlsEnableableConfig},
         SourceSender,

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -34,12 +34,13 @@ pub fn build_unix_datagram_source(
     shutdown: ShutdownSignal,
     out: SourceSender,
 ) -> crate::Result<Source> {
-    let socket = UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
-    info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
-
-    change_socket_permissions(&listen_path, socket_file_mode)?;
-
     Ok(Box::pin(async move {
+        let socket = UnixDatagram::bind(&listen_path).expect("Failed to bind to datagram socket");
+        info!(message = "Listening.", path = ?listen_path, r#type = "unix_datagram");
+
+        change_socket_permissions(&listen_path, socket_file_mode)
+            .expect("Failed to set socket permissions");
+
         let result = listen(socket, max_length, decoder, shutdown, handle_events, out).await;
 
         // Delete socket file.

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -40,12 +40,13 @@ pub fn build_unix_stream_source(
     shutdown: ShutdownSignal,
     out: SourceSender,
 ) -> crate::Result<Source> {
-    let listener = UnixListener::bind(&listen_path).expect("Failed to bind to listener socket");
-    info!(message = "Listening.", path = ?listen_path, r#type = "unix");
-
-    change_socket_permissions(&listen_path, socket_file_mode)?;
-
     Ok(Box::pin(async move {
+        let listener = UnixListener::bind(&listen_path).expect("Failed to bind to listener socket");
+        info!(message = "Listening.", path = ?listen_path, r#type = "unix");
+
+        change_socket_permissions(&listen_path, socket_file_mode)
+            .expect("Failed to set socket permssions");
+
         let connection_open = OpenGauge::new();
         let stream = UnixListenerStream::new(listener).take_until(shutdown.clone());
         tokio::pin!(stream);

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -40,7 +40,9 @@ pub fn build_unix_stream_source(
     shutdown: ShutdownSignal,
     out: SourceSender,
 ) -> crate::Result<Source> {
+    dbg!("hello");
     Ok(Box::pin(async move {
+        dbg!("creating");
         let listener = UnixListener::bind(&listen_path).expect("Failed to bind to listener socket");
         info!(message = "Listening.", path = ?listen_path, r#type = "unix");
 


### PR DESCRIPTION
`vector validate` was creating the unix socket because it constructs all
components (when `--no-environment` is not passed).

This was a regression from https://github.com/vectordotdev/vector/issues/12115

Ideally we'd do something more sophisticated here in the future, but the
pattern for this sort of failure is simply to `panic` to cause Vector to
shutdown (see the `bind` call).

Fixes: #13018

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
