### PR TITLE
fix(sink) Increase maximum payload size to match datadog API expectations

### DIFF
--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -35,7 +35,7 @@ const DEFAULT_REQUEST_LIMITS: TowerRequestConfig =
 // conservative, though, we use 100K here.  This will also get a little more tricky when it comes to
 // distributions and sketches, but we're going to have to implement incremental encoding to handle
 // "we've exceeded our maximum payload size, split this batch" scenarios anyways.
-pub const MAXIMUM_PAYLOAD_COMPRESSED_SIZE: usize = 3_200_000;
+pub const MAXIMUM_PAYLOAD_COMPRESSED_SIZE: usize = 5_242_880;
 pub const MAXIMUM_PAYLOAD_SIZE: usize = 62_914_560;
 
 #[derive(Clone, Copy, Debug, Default)]


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
The Datadog HTTP API endpoint specifies a [maximum compressed payload size of 5MB](https://docs.datadoghq.com/api/latest/metrics/). I've modified datadog sink hardcoded maximum compressed size value to match that expectation. 