### PR TITLE
fix(vrl): fix metadata insert/remove

### DIFF
--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -310,7 +310,7 @@ impl MetadataTarget for VrlTarget {
     }
 
     fn remove_metadata(&mut self, path: &LookupBuf) -> Result<(), String> {
-        self.metadata_mut().value_mut().remove_by_path(path, true);
+        self.metadata_mut().value_mut().remove_by_path(path, false);
         Ok(())
     }
 }

--- a/lib/vector-vrl-functions/src/set_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/set_metadata_field.rs
@@ -14,7 +14,7 @@ fn set_metadata_field(
             Value::Null
         }
         MetadataKey::Query(query) => {
-            ctx.target_mut().remove_metadata(query.path())?;
+            ctx.target_mut().set_metadata(query.path(), value)?;
             Value::Null
         }
     })

--- a/lib/vrl/core/src/target.rs
+++ b/lib/vrl/core/src/target.rs
@@ -112,7 +112,7 @@ impl MetadataTarget for TargetValueRef<'_> {
     }
 
     fn remove_metadata(&mut self, path: &LookupBuf) -> Result<(), String> {
-        self.metadata.remove_by_path(path, true);
+        self.metadata.remove_by_path(path, false);
         Ok(())
     }
 }
@@ -168,7 +168,7 @@ impl MetadataTarget for TargetValue {
     }
 
     fn remove_metadata(&mut self, path: &LookupBuf) -> Result<(), String> {
-        self.metadata.remove_by_path(path, true);
+        self.metadata.remove_by_path(path, false);
         Ok(())
     }
 }

--- a/lib/vrl/tests/tests/functions/metadata_read_write_delete.vrl
+++ b/lib/vrl/tests/tests/functions/metadata_read_write_delete.vrl
@@ -1,0 +1,14 @@
+# result:
+# {
+#    "a": {"foo": {"a": 1, "b": 2}},
+#    "b": {"foo": {"b": 2}},
+#    "c": {"foo": {}}
+# }
+
+set_metadata_field(.foo, {"a": 1, "b": 2})
+.a = get_metadata_field(.)
+remove_metadata_field(.foo.a)
+.b = get_metadata_field(.)
+remove_metadata_field(.foo.b)
+.c = get_metadata_field(.)
+.


### PR DESCRIPTION
fixed `set_metadata_field`, and switched `remove_metadata_field` to not compact (to match the `del` function)

note: These new features haven't made it into a release yet, so there's no breaking change.