### PR TITLE
fix(datadog_agent source): Remove the `status` field footgun for logs.

### DIFF
--- a/src/sources/datadog/agent/logs.rs
+++ b/src/sources/datadog/agent/logs.rs
@@ -105,7 +105,6 @@ pub(crate) fn decode_log_body(
                 Ok(Some((events, _byte_size))) => {
                     for mut event in events {
                         if let Event::Log(ref mut log) = event {
-                            // log.try_insert(path!("status"), status.clone());
                             log.try_insert(path!("timestamp"), timestamp);
                             log.try_insert(path!("hostname"), hostname.clone());
                             log.try_insert(path!("service"), service.clone());

--- a/src/sources/datadog/agent/logs.rs
+++ b/src/sources/datadog/agent/logs.rs
@@ -89,12 +89,12 @@ pub(crate) fn decode_log_body(
 
     for LogMsg {
         message,
-        status,
         timestamp,
         hostname,
         service,
         ddsource,
         ddtags,
+        ..
     } in messages
     {
         let mut decoder = source.decoder.clone();
@@ -105,7 +105,7 @@ pub(crate) fn decode_log_body(
                 Ok(Some((events, _byte_size))) => {
                     for mut event in events {
                         if let Event::Log(ref mut log) = event {
-                            log.try_insert(path!("status"), status.clone());
+                            // log.try_insert(path!("status"), status.clone());
                             log.try_insert(path!("timestamp"), timestamp);
                             log.try_insert(path!("hostname"), hostname.clone());
                             log.try_insert(path!("service"), service.clone());

--- a/src/sources/datadog/agent/tests.rs
+++ b/src/sources/datadog/agent/tests.rs
@@ -102,7 +102,6 @@ fn test_decode_log_body() {
         for (msg, event) in msgs.into_iter().zip(events.into_iter()) {
             let log = event.as_log();
             assert_eq!(log["message"], msg.message.into());
-            assert_eq!(log["status"], msg.status.into());
             assert_eq!(log["timestamp"], msg.timestamp.into());
             assert_eq!(log["hostname"], msg.hostname.into());
             assert_eq!(log["service"], msg.service.into());
@@ -227,7 +226,7 @@ async fn full_payload_v1() {
             assert_eq!(log["message"], "foo".into());
             assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -280,7 +279,7 @@ async fn full_payload_v2() {
             assert_eq!(log["message"], "foo".into());
             assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -333,7 +332,7 @@ async fn no_api_key() {
             assert_eq!(log["message"], "foo".into());
             assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -386,7 +385,7 @@ async fn api_key_in_url() {
             assert_eq!(log["message"], "bar".into());
             assert_eq!(log["timestamp"], Utc.timestamp(456, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -442,7 +441,7 @@ async fn api_key_in_query_params() {
             assert_eq!(log["message"], "bar".into());
             assert_eq!(log["timestamp"], Utc.timestamp(456, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -504,7 +503,7 @@ async fn api_key_in_header() {
             assert_eq!(log["message"], "baz".into());
             assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -636,7 +635,7 @@ async fn ignores_api_key() {
             assert_eq!(log["message"], "baz".into());
             assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -1267,7 +1266,7 @@ async fn split_outputs() {
             assert_eq!(log["message"], "baz".into());
             assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log["status"], "notice".into());
+            assert_eq!(log.contains("status"), false);
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());


### PR DESCRIPTION
Testing and customer experience have revealed that the `status` field is an unnecessary footgun that trips up attempts to process log messages sourced from the Datadog agent.

Some context, friend: when the Datadog agent collects logs from a [Docker](https://cs.github.com/DataDog/datadog-agent/blob/433bc3f47d0bdc891e06611ea331cc1dfce7bdfa/pkg/logs/internal/parsers/dockerstream/docker_stream.go?q=stderr+language%3AGo+path%3A*%2Fdocker*#L110) or a [Kubernetes](https://cs.github.com/DataDog/datadog-agent/blob/433bc3f47d0bdc891e06611ea331cc1dfce7bdfa/pkg/logs/internal/parsers/kubernetes/kubernetes.go?q=stderr+language%3AGo+path%3A*%2Fkubernetes*#L83) container, it will tag the log line with a status based entirely on the stream that it read that log from. `stdout` will always be tagged `INFO`, and `stderr` will always be tagged `ERROR`, no matter the contents of the line itself.

It then appears that the normal Datadog Agent ingest endpoint strips this attribute out. Vector's does not, and some strange behavior in Datadog's backend means that the `status` attribute will override whatever is parsed from the log line, always, which means that users are in for a surprise when they switch to Vector.

We have a small VRL snippet in the Workshop materials that removes this attribute, but I find this unsatisfactory. **The right thing to do is not the default thing to do** in Vector currently, which if nothing else means that users who do not go through our Workshops or somehow miss that snippet will have invisibly wrong behavior until the wrong moment.

It is obvious that Datadog does not consider this field valid, and this change can operate as a bandaid while I work on a diff to strip its processing out from the Agent itself.
