### PR TITLE
chore(dev): drop unneeded dependencies and coalesce some others

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "1a6ec150ac445a660169a3ad5075b953a7351ec75fe28095e639f6282aac9fdb"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling 0.13.4",
+ "darling",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -2027,18 +2027,8 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
-dependencies = [
- "darling_core 0.14.1",
- "darling_macro 0.14.1",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2056,37 +2046,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
-dependencies = [
- "darling_core 0.14.1",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -4720,7 +4685,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
 dependencies = [
- "darling 0.13.4",
+ "darling",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -6926,7 +6891,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling 0.13.4",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -8837,7 +8802,7 @@ dependencies = [
 name = "vector_config_common"
 version = "0.1.0"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "proc-macro2",
  "quote",
  "schemars",
@@ -8848,7 +8813,7 @@ dependencies = [
 name = "vector_config_macros"
 version = "0.1.0"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "proc-macro2",
  "quote",
  "serde_derive_internals",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,36 +455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
-name = "attohttpc"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe174d1b67f7b2bafed829c09db039301eb5841f66e43be2cf60b326e7f8e2cc"
-dependencies = [
- "flate2",
- "http",
- "log",
- "url",
-]
-
-[[package]]
-name = "attohttpc"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8bda305457262b339322106c776e3fd21df860018e566eb6a5b1aa4b6ae02d"
-dependencies = [
- "flate2",
- "http",
- "log",
- "rustls 0.18.1",
- "serde",
- "serde_urlencoded 0.6.1",
- "url",
- "webpki 0.21.4",
- "webpki-roots 0.19.0",
- "wildmatch",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,8 +485,8 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "strum 0.18.0",
- "strum_macros 0.18.0",
+ "strum",
+ "strum_macros",
  "thiserror",
  "typed-builder 0.5.1",
  "uuid 0.8.2",
@@ -1001,7 +971,7 @@ version = "0.2.2"
 source = "git+https://github.com/Azure/azure-sdk-for-rust.git?rev=b7171eb40909f7f2805f4622e076f8a6dbbe2d98#b7171eb40909f7f2805f4622e076f8a6dbbe2d98"
 dependencies = [
  "async-trait",
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "chrono",
  "dyn-clone",
@@ -1031,7 +1001,7 @@ dependencies = [
  "async-timer",
  "async-trait",
  "azure_core",
- "base64 0.13.0",
+ "base64",
  "chrono",
  "futures 0.3.21",
  "log",
@@ -1052,7 +1022,7 @@ dependencies = [
  "RustyXML",
  "async-trait",
  "azure_core",
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "chrono",
  "futures 0.3.21",
@@ -1078,7 +1048,7 @@ dependencies = [
  "RustyXML",
  "azure_core",
  "azure_storage",
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "chrono",
  "futures 0.3.21",
@@ -1122,12 +1092,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -1138,7 +1102,7 @@ version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -1272,7 +1236,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d4b9e55620571c2200f4be87db2a9a69e2a107fc7d206a6accad58c3536cb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bollard-stubs",
  "bytes 1.1.0",
  "chrono",
@@ -1292,13 +1256,13 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_urlencoded 0.7.1",
+ "serde_urlencoded",
  "thiserror",
  "tokio",
  "tokio-util 0.7.1",
  "url",
  "webpki 0.22.0",
- "webpki-roots 0.22.3",
+ "webpki-roots",
  "winapi 0.3.9",
 ]
 
@@ -1320,7 +1284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60a2c7c80a7850b56df4b8e98e8e4932c34877b8add4f13e8350499cc1e4572"
 dependencies = [
  "ahash",
- "base64 0.13.0",
+ "base64",
  "chrono",
  "hex",
  "indexmap",
@@ -2110,7 +2074,6 @@ dependencies = [
  "peeking_take_while",
  "regex",
  "serde_json",
- "strum_macros 0.24.1",
  "thiserror",
  "tracing 0.1.34",
  "tracing-test 0.2.1",
@@ -2892,17 +2855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcemeta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b740806c16b381ca8d78cb3869fb47ce5b490db28c5f19bc0336a9b9aaca6e"
-dependencies = [
- "attohttpc 0.15.0",
- "lazy_static",
- "serde_json",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,20 +2937,6 @@ dependencies = [
  "smpl_jwt",
  "time",
  "tokio",
-]
-
-[[package]]
-name = "gouth"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c138d157085ba4eb1aaa86e622dc348b956d5ac9d2e446b65941467ebffefdd6"
-dependencies = [
- "attohttpc 0.17.0",
- "gcemeta",
- "jsonwebtoken",
- "serde",
- "serde_json",
- "url",
 ]
 
 [[package]]
@@ -3139,7 +3077,7 @@ version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -3153,7 +3091,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bitflags",
  "bytes 1.1.0",
  "headers-core",
@@ -3382,7 +3320,7 @@ checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
  "async-channel",
- "base64 0.13.0",
+ "base64",
  "futures-lite",
  "http",
  "infer 0.2.3",
@@ -3391,7 +3329,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "serde_urlencoded 0.7.1",
+ "serde_urlencoded",
  "url",
 ]
 
@@ -3800,20 +3738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
-dependencies = [
- "base64 0.12.3",
- "pem 0.8.3",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "k8s-e2e-tests"
 version = "0.1.0"
 dependencies = [
@@ -3836,7 +3760,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0489fc937cc7616a9abfa61bf39c250d7e32e1325ef028c8d9278dd24ea395b3"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "chrono",
  "http",
@@ -3902,7 +3826,7 @@ version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f69a504997799340408635d6e351afb8aab2c34ca3165e162f41b3b34a69a79"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "chrono",
  "dirs-next",
@@ -4501,7 +4425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28f3943e379e9dcaaab9dc319c308a8caaf9e7ff083c6838dff740afbba59df7"
 dependencies = [
  "async-trait",
- "base64 0.13.0",
+ "base64",
  "bitflags",
  "bson",
  "chrono",
@@ -4537,7 +4461,7 @@ dependencies = [
  "trust-dns-resolver",
  "typed-builder 0.10.0",
  "uuid 0.8.2",
- "webpki-roots 0.22.3",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4588,7 +4512,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a916657662da9799246f1ac8dda022c48c4d1c97a9208121ffecc658cef20f"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "base64-url",
  "blocking",
  "crossbeam-channel",
@@ -4976,7 +4900,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e47cfc4c0a1a519d9a025ebfbac3a2439d1b5cdf397d72dcb79b11d9920dab"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "chrono",
  "getrandom 0.2.6",
  "http",
@@ -5252,7 +5176,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "once_cell",
  "regex",
 ]
@@ -5263,7 +5187,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -5512,7 +5436,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "bytes 1.1.0",
  "fallible-iterator",
@@ -6196,7 +6120,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "encoding_rs",
  "futures-core",
@@ -6216,7 +6140,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded 0.7.1",
+ "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
  "tokio-util 0.7.1",
@@ -6350,7 +6274,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -6423,24 +6347,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
-dependencies = [
- "base64 0.12.3",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "log",
  "ring",
  "sct 0.6.1",
@@ -6489,7 +6400,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -6498,7 +6409,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -6507,7 +6418,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -6853,18 +6764,6 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-dependencies = [
- "dtoa",
- "itoa 0.4.8",
- "serde",
- "url",
-]
-
-[[package]]
-name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
@@ -7053,17 +6952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a30f10c911c0355f80f1c2faa8096efc4a58cdf8590b954d5b395efa071c711"
 
 [[package]]
-name = "simple_asn1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
-dependencies = [
- "chrono",
- "num-bigint 0.2.6",
- "num-traits",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7111,7 +6999,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b6ff8c21c74ce7744643a7cddbb02579a44f1f77e4316bff1ddb741aca8ac9"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "log",
  "openssl",
  "serde",
@@ -7280,12 +7168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 
 [[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
 name = "strum_macros"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7294,19 +7176,6 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9550962e7cf70d9980392878dfaf1dcc3ece024f4cf3bf3c46b978d0bad61d6c"
-dependencies = [
- "heck 0.4.0",
- "proc-macro2",
- "quote",
- "rustversion",
  "syn",
 ]
 
@@ -7782,7 +7651,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "flate2",
  "futures-core",
@@ -7848,7 +7717,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bitflags",
  "bytes 1.1.0",
  "futures-core",
@@ -8203,7 +8072,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "bytes 1.1.0",
  "http",
@@ -8222,7 +8091,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "bytes 1.1.0",
  "http",
@@ -8529,7 +8398,7 @@ dependencies = [
  "azure_identity",
  "azure_storage",
  "azure_storage_blobs",
- "base64 0.13.0",
+ "base64",
  "bloom",
  "bollard",
  "bytes 1.1.0",
@@ -8559,7 +8428,6 @@ dependencies = [
  "futures-util",
  "glob",
  "goauth",
- "gouth",
  "governor",
  "grok",
  "h2",
@@ -8642,8 +8510,6 @@ dependencies = [
  "socket2",
  "stream-cancel",
  "strip-ansi-escapes",
- "strum 0.24.1",
- "strum_macros 0.24.1",
  "syslog",
  "tempfile",
  "tikv-jemallocator",
@@ -8827,7 +8693,7 @@ version = "0.1.0"
 dependencies = [
  "async-graphql",
  "async-trait",
- "base64 0.13.0",
+ "base64",
  "bitmask-enum",
  "bytes 1.1.0",
  "chrono",
@@ -9005,7 +8871,7 @@ version = "0.1.0"
 dependencies = [
  "aes",
  "anyhow",
- "base64 0.13.0",
+ "base64",
  "bytes 1.1.0",
  "cbc",
  "cfb-mode",
@@ -9154,7 +9020,7 @@ dependencies = [
  "scoped-tls",
  "serde",
  "serde_json",
- "serde_urlencoded 0.7.1",
+ "serde_urlencoded",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.15.0",
@@ -9293,15 +9159,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
-dependencies = [
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
@@ -9340,12 +9197,6 @@ name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
-
-[[package]]
-name = "wildmatch"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,6 @@ prost-types = { version = "0.10.1", default-features = false, optional = true }
 
 # GCP
 goauth = { version = "0.13.0", optional = true }
-gouth = { version = "0.2.1", default-features = false, optional = true }
 smpl_jwt = { version = "0.7.1", default-features = false, optional = true }
 
 # API
@@ -290,8 +289,6 @@ snap = { version = "1.0.5", default-features = false, optional = true }
 socket2 = { version = "0.4.4", default-features = false }
 stream-cancel = { version = "0.8.1", default-features = false }
 strip-ansi-escapes = { version = "0.1.1", default-features = false }
-strum = { version = "0.24", default-features = false }
-strum_macros = { version = "0.24", default-features = false }
 syslog = { version = "6.0.1", default-features = false, optional = true }
 tikv-jemallocator = { version = "0.5.0", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.6", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
@@ -676,7 +673,7 @@ sinks-datadog_metrics = ["protobuf-build", "sinks-azure_blob"]
 sinks-datadog_traces = ["protobuf-build", "rmpv", "rmp-serde", "serde_bytes"]
 sinks-elasticsearch = ["aws-core", "aws-sigv4", "transforms-metric_to_log"]
 sinks-file = ["async-compression"]
-sinks-gcp = ["base64", "gcp", "gouth"]
+sinks-gcp = ["base64", "gcp"]
 sinks-honeycomb = []
 sinks-http = []
 sinks-humio = ["sinks-splunk_hec", "transforms-metric_to_log"]

--- a/lib/datadog/grok/Cargo.toml
+++ b/lib/datadog/grok/Cargo.toml
@@ -17,7 +17,6 @@ ordered-float = { version = "3", default-features = false }
 peeking_take_while = { version = "1.0.0", default-features = false }
 regex = { version = "1.5", default-features = false, features = ["perf"] }
 serde_json = { version = "1.0.81", default-features = false }
-strum_macros = { version = "0.24", default-features = false }
 thiserror = { version = "1", default-features = false }
 tracing = { version = "0.1.34", default-features = false }
 

--- a/lib/datadog/grok/src/grok_filter.rs
+++ b/lib/datadog/grok/src/grok_filter.rs
@@ -1,7 +1,6 @@
-use std::{convert::TryFrom, string::ToString};
+use std::{convert::TryFrom, string::ToString, fmt};
 
 use ordered_float::NotNan;
-use strum_macros::Display;
 use value::Value;
 
 use crate::{
@@ -12,7 +11,7 @@ use crate::{
     parse_grok_rules::Error as GrokStaticError,
 };
 
-#[derive(Debug, Display, Clone)]
+#[derive(Debug, Clone)]
 pub enum GrokFilter {
     Date(DateFilter),
     Integer,
@@ -32,6 +31,25 @@ pub enum GrokFilter {
         Box<Option<GrokFilter>>,
     ),
     KeyValue(KeyValueFilter),
+}
+
+impl fmt::Display for GrokFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GrokFilter::Date(..) => f.pad("Date(..)"),
+            GrokFilter::Integer => f.pad("Integer"),
+            GrokFilter::IntegerExt => f.pad("IntegerExt"),
+            GrokFilter::Number => f.pad("Number"),
+            GrokFilter::NumberExt => f.pad("NumberExt"),
+            GrokFilter::NullIf(..) => f.pad("NullIf(..)"),
+            GrokFilter::Scale(..) => f.pad("Scale(..)"),
+            GrokFilter::Lowercase => f.pad("Lowercase"),
+            GrokFilter::Uppercase => f.pad("Uppercase"),
+            GrokFilter::Json => f.pad("Json"),
+            GrokFilter::Array(..) => f.pad("Array(..)"),
+            GrokFilter::KeyValue(..) => f.pad("KeyValue(..)"),
+        }
+    }
 }
 
 impl TryFrom<&Function> for GrokFilter {

--- a/lib/vector-config-common/Cargo.toml
+++ b/lib/vector-config-common/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 darling = { version = "0.13", default-features = false, features = ["suggestions"] }
 proc-macro2 = { version = "1.0", default-features = false }
 schemars = { version = "0.8.10", default-features = false }
-syn = { version = "1.0", default-features = false }
+syn = { version = "1.0" }
 quote = { version = "1.0", default-features = false }

--- a/lib/vector-config-common/Cargo.toml
+++ b/lib/vector-config-common/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 darling = { version = "0.13", default-features = false, features = ["suggestions"] }
 proc-macro2 = { version = "1.0", default-features = false }
 schemars = { version = "0.8.10", default-features = false }
-syn = { version = "1.0" }
+syn = { version = "1.0", features = ["full", "extra-traits", "visit-mut", "visit"] }
 quote = { version = "1.0", default-features = false }

--- a/lib/vector-config-common/Cargo.toml
+++ b/lib/vector-config-common/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-darling = { version = "0.14", default-features = false, features = ["suggestions"] }
+darling = { version = "0.13", default-features = false, features = ["suggestions"] }
 proc-macro2 = { version = "1.0", default-features = false }
 schemars = { version = "0.8.10", default-features = false }
 syn = { version = "1.0", default-features = false }

--- a/lib/vector-config-common/src/validation.rs
+++ b/lib/vector-config-common/src/validation.rs
@@ -142,24 +142,23 @@ pub enum Validation {
     /// When used for strings, applies to the number of characters. When used for arrays, applies to the number of
     /// items. When used for objects, applies to the number of properties.
     Length {
-        #[darling(rename = "min")]
+        #[darling(default, rename = "min")]
         minimum: Option<u32>,
-        #[darling(rename = "max")]
+        #[darling(default, rename = "max")]
         maximum: Option<u32>,
     },
     /// A minimum and/or maximum range, or bound.
     ///
     /// Can only be used for numbers.
     Range {
-        #[darling(rename = "min", with = "maybe_float_or_int")]
+        #[darling(default, rename = "min", with = "maybe_float_or_int")]
         minimum: Option<f64>,
-        #[darling(rename = "max", with = "maybe_float_or_int")]
+        #[darling(default, rename = "max", with = "maybe_float_or_int")]
         maximum: Option<f64>,
     },
     /// A regular expression pattern.
     ///
     /// Can only be used for strings.
-    //#[darling(with = "from_lit_str")]
     Pattern(String),
 }
 

--- a/lib/vector-config-macros/Cargo.toml
+++ b/lib/vector-config-macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-darling = { version = "0.14", default-features = false, features = ["suggestions"] }
+darling = { version = "0.13", default-features = false, features = ["suggestions"] }
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
 serde_derive_internals = "0.26"

--- a/lib/vector-config-macros/Cargo.toml
+++ b/lib/vector-config-macros/Cargo.toml
@@ -11,5 +11,5 @@ darling = { version = "0.13", default-features = false, features = ["suggestions
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
 serde_derive_internals = "0.26"
-syn = { version = "1.0", default-features = false }
+syn = { version = "1.0", default-features = false, features = ["full", "extra-traits", "visit-mut", "visit"] }
 vector_config_common = { path = "../vector-config-common" }

--- a/lib/vector-config-macros/src/ast/container.rs
+++ b/lib/vector-config-macros/src/ast/container.rs
@@ -175,7 +175,7 @@ impl<'a> Container<'a> {
     }
 
     pub fn deprecated(&self) -> bool {
-        self.attrs.deprecated.is_present()
+        self.attrs.deprecated.is_some()
     }
 
     pub fn metadata(&self) -> impl Iterator<Item = &(String, String)> {
@@ -186,11 +186,14 @@ impl<'a> Container<'a> {
     }
 }
 
-#[derive(Debug, FromAttributes)]
-#[darling(attributes(configurable))]
+#[derive(Debug, Default, FromAttributes)]
+#[darling(default, attributes(configurable))]
 struct Attributes {
+    #[darling(default)]
     title: Option<String>,
+    #[darling(default)]
     description: Option<String>,
+    #[darling(default)]
     deprecated: Flag,
     #[darling(multiple)]
     metadata: Vec<Metadata>,

--- a/lib/vector-config-macros/src/ast/field.rs
+++ b/lib/vector-config-macros/src/ast/field.rs
@@ -55,11 +55,11 @@ impl<'a> Field<'a> {
     }
 
     pub fn transparent(&self) -> bool {
-        self.attrs.transparent.is_present()
+        self.attrs.transparent.is_some()
     }
 
     pub fn deprecated(&self) -> bool {
-        self.attrs.deprecated.is_present()
+        self.attrs.deprecated.is_some()
     }
 
     pub fn validation(&self) -> &[Validation] {
@@ -75,8 +75,8 @@ impl<'a> Field<'a> {
     }
 }
 
-#[derive(Debug, FromAttributes)]
-#[darling(attributes(configurable))]
+#[derive(Debug, Default, FromAttributes)]
+#[darling(default, attributes(configurable))]
 struct Attributes {
     title: Option<String>,
     description: Option<String>,
@@ -120,8 +120,8 @@ impl Attributes {
         // If a field is flattened, that's also another form of derivation so we don't require a description in that
         // scenario either.
         if self.description.is_none()
-            && !self.derived.is_present()
-            && !self.transparent.is_present()
+            && !self.derived.is_some()
+            && !self.transparent.is_some()
             && self.visible
             && !self.flatten
         {

--- a/lib/vector-config-macros/src/ast/variant.rs
+++ b/lib/vector-config-macros/src/ast/variant.rs
@@ -71,7 +71,7 @@ impl<'a> Variant<'a> {
     }
 
     pub fn deprecated(&self) -> bool {
-        self.attrs.deprecated.is_present()
+        self.attrs.deprecated.is_some()
     }
 
     pub fn visible(&self) -> bool {
@@ -85,8 +85,8 @@ impl<'a> Spanned for Variant<'a> {
     }
 }
 
-#[derive(Debug, FromAttributes)]
-#[darling(attributes(configurable))]
+#[derive(Debug, Default, FromAttributes)]
+#[darling(default, attributes(configurable))]
 struct Attributes {
     title: Option<String>,
     description: Option<String>,

--- a/src/api/schema/components/source.rs
+++ b/src/api/schema/components/source.rs
@@ -1,8 +1,6 @@
 use std::cmp;
 
 use async_graphql::{Enum, InputObject, Object};
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
 
 use super::{sink, state, transform, Component};
 use crate::{
@@ -15,7 +13,8 @@ use crate::{
     filter_check,
 };
 
-#[derive(Debug, Enum, EnumIter, Eq, PartialEq, Copy, Clone, Ord, PartialOrd)]
+//#[derive(Debug, Enum, EnumIter, Eq, PartialEq, Copy, Clone, Ord, PartialOrd)]
+#[derive(Debug, Enum, Eq, PartialEq, Copy, Clone, Ord, PartialOrd)]
 pub enum SourceOutputType {
     Log,
     Metric,
@@ -49,9 +48,9 @@ impl Source {
         self.0.component_type.as_str()
     }
     pub fn get_output_types(&self) -> Vec<SourceOutputType> {
-        SourceOutputType::iter()
+        [SourceOutputType::Log, SourceOutputType::Metric, SourceOutputType::Trace].iter()
+            .copied()
             .filter(|s| self.0.output_type.contains(s.into()))
-            .map(Into::into)
             .collect()
     }
 

--- a/src/api/schema/components/source.rs
+++ b/src/api/schema/components/source.rs
@@ -13,7 +13,6 @@ use crate::{
     filter_check,
 };
 
-//#[derive(Debug, Enum, EnumIter, Eq, PartialEq, Copy, Clone, Ord, PartialOrd)]
 #[derive(Debug, Enum, Eq, PartialEq, Copy, Clone, Ord, PartialOrd)]
 pub enum SourceOutputType {
     Log,

--- a/src/config/loading/loader.rs
+++ b/src/config/loading/loader.rs
@@ -1,8 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use serde_toml_merge::merge_into_table;
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
 use toml::value::{Table, Value};
 
 use super::{component_name, open_file, read_dir, Format};
@@ -10,7 +8,8 @@ use crate::config::format;
 
 /// Provides a hint to the loading system of the type of components that should be found
 /// when traversing an explicitly named directory.
-#[derive(Debug, Copy, Clone, EnumIter)]
+//#[derive(Debug, Copy, Clone, EnumIter)]
+#[derive(Debug, Copy, Clone)]
 pub enum ComponentHint {
     Source,
     Transform,
@@ -244,7 +243,8 @@ where
     /// Returns a vector of non-fatal warnings on success, or a vector of error strings on failure.
     fn load_from_dir(&mut self, path: &Path) -> Result<Vec<String>, Vec<String>> {
         // Iterator containing component-specific sub-folders to attempt traversing into.
-        let paths = ComponentHint::iter().map(|hint| (hint.join_path(path), hint));
+        let hints = [ComponentHint::Source, ComponentHint::Transform, ComponentHint::Sink, ComponentHint::Test, ComponentHint::EnrichmentTable];
+        let paths = hints.iter().copied().map(|hint| (hint.join_path(path), hint));
 
         // Get files from the root of the folder. These represent top-level config settings,
         // and need to merged down first to represent a more 'complete' config.


### PR DESCRIPTION
This PR works to reduce some duplicate crate dependencies, and in turn, the need to compile them.

In no particular order:
- switch from `gouth` to `goauth` the `stackdriver_metrics` sink (`stackdriver_logs` already used `goauth`)
- remove `strum`/`strum_macros` as they provide little value over simple hand-rolled impls of common traits, at least where we happened to use them
- _remove_ the `default-features = false` for `syn` in `vector-config-common`, which was manifesting as an entirely distinct version of `syn` needing to be compiled
- switch to `darling@0.13` (down from `0.14`) for `vector-config-common` and friends, as this let us line up with other dependencies we have which use `0.13`

For both clean debug and release builds, this shaves a good 5-10s off the full build. With these changes, the debug binary is about 10MB smaller (but still 2.47GB) and the release binary is about 2MB smaller (but still 148MB).