### PR TITLE
chore(buffers): Use event finalization for acking disk buffers

### DIFF
--- a/lib/vector-buffers/benches/common.rs
+++ b/lib/vector-buffers/benches/common.rs
@@ -14,6 +14,7 @@ use vector_buffers::{
     BufferType, EventCount,
 };
 use vector_common::byte_size_of::ByteSizeOf;
+use vector_common::finalization::{AddBatchNotifier, BatchNotifier};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Message<const N: usize> {
@@ -27,6 +28,12 @@ impl<const N: usize> Message<N> {
             id,
             _padding: [0; N],
         }
+    }
+}
+
+impl<const N: usize> AddBatchNotifier for Message<N> {
+    fn add_batch_notifier(&mut self, batch: BatchNotifier) {
+        drop(batch); // Incorrect but fast
     }
 }
 

--- a/lib/vector-buffers/examples/buffer_perf.rs
+++ b/lib/vector-buffers/examples/buffer_perf.rs
@@ -24,20 +24,34 @@ use vector_buffers::{
     Acker, BufferType, Bufferable, EventCount, WhenFull,
 };
 use vector_common::byte_size_of::ByteSizeOf;
+use vector_common::finalization::{
+    AddBatchNotifier, BatchNotifier, EventFinalizer, EventFinalizers,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VariableMessage {
     id: u64,
     payload: Vec<u8>,
+    finalizer: EventFinalizers,
 }
 
 impl VariableMessage {
     pub fn new(id: u64, payload: Vec<u8>) -> Self {
-        VariableMessage { id, payload }
+        VariableMessage {
+            id,
+            payload,
+            finalizer: Default::default(),
+        }
     }
 
     pub fn id(&self) -> u64 {
         self.id
+    }
+}
+
+impl AddBatchNotifier for VariableMessage {
+    fn add_batch_notifier(&mut self, batch: BatchNotifier) {
+        self.finalizer.add(EventFinalizer::new(batch));
     }
 }
 

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -37,7 +37,7 @@ use std::fmt::Debug;
 #[cfg(test)]
 use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
-use vector_common::byte_size_of::ByteSizeOf;
+use vector_common::{byte_size_of::ByteSizeOf, finalization::AddBatchNotifier};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -71,13 +71,31 @@ impl Arbitrary for WhenFull {
 ///
 /// This supertrait serves as the base trait for any item that can be pushed into a buffer.
 pub trait Bufferable:
-    ByteSizeOf + Encodable + EventCount + Debug + Send + Sync + Unpin + Sized + 'static
+    AddBatchNotifier
+    + ByteSizeOf
+    + Encodable
+    + EventCount
+    + Debug
+    + Send
+    + Sync
+    + Unpin
+    + Sized
+    + 'static
 {
 }
 
 // Blanket implementation for anything that is already bufferable.
 impl<T> Bufferable for T where
-    T: ByteSizeOf + Encodable + EventCount + Debug + Send + Sync + Unpin + Sized + 'static
+    T: AddBatchNotifier
+        + ByteSizeOf
+        + Encodable
+        + EventCount
+        + Debug
+        + Send
+        + Sync
+        + Unpin
+        + Sized
+        + 'static
 {
 }
 

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -282,14 +282,15 @@ mod tests {
 
     use super::TopologyBuilder;
     use crate::{
-        topology::{builder::TopologyError, test_util::assert_current_send_capacity},
+        topology::builder::TopologyError,
+        topology::test_util::{assert_current_send_capacity, Sample},
         variants::MemoryBuffer,
         WhenFull,
     };
 
     #[tokio::test]
     async fn single_stage_topology_block() {
-        let mut builder = TopologyBuilder::<u64>::default();
+        let mut builder = TopologyBuilder::<Sample>::default();
         builder.stage(
             MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
             WhenFull::Block,
@@ -303,7 +304,7 @@ mod tests {
 
     #[tokio::test]
     async fn single_stage_topology_drop_newest() {
-        let mut builder = TopologyBuilder::<u64>::default();
+        let mut builder = TopologyBuilder::<Sample>::default();
         builder.stage(
             MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
             WhenFull::DropNewest,
@@ -317,7 +318,7 @@ mod tests {
 
     #[tokio::test]
     async fn single_stage_topology_overflow() {
-        let mut builder = TopologyBuilder::<u64>::default();
+        let mut builder = TopologyBuilder::<Sample>::default();
         builder.stage(
             MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
             WhenFull::Overflow,
@@ -331,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn two_stage_topology_block() {
-        let mut builder = TopologyBuilder::<u64>::default();
+        let mut builder = TopologyBuilder::<Sample>::default();
         builder.stage(
             MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
             WhenFull::Block,
@@ -349,7 +350,7 @@ mod tests {
 
     #[tokio::test]
     async fn two_stage_topology_drop_newest() {
-        let mut builder = TopologyBuilder::<u64>::default();
+        let mut builder = TopologyBuilder::<Sample>::default();
         builder.stage(
             MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
             WhenFull::DropNewest,
@@ -367,7 +368,7 @@ mod tests {
 
     #[tokio::test]
     async fn two_stage_topology_overflow() {
-        let mut builder = TopologyBuilder::<u64>::default();
+        let mut builder = TopologyBuilder::<Sample>::default();
         builder.stage(
             MemoryBuffer::new(NonZeroUsize::new(1).unwrap()),
             WhenFull::Overflow,

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -254,7 +254,10 @@ mod tests {
     use tokio_test::{assert_pending, assert_ready, task::spawn};
 
     use super::limited;
-    use crate::{test::common::MultiEventRecord, topology::channel::limited_queue::SendError};
+    use crate::{
+        test::common::MultiEventRecord, topology::channel::limited_queue::SendError,
+        topology::test_util::Sample,
+    };
 
     #[tokio::test]
     async fn send_receive() {
@@ -262,7 +265,7 @@ mod tests {
 
         assert_eq!(2, tx.available_capacity());
 
-        let msg = 42;
+        let msg = Sample(42);
 
         // Create our send and receive futures.
         let mut send = spawn(async { tx.send(msg).await });
@@ -290,8 +293,8 @@ mod tests {
 
         assert_eq!(1, tx.available_capacity());
 
-        let msg1 = 42;
-        let msg2 = 43;
+        let msg1 = Sample(42);
+        let msg2 = Sample(43);
 
         // Create our send and receive futures.
         let mut send1 = spawn(async { tx.send(msg1).await });
@@ -440,7 +443,7 @@ mod tests {
         assert_eq!(1, tx.available_capacity());
 
         let tx2 = tx.clone();
-        let msg = 42;
+        let msg = Sample(42);
 
         // Create our send and receive futures.
         let mut send = spawn(async { tx.send(msg).await });
@@ -477,7 +480,7 @@ mod tests {
 
     #[test]
     fn receiver_returns_none_once_empty_when_last_sender_drops() {
-        let (tx, mut rx) = limited::<u64>(1);
+        let (tx, mut rx) = limited::<Sample>(1);
 
         assert_eq!(1, tx.available_capacity());
 

--- a/lib/vector-buffers/src/variants/disk_v1/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/mod.rs
@@ -396,8 +396,9 @@ fn build<T: Bufferable>(
         let ack_counter = Arc::clone(&ack_counter);
         let read_waker = Arc::clone(&read_waker);
         tokio::spawn(async move {
-            while let Some((_status, amount)) = stream.next().await {
-                ack_counter.fetch_add(amount as usize, Ordering::Relaxed);
+            while let Some((_status, amount)) = dbg!(stream.next().await) {
+                let amount = amount.try_into().expect("too many records on 32-bit");
+                ack_counter.fetch_add(amount, Ordering::Relaxed);
                 read_waker.notify_one();
             }
         });

--- a/lib/vector-buffers/src/variants/disk_v1/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/mod.rs
@@ -15,12 +15,13 @@ use std::{
     num::NonZeroU64,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicU64, AtomicUsize},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
 };
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use leveldb::{
     batch::{Batch, Writebatch},
     database::Database,
@@ -29,6 +30,7 @@ use leveldb::{
 };
 use snafu::{ResultExt, Snafu};
 use tokio::{sync::Notify, time::Instant};
+use vector_common::{finalizer::OrderedFinalizer, shutdown::ShutdownSignal};
 
 use self::key::Key;
 pub use self::{acknowledgements::create_disk_v1_acker, reader::Reader, writer::Writer};
@@ -389,6 +391,17 @@ fn build<T: Bufferable>(
     let write_waker = Arc::new(Notify::new());
     let ack_counter = Arc::new(AtomicUsize::new(0));
     let acker = create_disk_v1_acker(&ack_counter, &read_waker);
+    let (finalizer, mut stream) = OrderedFinalizer::<u64>::new(ShutdownSignal::noop());
+    {
+        let ack_counter = Arc::clone(&ack_counter);
+        let read_waker = Arc::clone(&read_waker);
+        tokio::spawn(async move {
+            while let Some((_status, amount)) = stream.next().await {
+                ack_counter.fetch_add(amount as usize, Ordering::Relaxed);
+                read_waker.notify_one();
+            }
+        });
+    }
 
     let writer = Writer {
         db: Some(Arc::clone(&db)),
@@ -422,6 +435,7 @@ fn build<T: Bufferable>(
         pending_read: None,
         usage_handle,
         phantom: PhantomData,
+        finalizer,
     };
 
     Ok((writer, reader, acker))

--- a/lib/vector-buffers/src/variants/disk_v1/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/reader.rs
@@ -18,6 +18,7 @@ use leveldb::database::{
     Database,
 };
 use tokio::{sync::Notify, task::JoinHandle, time::Instant};
+use vector_common::finalizer::OrderedFinalizer;
 
 use super::Key;
 use crate::{
@@ -88,6 +89,7 @@ pub struct Reader<T> {
     // Buffer usage data.
     pub(crate) usage_handle: BufferUsageHandle,
     pub(crate) phantom: PhantomData<T>,
+    pub(crate) finalizer: OrderedFinalizer<u64>,
 }
 
 impl<T> Reader<T>

--- a/lib/vector-buffers/src/variants/disk_v1/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/reader.rs
@@ -18,7 +18,7 @@ use leveldb::database::{
     Database,
 };
 use tokio::{sync::Notify, task::JoinHandle, time::Instant};
-use vector_common::finalizer::OrderedFinalizer;
+use vector_common::{finalization::BatchNotifier, finalizer::OrderedFinalizer};
 
 use super::Key;
 use crate::{
@@ -129,8 +129,12 @@ where
             if let Some((key, item_bytes, decode_result)) = self.decode_next_record() {
                 trace!(?key, item_bytes, "Got record decode attempt.");
                 match decode_result {
-                    Ok(item) => {
-                        self.track_unacked_read(key.0, Some(item.event_count()), item_bytes);
+                    Ok(mut item) => {
+                        let count = item.event_count();
+                        self.track_unacked_read(key.0, Some(count), item_bytes);
+                        let (batch, receiver) = BatchNotifier::new_with_receiver();
+                        item.add_batch_notifier(batch);
+                        self.finalizer.add(count as u64, receiver);
                         return Some(item);
                     }
                     Err(error) => {

--- a/lib/vector-buffers/src/variants/disk_v1/tests/acknowledgements.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/acknowledgements.rs
@@ -25,7 +25,7 @@ async fn acking_single_event_advances_delete_offset() {
 
             // Write a simple single-event record and make writer offset moves forward by the
             // expected amount, since the entry key should be increment by event count:
-            let record = SizedRecord(360);
+            let record = SizedRecord::new(360);
             assert_eq!(record.event_count(), 1);
             writer.send(record.clone()).await;
             writer.flush();
@@ -137,72 +137,6 @@ async fn acking_multi_event_advances_delete_offset() {
             drop(staged_read);
 
             assert_reader_v1_delete_position!(reader, record.event_count());
-        }
-    })
-    .await;
-}
-
-#[tokio::test]
-async fn acking_multi_event_advances_delete_offset_incremental() {
-    let _a = install_tracing_helpers();
-    with_temp_dir(|dir| {
-        let data_dir = dir.to_path_buf();
-
-        async move {
-            // Create a regular buffer, no customizations required.
-            let (mut writer, mut reader, acker) = create_default_buffer_v1(data_dir);
-            assert_reader_writer_v1_positions!(reader, writer, 0, 0);
-
-            // Write a simple multi-event record and make writer offset moves forward by the
-            // expected amount, since the entry key should be increment by event count:
-            let record = MultiEventRecord(14);
-            assert_eq!(record.event_count(), 14);
-            writer.send(record).await;
-            writer.flush();
-            assert_reader_writer_v1_positions!(reader, writer, 0, record.event_count());
-
-            // And now read it out which should give us a matching record, while our delete offset
-            // is still lagging behind the read offset since we haven't yet acknowledged the record:
-            let read_record = reader.next().await.expect("read should not fail");
-            assert_reader_writer_v1_positions!(
-                reader,
-                writer,
-                record.event_count(),
-                record.event_count()
-            );
-
-            assert_eq!(record, read_record);
-
-            // Now ack the record by using an amount equal to the record's event count, but do it
-            // incrementally.
-            //
-            // Since the logic to acknowledge records is driven by trying to read, we have to
-            // initiate a read first and then do our checks, but it also has to be fake spawned
-            // since there's nothing else to read and we'd be awaiting forever.
-            //
-            // Additionally -- I know, I know -- we have to advance time to clear the flush
-            // interval, since we only flush after a certain amount of time has elapsed to batch
-            // deletes to the database:
-            assert_reader_v1_delete_position!(reader, 0);
-            assert_eq!(read_record.event_count(), 14);
-
-            // Make sure our increments don't exceed the actual event count for the record:
-            let increments = [4, 7, 2, 1];
-            assert_eq!(read_record.event_count(), increments.iter().sum::<usize>());
-
-            tokio::time::pause();
-
-            // We expect the first three acknowledgements to do nothing, because the record will
-            // still not have been fully acknowledged yet, but the fourth acknowledgement will make
-            // the record eligible for deletion which should be reflected immediately:
-            let expected_delete_pos = [0, 0, 0, record.event_count()];
-            for (increment, expected) in increments.into_iter().zip(expected_delete_pos.into_iter())
-            {
-                acker.ack(increment);
-                drive_reader_to_flush(&mut reader).await;
-
-                assert_reader_v1_delete_position!(reader, expected);
-            }
         }
     })
     .await;

--- a/lib/vector-buffers/src/variants/disk_v1/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/basic.rs
@@ -24,7 +24,7 @@ async fn basic_read_write_loop() {
                 .into_iter()
                 .cycle()
                 .take(2000)
-                .map(SizedRecord)
+                .map(SizedRecord::new)
                 .collect::<Vec<_>>();
             let input_items = expected_items.clone();
             let expected_position = expected_items

--- a/lib/vector-buffers/src/variants/disk_v1/tests/size_limits.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/size_limits.rs
@@ -27,7 +27,7 @@ async fn ensure_write_offset_valid_after_reload_with_multievent() {
             // haven't exceed our total buffer size limit yet, or the size limit of the data file
             // itself.  We do need this write to be big enough to exceed the total buffer size
             // limit, though.
-            let first_record = SizedRecord(first_write_size);
+            let first_record = SizedRecord::new(first_write_size);
             let first_write_result = writer.try_send(first_record);
             assert_eq!(first_write_result, None);
             writer.flush();
@@ -35,7 +35,7 @@ async fn ensure_write_offset_valid_after_reload_with_multievent() {
             // This write should return immediately because will have exceeded our 100 byte total
             // buffer size limit handily with the first write we did, but since it's a fallible
             // write attempt, it can already tell that the write will not fit anyways:
-            let record = SizedRecord(second_write_size);
+            let record = SizedRecord::new(second_write_size);
             let second_write_result = writer.try_send(record.clone());
 
             assert_eq!(second_write_result, Some(record));

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -2,6 +2,7 @@ use std::{
     fmt, io,
     path::PathBuf,
     sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
+    sync::Arc,
     time::Instant,
 };
 
@@ -9,9 +10,11 @@ use bytecheck::CheckBytes;
 use bytes::BytesMut;
 use crossbeam_utils::atomic::AtomicCell;
 use fslock::LockFile;
+use futures::StreamExt;
 use rkyv::{with::Atomic, Archive, Serialize};
 use snafu::{ResultExt, Snafu};
 use tokio::{fs, io::AsyncWriteExt, sync::Notify};
+use vector_common::{finalizer::OrderedFinalizer, shutdown::ShutdownSignal};
 
 use super::{
     backed_archive::BackedArchive,
@@ -539,7 +542,7 @@ where
 
 impl<FS> Ledger<FS>
 where
-    FS: Filesystem,
+    FS: Filesystem + 'static,
     FS::File: Unpin,
 {
     /// Loads or creates a ledger for the given [`DiskBufferConfig`].
@@ -695,6 +698,18 @@ where
         self.increment_total_buffer_size(total_buffer_size);
 
         Ok(())
+    }
+
+    #[must_use]
+    pub(super) fn spawn_finalizer(self: Arc<Self>) -> OrderedFinalizer<u64> {
+        let (finalizer, mut stream) = OrderedFinalizer::new(ShutdownSignal::noop());
+        tokio::spawn(async move {
+            while let Some((_status, amount)) = stream.next().await {
+                self.increment_pending_acks(amount);
+                self.notify_reader_waiters();
+            }
+        });
+        finalizer
     }
 }
 

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -704,7 +704,7 @@ where
     pub(super) fn spawn_finalizer(self: Arc<Self>) -> OrderedFinalizer<u64> {
         let (finalizer, mut stream) = OrderedFinalizer::new(ShutdownSignal::noop());
         tokio::spawn(async move {
-            while let Some((_status, amount)) = stream.next().await {
+            while let Some((_status, amount)) = dbg!(stream.next().await) {
                 self.increment_pending_acks(amount);
                 self.notify_reader_waiters();
             }

--- a/lib/vector-buffers/src/variants/disk_v2/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/mod.rs
@@ -227,7 +227,9 @@ where
             .await
             .context(WriterSeekFailedSnafu)?;
 
-        let mut reader = Reader::new(Arc::clone(&ledger));
+        let finalizer = Arc::clone(&ledger).spawn_finalizer();
+
+        let mut reader = Reader::new(Arc::clone(&ledger), finalizer);
         reader
             .seek_to_next_record()
             .await

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -11,7 +11,7 @@ use crc32fast::Hasher;
 use rkyv::{archived_root, AlignedVec};
 use snafu::{ResultExt, Snafu};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
-use vector_common::{finalizer::OrderedFinalizer, internal_event::emit};
+use vector_common::{finalization::BatchNotifier, finalizer::OrderedFinalizer};
 
 use super::{
     common::create_crc32c_hasher,
@@ -1073,7 +1073,7 @@ where
             .reader
             .as_mut()
             .expect("reader should exist after `ensure_ready_for_read`");
-        let record = reader.read_record(token)?;
+        let mut record = reader.read_record(token)?;
 
         let record_events: u64 = record
             .event_count()
@@ -1083,6 +1083,10 @@ where
             .try_into()
             .map_err(|_| ReaderError::EmptyRecord)?;
         self.track_read(record_id, record_bytes, record_events);
+
+        let (batch, receiver) = BatchNotifier::new_with_receiver();
+        record.add_batch_notifier(batch);
+        self.finalizer.add(record_events.get(), receiver);
 
         if self.ready_to_read {
             trace!(

--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -26,7 +26,7 @@ async fn basic_read_write_loop() {
                 .into_iter()
                 .cycle()
                 .take(10)
-                .map(SizedRecord)
+                .map(SizedRecord::new)
                 .collect::<Vec<_>>();
             let input_items = expected_items.clone();
 
@@ -80,7 +80,7 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
 
             // Now write a single value and close the writer.
             writer
-                .write_record(SizedRecord(32))
+                .write_record(SizedRecord::new(32))
                 .await
                 .expect("write should not fail");
             writer.flush().await.expect("writer flush should not fail");
@@ -89,7 +89,7 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
 
             // And read that single value.
             let first_read = reader.next().await.expect("read should not fail");
-            assert_eq!(first_read, Some(SizedRecord(32)));
+            assert_eq!(first_read, Some(SizedRecord::new(32)));
             assert_buffer_records!(ledger, 1);
 
             // Now, we haven't acknowledged that read yet, so our next read should see the writer as

--- a/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
@@ -50,7 +50,7 @@ async fn pending_read_returns_none_when_writer_closed_with_unflushed_write() {
 
             // Write a small record but _don't_ flush it.
             let bytes_written = writer
-                .write_record(SizedRecord(64))
+                .write_record(SizedRecord::new(64))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(bytes_written, SizedRecord, 64);
@@ -98,7 +98,7 @@ async fn last_record_is_valid_during_load_when_buffer_correctly_flushed_and_stop
             // Create a normal buffer.
             let (mut writer, _, _, ledger) = create_default_buffer_v2(data_dir.clone()).await;
             let bytes_written = writer
-                .write_record(SizedRecord(64))
+                .write_record(SizedRecord::new(64))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(bytes_written, SizedRecord, 64);
@@ -150,7 +150,7 @@ async fn file_id_wraps_around_when_max_file_id_hit() {
             let mut reader_file_id = 0;
             let mut writer_file_id = 0;
             while id < target_id {
-                let record = SizedRecord(record_size);
+                let record = SizedRecord::new(record_size);
                 let bytes_written = writer
                     .write_record(record.clone())
                     .await
@@ -222,7 +222,7 @@ async fn writer_stops_when_hitting_file_that_reader_is_still_on() {
             let mut id = 0;
             let mut total_size = 0;
             while id < file_id_upper {
-                let record = SizedRecord(record_size);
+                let record = SizedRecord::new(record_size);
                 let bytes_written = writer
                     .write_record(record)
                     .await
@@ -250,7 +250,7 @@ async fn writer_stops_when_hitting_file_that_reader_is_still_on() {
             // Now we should be consuming all data files, and our next write should block trying to
             // open the "first" data file until we do a read.
             let mut blocked_write = spawn(async {
-                let record = SizedRecord(record_size);
+                let record = SizedRecord::new(record_size);
                 writer.write_record(record).await
             });
 
@@ -282,7 +282,7 @@ async fn writer_stops_when_hitting_file_that_reader_is_still_on() {
             // first data file since we haven't acknowledged the read yet, so the file can't yet be
             // deleted.
             let first_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(first_record_read, Some(SizedRecord(record_size)));
+            assert_eq!(first_record_read, Some(SizedRecord::new(record_size)));
             assert_buffer_size!(ledger, MAX_FILE_ID, total_size);
             assert_reader_writer_v2_file_positions!(ledger, 0, MAX_FILE_ID - 1);
 
@@ -296,7 +296,7 @@ async fn writer_stops_when_hitting_file_that_reader_is_still_on() {
             assert_pending!(blocked_write.poll());
 
             let second_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(second_record_read, Some(SizedRecord(record_size)));
+            assert_eq!(second_record_read, Some(SizedRecord::new(record_size)));
             assert_buffer_records!(ledger, MAX_FILE_ID - 1);
             assert_reader_writer_v2_file_positions!(ledger, 1, MAX_FILE_ID - 1);
 
@@ -366,7 +366,7 @@ async fn reader_still_works_when_record_id_wraps_around() {
             let next_record_id = ledger.state().get_next_writer_record_id();
             let first_record_size = 14;
             let first_bytes_written = writer
-                .write_record(SizedRecord(first_record_size))
+                .write_record(SizedRecord::new(first_record_size))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(first_bytes_written, SizedRecord, first_record_size);
@@ -382,7 +382,7 @@ async fn reader_still_works_when_record_id_wraps_around() {
             let next_record_id = ledger.state().get_next_writer_record_id();
             let second_record_size = 256;
             let second_bytes_written = writer
-                .write_record(SizedRecord(second_record_size))
+                .write_record(SizedRecord::new(second_record_size))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(second_bytes_written, SizedRecord, second_record_size);
@@ -399,14 +399,17 @@ async fn reader_still_works_when_record_id_wraps_around() {
 
             // Now we should be able to read both records without the reader getting angry.
             let first_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(first_record_read, Some(SizedRecord(first_record_size)));
+            assert_eq!(first_record_read, Some(SizedRecord::new(first_record_size)));
             assert_eq!(u64::MAX - 1, ledger.state().get_last_reader_record_id());
             assert_buffer_records!(ledger, 2);
 
             acker.ack(1);
 
             let second_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(second_record_read, Some(SizedRecord(second_record_size)));
+            assert_eq!(
+                second_record_read,
+                Some(SizedRecord::new(second_record_size))
+            );
             assert_eq!(u64::MAX, ledger.state().get_last_reader_record_id());
             assert_buffer_records!(ledger, 1);
 
@@ -470,7 +473,7 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
             // the wrapping threshold.
             let first_record_size = 64;
             let first_bytes_written = writer
-                .write_record(SizedRecord(first_record_size))
+                .write_record(SizedRecord::new(first_record_size))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(first_bytes_written, SizedRecord, first_record_size);
@@ -481,7 +484,7 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
 
             let second_record_size = 66;
             let second_bytes_written = writer
-                .write_record(SizedRecord(second_record_size))
+                .write_record(SizedRecord::new(second_record_size))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(second_bytes_written, SizedRecord, second_record_size);
@@ -495,7 +498,7 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
             // file after we read and ack the first two writes.
             let third_record_size = 68;
             let third_bytes_written = writer
-                .write_record(SizedRecord(third_record_size))
+                .write_record(SizedRecord::new(third_record_size))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(third_bytes_written, SizedRecord, third_record_size);
@@ -507,7 +510,7 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
             // Our fourth write should fit just fine in the new data file, so no change there:
             let fourth_record_size = 70;
             let fourth_bytes_written = writer
-                .write_record(SizedRecord(fourth_record_size))
+                .write_record(SizedRecord::new(fourth_record_size))
                 .await
                 .expect("write should not fail");
             assert_enough_bytes_written!(fourth_bytes_written, SizedRecord, fourth_record_size);
@@ -528,7 +531,7 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
                 .finalize();
 
             let first_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(first_record_read, Some(SizedRecord(first_record_size)));
+            assert_eq!(first_record_read, Some(SizedRecord::new(first_record_size)));
             assert_eq!(u64::MAX - 1, ledger.state().get_last_reader_record_id());
             assert_buffer_records!(ledger, 4);
             assert_reader_writer_v2_file_positions!(ledger, 0, next_writer_file_id);
@@ -537,7 +540,10 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
             assert!(!deleted_data_file.try_assert());
 
             let second_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(second_record_read, Some(SizedRecord(second_record_size)));
+            assert_eq!(
+                second_record_read,
+                Some(SizedRecord::new(second_record_size))
+            );
             assert_eq!(u64::MAX, ledger.state().get_last_reader_record_id());
             assert_buffer_records!(ledger, 3);
             assert_reader_writer_v2_file_positions!(ledger, 0, next_writer_file_id);
@@ -548,7 +554,7 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
             // This read should be where we actually delete the file since we've acknowledged all of
             // the reads from the first data file:
             let third_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(third_record_read, Some(SizedRecord(third_record_size)));
+            assert_eq!(third_record_read, Some(SizedRecord::new(third_record_size)));
             assert_eq!(0, ledger.state().get_last_reader_record_id());
             assert_buffer_records!(ledger, 2);
             assert_reader_writer_v2_file_positions!(ledger, 1, next_writer_file_id);
@@ -557,7 +563,10 @@ async fn reader_deletes_data_file_around_record_id_wraparound() {
             assert!(deleted_data_file.try_assert());
 
             let fourth_record_read = reader.next().await.expect("read should not fail");
-            assert_eq!(fourth_record_read, Some(SizedRecord(fourth_record_size)));
+            assert_eq!(
+                fourth_record_read,
+                Some(SizedRecord::new(fourth_record_size))
+            );
             assert_eq!(1, ledger.state().get_last_reader_record_id());
             assert_buffer_records!(ledger, 1);
             assert_reader_writer_v2_file_positions!(ledger, 1, next_writer_file_id);
@@ -631,7 +640,7 @@ async fn writer_waits_for_reader_after_validate_last_write_fails_and_data_file_s
             let mut writer_file_id = 0;
             while writer_file_id != target_writer_file_id {
                 for _ in 0..2 {
-                    let record = SizedRecord(record_size);
+                    let record = SizedRecord::new(record_size);
                     bytes_written = writer
                         .write_record(record.clone())
                         .await
@@ -708,7 +717,7 @@ async fn writer_waits_for_reader_after_validate_last_write_fails_and_data_file_s
             // The writer correctly reset/marked itself as needing to skip the current data file,
             // but we need to actually attempt a write to drive the logic where it tries to open up
             // the next data file, so we do that here, expecting it to end up blocked on the reader.
-            let mut blocked_write = spawn(writer.write_record(SizedRecord(record_size)));
+            let mut blocked_write = spawn(writer.write_record(SizedRecord::new(record_size)));
 
             while !waiting_on_reader.try_assert() {
                 assert_pending!(blocked_write.poll());
@@ -722,13 +731,13 @@ async fn writer_waits_for_reader_after_validate_last_write_fails_and_data_file_s
             // will move forward, which should allow deleting the first data file, aka "next", which
             // is what the writer is waiting on.
             let first_good_read = reader.next().await.expect("read should not fail");
-            assert_eq!(first_good_read, Some(SizedRecord(record_size)));
+            assert_eq!(first_good_read, Some(SizedRecord::new(record_size)));
             acker.ack(1);
             assert_pending!(blocked_write.poll());
             assert_reader_writer_v2_file_positions!(ledger, next_data_file_id, writer_file_id);
 
             let second_good_read = reader.next().await.expect("read should not fail");
-            assert_eq!(second_good_read, Some(SizedRecord(record_size)));
+            assert_eq!(second_good_read, Some(SizedRecord::new(record_size)));
             acker.ack(1);
             assert_reader_writer_v2_file_positions!(ledger, next_data_file_id + 1, writer_file_id);
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
@@ -344,12 +344,12 @@ impl ReaderModel {
         while self.unconsumed_event_acks > 0 && !self.pending_record_acks.is_empty() {
             let (required_event_acks, record_bytes) =
                 self.pending_record_acks.front().copied().unwrap();
-            if self.unconsumed_event_acks >= required_event_acks {
+            if self.unconsumed_event_acks > 0 {
                 // We have enough unconsumed event acknowledgements to fully acknowledge this
                 // record. Remove it, consume the event acknowledgements, add a record
                 // acknowledgement, and update the buffer size.
                 let _ = self.pending_record_acks.pop_front().unwrap();
-                self.unconsumed_event_acks -= required_event_acks;
+                self.unconsumed_event_acks -= 1;
                 self.unconsumed_record_acks += 1;
 
                 self.ledger.decrement_buffer_size(record_bytes);
@@ -463,7 +463,7 @@ impl ReaderModel {
         // records read vs the number of their events that have been acknowledged, as we only adjust
         // the buffer size when a record has been fully acknowledged, since one record may contain
         // multiple events.
-        self.outstanding_event_acks += event_count;
+        self.outstanding_event_acks += 1;
         self.pending_record_acks
             .push_back((event_count, bytes_read));
 
@@ -472,22 +472,21 @@ impl ReaderModel {
         self.current_file_bytes_read += bytes_read;
     }
 
-    fn acknowledge_reads(&mut self, amount: usize) {
+    fn acknowledge_read(&mut self) {
         // We check to make sure that we're not about to acknowledge more events than we actually
         // have read but have not yet been acknowledged, because that just should be possible.
         assert!(
-            amount <= self.outstanding_event_acks,
-            "invariant violation: {} events unacked, tried to ack {}",
+            self.outstanding_event_acks > 0,
+            "invariant violation: {} events unacked, tried to ack 1",
             self.outstanding_event_acks,
-            amount
         );
 
         // Update the outstanding count of events which have not yet been acknowledged, and also
         // update the total number of acknowledgements we've gotten but have not yet been consumed,
         // as a record may have multiple events and they all need to be acknowledged before we can
         // actually count the record as fully acknowledged and removed from the buffer, etc.
-        self.outstanding_event_acks -= amount;
-        self.unconsumed_event_acks += amount;
+        self.outstanding_event_acks -= 1;
+        self.unconsumed_event_acks += 1;
     }
 }
 
@@ -761,8 +760,8 @@ impl BufferModel {
         self.reader.read_record()
     }
 
-    fn acknowledge_reads(&mut self, amount: usize) {
-        self.reader.acknowledge_reads(amount);
+    fn acknowledge_read(&mut self) {
+        self.reader.acknowledge_read();
     }
 
     fn close_writer(&mut self) {
@@ -830,16 +829,24 @@ proptest! {
             let mut model = BufferModel::from_config(&config);
 
             let usage_handle = BufferUsageHandle::noop();
-            let (writer, reader, acker, ledger) =
+            let (writer, reader, _acker, ledger) =
                 Buffer::<Record>::from_config_inner(config, usage_handle)
                     .await
                     .expect("should not fail to build buffer");
 
-            let mut sequencer = ActionSequencer::new(actions, reader, writer, acker);
+            let mut sequencer = ActionSequencer::new(actions, reader, writer);
 
             let mut closed_writers = false;
 
             loop {
+                // The model runs in a current-thread tokio runtime,
+                // but the acknowledgement handling runs in a
+                // background task. This yields to any such background
+                // task before returning in order to ensure
+                // acknowledgements are fully accounted for before
+                // doing the next operation.
+                tokio::task::yield_now().await;
+
                 // We manully check if the sequencer has any write operations left, either
                 // in-flight or yet-to-be-triggered, and if none are left, we mark the writer
                 // closed.  This allows us to properly inform the model that reads should start
@@ -856,9 +863,9 @@ proptest! {
                 // run against the model.  If it's an action that may be asynchronous/blocked on
                 // progress of another component, we try it later on, which lets us deduplicate some code.
                 if let Some(action) = sequencer.trigger_next_runnable_action() {
-                    if let Action::AcknowledgeRead(amount) = action {
+                    if let Action::AcknowledgeRead = action {
                         // Acknowledgements are based on atomics, so they never wait asynchronously.
-                        model.acknowledge_reads(amount);
+                        model.acknowledge_read();
                     }
                 } else {
                     let mut made_progress = false;

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/record.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/record.rs
@@ -30,7 +30,7 @@ impl fmt::Display for DecodeError {
 
 impl error::Error for DecodeError {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq)]
 pub struct Record {
     id: u32,
     size: u32,
@@ -54,6 +54,12 @@ impl Record {
 
     pub const fn len(&self) -> usize {
         Self::header_len() + self.size as usize
+    }
+}
+
+impl PartialEq for Record {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.size == other.size && self.event_count == other.event_count
     }
 }
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/sequencer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/sequencer.rs
@@ -1,4 +1,4 @@
-use std::{io, mem, task::Poll};
+use std::{collections::VecDeque, io, mem, task::Poll};
 
 use futures::{future::BoxFuture, Future, FutureExt};
 use tokio_test::task::{spawn, Spawn};
@@ -8,7 +8,6 @@ use super::{
     common::{ReaderResult, TestReader, TestWriter, WriterResult},
     record::Record,
 };
-use crate::{Acker, EventCount};
 
 /// A wrapper that can track whether or not a future has already been polled.
 ///
@@ -202,19 +201,17 @@ pub struct ActionSequencer {
     actions: Vec<Action>,
     read_state: ReadState,
     write_state: WriteState,
-    acker: Acker,
-    unacked_events: usize,
+    unacked_events: VecDeque<Record>,
 }
 
 impl ActionSequencer {
     /// Creates a new `ActionSequencer` for the given SUT components.
-    pub fn new(actions: Vec<Action>, reader: TestReader, writer: TestWriter, acker: Acker) -> Self {
+    pub fn new(actions: Vec<Action>, reader: TestReader, writer: TestWriter) -> Self {
         Self {
             actions,
             read_state: ReadState::Idle(reader),
             write_state: WriteState::Idle(writer),
-            acker,
-            unacked_events: 0,
+            unacked_events: Default::default(),
         }
     }
 
@@ -239,7 +236,7 @@ impl ActionSequencer {
         self.actions.iter().position(|a| match a {
             Action::WriteRecord(_) | Action::FlushWrites => allow_write,
             Action::ReadRecord => allow_read,
-            Action::AcknowledgeRead(amount) => self.unacked_events >= *amount,
+            Action::AcknowledgeRead => !self.unacked_events.is_empty(),
         })
     }
 
@@ -289,10 +286,9 @@ impl ActionSequencer {
                     self.read_state.transition_to_read();
                     Some(a)
                 }
-                Action::AcknowledgeRead(amount) => {
-                    self.unacked_events -= amount;
-                    self.acker.ack(amount);
-                    Some(Action::AcknowledgeRead(amount))
+                Action::AcknowledgeRead => {
+                    drop(self.unacked_events.pop_front().expect("FIXME"));
+                    Some(Action::AcknowledgeRead)
                 }
             }
         } else {
@@ -382,7 +378,7 @@ impl ActionSequencer {
                         Poll::Ready((reader, result)) => {
                             // If a record was actually read back, track it as an unacknowledged read.
                             if let Ok(Some(record)) = &result {
-                                self.unacked_events += record.event_count();
+                                self.unacked_events.push_back(record.clone());
                             }
 
                             (

--- a/lib/vector-buffers/src/variants/disk_v2/tests/record.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/record.rs
@@ -13,7 +13,7 @@ async fn roundtrip_through_record_writer_and_record_reader() {
     let mut record_writer = RecordWriter::new(writer_io, 0, 16_384, u64::MAX, 2048);
     let mut record_reader = RecordReader::new(reader_io);
 
-    let record = SizedRecord(73);
+    let record = SizedRecord::new(73);
 
     let (bytes_written, flush_result) = record_writer
         .write_record(314, record.clone())

--- a/lib/vector-common/src/finalization.rs
+++ b/lib/vector-common/src/finalization.rs
@@ -48,6 +48,9 @@ impl ByteSizeOf for EventFinalizers {
 }
 
 impl EventFinalizers {
+    /// Default empty finalizer set for use in `const` contexts.
+    pub const DEFAULT: Self = Self(Vec::new());
+
     /// Creates a new `EventFinalizers` based on the given event finalizer.
     #[must_use]
     pub fn new(finalizer: EventFinalizer) -> Self {

--- a/lib/vector-common/src/finalizer.rs
+++ b/lib/vector-common/src/finalizer.rs
@@ -30,6 +30,7 @@ pub type UnorderedFinalizer<T> = FinalizerSet<T, FuturesUnordered<FinalizerFutur
 /// stream of acknowledgements that comes out, extracting just the
 /// identifier and sending that into the returned stream. The type `T`
 /// is the source-specific data associated with each entry.
+#[derive(Debug)]
 pub struct FinalizerSet<T, S> {
     sender: Option<UnboundedSender<(BatchStatusReceiver, T)>>,
     _phantom: PhantomData<S>,


### PR DESCRIPTION
The current disk buffer implementation uses an explicit `Acker` to indicate when events have completed the delivery process. This acker effectively duplicates the implicit logic happening automatically with event finalization, but with added bugs due to the manual nature of the process. This PR replaces the acking logic within the disk buffers with the adding a finalizer and using the `OrderedFinalizer` to return them in sequential order.

This is the first half of #13023, with the removal of the acker logic to follow in a separate PR. Note that this should not be merged before #13020 is finished.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
