### PR TITLE
chore(observability): Namespace enterprise metrics with `vector`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -707,6 +707,7 @@ enterprise = [
   "sources-internal_logs",
   "sources-internal_metrics",
   "transforms-remap",
+  "transforms-filter",
 ]
 
 # Identifies that the build is a nightly build

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -474,13 +474,16 @@ fn setup_metrics_reporting(
     // Create internal sources for host and internal metrics. We're using distinct sources here and
     // not attempting to reuse existing ones, to configure according to enterprise requirements.
     let host_metrics = HostMetricsConfig {
-        namespace: host_metrics::Namespace::from(Some("pipelines".to_owned())),
+        namespace: host_metrics::Namespace::from(Some("vector.host".to_owned())),
         scrape_interval_secs: datadog.reporting_interval_secs,
         ..Default::default()
     };
 
     let internal_metrics = InternalMetricsConfig {
-        namespace: Some("pipelines".to_owned()),
+        // While the default namespace for internal metrics is already "vector",
+        // setting the namespace here is meant for clarity and resistance
+        // against any future or accidental changes.
+        namespace: Some("vector".to_owned()),
         scrape_interval_secs: datadog.reporting_interval_secs,
         ..Default::default()
     };

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -23,6 +23,7 @@ use super::{
 use crate::{
     built_info,
     common::datadog::{get_api_base_endpoint, Region},
+    conditions::AnyCondition,
     http::{HttpClient, HttpError},
     sinks::{
         datadog::{logs::DatadogLogsConfig, metrics::DatadogMetricsConfig},
@@ -33,12 +34,14 @@ use crate::{
         internal_logs::InternalLogsConfig,
         internal_metrics::InternalMetricsConfig,
     },
-    transforms::remap::RemapConfig,
+    transforms::{filter::FilterConfig, remap::RemapConfig},
 };
 
 static HOST_METRICS_KEY: &str = "#datadog_host_metrics";
 static TAG_METRICS_KEY: &str = "#datadog_tag_metrics";
 static TAG_LOGS_KEY: &str = "#datadog_tag_logs";
+static FILTER_METRICS_KEY: &str = "#datadog_filter_metrics";
+static PIPELINES_NAMESPACE_METRICS_KEY: &str = "#datadog_pipelines_namespace_metrics";
 static INTERNAL_METRICS_KEY: &str = "#datadog_internal_metrics";
 static INTERNAL_LOGS_KEY: &str = "#datadog_internal_logs";
 static DATADOG_METRICS_KEY: &str = "#datadog_metrics";
@@ -469,6 +472,9 @@ fn setup_metrics_reporting(
     let host_metrics_id = OutputId::from(ComponentKey::from(HOST_METRICS_KEY));
     let tag_metrics_id = OutputId::from(ComponentKey::from(TAG_METRICS_KEY));
     let internal_metrics_id = OutputId::from(ComponentKey::from(INTERNAL_METRICS_KEY));
+    let filter_metrics_id = OutputId::from(ComponentKey::from(FILTER_METRICS_KEY));
+    let pipelines_namespace_metrics_id =
+        OutputId::from(ComponentKey::from(PIPELINES_NAMESPACE_METRICS_KEY));
     let datadog_metrics_id = ComponentKey::from(DATADOG_METRICS_KEY);
 
     // Create internal sources for host and internal metrics. We're using distinct sources here and
@@ -508,6 +514,16 @@ fn setup_metrics_reporting(
         ..Default::default()
     };
 
+    // Preserve the `pipelines` namespace for specific metrics
+    let filter_metrics = FilterConfig::from(AnyCondition::String(
+        r#".name == "component_received_bytes_total""#.to_string(),
+    ));
+
+    let pipelines_namespace_metrics = RemapConfig {
+        source: Some(r#".namespace = "pipelines""#.to_string()),
+        ..Default::default()
+    };
+
     // Create a Datadog metrics sink to consume and emit internal + host metrics.
     let datadog_metrics = DatadogMetricsConfig {
         default_api_key: api_key,
@@ -531,9 +547,22 @@ fn setup_metrics_reporting(
         TransformOuter::new(vec![host_metrics_id, internal_metrics_id], tag_metrics),
     );
 
+    config.transforms.insert(
+        filter_metrics_id.component.clone(),
+        TransformOuter::new(vec![tag_metrics_id.clone()], filter_metrics),
+    );
+
+    config.transforms.insert(
+        pipelines_namespace_metrics_id.component.clone(),
+        TransformOuter::new(vec![filter_metrics_id], pipelines_namespace_metrics),
+    );
+
     config.sinks.insert(
         datadog_metrics_id,
-        SinkOuter::new(vec![tag_metrics_id], Box::new(datadog_metrics)),
+        SinkOuter::new(
+            vec![tag_metrics_id, pipelines_namespace_metrics_id],
+            Box::new(datadog_metrics),
+        ),
     );
 }
 

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -42,6 +42,7 @@ static TAG_METRICS_KEY: &str = "#datadog_tag_metrics";
 static TAG_LOGS_KEY: &str = "#datadog_tag_logs";
 static FILTER_METRICS_KEY: &str = "#datadog_filter_metrics";
 static PIPELINES_NAMESPACE_METRICS_KEY: &str = "#datadog_pipelines_namespace_metrics";
+static METERING_METRICS_KEY: &str = "#datadog_metering_metrics";
 static INTERNAL_METRICS_KEY: &str = "#datadog_internal_metrics";
 static INTERNAL_LOGS_KEY: &str = "#datadog_internal_logs";
 static DATADOG_METRICS_KEY: &str = "#datadog_metrics";
@@ -475,6 +476,7 @@ fn setup_metrics_reporting(
     let filter_metrics_id = OutputId::from(ComponentKey::from(FILTER_METRICS_KEY));
     let pipelines_namespace_metrics_id =
         OutputId::from(ComponentKey::from(PIPELINES_NAMESPACE_METRICS_KEY));
+    let metering_metrics_id = OutputId::from(ComponentKey::from(METERING_METRICS_KEY));
     let datadog_metrics_id = ComponentKey::from(DATADOG_METRICS_KEY);
 
     // Create internal sources for host and internal metrics. We're using distinct sources here and
@@ -524,6 +526,17 @@ fn setup_metrics_reporting(
         ..Default::default()
     };
 
+    let metering_metrics = RemapConfig {
+        source: Some(
+            r#"
+            .namespace = "datadog.observability_pipelines"
+            .name = "billed_bytes_total"
+        "#
+            .to_string(),
+        ),
+        ..Default::default()
+    };
+
     // Create a Datadog metrics sink to consume and emit internal + host metrics.
     let datadog_metrics = DatadogMetricsConfig {
         default_api_key: api_key,
@@ -554,13 +567,22 @@ fn setup_metrics_reporting(
 
     config.transforms.insert(
         pipelines_namespace_metrics_id.component.clone(),
-        TransformOuter::new(vec![filter_metrics_id], pipelines_namespace_metrics),
+        TransformOuter::new(vec![filter_metrics_id.clone()], pipelines_namespace_metrics),
+    );
+
+    config.transforms.insert(
+        metering_metrics_id.component.clone(),
+        TransformOuter::new(vec![filter_metrics_id], metering_metrics),
     );
 
     config.sinks.insert(
         datadog_metrics_id,
         SinkOuter::new(
-            vec![tag_metrics_id, pipelines_namespace_metrics_id],
+            vec![
+                tag_metrics_id,
+                pipelines_namespace_metrics_id,
+                metering_metrics_id,
+            ],
             Box::new(datadog_metrics),
         ),
     );


### PR DESCRIPTION
Closes [OP-452](https://datadoghq.atlassian.net/browse/OP-452)

This PR
- Namespaces enterprise `internal_metrics` with `vector` and `host_metrics` with `vector.host`
- Preserves a `pipelines` namespace metric

## Testing

Build this branch locally and create a new OP configuration in Datadog. The below examples use the following configuration

```toml
[api]
enabled = true

[enterprise]
...

[sources.foo_op_452]
type = "demo_logs"
format = "json"

[sources.stdin_op_452]
type = "stdin"

[transforms.remap_op_452]
type = "remap"
inputs = ["foo_op_452"]
source = '''
  log("I'm an internal log")
'''

[sinks.bar_op_452]
type = "blackhole"
inputs = ["*"]
```

Run your configuration `target/debug/vector -c {your config}`, and navigate to DD metrics explorer. You should see metrics like the following
- `vector` namespaced metrics
<img width="1271" alt="Screen Shot 2022-06-08 at 8 07 42 AM" src="https://user-images.githubusercontent.com/43912346/172654808-6e65c1d9-7cfa-43c3-bb0c-63d0910f3233.png">


- `vector.host` namespaced host metrics

<img width="1270" alt="Screen Shot 2022-06-08 at 8 07 57 AM" src="https://user-images.githubusercontent.com/43912346/172654891-8860bfce-1792-4949-85f7-b98fec696dcd.png">


- `pipelines.component_received_bytes_total`

<img width="1275" alt="Screen Shot 2022-06-08 at 8 08 27 AM" src="https://user-images.githubusercontent.com/43912346/172654934-cdb62a45-f4f7-45be-96be-b6bb60ca7152.png">