### PR TITLE
chore: Drop `Event::new_empty_log`

### DIFF
--- a/benches/dnstap/mod.rs
+++ b/benches/dnstap/mod.rs
@@ -1,15 +1,13 @@
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use vector::{
-    event::Event,
+    event::LogEvent,
     sources::dnstap::{schema::DnstapEventSchema, DnstapParser},
 };
 
 fn benchmark_query_parsing(c: &mut Criterion) {
-    let mut event = Event::new_empty_log();
-    let log_event = event.as_mut_log();
     let schema = DnstapEventSchema::new();
-    let mut parser = DnstapParser::new(&schema, log_event);
+    let mut parser = DnstapParser::new(&schema, &mut event);
     let raw_dnstap_data = "ChVqYW1lcy1WaXJ0dWFsLU1hY2hpbmUSC0JJTkQgOS4xNi4zcnoIAxACGAEiEAAAAAAAAA\
     AAAAAAAAAAAAAqECABBQJwlAAAAAAAAAAAADAw8+0CODVA7+zq9wVNMU3WNlI2kwIAAAABAAAAAAABCWZhY2Vib29rMQNjb\
     20AAAEAAQAAKQIAAACAAAAMAAoACOxjCAG9zVgzWgUDY29tAHgB";
@@ -29,10 +27,9 @@ fn benchmark_query_parsing(c: &mut Criterion) {
 }
 
 fn benchmark_update_parsing(c: &mut Criterion) {
-    let mut event = Event::new_empty_log();
-    let log_event = event.as_mut_log();
+    let mut event = LogEvent::default();
     let schema = DnstapEventSchema::new();
-    let mut parser = DnstapParser::new(&schema, log_event);
+    let mut parser = DnstapParser::new(&schema, &mut event);
     let raw_dnstap_data = "ChVqYW1lcy1WaXJ0dWFsLU1hY2hpbmUSC0JJTkQgOS4xNi4zcmsIDhABGAEiBH8AAA\
     EqBH8AAAEwrG44AEC+iu73BU14gfofUh1wi6gAAAEAAAAAAAAHZXhhbXBsZQNjb20AAAYAAWC+iu73BW0agDwvch1wi6gAA\
     AEAAAAAAAAHZXhhbXBsZQNjb20AAAYAAXgB";

--- a/benches/dnstap/mod.rs
+++ b/benches/dnstap/mod.rs
@@ -6,6 +6,7 @@ use vector::{
 };
 
 fn benchmark_query_parsing(c: &mut Criterion) {
+    let mut event = LogEvent::default();
     let schema = DnstapEventSchema::new();
     let mut parser = DnstapParser::new(&schema, &mut event);
     let raw_dnstap_data = "ChVqYW1lcy1WaXJ0dWFsLU1hY2hpbmUSC0JJTkQgOS4xNi4zcnoIAxACGAEiEAAAAAAAAA\

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -5,13 +5,13 @@ use futures::{stream, SinkExt, Stream, StreamExt};
 use indoc::indoc;
 use transforms::lua::v2::LuaConfig;
 use vector::{
-    event::Event,
+    event::{Event, LogEvent},
     test_util::collect_ready,
     transforms::{self, OutputBuffer, Transform},
 };
 
 fn bench_add_fields(c: &mut Criterion) {
-    let event = Event::new_empty_log();
+    let event = Event::from(LogEvent::default());
 
     let key = "the_key";
     let value = "this is the value";
@@ -86,9 +86,9 @@ fn bench_field_filter(c: &mut Criterion) {
     let num_events = 10;
     let events = (0..num_events)
         .map(|i| {
-            let mut event = Event::new_empty_log();
-            event.as_mut_log().insert("the_field", (i % 10).to_string());
-            event
+            let mut event = LogEvent::default();
+            event.insert("the_field", (i % 10).to_string());
+            Event::from(event)
         })
         .collect::<Vec<_>>();
 

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -75,8 +75,8 @@ mod test {
 
     #[test]
     fn to_lua_log() {
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("field", "value");
+        let mut event = LogEvent::default();
+        event.insert("field", "value");
 
         let assertions = vec![
             "type(event) == 'table'",
@@ -85,7 +85,7 @@ mod test {
             "event.log.field == 'value'",
         ];
 
-        assert_event(event, assertions);
+        assert_event(event.into(), assertions);
     }
 
     #[test]

--- a/lib/vector-core/src/event/lua/log.rs
+++ b/lib/vector-core/src/event/lua/log.rs
@@ -20,12 +20,10 @@ impl<'a> FromLua<'a> for LogEvent {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::event::Event;
 
     #[test]
     fn to_lua() {
-        let mut event = Event::new_empty_log();
-        let log = event.as_mut_log();
+        let mut log = LogEvent::default();
         log.insert("a", 1);
         log.insert("nested.field", "2");
         log.insert("nested.array[0]", "example value");

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -80,11 +80,6 @@ impl Finalizable for Event {
 }
 
 impl Event {
-    #[must_use]
-    pub fn new_empty_log() -> Self {
-        Event::Log(LogEvent::default())
-    }
-
     /// Return self as a `LogEvent`
     ///
     /// # Panics

--- a/lib/vector-core/src/event/test/mod.rs
+++ b/lib/vector-core/src/event/test/mod.rs
@@ -8,17 +8,12 @@ use super::*;
 
 #[test]
 fn event_iteration() {
-    let mut event = Event::new_empty_log();
+    let mut log = LogEvent::default();
 
-    event
-        .as_mut_log()
-        .insert("\"Ke$ha\"", "It's going down, I'm yelling timber");
-    event
-        .as_mut_log()
-        .insert("Pitbull", "The bigger they are, the harder they fall");
+    log.insert("\"Ke$ha\"", "It's going down, I'm yelling timber");
+    log.insert("Pitbull", "The bigger they are, the harder they fall");
 
-    let all = event
-        .as_log()
+    let all = log
         .all_fields()
         .unwrap()
         .map(|(k, v)| (k, v.to_string_lossy()))
@@ -42,8 +37,7 @@ fn event_iteration() {
 
 #[test]
 fn event_iteration_order() {
-    let mut event = Event::new_empty_log();
-    let log = event.as_mut_log();
+    let mut log = LogEvent::default();
     log.insert("lZDfzKIL", Value::from("tOVrjveM"));
     log.insert("o9amkaRY", Value::from("pGsfG7Nr"));
     log.insert("YRjhxXcg", Value::from("nw8iM5Jr"));

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -77,7 +77,7 @@ async fn sink_events() {
 
     // Send some events down the wire. Waiting until the first notifications are in
     // to ensure the event handler has been initialized.
-    let log_event = Event::new_empty_log();
+    let log_event = Event::from(LogEvent::default());
     let metric_event = Event::from(Metric::new(
         id.to_string(),
         MetricKind::Incremental,

--- a/src/sinks/console/sink.rs
+++ b/src/sinks/console/sink.rs
@@ -82,7 +82,7 @@ mod test {
     use crate::{
         event::{
             metric::{Metric, MetricKind, MetricValue, StatisticKind},
-            Event, Value,
+            Event, LogEvent, Value,
         },
         sinks::util::encoding::{
             EncodingConfig, EncodingConfigWithFramingAdapter, StandardEncodings,
@@ -144,13 +144,15 @@ mod test {
 
     #[test]
     fn encodes_log_events() {
-        let mut event = Event::new_empty_log();
-        let log = event.as_mut_log();
+        let mut log = LogEvent::default();
         log.insert("x", Value::from("23"));
         log.insert("z", Value::from(25));
         log.insert("a", Value::from("0"));
 
-        let encoded = encode_event(event, EncodingConfig::from(StandardEncodings::Json).into());
+        let encoded = encode_event(
+            log.into(),
+            EncodingConfig::from(StandardEncodings::Json).into(),
+        );
         let expected = r#"{"a":"0","x":"23","z":25}"#;
         assert_eq!(encoded.unwrap(), expected);
     }

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -976,7 +976,7 @@ mod tests {
         assert_eq!(uuid1.len(), 36);
 
         // check that the second batch has a different UUID
-        let log2 = Event::new_empty_log();
+        let log2 = LogEvent::default().into();
 
         let key = partitioner.partition(&log2).expect("key wasn't provided");
         let (metadata, _events) = request_builder.split_input((key, vec![log2]));

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -352,6 +352,7 @@ mod tests {
     use futures_util::{future::ready, stream};
     use vector_core::partition::Partitioner;
 
+    use crate::event::LogEvent;
     use crate::test_util::{
         components::{run_and_assert_sink_compliance, SINK_TAGS},
         http::{always_200_response, spawn_blackhole_http_server},
@@ -414,7 +415,6 @@ mod tests {
     }
 
     fn build_request(extension: Option<&str>, uuid: bool, compression: Compression) -> GcsRequest {
-        let log = Event::new_empty_log();
         let sink_config = GcsSinkConfig {
             key_prefix: Some("key/".into()),
             filename_time_format: Some("date".into()),
@@ -423,6 +423,7 @@ mod tests {
             compression,
             ..default_config(StandardEncodings::Ndjson)
         };
+        let log = LogEvent::default().into();
         let key = sink_config
             .key_partitioner()
             .unwrap()

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -491,18 +491,14 @@ mod tests {
 
     #[test]
     fn test_encode_nested_fields() {
-        let mut event = Event::new_empty_log();
+        let mut event = LogEvent::default();
 
-        event.as_mut_log().insert("a", 1);
-        event.as_mut_log().insert("nested.field", "2");
-        event.as_mut_log().insert("nested.bool", true);
-        event
-            .as_mut_log()
-            .insert("nested.array[0]", "example-value");
-        event
-            .as_mut_log()
-            .insert("nested.array[2]", "another-value");
-        event.as_mut_log().insert("nested.array[3]", 15);
+        event.insert("a", 1);
+        event.insert("nested.field", "2");
+        event.insert("nested.bool", true);
+        event.insert("nested.array[0]", "example-value");
+        event.insert("nested.array[2]", "another-value");
+        event.insert("nested.array[3]", 15);
 
         let sink = create_sink(
             "http://localhost:9999",
@@ -513,7 +509,7 @@ mod tests {
         );
         let mut encoder = sink.build_encoder();
 
-        let bytes = encoder.encode_event(event).unwrap();
+        let bytes = encoder.encode_event(event.into()).unwrap();
         let string = std::str::from_utf8(&bytes).unwrap();
 
         let line_protocol = split_line_protocol(string);

--- a/src/sinks/util/encoding/mod.rs
+++ b/src/sinks/util/encoding/mod.rs
@@ -401,9 +401,8 @@ mod tests {
     fn test_except() {
         let config: TestConfig = toml::from_str(TOML_EXCEPT_FIELD).unwrap();
         config.encoding.validate().unwrap();
-        let mut event = Event::new_empty_log();
+        let mut log = LogEvent::default();
         {
-            let log = event.as_mut_log();
             log.insert("a", 1);
             log.insert("a.b", 1);
             log.insert("a.b.c", 1);
@@ -416,6 +415,7 @@ mod tests {
             log.insert("e.a", 1);
             log.insert("e.b", 1);
         }
+        let mut event = Event::from(log);
         config.encoding.apply_rules(&mut event);
         assert!(!event.as_mut_log().contains("a.b.c"));
         assert!(!event.as_mut_log().contains("b"));
@@ -437,9 +437,8 @@ mod tests {
     fn test_only() {
         let config: TestConfig = toml::from_str(TOML_ONLY_FIELD).unwrap();
         config.encoding.validate().unwrap();
-        let mut event = Event::new_empty_log();
+        let mut log = LogEvent::default();
         {
-            let log = event.as_mut_log();
             log.insert("a", 1);
             log.insert("a.b", 1);
             log.insert("a.b.c", 1);
@@ -457,6 +456,7 @@ mod tests {
             log.insert("h", BTreeMap::new());
             log.insert("i", Vec::<Value>::new());
         }
+        let mut event = Event::from(log);
         config.encoding.apply_rules(&mut event);
         assert!(event.as_mut_log().contains("a.b.c"));
         assert!(event.as_mut_log().contains("b"));

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -389,7 +389,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{SinkConfig, SinkContext},
-        event::{Event, Value as EventValue},
+        event::{Event, LogEvent, Value as EventValue},
         sinks::util::encoding::{
             EncodingConfig, EncodingConfigAdapter, StandardEncodings, StandardEncodingsMigrator,
         },
@@ -428,13 +428,15 @@ mod tests {
 
     #[test]
     fn encodes_log_events() {
-        let mut event = Event::new_empty_log();
+        let mut log = LogEvent::default();
 
-        let log = event.as_mut_log();
         log.insert("str", EventValue::from("bar"));
         log.insert("num", EventValue::from(10));
 
-        let encoded = encode_event(event, EncodingConfig::from(StandardEncodings::Json).into());
+        let encoded = encode_event(
+            log.into(),
+            EncodingConfig::from(StandardEncodings::Json).into(),
+        );
         let expected = Message::text(r#"{"num":10,"str":"bar"}"#);
         assert_eq!(expected, encoded.unwrap());
     }

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -7,7 +7,7 @@ use vector_core::ByteSizeOf;
 use super::util::framestream::{build_framestream_unix_source, FrameHandler};
 use crate::{
     config::{log_schema, DataType, Output, SourceConfig, SourceContext, SourceDescription},
-    event::Event,
+    event::{Event, LogEvent},
     internal_events::{BytesReceived, DnstapParseError, EventsReceived},
     Result,
 };
@@ -196,9 +196,7 @@ impl FrameHandler for DnstapFrameHandler {
             byte_size: frame.len(),
             protocol: "protobuf",
         });
-        let mut event = Event::new_empty_log();
-
-        let log_event = event.as_mut_log();
+        let mut log_event = LogEvent::default();
 
         if let Some(host) = received_from {
             log_event.insert(self.host_key().as_str(), host);
@@ -209,13 +207,14 @@ impl FrameHandler for DnstapFrameHandler {
                 self.schema.dnstap_root_data_schema().raw_data(),
                 base64::encode(&frame),
             );
+            let event = Event::from(log_event);
             emit!(EventsReceived {
                 count: 1,
                 byte_size: event.size_of(),
             });
             Some(event)
         } else {
-            match parse_dnstap_data(&self.schema, log_event, frame) {
+            match parse_dnstap_data(&self.schema, &mut log_event, frame) {
                 Err(err) => {
                     emit!(DnstapParseError {
                         error: format!("Dnstap protobuf decode error {:?}.", err).as_str()
@@ -223,6 +222,7 @@ impl FrameHandler for DnstapFrameHandler {
                     None
                 }
                 Ok(_) => {
+                    let event = Event::from(log_event);
                     emit!(EventsReceived {
                         count: 1,
                         byte_size: event.size_of(),

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -962,14 +962,13 @@ fn to_dnstap_message_type(type_id: i32) -> String {
 #[cfg(test)]
 mod tests {
     use super::{super::schema::DnstapEventSchema, *};
-    use crate::event::{Event, Value};
+    use crate::event::Value;
 
     #[test]
     fn test_parse_dnstap_data_with_query_message() {
-        let mut event = Event::new_empty_log();
-        let log_event = event.as_mut_log();
+        let mut log_event = LogEvent::default();
         let schema = DnstapEventSchema::new();
-        let mut parser = DnstapParser::new(&schema, log_event);
+        let mut parser = DnstapParser::new(&schema, &mut log_event);
         let raw_dnstap_data = "ChVqYW1lcy1WaXJ0dWFsLU1hY2hpbmUSC0JJTkQgOS4xNi4zcnoIAxACGAEiEAAAAAAAAA\
         AAAAAAAAAAAAAqECABBQJwlAAAAAAAAAAAADAw8+0CODVA7+zq9wVNMU3WNlI2kwIAAAABAAAAAAABCWZhY2Vib29rMQNjb\
         20AAAEAAQAAKQIAAACAAAAMAAoACOxjCAG9zVgzWgUDY29tAHgB";
@@ -1017,10 +1016,9 @@ mod tests {
 
     #[test]
     fn test_parse_dnstap_data_with_update_message() {
-        let mut event = Event::new_empty_log();
-        let log_event = event.as_mut_log();
+        let mut log_event = LogEvent::default();
         let schema = DnstapEventSchema::new();
-        let mut parser = DnstapParser::new(&schema, log_event);
+        let mut parser = DnstapParser::new(&schema, &mut log_event);
         let raw_dnstap_data = "ChVqYW1lcy1WaXJ0dWFsLU1hY2hpbmUSC0JJTkQgOS4xNi4zcmsIDhABGAEiBH8AAA\
         EqBH8AAAEwrG44AEC+iu73BU14gfofUh1wi6gAAAEAAAAAAAAHZXhhbXBsZQNjb20AAAYAAWC+iu73BW0agDwvch1wi6gAA\
         AEAAAAAAAAHZXhhbXBsZQNjb20AAAYAAXgB";
@@ -1070,10 +1068,9 @@ mod tests {
 
     #[test]
     fn test_parse_dnstap_data_with_invalid_data() {
-        let mut event = Event::new_empty_log();
-        let log_event = event.as_mut_log();
+        let mut log_event = LogEvent::default();
         let schema = DnstapEventSchema::new();
-        let mut parser = DnstapParser::new(&schema, log_event);
+        let mut parser = DnstapParser::new(&schema, &mut log_event);
         let e = parser
             .parse_dnstap_data(Bytes::from(vec![1, 2, 3]))
             .expect_err("Expected TrustDnsError.");

--- a/src/sources/kubernetes_logs/parser/mod.rs
+++ b/src/sources/kubernetes_logs/parser/mod.rs
@@ -76,7 +76,7 @@ impl FunctionTransform for Parser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{event::Event, test_util::trace_init, transforms::Transform};
+    use crate::{event::Event, event::LogEvent, test_util::trace_init, transforms::Transform};
 
     /// Picker has to work for all test cases for underlying parsers.
     fn cases() -> Vec<(String, Vec<Event>)> {
@@ -113,12 +113,12 @@ mod tests {
 
         let cases = vec![
             // No `message` field.
-            Event::new_empty_log(),
+            Event::from(LogEvent::default()),
             // Non-bytes `message` field.
             {
-                let mut input = Event::new_empty_log();
-                input.as_mut_log().insert("message", 123);
-                input
+                let mut input = LogEvent::default();
+                input.insert("message", 123);
+                input.into()
             },
         ];
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -287,7 +287,7 @@ mod test {
         config::{
             log_schema, ComponentKey, GlobalOptions, SinkContext, SourceConfig, SourceContext,
         },
-        event::Event,
+        event::{Event, LogEvent},
         shutdown::{ShutdownSignal, SourceShutdownCoordinator},
         sinks::util::tcp::TcpSinkConfig,
         test_util::{
@@ -571,9 +571,7 @@ mod test {
             let (sink, _healthcheck) = sink_config.build(cx, Default::default(), encoder).unwrap();
 
             tokio::spawn(async move {
-                let input = stream::repeat(())
-                    .map(move |_| Event::new_empty_log().into())
-                    .boxed();
+                let input = stream::repeat_with(|| LogEvent::default().into()).boxed();
                 sink.run(input).await.unwrap();
             });
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -14,7 +14,6 @@ use serde::Serialize;
 use serde_json::{de::Read as JsonRead, Deserializer, Value as JsonValue};
 use snafu::Snafu;
 use tracing::Span;
-use vector_common::finalization::AddBatchNotifier;
 use vector_config::configurable_component;
 use vector_core::{event::BatchNotifier, ByteSizeOf};
 use warp::{filters::BoxedFilter, path, reject::Rejection, reply::Response, Filter, Reply};
@@ -562,8 +561,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
 
     fn build_event(&mut self, mut json: JsonValue) -> Result<Event, Rejection> {
         // Construct Event from parsed json event
-        let mut event = Event::new_empty_log();
-        let log = event.as_mut_log();
+        let mut log = LogEvent::default();
 
         // Add source type
         log.insert(log_schema().source_type_key(), Bytes::from("splunk_hec"));
@@ -652,7 +650,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
 
         // Extract default extracted fields
         for de in self.extractors.iter_mut() {
-            de.extract(log, &mut json);
+            de.extract(&mut log, &mut json);
         }
 
         // Add passthrough token if present
@@ -661,12 +659,12 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         }
 
         if let Some(batch) = self.batch.clone() {
-            event.add_batch_notifier(batch);
+            log = log.with_batch_notifier(&batch);
         }
 
         self.events += 1;
 
-        Ok(event)
+        Ok(log.into())
     }
 }
 
@@ -802,8 +800,7 @@ fn raw_event(
     };
 
     // Construct event
-    let mut event = Event::new_empty_log();
-    let log = event.as_mut_log();
+    let mut log = LogEvent::default();
 
     // Add message
     log.insert(log_schema().message_key(), message);
@@ -824,13 +821,12 @@ fn raw_event(
     log.insert(log_schema().timestamp_key(), Utc::now());
 
     // Add source type
-    event
-        .as_mut_log()
-        .try_insert(log_schema().source_type_key(), Bytes::from("splunk_hec"));
+    log.try_insert(log_schema().source_type_key(), Bytes::from("splunk_hec"));
     if let Some(batch) = batch {
-        event.add_batch_notifier(batch);
+        log = log.with_batch_notifier(&batch);
     }
 
+    let event = Event::from(log);
     emit!(EventsReceived {
         count: 1,
         byte_size: event.size_of(),
@@ -1010,7 +1006,7 @@ mod tests {
     use super::{acknowledgements::HecAcknowledgementsConfig, parse_timestamp, SplunkConfig};
     use crate::{
         config::{log_schema, SinkConfig, SinkContext, SourceConfig, SourceContext},
-        event::Event,
+        event::{Event, LogEvent},
         sinks::{
             splunk_hec::common::timestamp_key,
             splunk_hec::logs::config::{HecEncoding, HecLogsSinkConfig},
@@ -1293,19 +1289,16 @@ mod tests {
     async fn json_event() {
         let (sink, source) = start(HecEncoding::Json, Compression::gzip_default(), None).await;
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("greeting", "hello");
-        event.as_mut_log().insert("name", "bob");
-        sink.run_events(vec![event]).await.unwrap();
+        let mut log = LogEvent::default();
+        log.insert("greeting", "hello");
+        log.insert("name", "bob");
+        sink.run_events(vec![log.into()]).await.unwrap();
 
-        let event = collect_n(source, 1).await.remove(0);
-        assert_eq!(event.as_log()["greeting"], "hello".into());
-        assert_eq!(event.as_log()["name"], "bob".into());
-        assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
-        assert_eq!(
-            event.as_log()[log_schema().source_type_key()],
-            "splunk_hec".into()
-        );
+        let event = collect_n(source, 1).await.remove(0).into_log();
+        assert_eq!(event["greeting"], "hello".into());
+        assert_eq!(event["name"], "bob".into());
+        assert!(event.get(log_schema().timestamp_key()).is_some());
+        assert_eq!(event[log_schema().source_type_key()], "splunk_hec".into());
         assert!(event.metadata().splunk_hec_token().is_none());
     }
 
@@ -1313,9 +1306,9 @@ mod tests {
     async fn line_to_message() {
         let (sink, source) = start(HecEncoding::Json, Compression::gzip_default(), None).await;
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("line", "hello");
-        sink.run_events(vec![event]).await.unwrap();
+        let mut event = LogEvent::default();
+        event.insert("line", "hello");
+        sink.run_events(vec![event.into()]).await.unwrap();
 
         let event = collect_n(source, 1).await.remove(0);
         assert_eq!(event.as_log()[log_schema().message_key()], "hello".into());

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -282,7 +282,7 @@ pub fn format_error(error: &mlua::Error) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{Event, Value};
+    use crate::event::{Event, LogEvent, Value};
 
     #[test]
     fn lua_add_field() {
@@ -335,9 +335,9 @@ mod tests {
         )
         .unwrap();
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("name", "Bob");
-        let event = transform.transform_one(event).unwrap();
+        let mut log = LogEvent::default();
+        log.insert("name", "Bob");
+        let event = transform.transform_one(log.into()).unwrap();
 
         assert!(event.as_log().get("name").is_none());
     }
@@ -353,9 +353,9 @@ mod tests {
         )
         .unwrap();
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("name", "Bob");
-        let event = transform.transform_one(event);
+        let mut log = LogEvent::default();
+        log.insert("name", "Bob");
+        let event = transform.transform_one(log.into());
 
         assert!(event.is_none());
     }
@@ -376,8 +376,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
-        let event = transform.transform_one(event).unwrap();
+        let event = transform.transform_one(LogEvent::default().into()).unwrap();
 
         assert_eq!(event.as_log()["result"], "empty".into());
     }
@@ -394,7 +393,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = transform.transform_one(Event::new_empty_log()).unwrap();
+        let event = transform.transform_one(LogEvent::default().into()).unwrap();
         assert_eq!(event.as_log()["number"], Value::Integer(3));
     }
 
@@ -410,7 +409,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = transform.transform_one(Event::new_empty_log()).unwrap();
+        let event = transform.transform_one(LogEvent::default().into()).unwrap();
         assert_eq!(event.as_log()["number"], Value::from(3.14159));
     }
 
@@ -426,7 +425,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = transform.transform_one(Event::new_empty_log()).unwrap();
+        let event = transform.transform_one(LogEvent::default().into()).unwrap();
         assert_eq!(event.as_log()["bool"], Value::Boolean(true));
     }
 
@@ -442,7 +441,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = transform.transform_one(Event::new_empty_log()).unwrap();
+        let event = transform.transform_one(LogEvent::default().into()).unwrap();
         assert_eq!(event.as_log().get("junk"), None);
     }
 
@@ -458,7 +457,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = transform.process(Event::new_empty_log()).unwrap_err();
+        let err = transform.process(LogEvent::default().into()).unwrap_err();
         let err = format_error(&err);
         assert!(
             err.contains("error converting Lua boolean to String"),
@@ -479,7 +478,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = transform.process(Event::new_empty_log()).unwrap_err();
+        let err = transform.process(LogEvent::default().into()).unwrap_err();
         let err = format_error(&err);
         assert!(
             err.contains("error converting Lua boolean to String"),
@@ -500,7 +499,7 @@ mod tests {
         )
         .unwrap();
 
-        let err = transform.process(Event::new_empty_log()).unwrap_err();
+        let err = transform.process(LogEvent::default().into()).unwrap_err();
         let err = format_error(&err);
         assert!(err.contains("this is an error"), "{}", err);
     }
@@ -553,7 +552,7 @@ mod tests {
 
         let mut transform =
             Lua::new(source, vec![dir.path().to_string_lossy().into_owned()]).unwrap();
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let event = transform.transform_one(event).unwrap();
         assert_eq!(event.as_log()["\"new field\""], "new value".into());
     }
@@ -572,11 +571,11 @@ mod tests {
         )
         .unwrap();
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("name", "Bob");
-        event.as_mut_log().insert("friend", "Alice");
+        let mut event = LogEvent::default();
+        event.insert("name", "Bob");
+        event.insert("friend", "Alice");
 
-        let event = transform.transform_one(event).unwrap();
+        let event = transform.transform_one(event.into()).unwrap();
 
         assert_eq!(event.as_log()["name"], "nameBob".into());
         assert_eq!(event.as_log()["friend"], "friendAlice".into());

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -351,7 +351,7 @@ mod tests {
     use crate::{
         event::{
             metric::{Metric, MetricKind, MetricValue},
-            Event, Value,
+            Event, LogEvent, Value,
         },
         test_util::trace_init,
         transforms::TaskTransform,
@@ -425,10 +425,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("name", "Bob");
+        let mut event = LogEvent::default();
+        event.insert("name", "Bob");
 
-        let in_stream = Box::pin(stream::iter(vec![event]));
+        let in_stream = Box::pin(stream::iter(vec![event.into()]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
 
@@ -450,7 +450,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await;
@@ -474,9 +474,9 @@ mod tests {
         )
         .unwrap();
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("host", "127.0.0.1");
-        let input = Box::pin(stream::iter(vec![event]));
+        let mut event = LogEvent::default();
+        event.insert("host", "127.0.0.1");
+        let input = Box::pin(stream::iter(vec![event.into()]));
         let output = transform.transform(input);
         let out = output.collect::<Vec<_>>().await;
 
@@ -503,7 +503,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
 
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
@@ -528,7 +528,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
@@ -552,7 +552,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
@@ -576,7 +576,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
@@ -600,7 +600,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
@@ -625,7 +625,7 @@ mod tests {
         .unwrap();
 
         let err = transform
-            .process_single(Event::new_empty_log())
+            .process_single(LogEvent::default().into())
             .unwrap_err();
         let err = format_error(&err);
         assert!(
@@ -651,7 +651,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
@@ -674,7 +674,7 @@ mod tests {
         .unwrap();
 
         let err = transform
-            .process_single(Event::new_empty_log())
+            .process_single(LogEvent::default().into())
             .unwrap_err();
         let err = format_error(&err);
         assert!(err.contains("this is an error"), "{}", err);
@@ -737,7 +737,7 @@ mod tests {
         );
         let transform = from_config(&config).unwrap();
 
-        let event = Event::new_empty_log();
+        let event = LogEvent::default().into();
         let in_stream = Box::pin(stream::iter(vec![event]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
@@ -763,11 +763,11 @@ mod tests {
         )
         .unwrap();
 
-        let mut event = Event::new_empty_log();
-        event.as_mut_log().insert("name", "Bob");
-        event.as_mut_log().insert("friend", "Alice");
+        let mut event = LogEvent::default();
+        event.insert("name", "Bob");
+        event.insert("friend", "Alice");
 
-        let in_stream = Box::pin(stream::iter(vec![event]));
+        let in_stream = Box::pin(stream::iter(vec![event.into()]));
         let mut out_stream = transform.transform(in_stream);
         let output = out_stream.next().await.unwrap();
 

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -612,7 +612,7 @@ mod test {
     use serde_json::json;
 
     use super::*;
-    use crate::event::Event;
+    use crate::event::LogEvent;
 
     #[test]
     fn initial_values() {
@@ -872,9 +872,8 @@ mod test {
     fn merge(initial: Value, additional: Value, strategy: &MergeStrategy) -> Result<Value, String> {
         let mut merger = get_value_merger(initial, strategy)?;
         merger.add(additional)?;
-        let mut output = Event::new_empty_log();
-        let output = output.as_mut_log();
-        merger.insert_into("out".into(), output)?;
+        let mut output = LogEvent::default();
+        merger.insert_into("out".into(), &mut output)?;
         Ok(output.remove("out").unwrap())
     }
 }

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -197,7 +197,7 @@ mod tests {
     use futures::SinkExt;
 
     use super::*;
-    use crate::event::Event;
+    use crate::event::LogEvent;
 
     #[test]
     fn generate_config() {
@@ -228,8 +228,8 @@ window_secs = 5
         // we trip it/set the interval in the future
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
-        tx.send(Event::new_empty_log()).await.unwrap();
-        tx.send(Event::new_empty_log()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
 
         let mut count = 0_u8;
         while count < 2 {
@@ -243,14 +243,14 @@ window_secs = 5
 
         clock.advance(Duration::from_secs(2));
 
-        tx.send(Event::new_empty_log()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
 
         // We should be back to pending, having the second event dropped
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
         clock.advance(Duration::from_secs(3));
 
-        tx.send(Event::new_empty_log()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
 
         // The rate limiter should now be refreshed and allow an additional event through
         if let Some(_event) = out_stream.next().await {
@@ -294,8 +294,8 @@ exists(.special)
         // we trip it/set the interval in the future
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
-        tx.send(Event::new_empty_log()).await.unwrap();
-        tx.send(Event::new_empty_log()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
 
         let mut count = 0_u8;
         while count < 2 {
@@ -309,14 +309,14 @@ exists(.special)
 
         clock.advance(Duration::from_secs(2));
 
-        tx.send(Event::new_empty_log()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
 
         // We should be back to pending, having the second event dropped
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
-        let mut special_log = Event::new_empty_log();
-        special_log.as_mut_log().insert("special", "true");
-        tx.send(special_log).await.unwrap();
+        let mut special_log = LogEvent::default();
+        special_log.insert("special", "true");
+        tx.send(special_log.into()).await.unwrap();
         // The rate limiter should allow this log through regardless of current limit
         if let Some(_event) = out_stream.next().await {
         } else {
@@ -325,7 +325,7 @@ exists(.special)
 
         clock.advance(Duration::from_secs(3));
 
-        tx.send(Event::new_empty_log()).await.unwrap();
+        tx.send(LogEvent::default().into()).await.unwrap();
 
         // The rate limiter should now be refreshed and allow an additional event through
         if let Some(_event) = out_stream.next().await {
@@ -367,12 +367,12 @@ key_field = "{{ bucket }}"
         // we trip it/set the interval in the future
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
-        let mut log_a = Event::new_empty_log();
-        log_a.as_mut_log().insert("bucket", "a");
-        let mut log_b = Event::new_empty_log();
-        log_b.as_mut_log().insert("bucket", "b");
-        tx.send(log_a).await.unwrap();
-        tx.send(log_b).await.unwrap();
+        let mut log_a = LogEvent::default();
+        log_a.insert("bucket", "a");
+        let mut log_b = LogEvent::default();
+        log_b.insert("bucket", "b");
+        tx.send(log_a.into()).await.unwrap();
+        tx.send(log_b.into()).await.unwrap();
 
         let mut count = 0_u8;
         while count < 2 {


### PR DESCRIPTION
The use of this function has been discouraged for some time, and there
are few enough uses now to just get rid of it. This change is mostly
pretty mechanical.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
