### PR TITLE
bug(buffers): avoid panicking on recoverable disk_v2 reader errors

### DIFF
--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -69,6 +69,7 @@ impl InternalEvent for BufferEventsDropped {
                 count = %self.count,
                 intentional = %intentional_str,
                 reason = %self.reason,
+                stage = %self.idx,
             );
         } else {
             error!(
@@ -76,6 +77,7 @@ impl InternalEvent for BufferEventsDropped {
                 count = %self.count,
                 intentional = %intentional_str,
                 reason = %self.reason,
+                stage = %self.idx,
             );
         }
         counter!(

--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -1,6 +1,24 @@
 use metrics::{counter, decrement_gauge, gauge, increment_gauge};
 use vector_common::internal_event::InternalEvent;
 
+pub struct BufferCreated {
+    pub idx: usize,
+    pub max_size_events: Option<usize>,
+    pub max_size_bytes: Option<u64>,
+}
+
+impl InternalEvent for BufferCreated {
+    #[allow(clippy::cast_precision_loss)]
+    fn emit(self) {
+        if let Some(max_size) = self.max_size_events {
+            gauge!("buffer_max_event_size", max_size as f64, "stage" => self.idx.to_string());
+        }
+        if let Some(max_size) = self.max_size_bytes {
+            gauge!("buffer_max_byte_size", max_size as f64, "stage" => self.idx.to_string());
+        }
+    }
+}
+
 pub struct BufferEventsReceived {
     pub idx: usize,
     pub count: u64,
@@ -37,41 +55,58 @@ pub struct BufferEventsDropped {
     pub idx: usize,
     pub count: u64,
     pub byte_size: u64,
+    pub intentional: bool,
+    pub reason: &'static str,
 }
 
 impl InternalEvent for BufferEventsDropped {
     #[allow(clippy::cast_precision_loss)]
     fn emit(self) {
-        counter!("buffer_discarded_events_total", self.count, "stage" => self.idx.to_string());
+        let intentional_str = if self.intentional { "true" } else { "false" };
+        if self.intentional {
+            debug!(
+                message = "Events dropped.",
+                count = %self.count,
+                intentional = %intentional_str,
+                reason = %self.reason,
+            );
+        } else {
+            error!(
+                message = "Events dropped.",
+                count = %self.count,
+                intentional = %intentional_str,
+                reason = %self.reason,
+            );
+        }
+        counter!(
+            "buffer_discarded_events_total", self.count,
+            "intentional" => intentional_str,
+        );
         decrement_gauge!("buffer_events", self.count as f64, "stage" => self.idx.to_string());
         decrement_gauge!("buffer_byte_size", self.byte_size as f64, "stage" => self.idx.to_string());
     }
 }
 
-pub struct EventsCorrupted {
-    pub count: u64,
+pub struct BufferReadError {
+    pub error_code: &'static str,
+    pub error: String,
 }
 
-impl InternalEvent for EventsCorrupted {
+impl InternalEvent for BufferReadError {
     fn emit(self) {
-        counter!("buffer_corrupted_events_total", self.count);
-    }
-}
-
-pub struct BufferCreated {
-    pub idx: usize,
-    pub max_size_events: Option<usize>,
-    pub max_size_bytes: Option<u64>,
-}
-
-impl InternalEvent for BufferCreated {
-    #[allow(clippy::cast_precision_loss)]
-    fn emit(self) {
-        if let Some(max_size) = self.max_size_events {
-            gauge!("buffer_max_event_size", max_size as f64, "stage" => self.idx.to_string());
-        }
-        if let Some(max_size) = self.max_size_bytes {
-            gauge!("buffer_max_byte_size", max_size as f64, "stage" => self.idx.to_string());
-        }
+        error!(
+            message = "Error encountered during buffer read.",
+            error = %self.error,
+            error_code = self.error_code,
+            error_type = "reader_failed",
+            stage = "processing",
+            internal_log_rate_secs = 10,
+        );
+        counter!(
+            "buffer_errors_total", 1,
+            "error_code" => self.error_code,
+            "error_type" => "reader_failed",
+            "stage" => "processing",
+        );
     }
 }

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -136,7 +136,7 @@ impl<T: Bufferable> TopologyBuilder<T> {
             // sender/receiver/acker.  This is slightly awkward since we just end up actually giving
             // the handle to the `BufferSender`/`BufferReceiver` wrappers, but that's the price we
             // have to pay for letting each stage function in an opaque way when wrapped.
-            let usage_handle = buffer_usage.add_stage(stage_idx, stage.when_full);
+            let usage_handle = buffer_usage.add_stage(stage_idx);
             let provides_instrumentation = stage.untransformed.provides_instrumentation();
             let (sender, receiver, acker) = stage
                 .untransformed
@@ -211,7 +211,7 @@ impl<T: Bufferable> TopologyBuilder<T> {
         max_events: NonZeroUsize,
         when_full: WhenFull,
     ) -> (BufferSender<T>, BufferReceiver<T>) {
-        let usage_handle = BufferUsageHandle::noop(when_full);
+        let usage_handle = BufferUsageHandle::noop();
 
         let memory_buffer = Box::new(MemoryBuffer::new(max_events));
         let (sender, receiver, _) = memory_buffer

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -242,9 +242,10 @@ impl<T: Bufferable> BufferSender<T> {
                 }
 
                 if was_dropped {
-                    instrumentation.try_increment_dropped_event_count_and_byte_size(
+                    instrumentation.increment_dropped_event_count_and_byte_size(
                         item_count as u64,
                         item_size as u64,
+                        true,
                     );
                 }
             }

--- a/lib/vector-buffers/src/topology/channel/tests.rs
+++ b/lib/vector-buffers/src/topology/channel/tests.rs
@@ -199,7 +199,7 @@ async fn test_buffer_metrics_normal() {
     let snapshot = handle.snapshot();
     assert_eq!(3, snapshot.received_event_count);
     assert_eq!(0, snapshot.sent_event_count);
-    assert_eq!(None, snapshot.dropped_event_count);
+    assert_eq!(0, snapshot.dropped_event_count_intentional);
 
     // Then, when we collect all of the messages from the receiver, the metrics should also reflect that.
     let mut results = drain_receiver(tx, rx).await;
@@ -209,7 +209,7 @@ async fn test_buffer_metrics_normal() {
     let snapshot = handle.snapshot();
     assert_eq!(3, snapshot.received_event_count);
     assert_eq!(3, snapshot.sent_event_count);
-    assert_eq!(None, snapshot.dropped_event_count);
+    assert_eq!(0, snapshot.dropped_event_count_intentional);
 }
 
 #[tokio::test]
@@ -226,7 +226,7 @@ async fn test_buffer_metrics_drop_newest() {
     let snapshot = handle.snapshot();
     assert_eq!(3, snapshot.received_event_count);
     assert_eq!(0, snapshot.sent_event_count);
-    assert_eq!(Some(1), snapshot.dropped_event_count);
+    assert_eq!(1, snapshot.dropped_event_count_intentional);
 
     // Then, when we collect all of the messages from the receiver, the metrics should also reflect that.
     let mut results = drain_receiver(tx, rx).await;
@@ -236,5 +236,5 @@ async fn test_buffer_metrics_drop_newest() {
     let snapshot = handle.snapshot();
     assert_eq!(3, snapshot.received_event_count);
     assert_eq!(2, snapshot.sent_event_count);
-    assert_eq!(Some(1), snapshot.dropped_event_count);
+    assert_eq!(1, snapshot.dropped_event_count_intentional);
 }

--- a/lib/vector-buffers/src/topology/test_util.rs
+++ b/lib/vector-buffers/src/topology/test_util.rs
@@ -63,7 +63,7 @@ pub async fn build_buffer(
     mode: WhenFull,
     overflow_mode: Option<WhenFull>,
 ) -> (BufferSender<u64>, BufferReceiver<u64>, BufferUsageHandle) {
-    let handle = BufferUsageHandle::noop(mode);
+    let handle = BufferUsageHandle::noop();
     let (tx, rx) = match mode {
         WhenFull::Overflow => {
             let overflow_mode = overflow_mode.expect("overflow mode cannot be empty");

--- a/lib/vector-buffers/src/variants/disk_v1/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/mod.rs
@@ -6,7 +6,7 @@ use tracing::{Metadata, Span};
 use super::{open, Reader, Writer};
 use crate::{
     buffer_usage_data::BufferUsageHandle, test::common::install_tracing_helpers,
-    variants::disk_v1::reader::FLUSH_INTERVAL, Acker, Bufferable, WhenFull,
+    variants::disk_v1::reader::FLUSH_INTERVAL, Acker, Bufferable,
 };
 
 mod acknowledgements;
@@ -24,7 +24,7 @@ where
     P: AsRef<Path>,
     R: Bufferable + Clone,
 {
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
     open(
         data_dir.as_ref(),
         "disk_buffer_v1",
@@ -42,7 +42,7 @@ where
     P: AsRef<Path>,
     R: Bufferable + Clone,
 {
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
     let (writer, reader, acker) = open(
         data_dir.as_ref(),
         "disk_buffer_v1",
@@ -65,7 +65,7 @@ where
 {
     let max_buffer_size =
         NonZeroU64::new(max_buffer_size).expect("max buffer size must be non-zero");
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
     let (writer, reader, acker) = open(
         data_dir.as_ref(),
         "disk_buffer_v1",

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -522,6 +522,19 @@ where
                 initial_buffer_size,
             );
     }
+
+    pub fn track_dropped_events(&self, count: u64) {
+        // We don't know how many bytes are represented by dropped events because we never actually had a chance to read
+        // them, so we have to use a byte size of 0 here.
+        //
+        // On the flipside, this would only matter if we incremented the buffer size and simultaneously skipped/lost the
+        // events within the same process lifecycle, since otherwise we'd start from the correct buffer size when
+        // loading the buffer initially.
+        //
+        // TODO: Can we do better here?
+        self.usage_handle
+            .increment_dropped_event_count_and_byte_size(count, 0, false);
+    }
 }
 
 impl<FS> Ledger<FS>

--- a/lib/vector-buffers/src/variants/disk_v2/tests/acknowledgements.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/acknowledgements.rs
@@ -8,7 +8,6 @@ use crate::{
     variants::disk_v2::{
         acknowledgements::create_disk_v2_acker, ledger::Ledger, DiskBufferConfigBuilder,
     },
-    WhenFull,
 };
 
 #[tokio::test]
@@ -18,7 +17,7 @@ async fn ack_updates_ledger_correctly() {
 
         async move {
             // Create a standalone ledger.
-            let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+            let usage_handle = BufferUsageHandle::noop();
             let config = DiskBufferConfigBuilder::from_path(data_dir)
                 .build()
                 .expect("creating buffer should not fail");
@@ -48,7 +47,7 @@ async fn ack_wakes_reader() {
 
         async move {
             // Create a standalone ledger.
-            let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+            let usage_handle = BufferUsageHandle::noop();
             let config = DiskBufferConfigBuilder::from_path(data_dir)
                 .build()
                 .expect("creating buffer should not fail");

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -11,7 +11,7 @@ use super::{
     io::{AsyncFile, Metadata, ProductionFilesystem, ReadableMemoryMap, WritableMemoryMap},
     Buffer, DiskBufferConfigBuilder, Ledger, Reader, Writer,
 };
-use crate::{buffer_usage_data::BufferUsageHandle, Acker, Bufferable, WhenFull};
+use crate::{buffer_usage_data::BufferUsageHandle, Acker, Bufferable};
 
 type FilesystemUnderTest = ProductionFilesystem;
 
@@ -181,7 +181,7 @@ where
     let config = DiskBufferConfigBuilder::from_path(data_dir)
         .build()
         .expect("creating buffer should not fail");
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
     Buffer::from_config_inner(config, usage_handle)
         .await
         .expect("should not fail to create buffer")
@@ -203,7 +203,7 @@ where
     let config = DiskBufferConfigBuilder::from_path(data_dir)
         .build()
         .expect("creating buffer should not fail");
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
     let (writer, reader, acker, ledger) = Buffer::from_config_inner(config, usage_handle.clone())
         .await
         .expect("should not fail to create buffer");
@@ -229,7 +229,7 @@ where
         .build()
         .expect("creating buffer should not fail");
     config.max_buffer_size = max_buffer_size;
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
 
     Buffer::from_config_inner(config, usage_handle)
         .await
@@ -253,7 +253,7 @@ where
         .max_record_size(max_record_size)
         .build()
         .expect("creating buffer should not fail");
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
 
     Buffer::from_config_inner(config, usage_handle)
         .await
@@ -277,7 +277,7 @@ where
         .max_data_file_size(max_data_file_size)
         .build()
         .expect("creating buffer should not fail");
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
 
     Buffer::from_config_inner(config, usage_handle)
         .await
@@ -301,7 +301,7 @@ where
         .write_buffer_size(write_buffer_size)
         .build()
         .expect("creating buffer should not fail");
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
 
     Buffer::from_config_inner(config, usage_handle)
         .await

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     variants::disk_v2::{
         common::MAX_FILE_ID, writer::RecordWriter, Buffer, DiskBufferConfig, WriterError,
     },
-    EventCount, WhenFull,
+    EventCount,
 };
 
 mod action;
@@ -829,7 +829,7 @@ proptest! {
             // actions that are coupled to one another, in a lockstep fashion, with the model.
             let mut model = BufferModel::from_config(&config);
 
-            let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+            let usage_handle = BufferUsageHandle::noop();
             let (writer, reader, acker, ledger) =
                 Buffer::<Record>::from_config_inner(config, usage_handle)
                     .await

--- a/lib/vector-buffers/src/variants/disk_v2/v1_migration.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/v1_migration.rs
@@ -7,7 +7,7 @@ use crate::{
         disk_v2::{build_disk_v2_buffer, get_disk_v2_data_dir_path},
         DiskV1Buffer,
     },
-    Acker, Bufferable, WhenFull,
+    Acker, Bufferable,
 };
 
 pub async fn try_disk_v1_migration<T>(base_data_dir: &Path, id: &str) -> Result<(), String>
@@ -16,7 +16,7 @@ where
 {
     // Set both buffers to an essentially unlimited size so we can ensure that whatever is in the
     // source buffer can be written to the destination buffer.
-    let usage_handle = BufferUsageHandle::noop(WhenFull::Block);
+    let usage_handle = BufferUsageHandle::noop();
     let buffer_max_size = NonZeroU64::new(u64::MAX).expect("cannot fail");
 
     // Try and build the disk v1 buffer without creating it if it is missing, so that we only open


### PR DESCRIPTION
# Context

In #13178, we outlined a situation where a user discovered that restarting Vector, after crashing due to the `disk_v2` buffer hitting an "out of space" I/O error on the write path, they received a` PartialWrite` error on the _read_ path, which also got raised as a panic.

In almost all cases, errors on the read path are recoverable, or at least can be moved past: if we fail to deserialize a record, or we detect a partial write, we still know how to set ourselves to try and read the next valid record, or continue trying if we hit further such errors.

# Solution

The `disk_v2` reader already had a notion of an error that was recoverable, but it never encoded that in any way except through doc comments.

This PR exposes a way to convert a `ReaderError` into an event that can be emitted -- which allows us to further drive towards 100% compliance of the Buffer specification -- and instead of packing, will emit that event and continue polling the reader for the next valid record.

The core change is fairly small -- a `loop` in `ReceiverAdapter` that panics if the error isn't marked as recoverable, and continues trying if it is -- but we've also done a bit of work rearranging the `BufferUsage*` family of types, and the internal events they emit, to properly categorize not only the read error events, but also the `BufferEventsDropped` event, ensuring that it follows the Buffer specification and indicates when events are intentionally or unintentionally dropped.

# Testing

I reproduced the example in #13001 and got a buffer to a state where it was left with a partial write. With a build from `master`, restarting Vector with such a buffer state never works correctly. With this PR, it correctly detects the partial write, simply emits an error, and continues reading. In doing so, it allows subsequent writes to proceed.

This PR doesn't fix the overall problem with the write path panicking when there is not enough space to continue writing, but that is documented and addressed in #13044 and will be tackled in the short term.