### PR TITLE
chore(core): avoid cloning event message in `tracing-limit` when rate limited

### DIFF
--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -26,7 +26,6 @@ const MESSAGE_FIELD: &str = "message";
 // These fields will cause events to be independently rate limited by the values
 // for these keys
 const COMPONENT_ID_FIELD: &str = "component_id";
-const VRL_LINE_NUMBER: &str = "vrl_line_number";
 const VRL_POSITION: &str = "vrl_position";
 
 #[derive(Eq, PartialEq, Hash, Clone)]
@@ -116,69 +115,64 @@ where
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
-        let metadata = event.metadata();
-
-        // if the event is not rate limited, just pass through
-        if !is_limited(metadata) {
-            return self.inner.on_event(event, ctx);
-        }
-
+        // Visit the event, grabbing the limit if one is defined. If we can't find a rate limit field, or the rate limit
+        // is set as 0, then we let it pass through untouched.
         let mut limit_visitor = LimitVisitor::default();
         event.record(&mut limit_visitor);
 
         let limit = limit_visitor.limit.unwrap_or(0);
-        // If the event has a rate limit of 0 or an invalid rate limit, just pass through.
-        // This has the same effect as allowing it through without the additional locking and state
-        // initialization.
         if limit == 0 {
             return self.inner.on_event(event, ctx);
         }
 
+        // Visit all of the spans in the scope of this event, looking for specific fields that we use to differentiate
+        // rate-limited events. This ensures that we don't rate limit an event's _callsite_, but the specific usage of a
+        // callsite, since multiple copies of the same component could be running, etc.
         let rate_limit_key_values = {
             let mut keys = RateLimitedSpanKeys::default();
             event.record(&mut keys);
 
-            let scope = ctx
-                .lookup_current()
+            ctx.lookup_current()
                 .into_iter()
-                .flat_map(|span| span.scope().from_root());
-
-            scope.fold(keys, |mut keys, span| {
-                let extensions = span.extensions();
-                if let Some(span_keys) = extensions.get::<RateLimitedSpanKeys>() {
-                    keys.merge(span_keys);
-                }
-                keys
-            })
+                .flat_map(|span| span.scope().from_root())
+                .fold(keys, |mut keys, span| {
+                    let extensions = span.extensions();
+                    if let Some(span_keys) = extensions.get::<RateLimitedSpanKeys>() {
+                        keys.merge(span_keys);
+                    }
+                    keys
+                })
         };
 
+        // Build the key to represent this event, given its span fields, and see if we're already rate limiting it. If
+        // not, we'll initialize an entry for it.
+        let metadata = event.metadata();
         let id = RateKeyIdentifier {
             callsite: metadata.callsite(),
             rate_limit_key_values,
         };
 
