### PR TITLE
fix(syslog source): update syslog_loose to handle empty param values.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7229,9 +7229,9 @@ dependencies = [
 
 [[package]]
 name = "syslog_loose"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8417c2dcaef3d8016608956f3a5b70ad9cf4efe44b5546c93ca4934903c16749"
+checksum = "1c4eae4d024d7912b5bea75e54319445d0ffe7f423bb4b68a46129cdcebecaef"
 dependencies = [
  "chrono",
  "nom",

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -15,7 +15,7 @@ prost = { version = "0.10.4", default-features = false, features = ["std"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
 smallvec = { version = "1", default-features = false, features = ["union"] }
-syslog_loose = { version = "0.16", default-features = false, optional = true }
+syslog_loose = { version = "0.17", default-features = false, optional = true }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 tracing = { version = "0.1", default-features = false }
 value = { path = "../value", default-features = false }

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -39,7 +39,7 @@ sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
-syslog_loose = { version = "0.16", optional = true }
+syslog_loose = { version = "0.17", optional = true }
 tracing = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -253,6 +253,23 @@ mod tests {
             tdef: TypeDef::object(inner_kind()).fallible(),
         }
 
+        empty_sd_value {
+            args: func_args![value: r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - [non_empty x=""][empty] qwerty"#],
+            want: Ok(btreemap!{
+                "message" => "qwerty",
+                "appname" => "root",
+                "facility" => "user",
+                "hostname" => "74794bfb6795",
+                "message" => "qwerty",
+                "procid" => 8449,
+                "severity" => "notice",
+                "timestamp" => chrono::Utc.ymd(2019, 2, 13).and_hms_milli(19, 48, 34, 0),
+                "version" => 1,
+                "non_empty.x" => "",
+            }),
+            tdef: TypeDef::object(inner_kind()).fallible(),
+        }
+
         non_structured_data_in_message {
             args: func_args![value: "<131>Jun 8 11:54:08 master apache_error [Tue Jun 08 11:54:08.929301 2021] [php7:emerg] [pid 1374899] [client 95.223.77.60:41888] rest of message"],
             want: Ok(btreemap!{


### PR DESCRIPTION
Fixes #13165 

This updates `syslog_loose` with [this](https://github.com/StephenWakely/syslog-loose/pull/17) so it can now handle empty param values in the structured data.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

