### PR TITLE
chore(logdna sink): Use `Transformer` in `logdna` sink and remove `EncodingConfigWithDefault`

### DIFF
--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -14,7 +14,7 @@ use crate::{
     event::Event,
     http::{Auth, HttpClient},
     sinks::util::{
-        encoding::{EncodingConfigWithDefault, EncodingConfiguration},
+        encoding::Transformer,
         http::{HttpEventEncoder, HttpSink, PartitionHttpSink},
         BatchConfig, BoxedRawValue, JsonArrayBuffer, PartitionBuffer, PartitionInnerBuffer,
         RealtimeSizeBasedDefaultBatchSettings, TowerRequestConfig, UriSerde,
@@ -39,10 +39,10 @@ pub(super) struct LogdnaConfig {
     tags: Option<Vec<Template>>,
 
     #[serde(
-        skip_serializing_if = "crate::serde::skip_serializing_if_default",
-        default
+        default,
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
-    pub encoding: EncodingConfigWithDefault<Encoding>,
+    pub encoding: Transformer,
 
     default_app: Option<String>,
     default_env: Option<String>,
@@ -131,7 +131,7 @@ pub struct PartitionKey {
 pub struct LogdnaEventEncoder {
     hostname: Template,
     tags: Option<Vec<Template>>,
-    encoding: EncodingConfigWithDefault<Encoding>,
+    transformer: Transformer,
     default_app: Option<String>,
     default_env: Option<String>,
 }
@@ -178,7 +178,7 @@ impl HttpEventEncoder<PartitionInnerBuffer<serde_json::Value, PartitionKey>>
             })
             .ok()?;
 
-        self.encoding.apply_rules(&mut event);
+        self.transformer.transform(&mut event);
         let mut log = event.into_log();
 
         let line = log
@@ -238,7 +238,7 @@ impl HttpSink for LogdnaConfig {
         LogdnaEventEncoder {
             hostname: self.hostname.clone(),
             tags: self.tags.clone(),
-            encoding: self.encoding.clone(),
+            transformer: self.encoding.clone(),
             default_app: self.default_app.clone(),
             default_env: self.default_env.clone(),
         }


### PR DESCRIPTION
Related to #9459.

While we don't allow setting a codec (just as previously), we deprecate the usage of the former `EncodingConfigWithDefault` for the new `Transformer` here, for internal consistency and to make the intent clear.