### PR TITLE
chore(file source): Optimize filename copy

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -252,7 +252,7 @@ where
 
                     lines.push(Line {
                         text: line,
-                        filename: watcher.path.to_str().expect("not a valid path").to_owned(),
+                        filename: Arc::clone(&watcher.path_str),
                         file_id,
                         offset: watcher.get_file_position(),
                     });
@@ -513,7 +513,7 @@ impl Default for TimingStats {
 #[derive(Debug)]
 pub struct Line {
     pub text: Bytes,
-    pub filename: String,
+    pub filename: Arc<str>,
     pub file_id: FileFingerprint,
     pub offset: u64,
 }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -166,7 +166,7 @@ const fn default_lines() -> usize {
 
 #[derive(Debug)]
 pub(crate) struct FinalizerEntry {
-    pub(crate) file_name: String,
+    pub(crate) file_name: Arc<str>,
     pub(crate) file_id: FileFingerprint,
     pub(crate) offset: u64,
 }


### PR DESCRIPTION
Each line of the source file is returned as a structure containing the
filename. That filename will be constant over all those lines, but is
allocated and deallocated repeatedly for each. This changes the filename
to a shared `Arc` string to reduce that copy cost.

Pushing this out to see if it moves the needle at all on the file source soak.