### PR TITLE
chore(observability): Remove build info fields from enterprise logs

### DIFF
--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -21,7 +21,6 @@ use super::{
     SourceOuter, TransformOuter,
 };
 use crate::{
-    built_info,
     common::datadog::{get_api_base_endpoint, Region},
     conditions::AnyCondition,
     http::{HttpClient, HttpError},
@@ -417,9 +416,6 @@ fn setup_logs_reporting(
 
     let configuration_key = &datadog.configuration_key;
     let vector_version = crate::vector_version();
-    let build_arch = built_info::TARGET_ARCH;
-    let build_os = built_info::TARGET_OS;
-    let build_vendor = built_info::TARGET_VENDOR;
     let tag_logs = RemapConfig {
         source: Some(format!(
             r#"
@@ -427,9 +423,6 @@ fn setup_logs_reporting(
             .vector.configuration_key = "{configuration_key}"
             .vector.configuration_version_hash = "{configuration_version_hash}"
             .vector.version = "{vector_version}"
-            .vector.arch = "{build_arch}"
-            .vector.os = "{build_os}"
-            .vector.vendor = "{build_vendor}"
             {}
         "#,
             custom_logs_tags_vrl,


### PR DESCRIPTION
Closes [OP-505](https://datadoghq.atlassian.net/browse/OP-505)

This PR
- Removes the build info related fields on enterprise logs
  - As documented in the ticket, we're ok with doing this prior to implementing https://datadoghq.atlassian.net/browse/OP-349 (which is the path forward to retrieving this information in the future).
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
