### PR TITLE
feat(sources): opentelemetry log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5048,6 +5048,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
+name = "otel_proto"
+version = "0.1.0"
+dependencies = [
+ "bytes 1.1.0",
+ "hex",
+ "ordered-float 3.0.0",
+ "prost",
+ "prost-build",
+ "tonic",
+ "tonic-build",
+ "value",
+ "vector_core",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8365,6 +8380,7 @@ dependencies = [
  "openssl",
  "openssl-probe",
  "ordered-float 3.0.0",
+ "otel_proto",
  "percent-encoding",
  "pin-project",
  "portpicker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
   "lib/datadog/grok",
   "lib/datadog/search-syntax",
   "lib/datadog/filter",
+  "lib/opentelemetry",
 ]
 
 [dependencies]
@@ -116,6 +117,7 @@ enrichment = { path = "lib/enrichment" }
 fakedata = { path = "lib/fakedata", optional = true }
 file-source = { path = "lib/file-source", optional = true }
 lookup = { path = "lib/lookup" }
+otel_proto = { path = "lib/opentelemetry", optional = true }
 portpicker = { path = "lib/portpicker" }
 prometheus-parser = { path = "lib/prometheus-parser", optional = true }
 tracing-limit = { path = "lib/tracing-limit" }
@@ -451,6 +453,7 @@ sources-logs = [
   "sources-kubernetes_logs",
   "sources-logstash",
   "sources-nats",
+  "sources-opentelemetry",
   "sources-redis",
   "sources-socket",
   "sources-splunk_hec",
@@ -498,6 +501,7 @@ sources-logstash = ["listenfd", "tokio-util/net", "sources-utils-tcp-keepalive",
 sources-mongodb_metrics = ["dep:mongodb"]
 sources-nats = ["dep:nats", "dep:nkeys"]
 sources-nginx_metrics = ["dep:nom"]
+sources-opentelemetry = ["sources-vector", "dep:otel_proto"]
 sources-postgresql_metrics = ["dep:postgres-openssl", "dep:tokio-postgres"]
 sources-prometheus = ["dep:prometheus-parser", "sinks-prometheus", "sources-http", "sources-utils-http"]
 sources-redis= ["dep:redis"]

--- a/lib/opentelemetry/Cargo.toml
+++ b/lib/opentelemetry/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "otel_proto"
+version = "0.1.0"
+authors = ["caibirdme <ronaldoliu@tencent.com>"]
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[build-dependencies]
+prost-build = { version = "0.10.4"}
+tonic-build = { version = "0.7", default-features = false, features = ["transport", "prost", "compression"]}
+
+[dependencies]
+tonic = {version="0.7.2", features = ["transport", "codegen", "prost", "tls", "tls-roots", "compression"]}
+prost = { version="0.10.4", features = ["std"] }
+bytes = { version = "1.1.0", default-features = false, features = ["serde"] }
+vector_core = { path = "../vector-core"}
+value = {path = "../value"}
+hex = { version = "0.4.3", features = ["std"]}
+ordered-float = { version = "3.0.0", default-features = false }

--- a/lib/opentelemetry/build.rs
+++ b/lib/opentelemetry/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    {
+        let mut prost_build = prost_build::Config::new();
+        prost_build.btree_map(&["."]);
+
+        tonic_build::configure()
+            .compile_with_config(
+                prost_build,
+                &["opentelemetry/proto/collector/logs/v1/logs_service.proto"],
+                &["."],
+            )
+            .unwrap();
+    }
+}

--- a/lib/opentelemetry/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/lib/opentelemetry/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -1,0 +1,45 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.collector.logs.v1;
+
+import "opentelemetry/proto/logs/v1/logs.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.collector.logs.v1";
+option java_outer_classname = "LogsServiceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/logs/v1";
+
+// Service that can be used to push logs between one Application instrumented with
+// OpenTelemetry and an collector, or between an collector and a central collector (in this
+// case logs are sent/received to/from multiple Applications).
+service LogsService {
+  // For performance reasons, it is recommended to keep this RPC
+  // alive for the entire life of the application.
+  rpc Export(ExportLogsServiceRequest) returns (ExportLogsServiceResponse) {}
+}
+
+message ExportLogsServiceRequest {
+  // An array of ResourceLogs.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated opentelemetry.proto.logs.v1.ResourceLogs resource_logs = 1;
+}
+
+message ExportLogsServiceResponse {
+}

--- a/lib/opentelemetry/opentelemetry/proto/common/v1/common.proto
+++ b/lib/opentelemetry/opentelemetry/proto/common/v1/common.proto
@@ -1,0 +1,87 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
+
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+message AnyValue {
+  // The value is one of the listed fields. It is valid for all values to be unspecified
+  // in which case this AnyValue is considered to be "empty".
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
+message ArrayValue {
+  // Array of values. The array may be empty (contain 0 elements).
+  repeated AnyValue values = 1;
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+message KeyValueList {
+  // A collection of key/value pairs of key-value pairs. The list may be empty (may
+  // contain 0 elements).
+  // The keys MUST be unique (it is not allowed to have more than one
+  // value with the same key).
+  repeated KeyValue values = 1;
+}
+
+// KeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+}
+
+// InstrumentationLibrary is a message representing the instrumentation library information
+// such as the fully qualified name and version.
+// InstrumentationLibrary is wire-compatible with InstrumentationScope for binary
+// Protobuf format.
+// This message is deprecated and will be removed on June 15, 2022.
+message InstrumentationLibrary {
+  option deprecated = true;
+
+  // An empty instrumentation library name means the name is unknown.
+  string name = 1;
+  string version = 2;
+}
+
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version.
+message InstrumentationScope {
+  // An empty instrumentation scope name means the name is unknown.
+  string name = 1;
+  string version = 2;
+}

--- a/lib/opentelemetry/opentelemetry/proto/logs/v1/logs.proto
+++ b/lib/opentelemetry/opentelemetry/proto/logs/v1/logs.proto
@@ -1,0 +1,222 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.logs.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/resource/v1/resource.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.logs.v1";
+option java_outer_classname = "LogsProto";
+option go_package = "go.opentelemetry.io/proto/otlp/logs/v1";
+
+// LogsData represents the logs data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP logs data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message LogsData {
+  // An array of ResourceLogs.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceLogs resource_logs = 1;
+}
+
+// A collection of ScopeLogs from a Resource.
+message ResourceLogs {
+  // The resource for the logs in this message.
+  // If this field is not set then resource info is unknown.
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+
+  // A list of ScopeLogs that originate from a resource.
+  repeated ScopeLogs scope_logs = 2;
+
+  // A list of InstrumentationLibraryLogs that originate from a resource.
+  // This field is deprecated and will be removed after grace period expires on June 15, 2022.
+  //
+  // During the grace period the following rules SHOULD be followed:
+  //
+  // For Binary Protobufs
+  // ====================
+  // Binary Protobuf senders SHOULD NOT set instrumentation_library_logs. Instead
+  // scope_logs SHOULD be set.
+  //
+  // Binary Protobuf receivers SHOULD check if instrumentation_library_logs is set
+  // and scope_logs is not set then the value in instrumentation_library_logs
+  // SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
+  // If scope_logs is set then instrumentation_library_logs SHOULD be ignored.
+  //
+  // For JSON
+  // ========
+  // JSON senders that set instrumentation_library_logs field MAY also set
+  // scope_logs to carry the same logs, essentially double-publishing the same data.
+  // Such double-publishing MAY be controlled by a user-settable option.
+  // If double-publishing is not used then the senders SHOULD set scope_logs and
+  // SHOULD NOT set instrumentation_library_logs.
+  //
+  // JSON receivers SHOULD check if instrumentation_library_logs is set and
+  // scope_logs is not set then the value in instrumentation_library_logs
+  // SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
+  // If scope_logs is set then instrumentation_library_logs field SHOULD be ignored.
+  repeated InstrumentationLibraryLogs instrumentation_library_logs = 1000 [deprecated = true];
+
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "scope_logs" field which have their own schema_url field.
+  string schema_url = 3;
+}
+
+// A collection of Logs produced by a Scope.
+message ScopeLogs {
+  // The instrumentation scope information for the logs in this message.
+  // Semantically when InstrumentationScope isn't set, it is equivalent with
+  // an empty instrumentation scope name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+
+  // A list of log records.
+  repeated LogRecord log_records = 2;
+
+  // This schema_url applies to all logs in the "logs" field.
+  string schema_url = 3;
+}
+
+// A collection of Logs produced by an InstrumentationLibrary.
+// InstrumentationLibraryLogs is wire-compatible with ScopeLogs for binary
+// Protobuf format.
+// This message is deprecated and will be removed on June 15, 2022.
+message InstrumentationLibraryLogs {
+  option deprecated = true;
+
+  // The instrumentation library information for the logs in this message.
+  // Semantically when InstrumentationLibrary isn't set, it is equivalent with
+  // an empty instrumentation library name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationLibrary instrumentation_library = 1;
+
+  // A list of logs that originate from an instrumentation library.
+  repeated LogRecord log_records = 2;
+
+  // This schema_url applies to all logs in the "logs" field.
+  string schema_url = 3;
+}
+
+// Possible values for LogRecord.SeverityNumber.
+enum SeverityNumber {
+  // UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
+  SEVERITY_NUMBER_UNSPECIFIED = 0;
+  SEVERITY_NUMBER_TRACE  = 1;
+  SEVERITY_NUMBER_TRACE2 = 2;
+  SEVERITY_NUMBER_TRACE3 = 3;
+  SEVERITY_NUMBER_TRACE4 = 4;
+  SEVERITY_NUMBER_DEBUG  = 5;
+  SEVERITY_NUMBER_DEBUG2 = 6;
+  SEVERITY_NUMBER_DEBUG3 = 7;
+  SEVERITY_NUMBER_DEBUG4 = 8;
+  SEVERITY_NUMBER_INFO   = 9;
+  SEVERITY_NUMBER_INFO2  = 10;
+  SEVERITY_NUMBER_INFO3  = 11;
+  SEVERITY_NUMBER_INFO4  = 12;
+  SEVERITY_NUMBER_WARN   = 13;
+  SEVERITY_NUMBER_WARN2  = 14;
+  SEVERITY_NUMBER_WARN3  = 15;
+  SEVERITY_NUMBER_WARN4  = 16;
+  SEVERITY_NUMBER_ERROR  = 17;
+  SEVERITY_NUMBER_ERROR2 = 18;
+  SEVERITY_NUMBER_ERROR3 = 19;
+  SEVERITY_NUMBER_ERROR4 = 20;
+  SEVERITY_NUMBER_FATAL  = 21;
+  SEVERITY_NUMBER_FATAL2 = 22;
+  SEVERITY_NUMBER_FATAL3 = 23;
+  SEVERITY_NUMBER_FATAL4 = 24;
+}
+
+// Masks for LogRecord.flags field.
+enum LogRecordFlags {
+  LOG_RECORD_FLAG_UNSPECIFIED = 0;
+  LOG_RECORD_FLAG_TRACE_FLAGS_MASK = 0x000000FF;
+}
+
+// A log record according to OpenTelemetry Log Data Model:
+// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
+message LogRecord {
+  reserved 4;
+
+  // time_unix_nano is the time when the event occurred.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  // Value of 0 indicates unknown or missing timestamp.
+  fixed64 time_unix_nano = 1;
+
+  // Time when the event was observed by the collection system.
+  // For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+  // this timestamp is typically set at the generation time and is equal to Timestamp.
+  // For events originating externally and collected by OpenTelemetry (e.g. using
+  // Collector) this is the time when OpenTelemetry's code observed the event measured
+  // by the clock of the OpenTelemetry code. This field MUST be set once the event is
+  // observed by OpenTelemetry.
+  //
+  // For converting OpenTelemetry log data to formats that support only one timestamp or
+  // when receiving OpenTelemetry log data by recipients that support only one timestamp
+  // internally the following logic is recommended:
+  //   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  // Value of 0 indicates unknown or missing timestamp.
+  fixed64 observed_time_unix_nano = 11;
+
+  // Numerical value of the severity, normalized to values described in Log Data Model.
+  // [Optional].
+  SeverityNumber severity_number = 2;
+
+  // The severity text (also known as log level). The original string representation as
+  // it is known at the source. [Optional].
+  string severity_text = 3;
+
+  // A value containing the body of the log record. Can be for example a human-readable
+  // string message (including multi-line) describing the event in a free form or it can
+  // be a structured data composed of arrays and maps of other values. [Optional].
+  opentelemetry.proto.common.v1.AnyValue body = 5;
+
+  // Additional attributes that describe the specific event occurrence. [Optional].
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 6;
+  uint32 dropped_attributes_count = 7;
+
+  // Flags, a bit field. 8 least significant bits are the trace flags as
+  // defined in W3C Trace Context specification. 24 most significant bits are reserved
+  // and must be set to 0. Readers must not assume that 24 most significant bits
+  // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+  // flags & TRACE_FLAGS_MASK). [Optional].
+  fixed32 flags = 8;
+
+  // A unique identifier for a trace. All logs from the same trace share
+  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
+  // is considered invalid. Can be set for logs that are part of request processing
+  // and have an assigned trace id. [Optional].
+  bytes trace_id = 9;
+
+  // A unique identifier for a span within a trace, assigned when the span
+  // is created. The ID is an 8-byte array. An ID with all zeroes is considered
+  // invalid. Can be set for logs that are part of a particular processing span.
+  // If span_id is present trace_id SHOULD be also present. [Optional].
+  bytes span_id = 10;
+}

--- a/lib/opentelemetry/opentelemetry/proto/resource/v1/resource.proto
+++ b/lib/opentelemetry/opentelemetry/proto/resource/v1/resource.proto
@@ -1,0 +1,36 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.resource.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.resource.v1";
+option java_outer_classname = "ResourceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/resource/v1";
+
+// Resource information.
+message Resource {
+  // Set of attributes that describe the resource.
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+
+  // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
+  // no attributes were dropped.
+  uint32 dropped_attributes_count = 2;
+}

--- a/lib/opentelemetry/src/convert.rs
+++ b/lib/opentelemetry/src/convert.rs
@@ -1,0 +1,159 @@
+use super::{
+    Common::{any_value::Value as PBValue, InstrumentationScope, KeyValue},
+    Logs::{InstrumentationLibraryLogs, LogRecord, ResourceLogs, ScopeLogs, SeverityNumber},
+    Resource as OtelResource,
+};
+use bytes::Bytes;
+use ordered_float::NotNan;
+use std::{
+    collections::BTreeMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use value::Value;
+use vector_core::{
+    config::log_schema,
+    event::{Event, LogEvent},
+};
+
+const RESOURCE_KEY: &str = "resources";
+const ATTRIBUTES_KEY: &str = "attributes";
+const TRACE_ID_KEY: &str = "trace_id";
+const SPAN_ID_KEY: &str = "span_id";
+const SEVERITY_TEXT_KEY: &str = "severity_text";
+const SEVERITY_NUMBER_KEY: &str = "severity_number";
+const OBSERVED_TIME_UNIX_NANO_KEY: &str = "observed_time_unix_nano";
+const DROPPED_ATTRIBUTES_COUNT_KEY: &str = "dropped_attributes_count";
+const FLAGS_KEY: &str = "flags";
+
+impl From<InstrumentationLibraryLogs> for ScopeLogs {
+    fn from(v: InstrumentationLibraryLogs) -> Self {
+        Self {
+            scope: v.instrumentation_library.map(|v| InstrumentationScope {
+                name: v.name,
+                version: v.version,
+            }),
+            log_records: v.log_records,
+            schema_url: v.schema_url,
+        }
+    }
+}
+
+impl IntoIterator for ResourceLogs {
+    type Item = Event;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    #[allow(deprecated)]
+    fn into_iter(self) -> Self::IntoIter {
+        let resource = self.resource;
+        // convert instrumentation_library_logs(deprecated) into scope_logs
+        let scope_logs: Vec<ScopeLogs> = if !self.scope_logs.is_empty() {
+            self.scope_logs
+        } else {
+            self.instrumentation_library_logs
+                .into_iter()
+                .map(ScopeLogs::from)
+                .collect()
+        };
+
+        scope_logs
+            .into_iter()
+            .flat_map(|scope_log| scope_log.log_records)
+            .map(|log_record| {
+                ResourceLog {
+                    resource: resource.clone(),
+                    log_record,
+                }
+                .into()
+            })
+            .collect::<Vec<Event>>()
+            .into_iter()
+    }
+}
+
+impl From<PBValue> for Value {
+    fn from(av: PBValue) -> Self {
+        match av {
+            PBValue::StringValue(v) => Value::Bytes(Bytes::from(v)),
+            PBValue::BoolValue(v) => Value::Boolean(v),
+            PBValue::IntValue(v) => Value::Integer(v),
+            PBValue::DoubleValue(v) => Value::Float(NotNan::new(v).unwrap()),
+            PBValue::BytesValue(v) => Value::Bytes(Bytes::from(v)),
+            PBValue::ArrayValue(arr) => Value::Array(
+                arr.values
+                    .into_iter()
+                    .map(|av| av.value.map(Into::into).unwrap_or(Value::Null))
+                    .collect::<Vec<Value>>(),
+            ),
+            PBValue::KvlistValue(arr) => kv_list_into_value(arr.values),
+        }
+    }
+}
+
+struct ResourceLog {
+    resource: Option<OtelResource>,
+    log_record: LogRecord,
+}
+
+fn kv_list_into_value(arr: Vec<KeyValue>) -> Value {
+    Value::Object(
+        arr.into_iter()
+            .filter_map(|kv| {
+                kv.value
+                    .map(|av| (kv.key, av.value.map(Into::into).unwrap_or(Value::Null)))
+            })
+            .collect::<BTreeMap<String, Value>>(),
+    )
+}
+
+impl From<ResourceLog> for Event {
+    fn from(rl: ResourceLog) -> Self {
+        let mut le = LogEvent::default();
+
+        // optional fields
+        if let Some(resource) = rl.resource {
+            if !resource.attributes.is_empty() {
+                le.insert(RESOURCE_KEY, kv_list_into_value(resource.attributes));
+            }
+        }
+        if !rl.log_record.attributes.is_empty() {
+            le.insert(ATTRIBUTES_KEY, kv_list_into_value(rl.log_record.attributes));
+        }
+        if let Some(v) = rl.log_record.body.and_then(|av| av.value) {
+            le.insert(log_schema().message_key(), v);
+        }
+        if !rl.log_record.trace_id.is_empty() {
+            le.insert(
+                TRACE_ID_KEY,
+                Value::Bytes(Bytes::from(hex::encode(rl.log_record.trace_id))),
+            );
+        }
+        if !rl.log_record.span_id.is_empty() {
+            le.insert(
+                SPAN_ID_KEY,
+                Value::Bytes(Bytes::from(hex::encode(rl.log_record.span_id))),
+            );
+        }
+        if !rl.log_record.severity_text.is_empty() {
+            le.insert(SEVERITY_TEXT_KEY, rl.log_record.severity_text);
+        }
+        if rl.log_record.severity_number != SeverityNumber::Unspecified as i32 {
+            le.insert(SEVERITY_NUMBER_KEY, rl.log_record.severity_number);
+        }
+        if rl.log_record.flags > 0 {
+            le.insert(FLAGS_KEY, rl.log_record.flags);
+        }
+
+        // NOT optional fields
+        le.insert(log_schema().timestamp_key(), rl.log_record.time_unix_nano);
+        // according to proto, if observed_time_unix_nano is missing, collector should set it
+        let observed_timestamp = if rl.log_record.observed_time_unix_nano > 0 {
+            rl.log_record.observed_time_unix_nano
+        } else {
+            SystemTime::now().duration_since(UNIX_EPOCH)
+                .expect("SystemTime before UNIX EPOCH!").as_nanos() as u64
+        };
+        le.insert(OBSERVED_TIME_UNIX_NANO_KEY, observed_timestamp);
+        le.insert(DROPPED_ATTRIBUTES_COUNT_KEY, rl.log_record.dropped_attributes_count);
+
+        le.into()
+    }
+}

--- a/lib/opentelemetry/src/lib.rs
+++ b/lib/opentelemetry/src/lib.rs
@@ -1,0 +1,7 @@
+pub use proto::collector::logs::v1 as LogService;
+pub use proto::common::v1 as Common;
+pub use proto::logs::v1 as Logs;
+pub use proto::resource::v1::Resource;
+
+mod convert;
+mod proto;

--- a/lib/opentelemetry/src/proto/collector/mod.rs
+++ b/lib/opentelemetry/src/proto/collector/mod.rs
@@ -1,0 +1,5 @@
+pub mod logs {
+    pub mod v1 {
+        tonic::include_proto!("opentelemetry.proto.collector.logs.v1");
+    }
+}

--- a/lib/opentelemetry/src/proto/common/mod.rs
+++ b/lib/opentelemetry/src/proto/common/mod.rs
@@ -1,0 +1,3 @@
+pub mod v1 {
+    tonic::include_proto!("opentelemetry.proto.common.v1");
+}

--- a/lib/opentelemetry/src/proto/logs/mod.rs
+++ b/lib/opentelemetry/src/proto/logs/mod.rs
@@ -1,0 +1,3 @@
+pub mod v1 {
+    tonic::include_proto!("opentelemetry.proto.logs.v1");
+}

--- a/lib/opentelemetry/src/proto/mod.rs
+++ b/lib/opentelemetry/src/proto/mod.rs
@@ -1,0 +1,4 @@
+pub mod collector;
+pub mod common;
+pub mod logs;
+pub mod resource;

--- a/lib/opentelemetry/src/proto/resource/mod.rs
+++ b/lib/opentelemetry/src/proto/resource/mod.rs
@@ -1,0 +1,3 @@
+pub mod v1 {
+    tonic::include_proto!("opentelemetry.proto.resource.v1");
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -52,6 +52,8 @@ pub mod mongodb_metrics;
 pub mod nats;
 #[cfg(feature = "sources-nginx_metrics")]
 pub mod nginx_metrics;
+#[cfg(feature = "sources-opentelemetry")]
+pub mod opentelemetry;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub mod postgresql_metrics;
 #[cfg(feature = "sources-prometheus")]

--- a/src/sources/opentelemetry/log.rs
+++ b/src/sources/opentelemetry/log.rs
@@ -1,0 +1,133 @@
+use crate::{
+    config::{
+        AcknowledgementsConfig, DataType, GenerateConfig, Output, Resource, SourceConfig,
+        SourceContext,
+    },
+    internal_events::{EventsReceived, StreamClosedError},
+    serde::bool_or_struct,
+    sources::{util::grpc::run_grpc_server, Source},
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
+    SourceSender,
+};
+use futures::TryFutureExt;
+use otel_proto::LogService::{
+    logs_service_server::{LogsService, LogsServiceServer},
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use tonic::{Request, Response, Status};
+use vector_core::{
+    event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event},
+    ByteSizeOf,
+};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct OpentelemetryLogConfig {
+    address: SocketAddr,
+    #[serde(default)]
+    tls: Option<TlsEnableableConfig>,
+    #[serde(default, deserialize_with = "bool_or_struct")]
+    acknowledgements: AcknowledgementsConfig,
+}
+
+impl GenerateConfig for OpentelemetryLogConfig {
+    fn generate_config() -> toml::Value {
+        toml::Value::try_from(Self {
+            address: "0.0.0.0:6788".parse().unwrap(),
+            tls: None,
+            acknowledgements: Default::default(),
+        })
+        .unwrap()
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "opentelemetry")]
+impl SourceConfig for OpentelemetryLogConfig {
+    async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
+        let tls_settings = MaybeTlsSettings::from_config(&self.tls, true)?;
+        let acknowledgements = cx.do_acknowledgements(&self.acknowledgements);
+        let service = LogsServiceServer::new(Service {
+            pipeline: cx.out,
+            acknowledgements,
+        })
+        .accept_gzip();
+        let source =
+            run_grpc_server(self.address, tls_settings, service, cx.shutdown).map_err(|error| {
+                error!(message = "Source future failed.", %error);
+            });
+
+        Ok(Box::pin(source))
+    }
+
+    fn outputs(&self) -> Vec<Output> {
+        vec![Output::default(DataType::Log)]
+    }
+
+    fn source_type(&self) -> &'static str {
+        "opentelemetry"
+    }
+
+    fn resources(&self) -> Vec<Resource> {
+        vec![Resource::tcp(self.address)]
+    }
+
+    fn can_acknowledge(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Service {
+    pipeline: SourceSender,
+    acknowledgements: bool,
+}
+
+#[tonic::async_trait]
+impl LogsService for Service {
+    async fn export(
+        &self,
+        request: Request<ExportLogsServiceRequest>,
+    ) -> Result<Response<ExportLogsServiceResponse>, Status> {
+        let mut events: Vec<Event> = request
+            .into_inner()
+            .resource_logs
+            .into_iter()
+            .flat_map(|v| v.into_iter())
+            .collect();
+
+        let count = events.len();
+        let byte_size = events.size_of();
+
+        emit!(EventsReceived { count, byte_size });
+
+        let receiver = BatchNotifier::maybe_apply_to(self.acknowledgements, &mut events);
+
+        self.pipeline
+            .clone()
+            .send_batch(events)
+            .map_err(|error| {
+                let message = error.to_string();
+                emit!(StreamClosedError { error, count });
+                Status::unavailable(message)
+            })
+            .and_then(|_| handle_batch_status(receiver))
+            .await?;
+        Ok(Response::new(ExportLogsServiceResponse {}))
+    }
+}
+
+async fn handle_batch_status(receiver: Option<BatchStatusReceiver>) -> Result<(), Status> {
+    let status = match receiver {
+        Some(receiver) => receiver.await,
+        None => BatchStatus::Delivered,
+    };
+
+    match status {
+        BatchStatus::Errored => Err(Status::internal("Delivery error")),
+        BatchStatus::Rejected => Err(Status::data_loss("Delivery failed")),
+        BatchStatus::Delivered => Ok(()),
+    }
+}

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -1,0 +1,8 @@
+mod log;
+
+use crate::config::SourceDescription;
+use log::OpentelemetryLogConfig;
+
+inventory::submit! {
+    SourceDescription::new::<OpentelemetryLogConfig>("opentelemetry")
+}


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Example:
```yaml
sources:
  otel:
    type: opentelemetry
    address: 0.0.0.0:6788
```

the opentelemetry log will be converted into EventLog:
```javascript
{
  // optional
  "attributes": [{"k1": "v1"}],
  "resources": [{"k1": "v1"}],
  "message": "xxx",
  "trace_id": "xxx", 
  "span_id": "xxx",
  "severity_number": 1,
  "severity_text": "xxx",
  "flags": 1,

  // required
  "timestamp": ts_nano,
  "observed_time_unix_nano": ts_nano,
  "dropped_attributes_count": 0

}
```

I've been testing this source in out production for 1 week, and it works well! Hope this feature can be merged and I can continue to work on opentelemetry-metrics
