### PR TITLE
feat(vrl): add `filter` enumeration function

### DIFF
--- a/lib/vrl/compiler/src/function/closure.rs
+++ b/lib/vrl/compiler/src/function/closure.rs
@@ -158,16 +158,15 @@ where
     /// Run the closure to completion, given the provided key/value pair, and
     /// the runtime context.
     ///
-    /// The provided values are *NOT* mutated during the run, and no return
-    /// value is provided by this method. See `map_key` or `map_value` for
-    /// mutating alternatives.
+    /// The provided values are *NOT* mutated during the run. See `map_key` or
+    /// `map_value` for mutating alternatives.
     pub fn run_key_value(
         &self,
         ctx: &mut Context,
         key: &str,
         value: &Value,
-    ) -> Result<(), ExpressionError> {
-        // TODO: we need to allow `LocalEnv` to take a muable reference to
+    ) -> Result<Value, ExpressionError> {
+        // TODO: we need to allow `LocalEnv` to take a mutable reference to
         // values, instead of owning them.
         let cloned_key = key.to_owned();
         let cloned_value = value.clone();
@@ -178,27 +177,26 @@ where
         let old_key = insert(ctx.state_mut(), key_ident, cloned_key.into());
         let old_value = insert(ctx.state_mut(), value_ident, cloned_value);
 
-        (self.runner)(ctx)?;
+        let value = (self.runner)(ctx)?;
 
         cleanup(ctx.state_mut(), key_ident, old_key);
         cleanup(ctx.state_mut(), value_ident, old_value);
 
-        Ok(())
+        Ok(value)
     }
 
     /// Run the closure to completion, given the provided index/value pair, and
     /// the runtime context.
     ///
-    /// The provided values are *NOT* mutated during the run, and no return
-    /// value is provided by this method. See `map_key` or `map_value` for
-    /// mutating alternatives.
+    /// The provided values are *NOT* mutated during the run. See `map_key` or
+    /// `map_value` for mutating alternatives.
     pub fn run_index_value(
         &self,
         ctx: &mut Context,
         index: usize,
         value: &Value,
-    ) -> Result<(), ExpressionError> {
-        // TODO: we need to allow `LocalEnv` to take a muable reference to
+    ) -> Result<Value, ExpressionError> {
+        // TODO: we need to allow `LocalEnv` to take a mutable reference to
         // values, instead of owning them.
         let cloned_value = value.clone();
 
@@ -208,12 +206,12 @@ where
         let old_index = insert(ctx.state_mut(), index_ident, index.into());
         let old_value = insert(ctx.state_mut(), value_ident, cloned_value);
 
-        (self.runner)(ctx)?;
+        let value = (self.runner)(ctx)?;
 
         cleanup(ctx.state_mut(), index_ident, old_index);
         cleanup(ctx.state_mut(), value_ident, old_value);
 
-        Ok(())
+        Ok(value)
     }
 
     /// Run the closure to completion, given the provided key, and the runtime
