### PR TITLE
docs(buffers): Document disk buffer minimum size

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -85,7 +85,12 @@ components: sinks: [Name=string]: {
 						}
 					}
 					max_size: {
-						description:   "The maximum size of the buffer on the disk."
+						description: """
+							The maximum size of the buffer on the disk. Must be at least 128 megabytes (134217728 bytes).
+
+							Note that during normal disk buffer operation, the disk buffer can create one additional 128
+							megabyte block so the minimum disk space required is actually 256 megabytes.
+							"""
 						required:      true
 						relevant_when: "type = \"disk\""
 						type: uint: {


### PR DESCRIPTION
Closes: https://github.com/vectordotdev/vector/issues/13263

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
