### PR TITLE
docs(prometheus_exporter sink): Document that metrics are at /metrics

### DIFF
--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -59,7 +59,7 @@ components: sinks: prometheus_exporter: {
 
 	configuration: {
 		address: {
-			description: "The address to expose for scraping."
+			description: "The address to expose for scraping. The metrics are exposed at the typical Prometheus exporter path, `/metrics`"
 			required:    true
 			warnings: []
 			type: string: {


### PR DESCRIPTION
Closes: #13303

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
