### PR TITLE
chore(vrl): remove separate optional field from schema

### DIFF
--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -32,7 +32,7 @@ impl BytesDeserializerConfig {
 
     /// The schema produced by the deserializer.
     pub fn schema_definition(&self) -> schema::Definition {
-        schema::Definition::empty().required_field(
+        schema::Definition::empty().with_field(
             log_schema().message_key(),
             Kind::bytes(),
             Some("message"),

--- a/lib/codecs/src/decoding/format/json.rs
+++ b/lib/codecs/src/decoding/format/json.rs
@@ -31,7 +31,7 @@ impl JsonDeserializerConfig {
     /// The schema produced by the deserializer.
     pub fn schema_definition(&self) -> schema::Definition {
         schema::Definition::empty()
-            .required_field(
+            .with_field(
                 log_schema().timestamp_key(),
                 // The JSON decoder will try to insert a new `timestamp`-type value into the
                 // "timestamp_key" field, but only if that field doesn't already exist.

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -32,7 +32,7 @@ impl SyslogDeserializerConfig {
         schema::Definition::empty()
             // The `message` field is always defined. If parsing fails, the entire body becomes the
             // message.
-            .required_field(log_schema().message_key(), Kind::bytes(), Some("message"))
+            .with_field(log_schema().message_key(), Kind::bytes(), Some("message"))
             // All other fields are optional.
             .optional_field(
                 log_schema().timestamp_key(),

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -236,7 +236,7 @@ impl Definition {
         }
     }
 
-    pub fn meanings(&self) -> impl Iterator<Item=(&String, &LookupBuf)> {
+    pub fn meanings(&self) -> impl Iterator<Item = (&String, &LookupBuf)> {
         self.meaning
             .iter()
             .filter_map(|(id, pointer)| match pointer {
@@ -305,11 +305,13 @@ mod tests {
                         collection: BTreeMap::from([(
                             "foo".into(),
                             Kind::object(BTreeMap::from([("bar".into(), Kind::regex().or_null())])),
-                        )]).into(),
+                        )])
+                        .into(),
                         meaning: [(
                             "foobar".to_owned(),
                             LookupBuf::from_str(".foo.bar").unwrap().into(),
-                        )].into(),
+                        )]
+                        .into(),
                     },
                 },
             ),
@@ -358,7 +360,8 @@ mod tests {
                     kind: Kind::boolean(),
                     meaning: Some("foo_meaning"),
                     want: Definition {
-                        collection: BTreeMap::from([("foo".into(), Kind::boolean().or_null())]).into(),
+                        collection: BTreeMap::from([("foo".into(), Kind::boolean().or_null())])
+                            .into(),
                         meaning: [("foo_meaning".to_owned(), "foo".into())].into(),
                     },
                 },
@@ -373,11 +376,13 @@ mod tests {
                         collection: BTreeMap::from([(
                             "foo".into(),
                             Kind::object(BTreeMap::from([("bar".into(), Kind::regex().or_null())])),
-                        )]).into(),
+                        )])
+                        .into(),
                         meaning: [(
                             "foobar".to_owned(),
                             LookupBuf::from_str(".foo.bar").unwrap().into(),
-                        )].into(),
+                        )]
+                        .into(),
                     },
                 },
             ),
