### PR TITLE
chore(gcp_pubsub source): Rename `_seconds` settings to `_secs`

### DIFF
--- a/website/cue/reference/components/sources/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/gcp_pubsub.cue
@@ -60,6 +60,16 @@ components: sources: gcp_pubsub: {
 		acknowledgements: configuration._source_acknowledgements
 		ack_deadline_seconds: {
 			common:      false
+			description: "The acknowledgement deadline to use for this stream. Messages that are not acknowledged when this deadline expires may be retransmitted. This setting is deprecated and will be removed in a future version."
+			required:    false
+			type: uint: {
+				default: 600
+				examples: [10, 600]
+				unit: "seconds"
+			}
+		}
+		ack_deadline_secs: {
+			common:      false
 			description: "The acknowledgement deadline to use for this stream. Messages that are not acknowledged when this deadline expires may be retransmitted."
 			required:    false
 			type: uint: {
@@ -96,6 +106,16 @@ components: sources: gcp_pubsub: {
 			}
 		}
 		retry_delay_seconds: {
+			common:      false
+			description: "The amount of time to wait between retry attempts after an error. This setting is deprecated and will be removed in a future version."
+			required:    false
+			type: float: {
+				default: 1.0
+				examples: [0.5]
+				unit: "seconds"
+			}
+		}
+		retry_delay_secs: {
 			common:      false
 			description: "The amount of time to wait between retry attempts after an error."
 			required:    false


### PR DESCRIPTION
The `_secs` naming is the common convention in Vector. This adds the new
options and adds a deprecation notice for the old ones.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
