### PR TITLE
docs(external docs): add highlight about removal of VRL VM runtime

### DIFF
--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -18,6 +18,7 @@ Vector's 0.23.0 release includes **breaking changes**:
 5. [`humio_metrics` sink no longer has "encoding" option](#humio_metrics-sink-fixed-encoding)
 6. [VRL conditions are now checked for mutations at compile time](#read_only_check)
 7. [`syslog` source and VRL's `parse_syslog` structured data fields made consistent](#parse-syslog)
+8. [VRL VM beta runtime removed](#vrl-vm-removed)
 
 We cover them below to help you upgrade quickly:
 
@@ -210,3 +211,9 @@ function like:
 ```coffeescript
 flatten(parse_syslog!(s'<1>1 2022-04-25T23:21:45.715740Z Gregorys-MacBook-Pro.local 2d4d9490-794a-4e60-814c-5597bd5b7b7d 79978 - [exampleSDID@32473 foo.baz="bar"] test message'))
 ```
+#### [VRL VM beta runtime removed] {#vrl-vm-removed}
+
+The experimental VM runtime for VRL-based components has been removed. The
+stable AST runtime remains in place, and is now nearly identical in performance
+to the VM runtime. If you have `runtime = "vm"` configured in your config, you
+need to remove it to avoid Vector from erroring on startup.

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -211,6 +211,7 @@ function like:
 ```coffeescript
 flatten(parse_syslog!(s'<1>1 2022-04-25T23:21:45.715740Z Gregorys-MacBook-Pro.local 2d4d9490-794a-4e60-814c-5597bd5b7b7d 79978 - [exampleSDID@32473 foo.baz="bar"] test message'))
 ```
+
 #### [VRL VM beta runtime removed] {#vrl-vm-removed}
 
 The experimental VM runtime for VRL-based components has been removed. The


### PR DESCRIPTION
This adds a highlight note about the removal of the VRL VM runtime. See #12888.