### PR TITLE
fix(vrl): fix parse_int("0")

### DIFF
--- a/lib/vrl/stdlib/src/parse_int.rs
+++ b/lib/vrl/stdlib/src/parse_int.rs
@@ -21,7 +21,7 @@ fn parse_int(value: Value, base: Option<Value>) -> Resolved {
                 Some('b') => (2, 2),
                 Some('o') => (8, 2),
                 Some('x') => (16, 2),
-                _ => (8, 1),
+                _ => (8, 0),
             },
             Some(_) => (10u32, 0),
             None => return Err("value is empty".into()),
@@ -141,6 +141,12 @@ mod tests {
              args: func_args![value: "0x2a"],
              want: Ok(42),
              tdef: TypeDef::integer().fallible(),
+        }
+
+        zero {
+            args: func_args![value: "0"],
+            want: Ok(0),
+            tdef: TypeDef::integer().fallible(),
         }
 
         explicit_hexadecimal {

--- a/lib/vrl/stdlib/src/parse_int.rs
+++ b/lib/vrl/stdlib/src/parse_int.rs
@@ -120,27 +120,27 @@ mod tests {
         parse_int => ParseInt;
 
         decimal {
-             args: func_args![value: "-42"],
-             want: Ok(-42),
-             tdef: TypeDef::integer().fallible(),
+            args: func_args![value: "-42"],
+            want: Ok(-42),
+            tdef: TypeDef::integer().fallible(),
         }
 
         binary {
-             args: func_args![value: "0b1001"],
-             want: Ok(9),
-             tdef: TypeDef::integer().fallible(),
+            args: func_args![value: "0b1001"],
+            want: Ok(9),
+            tdef: TypeDef::integer().fallible(),
         }
 
         octal {
-             args: func_args![value: "042"],
-             want: Ok(34),
-             tdef: TypeDef::integer().fallible(),
+            args: func_args![value: "042"],
+            want: Ok(34),
+            tdef: TypeDef::integer().fallible(),
         }
 
         hexadecimal {
-             args: func_args![value: "0x2a"],
-             want: Ok(42),
-             tdef: TypeDef::integer().fallible(),
+            args: func_args![value: "0x2a"],
+            want: Ok(42),
+            tdef: TypeDef::integer().fallible(),
         }
 
         zero {
@@ -150,9 +150,9 @@ mod tests {
         }
 
         explicit_hexadecimal {
-             args: func_args![value: "2a", base: 16],
-             want: Ok(42),
-             tdef: TypeDef::integer().fallible(),
+            args: func_args![value: "2a", base: 16],
+            want: Ok(42),
+            tdef: TypeDef::integer().fallible(),
         }
     ];
 }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

This PR fixes a problem that `parse_int("0")` does not work without setting the base explicitly. The problem comes from the base inference. When the value starts with `0`, the function assumes it to be octal and start parsing from index 1. However, for `"0"`, there is nothing from index 1 so it ends up with an error complaining about empty string:
```
---- parse_int::tests::parse_int_zero stdout ----
thread 'parse_int::tests::parse_int_zero' panicked at 'assertion failed: `(left == right)`
  left: `Err("could not parse integer: cannot parse integer from empty string")`,
 right: `Ok(Integer(0))`', lib/vrl/stdlib/src/parse_int.rs:119:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This PR fixes the problem by parsing values starts with `0` from the beginning. A leading zero shouldn't be a problem.
