### PR TITLE
chore: Fix overwriting cargo config in bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,8 @@ check-component-features: ## Check that all component features are setup properl
 
 .PHONY: check-clippy
 check-clippy: ## Check code with Clippy
-	${MAYBE_ENVIRONMENT_EXEC} cargo clippy --workspace --all-targets --features all-integration-tests -- -D warnings
+	cat .cargo/config.toml
+	${MAYBE_ENVIRONMENT_EXEC} cargo clippy --verbose --workspace --all-targets --features all-integration-tests -- -D warnings
 
 .PHONY: check-docs
 check-docs: ## Check that all /docs file are valid

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -134,7 +134,7 @@ CARGO_OVERRIDE_DIR="${HOME}/.csh check for exisargo"
 mkdir -p "${CARGO_OVERRIDE_DIR}"
 
 CARGO_OVERRIDE_CONF="${CARGO_OVERRIDE_DIR}/config.toml"
-cat <<EOF >"${CARGO_OVERRIDE_CONF}"
+cat <<EOF >>"${CARGO_OVERRIDE_CONF}"
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=/usr/bin/mold"]
 EOF


### PR DESCRIPTION
The Ubuntu bootstrap script overwrites the `.cargo/config.toml` file in
order to install the `mold` linker. This leads to the removal of the
clippy flag options that provide extra links that we want to apply to
all crates. This was discovered by `make check-clippy` passing in CI but
failing on non-CI systems.

This change appends to the cargo config instead of overwriting it to
allow both.

Note that this should fail CI at this point, I will add another commit to fix the clippy issues as soon as it is confirmed this change works.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
