### PR TITLE
fix(docs): Updated the splunk_hec_logs sink component documentation with timestamp_key

### DIFF
--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -133,6 +133,19 @@ components: sinks: splunk_hec_logs: {
 				syntax: "template"
 			}
 		}
+		timestamp_key: {
+			common:      true
+			description: """
+				The name of the log field to be used as the timestamp sent to Splunk HEC. This overrides the
+				[global `timestamp_key` option](\(urls.vector_configuration)/global-options#log_schema.timestamp_key).
+				When set to "", vector omits setting a timestamp in the events sent to Splunk HEC.
+				"""
+			required:    false
+			type: string: {
+				default: null
+				examples: ["timestamp", ""]
+			}
+		}
 	}
 
 	input: {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Closes #13076.

The changes in https://github.com/vectordotdev/vector/pull/12946 missed the documentation updates to the ./website. This issue is to update the documentation with the new config option.