### PR TITLE
chore: avoid a possible panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ where
 }
 
 pub fn num_threads() -> usize {
-    std::thread::available_parallelism()
-        .expect("Could not determine available parallelism")
-        .into()
+    usize::from(
+        std::thread::available_parallelism().unwrap_or(std::num::NonZeroUsize::new(1).unwrap()),
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub fn num_threads() -> usize {
     let count = match std::thread::available_parallelism() {
         Ok(count) => count,
         Err(error) => {
-            warn!(message = "Failed to acquire thread count... defaulting to 1.", %error);
+            warn!(message = "Failed to determine available parallelism for thread count, defaulting to 1.", %error);
             std::num::NonZeroUsize::new(1).unwrap()
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,12 @@ where
 }
 
 pub fn num_threads() -> usize {
-    usize::from(
-        std::thread::available_parallelism().unwrap_or(std::num::NonZeroUsize::new(1).unwrap()),
-    )
+    let count = match std::thread::available_parallelism() {
+        Ok(count) => count,
+        Err(error) => {
+            warn!(message = "Failed to acquire thread count... defaulting to 1.", %error);
+            std::num::NonZeroUsize::new(1).unwrap()
+        }
+    };
+    usize::from(count)
 }

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -1,4 +1,4 @@
-use std::{cmp, future::ready, panic, sync::Arc};
+use std::{future::ready, panic, sync::Arc};
 
 use aws_sdk_s3::error::GetObjectError;
 use aws_sdk_s3::Client as S3Client;
@@ -110,7 +110,7 @@ const fn default_true() -> bool {
 }
 
 fn default_client_concurrency() -> u32 {
-    cmp::max(1, crate::num_threads() as u32)
+    crate::num_threads() as u32
 }
 
 #[derive(Debug, Snafu)]

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use vector_config::configurable_component;
 
@@ -143,7 +141,7 @@ const fn default_poll_secs() -> u32 {
 }
 
 fn default_client_concurrency() -> u32 {
-    cmp::max(1, crate::num_threads() as u32)
+    crate::num_threads() as u32
 }
 
 const fn default_visibility_timeout_secs() -> u32 {


### PR DESCRIPTION
This also removes needless checks, since `available_parallelism` cannot be < 1 (as guaranteed by the type).

As a somewhat related changed, maybe a future PR should also change `client_concurrency` fields to also be `NonZeroUsize`, to avoid the `as` casts.