### PR TITLE
chore(buffers): max default max record size to align with default max data file size

### DIFF
--- a/lib/vector-buffers/src/variants/disk_v2/common.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/common.rs
@@ -18,7 +18,11 @@ pub const DEFAULT_MAX_DATA_FILE_SIZE: usize = 128 * 1024 * 1024;
 // _exceed_ the size of a data file, even if they're the first write to a data file.
 pub const DEFAULT_MAX_RECORD_SIZE: usize = DEFAULT_MAX_DATA_FILE_SIZE;
 
-// We want to ensure a reasonably time fsync/flush to disk, which 500ms should provide for normal workloads.
+// We want to ensure a reasonable time before we `fsync`/flush to disk, and 500ms should provide that for non-critical
+// workloads.
+//
+// Practically, it's far more definitive than `disk_v1` which does not definitvely `fsync` at all, at least with how we
+// have it configured.
 pub const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
 
 // Using 256KB as it aligns nicely with the I/O size exposed by major cloud providers.  This may not

--- a/lib/vector-buffers/src/variants/disk_v2/common.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/common.rs
@@ -283,9 +283,9 @@ where
             });
         }
 
-        // In practice, we calculate our current buffer size based on the number of unacknowledged records. However, we
-        // only delete data files once they've been entirely acknowledged. This means that we may report a current
-        // buffer size that is smaller than the sum of the size of the data files currently on disk.
+        // We calculate our current buffer size based on the number of unacknowledged records. However, we only delete
+        // data files once they've been entirely acknowledged. This means that we may report a current buffer size that
+        // is smaller than the sum of the size of the data files currently on disk.
         //
         // We do this because if we used the true on-disk total buffer size, we might stall further writes until an
         // entire data file was deleted, even if we had fully acknowledged all but the last record in a data file, etc.

--- a/lib/vector-buffers/src/variants/disk_v2/common.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/common.rs
@@ -10,9 +10,17 @@ use snafu::Snafu;
 use super::io::{Filesystem, ProductionFilesystem};
 
 // We don't want data files to be bigger than 128MB, but we might end up overshooting slightly.
-pub const DEFAULT_MAX_DATA_FILE_SIZE: u64 = 128 * 1024 * 1024;
-// There's no particular reason that _has_ to be 8MB, it's just a simple default we've chosen here.
-pub const DEFAULT_MAX_RECORD_SIZE: usize = 8 * 1024 * 1024;
+pub const DEFAULT_MAX_DATA_FILE_SIZE: usize = 128 * 1024 * 1024;
+
+// We allow records to be as large as a data file.
+//
+// Practically, this means we'll allow records that are just about as big as as a single data file, but they won't
+// _exceed_ the size of a data file, even if they're the first write to a data file.
+pub const DEFAULT_MAX_RECORD_SIZE: usize = DEFAULT_MAX_DATA_FILE_SIZE;
+
+// We want to ensure a reasonably time fsync/flush to disk, which 500ms should provide for normal workloads.
+pub const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
+
 // Using 256KB as it aligns nicely with the I/O size exposed by major cloud providers.  This may not
 // be the underlying block size used by the OS, but it still aligns well with what will happen on
 // the "backend" for cloud providers, which is simply a useful default for when we want to look at
@@ -36,7 +44,7 @@ pub enum BuildError {
     #[snafu(display("parameter '{}' was invalid: {}", param_name, reason))]
     InvalidParameter {
         param_name: &'static str,
-        reason: &'static str,
+        reason: String,
     },
 }
 
@@ -143,7 +151,7 @@ where
     /// amount, as we must account for one full data file's worth of extra data.
     ///
     /// Defaults to `usize::MAX`, or effectively no limit.  Due to the internal design of the
