### PR TITLE
chore(new_relic sink): Use `Transformer` in `new_relic` sink and remove `EncodingConfigFixed`

### DIFF
--- a/src/sinks/new_relic/encoding.rs
+++ b/src/sinks/new_relic/encoding.rs
@@ -1,19 +1,13 @@
-use std::{fmt::Debug, io};
+use std::io;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use super::{NewRelicApiModel, NewRelicSinkError};
-use crate::sinks::util::encoding::{as_tracked_write, Encoder, EncodingConfigFixed};
+use crate::sinks::util::encoding::{as_tracked_write, Encoder};
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
-#[serde(rename_all = "snake_case")]
-#[derivative(Default)]
-pub enum Encoding {
-    #[derivative(Default)]
-    Default,
-}
+pub struct NewRelicEncoder;
 
-impl Encoder<Result<NewRelicApiModel, NewRelicSinkError>> for EncodingConfigFixed<Encoding> {
+impl Encoder<Result<NewRelicApiModel, NewRelicSinkError>> for NewRelicEncoder {
     fn encode_input(
         &self,
         input: Result<NewRelicApiModel, NewRelicSinkError>,


### PR DESCRIPTION
Related to https://github.com/vectordotdev/vector/issues/9459.

While we don't allow setting a codec (just as previously), we deprecate the usage of the former `EncodingConfigFixed` for the new `Transformer` here, for internal consistency and to make the intent clear.