### PR TITLE
chore(observability): Set `collectors` in enterprise `host_metrics`

### DIFF
--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -30,7 +30,8 @@ use crate::{
         util::retries::ExponentialBackoff,
     },
     sources::{
-        host_metrics::HostMetricsConfig, internal_logs::InternalLogsConfig,
+        host_metrics::{Collector, HostMetricsConfig},
+        internal_logs::InternalLogsConfig,
         internal_metrics::InternalMetricsConfig,
     },
     transforms::{filter::FilterConfig, remap::RemapConfig},
@@ -478,9 +479,21 @@ fn setup_metrics_reporting(
 
     // Create internal sources for host and internal metrics. We're using distinct sources here and
     // not attempting to reuse existing ones, to configure according to enterprise requirements.
+
+    // By default, host_metrics generates many metrics and some with high
+    // cardinality which can negatively impact customers' costs and downstream
+    // systems' performance. To avoid this, we explicitly set `collectors`.
     let host_metrics = HostMetricsConfig {
         namespace: Some("vector.host".to_owned()),
         scrape_interval_secs: datadog.reporting_interval_secs,
+        collectors: Some(vec![
+            Collector::Cpu,
+            Collector::Disk,
+            Collector::Load,
+            Collector::Host,
+            Collector::Memory,
+            Collector::Network,
+        ]),
         ..Default::default()
     };
 


### PR DESCRIPTION
Closes OP-479

This PR
- Explicitly configures enterprise `host_metrics` `collectors` to avoid generating too many metrics and metrics of high cardinality.

## Example

Using a config like the following with an associated Observability Pipelines configuration,

```toml
[enterprise]
...

[sources.foo-op-479]
type = "demo_logs"
format = "json"

[sinks.out-op-479]
type = "blackhole"
inputs = ["*"]
```

You should see only the relevant `vector.host` metrics

![Screen Shot 2022-06-13 at 10 33 11 AM](https://user-images.githubusercontent.com/43912346/173412244-efe2985e-f210-4302-8d8c-443d68013dff.png)


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
