### PR TITLE
docs(vector source, vector sink): Fix default version documentation

### DIFF
--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -100,7 +100,7 @@ components: sinks: vector: {
 					"1": "Vector sink API version 1"
 					"2": "Vector sink API version 2"
 				}
-				default: "1"
+				default: "2"
 			}
 		}
 	}

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -82,7 +82,7 @@ components: sources: vector: {
 					"1": "Vector source API version 1"
 					"2": "Vector source API version 2"
 				}
-				default: "1"
+				default: "2"
 			}
 		}
 	}


### PR DESCRIPTION
The actual default is 2.

Closes: #13301

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
