### PR TITLE
fix(template website): Fix data template reference to .config

### DIFF
--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -1903,11 +1903,11 @@
       </span>
 
       <span class="flex space-x-1">
-        {{ if .config.common }}
+        {{ if $v.common }}
         {{ partial "badge.html" (dict "word" "common" "color" "blue") }}
         {{ end }}
 
-        {{ if .config.required }}
+        {{ if $v.required }}
         {{ partial "badge.html" (dict "word" "required" "color" "red") }}
         {{ else }}
         {{ partial "badge.html" (dict "word" "optional" "color" "blue") }}


### PR DESCRIPTION
## What does this PR do?
- Updates data template reference to `.required` and `.common` of the `.config` object

## Motivation
https://datadoghq.atlassian.net/browse/WEB-2162

## Example
- encoding.codec is marked as required and should have a "required" badge (fixed), not "optional" (live)
  - https://deploy-preview-13353--vector-project.netlify.app/docs/reference/configuration/sinks/gcp_cloud_storage/#encoding.codec