### PR TITLE
enhancement(gcp_pubsub source): Add an inactivity timeout keepalive

### DIFF
--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -138,6 +138,12 @@ pub struct PubsubConfig {
     #[serde(default = "default_retry_delay")]
     pub retry_delay_seconds: f64,
 
+    /// The amount of time, in seconds, with no received activity
+    /// before sending a keepalive request. If this is set larger than
+    /// `60`, you may see periodic errors sent from the server.
+    #[serde(default = "default_inactivity_timeout")]
+    pub inactivity_timeout_seconds: f64,
+
     #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
@@ -159,6 +165,10 @@ const fn default_ack_deadline() -> i32 {
 
 const fn default_retry_delay() -> f64 {
     1.0
+}
+
+const fn default_inactivity_timeout() -> f64 {
+    60.0
 }
 
 #[async_trait::async_trait]
@@ -194,6 +204,7 @@ impl SourceConfig for PubsubConfig {
             out: cx.out,
             ack_deadline_seconds: self.ack_deadline_seconds,
             retry_delay: Duration::from_secs_f64(self.retry_delay_seconds),
+            inactivity_timeout: Duration::from_secs_f64(self.inactivity_timeout_seconds),
         }
         .run()
         .map_err(|error| error!(message = "Source failed.", %error));
@@ -227,6 +238,7 @@ struct PubsubSource {
     shutdown: ShutdownSignal,
     out: SourceSender,
     retry_delay: Duration,
+    inactivity_timeout: Duration,
 }
 
 enum State {
@@ -361,7 +373,8 @@ impl PubsubSource {
         let subscription = self.subscription.clone();
         let client_id = CLIENT_ID.clone();
         let stream_ack_deadline_seconds = self.ack_deadline_seconds;
-        let ack_ids = ReceiverStream::new(ack_ids);
+        let mut ack_ids = ReceiverStream::new(ack_ids).ready_chunks(ACK_QUEUE_SIZE);
+        let timeout = self.inactivity_timeout;
 
         stream::once(async move {
             // These fields are only valid on the first request in the
@@ -373,17 +386,30 @@ impl PubsubSource {
                 ..Default::default()
             }
         })
-        .chain(ack_ids.ready_chunks(ACK_QUEUE_SIZE).map(|chunks| {
-            // These "requests" serve only to send updates about
-            // acknowledgements to the server. None of the above
-            // fields need to be repeated and, in fact, will cause
-            // an stream error and cancellation if they are
-            // present.
-            proto::StreamingPullRequest {
-                ack_ids: chunks.into_iter().flatten().collect(),
-                ..Default::default()
+        .chain(async_stream::stream! {
+            loop {
+                // GCP Pub/Sub likes to time out connections after
+                // about 75 seconds of inactivity. To forestall the
+                // resulting error, send an empty array of
+                // acknowledgement IDs to the request stream if no
+                // other activity has happened. This will result in a
+                // new request with empty fields, effectively a
+                // keepalive.
+                let ack_ids: Vec<String> = tokio::select! {
+                    chunks = ack_ids.next() => chunks.into_iter().flatten().flatten().collect(),
+                    _ = tokio::time::sleep(timeout) => Vec::new(),
+                };
+                // These "requests" serve only to send updates about
+                // acknowledgements to the server. None of the above
+                // fields need to be repeated and, in fact, will cause
+                // an stream error and cancellation if they are
+                // present.
+                yield proto::StreamingPullRequest {
+                    ack_ids,
+                    ..Default::default()
+                };
             }
-        }))
+        })
     }
 
     async fn handle_response(

--- a/website/cue/reference/components/sources/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/gcp_pubsub.cue
@@ -79,7 +79,7 @@ components: sources: gcp_pubsub: {
 				examples: ["https://us-central1-pubsub.googleapis.com"]
 			}
 		}
-		inactivity_timeout_seconds: {
+		keepalive_secs: {
 			common:      false
 			description: "The amount of time, in seconds, with no received activity before sending a keepalive request. If this is set larger than `60`, you may see periodic errors sent from the server."
 			required:    false

--- a/website/cue/reference/components/sources/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/gcp_pubsub.cue
@@ -79,6 +79,15 @@ components: sources: gcp_pubsub: {
 				examples: ["https://us-central1-pubsub.googleapis.com"]
 			}
 		}
+		inactivity_timeout_seconds: {
+			common:      false
+			description: "The amount of time, in seconds, with no received activity before sending a keepalive request. If this is set larger than `60`, you may see periodic errors sent from the server."
+			required:    false
+			type: float: {
+				default: 60.0
+				examples: [10.0]
+			}
+		}
 		project: {
 			description: "The project name from which to pull logs."
 			required:    true


### PR DESCRIPTION
If there is no activity on the connection for roughly 75 seconds, the
GCP Pub/Sub server will send an error response with an error code of
"Unavailable". This is harmless but results in nuisance error messages
in the logs.

This patch avoids that problem by sending "keepalive" empty requests
after periods of inactivity. This avoids the error message.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
