### PR TITLE
feature(vrl): Add read-only support to `ExternalEnv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9094,6 +9094,7 @@ dependencies = [
  "clap 3.1.18",
  "enrichment",
  "glob",
+ "lookup",
  "prettydiff",
  "regex",
  "serde",

--- a/lib/lookup/src/lookup_buf/mod.rs
+++ b/lib/lookup/src/lookup_buf/mod.rs
@@ -254,8 +254,14 @@ impl Look<'static> for LookupBuf {
     }
 
     /// Returns `true` if `needle` is a prefix of the lookup.
-    pub fn starts_with(&self, needle: &LookupBuf) -> bool {
-        needle.iter().zip(&self.segments).all(|(n, s)| n == s)
+    pub fn starts_with(&self, prefix: &LookupBuf) -> bool {
+        let mut self_iter = self.iter();
+        for prefix_segment in prefix.iter() {
+            if self_iter.next() != Some(prefix_segment) {
+                return false;
+            }
+        }
+        true
     }
 }
 

--- a/lib/vector-vrl-functions/src/remove_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/remove_metadata_field.rs
@@ -44,14 +44,14 @@ impl Function for RemoveMetadataField {
 
     fn compile(
         &self,
-        state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        (_, external): (&mut state::LocalEnv, &mut state::ExternalEnv),
         _ctx: &mut FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let key = get_metadata_key(&mut arguments)?;
 
         if let MetadataKey::Query(query) = &key {
-            if state.1.is_read_only_metadata_path(query.path()) {
+            if external.is_read_only_metadata_path(query.path()) {
                 return Err(vrl::function::Error::ReadOnlyMutation {
                     context: format!("{} is read-only, and cannot be removed", query),
                 }

--- a/lib/vector-vrl-functions/src/remove_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/remove_metadata_field.rs
@@ -29,7 +29,7 @@ impl Function for RemoveMetadataField {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "key",
-            kind: kind::BYTES,
+            kind: kind::ANY,
             required: true,
         }]
     }
@@ -44,11 +44,21 @@ impl Function for RemoveMetadataField {
 
     fn compile(
         &self,
-        _state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        state: (&mut state::LocalEnv, &mut state::ExternalEnv),
         _ctx: &mut FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let key = get_metadata_key(&mut arguments)?;
+
+        if let MetadataKey::Query(query) = &key {
+            if state.1.is_read_only_metadata_path(query.path()) {
+                return Err(vrl::function::Error::ReadOnlyMutation {
+                    context: format!("{} is read-only, and cannot be removed", query),
+                }
+                .into());
+            }
+        }
+
         Ok(Box::new(RemoveMetadataFieldFn { key }))
     }
 }

--- a/lib/vector-vrl-functions/src/set_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/set_metadata_field.rs
@@ -53,7 +53,7 @@ impl Function for SetMetadataField {
 
     fn compile(
         &self,
-        state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        (local, external): (&mut state::LocalEnv, &mut state::ExternalEnv),
         _ctx: &mut FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
@@ -61,7 +61,7 @@ impl Function for SetMetadataField {
         let value = arguments.required_expr("value");
 
         if let MetadataKey::Query(query) = &key {
-            if state.1.is_read_only_metadata_path(query.path()) {
+            if external.is_read_only_metadata_path(query.path()) {
                 return Err(vrl::function::Error::ReadOnlyMutation {
                     context: format!("{} is read-only, and cannot be modified", query),
                 }
@@ -70,7 +70,7 @@ impl Function for SetMetadataField {
         }
 
         // for backwards compatibility, make sure value is a string when using legacy.
-        if matches!(key, MetadataKey::Legacy(_)) && !value.type_def((state.0, state.1)).is_bytes() {
+        if matches!(key, MetadataKey::Legacy(_)) && !value.type_def((local, external)).is_bytes() {
             return Err(vrl::function::Error::UnexpectedExpression {
                 keyword: "value",
                 expected: "string",

--- a/lib/vector-vrl-functions/src/set_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/set_metadata_field.rs
@@ -32,7 +32,7 @@ impl Function for SetMetadataField {
         &[
             Parameter {
                 keyword: "key",
-                kind: kind::BYTES,
+                kind: kind::ANY,
                 required: true,
             },
             Parameter {
@@ -59,6 +59,15 @@ impl Function for SetMetadataField {
     ) -> Compiled {
         let key = get_metadata_key(&mut arguments)?;
         let value = arguments.required_expr("value");
+
+        if let MetadataKey::Query(query) = &key {
+            if state.1.is_read_only_metadata_path(query.path()) {
+                return Err(vrl::function::Error::ReadOnlyMutation {
+                    context: format!("{} is read-only, and cannot be modified", query),
+                }
+                .into());
+            }
+        }
 
         // for backwards compatibility, make sure value is a string when using legacy.
         if matches!(key, MetadataKey::Legacy(_)) && !value.type_def((state.0, state.1)).is_bytes() {

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -31,7 +31,7 @@ core = { package = "vrl-core", path = "../core", default-features = false }
 diagnostic = { package = "vrl-diagnostic", path = "../diagnostic" }
 parser = { package = "vrl-parser", path = "../parser" }
 lookup = { path = "../../lookup" }
-vector_common = { path = "../../vector-common", default-features = false, features = ["conversion"] }
+vector_common = { path = "../../vector-common", default-features = false, features = ["conversion", "serde"] }
 value = { path = "../../value" }
 
 bytes = { version = "1.1.0", default-features = false }

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -60,6 +60,7 @@ impl Assignment {
 
                 let expr = expr.into_inner();
                 let target = Target::try_from(target.into_inner())?;
+                verify_mutable(&target, external, target_span, assignment_span)?;
                 let value = expr.as_value();
 
                 target.insert_type_def(local, external, type_def, value);
@@ -109,6 +110,7 @@ impl Assignment {
                 // set to being infallible, as the error will be captured by the
                 // "err" target.
                 let ok = Target::try_from(ok.into_inner())?;
+                verify_mutable(&ok, external, expr_span, ok_span)?;
                 let type_def = type_def.infallible();
                 let default_value = type_def.default_value();
                 let value = expr.as_value();
@@ -118,6 +120,7 @@ impl Assignment {
                 // "err" target is assigned `null` or a string containing the
                 // error message.
                 let err = Target::try_from(err.into_inner())?;
+                verify_mutable(&err, external, expr_span, err_span)?;
                 let type_def = TypeDef::bytes().add_null().infallible();
 
                 err.insert_type_def(local, external, type_def, None);
@@ -150,6 +153,28 @@ impl Assignment {
         }
 
         targets
+    }
+}
+
+fn verify_mutable(
+    target: &Target,
+    external: &ExternalEnv,
+    expr_span: Span,
+    assignment_span: Span,
+) -> Result<(), Error> {
+    match target {
+        Target::External(lookup_buf) => {
+            if external.is_read_only_event_path(&lookup_buf) {
+                Err(Error {
+                    variant: ErrorVariant::ReadOnly,
+                    expr_span,
+                    assignment_span,
+                })
+            } else {
+                Ok(())
+            }
+        }
+        Target::Internal(_, _) | Target::Noop => Ok(()),
     }
 }
 
@@ -434,6 +459,9 @@ pub(crate) enum ErrorVariant {
 
     #[error("invalid assignment target")]
     InvalidTarget(Span),
+
+    #[error("mutation of read-only value")]
+    ReadOnly,
 }
 
 impl fmt::Display for Error {
@@ -457,6 +485,7 @@ impl DiagnosticMessage for Error {
             FallibleAssignment(..) => 103,
             InfallibleAssignment(..) => 104,
             InvalidTarget(..) => 641,
+            ReadOnly => 315,
         }
     }
 
@@ -487,6 +516,10 @@ impl DiagnosticMessage for Error {
                 Label::primary("invalid assignment target", span),
                 Label::context("use one of variable or path", span),
             ],
+            ReadOnly => vec![Label::primary(
+                "mutation of read-only value",
+                self.assignment_span,
+            )],
         }
     }
 

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -164,7 +164,7 @@ fn verify_mutable(
 ) -> Result<(), Error> {
     match target {
         Target::External(lookup_buf) => {
-            if external.is_read_only_event_path(&lookup_buf) {
+            if external.is_read_only_event_path(lookup_buf) {
                 Err(Error {
                     variant: ErrorVariant::ReadOnly,
                     expr_span,

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -625,7 +625,7 @@ impl diagnostic::DiagnosticMessage for Error {
 
             ExpectedFunctionClosure => vec![],
             ReadOnlyMutation { context } => vec![
-                Label::primary(format!(r#"mutation of read-only value"#), Span::default()),
+                Label::primary(r#"mutation of read-only value"#, Span::default()),
                 Label::context(context, Span::default()),
             ],
         }

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -543,6 +543,9 @@ pub enum Error {
 
     #[error(r#"missing function closure"#)]
     ExpectedFunctionClosure,
+
+    #[error(r#"mutation of read-only value"#)]
+    ReadOnlyMutation { context: String },
 }
 
 impl diagnostic::DiagnosticMessage for Error {
@@ -555,6 +558,7 @@ impl diagnostic::DiagnosticMessage for Error {
             ExpectedStaticExpression { .. } => 402,
             InvalidArgument { .. } => 403,
             ExpectedFunctionClosure => 420,
+            ReadOnlyMutation { .. } => 315,
         }
     }
 
@@ -620,6 +624,10 @@ impl diagnostic::DiagnosticMessage for Error {
             ],
 
             ExpectedFunctionClosure => vec![],
+            ReadOnlyMutation { context } => vec![
+                Label::primary(format!(r#"mutation of read-only value"#), Span::default()),
+                Label::context(context, Span::default()),
+            ],
         }
     }
 

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -133,7 +133,7 @@ impl ExternalEnv {
     }
 
     /// Adds a path that is considered read only. Assignments to any paths that match
-    /// will fail at compile time
+    /// will fail at compile time.
     ///
     /// # Panics
     ///

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -181,6 +181,14 @@ impl ExternalEnv {
         self.custom.insert::<T>(data);
     }
 
+    /// Marks everything as read only. Any mutations on read-only values will result in a
+    /// compile time error.
+    pub fn read_only(mut self) -> Self {
+        self.add_read_only_event_path(LookupBuf::root(), true);
+        self.add_read_only_metadata_path(LookupBuf::root(), true);
+        self
+    }
+
     /// Get external context data from the external environment.
     pub fn get_external_context<T: 'static>(&self) -> Option<&T> {
         self.custom.get::<T>()

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -1,6 +1,7 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use anymap::AnyMap;
+use lookup::LookupBuf;
 use value::{Kind, Value};
 
 use crate::value::Collection;
@@ -61,8 +62,24 @@ pub struct ExternalEnv {
     /// The external target of the program.
     target: Details,
 
+    read_only_paths: Vec<ReadOnlyPath>,
+
     /// Custom context injected by the external environment
     custom: AnyMap,
+}
+
+// temporary until paths can point to metadata
+#[derive(Debug, PartialEq)]
+pub enum PathRoot {
+    Event,
+    Metadata,
+}
+
+#[derive(Debug)]
+pub struct ReadOnlyPath {
+    path: LookupBuf,
+    recursive: bool,
+    root: PathRoot,
 }
 
 impl Default for ExternalEnv {
@@ -81,7 +98,65 @@ impl ExternalEnv {
                 value: None,
             },
             custom: AnyMap::new(),
+            read_only_paths: vec![],
         }
+    }
+
+    pub fn is_read_only_event_path(&self, path: &LookupBuf) -> bool {
+        self.is_read_only_path(path, PathRoot::Event)
+    }
+
+    pub fn is_read_only_metadata_path(&self, path: &LookupBuf) -> bool {
+        self.is_read_only_path(path, PathRoot::Metadata)
+    }
+
+    pub(crate) fn is_read_only_path(&self, path: &LookupBuf, root: PathRoot) -> bool {
+        for read_only_path in &self.read_only_paths {
+            if read_only_path.root != root {
+                continue;
+            }
+
+            // any paths that are a parent of read-only paths also can't be modified
+            if read_only_path.path.starts_with(path) {
+                return true;
+            }
+
+            if read_only_path.recursive {
+                if path.starts_with(&read_only_path.path) {
+                    return true;
+                }
+            } else {
+                if path == &read_only_path.path {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Adds a path that is considered read only. Assignments to any paths that match
+    /// will fail at compile time
+    ///
+    /// # Panics
+    ///
+    /// Panics if the path contains coalescing.
+    pub(crate) fn add_read_only_path(&mut self, path: LookupBuf, recursive: bool, root: PathRoot) {
+        if path.as_segments().iter().any(|x| x.is_coalesce()) {
+            panic!("Coalesced paths not supported for read-only paths");
+        }
+        self.read_only_paths.push(ReadOnlyPath {
+            path,
+            recursive,
+            root,
+        });
+    }
+
+    pub fn add_read_only_event_path(&mut self, path: LookupBuf, recursive: bool) {
+        self.add_read_only_path(path, recursive, PathRoot::Event);
+    }
+
+    pub fn add_read_only_metadata_path(&mut self, path: LookupBuf, recursive: bool) {
+        self.add_read_only_path(path, recursive, PathRoot::Metadata);
     }
 
     pub(crate) fn target(&self) -> &Details {

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -125,10 +125,8 @@ impl ExternalEnv {
                 if path.starts_with(&read_only_path.path) {
                     return true;
                 }
-            } else {
-                if path == &read_only_path.path {
-                    return true;
-                }
+            } else if path == &read_only_path.path {
+                return true;
             }
         }
         false

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -83,11 +83,18 @@ impl Function for Del {
 
     fn compile(
         &self,
-        _state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        state: (&mut state::LocalEnv, &mut state::ExternalEnv),
         _ctx: &mut FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let query = arguments.required_query("target")?;
+
+        if state.1.is_read_only_event_path(query.path()) {
+            return Err(vrl::function::Error::ReadOnlyMutation {
+                context: format!("{} is read-only, and cannot be deleted", query),
+            }
+            .into());
+        }
 
         Ok(Box::new(DelFn { query }))
     }

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -83,13 +83,13 @@ impl Function for Del {
 
     fn compile(
         &self,
-        state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        (_, external): (&mut state::LocalEnv, &mut state::ExternalEnv),
         _ctx: &mut FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
         let query = arguments.required_query("target")?;
 
-        if state.1.is_read_only_event_path(query.path()) {
+        if external.is_read_only_event_path(query.path()) {
             return Err(vrl::function::Error::ReadOnlyMutation {
                 context: format!("{} is read-only, and cannot be deleted", query),
             }

--- a/lib/vrl/tests/Cargo.toml
+++ b/lib/vrl/tests/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 enrichment = { path = "../../enrichment" }
+lookup = { path = "../../lookup" }
 stdlib = { package = "vrl-stdlib", path = "../stdlib" }
 vector_common = { path = "../../vector-common", default-features = false }
 vrl = { path = "../vrl" }

--- a/lib/vrl/tests/src/docs.rs
+++ b/lib/vrl/tests/src/docs.rs
@@ -193,6 +193,8 @@ impl Test {
             result,
             result_approx: false,
             skip,
+            read_only_paths: vec![],
+            read_only_metadata_paths: vec![],
         }
     }
 }

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -179,11 +179,19 @@ fn main() {
         functions.append(&mut vector_vrl_functions::vrl_functions());
         let test_enrichment = test_enrichment::test_enrichment_table();
 
-        let mut state = vrl::state::ExternalEnv::default();
-        state.set_external_context(test_enrichment.clone());
+        let mut external_env = vrl::state::ExternalEnv::default();
+        external_env.set_external_context(test_enrichment.clone());
+
+        // Set some read-only paths that can be tested
+        for (path, recursive) in &test.read_only_paths {
+            external_env.add_read_only_event_path(path.clone(), *recursive);
+        }
+        for (path, recursive) in &test.read_only_metadata_paths {
+            external_env.add_read_only_metadata_path(path.clone(), *recursive);
+        }
 
         let compile_start = Instant::now();
-        let program = vrl::compile_with_state(&test.source, &functions, &mut state);
+        let program = vrl::compile_with_state(&test.source, &functions, &mut external_env);
         let compile_end = compile_start.elapsed();
 
         let want = test.result.clone();

--- a/lib/vrl/tests/src/test.rs
+++ b/lib/vrl/tests/src/test.rs
@@ -1,6 +1,8 @@
+use std::str::FromStr;
 use std::{collections::BTreeMap, fs, path::Path};
 
 use ::value::Value;
+use lookup::LookupBuf;
 use vrl::function::Example;
 
 #[derive(Debug)]
@@ -13,6 +15,10 @@ pub struct Test {
     pub result: String,
     pub result_approx: bool,
     pub skip: bool,
+
+    // paths set to read-only. (can be merged once paths support metadata)
+    pub read_only_paths: Vec<(LookupBuf, bool)>,
+    pub read_only_metadata_paths: Vec<(LookupBuf, bool)>,
 }
 
 enum CaptureMode {
@@ -38,6 +44,9 @@ impl Test {
             skip = true;
         }
 
+        let mut read_only_paths = vec![];
+        let mut read_only_metadata_paths = vec![];
+
         let mut capture_mode = CaptureMode::None;
         for mut line in content.lines() {
             if line.starts_with('#') && !matches!(capture_mode, CaptureMode::Done) {
@@ -54,6 +63,30 @@ impl Test {
                 } else if line.starts_with("result:") {
                     capture_mode = CaptureMode::Result;
                     line = line.strip_prefix("result:").expect("result").trim_start();
+                } else if line.starts_with("read_only:") {
+                    let path_str = line.strip_prefix("read_only:").expect("read-only");
+                    read_only_paths.push((FromStr::from_str(path_str).expect("valid path"), false));
+                    continue;
+                } else if line.starts_with("read_only_recursive:") {
+                    let path_str = line
+                        .strip_prefix("read_only_recursive:")
+                        .expect("read-only");
+                    read_only_paths.push((FromStr::from_str(path_str).expect("valid path"), true));
+                    continue;
+                } else if line.starts_with("read_only_metadata:") {
+                    let path_str = line
+                        .strip_prefix("read_only_metadata:")
+                        .expect("read_only_metadata");
+                    read_only_metadata_paths
+                        .push((FromStr::from_str(path_str).expect("valid path"), false));
+                    continue;
+                } else if line.starts_with("read_only_metadata_recursive:") {
+                    let path_str = line
+                        .strip_prefix("read_only_metadata_recursive:")
+                        .expect("read-read_only_metadata_recursive");
+                    read_only_metadata_paths
+                        .push((FromStr::from_str(path_str).expect("valid path"), true));
+                    continue;
                 }
 
                 match capture_mode {
@@ -98,6 +131,8 @@ impl Test {
             result,
             result_approx,
             skip,
+            read_only_paths,
+            read_only_metadata_paths,
         }
     }
 
@@ -117,6 +152,8 @@ impl Test {
             result,
             result_approx: false,
             skip: false,
+            read_only_paths: vec![],
+            read_only_metadata_paths: vec![],
         }
     }
 }

--- a/lib/vrl/tests/tests/expressions/assignment/read_only.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/read_only.vrl
@@ -1,0 +1,11 @@
+# read_only: .read_only
+# result:
+# error[E315]: mutation of read-only value
+#   ┌─ :2:1
+#   │
+# 2 │ .read_only = 5
+#   │ ^^^^^^^^^^^^ mutation of read-only value
+#   │
+#   = see language documentation at https://vrl.dev
+
+.read_only = 5

--- a/lib/vrl/tests/tests/expressions/assignment/read_only_nested.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/read_only_nested.vrl
@@ -1,0 +1,5 @@
+# read_only: .read_only
+# result: {"read_only": {"nested": 5}}
+
+.read_only.nested = 5
+.

--- a/lib/vrl/tests/tests/expressions/assignment/read_only_nested_recursive.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/read_only_nested_recursive.vrl
@@ -1,0 +1,12 @@
+# read_only_recursive: .read_only
+# result:
+# error[E315]: mutation of read-only value
+#   ┌─ :2:1
+#   │
+# 2 │ .read_only.nested = 5
+#   │ ^^^^^^^^^^^^^^^^^^^ mutation of read-only value
+#   │
+#   = see language documentation at https://vrl.dev
+
+.read_only.nested = 5
+.

--- a/lib/vrl/tests/tests/expressions/assignment/read_only_recursive.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/read_only_recursive.vrl
@@ -1,0 +1,11 @@
+# read_only_recursive: .read_only
+# result:
+# error[E315]: mutation of read-only value
+#   ┌─ :2:1
+#   │
+# 2 │ .read_only = 5
+#   │ ^^^^^^^^^^^^ mutation of read-only value
+#   │
+#   = see language documentation at https://vrl.dev
+
+.read_only = 5

--- a/lib/vrl/tests/tests/expressions/assignment/read_only_root.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/read_only_root.vrl
@@ -1,0 +1,11 @@
+# read_only: .read_only
+# result:
+# error[E315]: mutation of read-only value
+#   ┌─ :2:1
+#   │
+# 2 │ . = 5
+#   │ ^^^ mutation of read-only value
+#   │
+#   = see language documentation at https://vrl.dev
+
+. = 5

--- a/lib/vrl/tests/tests/expressions/assignment/read_only_root_recursive.vrl
+++ b/lib/vrl/tests/tests/expressions/assignment/read_only_root_recursive.vrl
@@ -1,0 +1,11 @@
+# read_only_recursive: .read_only
+# result:
+# error[E315]: mutation of read-only value
+#   ┌─ :2:1
+#   │
+# 2 │ . = 5
+#   │ ^^^ mutation of read-only value
+#   │
+#   = see language documentation at https://vrl.dev
+
+. = 5

--- a/lib/vrl/tests/tests/functions/remove_metadata_read_only.vrl
+++ b/lib/vrl/tests/tests/functions/remove_metadata_read_only.vrl
@@ -1,0 +1,15 @@
+# read_only_metadata: read_only
+# result:
+# error[E610]: function compilation error: error[E315] mutation of read-only value
+#   ┌─ :2:1
+#   │
+# 2 │ remove_metadata_field(.read_only)
+#   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#   │ │
+#   │ mutation of read-only value
+#   │ .read_only is read-only, and cannot be removed
+#   │
+#   = learn more about error code 315 at https://errors.vrl.dev/315
+#   = see language documentation at https://vrl.dev
+
+remove_metadata_field(.read_only)

--- a/lib/vrl/tests/tests/functions/set_metadata_read_only.vrl
+++ b/lib/vrl/tests/tests/functions/set_metadata_read_only.vrl
@@ -1,0 +1,15 @@
+# read_only_metadata: read_only
+# result:
+# error[E610]: function compilation error: error[E315] mutation of read-only value
+#   ┌─ :2:1
+#   │
+# 2 │ set_metadata_field(.read_only, 5)
+#   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#   │ │
+#   │ mutation of read-only value
+#   │ .read_only is read-only, and cannot be modified
+#   │
+#   = learn more about error code 315 at https://errors.vrl.dev/315
+#   = see language documentation at https://vrl.dev
+
+set_metadata_field(.read_only, 5)

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -658,9 +658,9 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("neither");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ message.equals: \"foo\", other_thing.eq: \"bar\", third_thing.eq: [\"hello\", \"world\"] ]"
                     .to_owned()
@@ -668,25 +668,25 @@ mod test {
         );
 
         event.as_mut_log().insert("message", "foo");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ other_thing.eq: \"bar\", third_thing.eq: [\"hello\", \"world\"] ]".to_owned())
         );
 
         event.as_mut_log().insert("other_thing", "bar");
         event.as_mut_log().insert("third_thing", "hello");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("third_thing", "world");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("message", "not foo");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ message.equals: \"foo\" ]".to_owned())
         );
     }
@@ -712,9 +712,9 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("neither");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ message.contains: \"foo\", other_thing.contains: \"bar\", third_thing.contains: [\"hello\", \"world\"] ]"
                     .to_owned()
@@ -723,33 +723,33 @@ mod test {
 
         event.as_mut_log().insert("message", "hello foo world");
         event.as_mut_log().insert("third_thing", "hello world");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ other_thing.contains: \"bar\" ]".to_owned())
         );
 
         event.as_mut_log().insert("other_thing", "hello bar world");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event
             .as_mut_log()
             .insert("third_thing", "not hell0 or w0rld");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ third_thing.contains: [\"hello\", \"world\"] ]".to_owned()),
         );
 
         event.as_mut_log().insert("third_thing", "world");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("message", "not fo0");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ message.contains: \"foo\" ]".to_owned())
         );
     }
@@ -771,9 +771,9 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("neither");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ message.prefix: \"foo\", other_thing.prefix: \"bar\" ]"
                     .to_owned()
@@ -781,20 +781,20 @@ mod test {
         );
 
         event.as_mut_log().insert("message", "foo hello world");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ other_thing.prefix: \"bar\" ]".to_owned())
         );
 
         event.as_mut_log().insert("other_thing", "bar hello world");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("message", "not prefixed");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ message.prefix: \"foo\" ]".to_owned())
         );
     }
@@ -820,9 +820,9 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("neither");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ message.starts_with: \"foo\", other_thing.starts_with: \"bar\", third_thing.starts_with: [\"hello\", \"world\"] ]"
                     .to_owned()
@@ -831,35 +831,35 @@ mod test {
 
         event.as_mut_log().insert("third_thing", "hello world");
         event.as_mut_log().insert("message", "foo hello world");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ other_thing.starts_with: \"bar\" ]".to_owned())
         );
 
         event.as_mut_log().insert("other_thing", "bar hello world");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event
             .as_mut_log()
             .insert("third_thing", "wrong hello world");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ third_thing.starts_with: [\"hello\", \"world\"] ]".to_owned()
             ),
         );
 
         event.as_mut_log().insert("third_thing", "world");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("message", "not prefixed");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ message.starts_with: \"foo\" ]".to_owned())
         );
     }
@@ -885,9 +885,9 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("neither");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ message.ends_with: \"foo\", other_thing.ends_with: \"bar\", third_thing.ends_with: [\"hello\", \"world\"] ]"
                     .to_owned()
@@ -896,31 +896,31 @@ mod test {
 
         event.as_mut_log().insert("message", "hello world foo");
         event.as_mut_log().insert("third_thing", "hello world");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ other_thing.ends_with: \"bar\" ]".to_owned())
         );
 
         event.as_mut_log().insert("other_thing", "hello world bar");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("third_thing", "hello world bad");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ third_thing.ends_with: [\"hello\", \"world\"] ]".to_owned()),
         );
 
         event.as_mut_log().insert("third_thing", "world hello");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("message", "not suffixed");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ message.ends_with: \"foo\" ]".to_owned())
         );
     }
@@ -946,9 +946,9 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("not foo");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ other_thing.neq: \"bar\", third_thing.neq: [\"hello\", \"world\"] ]".to_owned())
         );
 
@@ -956,35 +956,35 @@ mod test {
         event
             .as_mut_log()
             .insert("third_thing", "not hello or world");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("third_thing", "world");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ third_thing.neq: [\"hello\", \"world\"] ]".to_owned()),
         );
 
         event.as_mut_log().insert("third_thing", "hello");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ third_thing.neq: [\"hello\", \"world\"] ]".to_owned()),
         );
 
         event.as_mut_log().insert("third_thing", "safe");
         event.as_mut_log().insert("other_thing", "bar");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ other_thing.neq: \"bar\" ]".to_owned())
         );
 
         event.as_mut_log().insert("message", "foo");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ message.not_equals: \"foo\", other_thing.neq: \"bar\" ]"
                     .to_owned()
@@ -1009,27 +1009,27 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("starts with a bang");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(r#"predicates failed: [ other_thing.regex: "end$" ]"#.to_owned())
         );
 
         event.as_mut_log().insert("other_thing", "at the end");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("other_thing", "end up here");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(r#"predicates failed: [ other_thing.regex: "end$" ]"#.to_owned())
         );
 
         event.as_mut_log().insert("message", "foo");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 r#"predicates failed: [ message.regex: "^start", other_thing.regex: "end$" ]"#
                     .to_owned()
@@ -1054,16 +1054,16 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("ignored message");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ foo.ip_cidr_contains: \"10.0.0.0/8\", bar.ip_cidr_contains: [\"2000::/3\", \"192.168.0.0/16\"] ]".to_owned()),
         );
 
         event.as_mut_log().insert("foo", "10.1.2.3");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err(
                 "predicates failed: [ bar.ip_cidr_contains: [\"2000::/3\", \"192.168.0.0/16\"] ]"
                     .to_owned()
@@ -1071,24 +1071,24 @@ mod test {
         );
 
         event.as_mut_log().insert("bar", "2000::");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("bar", "192.168.255.255");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("foo", "192.200.200.200");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ foo.ip_cidr_contains: \"10.0.0.0/8\" ]".to_owned()),
         );
 
         event.as_mut_log().insert("foo", "not an ip");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ foo.ip_cidr_contains: \"10.0.0.0/8\" ]".to_owned()),
         );
     }
@@ -1104,20 +1104,20 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("ignored field");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ foo.exists: true ]".to_owned())
         );
 
         event.as_mut_log().insert("foo", "not ignored");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("bar", "also not ignored");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ bar.exists: false ]".to_owned())
         );
     }
@@ -1133,22 +1133,22 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ foo.length_eq: 10, bar.length_eq: 4 ]".to_owned())
         );
 
         event.as_mut_log().insert("foo", "helloworld");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ bar.length_eq: 4 ]".to_owned())
         );
 
         event.as_mut_log().insert("bar", vec![0, 1, 2, 3]);
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
     }
 
     #[test]
@@ -1163,13 +1163,13 @@ mod test {
             .unwrap();
 
         let mut event = Event::from("ignored field");
-        assert!(cond.check(&event));
-        assert_eq!(cond.check_with_context(&event), Ok(()));
+        assert!(cond.check(event.clone()).0);
+        assert_eq!(cond.check_with_context(event.clone()).0, Ok(()));
 
         event.as_mut_log().insert("foo", "not ignored");
-        assert!(!cond.check(&event));
+        assert!(!cond.check(event.clone()).0);
         assert_eq!(
-            cond.check_with_context(&event),
+            cond.check_with_context(event.clone()).0,
             Err("predicates failed: [ foo.not_exists: true ]".into())
         );
     }

--- a/src/conditions/check_fields.rs
+++ b/src/conditions/check_fields.rs
@@ -555,24 +555,28 @@ pub struct CheckFields {
 }
 
 impl Conditional for CheckFields {
-    fn check(&self, e: &Event) -> bool {
-        self.predicates.iter().all(|(_, p)| p.check(e))
+    fn check(&self, e: Event) -> (bool, Event) {
+        let result = self.predicates.iter().all(|(_, p)| p.check(&e));
+        (result, e)
     }
 
-    fn check_with_context(&self, e: &Event) -> Result<(), String> {
+    fn check_with_context(&self, e: Event) -> (Result<(), String>, Event) {
         let failed_preds = self
             .predicates
             .iter()
-            .filter(|(_, p)| !p.check(e))
+            .filter(|(_, p)| !p.check(&e))
             .map(|(n, _)| n.to_owned())
             .collect::<Vec<_>>();
         if failed_preds.is_empty() {
-            Ok(())
+            (Ok(()), e)
         } else {
-            Err(format!(
-                "predicates failed: [ {} ]",
-                failed_preds.join(", ")
-            ))
+            (
+                Err(format!(
+                    "predicates failed: [ {} ]",
+                    failed_preds.join(", ")
+                )),
+                e,
+            )
         }
     }
 }

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -32,8 +32,9 @@ pub struct DatadogSearchRunner {
 }
 
 impl Conditional for DatadogSearchRunner {
-    fn check(&self, e: &Event) -> bool {
-        self.matcher.run(e)
+    fn check(&self, e: Event) -> (bool, Event) {
+        let result = self.matcher.run(&e);
+        (result, e)
     }
 }
 

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -1066,14 +1066,14 @@ mod test {
                 .unwrap_or_else(|_| panic!("build failed: {}", source));
 
             assert!(
-                cond.check_with_context(&pass).is_ok(),
+                cond.check_with_context(pass.clone()).0.is_ok(),
                 "should pass: {}\nevent: {:?}",
                 source,
                 pass.as_log()
             );
 
             assert!(
-                cond.check_with_context(&fail).is_err(),
+                cond.check_with_context(fail.clone()).0.is_err(),
                 "should fail: {}\nevent: {:?}",
                 source,
                 fail.as_log()

--- a/src/conditions/is_log.rs
+++ b/src/conditions/is_log.rs
@@ -62,11 +62,15 @@ mod test {
     fn is_log_basic() {
         let cond = IsLogConfig {}.build(&Default::default()).unwrap();
 
-        assert!(cond.check(&Event::from("just a log")));
-        assert!(!cond.check(&Event::from(Metric::new(
-            "test metric",
-            MetricKind::Incremental,
-            MetricValue::Counter { value: 1.0 },
-        ))),);
+        assert!(cond.check(Event::from("just a log")).0);
+        assert!(
+            !cond
+                .check(Event::from(Metric::new(
+                    "test metric",
+                    MetricKind::Incremental,
+                    MetricValue::Counter { value: 1.0 },
+                )))
+                .0,
+        );
     }
 }

--- a/src/conditions/is_log.rs
+++ b/src/conditions/is_log.rs
@@ -29,15 +29,16 @@ impl ConditionConfig for IsLogConfig {
 pub struct IsLog {}
 
 impl Conditional for IsLog {
-    fn check(&self, e: &Event) -> bool {
-        matches!(e, Event::Log(_))
+    fn check(&self, e: Event) -> (bool, Event) {
+        (matches!(e, Event::Log(_)), e)
     }
 
-    fn check_with_context(&self, e: &Event) -> Result<(), String> {
-        if self.check(e) {
-            Ok(())
+    fn check_with_context(&self, e: Event) -> (Result<(), String>, Event) {
+        let (result, event) = self.check(e);
+        if result {
+            (Ok(()), event)
         } else {
-            Err("event is not a log type".to_string())
+            (Err("event is not a log type".to_string()), event)
         }
     }
 }

--- a/src/conditions/is_metric.rs
+++ b/src/conditions/is_metric.rs
@@ -62,11 +62,14 @@ mod test {
     fn is_metric_basic() {
         let cond = IsMetricConfig {}.build(&Default::default()).unwrap();
 
-        assert!(!cond.check(&Event::from("just a log")));
-        assert!(cond.check(&Event::from(Metric::new(
-            "test metric",
-            MetricKind::Incremental,
-            MetricValue::Counter { value: 1.0 },
-        ))),);
+        assert!(!cond.check(Event::from("just a log")).0);
+        assert!(
+            cond.check(Event::from(Metric::new(
+                "test metric",
+                MetricKind::Incremental,
+                MetricValue::Counter { value: 1.0 },
+            )))
+            .0,
+        );
     }
 }

--- a/src/conditions/is_metric.rs
+++ b/src/conditions/is_metric.rs
@@ -29,15 +29,16 @@ impl ConditionConfig for IsMetricConfig {
 pub struct IsMetric {}
 
 impl Conditional for IsMetric {
-    fn check(&self, e: &Event) -> bool {
-        matches!(e, Event::Metric(_))
+    fn check(&self, e: Event) -> (bool, Event) {
+        (matches!(e, Event::Metric(_)), e)
     }
 
-    fn check_with_context(&self, e: &Event) -> Result<(), String> {
-        if self.check(e) {
-            Ok(())
+    fn check_with_context(&self, e: Event) -> (Result<(), String>, Event) {
+        let (result, event) = self.check(e);
+        if result {
+            (Ok(()), event)
         } else {
-            Err("event is not a metric type".to_string())
+            (Err("event is not a metric type".to_string()), event)
         }
     }
 }

--- a/src/conditions/not.rs
+++ b/src/conditions/not.rs
@@ -25,14 +25,16 @@ impl ConditionConfig for NotConfig {
 pub struct Not(Box<Condition>);
 
 impl Conditional for Not {
-    fn check(&self, e: &Event) -> bool {
-        !self.0.check(e)
+    fn check(&self, e: Event) -> (bool, Event) {
+        let (result, event) = self.0.check(e);
+        (!result, event)
     }
 
-    fn check_with_context(&self, e: &Event) -> Result<(), String> {
-        match self.0.check_with_context(e) {
-            Ok(()) => Err("event matches inner condition".to_string()),
-            Err(_) => Ok(()),
+    fn check_with_context(&self, e: Event) -> (Result<(), String>, Event) {
+        let (result, event) = self.0.check_with_context(e);
+        match result {
+            Ok(()) => (Err("event matches inner condition".to_string()), event),
+            Err(_) => (Ok(()), event),
         }
     }
 }

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -247,7 +247,7 @@ mod test {
 
             if let Ok(cond) = config.build(&Default::default()) {
                 assert_eq!(
-                    cond.check_with_context(&event),
+                    cond.check_with_context(event.clone()).0,
                     check.map_err(|e| e.to_string())
                 );
             }

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -38,19 +38,13 @@ impl ConditionConfig for VrlConfig {
         //     },
         // };
 
-        // Filter out functions that directly mutate the event.
-        //
-        // TODO(jean): expose this as a method on the `Function` trait, so we
-        // don't need to do this manually.
         let functions = vrl_stdlib::all()
             .into_iter()
-            .filter(|f| f.identifier() != "del")
-            .filter(|f| f.identifier() != "only_fields")
             .chain(enrichment::vrl_functions().into_iter())
             .chain(vector_vrl_functions::vrl_functions())
             .collect::<Vec<_>>();
 
-        let mut state = vrl::state::ExternalEnv::default();
+        let mut state = vrl::state::ExternalEnv::default().read_only();
         state.set_external_context(enrichment_tables.clone());
 
         let (program, warnings) = vrl::compile_with_state(&self.source, &functions, &mut state)

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -151,7 +151,7 @@ impl StreamSink<Event> for UnitTestSink {
                         for (j, condition) in check.iter().enumerate() {
                             let mut condition_errors = Vec::new();
                             for event in output_events.iter() {
-                                match condition.check_with_context(event) {
+                                match condition.check_with_context(event.clone()).0 {
                                     Ok(_) => {
                                         condition_errors.clear();
                                         break;

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -89,7 +89,8 @@ impl Filter {
 
 impl FunctionTransform for Filter {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
-        if self.condition.check(&event) {
+        let (result, event) = self.condition.check(event);
+        if result {
             output.push(event);
         } else if self.last_emission.elapsed() >= self.emissions_max_delay {
             emit!(FilterEventDiscarded {

--- a/src/transforms/pipelines/config.rs
+++ b/src/transforms/pipelines/config.rs
@@ -200,7 +200,8 @@ impl SyncTransform for Pipeline {
         let ev_container = events.into_events();
         if let Some(condition) = &self.condition {
             for event in ev_container {
-                if condition.check(&event) {
+                let (result, event) = condition.check(event);
+                if result {
                     self.buf_out.push(event);
                 } else {
                     output.push(event);

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -237,16 +237,15 @@ impl Reduce {
     }
 
     fn transform_one(&mut self, output: &mut Vec<Event>, event: Event) {
-        let starts_here = self
-            .starts_when
-            .as_ref()
-            .map(|c| c.check(&event))
-            .unwrap_or(false);
-        let ends_here = self
-            .ends_when
-            .as_ref()
-            .map(|c| c.check(&event))
-            .unwrap_or(false);
+        let (starts_here, event) = match &self.starts_when {
+            Some(condition) => condition.check(event),
+            None => (false, event),
+        };
+
+        let (ends_here, event) = match &self.ends_when {
+            Some(condition) => condition.check(event),
+            None => (false, event),
+        };
 
         let event = event.into_log();
         let discriminant = Discriminant::from_log_event(&event, &self.group_by);

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -41,8 +41,9 @@ impl SyncTransform for Route {
     ) {
         let mut check_failed: usize = 0;
         for (output_name, condition) in &self.conditions {
-            if condition.check(&event) {
-                output.push_named(output_name, event.clone());
+            let (result, event) = condition.check(event.clone());
+            if result {
+                output.push_named(output_name, event);
             } else {
                 check_failed += 1;
             }

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -110,13 +110,20 @@ impl Sample {
 }
 
 impl FunctionTransform for Sample {
-    fn transform(&mut self, output: &mut OutputBuffer, mut event: Event) {
-        if let Some(condition) = self.exclude.as_ref() {
-            if condition.check(&event) {
-                output.push(event);
-                return;
+    fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
+        let mut event = {
+            if let Some(condition) = self.exclude.as_ref() {
+                let (result, event) = condition.check(event);
+                if result {
+                    output.push(event);
+                    return;
+                } else {
+                    event
+                }
+            } else {
+                event
             }
-        }
+        };
 
         let value = self
             .key_field

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -128,9 +128,14 @@ where
                         match maybe_event {
                             None => true,
                             Some(event) => {
-                                match self.exclude.as_ref() {
-                                  Some(condition) if condition.check(&event) => output.push(event),
-                                  _ => {
+                                let (throttle, event) = match self.exclude.as_ref() {
+                                        Some(condition) => {
+                                            let (result, event) = condition.check(event);
+                                            (!result, event)
+                                        },
+                                        _ => (true, event)
+                                    };
+                                    if throttle {
                                         let key = self.key_field.as_ref().and_then(|t| {
                                             t.render_string(&event)
                                                 .map_err(|error| {
@@ -155,8 +160,9 @@ where
                                                 }
                                             }
                                         }
+                                    } else {
+                                        output.push(event)
                                     }
-                                }
                                 false
                             }
                         }

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -15,6 +15,7 @@ Vector's 0.23.0 release includes **breaking changes**:
 2. [VRL type definition updates](#vrl-type-def)
 3. ["remove_empty" option dropped from VRL's `parse_grok` and `parse_groks`](#vrl-parse_grok)
 4. [`gcp_pubsub` sink requires setting "encoding" option](#sinks-mandatory-encoding)
+5. [VRL conditions are now checked for mutations at compile time](#read_only_check)
 
 We cover them below to help you upgrade quickly:
 
@@ -77,3 +78,32 @@ encoding.codec = "json"
 ```
 
 to the config of your `gcp_pubsub` sink.