@@ -388,7 +393,8 @@ mod tests {
                     kind: Kind::boolean(),
                     meaning: None,
                     want: Definition {
-                        collection: BTreeMap::from([("foo".into(), Kind::boolean().or_null())]).into(),
+                        collection: BTreeMap::from([("foo".into(), Kind::boolean().or_null())])
+                            .into(),
                         meaning: BTreeMap::default(),
                     },
                 },

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -307,11 +307,7 @@ mod tests {
                 "invalid required meaning kind",
                 TestCase {
                     requirement: Requirement::empty().required_meaning("foo", Kind::boolean()),
-                    definition: Definition::empty().required_field(
-                        "foo",
-                        Kind::integer(),
-                        Some("foo"),
-                    ),
+                    definition: Definition::empty().with_field("foo", Kind::integer(), Some("foo")),
                     errors: vec![ValidationError::MeaningKind {
                         identifier: "foo",
                         want: Kind::boolean(),
@@ -323,11 +319,7 @@ mod tests {
                 "invalid optional meaning kind",
                 TestCase {
                     requirement: Requirement::empty().optional_meaning("foo", Kind::boolean()),
-                    definition: Definition::empty().required_field(
-                        "foo",
-                        Kind::integer(),
-                        Some("foo"),
-                    ),
+                    definition: Definition::empty().with_field("foo", Kind::integer(), Some("foo")),
                     errors: vec![ValidationError::MeaningKind {
                         identifier: "foo",
                         want: Kind::boolean(),
@@ -340,12 +332,8 @@ mod tests {
                 TestCase {
                     requirement: Requirement::empty().optional_meaning("foo", Kind::boolean()),
                     definition: Definition::empty()
-                        .required_field("foo", Kind::integer(), Some("foo"))
-                        .merge(Definition::empty().required_field(
-                            "bar",
-                            Kind::boolean(),
-                            Some("foo"),
-                        )),
+                        .with_field("foo", Kind::integer(), Some("foo"))
+                        .merge(Definition::empty().with_field("bar", Kind::boolean(), Some("foo"))),
                     errors: vec![ValidationError::MeaningDuplicate {
                         identifier: "foo",
                         paths: BTreeSet::from(["foo".into(), "bar".into()]),

--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -172,13 +172,13 @@ impl SourceConfig for DatadogAgentConfig {
         let definition = match self.decoding {
             // See: `LogMsg` struct.
             DeserializerConfig::Bytes => schema::Definition::empty()
-                .required_field("message", Kind::bytes(), Some("message"))
-                .required_field("status", Kind::bytes(), Some("severity"))
-                .required_field("timestamp", Kind::timestamp(), Some("timestamp"))
-                .required_field("hostname", Kind::bytes(), Some("host"))
-                .required_field("service", Kind::bytes(), Some("service"))
-                .required_field("ddsource", Kind::bytes(), Some("source"))
-                .required_field("ddtags", Kind::bytes(), Some("tags"))
+                .with_field("message", Kind::bytes(), Some("message"))
+                .with_field("status", Kind::bytes(), Some("severity"))
+                .with_field("timestamp", Kind::timestamp(), Some("timestamp"))
+                .with_field("hostname", Kind::bytes(), Some("host"))
+                .with_field("service", Kind::bytes(), Some("service"))
+                .with_field("ddsource", Kind::bytes(), Some("source"))
+                .with_field("ddtags", Kind::bytes(), Some("tags"))
                 .merge(self.decoding.schema_definition()),
 
             // JSON deserializer can overwrite existing fields at runtime, so we have to treat

--- a/src/sources/datadog/agent/tests.rs
+++ b/src/sources/datadog/agent/tests.rs
@@ -50,7 +50,7 @@ mod dd_traces_proto {
 }
 
 fn test_logs_schema_definition() -> schema::Definition {
-    schema::Definition::empty().required_field(
+    schema::Definition::empty().with_field(
         "a log field",
         Kind::integer().or_bytes(),
         Some("log field"),
@@ -58,11 +58,7 @@ fn test_logs_schema_definition() -> schema::Definition {
 }
 
 fn test_metrics_schema_definition() -> schema::Definition {
-    schema::Definition::empty().required_field(
-        "a schema tag",
-        Kind::boolean().or_null(),
-        Some("tag"),
-    )
+    schema::Definition::empty().with_field("a schema tag", Kind::boolean().or_null(), Some("tag"))
 }
 
 impl Arbitrary for LogMsg {
@@ -1284,13 +1280,13 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty()
-                            .required_field("message", Kind::bytes(), Some("message"))
-                            .required_field("status", Kind::bytes(), Some("severity"))
-                            .required_field("timestamp", Kind::timestamp(), Some("timestamp"))
-                            .required_field("hostname", Kind::bytes(), Some("host"))
-                            .required_field("service", Kind::bytes(), Some("service"))
-                            .required_field("ddsource", Kind::bytes(), Some("source"))
-                            .required_field("ddtags", Kind::bytes(), Some("tags")),
+                            .with_field("message", Kind::bytes(), Some("message"))
+                            .with_field("status", Kind::bytes(), Some("severity"))
+                            .with_field("timestamp", Kind::timestamp(), Some("timestamp"))
+                            .with_field("hostname", Kind::bytes(), Some("host"))
+                            .with_field("service", Kind::bytes(), Some("service"))
+                            .with_field("ddsource", Kind::bytes(), Some("source"))
+                            .with_field("ddtags", Kind::bytes(), Some("tags")),
                     ),
                 )]),
             },
@@ -1304,13 +1300,13 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty()
-                            .required_field("message", Kind::bytes(), Some("message"))
-                            .required_field("status", Kind::bytes(), Some("severity"))
-                            .required_field("timestamp", Kind::timestamp(), Some("timestamp"))
-                            .required_field("hostname", Kind::bytes(), Some("host"))
-                            .required_field("service", Kind::bytes(), Some("service"))
-                            .required_field("ddsource", Kind::bytes(), Some("source"))
-                            .required_field("ddtags", Kind::bytes(), Some("tags")),
+                            .with_field("message", Kind::bytes(), Some("message"))
+                            .with_field("status", Kind::bytes(), Some("severity"))
+                            .with_field("timestamp", Kind::timestamp(), Some("timestamp"))
+                            .with_field("hostname", Kind::bytes(), Some("host"))
+                            .with_field("service", Kind::bytes(), Some("service"))
+                            .with_field("ddsource", Kind::bytes(), Some("source"))
+                            .with_field("ddtags", Kind::bytes(), Some("tags")),
                     ),
                 )]),
             },
@@ -1325,13 +1321,13 @@ fn test_config_outputs() {
                         Some(LOGS),
                         Some(
                             schema::Definition::empty()
-                                .required_field("message", Kind::bytes(), Some("message"))
-                                .required_field("status", Kind::bytes(), Some("severity"))
-                                .required_field("timestamp", Kind::timestamp(), Some("timestamp"))
-                                .required_field("hostname", Kind::bytes(), Some("host"))
-                                .required_field("service", Kind::bytes(), Some("service"))
-                                .required_field("ddsource", Kind::bytes(), Some("source"))
-                                .required_field("ddtags", Kind::bytes(), Some("tags")),
+                                .with_field("message", Kind::bytes(), Some("message"))
+                                .with_field("status", Kind::bytes(), Some("severity"))
+                                .with_field("timestamp", Kind::timestamp(), Some("timestamp"))
+                                .with_field("hostname", Kind::bytes(), Some("host"))
+                                .with_field("service", Kind::bytes(), Some("service"))
+                                .with_field("ddsource", Kind::bytes(), Some("source"))
+                                .with_field("ddtags", Kind::bytes(), Some("tags")),
                         ),
                     ),
                     (Some(METRICS), None),
@@ -1348,11 +1344,7 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty()
-                            .required_field(
-                                "timestamp",
-                                Kind::json().or_timestamp(),
-                                Some("timestamp"),
-                            )
+                            .with_field("timestamp", Kind::json().or_timestamp(), Some("timestamp"))
                             .unknown_fields(Kind::json()),
                     ),
                 )]),
@@ -1368,7 +1360,7 @@ fn test_config_outputs() {
                         Some(LOGS),
                         Some(
                             schema::Definition::empty()
-                                .required_field(
+                                .with_field(
                                     "timestamp",
                                     Kind::json().or_timestamp(),
                                     Some("timestamp"),
@@ -1391,7 +1383,7 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty()
-                            .required_field("message", Kind::bytes(), Some("message"))
+                            .with_field("message", Kind::bytes(), Some("message"))
                             .optional_field("timestamp", Kind::timestamp(), Some("timestamp"))
                             .optional_field("hostname", Kind::bytes(), None)
                             .optional_field("severity", Kind::bytes(), Some("severity"))
@@ -1416,7 +1408,7 @@ fn test_config_outputs() {
                         Some(LOGS),
                         Some(
                             schema::Definition::empty()
-                                .required_field("message", Kind::bytes(), Some("message"))
+                                .with_field("message", Kind::bytes(), Some("message"))
                                 .optional_field("timestamp", Kind::timestamp(), Some("timestamp"))
                                 .optional_field("hostname", Kind::bytes(), None)
                                 .optional_field("severity", Kind::bytes(), Some("severity"))

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -355,7 +355,7 @@ mod tests {
                     sources: IndexMap::from([(
                         "source-foo",
                         vec![Output::default(DataType::all()).with_schema_definition(
-                            Definition::empty().required_field(
+                            Definition::empty().with_field(
                                 "foo",
                                 Kind::integer().or_bytes(),
                                 Some("foo bar"),
@@ -363,7 +363,7 @@ mod tests {
                         )],
                     )]),
                     transforms: IndexMap::default(),
-                    want: Definition::empty().required_field(
+                    want: Definition::empty().with_field(
                         "foo",
                         Kind::integer().or_bytes(),
                         Some("foo bar"),
@@ -378,7 +378,7 @@ mod tests {
                         (
                             "source-foo",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
+                                Definition::empty().with_field(
                                     "foo",
                                     Kind::integer().or_bytes(),
                                     Some("foo bar"),
@@ -388,7 +388,7 @@ mod tests {
                         (
                             "source-bar",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
+                                Definition::empty().with_field(
                                     "foo",
                                     Kind::timestamp(),
                                     Some("baz qux"),
@@ -398,8 +398,8 @@ mod tests {
                     ]),
                     transforms: IndexMap::default(),
                     want: Definition::empty()
-                        .required_field("foo", Kind::integer().or_bytes(), Some("foo bar"))
-                        .required_field("foo", Kind::timestamp(), Some("baz qux")),
+                        .with_field("foo", Kind::integer().or_bytes(), Some("foo bar"))
+                        .with_field("foo", Kind::timestamp(), Some("baz qux")),
                 },
             ),
         ]) {
@@ -471,7 +471,7 @@ mod tests {
                     sources: IndexMap::from([(
                         "source-foo",
                         vec![Output::default(DataType::all()).with_schema_definition(
-                            Definition::empty().required_field(
+                            Definition::empty().with_field(
                                 "foo",
                                 Kind::integer().or_bytes(),
                                 Some("foo bar"),
@@ -479,7 +479,7 @@ mod tests {
                         )],
                     )]),
                     transforms: IndexMap::default(),
-                    want: vec![Definition::empty().required_field(
+                    want: vec![Definition::empty().with_field(
                         "foo",
                         Kind::integer().or_bytes(),
                         Some("foo bar"),
@@ -494,7 +494,7 @@ mod tests {
                         (
                             "source-foo",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
+                                Definition::empty().with_field(
                                     "foo",
                                     Kind::integer().or_bytes(),
                                     Some("foo bar"),
@@ -504,7 +504,7 @@ mod tests {
                         (
                             "source-bar",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
+                                Definition::empty().with_field(
                                     "foo",
                                     Kind::timestamp(),
                                     Some("baz qux"),
@@ -514,16 +514,12 @@ mod tests {
                     ]),
                     transforms: IndexMap::default(),
                     want: vec![
-                        Definition::empty().required_field(
+                        Definition::empty().with_field(
                             "foo",
                             Kind::integer().or_bytes(),
                             Some("foo bar"),
                         ),
-                        Definition::empty().required_field(
-                            "foo",
-                            Kind::timestamp(),
-                            Some("baz qux"),
-                        ),
+                        Definition::empty().with_field("foo", Kind::timestamp(), Some("baz qux")),
                     ],
                 },
             ),
@@ -535,21 +531,13 @@ mod tests {
                         (
                             "source-foo",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
-                                    "foo",
-                                    Kind::boolean(),
-                                    Some("foo"),
-                                ),
+                                Definition::empty().with_field("foo", Kind::boolean(), Some("foo")),
                             )],
                         ),
                         (
                             "source-bar",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
-                                    "bar",
-                                    Kind::integer(),
-                                    Some("bar"),
-                                ),
+                                Definition::empty().with_field("bar", Kind::integer(), Some("bar")),
                             )],
                         ),
                     ]),
@@ -558,17 +546,13 @@ mod tests {
                         (
                             vec![OutputId::from("source-foo")],
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
-                                    "baz",
-                                    Kind::regex(),
-                                    Some("baz"),
-                                ),
+                                Definition::empty().with_field("baz", Kind::regex(), Some("baz")),
                             )],
                         ),
                     )]),
                     want: vec![
-                        Definition::empty().required_field("bar", Kind::integer(), Some("bar")),
-                        Definition::empty().required_field("baz", Kind::regex(), Some("baz")),
+                        Definition::empty().with_field("bar", Kind::integer(), Some("bar")),
+                        Definition::empty().with_field("baz", Kind::regex(), Some("baz")),
                     ],
                 },
             ),
@@ -588,7 +572,7 @@ mod tests {
                         (
                             "Source 1",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
+                                Definition::empty().with_field(
                                     "source-1",
                                     Kind::boolean(),
                                     Some("source-1"),
@@ -598,7 +582,7 @@ mod tests {
                         (
                             "Source 2",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty().required_field(
+                                Definition::empty().with_field(
                                     "source-2",
                                     Kind::integer(),
                                     Some("source-2"),
@@ -612,7 +596,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 1")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty().required_field(
+                                    Definition::empty().with_field(
                                         "transform-1",
                                         Kind::regex(),
                                         None,
@@ -625,7 +609,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 2")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty().required_field(
+                                    Definition::empty().with_field(
                                         "transform-2",
                                         Kind::float().or_null(),
                                         Some("transform-2"),
@@ -638,7 +622,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 2")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty().required_field(
+                                    Definition::empty().with_field(
                                         "transform-3",
                                         Kind::integer(),
                                         Some("transform-3"),
@@ -651,7 +635,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 2")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty().required_field(
+                                    Definition::empty().with_field(
                                         "transform-4",
                                         Kind::timestamp().or_bytes(),
                                         Some("transform-4"),
@@ -664,7 +648,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Transform 3"), OutputId::from("Transform 4")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty().required_field(
+                                    Definition::empty().with_field(
                                         "transform-5",
                                         Kind::boolean(),
                                         Some("transform-5"),
@@ -675,21 +659,21 @@ mod tests {
                     ]),
                     want: vec![
                         // Pipeline 1
-                        Definition::empty().required_field("transform-1", Kind::regex(), None),
+                        Definition::empty().with_field("transform-1", Kind::regex(), None),
                         // Pipeline 2
-                        Definition::empty().required_field(
+                        Definition::empty().with_field(
                             "transform-2",
                             Kind::float().or_null(),
                             Some("transform-2"),
                         ),
                         // Pipeline 3
-                        Definition::empty().required_field(
+                        Definition::empty().with_field(
                             "transform-5",
                             Kind::boolean(),
                             Some("transform-5"),
                         ),
                         // Pipeline 4
-                        Definition::empty().required_field(
+                        Definition::empty().with_field(
                             "transform-5",
                             Kind::boolean(),
                             Some("transform-5"),

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -77,7 +77,9 @@ impl RemapConfig {
         functions.append(&mut enrichment::vrl_functions());
         functions.append(&mut vector_vrl_functions::vrl_functions());
 
-        let mut state = vrl::state::ExternalEnv::new_with_kind(merged_schema_definition.into());
+        let mut state = vrl::state::ExternalEnv::new_with_kind(
+            merged_schema_definition.collection().clone().into(),
+        );
         state.set_external_context(enrichment_tables);
         state.set_external_context(MeaningList::default());
 
@@ -165,7 +167,7 @@ impl TransformConfig for RemapConfig {
 
         // When a message is dropped and re-routed, we keep the original event, but also annotate
         // it with additional metadata.
-        let dropped_definition = merged_definition.clone().required_field(
+        let dropped_definition = merged_definition.clone().with_field(
             log_schema().metadata_key(),
             Kind::object(BTreeMap::from([
                 ("reason".into(), Kind::bytes()),
@@ -494,7 +496,7 @@ mod tests {
     };
 
     fn test_default_schema_definition() -> schema::Definition {
-        schema::Definition::empty().required_field(
+        schema::Definition::empty().with_field(
             "a default field",
             Kind::integer().or_bytes(),
             Some("default"),
@@ -502,7 +504,7 @@ mod tests {
     }
 
     fn test_dropped_schema_definition() -> schema::Definition {
-        schema::Definition::empty().required_field(
+        schema::Definition::empty().with_field(
             "a dropped field",
             Kind::boolean().or_null(),
             Some("dropped"),
@@ -925,7 +927,7 @@ mod tests {
         let context = TransformContext {
             key: Some(ComponentKey::from("remapper")),
             schema_definitions,
-            merged_schema_definition: schema::Definition::empty().required_field(
+            merged_schema_definition: schema::Definition::empty().with_field(
                 "hello",
                 Kind::bytes(),
                 None,
@@ -1175,8 +1177,8 @@ mod tests {
         };
 
         let schema_definition = schema::Definition::empty()
-            .required_field("foo", Kind::bytes(), None)
-            .required_field(
+            .with_field("foo", Kind::bytes(), None)
+            .with_field(
                 "tags",
                 Kind::object(BTreeMap::from([("foo".into(), Kind::bytes())])),
                 None,


### PR DESCRIPTION
This removes the `optional` field from the schema definition. Instead of storing them separately, it now just appends a `null` to the `Kind` type.

`required_field` was renamed to `with_field`. The "required" naming was confusing since you could set a nullable type.

This is purely an internal code cleanup. There should be no behavior changes.