### PR TITLE
chore(ci): Remove `--nocapture` from integration tests

### DIFF
--- a/scripts/integration/docker-compose.aws.yml
+++ b/scripts/integration/docker-compose.aws.yml
@@ -39,8 +39,6 @@ services:
       - "aws-integration-tests"
       - "--lib"
       - "${FILTER:-::aws_}"
-      - "--"
-      - "--nocapture"
     depends_on:
       - mock-ec2-metadata
       - mock-localstack

--- a/scripts/integration/docker-compose.azure.yml
+++ b/scripts/integration/docker-compose.azure.yml
@@ -23,8 +23,6 @@ services:
       - "azure-integration-tests"
       - "--lib"
       - "::azure_"
-      - "--"
-      - "--nocapture"
     environment:
       - AZURE_ADDRESS=local-azure-blob
       - HEARTBEAT_ADDRESS=0.0.0.0:8080

--- a/scripts/integration/docker-compose.clickhouse.yml
+++ b/scripts/integration/docker-compose.clickhouse.yml
@@ -21,8 +21,6 @@ services:
       - "clickhouse-integration-tests"
       - "--lib"
       - "::clickhouse::"
-      - "--"
-      - "--nocapture"
     environment:
       - CLICKHOUSE_ADDRESS=http://clickhouse:8123
     depends_on:

--- a/scripts/integration/docker-compose.datadog-agent.yml
+++ b/scripts/integration/docker-compose.datadog-agent.yml
@@ -47,7 +47,6 @@ services:
       - "--no-default-features"
       - "--features"
       - "datadog-agent-integration-tests"
-      - "--no-capture"
       - "--lib"
       - "sources::datadog::agent::integration_tests::"
     environment:

--- a/scripts/integration/docker-compose.datadog-logs.yml
+++ b/scripts/integration/docker-compose.datadog-logs.yml
@@ -18,8 +18,6 @@ services:
       - "datadog-logs-integration-tests"
       - "--lib"
       - "::datadog::logs::"
-      - "--"
-      - "--nocapture"
     environment:
       - TEST_DATADOG_API_KEY
     volumes:

--- a/scripts/integration/docker-compose.datadog-metrics.yml
+++ b/scripts/integration/docker-compose.datadog-metrics.yml
@@ -18,8 +18,6 @@ services:
       - "datadog-metrics-integration-tests"
       - "--lib"
       - "::datadog::metrics::"
-      - "--"
-      - "--nocapture"
     environment:
       - TEST_DATADOG_API_KEY
     volumes:

--- a/scripts/integration/docker-compose.datadog-traces.yml
+++ b/scripts/integration/docker-compose.datadog-traces.yml
@@ -18,8 +18,6 @@ services:
       - "datadog-traces-integration-tests"
       - "--lib"
       - "::datadog::traces::"
-      - "--"
-      - "--nocapture"
     environment:
       - TEST_DATADOG_API_KEY
     volumes:

--- a/scripts/integration/docker-compose.dnstap.yml
+++ b/scripts/integration/docker-compose.dnstap.yml
@@ -27,8 +27,6 @@ services:
       - "dnstap-integration-tests"
       - "--lib"
       - "::dnstap::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - dnstap
     environment:

--- a/scripts/integration/docker-compose.docker-logs.yml
+++ b/scripts/integration/docker-compose.docker-logs.yml
@@ -18,8 +18,6 @@ services:
       - "docker-logs-integration-tests"
       - "--lib"
       - "::docker_::"
-      - "--"
-      - "--nocapture"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}:/code

--- a/scripts/integration/docker-compose.elasticsearch.yml
+++ b/scripts/integration/docker-compose.elasticsearch.yml
@@ -48,8 +48,6 @@ services:
       - "es-integration-tests"
       - "--lib"
       - "::elasticsearch::integration_tests::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - localstack
       - elasticsearch

--- a/scripts/integration/docker-compose.eventstoredb.yml
+++ b/scripts/integration/docker-compose.eventstoredb.yml
@@ -25,8 +25,6 @@ services:
       - "eventstoredb_metrics-integration-tests"
       - "--lib"
       - "::eventstoredb_metrics::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - eventstoredb
     volumes:

--- a/scripts/integration/docker-compose.fluent.yml
+++ b/scripts/integration/docker-compose.fluent.yml
@@ -19,8 +19,6 @@ services:
       - "fluent-integration-tests"
       - "--lib"
       - "::fluent::"
-      - "--"
-      - "--nocapture"
     volumes:
       - ${PWD}:/code
       - target:/code/target

--- a/scripts/integration/docker-compose.gcp.yml
+++ b/scripts/integration/docker-compose.gcp.yml
@@ -23,8 +23,6 @@ services:
       - "gcp-integration-tests"
       - "--lib"
       - "::gcp::"
-      - "--"
-      - "--nocapture"
     environment:
       - EMULATOR_ADDRESS=http://gcloud-pubsub:8681
     depends_on:

