### PR TITLE
docs(statsd sink, statsd source): A few docs fixes

### DIFF
--- a/website/content/en/docs/reference/configuration/sinks/statsd.md
+++ b/website/content/en/docs/reference/configuration/sinks/statsd.md
@@ -1,9 +1,9 @@
 ---
 title: Statsd
-description: Deliver log data to a [StatsD](https://github.com/statsd/statsd) aggregator
+description: Deliver metric data to a [StatsD](https://github.com/statsd/statsd) aggregator
 kind: sink
 layout: component
-tags: ["statsd", "component", "sink", "logs"]
+tags: ["statsd", "component", "sink", "metrics"]
 ---
 
 {{/*

--- a/website/content/en/docs/reference/configuration/sources/statsd.md
+++ b/website/content/en/docs/reference/configuration/sources/statsd.md
@@ -1,9 +1,9 @@
 ---
 title: StatsD
-description: Collect logs emitted by the [StatsD](https://github.com/statsd/statsd) aggregator
+description: Collect metrics emitted by the [StatsD](https://github.com/statsd/statsd) aggregator
 kind: source
 layout: component
-tags: ["statsd", "component", "source", "logs"]
+tags: ["statsd", "component", "source", "metrics"]
 ---
 
 {{/*

--- a/website/cue/reference/components/sinks/statsd.cue
+++ b/website/cue/reference/components/sinks/statsd.cue
@@ -46,8 +46,34 @@ components: sinks: statsd: {
 		traces: false
 	}
 
-	configuration: sinks.socket.configuration & {
-		"type": "type": string: enum: statsd: "The type of this component."
+	configuration: {
+		address: {
+			description:   "The address to connect to. The address _must_ include a port."
+			relevant_when: "mode = `tcp` or `udp`"
+			required:      true
+			type: string: {
+				examples: ["92.12.333.224:5000"]
+			}
+		}
+		mode: {
+			description: "The type of socket to use."
+			required:    true
+			type: string: {
+				enum: {
+					tcp:  "TCP socket"
+					udp:  "UDP socket"
+					unix: "Unix domain socket"
+				}
+			}
+		}
+		path: {
+			description:   "The unix socket path. This should be the absolute path."
+			relevant_when: "mode = `unix`"
+			required:      true
+			type: string: {
+				examples: ["/path/to/socket"]
+			}
+		}
 		default_namespace: {
 			common: true
 			description: """


### PR DESCRIPTION
The statsd components deal with metrics, not logs.

The statsd sink was inheriting from socket and so was incorrectly
documenting support for configuration options like `encoding`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