+
+#### [VRL conditions are now checked for mutations at compile time] {#read_only_check}
+
+VRL conditions, for example those used in the `filter` transform, are not supposed to mutate the event. Previously
+the mutations would be silently ignored after a condition ran. Now the compiler has support for read-only values, and
+will give a compile-time error if you try to mutate the event in a condition.
+
+Example filter transform config
+```toml
+[transforms.filter]
+type = "filter"
+inputs = [ "input" ]
+condition.type = "vrl"
+condition.source = """
+.foo = "bar"
+true
+"""
+```
+
+New error
+```
+error[E315]: mutation of read-only value
+  ┌─ :1:1
+  │
+1 │ .foo = "bar"
+  │ ^^^^^^ mutation of read-only value
+  │
+  = see language documentation at https://vrl.dev
+```

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -86,6 +86,7 @@ the mutations would be silently ignored after a condition ran. Now the compiler 
 will give a compile-time error if you try to mutate the event in a condition.
 
 Example filter transform config
+
 ```toml
 [transforms.filter]
 type = "filter"
@@ -98,7 +99,8 @@ true
 ```
 
 New error
-```
+
+```text
 error[E315]: mutation of read-only value
   ┌─ :1:1
   │

--- a/website/cue/reference/remap/errors/315_read_only_mutation_error.cue
+++ b/website/cue/reference/remap/errors/315_read_only_mutation_error.cue
@@ -1,0 +1,6 @@
+package metadata
+
+remap: errors: "315": {
+	title:       "mutation of read-only value"
+	description: "This value is read-only and cannot be deleted or mutated."
+}


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/4744
adds ~90% of the changes needed for: https://github.com/vectordotdev/vector/issues/12731

changes:
- add VRL error code 315: "mutation of read-only value"
- add list of read-only paths to `ExternalEnv`. Paths are optionally recursive. There is a list for both the event, and metadata.
- check for read-only fields in `set_metadata_field` VRL function
- check for read-only fields in `remove_metadata_field` VRL function
- check for read-only fields in `del` VRL function
- check for read-only fields in assignment expressions
- add support for read-only paths to VRL tests, and add tests
- VRL conditions are now compiled as read-only, allowing the removal of an `Event` clone
- fix the `Look::starts_with` implementation for `LookupBuf`

## Example

config
```
[transforms.filter]
type = "filter"
inputs = [ "input" ]
condition.type = "vrl"
condition.source = """
. = "foo"
true
"""
```

error
```
error[E315]: mutation of read-only value
  ┌─ :1:1
  │
1 │ . = "foo"
  │ ^^^ mutation of read-only value
  │
  = see language documentation at https://vrl.dev
```