--- a/scripts/integration/docker-compose.humio.yml
+++ b/scripts/integration/docker-compose.humio.yml
@@ -22,8 +22,6 @@ services:
       - "humio-integration-tests"
       - "--lib"
       - "sinks::humio::"
-      - "--"
-      - "--nocapture"
     environment:
       - HUMIO_ADDRESS=http://localhost:8080
     depends_on:

--- a/scripts/integration/docker-compose.influxdb.yml
+++ b/scripts/integration/docker-compose.influxdb.yml
@@ -36,8 +36,6 @@ services:
       - "influxdb-integration-tests"
       - "--lib"
       - "${FILTER:-::influxdb::}"
-      - "--"
-      - "--nocapture"
     depends_on:
       - influxdb-v1
       - influxdb-v1-tls

--- a/scripts/integration/docker-compose.kafka.yml
+++ b/scripts/integration/docker-compose.kafka.yml
@@ -48,8 +48,6 @@ services:
       - "kafka-integration-tests"
       - "--lib"
       - "${FILTER:-::kafka::}"
-      - "--"
-      - "--nocapture"
     depends_on:
       - kafka
     environment:

--- a/scripts/integration/docker-compose.logstash.yml
+++ b/scripts/integration/docker-compose.logstash.yml
@@ -36,8 +36,6 @@ services:
       - "logstash-integration-tests"
       - "--lib"
       - "::logstash::integration_tests::"
-      - "--"
-      - "--nocapture"
     environment:
       - HEARTBEAT_ADDRESS=0.0.0.0:8080
       - LOGSTASH_ADDRESS=0.0.0.0:8081

--- a/scripts/integration/docker-compose.loki.yml
+++ b/scripts/integration/docker-compose.loki.yml
@@ -21,8 +21,6 @@ services:
       - "loki-integration-tests"
       - "--lib"
       - "::loki::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - loki
     environment:

--- a/scripts/integration/docker-compose.mongodb.yml
+++ b/scripts/integration/docker-compose.mongodb.yml
@@ -53,8 +53,6 @@ services:
       - "mongodb_metrics-integration-tests"
       - "--lib"
       - "::mongodb_metrics::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - mongodb-primary
       - mongodb-secondary

--- a/scripts/integration/docker-compose.nats.yml
+++ b/scripts/integration/docker-compose.nats.yml
@@ -62,8 +62,6 @@ services:
       - "nats-integration-tests"
       - "--lib"
       - "::nats::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - nats
       - nats-userpass

--- a/scripts/integration/docker-compose.nginx.yml
+++ b/scripts/integration/docker-compose.nginx.yml
@@ -37,8 +37,6 @@ services:
       - "nginx-integration-tests"
       - "--lib"
       - "::nginx_metrics::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - nginx
       - squid

--- a/scripts/integration/docker-compose.postgres.yml
+++ b/scripts/integration/docker-compose.postgres.yml
@@ -28,8 +28,6 @@ services:
       - "postgresql_metrics-integration-tests"
       - "--lib"
       - "${FILTER:-::postgres}"
-      - "--"
-      - "--nocapture"
     depends_on:
       - postgres
     environment:

--- a/scripts/integration/docker-compose.prometheus.yml
+++ b/scripts/integration/docker-compose.prometheus.yml
@@ -42,8 +42,6 @@ services:
       - "prometheus-integration-tests"
       - "--lib"
       - "${FILTER:-::prometheus::}"
-      - "--"
-      - "--nocapture"
     depends_on:
       - influxdb
       - influxdb-tls

--- a/scripts/integration/docker-compose.pulsar.yml
+++ b/scripts/integration/docker-compose.pulsar.yml
@@ -23,8 +23,6 @@ services:
       - "pulsar-integration-tests"
       - "--lib"
       - "::pulsar::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - pulsar
     environment:

--- a/scripts/integration/docker-compose.redis.yml
+++ b/scripts/integration/docker-compose.redis.yml
@@ -22,8 +22,6 @@ services:
       - "redis-integration-tests"
       - "--lib"
       - "::redis::"
-      - "--"
-      - "--nocapture"
     depends_on:
       - redis
     environment:

--- a/scripts/integration/docker-compose.splunk.yml
+++ b/scripts/integration/docker-compose.splunk.yml
@@ -30,8 +30,6 @@ services:
       - "splunk-integration-tests"
       - "--lib"
       - "${FILTER:-::splunk_hec::}"
-      - "--"
-      - "--nocapture"
     depends_on:
       - splunk-hec
     environment:


### PR DESCRIPTION
This broke with the upgrade to `cargo nextest` 0.9.19 which wants you to
use an extra `--` to pass along extra flags to the test binary, but it
occurred to me that I don't think we need this flag. It's useful for
debugging, but otherwise we don't really need to see the integration
test output unless it fails, in which case it will output it.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
