### PR TITLE
chore: Fix no_run doc comment fences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8664,8 +8664,10 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
+ "serde",
  "serde_derive_internals",
  "syn",
+ "vector_config",
  "vector_config_common",
 ]
 

--- a/lib/vector-config-macros/Cargo.toml
+++ b/lib/vector-config-macros/Cargo.toml
@@ -13,3 +13,7 @@ quote = { version = "1.0", default-features = false }
 serde_derive_internals = "0.26"
 syn = { version = "1.0", default-features = false, features = ["full", "extra-traits", "visit-mut", "visit"] }
 vector_config_common = { path = "../vector-config-common" }
+
+[dev-dependencies]
+serde = { version = "1.0.137", default-features = false }
+vector_config = { path = "../vector-config" }

--- a/lib/vector-config-macros/src/lib.rs
+++ b/lib/vector-config-macros/src/lib.rs
@@ -15,7 +15,12 @@ mod configurable_component;
 /// in any other type also deriving `Configurable`:
 ///
 /// ```no_run
+/// use vector_config_macros::configurable_component;
+/// use serde;
+///
+/// /// Configuration for the Something struct
 /// #[configurable_component]
+/// #[derive(Clone, Debug)]
 /// pub struct Something {
 ///   // ...
 /// }
@@ -25,7 +30,12 @@ mod configurable_component;
 /// for a component by specifying the component type (`source`, `transform`, or `sink`) as the sole parameter:
 ///
 /// ```no_run
+/// use vector_config_macros::configurable_component;
+/// use serde;
+///
+/// /// Configuration for the `kafka` source
 /// #[configurable_component(source)]
+/// #[derive(Clone, Debug)]
 /// pub struct KafkaSourceConfig {
 ///   // ...
 /// }

--- a/lib/vector-config-macros/src/lib.rs
+++ b/lib/vector-config-macros/src/lib.rs
@@ -17,7 +17,7 @@ mod configurable_component;
 /// ```no_run
 /// #[configurable_component]
 /// pub struct Something {
-///   ...
+///   // ...
 /// }
 /// ```
 ///
@@ -27,7 +27,7 @@ mod configurable_component;
 /// ```no_run
 /// #[configurable_component(source)]
 /// pub struct KafkaSourceConfig {
-///   ...
+///   // ...
 /// }
 /// ```
 ///

--- a/lib/vector-config-macros/src/lib.rs
+++ b/lib/vector-config-macros/src/lib.rs
@@ -14,7 +14,7 @@ mod configurable_component;
 /// In its most basic form, this attribute macro can be used to simply derive the aforementioned traits, making it using
 /// in any other type also deriving `Configurable`:
 ///
-/// ```norun
+/// ```no_run
 /// #[configurable_component]
 /// pub struct Something {
 ///   ...
@@ -24,7 +24,7 @@ mod configurable_component;
 /// Additionally, callers can specify the component type, when being used directly on the top-level configuration object
 /// for a component by specifying the component type (`source`, `transform`, or `sink`) as the sole parameter:
 ///
-/// ```norun
+/// ```no_run
 /// #[configurable_component(source)]
 /// pub struct KafkaSourceConfig {
 ///   ...


### PR DESCRIPTION
Was generating warning:

> unknown attribute `norun`. Did you mean `no_run`?


Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