-        let mut state = self.events.entry(id).or_insert(State {
-            start: Instant::now(),
-            count: 0,
-            limit,
-            message: limit_visitor
+        let mut state = self.events.entry(id).or_insert_with(|| {
+            let mut message_visitor = MessageVisitor::default();
+            event.record(&mut message_visitor);
+
+            let message = message_visitor
                 .message
-                .unwrap_or_else(|| event.metadata().name().into()),
+                .unwrap_or_else(|| metadata.name().into());
+
+            State::new(message, limit)
         });
 
-        let prev = state.count;
-        state.count += 1;
-
-        //check if we are still rate limiting
-        if state.start.elapsed().as_secs() < state.limit {
-            // check and increment the current count
-            // if 0: this is the first message, just pass it through
-            // if 1: this is the first rate limited message
-            // otherwise suppress it until the rate limit expires
-            match prev {
+        // Update our rate limiting state for this event, and see if we should still be rate limiting it.
+        //
+        // When this is the first time seeing the event, we emit it like we normally would. The second time we see it in
+        // the limit period, we emit a new event to indicate that the original event is being actively rate limited.
+        // Otherwise, we don't emit anything.
+        let previous_count = state.increment_count();
+        if state.should_limit() {
+            match previous_count {
                 0 => self.inner.on_event(event, ctx),
                 1 => {
-                    // output first rate limited log
                     let message =
                         format!("Internal log [{}] is being rate limited.", state.message);
                     self.create_event(&ctx, metadata, message, state.limit);
@@ -186,22 +180,23 @@ where
                 _ => {}
             }
         } else {
-            // done rate limiting
-
-            // output a message if any events were rate limited
-            if prev > 1 {
+            // If we saw this event 3 or more times total, emit an event that indicates the total number of times we
+            // rate limited the event in the limit period.
+            if previous_count > 1 {
                 let message = format!(
                     "Internal log [{}] has been rate limited {} times.",
                     state.message,
-                    prev - 1
+                    previous_count - 1
                 );
 
                 self.create_event(&ctx, metadata, message, state.limit);
             }
+
+            // We're not rate limiting anymore, so we also emit the current event as normal.. but we update our rate
+            // limiting state since this is effectively equivalent to seeing the event again for the first time.
             self.inner.on_event(event, ctx);
-            state.start = Instant::now();
-            // we emitted the event, so the next one within `limit` should be rate limited
-            state.count = 1;
+
+            state.reset();
         }
     }
 
@@ -274,11 +269,30 @@ struct State {
     message: String,
 }
 
-fn is_limited(metadata: &Metadata<'_>) -> bool {
-    metadata
-        .fields()
-        .iter()
-        .any(|f| f.name() == RATE_LIMIT_SECS_FIELD)
+impl State {
+    fn new(message: String, limit: u64) -> Self {
+        Self {
+            start: Instant::now(),
+            count: 0,
+            limit,
+            message,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.start = Instant::now();
+        self.count = 1;
+    }
+
+    fn increment_count(&mut self) -> u64 {
+        let prev = self.count;
+        self.count += 1;
+        prev
+    }
+
+    fn should_limit(&self) -> bool {
+        self.start.elapsed().as_secs() < self.limit
+    }
 }
 
 #[derive(PartialEq, Eq, Clone, Hash)]
@@ -319,7 +333,6 @@ impl From<String> for TraceValue {
 #[derive(Default, Eq, PartialEq, Hash, Clone)]
 struct RateLimitedSpanKeys {
     component_id: Option<TraceValue>,
-    vrl_line_number: Option<TraceValue>,
     vrl_position: Option<TraceValue>,
 }
 
@@ -327,7 +340,6 @@ impl RateLimitedSpanKeys {
     fn record(&mut self, field: &Field, value: TraceValue) {
         match field.name() {
             COMPONENT_ID_FIELD => self.component_id = Some(value),
-            VRL_LINE_NUMBER => self.vrl_line_number = Some(value),
             VRL_POSITION => self.vrl_position = Some(value),
             _ => {}
         }
@@ -336,9 +348,6 @@ impl RateLimitedSpanKeys {
     fn merge(&mut self, other: &Self) {
         if let Some(component_id) = &other.component_id {
             self.component_id = Some(component_id.clone());
-        }
-        if let Some(vrl_line_number) = &other.vrl_line_number {
-            self.vrl_line_number = Some(vrl_line_number.clone());
         }
         if let Some(vrl_position) = &other.vrl_position {
             self.vrl_position = Some(vrl_position.clone());
@@ -371,30 +380,38 @@ impl Visit for RateLimitedSpanKeys {
 #[derive(Default)]
 struct LimitVisitor {
     pub limit: Option<u64>,
-    pub message: Option<String>,
 }
 
 impl Visit for LimitVisitor {
     fn record_u64(&mut self, field: &Field, value: u64) {
-        if field.name() == RATE_LIMIT_SECS_FIELD {
+        if self.limit.is_none() && field.name() == RATE_LIMIT_SECS_FIELD {
             self.limit = Some(value);
         }
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
-        if field.name() == RATE_LIMIT_SECS_FIELD {
+        if self.limit.is_none() && field.name() == RATE_LIMIT_SECS_FIELD {
             self.limit = Some(u64::try_from(value).unwrap_or_default());
         }
     }
 
+    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    pub message: Option<String>,
+}
+
+impl Visit for MessageVisitor {
     fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == MESSAGE_FIELD {
+        if self.message.is_none() && field.name() == MESSAGE_FIELD {
             self.message = Some(value.to_string());
         }
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        if field.name() == MESSAGE_FIELD {
+        if self.message.is_none() && field.name() == MESSAGE_FIELD {
             self.message = Some(format!("{:?}", value));
         }
     }
@@ -442,7 +459,7 @@ mod test {
         }
 
         fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-            let mut visitor = LimitVisitor::default();
+            let mut visitor = MessageVisitor::default();
             event.record(&mut visitor);
 
             let mut events = self.events.lock().unwrap();
@@ -495,7 +512,7 @@ mod test {
                 for key in &["foo", "bar"] {
                     for line_number in &[1, 2] {
                         let span =
-                            info_span!("span", component_id = &key, vrl_line_number = &line_number);
+                            info_span!("span", component_id = &key, vrl_position = &line_number);
                         let _enter = span.enter();
                         info!(
                             message =
@@ -564,7 +581,7 @@ mod test {
                                 format!("Hello {} on line_number {}!", key, line_number).as_str(),
                             internal_log_rate_secs = 1,
                             component_id = &key,
-                            vrl_line_number = &line_number
+                            vrl_position = &line_number
                         );
                     }
                 }


### PR DESCRIPTION
In `tracing-limit`, a lot of work is done before the point of figuring out whether or not the event in question should be limited. This includes cloning the event message itself.

We've cleaned up the logic and deferred visiting (and cloning) the event message until it's absolutely required. We've additionally dropped trying to read the `vrl_line_number` field, as that field is no longer used at all, being superseded by `vrl_position`.

This change won't have much of an effect for non-rate-limited events, but ironically will speed up components that are being heavily rate limited, allowing them to... fail at processing even faster. 😂 But seriously, it avoids a lot of pointless allocations that will inevitably get dropped since the event message is only needed when starting to track a new/not-yet-seen event message.