### PR TITLE
chore(buffers): don't emit `BufferEventsDropped` event unless count is non-zero

### DIFF
--- a/lib/vector-buffers/src/buffer_usage_data.rs
+++ b/lib/vector-buffers/src/buffer_usage_data.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU64, Ordering},
         Arc,
     },
     time::Duration,
@@ -15,6 +15,71 @@ use crate::{
     spawn_named,
 };
 
+/// Snapshot of category metrics.
+struct CategorySnapshot {
+    event_count: u64,
+    event_byte_size: u64,
+}
+
+impl CategorySnapshot {
+    /// Returns `true` if any of the values are non-zero.
+    fn has_updates(&self) -> bool {
+        self.event_count > 0 || self.event_byte_size > 0
+    }
+}
+
+/// Per-category metrics.
+///
+/// This tracks the number of events, and their size in the buffer, that a given category has interacted with. A
+/// category in this case could be something like the receive or send categories i.e. being written into the buffer, and
+/// then read out of the buffer. Overall, it's a simple grouping mechanism because we often want to track the change in
+/// both number of events, and their size as measured by the buffer.
+#[derive(Debug, Default)]
+struct CategoryMetrics {
+    event_count: AtomicU64,
+    event_byte_size: AtomicU64,
+}
+
+impl CategoryMetrics {
+    /// Increments the event count and byte size by the given amounts.
+    fn increment(&self, event_count: u64, event_byte_size: u64) {
+        self.event_count.fetch_add(event_count, Ordering::Relaxed);
+        self.event_byte_size
+            .fetch_add(event_byte_size, Ordering::Relaxed);
+    }
+
+    /// Sets the event count and event byte size to the given amount.
+    ///
+    /// Most updates are meant to be incremental, so this should be used sparingly.
+    fn set(&self, event_count: u64, event_byte_size: u64) {
+        self.event_count.store(event_count, Ordering::Release);
+        self.event_byte_size
+            .store(event_byte_size, Ordering::Release);
+    }
+
+    /// Gets a snapshot of the event count and event byte size.
+    fn get(&self) -> CategorySnapshot {
+        CategorySnapshot {
+            event_count: self.event_count.load(Ordering::Acquire),
+            event_byte_size: self.event_byte_size.load(Ordering::Acquire),
+        }
+    }
+
+    /// Gets a snapshot of the event count and event byte size by "consuming" the values.
+    ///
+    /// This essentially resets both metrics while capturing their value at the time they were reset. This is useful if
+    /// you want to only emit updates when values have been incremented/set to a non-zero value, as by consuming each
+    /// time, you can tell if anything has changed since the last call to `consume` without needing internal state to
+    /// track the last seen values.
+    fn consume(&self) -> CategorySnapshot {
+        CategorySnapshot {
+            event_count: self.event_count.swap(0, Ordering::AcqRel),
+            event_byte_size: self.event_byte_size.swap(0, Ordering::AcqRel),
+        }
+    }
+}
+
+/// Handle to buffer usage metrics for a specific buffer stage.
 #[derive(Clone, Debug)]
 pub struct BufferUsageHandle {
     state: Arc<BufferUsageData>,
@@ -30,52 +95,36 @@ impl BufferUsageHandle {
         }
     }
 
-    /// Gets a snapshot of the buffer usage data, representing an instantaneous view of the
-    /// different values.
+    /// Gets a snapshot of the buffer usage data, representing an instantaneous view of the different values.
     pub fn snapshot(&self) -> BufferUsageSnapshot {
         self.state.snapshot()
     }
 
     /// Sets the limits for this buffer component.
     ///
