### PR TITLE
chore(vrl): clippy deny+fix on compiler

### DIFF
--- a/lib/vrl/compiler/src/context.rs
+++ b/lib/vrl/compiler/src/context.rs
@@ -19,6 +19,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get a reference to the [`Target`].
+    #[must_use]
     pub fn target(&self) -> &dyn Target {
         self.target
     }
@@ -29,6 +30,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get a reference to the [`runtime state`](Runtime).
+    #[must_use]
     pub fn state(&self) -> &Runtime {
         self.state
     }
@@ -39,6 +41,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get a reference to the [`TimeZone`]
+    #[must_use]
     pub fn timezone(&self) -> &TimeZone {
         self.timezone
     }

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -138,8 +138,11 @@ pub enum Expr {
 
 impl Expr {
     pub fn as_str(&self) -> &str {
-        use container::Variant::*;
-        use Expr::*;
+        use container::Variant::{Array, Block, Group, Object};
+        use Expr::{
+            Abort, Assignment, Container, FunctionCall, IfStatement, Literal, Noop, Op, Query,
+            Unary, Variable,
+        };
 
         match self {
             #[cfg(feature = "expr-literal")]
@@ -228,7 +231,10 @@ impl Expr {
 
 impl Expression for Expr {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        use Expr::*;
+        use Expr::{
+            Abort, Assignment, Container, FunctionCall, IfStatement, Literal, Noop, Op, Query,
+            Unary, Variable,
+        };
 
         match self {
             #[cfg(feature = "expr-literal")]
@@ -254,7 +260,10 @@ impl Expression for Expr {
     }
 
     fn as_value(&self) -> Option<Value> {
-        use Expr::*;
+        use Expr::{
+            Abort, Assignment, Container, FunctionCall, IfStatement, Literal, Noop, Op, Query,
+            Unary, Variable,
+        };
 
         match self {
             #[cfg(feature = "expr-literal")]
@@ -280,7 +289,10 @@ impl Expression for Expr {
     }
 
     fn type_def(&self, state: (&LocalEnv, &ExternalEnv)) -> TypeDef {
-        use Expr::*;
+        use Expr::{
+            Abort, Assignment, Container, FunctionCall, IfStatement, Literal, Noop, Op, Query,
+            Unary, Variable,
+        };
 
         match self {
             #[cfg(feature = "expr-literal")]
@@ -308,7 +320,10 @@ impl Expression for Expr {
 
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Expr::*;
+        use Expr::{
+            Abort, Assignment, Container, FunctionCall, IfStatement, Literal, Noop, Op, Query,
+            Unary, Variable,
+        };
 
         match self {
             #[cfg(feature = "expr-literal")]
@@ -415,7 +430,7 @@ impl From<Value> for Expr {
     fn from(value: Value) -> Self {
         use std::collections::BTreeMap;
 
-        use value::Value::*;
+        use value::Value::{Array, Boolean, Bytes, Float, Integer, Null, Object, Regex, Timestamp};
 
         match value {
             Bytes(v) => Literal::from(v).into(),
@@ -465,7 +480,7 @@ pub enum Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use Error::*;
+        use Error::{Fallible, Missing};
 
         match self {
             Fallible { .. } => 100,
@@ -474,7 +489,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn labels(&self) -> Vec<Label> {
-        use Error::*;
+        use Error::{Fallible, Missing};
 
         match self {
             Fallible { span } => vec![
@@ -492,7 +507,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn notes(&self) -> Vec<Note> {
-        use Error::*;
+        use Error::{Fallible, Missing};
 
         match self {
             Fallible { .. } => vec![Note::SeeErrorDocs],

--- a/lib/vrl/compiler/src/expression/abort.rs
+++ b/lib/vrl/compiler/src/expression/abort.rs
@@ -18,6 +18,10 @@ pub struct Abort {
 }
 
 impl Abort {
+    /// # Errors
+    ///
+    /// * The optional message is fallible.
+    /// * The optional message does not resolve to a string.
     pub fn new(
         span: Span,
         message: Option<Node<Expr>>,
@@ -105,7 +109,7 @@ impl std::error::Error for Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use ErrorVariant::*;
+        use ErrorVariant::{FallibleExpr, NonString};
 
         match self.variant {
             FallibleExpr => 631,

--- a/lib/vrl/compiler/src/expression/array.rs
+++ b/lib/vrl/compiler/src/expression/array.rs
@@ -39,7 +39,7 @@ impl Expression for Array {
     fn as_value(&self) -> Option<Value> {
         self.inner
             .iter()
-            .map(|expr| expr.as_value())
+            .map(Expr::as_value)
             .collect::<Option<Vec<_>>>()
             .map(Value::Array)
     }
@@ -70,7 +70,7 @@ impl fmt::Display for Array {
         let exprs = self
             .inner
             .iter()
-            .map(|e| e.to_string())
+            .map(Expr::to_string)
             .collect::<Vec<_>>()
             .join(", ");
 

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -190,7 +190,7 @@ impl Expression for Assignment {
 
 impl fmt::Display for Assignment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Variant::*;
+        use Variant::{Infallible, Single};
 
         match &self.variant {
             Single { target, expr } => write!(f, "{} = {}", target, expr),
@@ -201,7 +201,7 @@ impl fmt::Display for Assignment {
 
 impl fmt::Debug for Assignment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Variant::*;
+        use Variant::{Infallible, Single};
 
         match &self.variant {
             Single { target, expr } => write!(f, "{:?} = {:?}", target, expr),
@@ -263,7 +263,7 @@ impl Target {
     }
 
     fn insert(&self, value: Value, ctx: &mut Context) {
-        use Target::*;
+        use Target::{External, Internal, Noop};
 
         match self {
             Noop => {}
@@ -294,7 +294,7 @@ impl Target {
 
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Target::*;
+        use Target::{External, Internal, Noop};
 
         match self {
             Noop => f.write_str("_"),
@@ -308,7 +308,7 @@ impl fmt::Display for Target {
 
 impl fmt::Debug for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Target::*;
+        use Target::{External, Internal, Noop};
 
         match self {
             Noop => f.write_str("Noop"),
@@ -324,7 +324,7 @@ impl TryFrom<ast::AssignmentTarget> for Target {
     type Error = Error;
 
     fn try_from(target: ast::AssignmentTarget) -> Result<Self, Error> {
-        use Target::*;
+        use Target::{External, Internal, Noop};
 
         let target = match target {
             ast::AssignmentTarget::Noop => Noop,
@@ -381,7 +381,7 @@ where
     U: Expression + Clone,
 {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        use Variant::*;
+        use Variant::{Infallible, Single};
 
         let value = match self {
             Single { target, expr } => {
@@ -413,7 +413,7 @@ where
     }
 
     fn type_def(&self, state: (&LocalEnv, &ExternalEnv)) -> TypeDef {
-        use Variant::*;
+        use Variant::{Infallible, Single};
 
         match self {
             Single { expr, .. } => expr.type_def(state),
@@ -428,7 +428,7 @@ where
     U: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Variant::*;
+        use Variant::{Infallible, Single};
 
         match self {
             Single { target, expr } => write!(f, "{} = {}", target, expr),
@@ -478,7 +478,9 @@ impl std::error::Error for Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use ErrorVariant::*;
+        use ErrorVariant::{
+            FallibleAssignment, InfallibleAssignment, InvalidTarget, ReadOnly, UnnecessaryNoop,
+        };
 
         match &self.variant {
             UnnecessaryNoop(..) => 640,
@@ -490,7 +492,9 @@ impl DiagnosticMessage for Error {
     }
 
     fn labels(&self) -> Vec<Label> {
-        use ErrorVariant::*;
+        use ErrorVariant::{
+            FallibleAssignment, InfallibleAssignment, InvalidTarget, ReadOnly, UnnecessaryNoop,
+        };
 
         match &self.variant {
             UnnecessaryNoop(target_span) => vec![
@@ -524,7 +528,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn notes(&self) -> Vec<Note> {
-        use ErrorVariant::*;
+        use ErrorVariant::{FallibleAssignment, InfallibleAssignment};
 
         match &self.variant {
             FallibleAssignment(..) | InfallibleAssignment(..) => vec![Note::SeeErrorDocs],

--- a/lib/vrl/compiler/src/expression/block.rs
+++ b/lib/vrl/compiler/src/expression/block.rs
@@ -19,10 +19,12 @@ pub struct Block {
 }
 
 impl Block {
+    #[must_use]
     pub fn new(inner: Vec<Expr>, local_env: LocalEnv) -> Self {
         Self { inner, local_env }
     }
 
+    #[must_use]
     pub fn into_inner(self) -> Vec<Expr> {
         self.inner
     }
@@ -54,7 +56,7 @@ impl Expression for Block {
     /// Type information of future expressions in this block should not be considered after
     /// a terminating expression.
     ///
-    /// Since type definitions due to assignments are calculated outside of the "type_def" function,
+    /// Since type definitions due to assignments are calculated outside of the "`type_def`" function,
     /// assignments that can never execute might still have adjusted the type definition.
     /// Therefore, expressions after a terminating expression must not be included in a block.
     /// It is considered an internal compiler error if this situation occurs, which is checked here
@@ -67,9 +69,7 @@ impl Expression for Block {
         let mut fallible = false;
         let mut has_terminated = false;
         for expr in &self.inner {
-            if has_terminated {
-                panic!("VRL block contains an expression after a terminating expression. This is an internal compiler error. Please submit a bug report.");
-            }
+            assert!(!has_terminated, "VRL block contains an expression after a terminating expression. This is an internal compiler error. Please submit a bug report.");
             last = expr.type_def((&self.local_env, external));
             if last.is_never() {
                 has_terminated = true;

--- a/lib/vrl/compiler/src/expression/container.rs
+++ b/lib/vrl/compiler/src/expression/container.rs
@@ -12,6 +12,7 @@ pub struct Container {
 }
 
 impl Container {
+    #[must_use]
     pub fn new(variant: Variant) -> Self {
         Self { variant }
     }
@@ -27,7 +28,7 @@ pub enum Variant {
 
 impl Expression for Container {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        use Variant::*;
+        use Variant::{Array, Block, Group, Object};
 
         match &self.variant {
             Group(v) => v.resolve(ctx),
@@ -38,7 +39,7 @@ impl Expression for Container {
     }
 
     fn as_value(&self) -> Option<Value> {
-        use Variant::*;
+        use Variant::{Array, Block, Group, Object};
 
         match &self.variant {
             Group(v) => v.as_value(),
@@ -49,7 +50,7 @@ impl Expression for Container {
     }
 
     fn type_def(&self, state: (&LocalEnv, &ExternalEnv)) -> TypeDef {
-        use Variant::*;
+        use Variant::{Array, Block, Group, Object};
 
         match &self.variant {
             Group(v) => v.type_def(state),
@@ -62,7 +63,7 @@ impl Expression for Container {
 
 impl fmt::Display for Container {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Variant::*;
+        use Variant::{Array, Block, Group, Object};
 
         match &self.variant {
             Group(v) => v.fmt(f),

--- a/lib/vrl/compiler/src/expression/function_argument.rs
+++ b/lib/vrl/compiler/src/expression/function_argument.rs
@@ -29,7 +29,7 @@ impl FunctionArgument {
 
     #[cfg(feature = "expr-function_call")]
     pub(crate) fn keyword_span(&self) -> Option<crate::Span> {
-        self.ident.as_ref().map(|node| node.span())
+        self.ident.as_ref().map(Node::span)
     }
 
     pub(crate) fn parameter(&self) -> Option<Parameter> {

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -333,7 +333,7 @@ impl<'a> Builder<'a> {
 
                             let details = Details { type_def, value };
 
-                            local.insert_variable(call_ident.to_owned().into_inner(), details);
+                            local.insert_variable(call_ident.clone().into_inner(), details);
                         }
 
                         let variables = variables
@@ -567,6 +567,7 @@ impl FunctionCall {
         Ok(result)
     }
 
+    #[must_use]
     pub fn arguments_fmt(&self) -> Vec<String> {
         self.arguments
             .iter()
@@ -574,6 +575,7 @@ impl FunctionCall {
             .collect::<Vec<_>>()
     }
 
+    #[must_use]
     pub fn arguments_dbg(&self) -> Vec<String> {
         self.arguments
             .iter()
@@ -827,7 +829,12 @@ pub(crate) enum Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use Error::*;
+        use Error::{
+            AbortInfallible, ClosureArityMismatch, ClosureParameterTypeMismatch, Compilation,
+            FallibleArgument, InvalidArgumentKind, MissingArgument, MissingClosure,
+            ReturnTypeMismatch, Undefined, UnexpectedClosure, UnknownKeyword, UpdateState,
+            WrongNumberOfArgs,
+        };
 
         match self {
             Undefined { .. } => 105,
@@ -848,7 +855,12 @@ impl DiagnosticMessage for Error {
     }
 
     fn labels(&self) -> Vec<Label> {
-        use Error::*;
+        use Error::{
+            AbortInfallible, ClosureArityMismatch, ClosureParameterTypeMismatch, Compilation,
+            FallibleArgument, InvalidArgumentKind, MissingArgument, MissingClosure,
+            ReturnTypeMismatch, Undefined, UnexpectedClosure, UnknownKeyword, UpdateState,
+            WrongNumberOfArgs,
+        };
 
         match self {
             Undefined {
@@ -1024,7 +1036,10 @@ impl DiagnosticMessage for Error {
     }
 
     fn notes(&self) -> Vec<Note> {
-        use Error::*;
+        use Error::{
+            AbortInfallible, Compilation, FallibleArgument, InvalidArgumentKind, MissingClosure,
+            WrongNumberOfArgs,
+        };
 
         match self {
             WrongNumberOfArgs { .. } => vec![Note::SeeDocs(

--- a/lib/vrl/compiler/src/expression/if_statement.rs
+++ b/lib/vrl/compiler/src/expression/if_statement.rs
@@ -25,8 +25,7 @@ impl Expression for IfStatement {
             false => self
                 .alternative
                 .as_ref()
-                .map(|block| block.resolve(ctx))
-                .unwrap_or(Ok(Value::Null)),
+                .map_or(Ok(Value::Null), |block| block.resolve(ctx)),
         }
     }
 

--- a/lib/vrl/compiler/src/expression/literal.rs
+++ b/lib/vrl/compiler/src/expression/literal.rs
@@ -32,15 +32,15 @@ impl Literal {
     /// the case of `Literal` means it always returns `Some(Value)`, requiring
     /// an extra `unwrap()`.
     pub fn to_value(&self) -> Value {
-        use Literal::*;
+        use Literal::{Boolean, Float, Integer, Null, Regex, String, Timestamp};
 
         match self {
             String(v) => Value::Bytes(v.clone()),
             Integer(v) => Value::Integer(*v),
-            Float(v) => Value::Float(v.to_owned()),
+            Float(v) => Value::Float(*v),
             Boolean(v) => Value::Boolean(*v),
             Regex(v) => Value::Regex(v.clone()),
-            Timestamp(v) => Value::Timestamp(v.to_owned()),
+            Timestamp(v) => Value::Timestamp(*v),
             Null => Value::Null,
         }
     }
@@ -56,7 +56,7 @@ impl Expression for Literal {
     }
 
     fn type_def(&self, _: (&LocalEnv, &ExternalEnv)) -> TypeDef {
-        use Literal::*;
+        use Literal::{Boolean, Float, Integer, Null, Regex, String, Timestamp};
 
         let type_def = match self {
             String(_) => TypeDef::bytes(),
@@ -74,7 +74,7 @@ impl Expression for Literal {
 
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Literal::*;
+        use Literal::{Boolean, Float, Integer, Null, Regex, String, Timestamp};
 
         match self {
             String(v) => write!(f, r#""{}""#, std::string::String::from_utf8_lossy(v)),
@@ -130,19 +130,19 @@ impl From<&str> for Literal {
 
 impl From<i8> for Literal {
     fn from(v: i8) -> Self {
-        Literal::Integer(v as i64)
+        Literal::Integer(i64::from(v))
     }
 }
 
 impl From<i16> for Literal {
     fn from(v: i16) -> Self {
-        Literal::Integer(v as i64)
+        Literal::Integer(i64::from(v))
     }
 }
 
 impl From<i32> for Literal {
     fn from(v: i32) -> Self {
-        Literal::Integer(v as i64)
+        Literal::Integer(i64::from(v))
     }
 }
 
@@ -154,13 +154,13 @@ impl From<i64> for Literal {
 
 impl From<u16> for Literal {
     fn from(v: u16) -> Self {
-        Literal::Integer(v as i64)
+        Literal::Integer(i64::from(v))
     }
 }
 
 impl From<u32> for Literal {
     fn from(v: u32) -> Self {
-        Literal::Integer(v as i64)
+        Literal::Integer(i64::from(v))
     }
 }
 
@@ -276,7 +276,7 @@ impl std::error::Error for Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use ErrorVariant::*;
+        use ErrorVariant::{InvalidRegex, InvalidTimestamp, NanFloat};
 
         match &self.variant {
             InvalidRegex(..) => 101,
@@ -286,7 +286,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn labels(&self) -> Vec<Label> {
-        use ErrorVariant::*;
+        use ErrorVariant::{InvalidRegex, InvalidTimestamp, NanFloat};
 
         match &self.variant {
             InvalidRegex(err) => {
@@ -319,7 +319,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn notes(&self) -> Vec<Note> {
-        use ErrorVariant::*;
+        use ErrorVariant::{InvalidRegex, InvalidTimestamp, NanFloat};
 
         match &self.variant {
             InvalidRegex(_) => vec![Note::SeeDocs(

--- a/lib/vrl/compiler/src/expression/noop.rs
+++ b/lib/vrl/compiler/src/expression/noop.rs
@@ -8,7 +8,7 @@ use crate::{
     Context, Expression, TypeDef,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Noop;
 
 impl Expression for Noop {

--- a/lib/vrl/compiler/src/expression/not.rs
+++ b/lib/vrl/compiler/src/expression/not.rs
@@ -84,7 +84,7 @@ impl std::error::Error for Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use ErrorVariant::*;
+        use ErrorVariant::NonBoolean;
 
         match &self.variant {
             NonBoolean(..) => 660,
@@ -92,7 +92,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn labels(&self) -> Vec<Label> {
-        use ErrorVariant::*;
+        use ErrorVariant::NonBoolean;
 
         match &self.variant {
             NonBoolean(kind) => vec![
@@ -106,7 +106,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn notes(&self) -> Vec<Note> {
-        use ErrorVariant::*;
+        use ErrorVariant::NonBoolean;
 
         match &self.variant {
             NonBoolean(..) => {

--- a/lib/vrl/compiler/src/expression/object.rs
+++ b/lib/vrl/compiler/src/expression/object.rs
@@ -14,6 +14,7 @@ pub struct Object {
 }
 
 impl Object {
+    #[must_use]
     pub fn new(inner: BTreeMap<String, Expr>) -> Self {
         Self { inner }
     }
@@ -31,7 +32,7 @@ impl Expression for Object {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         self.inner
             .iter()
-            .map(|(key, expr)| expr.resolve(ctx).map(|v| (key.to_owned(), v)))
+            .map(|(key, expr)| expr.resolve(ctx).map(|v| (key.clone(), v)))
             .collect::<Result<BTreeMap<_, _>, _>>()
             .map(Value::Object)
     }
@@ -39,7 +40,7 @@ impl Expression for Object {
     fn as_value(&self) -> Option<Value> {
         self.inner
             .iter()
-            .map(|(key, expr)| expr.as_value().map(|v| (key.to_owned(), v)))
+            .map(|(key, expr)| expr.as_value().map(|v| (key.clone(), v)))
             .collect::<Option<BTreeMap<_, _>>>()
             .map(Value::Object)
     }
@@ -48,7 +49,7 @@ impl Expression for Object {
         let type_defs = self
             .inner
             .iter()
-            .map(|(k, expr)| (k.to_owned(), expr.type_def(state)))
+            .map(|(k, expr)| (k.clone(), expr.type_def(state)))
             .collect::<BTreeMap<_, _>>();
 
         // If any of the stored expressions is fallible, the entire object is

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -79,8 +79,8 @@ impl Op {
 
 impl Expression for Op {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        use ast::Opcode::*;
-        use value::Value::*;
+        use ast::Opcode::{Add, And, Div, Eq, Err, Ge, Gt, Le, Lt, Merge, Mul, Ne, Or, Rem, Sub};
+        use value::Value::{Boolean, Null};
 
         match self.opcode {
             Err => return self.lhs.resolve(ctx).or_else(|_| self.rhs.resolve(ctx)),
@@ -122,7 +122,7 @@ impl Expression for Op {
     }
 
     fn type_def(&self, state: (&LocalEnv, &ExternalEnv)) -> TypeDef {
-        use ast::Opcode::*;
+        use ast::Opcode::{Add, And, Div, Eq, Err, Ge, Gt, Le, Lt, Merge, Mul, Ne, Or, Rem, Sub};
         use value::Kind as K;
 
         let mut lhs_def = self.lhs.type_def(state);
@@ -311,7 +311,7 @@ pub enum Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use Error::*;
+        use Error::{ChainedComparison, Expr, MergeNonObjects, UnnecessaryCoalesce};
 
         match self {
             ChainedComparison { .. } => 650,
@@ -322,7 +322,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn message(&self) -> String {
-        use Error::*;
+        use Error::Expr;
 
         match self {
             Expr(err) => err.message(),
@@ -331,7 +331,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn labels(&self) -> Vec<Label> {
-        use Error::*;
+        use Error::{ChainedComparison, Expr, MergeNonObjects, UnnecessaryCoalesce};
 
         match self {
             ChainedComparison { span } => vec![Label::primary("", span)],
@@ -366,7 +366,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn notes(&self) -> Vec<Note> {
-        use Error::*;
+        use Error::{ChainedComparison, Expr};
 
         match self {
             ChainedComparison { .. } => vec![Note::SeeDocs(
@@ -385,7 +385,10 @@ impl DiagnosticMessage for Error {
 mod tests {
     use std::convert::TryInto;
 
-    use ast::{Ident, Opcode::*};
+    use ast::{
+        Ident,
+        Opcode::{Add, And, Div, Eq, Err, Ge, Gt, Le, Lt, Mul, Ne, Or, Rem, Sub},
+    };
     use ordered_float::NotNan;
 
     use super::*;

--- a/lib/vrl/compiler/src/expression/predicate.rs
+++ b/lib/vrl/compiler/src/expression/predicate.rs
@@ -27,8 +27,7 @@ impl Predicate {
         let (span, exprs) = node.take();
         let type_def = exprs
             .last()
-            .map(|expr| expr.type_def(state))
-            .unwrap_or_else(TypeDef::null);
+            .map_or_else(TypeDef::null, |expr| expr.type_def(state));
 
         if let Some(error) = fallible_predicate {
             return Err(Error::Fallible {
@@ -48,6 +47,7 @@ impl Predicate {
         Ok(Self { inner: exprs })
     }
 
+    #[must_use]
     pub fn new_unchecked(inner: Vec<Expr>) -> Self {
         Self { inner }
     }
@@ -137,7 +137,7 @@ pub(crate) enum Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use Error::*;
+        use Error::{Fallible, NonBoolean};
 
         match self {
             NonBoolean { .. } => 102,
@@ -146,7 +146,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn labels(&self) -> Vec<Label> {
-        use Error::*;
+        use Error::{Fallible, NonBoolean};
 
         match self {
             NonBoolean { kind, span } => vec![
@@ -158,7 +158,7 @@ impl DiagnosticMessage for Error {
     }
 
     fn notes(&self) -> Vec<Note> {
-        use Error::*;
+        use Error::{Fallible, NonBoolean};
 
         match self {
             NonBoolean { .. } => vec![

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -82,7 +82,7 @@ impl Query {
 
 impl Expression for Query {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        use Target::*;
+        use Target::{Container, External, FunctionCall, Internal};
 
         let value = match &self.target {
             External => {
@@ -116,7 +116,7 @@ impl Expression for Query {
     }
 
     fn type_def(&self, state: (&LocalEnv, &ExternalEnv)) -> TypeDef {
-        use Target::*;
+        use Target::{Container, External, FunctionCall, Internal};
 
         match &self.target {
             External => state
@@ -165,7 +165,7 @@ pub enum Target {
 
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Target::*;
+        use Target::{Container, External, FunctionCall, Internal};
 
         match self {
             Internal(v) => v.fmt(f),
@@ -178,7 +178,7 @@ impl fmt::Display for Target {
 
 impl fmt::Debug for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Target::*;
+        use Target::{Container, External, FunctionCall, Internal};
 
         match self {
             Internal(v) => write!(f, "Internal({:?})", v),

--- a/lib/vrl/compiler/src/expression/unary.rs
+++ b/lib/vrl/compiler/src/expression/unary.rs
@@ -12,6 +12,7 @@ pub struct Unary {
 }
 
 impl Unary {
+    #[must_use]
     pub fn new(variant: Variant) -> Self {
         Self { variant }
     }
@@ -24,7 +25,7 @@ pub enum Variant {
 
 impl Expression for Unary {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        use Variant::*;
+        use Variant::Not;
 
         match &self.variant {
             Not(v) => v.resolve(ctx),
@@ -32,7 +33,7 @@ impl Expression for Unary {
     }
 
     fn type_def(&self, state: (&LocalEnv, &ExternalEnv)) -> TypeDef {
-        use Variant::*;
+        use Variant::Not;
 
         match &self.variant {
             Not(v) => v.type_def(state),
@@ -42,7 +43,7 @@ impl Expression for Unary {
 
 impl fmt::Display for Unary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Variant::*;
+        use Variant::Not;
 
         match &self.variant {
             Not(v) => v.fmt(f),

--- a/lib/vrl/compiler/src/function/closure.rs
+++ b/lib/vrl/compiler/src/function/closure.rs
@@ -115,6 +115,7 @@ pub enum Output {
 }
 
 impl Output {
+    #[must_use]
     pub fn into_kind(self) -> Kind {
         match self {
             Output::Array { elements } => {

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -9,22 +9,23 @@
     unused_comparisons
 )]
 #![allow(
-    clippy::similar_names, // allowed in initial deny commit
-    clippy::module_name_repetitions, // allowed in initial deny commit
-    clippy::match_bool, // allowed in initial deny commit
-    clippy::semicolon_if_nothing_returned,  // allowed in initial deny commit
+    clippy::cast_possible_truncation, // allowed in initial deny commit
     clippy::cast_possible_wrap, // allowed in initial deny commit
+    clippy::cast_precision_loss, // allowed in initial deny commit
     clippy::cast_sign_loss, // allowed in initial deny commit
-    clippy::missing_errors_doc, // allowed in initial deny commit
-    clippy::match_same_arms, // allowed in initial deny commit
-    clippy::too_many_lines, // allowed in initial deny commit
     clippy::if_not_else, // allowed in initial deny commit
     clippy::let_underscore_drop, // allowed in initial deny commit
+    clippy::match_bool, // allowed in initial deny commit
+    clippy::match_same_arms, // allowed in initial deny commit
+    clippy::match_wild_err_arm, // allowed in initial deny commit
+    clippy::missing_errors_doc, // allowed in initial deny commit
     clippy::missing_panics_doc, // allowed in initial deny commit
-    clippy::return_self_not_must_use, // allowed in initial deny commit
+    clippy::module_name_repetitions, // allowed in initial deny commit
     clippy::needless_pass_by_value, // allowed in initial deny commit
-    clippy::cast_possible_truncation, // allowed in initial deny commit
-    clippy::cast_precision_loss, // allowed in initial deny commit
+    clippy::return_self_not_must_use, // allowed in initial deny commit
+    clippy::semicolon_if_nothing_returned,  // allowed in initial deny commit
+    clippy::similar_names, // allowed in initial deny commit
+    clippy::too_many_lines, // allowed in initial deny commit
 )]
 
 mod compiler;

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -1,10 +1,31 @@
-#![deny(warnings)]
-#![deny(clippy::all)]
-#![deny(unreachable_pub)]
-#![deny(unused_allocation)]
-#![deny(unused_extern_crates)]
-#![deny(unused_assignments)]
-#![deny(unused_comparisons)]
+#![deny(
+    warnings,
+    clippy::all,
+    clippy::pedantic,
+    unreachable_pub,
+    unused_allocation,
+    unused_extern_crates,
+    unused_assignments,
+    unused_comparisons
+)]
+#![allow(
+    clippy::similar_names, // allowed in initial deny commit
+    clippy::module_name_repetitions, // allowed in initial deny commit
+    clippy::match_bool, // allowed in initial deny commit
+    clippy::semicolon_if_nothing_returned,  // allowed in initial deny commit
+    clippy::cast_possible_wrap, // allowed in initial deny commit
+    clippy::cast_sign_loss, // allowed in initial deny commit
+    clippy::missing_errors_doc, // allowed in initial deny commit
+    clippy::match_same_arms, // allowed in initial deny commit
+    clippy::too_many_lines, // allowed in initial deny commit
+    clippy::if_not_else, // allowed in initial deny commit
+    clippy::let_underscore_drop, // allowed in initial deny commit
+    clippy::missing_panics_doc, // allowed in initial deny commit
+    clippy::return_self_not_must_use, // allowed in initial deny commit
+    clippy::needless_pass_by_value, // allowed in initial deny commit
+    clippy::cast_possible_truncation, // allowed in initial deny commit
+    clippy::cast_precision_loss, // allowed in initial deny commit
+)]
 
 mod compiler;
 mod context;
@@ -37,7 +58,7 @@ pub use type_def::TypeDef;
 pub type Result<T = (Program, DiagnosticList)> = std::result::Result<T, DiagnosticList>;
 
 /// The choice of available runtimes.
-#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum VrlRuntime {
     Ast,

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -21,23 +21,29 @@ impl Program {
     ///
     /// Specifically, this is used by the VRL REPL to incrementally compile
     /// a program as each line is compiled.
+    #[must_use]
     pub fn local_env(&self) -> &LocalEnv {
         &self.expressions.local_env
     }
 
     /// Get detailed information about the program, as collected by the VRL
     /// compiler.
+    #[must_use]
     pub fn info(&self) -> &ProgramInfo {
         &self.info
     }
 
     /// Resolve the program to its final [`Value`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the program resulted in a runtime error.
     pub fn resolve(&self, ctx: &mut Context) -> Resolved {
         self.expressions.resolve(ctx)
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProgramInfo {
     /// Returns whether the compiled program can fail at runtime.
     ///

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -43,7 +43,7 @@ impl LocalEnv {
     }
 
     /// Merges two local envs together. This is useful in cases such as if statements
-    /// where different LocalEnv's can be created, and the result is decided at runtime.
+    /// where different `LocalEnv`'s can be created, and the result is decided at runtime.
     /// The compile-time type must be the union of the options.
     pub(crate) fn merge(mut self, other: Self) -> Self {
         for (ident, other_details) in other.bindings {
@@ -68,7 +68,7 @@ pub struct ExternalEnv {
 }
 
 // temporary until paths can point to metadata
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum PathRoot {
     Event,
     Metadata,
@@ -90,6 +90,7 @@ impl Default for ExternalEnv {
 impl ExternalEnv {
     /// Creates a new external environment that starts with an initial given
     /// [`Kind`].
+    #[must_use]
     pub fn new_with_kind(kind: Kind) -> Self {
         Self {
             target: Details {
@@ -138,9 +139,13 @@ impl ExternalEnv {
     ///
     /// Panics if the path contains coalescing.
     pub(crate) fn add_read_only_path(&mut self, path: LookupBuf, recursive: bool, root: PathRoot) {
-        if path.as_segments().iter().any(|x| x.is_coalesce()) {
-            panic!("Coalesced paths not supported for read-only paths");
-        }
+        assert!(
+            !path
+                .as_segments()
+                .iter()
+                .any(lookup::SegmentBuf::is_coalesce),
+            "Coalesced paths not supported for read-only paths"
+        );
         self.read_only_paths.push(ReadOnlyPath {
             path,
             recursive,
@@ -207,6 +212,7 @@ pub struct Runtime {
 }
 
 impl Runtime {
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.variables.is_empty()
     }
@@ -215,6 +221,7 @@ impl Runtime {
         self.variables.clear();
     }
 
+    #[must_use]
     pub fn variable(&self, ident: &Ident) -> Option<&Value> {
         self.variables.get(ident)
     }

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -1,4 +1,4 @@
-//! TypeDefs
+//! `TypeDefs`
 //!
 //! The type definitions for typedefs record the various possible type definitions for the state
 //! that can be passed through a VRL program.
@@ -67,6 +67,7 @@ impl DerefMut for TypeDef {
 }
 
 impl TypeDef {
+    #[must_use]
     pub fn kind(&self) -> &Kind {
         &self.kind
     }
@@ -79,12 +80,12 @@ impl TypeDef {
             .find_at_path(path)
             .ok()
             .flatten()
-            .map(Cow::into_owned)
-            .unwrap_or_else(Kind::any);
+            .map_or_else(Kind::any, Cow::into_owned);
 
         Self { fallible, kind }
     }
 
+    #[must_use]
     pub fn for_path(self, path: &Lookup<'_>) -> TypeDef {
         let fallible = self.fallible;
         let kind = self
@@ -102,105 +103,124 @@ impl TypeDef {
     }
 
     #[inline]
+    #[must_use]
     pub fn fallible(mut self) -> Self {
         self.fallible = true;
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn infallible(mut self) -> Self {
         self.fallible = false;
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn with_fallibility(mut self, fallible: bool) -> Self {
         self.fallible = fallible;
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn any() -> Self {
         Kind::any().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn bytes() -> Self {
         Kind::bytes().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn add_bytes(mut self) -> Self {
         self.kind.add_bytes();
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn integer() -> Self {
         Kind::integer().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn add_integer(mut self) -> Self {
         self.kind.add_integer();
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn float() -> Self {
         Kind::float().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn add_float(mut self) -> Self {
         self.kind.add_float();
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn boolean() -> Self {
         Kind::boolean().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn add_boolean(mut self) -> Self {
         self.kind.add_boolean();
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn timestamp() -> Self {
         Kind::timestamp().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn add_timestamp(mut self) -> Self {
         self.kind.add_timestamp();
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn regex() -> Self {
         Kind::regex().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn add_regex(mut self) -> Self {
         self.kind.add_regex();
         self
     }
 
     #[inline]
+    #[must_use]
     pub fn null() -> Self {
         Kind::null().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn never() -> Self {
         Kind::never().into()
     }
 
     #[inline]
+    #[must_use]
     pub fn add_null(mut self) -> Self {
         self.kind.add_null();
         self
@@ -225,6 +245,7 @@ impl TypeDef {
     ///
     /// `TypeDef`s fallibility is kept unmodified.
     #[inline]
+    #[must_use]
     pub fn restrict_array(self) -> Self {
         let fallible = self.fallible;
         let collection = match self.kind.into_array() {
@@ -257,6 +278,7 @@ impl TypeDef {
     ///
     /// `TypeDef`s fallibility is kept unmodified.
     #[inline]
+    #[must_use]
     pub fn restrict_object(self) -> Self {
         let fallible = self.fallible;
         let collection = match self.kind.into_object() {
@@ -271,6 +293,7 @@ impl TypeDef {
     }
 
     #[inline]
+    #[must_use]
     pub fn with_kind(mut self, kind: Kind) -> Self {
         self.kind = kind;
         self
@@ -281,6 +304,7 @@ impl TypeDef {
     ///
     /// Used for functions that cant determine which indexes of a collection have been used in the
     /// result.
+    #[must_use]
     pub fn collect_subtypes(mut self) -> Self {
         if let Some(object) = self.kind.as_object_mut() {
             object.set_unknown(None);
@@ -296,10 +320,12 @@ impl TypeDef {
 
     // -------------------------------------------------------------------------
 
+    #[must_use]
     pub fn is_fallible(&self) -> bool {
         self.fallible
     }
 
+    #[must_use]
     pub fn is_infallible(&self) -> bool {
         !self.is_fallible()
     }
@@ -315,6 +341,7 @@ impl TypeDef {
         self
     }
 
+    #[must_use]
     pub fn merge_deep(mut self, other: Self) -> Self {
         self.merge(
             other,
@@ -331,6 +358,7 @@ impl TypeDef {
     /// When merging arrays, the elements of `other` are *appended* to the elements of `self`.
     /// Meaning, the indices of `other` are updated, to continue onward from the last index of
     /// `self`.
+    #[must_use]
     pub fn merge_append(mut self, other: Self) -> Self {
         self.merge(
             other,
@@ -347,6 +375,7 @@ impl TypeDef {
         self.kind.merge(other.kind, strategy);
     }
 
+    #[must_use]
     pub fn with_type_set_at_path(self, path: &Lookup, other: Self) -> Self {
         if path.is_root() {
             other
@@ -355,6 +384,7 @@ impl TypeDef {
         }
     }
 
+    #[must_use]
     pub fn merge_overwrite(mut self, other: Self) -> Self {
         self.merge(
             other,

--- a/lib/vrl/compiler/src/value/arithmetic.rs
+++ b/lib/vrl/compiler/src/value/arithmetic.rs
@@ -285,7 +285,7 @@ impl VrlValueArithmetic for Value {
     /// Similar to [`std::cmp::Eq`], but does a lossless comparison for integers
     /// and floats.
     fn eq_lossy(&self, rhs: &Self) -> bool {
-        use Value::*;
+        use Value::{Float, Integer};
 
         match self {
             Integer(lhv) => rhs

--- a/lib/vrl/compiler/src/value/error.rs
+++ b/lib/vrl/compiler/src/value/error.rs
@@ -3,7 +3,7 @@ use diagnostic::DiagnosticMessage;
 use super::Kind;
 use crate::ExpressionError;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum Error {
     #[error(
         r#"expected {}, got {got}"#,
@@ -59,7 +59,10 @@ pub enum Error {
 
 impl DiagnosticMessage for Error {
     fn code(&self) -> usize {
-        use Error::*;
+        use Error::{
+            Add, And, Coerce, Div, DivideByZero, Expected, Ge, Gt, Le, Lt, Merge, Mul, NanFloat,
+            Or, Rem, Sub,
+        };
 
         match self {
             Expected { .. } => 300,


### PR DESCRIPTION
This PR is part of the ongoing "VRL compiler cleanup" work.

The PR denies all Clippy restrictions, similar to `vector-core`, and then allows those that cannot be fixed using the unstable `--fix` flag. In future PRs, some of these "allows" might be resolved and become denied, or we'll update the initial comment with one explaining why we want to explicitly allow the specific pattern.

Note that this PR is _not_ intended as a forum for discussion on the (lack of) individual merits of the enabled lints, as those discussions happened in #7341, #11597 and other places. This is merely following agreed-upon precedence. Reversing some of these precedences can be discussed in separate issues, without blocking this PR from being merged.

