### PR TITLE
chore(ci): Remove xtrace from rustc wrapper

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -160,7 +160,6 @@ if [ -z "${DISABLE_MOLD:-""}" ] ; then
     RUSTC_WRAPPER="${CARGO_BIN_DIR}/wrap-rustc"
     cat <<EOF >"$RUSTC_WRAPPER"
 #!/bin/sh
-set -x
 exec mold -run "\$@"
 EOF
     chmod +x "$RUSTC_WRAPPER"


### PR DESCRIPTION
It makes the component feature check pretty chatty.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
