### PR TITLE
docs(provider: humio): Fix indexed_fields example

### DIFF
--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -127,7 +127,7 @@ components: sinks: _humio: {
 			type: array: {
 				default: null
 				items: type: string: {
-					examples: ["#env", "#datacenter"]
+					examples: ["#env", "\"#datacenter\""]
 				}
 			}
 		}


### PR DESCRIPTION
The `#datacenter` key has to be quoted now due to changes in path syntax
handling per https://vector.dev/highlights/2022-03-22-0-21-0-upgrade-guide/#path-syntax-changes.

Closes: #13027

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
