### PR TITLE
chore: update x86_64_unknown-linux-gnu to use ubuntu not rhel

### DIFF
--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -2,7 +2,3 @@ FROM docker.io/rustembedded/cross:x86_64-unknown-linux-gnu
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh
-
-ENV LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ \
-  LIBCLANG_STATIC_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ \
-  CLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/bin/clang

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/rustembedded/cross:x86_64-unknown-linux-gnu
 
-COPY bootstrap-rhel.sh .
-RUN ./bootstrap-rhel.sh
+COPY bootstrap-ubuntu.sh .
+RUN ./bootstrap-ubuntu.sh
 
 ENV LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ \
   LIBCLANG_STATIC_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ \


### PR DESCRIPTION
A [recent change](https://github.com/cross-rs/cross/pull/764) to the default x86_64 cross-rs image changed it to use ubuntu rather than rhel.

This means our image no longer has access to `yum`. This changes it to bootstrap an ubuntu image.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
