### PR TITLE
fix(gcp service): Apply `api_key` configuration to all GCP components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,7 +424,7 @@ aws-core = [
 # Anything that requires Protocol Buffers.
 protobuf-build = ["dep:tonic-build", "dep:prost-build"]
 
-gcp = ["dep:goauth", "dep:smpl_jwt"]
+gcp = ["dep:base64", "dep:goauth", "dep:smpl_jwt"]
 
 # Enrichment Tables
 enrichment-tables = ["enrichment-tables-file"]

--- a/lib/vector-common/src/lib.rs
+++ b/lib/vector-common/src/lib.rs
@@ -43,6 +43,7 @@ pub mod event_test_util;
 
 pub mod finalization;
 pub mod finalizer;
+pub use finalizer::EmptyStream;
 
 pub mod internal_event;
 

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -162,8 +162,13 @@ impl GcpAuthenticator {
                     .as_ref()
                     .map_or("/", PathAndQuery::path);
                 let paq = format!("{path}?key={api_key}");
-                parts.path_and_query = Some(paq.parse().expect("FIXME"));
-                *uri = Uri::from_parts(parts).expect("FIXME");
+                // The API key is verified above to only contain
+                // URL-safe characters. That key is added to a path
+                // that came from a successfully parsed URI. As such,
+                // re-parsing the string cannot fail.
+                parts.path_and_query =
+                    Some(paq.parse().expect("Could not re-parse path and query"));
+                *uri = Uri::from_parts(parts).expect("Could not re-parse URL");
             }
         }
     }

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -35,7 +35,7 @@ use crate::{
     aws::{AwsAuthentication, RegionOrEndpoint},
     codecs::Encoder,
     config::{GenerateConfig, Input, SinkConfig, SinkContext},
-    gcp::{GcpAuthConfig, GcpCredentials},
+    gcp::{GcpAuthConfig, GcpAuthenticator},
     http::HttpClient,
     serde::json::to_string,
     sinks::{
@@ -301,7 +301,7 @@ impl DatadogArchivesSinkConfig {
         &self,
         client: HttpClient,
         base_url: String,
-        creds: Option<GcpCredentials>,
+        creds: Option<GcpAuthenticator>,
         cx: SinkContext,
     ) -> crate::Result<VectorSink> {
         let request = self.request.unwrap_with(&Default::default());

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -235,7 +235,7 @@ impl DatadogArchivesSinkConfig {
                     self.bucket.clone(),
                     client.clone(),
                     base_url.clone(),
-                    Some(auth.clone()),
+                    auth.clone(),
                 )?;
                 let sink = self
                     .build_gcs_sink(client, base_url, auth, cx)

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -377,7 +377,7 @@ mod tests {
             .build_sink(
                 client,
                 mock_endpoint.to_string(),
-                GcpAuthenticator::from_api_key("FAKE"),
+                GcpAuthenticator::from_api_key("FAKE").unwrap(),
                 context,
             )
             .expect("failed to build sink");

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -377,7 +377,7 @@ mod tests {
             .build_sink(
                 client,
                 mock_endpoint.to_string(),
-                GcpAuthenticator::from_api_key("FAKE").unwrap(),
+                GcpAuthenticator::None,
                 context,
             )
             .expect("failed to build sink");

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -21,7 +21,7 @@ use crate::{
         AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
     },
     event::Event,
-    gcp::{GcpAuthConfig, GcpCredentials, Scope},
+    gcp::{GcpAuthConfig, GcpAuthenticator, Scope},
     http::HttpClient,
     serde::json::to_string,
     sinks::{
@@ -168,7 +168,7 @@ impl GcsSinkConfig {
         &self,
         client: HttpClient,
         base_url: String,
-        creds: Option<GcpCredentials>,
+        creds: Option<GcpAuthenticator>,
         cx: SinkContext,
     ) -> crate::Result<VectorSink> {
         let request = self.request.unwrap_with(&TowerRequestConfig {

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -140,7 +140,7 @@ impl SinkConfig for GcsSinkConfig {
             self.bucket.clone(),
             client.clone(),
             base_url.clone(),
-            Some(auth.clone()),
+            auth.clone(),
         )?;
         let sink = self.build_sink(client, base_url, auth, cx)?;
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -14,7 +14,7 @@ use crate::{
         AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
     },
     event::Event,
-    gcp::{GcpAuthConfig, GcpCredentials, Scope, PUBSUB_URL},
+    gcp::{GcpAuthConfig, GcpAuthenticator, Scope, PUBSUB_URL},
     http::HttpClient,
     sinks::{
         gcs_common::config::healthcheck_response,
@@ -140,7 +140,7 @@ impl SinkConfig for PubsubConfig {
 
 struct PubsubSink {
     api_key: Option<String>,
-    creds: Option<GcpCredentials>,
+    creds: Option<GcpAuthenticator>,
     uri_base: String,
     transformer: Transformer,
     encoder: Encoder<()>,
@@ -237,7 +237,7 @@ impl HttpSink for PubsubSink {
 async fn healthcheck(
     client: HttpClient,
     uri: Uri,
-    creds: Option<GcpCredentials>,
+    creds: Option<GcpAuthenticator>,
 ) -> crate::Result<()> {
     let mut request = Request::get(uri).body(Body::empty()).unwrap();
     if let Some(creds) = creds.as_ref() {

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -384,7 +384,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            auth: GcpAuthenticator::from_api_key("FAKE").unwrap(),
+            auth: GcpAuthenticator::None,
             severity_key: Some("anumber".into()),
             uri: default_endpoint().parse().unwrap(),
         };
@@ -426,7 +426,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            auth: GcpAuthenticator::from_api_key("FAKE").unwrap(),
+            auth: GcpAuthenticator::None,
             severity_key: Some("anumber".into()),
             uri: default_endpoint().parse().unwrap(),
         };
@@ -495,7 +495,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            auth: GcpAuthenticator::from_api_key("FAKE").unwrap(),
+            auth: GcpAuthenticator::None,
             severity_key: None,
             uri: default_endpoint().parse().unwrap(),
         };

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -76,7 +76,7 @@ fn default_endpoint() -> String {
 #[derive(Clone, Debug)]
 struct StackdriverSink {
     config: StackdriverConfig,
-    creds: Option<GcpAuthenticator>,
+    auth: GcpAuthenticator,
     severity_key: Option<String>,
     uri: Uri,
 }
@@ -116,7 +116,7 @@ impl_generate_config_from_default!(StackdriverConfig);
 #[typetag::serde(name = "gcp_stackdriver_logs")]
 impl SinkConfig for StackdriverConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let creds = self.auth.make_credentials(Scope::LoggingWrite).await?;
+        let auth = self.auth.build(Scope::LoggingWrite).await?;
 
         let batch = self
             .batch
@@ -133,7 +133,7 @@ impl SinkConfig for StackdriverConfig {
 
         let sink = StackdriverSink {
             config: self.clone(),
-            creds,
+            auth,
             severity_key: self.severity_key.clone(),
             uri: self.endpoint.parse().unwrap(),
         };
@@ -255,10 +255,7 @@ impl HttpSink for StackdriverSink {
             .header("Content-Type", "application/json")
             .body(body)
             .unwrap();
-
-        if let Some(creds) = &self.creds {
-            creds.apply(&mut request);
-        }
+        self.auth.apply(&mut request);
 
         Ok(request)
     }
@@ -310,7 +307,7 @@ async fn healthcheck(client: HttpClient, sink: StackdriverSink) -> crate::Result
     let response = client.send(request).await?;
     healthcheck_response(
         response,
-        sink.creds.clone(),
+        Some(sink.auth.clone()),
         HealthcheckError::NotFound.into(),
     )
 }
@@ -387,7 +384,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            creds: None,
+            auth: GcpAuthenticator::from_api_key("FAKE"),
             severity_key: Some("anumber".into()),
             uri: default_endpoint().parse().unwrap(),
         };
@@ -429,7 +426,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            creds: None,
+            auth: GcpAuthenticator::from_api_key("FAKE"),
             severity_key: Some("anumber".into()),
             uri: default_endpoint().parse().unwrap(),
         };
@@ -498,7 +495,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            creds: None,
+            auth: GcpAuthenticator::from_api_key("FAKE"),
             severity_key: None,
             uri: default_endpoint().parse().unwrap(),
         };

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -11,7 +11,7 @@ use snafu::Snafu;
 use crate::{
     config::{log_schema, AcknowledgementsConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::{Event, Value},
-    gcp::{GcpAuthConfig, GcpCredentials, Scope},
+    gcp::{GcpAuthConfig, GcpAuthenticator, Scope},
     http::HttpClient,
     sinks::{
         gcs_common::config::healthcheck_response,
@@ -76,7 +76,7 @@ fn default_endpoint() -> String {
 #[derive(Clone, Debug)]
 struct StackdriverSink {
     config: StackdriverConfig,
-    creds: Option<GcpCredentials>,
+    creds: Option<GcpAuthenticator>,
     severity_key: Option<String>,
     uri: Uri,
 }

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -307,7 +307,7 @@ async fn healthcheck(client: HttpClient, sink: StackdriverSink) -> crate::Result
     let response = client.send(request).await?;
     healthcheck_response(
         response,
-        Some(sink.auth.clone()),
+        sink.auth.clone(),
         HealthcheckError::NotFound.into(),
     )
 }

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -384,7 +384,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            auth: GcpAuthenticator::from_api_key("FAKE"),
+            auth: GcpAuthenticator::from_api_key("FAKE").unwrap(),
             severity_key: Some("anumber".into()),
             uri: default_endpoint().parse().unwrap(),
         };
@@ -426,7 +426,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            auth: GcpAuthenticator::from_api_key("FAKE"),
+            auth: GcpAuthenticator::from_api_key("FAKE").unwrap(),
             severity_key: Some("anumber".into()),
             uri: default_endpoint().parse().unwrap(),
         };
@@ -495,7 +495,7 @@ mod tests {
 
         let sink = StackdriverSink {
             config,
-            auth: GcpAuthenticator::from_api_key("FAKE"),
+            auth: GcpAuthenticator::from_api_key("FAKE").unwrap(),
             severity_key: None,
             uri: default_endpoint().parse().unwrap(),
         };

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext, SinkDescription},
     event::{Event, Metric, MetricValue},
-    gcp::{GcpAuthConfig, GcpCredentials},
+    gcp::{GcpAuthConfig, GcpAuthenticator},
     http::HttpClient,
     sinks::{
         gcp,
@@ -120,7 +120,7 @@ impl SinkConfig for StackdriverConfig {
 struct HttpEventSink {
     config: StackdriverConfig,
     started: DateTime<Utc>,
-    creds: Option<GcpCredentials>,
+    creds: Option<GcpAuthenticator>,
 }
 
 struct StackdriverMetricsEncoder;

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -70,7 +70,7 @@ inventory::submit! {
 #[typetag::serde(name = "gcp_stackdriver_metrics")]
 impl SinkConfig for StackdriverConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let creds = self.auth.make_credentials(Scope::MonitoringWrite).await?;
+        let auth = self.auth.build(Scope::MonitoringWrite).await?;
 
         let healthcheck = healthcheck().boxed();
         let started = chrono::Utc::now();
@@ -86,7 +86,7 @@ impl SinkConfig for StackdriverConfig {
         let sink = HttpEventSink {
             config: self.clone(),
             started,
-            creds,
+            auth,
         };
 
         let sink = BatchedHttpSink::new(
@@ -120,7 +120,7 @@ impl SinkConfig for StackdriverConfig {
 struct HttpEventSink {
     config: StackdriverConfig,
     started: DateTime<Utc>,
-    creds: Option<GcpAuthenticator>,
+    auth: GcpAuthenticator,
 }
 
 struct StackdriverMetricsEncoder;
@@ -225,10 +225,7 @@ impl HttpSink for HttpEventSink {
         let mut request = hyper::Request::post(uri)
             .header("content-type", "application/json")
             .body(body)?;
-
-        if let Some(creds) = &self.creds {
-            creds.apply(&mut request);
-        }
+        self.auth.apply(&mut request);
 
         Ok(request)
     }

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -50,20 +50,18 @@ pub fn build_healthcheck(
     bucket: String,
     client: HttpClient,
     base_url: String,
-    creds: Option<GcpAuthenticator>,
+    auth: GcpAuthenticator,
 ) -> crate::Result<Healthcheck> {
     let healthcheck = async move {
         let uri = base_url.parse::<Uri>()?;
         let mut request = http::Request::head(uri).body(Body::empty())?;
 
-        if let Some(creds) = creds.as_ref() {
-            creds.apply(&mut request);
-        }
+        auth.apply(&mut request);
 
         let not_found_error = GcsError::BucketNotFound { bucket }.into();
 
         let response = client.send(request).await?;
-        healthcheck_response(response, creds, not_found_error)
+        healthcheck_response(response, auth, not_found_error)
     };
 
     Ok(healthcheck.boxed())
@@ -72,16 +70,14 @@ pub fn build_healthcheck(
 // Use this to map a healthcheck response, as it handles setting up the renewal task.
 pub fn healthcheck_response(
     response: http::Response<hyper::Body>,
-    creds: Option<GcpAuthenticator>,
+    auth: GcpAuthenticator,
     not_found_error: crate::Error,
 ) -> crate::Result<()> {
     // If there are credentials configured, the generated OAuth
     // token needs to be periodically regenerated. Since the
     // health check runs at startup, after a health check is a
     // good place to create the regeneration task.
-    if let Some(creds) = creds {
-        creds.spawn_regenerate_token();
-    }
+    auth.spawn_regenerate_token();
     match response.status() {
         StatusCode::OK => Ok(()),
         StatusCode::FORBIDDEN => Err(GcpError::HealthcheckForbidden.into()),

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 use crate::{
-    gcp::{GcpCredentials, GcpError},
+    gcp::{GcpAuthenticator, GcpError},
     http::HttpClient,
     sinks::{
         gcs_common::service::GcsResponse,
@@ -50,7 +50,7 @@ pub fn build_healthcheck(
     bucket: String,
     client: HttpClient,
     base_url: String,
-    creds: Option<GcpCredentials>,
+    creds: Option<GcpAuthenticator>,
 ) -> crate::Result<Healthcheck> {
     let healthcheck = async move {
         let uri = base_url.parse::<Uri>()?;
@@ -72,7 +72,7 @@ pub fn build_healthcheck(
 // Use this to map a healthcheck response, as it handles setting up the renewal task.
 pub fn healthcheck_response(
     response: http::Response<hyper::Body>,
-    creds: Option<GcpCredentials>,
+    creds: Option<GcpAuthenticator>,
     not_found_error: crate::Error,
 ) -> crate::Result<()> {
     // If there are credentials configured, the generated OAuth

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -22,19 +22,15 @@ use crate::{
 pub struct GcsService {
     client: HttpClient,
     base_url: String,
-    creds: Option<GcpAuthenticator>,
+    auth: GcpAuthenticator,
 }
 
 impl GcsService {
-    pub const fn new(
-        client: HttpClient,
-        base_url: String,
-        creds: Option<GcpAuthenticator>,
-    ) -> GcsService {
+    pub const fn new(client: HttpClient, base_url: String, auth: GcpAuthenticator) -> GcsService {
         GcsService {
             client,
             base_url,
-            creds,
+            auth,
         }
     }
 }
@@ -135,9 +131,7 @@ impl Service<GcsRequest> for GcsService {
         }
 
         let mut http_request = builder.body(Body::from(request.body)).unwrap();
-        if let Some(creds) = &self.creds {
-            creds.apply(&mut http_request);
-        }
+        self.auth.apply(&mut http_request);
 
         let mut client = self.client.clone();
         Box::pin(async move {

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -13,7 +13,7 @@ use vector_core::{buffers::Ackable, internal_event::EventsSent, stream::DriverRe
 
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    gcp::GcpCredentials,
+    gcp::GcpAuthenticator,
     http::{get_http_scheme_from_uri, HttpClient, HttpError},
     sinks::util::metadata::RequestMetadata,
 };
@@ -22,14 +22,14 @@ use crate::{
 pub struct GcsService {
     client: HttpClient,
     base_url: String,
-    creds: Option<GcpCredentials>,
+    creds: Option<GcpAuthenticator>,
 }
 
 impl GcsService {
     pub const fn new(
         client: HttpClient,
         base_url: String,
-        creds: Option<GcpCredentials>,
+        creds: Option<GcpAuthenticator>,
     ) -> GcsService {
         GcsService {
             client,

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -25,7 +25,7 @@ use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{AcknowledgementsConfig, DataType, Output, SourceConfig, SourceContext},
     event::{BatchNotifier, BatchStatus, Event, MaybeAsLogMut, Value},
-    gcp::{GcpAuthConfig, GcpCredentials, Scope, PUBSUB_URL},
+    gcp::{GcpAuthConfig, GcpAuthenticator, Scope, PUBSUB_URL},
     internal_events::{
         BytesReceived, GcpPubsubConnectError, GcpPubsubReceiveError, GcpPubsubStreamingPullError,
         StreamClosedError,
@@ -319,7 +319,7 @@ impl_generate_config_from_default!(PubsubConfig);
 struct PubsubSource {
     endpoint: Endpoint,
     uri: Uri,
-    credentials: Option<GcpCredentials>,
+    credentials: Option<GcpAuthenticator>,
     token_generator: watch::Receiver<()>,
     subscription: String,
     decoder: Decoder,

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -883,7 +883,10 @@ mod integration_tests {
                 project: PROJECT.into(),
                 subscription: self.subscription.clone(),
                 endpoint: Some(gcp::PUBSUB_ADDRESS.clone()),
-                skip_authentication: true,
+                auth: GcpAuthConfig {
+                    skip_authentication: true,
+                    ..Default::default()
+                },
                 ack_deadline_secs: Some(ACK_DEADLINE as i32),
                 ..Default::default()
             };

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -90,6 +90,7 @@ components: sinks: gcp_cloud_storage: {
 				}
 			}
 		}
+		api_key: configuration._gcp_api_key
 		bucket: {
 			description: "The GCS bucket name."
 			required:    true

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -64,6 +64,7 @@ components: sinks: gcp_stackdriver_logs: {
 	}
 
 	configuration: {
+		api_key: configuration._gcp_api_key
 		billing_account_id: {
 			common: false
 			description: """

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -64,6 +64,7 @@ components: sinks: gcp_stackdriver_metrics: {
 	}
 
 	configuration: {
+		api_key: configuration._gcp_api_key
 		credentials_path: {
 			common:      true
 			description: "The filename for a Google Cloud service account credentials JSON file used to authenticate access to the Stackdriver Logging API. If this is unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename.\n\nIf no filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is running on. If Vector is not running on a GCE instance, you must define a credentials file as above."


### PR DESCRIPTION
This is both a bug fix and an enhancement, as it unifies all of the GCP authorization handling and applies it to all GCP components. This adds support for `api_key` and the internal `skip_authentication` to several components that were missing support, fixing the components to match the documentation.

Closes #13221 