### PR TITLE
chore(internal_logs source): rate limit internal logs

### DIFF
--- a/src/trace.rs
+++ b/src/trace.rs
@@ -63,9 +63,12 @@ pub fn init(color: bool, json: bool, levels: &str) {
     let metrics_layer = metrics_layer_enabled()
         .then(|| MetricsLayer::new().with_filter(tracing_subscriber::filter::LevelFilter::INFO));
 
+    let broadcast_layer = RateLimitedLayer::new(BroadcastLayer::new())
+        .with_filter(fmt_filter.clone());
+
     let subscriber = tracing_subscriber::registry()
         .with(metrics_layer)
-        .with(BroadcastLayer::new().with_filter(fmt_filter.clone()));
+        .with(broadcast_layer);
 
     #[cfg(feature = "tokio-console")]
     let subscriber = {


### PR DESCRIPTION
Fixes #13151.

This PR wraps the `BroadcastLayer`, used to drive `internal_logs`, with a `RateLimitingLayer` that will ensure we also rate limit internal logs, rather than have them end up being a pure firehose of uncontrolled data costs. This can be particularly evident when errors occur at high event rates, in turn generating huge logging volume.

The rate limiting layer not only rate limits messages, but provides enough context while doing so to intuit how much actual log volume exists without needing to necessarily capture all of it.