### PR TITLE
chore(core): Make the base `BatchNotifier` type shared

### DIFF
--- a/lib/vector-common/src/finalization.rs
+++ b/lib/vector-common/src/finalization.rs
@@ -104,7 +104,7 @@ impl Finalizable for EventFinalizers {
 #[derive(Debug)]
 pub struct EventFinalizer {
     status: AtomicCell<EventStatus>,
-    batch: Arc<BatchNotifier>,
+    batch: BatchNotifier,
 }
 
 #[cfg(feature = "byte_size_of")]
@@ -119,7 +119,7 @@ impl ByteSizeOf for EventFinalizer {
 impl EventFinalizer {
     /// Creates a new `EventFinalizer` attached to the given `batch`.
     #[must_use]
-    pub fn new(batch: Arc<BatchNotifier>) -> Self {
+    pub fn new(batch: BatchNotifier) -> Self {
         let status = AtomicCell::new(EventStatus::Dropped);
         Self { status, batch }
     }
@@ -183,29 +183,24 @@ impl BatchStatusReceiver {
 /// A batch notifier contains the status of the current batch along with
 /// a one-shot notifier to send that status back to the source. It is
 /// shared among all events of a batch.
-#[derive(Debug)]
-pub struct BatchNotifier {
-    status: AtomicCell<BatchStatus>,
-    notifier: Option<oneshot::Sender<BatchStatus>>,
-}
+#[derive(Clone, Debug)]
+pub struct BatchNotifier(Arc<OwnedBatchNotifier>);
 
 impl BatchNotifier {
     /// Creates a new `BatchNotifier` along with the receiver used to await its finalization status.
     #[must_use]
-    pub fn new_with_receiver() -> (Arc<Self>, BatchStatusReceiver) {
+    pub fn new_with_receiver() -> (Self, BatchStatusReceiver) {
         let (sender, receiver) = oneshot::channel();
-        let notifier = Self {
+        let notifier = OwnedBatchNotifier {
             status: AtomicCell::new(BatchStatus::Delivered),
             notifier: Some(sender),
         };
-        (Arc::new(notifier), BatchStatusReceiver(receiver))
+        (Self(Arc::new(notifier)), BatchStatusReceiver(receiver))
     }
 
     /// Optionally creates a new `BatchNotifier` along with the receiver used to await its finalization status.
     #[must_use]
-    pub fn maybe_new_with_receiver(
-        enabled: bool,
-    ) -> (Option<Arc<Self>>, Option<BatchStatusReceiver>) {
+    pub fn maybe_new_with_receiver(enabled: bool) -> (Option<Self>, Option<BatchStatusReceiver>) {
         if enabled {
             let (batch, receiver) = Self::new_with_receiver();
             (Some(batch), Some(receiver))
@@ -224,7 +219,7 @@ impl BatchNotifier {
         enabled.then(|| {
             let (batch, receiver) = Self::new_with_receiver();
             for item in items {
-                item.add_batch_notifier(Arc::clone(&batch));
+                item.add_batch_notifier(batch.clone());
             }
             receiver
         })
@@ -235,12 +230,22 @@ impl BatchNotifier {
         // The status starts as Delivered and can only change if the new
         // status is different than that.
         if status != EventStatus::Delivered && status != EventStatus::Dropped {
-            self.status
+            self.0
+                .status
                 .fetch_update(|old_status| Some(old_status.update(status)))
                 .unwrap_or_else(|_| unreachable!());
         }
     }
+}
 
+/// The non-shared data underlying the shared `BatchNotifier`
+#[derive(Debug)]
+pub struct OwnedBatchNotifier {
+    status: AtomicCell<BatchStatus>,
+    notifier: Option<oneshot::Sender<BatchStatus>>,
+}
+
+impl OwnedBatchNotifier {
     /// Sends the status of the notifier back to the source.
     fn send_status(&mut self) {
         if let Some(notifier) = self.notifier.take() {
@@ -252,7 +257,7 @@ impl BatchNotifier {
     }
 }
 
-impl Drop for BatchNotifier {
+impl Drop for OwnedBatchNotifier {
     fn drop(&mut self) {
         self.send_status();
     }
@@ -357,7 +362,7 @@ impl EventStatus {
 /// An object to which we can add a batch notifier.
 pub trait AddBatchNotifier {
     /// Adds a single shared batch notifier to this type.
-    fn add_batch_notifier(&mut self, notifier: Arc<BatchNotifier>);
+    fn add_batch_notifier(&mut self, notifier: BatchNotifier);
 }
 
 /// An object that can be finalized.
@@ -459,9 +464,9 @@ mod tests {
     #[test]
     fn multi_event_batch() {
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
-        let event1 = EventFinalizers::new(EventFinalizer::new(Arc::clone(&batch)));
-        let mut event2 = EventFinalizers::new(EventFinalizer::new(Arc::clone(&batch)));
-        let event3 = EventFinalizers::new(EventFinalizer::new(Arc::clone(&batch)));
+        let event1 = EventFinalizers::new(EventFinalizer::new(batch.clone()));
+        let mut event2 = EventFinalizers::new(EventFinalizer::new(batch.clone()));
+        let event3 = EventFinalizers::new(EventFinalizer::new(batch.clone()));
         // Also clone one…
         let event4 = event1.clone();
         drop(batch);

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -185,13 +185,13 @@ impl LogEvent {
     }
 
     #[must_use]
-    pub fn with_batch_notifier(mut self, batch: &Arc<BatchNotifier>) -> Self {
+    pub fn with_batch_notifier(mut self, batch: &BatchNotifier) -> Self {
         self.metadata = self.metadata.with_batch_notifier(batch);
         self
     }
 
     #[must_use]
-    pub fn with_batch_notifier_option(mut self, batch: &Option<Arc<BatchNotifier>>) -> Self {
+    pub fn with_batch_notifier_option(mut self, batch: &Option<BatchNotifier>) -> Self {
         self.metadata = self.metadata.with_batch_notifier_option(batch);
         self
     }

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -124,15 +124,15 @@ impl EventMetadata {
 
     /// Replace the finalizer with a new one created from the given batch notifier.
     #[must_use]
-    pub fn with_batch_notifier(self, batch: &Arc<BatchNotifier>) -> Self {
-        self.with_finalizer(EventFinalizer::new(Arc::clone(batch)))
+    pub fn with_batch_notifier(self, batch: &BatchNotifier) -> Self {
+        self.with_finalizer(EventFinalizer::new(batch.clone()))
     }
 
     /// Replace the finalizer with a new one created from the given optional batch notifier.
     #[must_use]
-    pub fn with_batch_notifier_option(self, batch: &Option<Arc<BatchNotifier>>) -> Self {
+    pub fn with_batch_notifier_option(self, batch: &Option<BatchNotifier>) -> Self {
         match batch {
-            Some(batch) => self.with_finalizer(EventFinalizer::new(Arc::clone(batch))),
+            Some(batch) => self.with_finalizer(EventFinalizer::new(batch.clone())),
             None => self,
         }
     }

--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -4,7 +4,6 @@ use std::{
     collections::{btree_map, BTreeMap},
     convert::AsRef,
     fmt::{self, Display, Formatter},
-    sync::Arc,
 };
 
 use chrono::{DateTime, Utc};
@@ -102,14 +101,14 @@ impl Metric {
 
     /// Consumes this metric, returning it with an updated set of event finalizers attached to `batch`.
     #[must_use]
-    pub fn with_batch_notifier(mut self, batch: &Arc<BatchNotifier>) -> Self {
+    pub fn with_batch_notifier(mut self, batch: &BatchNotifier) -> Self {
         self.metadata = self.metadata.with_batch_notifier(batch);
         self
     }
 
     /// Consumes this metric, returning it with an optionally updated set of event finalizers attached to `batch`.
     #[must_use]
-    pub fn with_batch_notifier_option(mut self, batch: &Option<Arc<BatchNotifier>>) -> Self {
+    pub fn with_batch_notifier_option(mut self, batch: &Option<BatchNotifier>) -> Self {
         self.metadata = self.metadata.with_batch_notifier_option(batch);
         self
     }

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -2,7 +2,6 @@ use std::{
     collections::{BTreeMap, HashMap},
     convert::{TryFrom, TryInto},
     fmt::Debug,
-    sync::Arc,
 };
 
 pub use ::value::Value;
@@ -250,7 +249,7 @@ impl Event {
     }
 
     #[must_use]
-    pub fn with_batch_notifier(self, batch: &Arc<BatchNotifier>) -> Self {
+    pub fn with_batch_notifier(self, batch: &BatchNotifier) -> Self {
         match self {
             Self::Log(log) => log.with_batch_notifier(batch).into(),
             Self::Metric(metric) => metric.with_batch_notifier(batch).into(),
@@ -259,7 +258,7 @@ impl Event {
     }
 
     #[must_use]
-    pub fn with_batch_notifier_option(self, batch: &Option<Arc<BatchNotifier>>) -> Self {
+    pub fn with_batch_notifier_option(self, batch: &Option<BatchNotifier>) -> Self {
         match self {
             Self::Log(log) => log.with_batch_notifier_option(batch).into(),
             Self::Metric(metric) => metric.with_batch_notifier_option(batch).into(),
@@ -280,7 +279,7 @@ impl EventDataEq for Event {
 }
 
 impl finalization::AddBatchNotifier for Event {
-    fn add_batch_notifier(&mut self, batch: Arc<BatchNotifier>) {
+    fn add_batch_notifier(&mut self, batch: BatchNotifier) {
         let finalizer = EventFinalizer::new(batch);
         match self {
             Self::Log(log) => log.add_finalizer(finalizer),

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{collections::BTreeMap, fmt::Debug};
 
 use lookup::LookupBuf;
 use serde::{Deserialize, Serialize};
@@ -51,12 +51,12 @@ impl TraceEvent {
     }
 
     #[must_use]
-    pub fn with_batch_notifier(self, batch: &Arc<BatchNotifier>) -> Self {
+    pub fn with_batch_notifier(self, batch: &BatchNotifier) -> Self {
         Self(self.0.with_batch_notifier(batch))
     }
 
     #[must_use]
-    pub fn with_batch_notifier_option(self, batch: &Option<Arc<BatchNotifier>>) -> Self {
+    pub fn with_batch_notifier_option(self, batch: &Option<BatchNotifier>) -> Self {
         Self(self.0.with_batch_notifier_option(batch))
     }
 

--- a/src/sinks/datadog/events/tests.rs
+++ b/src/sinks/datadog/events/tests.rs
@@ -25,7 +25,7 @@ use crate::{
 fn random_events_with_stream(
     len: usize,
     count: usize,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> (Vec<String>, impl Stream<Item = EventArray>) {
     let (lines, stream) = random_lines_with_stream(len, count, batch);
     (

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, iter, num::NonZeroU8, sync::Arc};
+use std::{convert::TryFrom, iter, num::NonZeroU8};
 
 use futures::{future::ready, stream};
 
@@ -338,7 +338,7 @@ async fn splunk_indexer_acknowledgements() {
     let (sink, _) = config.build(cx).await.unwrap();
 
     let (tx, mut rx) = BatchNotifier::new_with_receiver();
-    let (messages, events) = random_lines_with_stream(100, 10, Some(Arc::clone(&tx)));
+    let (messages, events) = random_lines_with_stream(100, 10, Some(tx.clone()));
     drop(tx);
     run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
 
@@ -354,7 +354,7 @@ async fn splunk_indexer_acknowledgements_disabled_on_server() {
     let (sink, _) = config.build(cx).await.unwrap();
 
     let (tx, mut rx) = BatchNotifier::new_with_receiver();
-    let (messages, events) = random_lines_with_stream(100, 10, Some(Arc::clone(&tx)));
+    let (messages, events) = random_lines_with_stream(100, 10, Some(tx.clone()));
     drop(tx);
     run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
 

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, sync::Arc};
+use std::io::Read;
 
 use bytes::Bytes;
 use chrono::Utc;
@@ -67,7 +67,7 @@ pub async fn firehose(
 
                     for event in &mut events {
                         if let Some(batch) = &batch {
-                            event.add_batch_notifier(Arc::clone(batch));
+                            event.add_batch_notifier(batch.clone());
                         }
                         if let Event::Log(ref mut log) = event {
                             log.try_insert(

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -400,7 +400,7 @@ impl PubsubSource {
     async fn parse_messages(
         &self,
         response: Vec<proto::ReceivedMessage>,
-        batch: Option<Arc<BatchNotifier>>,
+        batch: Option<BatchNotifier>,
     ) -> (Vec<Event>, Vec<String>) {
         let mut ack_ids = Vec::with_capacity(response.len());
         let events = response
@@ -419,7 +419,7 @@ impl PubsubSource {
     fn parse_message<'a>(
         &self,
         message: proto::PubsubMessage,
-        batch: &'a Option<Arc<BatchNotifier>>,
+        batch: &'a Option<BatchNotifier>,
     ) -> impl Iterator<Item = Event> + 'a {
         let attributes = Value::Object(
             message

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -379,7 +379,7 @@ struct Batch<'a> {
     events: Vec<LogEvent>,
     record_size: usize,
     exiting: Option<bool>,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
     receiver: Option<BatchStatusReceiver>,
     source: &'a mut JournaldSource,
     cursor: Option<String>,
@@ -555,7 +555,7 @@ impl Drop for RunningJournalctl {
     }
 }
 
-fn create_event(record: Record, batch: &Option<Arc<BatchNotifier>>) -> LogEvent {
+fn create_event(record: Record, batch: &Option<BatchNotifier>) -> LogEvent {
     let mut log = LogEvent::from_iter(record).with_batch_notifier_option(batch);
 
     // Convert some journald-specific field names into Vector standard ones.

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -520,7 +520,7 @@ struct EventIterator<'de, R: JsonRead<'de>> {
     /// Remaining extracted default values
     extractors: [DefaultExtractor; 4],
     /// Event finalization
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
     /// Splunk HEC Token for passthrough
     token: Option<Arc<str>>,
 }
@@ -531,7 +531,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         channel: Option<String>,
         remote: Option<SocketAddr>,
         remote_addr: Option<String>,
-        batch: Option<Arc<BatchNotifier>>,
+        batch: Option<BatchNotifier>,
         token: Option<Arc<str>>,
     ) -> Self {
         EventIterator {
@@ -784,7 +784,7 @@ fn raw_event(
     channel: String,
     remote: Option<SocketAddr>,
     xff: Option<String>,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> Result<Event, Rejection> {
     // Process gzip
     let message: Value = if gzip {

--- a/src/sources/util/message_decoding.rs
+++ b/src/sources/util/message_decoding.rs
@@ -1,4 +1,4 @@
-use std::{iter, sync::Arc};
+use std::iter;
 
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Utc};
@@ -13,7 +13,7 @@ pub fn decode_message<'a>(
     source_type: &'static str,
     message: &[u8],
     timestamp: Option<DateTime<Utc>>,
-    batch: &'a Option<Arc<BatchNotifier>>,
+    batch: &'a Option<BatchNotifier>,
 ) -> impl Iterator<Item = Event> + 'a {
     let schema = log_schema();
 

--- a/src/sources/util/tcp/mod.rs
+++ b/src/sources/util/tcp/mod.rs
@@ -1,7 +1,7 @@
 mod request_limiter;
 
 use std::net::SocketAddr;
-use std::{fmt, io, mem::drop, sync::Arc, time::Duration};
+use std::{fmt, io, mem::drop, time::Duration};
 
 use bytes::Bytes;
 use codecs::StreamDecodingError;
@@ -332,7 +332,7 @@ async fn handle_stream<T>(
 
                         if let Some(batch) = batch {
                             for event in &mut events {
-                                event.add_batch_notifier(Arc::clone(&batch));
+                                event.add_batch_notifier(batch.clone());
                             }
                         }
 

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -204,7 +204,7 @@ pub fn temp_dir() -> PathBuf {
 
 pub fn map_event_batch_stream(
     stream: impl Stream<Item = Event>,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> impl Stream<Item = EventArray> {
     stream.map(move |event| event.with_batch_notifier_option(&batch).into())
 }
@@ -212,7 +212,7 @@ pub fn map_event_batch_stream(
 // TODO refactor to have a single implementation for `Event`, `LogEvent` and `Metric`.
 fn map_batch_stream(
     stream: impl Stream<Item = LogEvent>,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> impl Stream<Item = EventArray> {
     stream.map(move |log| vec![log.with_batch_notifier_option(&batch)].into())
 }
@@ -220,7 +220,7 @@ fn map_batch_stream(
 pub fn generate_lines_with_stream<Gen: FnMut(usize) -> String>(
     generator: Gen,
     count: usize,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> (Vec<String>, impl Stream<Item = EventArray>) {
     let lines = (0..count).map(generator).collect::<Vec<_>>();
     let stream = map_batch_stream(stream::iter(lines.clone()).map(LogEvent::from), batch);
@@ -230,7 +230,7 @@ pub fn generate_lines_with_stream<Gen: FnMut(usize) -> String>(
 pub fn random_lines_with_stream(
     len: usize,
     count: usize,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> (Vec<String>, impl Stream<Item = EventArray>) {
     let generator = move |_| random_string(len);
     generate_lines_with_stream(generator, count, batch)
@@ -239,7 +239,7 @@ pub fn random_lines_with_stream(
 pub fn generate_events_with_stream<Gen: FnMut(usize) -> Event>(
     generator: Gen,
     count: usize,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> (Vec<Event>, impl Stream<Item = EventArray>) {
     let events = (0..count).map(generator).collect::<Vec<_>>();
     let stream = map_batch_stream(
@@ -252,7 +252,7 @@ pub fn generate_events_with_stream<Gen: FnMut(usize) -> Event>(
 pub fn random_events_with_stream(
     len: usize,
     count: usize,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
 ) -> (Vec<Event>, impl Stream<Item = EventArray>) {
     let events = (0..count)
         .map(|_| Event::from(random_string(len)))
@@ -267,7 +267,7 @@ pub fn random_events_with_stream(
 pub fn random_updated_events_with_stream<F>(
     len: usize,
     count: usize,
-    batch: Option<Arc<BatchNotifier>>,
+    batch: Option<BatchNotifier>,
     update_fn: F,
 ) -> (Vec<Event>, impl Stream<Item = EventArray>)
 where


### PR DESCRIPTION
The `BatchNotifier` type is used as a shared reference wrapped in `Arc`
_everywhere_ except in its implementation. This change simplifies the
type naming and import requirements for this type.

Note that this was first attempted as a type alias, but that requires
more code changes as we can't implement methods on `Arc<T>`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
