### PR TITLE
enhancement(console sink): Add end-to-end acknowledgement support

### DIFF
--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -38,6 +38,12 @@ pub struct ConsoleSinkConfig {
         EncodingConfig<StandardEncodings>,
         StandardEncodingsWithFramingMigrator,
     >,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 impl GenerateConfig for ConsoleSinkConfig {
@@ -45,6 +51,7 @@ impl GenerateConfig for ConsoleSinkConfig {
         toml::Value::try_from(Self {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Json).into(),
+            acknowledgements: Default::default(),
         })
         .unwrap()
     }
@@ -97,7 +104,7 @@ impl SinkConfig for ConsoleSinkConfig {
     }
 
     fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/topology/test/doesnt_reload.rs
+++ b/src/topology/test/doesnt_reload.rs
@@ -20,6 +20,7 @@ async fn topology_doesnt_reload_new_data_dir() {
         ConsoleSinkConfig {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Text).into(),
+            acknowledgements: Default::default(),
         },
     );
     old_config.global.data_dir = Some(Path::new("/asdf").to_path_buf());

--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -39,6 +39,7 @@ async fn topology_reuse_old_port() {
         ConsoleSinkConfig {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Text).into(),
+            acknowledgements: Default::default(),
         },
     );
 
@@ -50,6 +51,7 @@ async fn topology_reuse_old_port() {
         ConsoleSinkConfig {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Text).into(),
+            acknowledgements: Default::default(),
         },
     );
 
@@ -73,6 +75,7 @@ async fn topology_rebuild_old() {
         ConsoleSinkConfig {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Text).into(),
+            acknowledgements: Default::default(),
         },
     );
 
@@ -84,6 +87,7 @@ async fn topology_rebuild_old() {
         ConsoleSinkConfig {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Text).into(),
+            acknowledgements: Default::default(),
         },
     );
 
@@ -109,6 +113,7 @@ async fn topology_old() {
         ConsoleSinkConfig {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Text).into(),
+            acknowledgements: Default::default(),
         },
     );
 

--- a/src/topology/test/source_finished.rs
+++ b/src/topology/test/source_finished.rs
@@ -21,6 +21,7 @@ async fn sources_finished() {
         ConsoleSinkConfig {
             target: Target::Stdout,
             encoding: EncodingConfig::from(StandardEncodings::Text).into(),
+            acknowledgements: Default::default(),
         },
     );
 

--- a/website/cue/reference/components/sinks/console.cue
+++ b/website/cue/reference/components/sinks/console.cue
@@ -13,7 +13,7 @@ components: sinks: console: {
 	}
 
 	features: {
-		acknowledgements: false
+		acknowledgements: true
 		healthcheck: enabled: false
 		send: {
 			compression: enabled: false


### PR DESCRIPTION
This is split into two commits. The first completes what is required of #13020, the second is for #9857. This is likely the most trivial example of both of those.