### PR TITLE
enhancement: Append (rather than prepend) bin dir to $PATH

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -168,6 +168,7 @@ install_from_archive() {
     printf " ✓\n"
 
     if [ "$modify_path" = "yes" ]; then
+      # shellcheck disable=SC2016 # We don't want to expand here.
       local _path='export PATH="$PATH:$HOME/.vector/bin"'
       add_to_path "${HOME}/.zprofile" "${_path}"
       add_to_path "${HOME}/.profile" "${_path}"

--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -168,7 +168,7 @@ install_from_archive() {
     printf " ✓\n"
 
     if [ "$modify_path" = "yes" ]; then
-      local _path="export PATH=\"\$HOME/.vector/bin:\$PATH\""
+      local _path='export PATH="$PATH:$HOME/.vector/bin"'
       add_to_path "${HOME}/.zprofile" "${_path}"
       add_to_path "${HOME}/.profile" "${_path}"
     fi


### PR DESCRIPTION
I think it's unwise to tell a system to look for everything in
~/.vector/bin before it looks in /usr/bin, /usr/local/bin, etc...

When I run `ssh`, I never expect or want to execute `~/.vector/bin/ssh`
however this install script put that bindir at the front of my $PATH.

It's only used so the `vector` binary can be located so there's no
reason it needs to be any earlier than the last entry on $PATH.

Dan Benjamin wrote a nice backgrounder called [Using
/usr/local](https://web.archive.org/web/20060321165501/http://hivelogic.com/articles/2005/11/29/using_usr_local) back in 2005.