-    /// Limits are exposed as gauges to provide stable values when superimposed on dashboards/graphs
-    /// with the "actual" usage amounts.
+    /// Limits are exposed as gauges to provide stable values when superimposed on dashboards/graphs with the "actual"
+    /// usage amounts.
     pub fn set_buffer_limits(&self, max_bytes: Option<u64>, max_events: Option<usize>) {
-        if let Some(max_bytes) = max_bytes {
-            self.state
-                .max_size_bytes
-                .store(max_bytes, Ordering::Relaxed);
-        }
+        let max_events = max_events
+            .and_then(|n| u64::try_from(n).ok().or(Some(u64::MAX)))
+            .unwrap_or(0);
+        let max_bytes = max_bytes.unwrap_or(0);
 
-        if let Some(max_events) = max_events {
-            self.state
-                .max_size_events
-                .store(max_events, Ordering::Relaxed);
-        }
+        self.state.max_size.set(max_events, max_bytes);
     }
 
     /// Increments the number of events (and their total size) received by this buffer component.
     ///
     /// This represents the events being sent into the buffer.
     pub fn increment_received_event_count_and_byte_size(&self, count: u64, byte_size: u64) {
-        self.state
-            .received_event_count
-            .fetch_add(count, Ordering::Relaxed);
-        self.state
-            .received_byte_size
-            .fetch_add(byte_size, Ordering::Relaxed);
+        self.state.received.increment(count, byte_size);
     }
 
     /// Increments the number of events (and their total size) sent by this buffer component.
     ///
     /// This represents the events being read out of the buffer.
     pub fn increment_sent_event_count_and_byte_size(&self, count: u64, byte_size: u64) {
-        self.state
-            .sent_event_count
-            .fetch_add(count, Ordering::Relaxed);
-        self.state
-            .sent_byte_size
-            .fetch_add(byte_size, Ordering::Relaxed);
+        self.state.sent.increment(count, byte_size);
     }
 
     /// Increment the number of dropped events (and their total size) for this buffer component.
@@ -86,75 +135,57 @@ impl BufferUsageHandle {
         intentional: bool,
     ) {
         if intentional {
-            self.state
-                .dropped_event_count_intentional
-                .fetch_add(count, Ordering::Relaxed);
-            self.state
-                .dropped_event_byte_size_intentional
-                .fetch_add(byte_size, Ordering::Relaxed);
+            self.state.dropped_intentional.increment(count, byte_size);
         } else {
-            self.state
-                .dropped_event_count
-                .fetch_add(count, Ordering::Relaxed);
-            self.state
-                .dropped_event_byte_size
-                .fetch_add(byte_size, Ordering::Relaxed);
+            self.state.dropped.increment(count, byte_size);
         }
     }
 }
 
