### PR TITLE
fix(datadog_agent source): Revert remove the `status` field footgun for logs

### DIFF
--- a/src/sources/datadog/agent/logs.rs
+++ b/src/sources/datadog/agent/logs.rs
@@ -89,12 +89,12 @@ pub(crate) fn decode_log_body(
 
     for LogMsg {
         message,
+        status,
         timestamp,
         hostname,
         service,
         ddsource,
         ddtags,
-        ..
     } in messages
     {
         let mut decoder = source.decoder.clone();
@@ -105,6 +105,7 @@ pub(crate) fn decode_log_body(
                 Ok(Some((events, _byte_size))) => {
                     for mut event in events {
                         if let Event::Log(ref mut log) = event {
+                            log.try_insert(path!("status"), status.clone());
                             log.try_insert(path!("timestamp"), timestamp);
                             log.try_insert(path!("hostname"), hostname.clone());
                             log.try_insert(path!("service"), service.clone());

--- a/src/sources/datadog/agent/tests.rs
+++ b/src/sources/datadog/agent/tests.rs
@@ -102,6 +102,7 @@ fn test_decode_log_body() {
         for (msg, event) in msgs.into_iter().zip(events.into_iter()) {
             let log = event.as_log();
             assert_eq!(log["message"], msg.message.into());
+            assert_eq!(log["status"], msg.status.into());
             assert_eq!(log["timestamp"], msg.timestamp.into());
             assert_eq!(log["hostname"], msg.hostname.into());
             assert_eq!(log["service"], msg.service.into());
@@ -226,7 +227,7 @@ async fn full_payload_v1() {
             assert_eq!(log["message"], "foo".into());
             assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -279,7 +280,7 @@ async fn full_payload_v2() {
             assert_eq!(log["message"], "foo".into());
             assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -332,7 +333,7 @@ async fn no_api_key() {
             assert_eq!(log["message"], "foo".into());
             assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -385,7 +386,7 @@ async fn api_key_in_url() {
             assert_eq!(log["message"], "bar".into());
             assert_eq!(log["timestamp"], Utc.timestamp(456, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -441,7 +442,7 @@ async fn api_key_in_query_params() {
             assert_eq!(log["message"], "bar".into());
             assert_eq!(log["timestamp"], Utc.timestamp(456, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -503,7 +504,7 @@ async fn api_key_in_header() {
             assert_eq!(log["message"], "baz".into());
             assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -635,7 +636,7 @@ async fn ignores_api_key() {
             assert_eq!(log["message"], "baz".into());
             assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
@@ -1266,7 +1267,7 @@ async fn split_outputs() {
             assert_eq!(log["message"], "baz".into());
             assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
             assert_eq!(log["hostname"], "festeburg".into());
-            assert_eq!(log.contains("status"), false);
+            assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());


### PR DESCRIPTION
Reverts vectordotdev/vector#13219

Apologies for not leaving a review quickly enough on vectordotdev/vector#13219. I'm not really sold on doing this in Vector. From Vector's perspective, it should receive the `status` field exactly as it was received from the Datadog agent for a couple of reasons:

* Users might have transformations they want to do based on the `status` field
* As a Vector user, if I setup `datadog_agent` -> `datadog_logs` I'd expect the data to go through to Datadog, unaltered.

I'm 💯 on adjusting the behavior to avoid the footgun of having `custom_level` added during Datadog ingestion (mapped from `status`), but I'd rather revert this Vector change until we are able to understand it better and identify the correct place to handle it.