### PR TITLE
fix(vrl): fix type def for the `parse_aws_cloudwatch_log_subscription_message` function

### DIFF
--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -138,11 +138,13 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
         ),
         (
             Field::from("log_events"),
-            Kind::object(BTreeMap::from([
-                (Field::from("id"), Kind::bytes()),
-                (Field::from("timestamp"), Kind::timestamp()),
-                (Field::from("message"), Kind::bytes()),
-            ])),
+            Kind::array(Collection::from_unknown(
+                Kind::object(BTreeMap::from([
+                    (Field::from("id"), Kind::bytes()),
+                    (Field::from("timestamp"), Kind::timestamp()),
+                    (Field::from("message"), Kind::bytes()),
+                ])),
+            ))
         ),
     ])
 }

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -138,13 +138,11 @@ fn inner_kind() -> BTreeMap<Field, Kind> {
         ),
         (
             Field::from("log_events"),
-            Kind::array(Collection::from_unknown(
-                Kind::object(BTreeMap::from([
-                    (Field::from("id"), Kind::bytes()),
-                    (Field::from("timestamp"), Kind::timestamp()),
-                    (Field::from("message"), Kind::bytes()),
-                ])),
-            ))
+            Kind::array(Collection::from_unknown(Kind::object(BTreeMap::from([
+                (Field::from("id"), Kind::bytes()),
+                (Field::from("timestamp"), Kind::timestamp()),
+                (Field::from("message"), Kind::bytes()),
+            ])))),
         ),
     ])
 }


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/13186

We don't have a great way to test this right now, so I created https://github.com/vectordotdev/vector/issues/13188 as a more general testing strategy for this.