-#[derive(Debug)]
-pub struct BufferUsageData {
+#[derive(Debug, Default)]
+struct BufferUsageData {
     idx: usize,
-    received_event_count: AtomicU64,
-    received_byte_size: AtomicU64,
-    sent_event_count: AtomicU64,
-    sent_byte_size: AtomicU64,
-    dropped_event_count: AtomicU64,
-    dropped_event_byte_size: AtomicU64,
-    dropped_event_count_intentional: AtomicU64,
-    dropped_event_byte_size_intentional: AtomicU64,
-    max_size_bytes: AtomicU64,
-    max_size_events: AtomicUsize,
+    received: CategoryMetrics,
+    sent: CategoryMetrics,
+    dropped: CategoryMetrics,
+    dropped_intentional: CategoryMetrics,
+    max_size: CategoryMetrics,
 }
 
 impl BufferUsageData {
-    pub fn new(idx: usize) -> Self {
+    fn new(idx: usize) -> Self {
         Self {
             idx,
-            received_event_count: AtomicU64::new(0),
-            received_byte_size: AtomicU64::new(0),
-            sent_event_count: AtomicU64::new(0),
-            sent_byte_size: AtomicU64::new(0),
-            dropped_event_count: AtomicU64::new(0),
-            dropped_event_byte_size: AtomicU64::new(0),
-            dropped_event_count_intentional: AtomicU64::new(0),
-            dropped_event_byte_size_intentional: AtomicU64::new(0),
-            max_size_bytes: AtomicU64::new(0),
-            max_size_events: AtomicUsize::new(0),
+            ..Default::default()
         }
     }
 
     fn snapshot(&self) -> BufferUsageSnapshot {
+        let received = self.received.get();
+        let sent = self.sent.get();
+        let dropped = self.dropped.get();
+        let dropped_intentional = self.dropped_intentional.get();
+        let max_size = self.max_size.get();
+
         BufferUsageSnapshot {
-            received_event_count: self.received_event_count.load(Ordering::Relaxed),
-            received_byte_size: self.received_byte_size.load(Ordering::Relaxed),
-            sent_event_count: self.sent_event_count.load(Ordering::Relaxed),
-            sent_byte_size: self.sent_byte_size.load(Ordering::Relaxed),
-            dropped_event_count: self.dropped_event_count.load(Ordering::Relaxed),
-            dropped_event_byte_size: self.dropped_event_byte_size.load(Ordering::Relaxed),
-            dropped_event_count_intentional: self
-                .dropped_event_count_intentional
-                .load(Ordering::Relaxed),
-            dropped_event_byte_size_intentional: self
-                .dropped_event_byte_size_intentional
-                .load(Ordering::Relaxed),
-            max_size_bytes: self.max_size_bytes.load(Ordering::Relaxed),
-            max_size_events: self.max_size_events.load(Ordering::Relaxed),
+            received_event_count: received.event_count,
+            received_byte_size: received.event_byte_size,
+            sent_event_count: sent.event_count,
+            sent_byte_size: sent.event_byte_size,
+            dropped_event_count: dropped.event_count,
+            dropped_event_byte_size: dropped.event_byte_size,
+            dropped_event_count_intentional: dropped_intentional.event_count,
+            dropped_event_byte_size_intentional: dropped_intentional.event_byte_size,
+            max_size_bytes: max_size.event_byte_size,
+            max_size_events: max_size
+                .event_count
+                .try_into()
+                .expect("should never be bigger than `usize`"),
         }
     }
 }
 
+/// Snapshot of buffer usage metrics.
 #[derive(Debug)]
 pub struct BufferUsageSnapshot {
     pub received_event_count: u64,
@@ -169,6 +200,11 @@ pub struct BufferUsageSnapshot {
     pub max_size_events: usize,
 }
 
+/// Builder for tracking buffer usage metrics.
+///
+/// While building a buffer topology, `BufferUsage` can be utilized to create metrics storage for each individual buffer
+/// stage. A handle is provided to allow each buffer stage to update their metrics from one or multiple locations, as
+/// needed. Reporting of the metrics is handled centrally to keep buffer stages simpler and ensure consistent reporting.
 pub struct BufferUsage {
     span: Span,
     stages: Vec<Arc<BufferUsageData>>,
@@ -177,7 +213,7 @@ pub struct BufferUsage {
 impl BufferUsage {
     /// Creates an instance of [`BufferUsage`] attached to the given span.
     ///
-    /// As buffers can have multiple stages, callers have the ability to register each stage via [`add_stage`]
+    /// As buffers can have multiple stages, callers have the ability to register each stage via [`add_stage`].
     pub fn from_span(span: Span) -> BufferUsage {
         Self {
             span,
@@ -187,9 +223,8 @@ impl BufferUsage {
 
     /// Adds a new stage to track usage for.
     ///
-    /// A [`BufferUsageHandle`] is returned that the caller can use to actually update the usage
-    /// metrics with.  This handle will only update the usage metrics for the particular stage it
-    /// was added for.
+    /// A [`BufferUsageHandle`] is returned that the caller can use to actually update the usage metrics with.  This
+    /// handle will only update the usage metrics for the particular stage it was added for.
     pub fn add_stage(&mut self, idx: usize) -> BufferUsageHandle {
         let data = Arc::new(BufferUsageData::new(idx));
         let handle = BufferUsageHandle {
@@ -200,6 +235,12 @@ impl BufferUsage {
         handle
     }
 
+    /// Installs a reporter for the configured stages which periodically reports buffer usage metrics.
+    ///
+    /// Metrics are reported every 2 seconds.
+    ///
+    /// The `buffer_id` should be a unique name -- ideally the `component_id` of the sink using this buffer -- but is
+    /// not used for anything other than reporting, and so has no _requirement_ to be unique.
     pub fn install(self, buffer_id: &str) {
         let span = self.span;
         let stages = self.stages;
@@ -210,53 +251,55 @@ impl BufferUsage {
                 interval.tick().await;
 
                 for stage in &stages {
-                    let max_size_bytes = match stage.max_size_bytes.load(Ordering::Relaxed) {
-                        0 => None,
-                        n => Some(n),
-                    };
-
-                    let max_size_events = match stage.max_size_events.load(Ordering::Relaxed) {
-                        0 => None,
-                        n => Some(n),
-                    };
-
+                    let max_size = stage.max_size.get();
                     emit(BufferCreated {
                         idx: stage.idx,
-                        max_size_bytes,
-                        max_size_events,
+                        max_size_bytes: max_size.event_byte_size,
+                        max_size_events: max_size
+                            .event_count
+                            .try_into()
+                            .expect("should never be bigger than `usize`"),
                     });
 
-                    emit(BufferEventsReceived {
-                        idx: stage.idx,
-                        count: stage.received_event_count.swap(0, Ordering::Relaxed),
-                        byte_size: stage.received_byte_size.swap(0, Ordering::Relaxed),
-                    });
+                    let received = stage.received.consume();
+                    if received.has_updates() {
+                        emit(BufferEventsReceived {
+                            idx: stage.idx,
+                            count: received.event_count,
+                            byte_size: received.event_byte_size,
+                        });
+                    }
 
-                    emit(BufferEventsSent {
-                        idx: stage.idx,
-                        count: stage.sent_event_count.swap(0, Ordering::Relaxed),
-                        byte_size: stage.sent_byte_size.swap(0, Ordering::Relaxed),
-                    });
+                    let sent = stage.sent.consume();
+                    if sent.has_updates() {
+                        emit(BufferEventsSent {
+                            idx: stage.idx,
+                            count: sent.event_count,
+                            byte_size: sent.event_byte_size,
+                        });
+                    }
 
-                    emit(BufferEventsDropped {
-                        idx: stage.idx,
-                        intentional: true,
-                        reason: "drop_newest",
-                        count: stage
-                            .dropped_event_count_intentional
-                            .swap(0, Ordering::Relaxed),
-                        byte_size: stage
-                            .dropped_event_byte_size_intentional
-                            .swap(0, Ordering::Relaxed),
-                    });
+                    let dropped = stage.dropped.consume();
+                    if dropped.has_updates() {
+                        emit(BufferEventsDropped {
+                            idx: stage.idx,
+                            intentional: false,
+                            reason: "corrupted_events",
+                            count: dropped.event_count,
+                            byte_size: dropped.event_byte_size,
+                        });
+                    }
 
-                    emit(BufferEventsDropped {
-                        idx: stage.idx,
-                        intentional: false,
-                        reason: "corrupted_events",
-                        count: stage.dropped_event_count.swap(0, Ordering::Relaxed),
-                        byte_size: stage.dropped_event_byte_size.swap(0, Ordering::Relaxed),
-                    });
+                    let dropped_intentional = stage.dropped_intentional.consume();
+                    if dropped_intentional.has_updates() {
+                        emit(BufferEventsDropped {
+                            idx: stage.idx,
+                            intentional: true,
+                            reason: "drop_newest",
+                            count: dropped_intentional.event_count,
+                            byte_size: dropped_intentional.event_byte_size,
+                        });
+                    }
                 }
             }
         };

--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -3,18 +3,18 @@ use vector_common::internal_event::InternalEvent;
 
 pub struct BufferCreated {
     pub idx: usize,
-    pub max_size_events: Option<usize>,
-    pub max_size_bytes: Option<u64>,
+    pub max_size_events: usize,
+    pub max_size_bytes: u64,
 }
 
 impl InternalEvent for BufferCreated {
     #[allow(clippy::cast_precision_loss)]
     fn emit(self) {
-        if let Some(max_size) = self.max_size_events {
-            gauge!("buffer_max_event_size", max_size as f64, "stage" => self.idx.to_string());
+        if self.max_size_events != 0 {
+            gauge!("buffer_max_event_size", self.max_size_events as f64, "stage" => self.idx.to_string());
         }
-        if let Some(max_size) = self.max_size_bytes {
-            gauge!("buffer_max_byte_size", max_size as f64, "stage" => self.idx.to_string());
+        if self.max_size_bytes != 0 {
+            gauge!("buffer_max_byte_size", self.max_size_bytes as f64, "stage" => self.idx.to_string());
         }
     }
 }


### PR DESCRIPTION
# Context

In #13180, we changed some code related to buffer usage metrics, in order to bring them more in line with the Buffer specification. As part of this, we started emitting an event (instead of only updating metrics) for `BufferEventsDropped`. This event is intended to be emitted when buffers drop events, as the name implies. However, the code that handles reporting buffer usage metrics emits them on an interval.... including even if the count is zero.

# Solution

This PR reworks some of the code in the buffer usage logic to reduce duplication/boilerplate, but also to more easily allow for writing code that only emits an event if values changed. In turn, we also now only emit the `BufferEventsDropped` event when events were actually dropped.

# Testing

I created a simple configuration that uses disk buffers, and ran it against Vector built on `master` and built from this PR branch. On `master`, the events dropped logging is emitted every time the reporter ticks. On this PR, it is not emitted every tick _unless_ events are dropped.

# Notes

For everything _but_ the "size" metrics -- i.e. the gauges for the max byte size and max event count -- we only emit them when there's a non-zero value for either the event count or the event byte size. For the size metrics, though, we always emit them because the value only emits once when the buffer is initialized, whereas the others will be updated any time there's buffer throughput. This means that if the system we're sending internal metrics to has issues, the size metrics could be lost if there was an issue when the buffer was initialized, so we always want to emit it, keep emitting it, to keep it alive/fresh... but we can depend on the others to be eventually consistent and get updated so long as they experience throughput.