-    /// buffer, the effective maximum limit is around `max_data_file_size + max_record_size` * 2^16.
+    /// buffer, the effective maximum limit is around `max_data_file_size` * 2^16.
     #[allow(dead_code)]
     pub fn max_buffer_size(mut self, amount: u64) -> Self {
         self.max_buffer_size = Some(amount);
@@ -169,7 +177,7 @@ where
     /// Any record which, when encoded, is larger than this amount (with a small caveat, see note)
     /// will not be written to the buffer.
     ///
-    /// Defaults to 8MB.
+    /// Defaults to 128MB.
     #[allow(dead_code)]
     pub fn max_record_size(mut self, amount: usize) -> Self {
         self.max_record_size = Some(amount);
@@ -230,53 +238,62 @@ where
     /// Consumes this builder and constructs a `DiskBufferConfig`.
     pub fn build(self) -> Result<DiskBufferConfig<FS>, BuildError> {
         let max_buffer_size = self.max_buffer_size.unwrap_or(u64::MAX);
-        let max_data_file_size = self
-            .max_data_file_size
-            .unwrap_or(DEFAULT_MAX_DATA_FILE_SIZE);
+        let max_data_file_size = self.max_data_file_size.unwrap_or_else(|| {
+            u64::try_from(DEFAULT_MAX_DATA_FILE_SIZE)
+                .expect("Vector does not support 128-bit platforms.")
+        });
         let max_record_size = self.max_record_size.unwrap_or(DEFAULT_MAX_RECORD_SIZE);
         let write_buffer_size = self.write_buffer_size.unwrap_or(DEFAULT_WRITE_BUFFER_SIZE);
-        let flush_interval = self
-            .flush_interval
-            .unwrap_or_else(|| Duration::from_millis(500));
+        let flush_interval = self.flush_interval.unwrap_or(DEFAULT_FLUSH_INTERVAL);
         let filesystem = self.filesystem;
 
         // Validate the input parameters.
-        if max_buffer_size == 0 {
-            return Err(BuildError::InvalidParameter {
-                param_name: "max_buffer_size",
-                reason: "cannot be zero",
-            });
-        }
-
         if max_data_file_size == 0 {
             return Err(BuildError::InvalidParameter {
                 param_name: "max_data_file_size",
-                reason: "cannot be zero",
+                reason: "cannot be zero".to_string(),
+            });
+        }
+
+        if max_buffer_size < max_data_file_size {
+            return Err(BuildError::InvalidParameter {
+                param_name: "max_buffer_size",
+                reason: format!(
+                    "must be greater than or equal to {} bytes",
+                    max_data_file_size
+                ),
             });
         }
 
         if max_record_size == 0 {
             return Err(BuildError::InvalidParameter {
                 param_name: "max_record_size",
-                reason: "cannot be zero",
+                reason: "cannot be zero".to_string(),
             });
         }
 
         if write_buffer_size == 0 {
             return Err(BuildError::InvalidParameter {
                 param_name: "write_buffer_size",
-                reason: "cannot be zero",
+                reason: "cannot be zero".to_string(),
             });
         }
 
-        // The actual on-disk maximum buffer size will be the user-supplied `max_buffer_size`
-        // rounded up to the next multiple of `DATA_FILE_TARGET_MAX_SIZE`.  Internally, we'll limit
-        // ourselves to `max_buffer_size` rounded _down_ to the next multiple of
-        // `DATA_FILE_TARGET_MAX_SIZE`, so that when we have a full data file hanging around
-        // mid-read, our actual on-disk usage will match what we've told the user to expect.
+        // In practice, we calculate our current buffer size based on the number of unacknowledged records. However, we
+        // only delete data files once they've been entirely acknowledged. This means that we may report a current
+        // buffer size that is smaller than the sum of the size of the data files currently on disk.
         //
-        // We also ensure that `max_buffer_size` is at least as big as `DATA_FILE_TARGET_MAX_SIZE`
-        // which means the overall minimum on-disk buffer size is 256MB (2x 128MB).
+        // We do this because if we used the true on-disk total buffer size, we might stall further writes until an
+        // entire data file was deleted, even if we had fully acknowledged all but the last record in a data file, etc.
+        // We essentially trade off using up to an additional `DEFAULT_MAX_DATA_FILE_SIZE` bytes to allow writers to
+        // make progress as records are read and acknowledged, when the buffer is riding close to the overall buffer
+        // size limit.
+        //
+        // In practical terms, this means the expected true on-disk total buffer size can grow to `max_buffer_size`,
+        // rounded up to the closest multiple of `DEFAULT_MAX_DATA_FILE_SIZE`. On the flipside, though, we limit our
+        // functional max buffer size -- the value we use internally for limiting writes until more records are
+        // acknowledged, etc -- to `max_buffer_size` rounded _down_ to the closest multiple of
+        // `DEFAULT_MAX_DATA_FILE_SIZE`.
         let max_buffer_size = max_buffer_size - (max_buffer_size % max_data_file_size);
         let max_buffer_size = cmp::max(max_buffer_size, max_data_file_size);
 
@@ -289,5 +306,36 @@ where
             flush_interval,
             filesystem,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{prop_assert, prop_assert_eq, proptest};
+
+    use crate::variants::disk_v2::{common::DEFAULT_MAX_DATA_FILE_SIZE, DiskBufferConfigBuilder};
+
+    const MAX_BUFFER_SIZE_TEST_UPPER_BOUND_INPUT: usize = DEFAULT_MAX_DATA_FILE_SIZE * 10;
+
+    proptest! {
+        #[test]
+        fn ensure_max_disk_buffer_size_lower_bound(max_buffer_size in DEFAULT_MAX_DATA_FILE_SIZE..MAX_BUFFER_SIZE_TEST_UPPER_BOUND_INPUT) {
+            // This is a little ugly but the `u64`/`usize` conversions make it annoying to do in a full const way.
+            let default_max_data_file_size = u64::try_from(DEFAULT_MAX_DATA_FILE_SIZE)
+                .expect("`DEFAULT_MAX_DATA_FILE_SIZE` should not ever be greater than `u64::MAX`.");
+            let max_buffer_size = u64::try_from(max_buffer_size)
+                .expect("`max_buffer_size` should not ever be greater than `u64::MAX`.");
+
+            let config = DiskBufferConfigBuilder::from_path("/tmp/dummy/path")
+                .max_buffer_size(max_buffer_size)
+                .build()
+                .expect("errors during the config build are all invalid here");
+
+            // Small sanity check to make sure our logic for enforcing the maximum buffer size doesn't truncate to zero.
+            prop_assert!(config.max_buffer_size != 0);
+
+            prop_assert_eq!(config.max_data_file_size, default_max_data_file_size, "the default max data file size should always match the default in this test");
+            prop_assert!(config.max_buffer_size >= default_max_data_file_size, "max_buffer_size should be at least as big as max data file size ({}), got {}", default_max_data_file_size, config.max_buffer_size);
+        }
     }
 }

--- a/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
@@ -20,7 +20,7 @@ async fn writer_error_when_record_is_over_the_limit() {
         let data_dir = dir.to_path_buf();
 
         async move {
-            // Create our buffer with and arbitrarily low max buffer size, and two write sizes where
+            // Create our buffer with and arbitrarily low max record size, and two write sizes where
             // the first will fit but the second will not.
             //
             // The sizes are different so that we can assert that we got back the expected record at

--- a/lib/vector-buffers/src/variants/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/writer.rs
@@ -66,8 +66,6 @@ where
     /// record being big enough that it would exceed the max data file size.
     ///
     /// The record that was given to write is returned.
-    ///
-    /// See lemma 5.
     #[snafu(display("data file full or record would exceed max data file size"))]
     DataFileFull { record: T, serialized_size: usize },
 
@@ -76,8 +74,6 @@ where
     /// This is nonsensicial because we don't intend to ever support encoding zero-sized types
     /// through the buffer, and the logic we use to count the number of actual events in the buffer
     /// transitively depends on not being able to represent more than one event per encoded byte.
-    ///
-    /// See lemma 4 for more information.
     #[snafu(display(
         "record reported event count ({}) higher than encoded length ({})",
         encoded_len,


### PR DESCRIPTION
# Context

In #13102, a user reported that they encountered an issue with trying to write too large of a record to their sink's disk buffer, which manifested as `EncodeError::BufferTooSmall`, emitted when we try to encode an `EventArray` and don't have enough space to do so.

When the disk buffer v2 implementation was initially written, we had only considered writing a single event per record, and so the current default limit of 8MB made sense. With the addition of supporting `EventArray`, this now makes far less sense as we can easily get 1000 events per array when using something like the `vector` source, which leaves a mere _8KB_ per event for the encoding budget.

It's not unreasonable to think that with encoding overhead, plus high-cardinality/rich metadata, that we could exceed this... or a user could simply send much larger batches of events and then the per-event budget is even that much smaller: 10k events would be ~840 bytes per event, and so on.

# Solution

In this PR, we've raised the default maximum record size to match the default maximum data file size, which is 128MB: a 16x increase.

Tactically, this should provide a meaningful reprieve for users currently hitting the 8MB limit without needing to sacrifice their batch sizing to cope with the limitations imposed by the disk buffer.

In the future, we likely want to tackle the overall problem of hidden configuration values by addressing #13120 and #13122.