### PR TITLE
chore(vrl): Reexport TimeZone type

### DIFF
--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -16,6 +16,7 @@ pub use compiler::{
 };
 pub use diagnostic;
 pub use runtime::{Runtime, RuntimeResult, Terminate};
+pub use vector_common::TimeZone;
 
 /// Compile a given source into the final [`Program`].
 pub fn compile(source: &str, fns: &[Box<dyn Function>]) -> compiler::Result {

--- a/lib/vrl/vrl/src/runtime.rs
+++ b/lib/vrl/vrl/src/runtime.rs
@@ -3,9 +3,8 @@ use std::{error::Error, fmt};
 use compiler::ExpressionError;
 use lookup::LookupBuf;
 use value::Value;
-use vector_common::TimeZone;
 
-use crate::{state, Context, Program, Target};
+use crate::{state, Context, Program, Target, TimeZone};
 
 pub type RuntimeResult = Result<Value, Terminate>;
 


### PR DESCRIPTION
So that callers don't need to also import `vector_common`.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
