### PR TITLE
docs(guides): `website/content/en/guides` readability improvements

### DIFF
--- a/website/content/en/guides/advanced/cloudwatch-logs-firehose.md
+++ b/website/content/en/guides/advanced/cloudwatch-logs-firehose.md
@@ -575,7 +575,7 @@ context:
 * `log_group` the log_group of the log event
 * `log_stream` the log_stream of the log event
 * `owner` the AWS account ID of the owner of the log event
-* `subcription_filters` the filters that matched to send the event
+* `subscription_filters` the filters that matched to send the event
 * `timestamp` is overwritten with the timestamp from the log event
 
 This is pretty good, but, our original events are also JSON and the `.id`,

--- a/website/content/en/guides/getting-started/getting-started.md
+++ b/website/content/en/guides/getting-started/getting-started.md
@@ -167,7 +167,7 @@ observability data. You can then route and output your events to dozens of desti
 
 ## What's next?
 
-We're just scatching the surface in this post. To get your hands dirty with Vector
+We're just scratching the surface in this post. To get your hands dirty with Vector
 check out:
 
 * All of Vector's [sources][docs.sources], [transforms][docs.transforms], and [sinks][docs.sinks].

--- a/website/content/en/guides/level-up/csv-enrichment-guide.md
+++ b/website/content/en/guides/level-up/csv-enrichment-guide.md
@@ -35,7 +35,7 @@ This guide walks through how you can start enriching your observability by
 ## Use Case 1 - IoT Devices
 
 When working with IoT devices, you often want to minimize payloads being
-emmitted by the devices, even when collecting events from those devices. This
+emitted by the devices, even when collecting events from those devices. This
 is where [Enrichment tables] comes in very handy. Let's assume that you have an
 IoT device that emits its status - `online`, `offline`, `transmitting`, and
 `error` states, but the device needs to emit as little payload as possible

--- a/website/content/en/guides/level-up/vector-tap-guide.md
+++ b/website/content/en/guides/level-up/vector-tap-guide.md
@@ -117,7 +117,7 @@ message=test1 source_type=demo_logs timestamp=2022-02-22T20:57:02.430987800Z
 
 ### Configuration reloading support
 
-`tap` is compatabile with configuration reloading. In other words, if you add,
+`tap` is compatible with configuration reloading. In other words, if you add,
 remove, or edit existing components in your configuration, `tap` will adapt
 accordingly by re-matching your provided patterns.
 
@@ -197,7 +197,7 @@ Running this configuration, we expect to see our favorite ice cream logs appear
 in `stdout`. Unfortunately, we see nothing at all. The desired events don't look
 like they're ever reaching their destination.
 
-We can verify this by examing the inputs of the `store` sink with `vector tap
+We can verify this by examining the inputs of the `store` sink with `vector tap
 --inputs-of "store"`: indeed, no events appear. We can also narrow in and
 inspect the output of relevant upstream components like our `remap` transform.
 `vector tap --outputs-of "picky"` (which, in this case, is effectively the same
@@ -232,7 +232,7 @@ especially in larger, more complex setups where mistakes are not easy to find
 by simply reading a configuration file.
 
 Ultimately, `vector tap` is one tool in the wide range of Vector features that
-lets you safely and reliably set up your observabillity pipelines. Be sure to
+lets you safely and reliably set up your observability pipelines. Be sure to
 also check out [Vector unit testing] to verify the expected behavior of your
 transforms and [Vector internal observability] for more insight into Vector
 itself.


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

minor readability fixes in `guides`