### PR TITLE
Introduce `http_text_to_http_json` soak

### DIFF
--- a/soaks/Dockerfile
+++ b/soaks/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # LADING
 #
-FROM ghcr.io/blt/lading@sha256:084ea90217d72d15174b6822890124f0c330a3aeef19195805dab625798323a3 as lading
+FROM ghcr.io/blt/lading@sha256:ed3b47d5987a5e35a67caa1812a8ba192bdebd238546506bac6bc8ff781f3151 as lading
 
 #
 # TARGET

--- a/soaks/tests/http_text_to_http_json/lading.yaml
+++ b/soaks/tests/http_text_to_http_json/lading.yaml
@@ -1,0 +1,15 @@
+generator:
+  http:
+    seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+    headers: {}
+    target_uri: "http://localhost:8282/"
+    bytes_per_second: "500 Mb"
+    parallel_connections: 10
+    method:
+      post:
+        maximum_prebuild_cache_size_bytes: "256 Mb"
+        variant: "apache_common"
+
+blackhole:
+  http:
+    binding_addr: "0.0.0.0:8080"

--- a/soaks/tests/http_text_to_http_json/vector.toml
+++ b/soaks/tests/http_text_to_http_json/vector.toml
@@ -1,0 +1,20 @@
+data_dir = "/var/lib/vector"
+
+##
+## Sources
+##
+
+[sources.logs]
+type = "http"
+address = "0.0.0.0:8282"
+encoding = "text"
+
+##
+## Sinks
+##
+
+[sinks.http_sink]
+type = "http"
+uri = "http://localhost:8080"
+inputs = ["logs"]
+encoding.codec = "json"


### PR DESCRIPTION
We've noticed that this pattern of Vector configuration is curiously slow, we
believe as a result of _something_ happening in the source. The exact details
are murky though, hence the soak.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
