### PR TITLE
fix(aws provider): Remove `endpoint` from metrics tags

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -227,7 +227,6 @@ where
         });
 
         let region = self.region.clone();
-        let endpoint = req.http().uri().to_string();
         let fut = self.inner.call(req);
 
         Box::pin(async move {
@@ -245,7 +244,6 @@ where
                     emit!(AwsBytesSent {
                         byte_size,
                         region: Some(region),
-                        endpoint: endpoint.as_str(),
                     });
                 }
             }

--- a/src/internal_events/aws.rs
+++ b/src/internal_events/aws.rs
@@ -1,13 +1,12 @@
 use metrics::counter;
 use vector_common::internal_event::InternalEvent;
 
-pub struct AwsBytesSent<'a> {
+pub struct AwsBytesSent {
     pub byte_size: usize,
     pub region: Option<aws_types::region::Region>,
-    pub endpoint: &'a str,
 }
 
-impl<'a> InternalEvent for AwsBytesSent<'a> {
+impl InternalEvent for AwsBytesSent {
     fn emit(self) {
         let region = self
             .region
@@ -18,13 +17,11 @@ impl<'a> InternalEvent for AwsBytesSent<'a> {
             protocol = "https",
             byte_size = %self.byte_size,
             region = ?self.region,
-            endpoint = %self.endpoint,
         );
         counter!(
             "component_sent_bytes_total", self.byte_size as u64,
             "protocol" => "https",
             "region" => region,
-            "endpoint" => self.endpoint.to_string(),
         );
     }
 }

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -62,7 +62,7 @@ pub const FILE_SINK_TAGS: [&str; 2] = ["file", "protocol"];
 pub const HTTP_SINK_TAGS: [&str; 2] = ["endpoint", "protocol"];
 
 /// The standard set of tags for all `AWS`-based sinks.
-pub const AWS_SINK_TAGS: [&str; 3] = ["endpoint", "protocol", "region"];
+pub const AWS_SINK_TAGS: [&str; 2] = ["protocol", "region"];
 
 /// This struct is used to describe a set of component tests.
 pub struct ComponentTests {


### PR DESCRIPTION
For `aws_s3`, the `endpoint` (which is the path) includes the object key
information resulting in very high cardinality tags. For example:

```
vector_processed_bytes_total{component_id="sink0",component_kind="sink",component_name="sink0",component_type="aws_s3",endpoint="/timberio-jesse-test/test-metric-cardinality/date%3D2022-06-22/1655913536-cc808697-2d56-43b3-a419-bd6148b9d368.log.gz?x-id=PutObject",protocol="https",region="us-east-1"} 402207 1655913540158```
```

I think this tags isn't useful for AWS sinks, generally.

I realize the component spec requires it though. There has been some
discussion of removing `endpoint` and other tags until we get user
requests for them and can understand the use cases better. The current
tags were optimistic in that we _thought_ users might want them, but
I don't know that we've actually had anyone ask for them.

Closes: #13284

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
