### PR TITLE
fix(vrl stdlib): Fix parsing of user for parse_nginx_log

### DIFF
--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -90,8 +90,8 @@ pub(crate) static REGEX_NGINX_COMBINED_LOG: Lazy<Regex> = Lazy::new(|| {
         r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
         ^\s*                                    # Start with any number of whitespaces.
         (-|(?P<client>\S+))\s+                  # Match `-` or any non space character
-        (-|(?P<user>\S+))\s+                    # Match `-` or any non space character
         \-\s+                                   # Always a dash
+        (-|(?P<user>\S+))\s+                    # Match `-` or any non space character
         \[(?P<timestamp>.+)\]\s+                # Match date between brackets
         "(?P<request>
         (?P<method>\w+)\s+                      # Match at least a word

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -258,7 +258,7 @@ mod tests {
 
         combined_line_valid_all_fields {
             args: func_args![
-                value: r#"172.17.0.1 alice - [01/Apr/2021:12:02:31 +0000] "POST /not-found HTTP/1.1" 404 153 "http://localhost/somewhere" "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36" "2.75""#,
+                value: r#"172.17.0.1 - alice [01/Apr/2021:12:02:31 +0000] "POST /not-found HTTP/1.1" 404 153 "http://localhost/somewhere" "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36" "2.75""#,
                 format: "combined"
             ],
             want: Ok(btreemap! {

--- a/website/cue/reference/remap/functions/parse_nginx_log.cue
+++ b/website/cue/reference/remap/functions/parse_nginx_log.cue
@@ -54,7 +54,7 @@ remap: functions: parse_nginx_log: {
 			title: "Parse via Nginx log format (combined)"
 			source: #"""
 				parse_nginx_log!(
-				    s'172.17.0.1 alice - [01/Apr/2021:12:02:31 +0000] "POST /not-found HTTP/1.1" 404 153 "http://localhost/somewhere" "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36" "2.75"',
+				    s'172.17.0.1 - alice [01/Apr/2021:12:02:31 +0000] "POST /not-found HTTP/1.1" 404 153 "http://localhost/somewhere" "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36" "2.75"',
 				    "combined",
 				)
 				"""#


### PR DESCRIPTION
The ordering of fields was incorrect. The format is:

```
log_format combined '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
                    '"$http_referer" "$http_user_agent"';
```

Closes: #13325

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
