### PR TITLE
docs(unit tests): Add example of an aggregated histogram metric

### DIFF
--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -376,6 +376,22 @@ kind = "absolute"
 counter = { value = 1 }
 ```
 
+Aggregated metrics are a little different:
+
+```yaml
+tests:
+  inputs:
+    insert_at: my_aggregate_metrics_transform
+    type: metric
+    metric:
+      name: http_rtt
+      kind: incremental
+      aggregated_histogram:
+        buckets: []
+        sum: 0
+        count: 0
+```
+
 Here's a full end-to-end example of unit testing a metric through a transform:
 
 ```toml


### PR DESCRIPTION
The aggregated histogram metrics work differently from the other kind. Had to dig into source to figure out if it was supported and how. Adding this to documentation should show that the framework supports it and how to use it.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
