### PR TITLE
chore(ci): Fail warnings

### DIFF
--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -2,6 +2,7 @@
 //! byte messages, byte frames and structured events.
 
 #![deny(missing_docs)]
+#![deny(warnings)]
 
 pub mod decoding;
 pub mod encoding;

--- a/lib/datadog/filter/src/lib.rs
+++ b/lib/datadog/filter/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(unreachable_pub)]

--- a/lib/datadog/grok/src/lib.rs
+++ b/lib/datadog/grok/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(unused_allocation)]
 #![deny(unused_extern_crates)]

--- a/lib/datadog/search-syntax/src/lib.rs
+++ b/lib/datadog/search-syntax/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(unused_allocation)]
 #![deny(unused_extern_crates)]

--- a/lib/dnsmsg-parser/src/lib.rs
+++ b/lib/dnsmsg-parser/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![warn(
     missing_debug_implementations,
     rust_2018_idioms,

--- a/lib/enrichment/src/lib.rs
+++ b/lib/enrichment/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 pub mod find_enrichment_table_records;
 pub mod get_enrichment_table_record;
 pub mod tables;

--- a/lib/fakedata/src/lib.rs
+++ b/lib/fakedata/src/lib.rs
@@ -1,1 +1,3 @@
+#![deny(warnings)]
+
 pub mod logs;

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 
 #[macro_use]

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use std::{collections::BTreeMap, env};
 
 use indoc::formatdoc;

--- a/lib/k8s-test-framework/src/lib.rs
+++ b/lib/k8s-test-framework/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 //! Kubernetes test framework.
 //!
 //! The main goal of the design of this test framework is to wire kubernetes

--- a/lib/lookup/src/lib.rs
+++ b/lib/lookup/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use std::{
     fmt::{Debug, Display},
     hash::Hash,

--- a/lib/portpicker/src/lib.rs
+++ b/lib/portpicker/src/lib.rs
@@ -26,6 +26,8 @@
 
 // For more information, please refer to <http://unlicense.org>
 
+#![deny(warnings)]
+
 use std::net::{IpAddr, SocketAddr, TcpListener, ToSocketAddrs, UdpSocket};
 
 use rand::{thread_rng, Rng};

--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use indexmap::IndexMap;

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use std::fmt;
 
 use dashmap::DashMap;

--- a/lib/value/src/lib.rs
+++ b/lib/value/src/lib.rs
@@ -1,6 +1,7 @@
 //! The `value` crate contains types shared across Vector libraries to support it's use of `Value`
 //! and the closely linked `Kind` in support of progressive type checking.
 
+#![deny(warnings)]
 #![deny(
     clippy::all,
     clippy::cargo,

--- a/lib/vector-api-client/src/lib.rs
+++ b/lib/vector-api-client/src/lib.rs
@@ -9,6 +9,7 @@
 //! deserialized JSON responses
 //!
 
+#![deny(warnings)]
 #![deny(missing_debug_implementations, missing_copy_implementations)]
 
 mod client;

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -3,6 +3,7 @@
 //! This library implements a channel like functionality, one variant which is
 //! solely in-memory and the other that is on-disk. Both variants are bounded.
 
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]

--- a/lib/vector-common/shared/src/lib.rs
+++ b/lib/vector-common/shared/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 #[cfg(feature = "aws_cloudwatch_logs_subscription")]
 pub mod aws_cloudwatch_logs_subscription;
 

--- a/lib/vector-common/src/lib.rs
+++ b/lib/vector-common/src/lib.rs
@@ -3,6 +3,7 @@
 //! This library includes common functionality relied upon by vector-core
 //! and core-related crates (e.g. buffers).
 
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(unreachable_pub)]

--- a/lib/vector-config-common/src/lib.rs
+++ b/lib/vector-config-common/src/lib.rs
@@ -6,5 +6,6 @@
 // not great from a UX perspective.  `darling` lacks the ability to incrementally parse a field to avoid having to
 // expose a custom type that gets used downstream...
 
+#![deny(warnings)]
 pub mod num;
 pub mod validation;

--- a/lib/vector-config-macros/src/lib.rs
+++ b/lib/vector-config-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use proc_macro::TokenStream;
 
 mod ast;

--- a/lib/vector-config/src/lib.rs
+++ b/lib/vector-config/src/lib.rs
@@ -82,6 +82,8 @@
 // Vector's template syntax, since doing `templateable = true` is weird given that we never otherwise specifically
 // disable it. In other words, we want a way to define feature flags in metadata.
 
+#![deny(warnings)]
+
 use core::fmt;
 use core::marker::PhantomData;
 

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! This library was extracted from the top-level project package, discussed in
 //! RFC 7027.
 
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(unreachable_pub)]

--- a/lib/vector-vrl-functions/src/lib.rs
+++ b/lib/vector-vrl-functions/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 pub mod get_metadata_field;
 pub mod get_secret;
 pub mod remove_metadata_field;

--- a/lib/vrl/cli/src/lib.rs
+++ b/lib/vrl/cli/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(unreachable_pub)]
 #![deny(unused_allocation)]

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(unreachable_pub)]
 #![deny(unused_allocation)]

--- a/lib/vrl/core/src/lib.rs
+++ b/lib/vrl/core/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(unreachable_pub)]
 #![deny(unused_allocation)]

--- a/lib/vrl/diagnostic/src/lib.rs
+++ b/lib/vrl/diagnostic/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 mod diagnostic;
 mod formatter;
 mod label;

--- a/lib/vrl/parser/src/lib.rs
+++ b/lib/vrl/parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use lalrpop_util::lalrpop_mod;
 lalrpop_mod!(
     #[allow(clippy::all)]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(unreachable_pub)]
 #![deny(unused_allocation)]

--- a/lib/vrl/tests/src/lib.rs
+++ b/lib/vrl/tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 pub mod docs;
 mod test;
 

--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(unreachable_pub)]
 #![deny(unused_allocation)]

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -131,7 +131,6 @@ CARGO_OVERRIDE_CONF="${CARGO_OVERRIDE_DIR}/config.toml"
 cat <<EOF >>"$CARGO_OVERRIDE_CONF"
 [target.'cfg(linux)']
 rustflags = [ "-D", "warnings" ]
-rustdocflags = [ "-D", "warnings" ]
 EOF
 
 # Install mold, because the system linker wastes a bunch of time.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(unused_allocation)]
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
+#![deny(warnings)]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::match_wild_err_arm)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 extern crate vector;
 use vector::app::Application;
 


### PR DESCRIPTION
Follow up to https://github.com/vectordotdev/vector/pull/13184 which
didn't actually cause docs warnings to fail.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
