### PR TITLE
enhancement(transforms): Implement `transform_all` for remap and condition transforms

### DIFF
--- a/src/conditions/is_log.rs
+++ b/src/conditions/is_log.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     conditions::{Condition, ConditionConfig, ConditionDescription, Conditional},
-    event::Event,
+    event::{Event, LogEvent, Metric, TraceEvent},
 };
 
 //------------------------------------------------------------------------------
@@ -29,12 +29,20 @@ impl ConditionConfig for IsLogConfig {
 pub struct IsLog {}
 
 impl Conditional for IsLog {
-    fn check(&self, e: Event) -> (bool, Event) {
-        (matches!(e, Event::Log(_)), e)
+    fn check_log(&self, log: LogEvent) -> (bool, LogEvent) {
+        (true, log)
     }
 
-    fn check_with_context(&self, e: Event) -> (Result<(), String>, Event) {
-        let (result, event) = self.check(e);
+    fn check_metric(&self, metric: Metric) -> (bool, Metric) {
+        (false, metric)
+    }
+
+    fn check_trace(&self, trace: TraceEvent) -> (bool, TraceEvent) {
+        (false, trace)
+    }
+
+    fn check_with_context(&self, event: Event) -> (Result<(), String>, Event) {
+        let (result, event) = self.check(event);
         if result {
             (Ok(()), event)
         } else {

--- a/src/conditions/is_metric.rs
+++ b/src/conditions/is_metric.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     conditions::{Condition, ConditionConfig, ConditionDescription, Conditional},
-    event::Event,
+    event::{Event, LogEvent, Metric, TraceEvent},
 };
 
 //------------------------------------------------------------------------------
@@ -29,12 +29,20 @@ impl ConditionConfig for IsMetricConfig {
 pub struct IsMetric {}
 
 impl Conditional for IsMetric {
-    fn check(&self, e: Event) -> (bool, Event) {
-        (matches!(e, Event::Metric(_)), e)
+    fn check_log(&self, log: LogEvent) -> (bool, LogEvent) {
+        (false, log)
     }
 
-    fn check_with_context(&self, e: Event) -> (Result<(), String>, Event) {
-        let (result, event) = self.check(e);
+    fn check_metric(&self, metric: Metric) -> (bool, Metric) {
+        (true, metric)
+    }
+
+    fn check_trace(&self, trace: TraceEvent) -> (bool, TraceEvent) {
+        (false, trace)
+    }
+
+    fn check_with_context(&self, event: Event) -> (Result<(), String>, Event) {
+        let (result, event) = self.check(event);
         if result {
             (Ok(()), event)
         } else {

--- a/src/conditions/not.rs
+++ b/src/conditions/not.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::{AnyCondition, Condition, ConditionConfig, Conditional};
-use crate::event::Event;
+use crate::event::{Event, LogEvent, Metric, TraceEvent};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct NotConfig(AnyCondition);
@@ -25,13 +25,23 @@ impl ConditionConfig for NotConfig {
 pub struct Not(Box<Condition>);
 
 impl Conditional for Not {
-    fn check(&self, e: Event) -> (bool, Event) {
-        let (result, event) = self.0.check(e);
+    fn check_log(&self, log: LogEvent) -> (bool, LogEvent) {
+        let (result, event) = self.0.check_log(log);
         (!result, event)
     }
 
-    fn check_with_context(&self, e: Event) -> (Result<(), String>, Event) {
-        let (result, event) = self.0.check_with_context(e);
+    fn check_metric(&self, metric: Metric) -> (bool, Metric) {
+        let (result, event) = self.0.check_metric(metric);
+        (!result, event)
+    }
+
+    fn check_trace(&self, trace: TraceEvent) -> (bool, TraceEvent) {
+        let (result, event) = self.0.check_trace(trace);
+        (!result, event)
+    }
+
+    fn check_with_context(&self, event: Event) -> (Result<(), String>, Event) {
+        let (result, event) = self.0.check_with_context(event);
         match result {
             Ok(()) => (Err("event matches inner condition".to_string()), event),
             Err(_) => (Ok(()), event),

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -1,6 +1,9 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use vector_core::transform::SyncTransform;
+use vector_core::{
+    event::{EventArray, EventContainer},
+    transform::SyncTransform,
+};
 
 use crate::{
     conditions::{AnyCondition, Condition},
@@ -50,6 +53,16 @@ impl SyncTransform for Route {
         }
         if check_failed == self.conditions.len() {
             output.push_named(UNMATCHED_ROUTE, event);
+        }
+    }
+
+    fn transform_all(
+        &mut self,
+        events: EventArray,
+        output: &mut vector_core::transform::TransformOutputsBuf,
+    ) {
+        for event in events.into_events() {
+            self.transform(event, output);
         }
     }
 }


### PR DESCRIPTION
This PR implements `transform_all` for more cache friendly processing of `EventArray`s in remap and condition transforms by running tighter loops on the batches.

This change is in preparation to accept a new `resolve_batch` interface in the VRL interpreter to amortize the cost of interpreting the program over a batch.