### PR TITLE
chore(ci): run integration tests on beefier runners + some `runs-on` consolidation

### DIFF
--- a/.github/audit.yml
+++ b/.github/audit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   security_audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/audit-check@v1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,6 +22,14 @@ on:
       - "rust-toolchain"
   pull_request:
 
+concurrency:
+  # For pull requests, cancel running workflows, for master, run all
+  #
+  # `github.event.number` exists for pull requests, otherwise fall back to SHA
+  # for master
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOINSTALL: true
   AWS_ACCESS_KEY_ID: "dummy"
@@ -37,20 +45,9 @@ env:
   PROFILE: debug
 
 jobs:
-  cancel-previous:
-    name: Cancel redundant jobs
-    runs-on: ubuntu-20.04
-    timeout-minutes: 3
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-          all_but_latest: true # can cancel workflows scheduled later
-
   test-integration:
     name: Integration - Linux, ${{ matrix.test }}
-    runs-on: ubuntu-20.04
+    runs-on: [linux, test-runner]
     if: |
       !github.event.pull_request
         || contains(github.event.pull_request.labels.*.name, 'ci-condition: integration tests enable')
@@ -104,7 +101,7 @@ jobs:
 
   test-integration-check:
     name: test-integration-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - test-integration
     steps:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -23,6 +23,14 @@ on:
       - "distribution/**"
   pull_request:
 
+concurrency:
+  # For pull requests, cancel running workflows, for master, run all
+  #
+  # `github.event.number` exists for pull requests, otherwise fall back to SHA
+  # for master
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   AUTOINSTALL: true
   AWS_ACCESS_KEY_ID: "dummy"
@@ -36,20 +44,9 @@ env:
   PROFILE: debug
 
 jobs:
-  cancel-previous:
-    name: Cancel redundant jobs
-    runs-on: ubuntu-20.04
-    timeout-minutes: 3
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-          all_but_latest: true # can cancel workflows scheduled later
-
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu
-    runs-on: ubuntu-20.04
+    runs-on: [linux, test-runner]
     if: |
       !github.event.pull_request
         || contains(github.event.pull_request.labels.*.name, 'ci-condition: k8s e2e tests enable')
@@ -85,7 +82,7 @@ jobs:
   # See https://github.community/t/feature-request-and-use-case-example-to-allow-matrix-in-if-s/126067
   compute-k8s-test-plan:
     name: Compute K8s test plan
-    runs-on: ubuntu-20.04
+    runs-on: [linux, test-runner]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     if: |
@@ -145,7 +142,7 @@ jobs:
 
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
-    runs-on: ubuntu-20.04
+    runs-on: [linux, test-runner]
     needs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/labeler@v4
       with:

--- a/.github/workflows/soak_comment.yml
+++ b/.github/workflows/soak_comment.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: >
       ${{ github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,7 +222,7 @@ jobs:
     # Full CI suites for this platform were only recently introduced.
     # Some failures are permitted until we can properly correct them.
     continue-on-error: true
-    runs-on: macos-latest
+    runs-on: macos-10.15
     needs: changes
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
 
   cross-linux-check:
     if: ${{ needs.changes.outputs.dependencies == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Cross - Linux
     needs: cross-linux
     steps:


### PR DESCRIPTION
Two primary changes here:

- integration tests (both component-level and Kubernetes) will run on our custom runner group instead of the public GHA runner pool, to speed up these runs
- changed all references of `ubuntu-latest` to `ubuntu-20.04`, and `macos-latest` to `macos-10.15`, in order to ensure we're pinning ourselves to a specific version.

In general, the integration test runner change should be obvious: they take a long time -- the Kubernetes test has a p95 of 1h30m -- and this sucks when you actually want to run them and not wait forever. This will be particularly important if/when we change more of these tests to run by default.

The runner image version thing is just common sense, IMO, given how often we have run up against issues of "why does this work in CI but not locally?" and so on, and pinning versions just makes things easier to debug. This change is currently a no-op for Ubuntu images as `latest` is pointed at `20.04`, but for `macos`, technically `latest` points to `11` but we use `10.15` everywhere else a macOS runner is involved.. so it felt prudent to drop back and use that instead to match.

There's something to be said for moving those tests to 11/12 (aka Big Sur and Monterey) given that most engineers developing on macOS are almost certainly on Big Sur, if not already on Monterey.