@@ -224,7 +222,7 @@ where
     ///
     /// See `run_key_value` and `run_index_value` for immutable alternatives.
     pub fn map_key(&self, ctx: &mut Context, key: &mut String) -> Result<(), ExpressionError> {
-        // TODO: we need to allow `LocalEnv` to take a muable reference to
+        // TODO: we need to allow `LocalEnv` to take a mutable reference to
         // values, instead of owning them.
         let cloned_key = key.clone();
         let ident = self.ident(0);
@@ -245,7 +243,7 @@ where
     ///
     /// See `run_key_value` and `run_index_value` for immutable alternatives.
     pub fn map_value(&self, ctx: &mut Context, value: &mut Value) -> Result<(), ExpressionError> {
-        // TODO: we need to allow `LocalEnv` to take a muable reference to
+        // TODO: we need to allow `LocalEnv` to take a mutable reference to
         // values, instead of owning them.
         let cloned_value = value.clone();
         let ident = self.ident(0);

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -72,6 +72,11 @@ impl TypeDef {
         &self.kind
     }
 
+    #[must_use]
+    pub fn kind_mut(&mut self) -> &mut Kind {
+        &mut self.kind
+    }
+
     pub fn at_path(&self, path: &Lookup<'_>) -> TypeDef {
         let fallible = self.fallible;
 

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -90,6 +90,7 @@ default = [
     "encrypt",
     "ends_with",
     "exists",
+    "filter",
     "find",
     "flatten",
     "float",
@@ -225,6 +226,7 @@ encode_percent = ["dep:percent-encoding"]
 encrypt = ["cryptography", "random_bytes", "decrypt"]
 ends_with = []
 exists = []
+filter = []
 find = ["dep:regex"]
 find_table_row = []
 flatten = []

--- a/lib/vrl/stdlib/src/filter.rs
+++ b/lib/vrl/stdlib/src/filter.rs
@@ -1,0 +1,142 @@
+use ::value::{kind::Collection, Value};
+use vrl::prelude::*;
+
+fn filter<T>(value: Value, ctx: &mut Context, runner: closure::Runner<T>) -> Resolved
+where
+    T: Fn(&mut Context) -> Resolved,
+{
+    match value {
+        Value::Object(object) => object
+            .into_iter()
+            .filter_map(
+                |(key, value)| match runner.run_key_value(ctx, &key, &value) {
+                    Ok(v) => v
+                        .as_boolean()
+                        .expect("compiler guarantees boolean return type")
+                        .then(|| Ok((key, value))),
+                    Err(err) => Some(Err(err)),
+                },
+            )
+            .collect::<Result<BTreeMap<_, _>>>()
+            .map(Into::into),
+
+        Value::Array(array) => array
+            .into_iter()
+            .enumerate()
+            .filter_map(
+                |(index, value)| match runner.run_index_value(ctx, index, &value) {
+                    Ok(v) => v
+                        .as_boolean()
+                        .expect("compiler guarantees boolean return type")
+                        .then(|| Ok(value)),
+                    Err(err) => Some(Err(err)),
+                },
+            )
+            .collect::<Result<Vec<_>>>()
+            .map(Into::into),
+
+        _ => unreachable!("function requires collection types as input"),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Filter;
+
+impl Function for Filter {
+    fn identifier(&self) -> &'static str {
+        "filter"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::OBJECT | kind::ARRAY,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "filter object",
+                source: r#"filter({ "a": 1, "b": 2 }) -> |key, _value| { key == "a" }"#,
+                result: Ok(r#"{ "a": 1 }"#),
+            },
+            Example {
+                title: "filter array",
+                source: r#"filter([1, 2]) -> |_index, value| { value < 2 }"#,
+                result: Ok("[1]"),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        _ctx: &mut FunctionCompileContext,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        let closure = arguments.required_closure()?;
+
+        Ok(Box::new(FilterFn { value, closure }))
+    }
+
+    fn closure(&self) -> Option<closure::Definition> {
+        use closure::{Definition, Input, Output, Variable, VariableKind};
+
+        Some(Definition {
+            inputs: vec![Input {
+                parameter_keyword: "value",
+                kind: Kind::object(Collection::any()).or_array(Collection::any()),
+                variables: vec![
+                    Variable {
+                        kind: VariableKind::TargetInnerKey,
+                    },
+                    Variable {
+                        kind: VariableKind::TargetInnerValue,
+                    },
+                ],
+                output: Output::Kind(Kind::boolean()),
+                example: Example {
+                    title: "filter array",
+                    source: r#"filter([1, 2]) -> |index, _value| { index == 0 }"#,
+                    result: Ok("[1]"),
+                },
+            }],
+            is_iterator: true,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FilterFn {
+    value: Box<dyn Expression>,
+    closure: FunctionClosure,
+}
+
+impl Expression for FilterFn {
+    fn resolve(&self, ctx: &mut Context) -> Result<Value> {
+        let value = self.value.resolve(ctx)?;
+        let FunctionClosure { variables, block } = &self.closure;
+        let runner = closure::Runner::new(variables, |ctx| block.resolve(ctx));
+
+        filter(value, ctx, runner)
+    }
+
+    fn type_def(&self, ctx: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
+        let mut type_def = self.value.type_def(ctx);
+
+        // erase any type information from the array or object, as we can't know
+        // which elements are removed at runtime.
+        if type_def.contains_array() {
+            type_def.kind_mut().add_array(Collection::any());
+        }
+
+        if type_def.contains_object() {
+            type_def.kind_mut().add_object(Collection::any());
+        }
+
+        type_def
+    }
+}

--- a/lib/vrl/stdlib/src/for_each.rs
+++ b/lib/vrl/stdlib/src/for_each.rs
@@ -9,7 +9,7 @@ where
         match item {
             IterItem::KeyValue(key, value) => runner.run_key_value(ctx, key, value)?,
             IterItem::IndexValue(index, value) => runner.run_index_value(ctx, index, value)?,
-            IterItem::Value(_) => {}
+            IterItem::Value(_) => continue,
         };
     }
 

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -70,6 +70,8 @@ mod encrypt;
 mod ends_with;
 #[cfg(feature = "exists")]
 mod exists;
+#[cfg(feature = "filter")]
+mod filter;
 #[cfg(feature = "find")]
 mod find;
 #[cfg(feature = "flatten")]
@@ -343,6 +345,8 @@ pub use encrypt::Encrypt;
 pub use ends_with::EndsWith;
 #[cfg(feature = "exists")]
 pub use exists::Exists;
+#[cfg(feature = "filter")]
+pub use filter::Filter;
 #[cfg(feature = "find")]
 pub use find::Find;
 #[cfg(feature = "flatten")]
@@ -616,6 +620,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(EndsWith),
         #[cfg(feature = "exists")]
         Box::new(Exists),
+        #[cfg(feature = "filter")]
+        Box::new(Filter),
         #[cfg(feature = "find")]
         Box::new(Find),
         #[cfg(feature = "flatten")]

--- a/website/cue/reference/remap/functions/filter.cue
+++ b/website/cue/reference/remap/functions/filter.cue
@@ -1,0 +1,52 @@
+package metadata
+
+remap: functions: filter: {
+	category:    "Enumerate"
+	description: """
+		Filter elements from a collection.
+
+		This function currently *does not* support recursive iteration.
+		If you have a need for recursive iteration using `filter`, then
+		[please let us know](\(urls.new_feature_request))!
+
+		The function uses the "function closure syntax" to allow reading
+		the key/value or index/value combination for each item in the
+		collection.
+
+		The same scoping rules apply to closure blocks as they do for
+		regular blocks, meaning, any variable defined in parent scopes
+		are accessible, and mutations to those variables are preserved,
+		but any new variables instantiated in the closure block are
+		unavailable outside of the block.
+
+		Check out the examples below to learn about the closure syntax.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The array or object to filter."
+			required:    true
+			type: ["array", "object"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["array", "object"]
+	}
+	examples: [
+		{
+			title: "Filter elements"
+			input: log: {
+				tags: ["foo", "bar", "foo", "baz"]
+			}
+			source: #"""
+				filter(array!(.tags)) -> |_index, value| {
+				    # remove any elements that aren't equal to "foo"
+				    value != "foo"
+				}
+				"""#
+			return: ["bar", "baz"]
+		},
+	]
+}


### PR DESCRIPTION
This PR adds a new enumeration function **filter**, allowing operators to remove elements from objects or arrays.



Here's one example of using this function, to remove specific fields.

```coffee
.kubernetes.pod_annotations = filter(.kubernetes.pod_annotations) { |key, _value|
    !starts_with(key, "checksum")
}
```

The function currently _does not_ support recursively iterating, but we could add that in the future, if there's enough demand.