### PR TITLE
fix(reload, shutdown): Handle signal overflows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -39,6 +39,8 @@ use crate::internal_events::{
     VectorStarted, VectorStopped,
 };
 
+use tokio::sync::broadcast::error::RecvError;
+
 pub struct ApplicationConfig {
     pub config_paths: Vec<config::ConfigPath>,
     pub topology: RunningTopology,
@@ -292,9 +294,9 @@ impl Application {
 
             let signal = loop {
                 tokio::select! {
-                    Ok(signal) = signal_rx.recv() => {
+                    signal = signal_rx.recv() => {
                         match signal {
-                            SignalTo::ReloadFromConfigBuilder(config_builder) => {
+                            Ok(SignalTo::ReloadFromConfigBuilder(config_builder)) => {
                                 match config_builder.build().map_err(handle_config_errors) {
                                     Ok(mut new_config) => {
                                         new_config.healthchecks.set_require_healthy(opts.require_healthy);
@@ -343,7 +345,7 @@ impl Application {
                                     }
                                 }
                             }
-                            SignalTo::ReloadFromDisk => {
+                            Ok(SignalTo::ReloadFromDisk) => {
                                 // Reload paths
                                 config_paths = config::process_paths(&opts.config_paths_with_formats()).unwrap_or(config_paths);
 
@@ -395,8 +397,10 @@ impl Application {
                                 } else {
                                     emit!(VectorConfigLoadError);
                                 }
-                            }
-                            _ => break signal,
+                            },
+                            Err(RecvError::Lagged(amt)) => warn!("Overflow, dropped {} signals", amt),
+                            Err(RecvError::Closed) => break SignalTo::Shutdown,
+                            Ok(signal) => break signal,
                         }
                     }
                     // Trigger graceful shutdown if a component crashed, or all sources have ended.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -29,10 +29,10 @@ pub struct SignalHandler {
 }
 
 impl SignalHandler {
-    /// Create a new signal handler. We'll have space for 2 control messages at a time, to
-    /// ensure the channel isn't blocking.
+    /// Create a new signal handler with space for 128 control messages at a time, to
+    /// ensure the channel doesn't overflow and drop signals.
     pub fn new() -> (Self, SignalRx) {
-        let (tx, rx) = broadcast::channel(2);
+        let (tx, rx) = broadcast::channel(128);
         let handler = Self {
             tx,
             shutdown_txs: vec![],


### PR DESCRIPTION
Warn on signal overflows instead of breaking out of the signal-handler loop.

Fixes #13239.

When a [`tokio::sync::broadcast`](https://docs.rs/tokio/0.2.22/tokio/sync/broadcast/index.html) channel receives and queues more messages than its specified capacity, it will return [`RecvError::Lagged`](https://docs.rs/tokio/0.2.22/tokio/sync/broadcast/index.html#lagging) indicating older messages have been dropped. The current code didn't handle this value and silently exits, causing no more signals to be handled. This PR changes the behavior to print a warning and continue handling signals properly.

I've also added a commit to increase the channel capacity to 128 to handle a few more signals before it starts dropping.