### PR TITLE
chore(vrl): rustfmt

### DIFF
--- a/lib/vrl/cli/src/repl.rs
+++ b/lib/vrl/cli/src/repl.rs
@@ -1,7 +1,7 @@
+use core::TargetValue;
 use std::borrow::Cow::{self, Borrowed, Owned};
 
 use ::value::Value;
-use core::TargetValue;
 use indoc::indoc;
 use once_cell::sync::Lazy;
 use prettytable::{format, Cell, Row, Table};
@@ -16,10 +16,8 @@ use rustyline::{
 };
 use value::Secrets;
 use vector_common::TimeZone;
-
 use vector_vrl_functions::vrl_functions;
-use vrl::prelude::BTreeMap;
-use vrl::{diagnostic::Formatter, state, Runtime, Target, VrlRuntime};
+use vrl::{diagnostic::Formatter, prelude::BTreeMap, state, Runtime, Target, VrlRuntime};
 
 // Create a list of all possible error values for potential docs lookup
 static ERRORS: Lazy<Vec<String>> = Lazy::new(|| {

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -2,9 +2,9 @@ use diagnostic::{DiagnosticList, DiagnosticMessage, Severity, Span};
 use lookup::LookupBuf;
 use parser::ast::{self, Node, QueryTarget};
 
-use crate::parser::ast::RootExpr;
 use crate::{
     expression::*,
+    parser::ast::RootExpr,
     program::ProgramInfo,
     state::{ExternalEnv, LocalEnv},
     Function, Program,

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -7,8 +7,7 @@ use super::Expr;
 use crate::{
     expression::{ExpressionError, Resolved},
     state::{ExternalEnv, LocalEnv},
-    value::Kind,
-    value::VrlValueConvert,
+    value::{Kind, VrlValueConvert},
     Context, Expression, Span, TypeDef,
 };
 

--- a/lib/vrl/compiler/src/expression/block.rs
+++ b/lib/vrl/compiler/src/expression/block.rs
@@ -1,9 +1,10 @@
+use std::fmt;
+
 use crate::{
     expression::{Expr, Resolved},
     state::{ExternalEnv, LocalEnv},
     Context, Expression, TypeDef,
 };
-use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Block {

--- a/lib/vrl/compiler/src/expression/not.rs
+++ b/lib/vrl/compiler/src/expression/not.rs
@@ -2,12 +2,11 @@ use std::fmt;
 
 use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
-use crate::value::VrlValueConvert;
 use crate::{
     expression::{Expr, Resolved},
     parser::Node,
     state::{ExternalEnv, LocalEnv},
-    value::Kind,
+    value::{Kind, VrlValueConvert},
     Context, Expression, Span, TypeDef,
 };
 

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -3,11 +3,11 @@ use std::fmt;
 use diagnostic::{DiagnosticMessage, Label, Note, Span, Urls};
 use value::Value;
 
-use crate::state::{ExternalEnv, LocalEnv};
-use crate::value::VrlValueArithmetic;
 use crate::{
     expression::{self, Expr, Resolved},
     parser::{ast, Node},
+    state::{ExternalEnv, LocalEnv},
+    value::VrlValueArithmetic,
     Context, Expression, TypeDef,
 };
 
@@ -385,8 +385,7 @@ impl DiagnosticMessage for Error {
 mod tests {
     use std::convert::TryInto;
 
-    use ast::Ident;
-    use ast::Opcode::*;
+    use ast::{Ident, Opcode::*};
     use ordered_float::NotNan;
 
     use super::*;

--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -1,5 +1,6 @@
-use diagnostic::{DiagnosticMessage, Label};
 use std::fmt;
+
+use diagnostic::{DiagnosticMessage, Label};
 use value::Value;
 
 use crate::{

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -4,8 +4,7 @@ use anymap::AnyMap;
 use lookup::LookupBuf;
 use value::{Kind, Value};
 
-use crate::value::Collection;
-use crate::{parser::ast::Ident, type_def::Details};
+use crate::{parser::ast::Ident, type_def::Details, value::Collection};
 
 /// Local environment, limited to a given scope.
 #[derive(Debug, Default, Clone, PartialEq)]

--- a/lib/vrl/compiler/src/value.rs
+++ b/lib/vrl/compiler/src/value.rs
@@ -7,5 +7,4 @@ pub use error::Error;
 pub use kind::{Collection, Field, Index, Kind};
 pub use value::value::IterItem;
 
-pub use self::arithmetic::VrlValueArithmetic;
-pub use self::convert::VrlValueConvert;
+pub use self::{arithmetic::VrlValueArithmetic, convert::VrlValueConvert};

--- a/lib/vrl/compiler/src/value/arithmetic.rs
+++ b/lib/vrl/compiler/src/value/arithmetic.rs
@@ -4,8 +4,10 @@ use bytes::{BufMut, Bytes, BytesMut};
 use value::Value;
 
 use super::Error;
-use crate::value::{Kind, VrlValueConvert};
-use crate::ExpressionError;
+use crate::{
+    value::{Kind, VrlValueConvert},
+    ExpressionError,
+};
 
 pub trait VrlValueArithmetic: Sized {
     /// Similar to [`std::ops::Mul`], but fallible (e.g. `TryMul`).

--- a/lib/vrl/compiler/src/value/convert.rs
+++ b/lib/vrl/compiler/src/value/convert.rs
@@ -2,12 +2,13 @@ use std::{borrow::Cow, collections::BTreeMap};
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use value::kind::Collection;
-use value::{Value, ValueRegex};
+use value::{kind::Collection, Value, ValueRegex};
 
-use crate::expression::{Container, Variant};
-use crate::value::{Error, Kind};
-use crate::{expression::Expr, Expression};
+use crate::{
+    expression::{Container, Expr, Variant},
+    value::{Error, Kind},
+    Expression,
+};
 
 pub trait VrlValueConvert: Sized {
     /// Convert a given [`Value`] into a [`Expression`] trait object.

--- a/lib/vrl/stdlib/src/decrypt.rs
+++ b/lib/vrl/stdlib/src/decrypt.rs
@@ -1,8 +1,9 @@
 use ::value::Value;
-use aes::cipher::block_padding::{AnsiX923, Iso10126, Iso7816, Pkcs7};
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::KeyIvInit;
-use aes::cipher::{AsyncStreamCipher, BlockDecryptMut, StreamCipher};
+use aes::cipher::{
+    block_padding::{AnsiX923, Iso10126, Iso7816, Pkcs7},
+    generic_array::GenericArray,
+    AsyncStreamCipher, BlockDecryptMut, KeyIvInit, StreamCipher,
+};
 use cfb_mode::Decryptor as Cfb;
 use ctr::Ctr64LE;
 use ofb::Ofb;

--- a/lib/vrl/stdlib/src/encrypt.rs
+++ b/lib/vrl/stdlib/src/encrypt.rs
@@ -1,9 +1,9 @@
 use ::value::Value;
-use aes::cipher::block_padding::{AnsiX923, Iso10126, Iso7816, Pkcs7};
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::KeyIvInit;
-use aes::cipher::StreamCipher;
-use aes::cipher::{AsyncStreamCipher, BlockEncryptMut};
+use aes::cipher::{
+    block_padding::{AnsiX923, Iso10126, Iso7816, Pkcs7},
+    generic_array::GenericArray,
+    AsyncStreamCipher, BlockEncryptMut, KeyIvInit, StreamCipher,
+};
 use cfb_mode::Encryptor as Cfb;
 use ctr::Ctr64LE;
 use ofb::Ofb;

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
 use ::value::Value;
-use serde_json::value::{RawValue, Value as JsonValue};
-use serde_json::{Error, Map};
+use serde_json::{
+    value::{RawValue, Value as JsonValue},
+    Error, Map,
+};
 use vrl::prelude::*;
 
 fn parse_json(value: Value) -> Resolved {

--- a/lib/vrl/stdlib/src/type_def.rs
+++ b/lib/vrl/stdlib/src/type_def.rs
@@ -1,6 +1,4 @@
-use vrl::prelude::*;
-
-use vrl::prelude::TypeDef as VrlTypeDef;
+use vrl::prelude::{TypeDef as VrlTypeDef, *};
 
 fn type_def(type_def: &VrlTypeDef) -> Resolved {
     let mut tree = type_def.kind().debug_info();

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -3,8 +3,7 @@
 
 mod test_enrichment;
 
-use std::str::FromStr;
-use std::time::Instant;
+use std::{str::FromStr, time::Instant};
 
 use ::value::Value;
 use ansi_term::Colour;
@@ -14,9 +13,11 @@ use clap::Parser;
 use glob::glob;
 use value::Secrets;
 use vector_common::TimeZone;
-use vrl::prelude::{BTreeMap, VrlValueConvert};
-use vrl::{diagnostic::Formatter, state, Runtime, SecretTarget, Terminate};
-use vrl::{TargetValueRef, VrlRuntime};
+use vrl::{
+    diagnostic::Formatter,
+    prelude::{BTreeMap, VrlValueConvert},
+    state, Runtime, SecretTarget, TargetValueRef, Terminate, VrlRuntime,
+};
 use vrl_tests::{docs, Test};
 
 #[cfg(not(target_env = "msvc"))]

--- a/lib/vrl/tests/src/test.rs
+++ b/lib/vrl/tests/src/test.rs
@@ -1,5 +1,4 @@
-use std::str::FromStr;
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path, str::FromStr};
 
 use ::value::Value;
 use lookup::LookupBuf;

--- a/lib/vrl/vrl/src/prelude.rs
+++ b/lib/vrl/vrl/src/prelude.rs
@@ -11,8 +11,7 @@ pub use compiler::{
 
 pub type Result<T> = std::result::Result<T, ExpressionError>;
 
-pub use std::collections::BTreeMap;
-pub use std::fmt;
+pub use std::{collections::BTreeMap, fmt};
 
 pub use bytes::Bytes;
 // pub use crate::{Error, Expr, Expression, Function, Object, Result, TypeDef, Value};


### PR DESCRIPTION
This applies `rustfmt` to VRL crates, using Vector's nightly only [config](https://github.com/vectordotdev/vector/blob/4972d4d770db3457ff7a9b7e30e2157374c9b8e0/.rustfmt.toml).