### PR TITLE
docs(external docs): add highlight about VRL assignment breaking change

### DIFF
--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -2,7 +2,7 @@
 date: "2022-06-16"
 title: "0.23 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.23.0"
-authors: ["akx", "jszwedko", "spencergilbert", "fuchsnj", "pablosichert"]
+authors: ["akx", "jszwedko", "spencergilbert", "fuchsnj", "pablosichert", "JeanMertz"]
 release: "0.23.0"
 hide_on_release_notes: false
 badges:
@@ -109,8 +109,6 @@ As suggested, you have a few options to solve errors like this.
 the expected type. You can call it as `string!` to abort if it's not the right type.
 3. Provide a default value if the function fails using the "error coalescing" operator (`??`), such as `to_string(msg) ?? "default"`
 4. Handle the error manually by capturing both the return value and possible error, such as `result, err = to_string(msg)`
-
-
 
 #### "remove_empty" option dropped from VRL's `parse_grok` and `parse_groks` {#vrl-parse_grok}
 
@@ -233,7 +231,7 @@ And the `syslog` source returned:
 }
 ```
 
-The previous `parse_syslog` behavior can be acheived by running the result through the `flatten`
+The previous `parse_syslog` behavior can be achieved by running the result through the `flatten`
 function like:
 
 ```coffeescript

--- a/website/content/en/highlights/2022-07-05-0-24-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-07-05-0-24-0-upgrade-guide.md
@@ -30,7 +30,7 @@ foo.bar = 3.14
 
 This is now rejected, and instead returns a compiler error:
 
-```
+```text
 error[E642]: parent path segment rejects this mutation
   ┌─ :1:5
   │

--- a/website/content/en/highlights/2022-07-05-0-24-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-07-05-0-24-0-upgrade-guide.md
@@ -1,0 +1,62 @@
+---
+date: "2022-07-05"
+title: "0.24 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.24.0"
+authors: ["JeanMertz"]
+release: "0.24.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.24.0 release includes **breaking changes**:
+
+1. [VRL rejects querying non-collection types on assignment](#vrl-query-assignment)
+
+We cover them below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Breaking changes
+
+#### [VRL rejects querying non-collection types on assignment] {#vrl-query-assignment}
+
+Previously, the following would work:
+
+```coffee
+foo = 42
+foo.bar = 3.14
+```
+
+This is now rejected, and instead returns a compiler error:
+
+```
+error[E642]: parent path segment rejects this mutation
+  ┌─ :1:5
+  │
+1 │ foo.bar = 3.14
+  │ --- ^^^ querying a field of a non-object type is unsupported
+  │ │
+  │ this path resolves to a value of type integer
+  │
+  = try: change parent value to object, before assignment
+  =
+  =     foo = {}
+  =     foo.bar = 3.14
+  =
+  = see documentation about error handling at https://errors.vrl.dev/#handling
+  = see language documentation at https://vrl.dev
+```
+
+This change was made to prevent accidentally overwriting non-collection types.
+As the diagnostic message suggests, you can still achieve the desired result by
+first re-writing the non-collection type to a collection type (`foo = {}`), and
+then mutating the collection itself.
+
+This change applies to both objects and arrays, so this example is also
+disallowed:
+
+```coffee
+foo = 42
+foo[0] = 3.14
+```


### PR DESCRIPTION
Adds a missing upgrade note for the breaking change introduced in #13317.