### PR TITLE
feat(datadog_agent source): Parse namespace out of incoming events

### DIFF
--- a/src/sources/datadog/agent/tests.rs
+++ b/src/sources/datadog/agent/tests.rs
@@ -697,6 +697,26 @@ async fn decode_series_endpoints() {
                     source_type_name: None,
                     device: None,
                 },
+                DatadogSeriesMetric {
+                    metric: "system.disk.free".to_string(),
+                    r#type: DatadogMetricType::Count,
+                    interval: None,
+                    points: vec![DatadogPoint(1542182955, 16777216_f64)],
+                    tags: None,
+                    host: None,
+                    source_type_name: None,
+                    device: None,
+                },
+                DatadogSeriesMetric {
+                    metric: "system.disk".to_string(),
+                    r#type: DatadogMetricType::Count,
+                    interval: None,
+                    points: vec![DatadogPoint(1542182955, 16777216_f64)],
+                    tags: None,
+                    host: None,
+                    source_type_name: None,
+                    device: None,
+                },
             ],
         };
         let events = spawn_collect_n(
@@ -713,13 +733,14 @@ async fn decode_series_endpoints() {
                 );
             },
             rx,
-            4,
+            6,
         )
         .await;
 
         {
             let mut metric = events[0].as_metric();
             assert_eq!(metric.name(), "dd_gauge");
+            assert_eq!(metric.namespace(), None);
             assert_eq!(
                 metric.timestamp(),
                 Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10))
@@ -736,6 +757,7 @@ async fn decode_series_endpoints() {
 
             metric = events[1].as_metric();
             assert_eq!(metric.name(), "dd_gauge");
+            assert_eq!(metric.namespace(), None);
             assert_eq!(
                 metric.timestamp(),
                 Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 11))
@@ -752,6 +774,7 @@ async fn decode_series_endpoints() {
 
             metric = events[2].as_metric();
             assert_eq!(metric.name(), "dd_rate");
+            assert_eq!(metric.namespace(), None);
             assert_eq!(
                 metric.timestamp(),
                 Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10))
@@ -789,6 +812,14 @@ async fn decode_series_endpoints() {
             );
             assert_eq!(metric.tags().unwrap()["host"], "a_host".to_string());
             assert_eq!(metric.tags().unwrap()["foobar"], "".to_string());
+
+            metric = events[4].as_metric();
+            assert_eq!(metric.name(), "disk.free");
+            assert_eq!(metric.namespace(), Some("system"));
+
+            metric = events[5].as_metric();
+            assert_eq!(metric.name(), "disk");
+            assert_eq!(metric.namespace(), Some("system"));
 
             assert_eq!(
                 &events[3].metadata().datadog_api_key().as_ref().unwrap()[..],


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Closes #12953.

- Added a helper function to extract the namespace from the input metric name from Datadog.


Tested by running the Datadog Agent locally and stdout as a sink:


/// before
```
{"name":"datadog.agent.started","tags":{"host":"i-0eacf44f2df5844ff","version":"7.36.1"},"timestamp":"2022-06-15T19:23:40Z","kind":"incremental","counter":{"value":1.0}

{"name":"system.disk.in_use","tags":{"device":"/dev/loop1","device_name":"loop1","host":"i-0eacf44f2df5844ff","source_type_name":"System"},"timestamp":"2022-06-15T19:23:57Z","kind":"absolute","gauge":{"value":1.0}}
{"name":"system.disk.free","tags":{"device":"/dev/loop3","device_name":"loop3","host":"i-0eacf44f2df5844ff","source_type_name":"System"},"timestamp":"2022-06-15T19:23:57Z","kind":"absolute","gauge":{"value":0.0}}
```

/// after
```
{"name":"net.bytes_rcvd","namespace":"system","tags":{"device":"lo","host":"i-0eacf44f2df5844ff","source_type_name":"System"},"timestamp":"2022-06-15T19:17:31Z","kind":"absolute","gauge":{"value":5981.857316429466}}
{"name":"net.bytes_sent","namespace":"system","tags":{"device":"lo","host":"i-0eacf44f2df5844ff","source_type_name":"System"},"timestamp":"2022-06-15T19:17:31Z","kind":"absolute","gauge":{"value":5981.857411510499}}
{"name":"agent.python.version","namespace":"datadog","tags":{"agent_version_major":"7","agent_version_minor":"36","agent_version_patch":"1","host":"i-0eacf44f2df5844ff","python_version":"3","source_type_name":"System"},"timestamp":"2022-06-15T19:17:42Z","kind":"absolute","gauge":{"value":1.0}}
{"name":"agent.running","namespace":"datadog","tags":{"host":"i-0eacf44f2df5844ff","source_type_name":"System","version":"7.36.1"},"timestamp":"2022-06-15T19:17:42Z","kind":"absolute","gauge":{"value":1.0}}
```