### PR TITLE
enhancement(humio_metrics sink)!: Remove `encoding` option from `humio_metrics` sink

### DIFF
--- a/soaks/tests/syslog_log2metric_humio_metrics/vector.toml
+++ b/soaks/tests/syslog_log2metric_humio_metrics/vector.toml
@@ -38,6 +38,5 @@ address = "0.0.0.0:9090"
 type = "humio_metrics"
 inputs = ["log2metric"]
 endpoint = "http://localhost:8080"
-encoding = "json"
 token = "humio_token"
 healthcheck.enabled = false

--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -14,8 +14,9 @@ Vector's 0.23.0 release includes **breaking changes**:
 1. [The `.deb` package no longer enables and starts the Vector systemd service](#systemd-autostart)
 2. [VRL type definition updates](#vrl-type-def)
 3. ["remove_empty" option dropped from VRL's `parse_grok` and `parse_groks`](#vrl-parse_grok)
-4. [`gcp_pubsub` sink requires setting "encoding" option](#sinks-mandatory-encoding)
-5. [VRL conditions are now checked for mutations at compile time](#read_only_check)
+4. [`gcp_pubsub` sink requires setting "encoding" option](#gcp_sink-mandatory-encoding)
+5. [`humio_metrics` sink no longer has "encoding" option](#humio_metrics-sink-fixed-encoding)
+6. [VRL conditions are now checked for mutations at compile time](#read_only_check)
 
 We cover them below to help you upgrade quickly:
 
@@ -71,7 +72,7 @@ expected = { "timestamp": "", "level": "", "message": ""}
 parsed = merge(expected, parsed)
 ```
 
-#### [`gcp_pubsub` sink requires setting "encoding" option] {#sinks-mandatory-encoding}
+#### [`gcp_pubsub` sink requires setting "encoding" option] {#gcp_sink-mandatory-encoding}
 
 The `gcp_pubsub` sink now supports a variety of codecs. To encode your logs as JSON before
 publishing them to Cloud Pub/Sub, add the following encoding option
@@ -81,6 +82,18 @@ encoding.codec = "json"
 ```
 
 to the config of your `gcp_pubsub` sink.
+
+#### [`humio_metrics` sink no longer has "encoding" option] {#humio_metrics-sink-fixed-encoding}
+
+The `humio_metrics` sink configuration no longer expects an "encoding" option.
+If you previously used the encoding option
+
+```toml
+encoding.codec = "json"
+```
+
+you need to remove the line from your `humio_metrics` config. Metrics are now
+always sent to Humio using the JSON format.
 
 #### [VRL conditions are now checked for mutations at compile time] {#read_only_check}
 

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -1,6 +1,8 @@
 package metadata
 
 components: sinks: _humio: {
+	_humio_encoding: enabled: false
+
 	classes: {
 		commonly_used: false
 		delivery:      "at_least_once"
@@ -32,13 +34,7 @@ components: sinks: _humio: {
 				algorithms: ["gzip"]
 				levels: ["none", "fast", "default", "best", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 			}
-			encoding: {
-				enabled: true
-				codec: {
-					enabled: true
-					enum: ["json", "text"]
-				}
-			}
+			encoding: _humio_encoding
 			proxy: enabled: true
 			request: {
 				enabled:                    true

--- a/website/cue/reference/components/sinks/humio_logs.cue
+++ b/website/cue/reference/components/sinks/humio_logs.cue
@@ -3,6 +3,14 @@ package metadata
 components: sinks: humio_logs: {
 	title: "Humio Logs"
 
+	_humio_encoding: {
+		enabled: true
+		codec: {
+			enabled: true
+			enum: ["json", "text"]
+		}
+	}
+
 	classes:       sinks._humio.classes
 	features:      sinks._humio.features
 	support:       sinks._humio.support


### PR DESCRIPTION
With this change, metrics are now always sent to Humio using the JSON format.