### PR TITLE
enhancement(file source): Add optional byte offset to file source events

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -240,7 +240,7 @@ where
                 let start = time::Instant::now();
                 let mut bytes_read: usize = 0;
                 while let Ok(Some(line)) = watcher.read_line() {
-                    let sz = line.len();
+                    let sz = line.bytes.len();
                     trace!(
                         message = "Read bytes.",
                         path = ?watcher.path,
@@ -251,10 +251,11 @@ where
                     bytes_read += sz;
 
                     lines.push(Line {
-                        text: line,
+                        text: line.bytes,
                         filename: watcher.path.to_str().expect("not a valid path").to_owned(),
                         file_id,
-                        offset: watcher.get_file_position(),
+                        start_offset: line.offset,
+                        end_offset: watcher.get_file_position(),
                     });
 
                     if bytes_read > self.max_read_bytes {
@@ -515,5 +516,6 @@ pub struct Line {
     pub text: Bytes,
     pub filename: String,
     pub file_id: FileFingerprint,
-    pub offset: u64,
+    pub start_offset: u64,
+    pub end_offset: u64,
 }

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -16,6 +16,17 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
+/// The `RawLine` struct is a thin wrapper around the bytes that have been read
+/// in order to retain the context of where in the file they have been read from.
+///
+/// The offset field contains the byte offset of the beginning of the line within
+/// the file that it was read from.
+#[derive(Debug)]
+pub struct RawLine {
+    pub offset: u64,
+    pub bytes: Bytes,
+}
+
 /// The `FileWatcher` struct defines the polling based state machine which reads
 /// from a file path, transparently updating the underlying file descriptor when
 /// the file has been rolled over, as is common for logs.
@@ -188,11 +199,12 @@ impl FileWatcher {
     /// This function will attempt to read a new line from its file, blocking,
     /// up to some maximum but unspecified amount of time. `read_line` will open
     /// a new file handler as needed, transparently to the caller.
-    pub fn read_line(&mut self) -> io::Result<Option<Bytes>> {
+    pub fn read_line(&mut self) -> io::Result<Option<RawLine>> {
         self.track_read_attempt();
 
         let reader = &mut self.reader;
         let file_position = &mut self.file_position;
+        let initial_position = *file_position;
         match read_until_with_max_size(
             reader,
             file_position,
@@ -202,7 +214,10 @@ impl FileWatcher {
         ) {
             Ok(Some(_)) => {
                 self.track_read_success();
-                Ok(Some(self.buf.split().freeze()))
+                Ok(Some(RawLine {
+                    offset: initial_position,
+                    bytes: self.buf.split().freeze(),
+                }))
             }
             Ok(None) => {
                 if !self.file_findable() {
@@ -215,7 +230,10 @@ impl FileWatcher {
                         // EOF
                         Ok(None)
                     } else {
-                        Ok(Some(buf))
+                        Ok(Some(RawLine {
+                            offset: initial_position,
+                            bytes: buf,
+                        }))
                     }
                 } else {
                     Ok(None)

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -22,7 +22,7 @@ mod tests;
 /// The offset field contains the byte offset of the beginning of the line within
 /// the file that it was read from.
 #[derive(Debug)]
-pub struct RawLine {
+pub(super) struct RawLine {
     pub offset: u64,
     pub bytes: Bytes,
 }
@@ -199,7 +199,7 @@ impl FileWatcher {
     /// This function will attempt to read a new line from its file, blocking,
     /// up to some maximum but unspecified amount of time. `read_line` will open
     /// a new file handler as needed, transparently to the caller.
-    pub fn read_line(&mut self) -> io::Result<Option<RawLine>> {
+    pub(super) fn read_line(&mut self) -> io::Result<Option<RawLine>> {
         self.track_read_attempt();
 
         let reader = &mut self.reader;

--- a/lib/file-source/src/file_watcher/tests/experiment.rs
+++ b/lib/file-source/src/file_watcher/tests/experiment.rs
@@ -95,7 +95,7 @@ fn experiment(actions: Vec<FileWatcherAction>) {
                         Err(_) => {
                             unreachable!();
                         }
-                        Ok(Some(line)) if line.is_empty() => {
+                        Ok(Some(line)) if line.bytes.is_empty() => {
                             attempts -= 1;
                             continue;
                         }

--- a/lib/file-source/src/file_watcher/tests/experiment_no_truncations.rs
+++ b/lib/file-source/src/file_watcher/tests/experiment_no_truncations.rs
@@ -62,7 +62,7 @@ fn experiment_no_truncations(actions: Vec<FileWatcherAction>) {
                         Err(_) => {
                             unreachable!();
                         }
-                        Ok(Some(line)) if line.is_empty() => {
+                        Ok(Some(line)) if line.bytes.is_empty() => {
                             attempts -= 1;
                             assert!(fwfiles[read_index].read_line().is_none());
                             continue;
@@ -74,7 +74,7 @@ fn experiment_no_truncations(actions: Vec<FileWatcherAction>) {
                         }
                         Ok(Some(line)) => {
                             let exp = fwfiles[read_index].read_line().expect("could not readline");
-                            assert_eq!(exp.into_bytes(), line);
+                            assert_eq!(exp.into_bytes(), line.bytes);
                             // assert_eq!(sz, buf.len() + 1);
                             break;
                         }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -544,8 +544,15 @@ pub fn file_source(
         let span2 = span.clone();
         let mut messages = messages.map(move |line| {
             let _enter = span2.enter();
-            let mut event =
-                create_event(line.text, &line.filename, &line.offset, &host_key, &hostname, &file_key, &offset_key);
+            let mut event = create_event(
+                line.text,
+                &line.filename,
+                &line.offset,
+                &host_key,
+                &hostname,
+                &file_key,
+                &offset_key,
+            );
             if let Some(finalizer) = &finalizer {
                 let (batch, receiver) = BatchNotifier::new_with_receiver();
                 event = event.with_batch_notifier(&batch);
@@ -630,7 +637,7 @@ fn create_event(
     host_key: &str,
     hostname: &Option<String>,
     file_key: &Option<String>,
-    offset_key: &Option<String>
+    offset_key: &Option<String>,
 ) -> LogEvent {
     let line_len = line.len();
 
@@ -810,7 +817,15 @@ mod tests {
         let file_key = Some("file".to_string());
         let offset_key = Some("offset".to_string());
 
-        let log = create_event(line, file, &line_end_offset, &host_key, &hostname, &file_key, &offset_key);
+        let log = create_event(
+            line,
+            file,
+            &line_end_offset,
+            &host_key,
+            &hostname,
+            &file_key,
+            &offset_key,
+        );
 
         assert_eq!(log["file"], file.into());
         assert_eq!(log["host"], "Some.Machine".into());

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -824,11 +824,13 @@ mod tests {
         let hostname = Some("Some.Machine".to_string());
         let file_key = Some("file".to_string());
         let offset_key = Some("offset".to_string());
+        let line_delimiter_len: usize = 1;
 
         let log = create_event(
             line,
             file,
             line_end_offset,
+            line_delimiter_len,
             &host_key,
             &hostname,
             &file_key,

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -659,7 +659,7 @@ fn create_event(line: Bytes, offset: u64, file: &str, meta: &EventMetadata) -> L
     event.insert(log_schema().source_type_key(), Bytes::from("file"));
 
     if let Some(offset_key) = &meta.offset_key {
-        event.insert(offset_key.as_str(), offset.to_string());
+        event.insert(offset_key.as_str(), offset);
     }
 
     if let Some(file_key) = &meta.file_key {
@@ -832,7 +832,7 @@ mod tests {
 
         assert_eq!(log["file"], file.into());
         assert_eq!(log["host"], "Some.Machine".into());
-        assert_eq!(log["offset"], "0".into());
+        assert_eq!(log["offset"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
         assert_eq!(log[log_schema().source_type_key()], "file".into());
     }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -547,7 +547,7 @@ pub fn file_source(
             let mut event = create_event(
                 line.text,
                 &line.filename,
-                &line.offset,
+                line.offset,
                 &host_key,
                 &hostname,
                 &file_key,
@@ -633,7 +633,7 @@ fn wrap_with_line_agg(
 fn create_event(
     line: Bytes,
     file: &str,
-    line_end_offset: &u64,
+    line_end_offset: u64,
     host_key: &str,
     hostname: &Option<String>,
     file_key: &Option<String>,
@@ -810,8 +810,12 @@ mod tests {
     fn file_create_event() {
         let line = Bytes::from("hello world");
         let file = "some_file.rs";
-        // Internal offset is indexed from 1
-        let line_end_offset: u64 = 11;
+
+        // Internal offset is the end of the line including the newline char,
+        // whereas the `line` variable contains the line with the newline stripped.
+        // So 11 characters in `line` -> internal offset is 12 including the newline.
+        let line_end_offset: u64 = 12;
+
         let host_key = "host".to_string();
         let hostname = Some("Some.Machine".to_string());
         let file_key = Some("file".to_string());
@@ -820,7 +824,7 @@ mod tests {
         let log = create_event(
             line,
             file,
-            &line_end_offset,
+            line_end_offset,
             &host_key,
             &hostname,
             &file_key,

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -407,6 +407,7 @@ pub fn file_source(
         None => Bytes::from(config.line_delimiter.clone()),
     };
 
+    let line_delimiter_len = line_delimiter_as_bytes.len();
     let checkpointer = Checkpointer::new(&data_dir);
     let file_server = FileServer {
         paths_provider,
@@ -548,6 +549,7 @@ pub fn file_source(
                 line.text,
                 &line.filename,
                 line.offset,
+                line_delimiter_len,
                 &host_key,
                 &hostname,
                 &file_key,
@@ -630,10 +632,12 @@ fn wrap_with_line_agg(
     )
 }
 
+
 fn create_event(
     line: Bytes,
     file: &str,
     line_end_offset: u64,
+    line_delimiter_len: usize,
     host_key: &str,
     hostname: &Option<String>,
     file_key: &Option<String>,
@@ -653,7 +657,7 @@ fn create_event(
     event.insert(log_schema().source_type_key(), Bytes::from("file"));
 
     if let Some(offset_key) = &offset_key {
-        let line_start_offset: u64 = line_end_offset - line_len as u64 - 1;
+        let line_start_offset: u64 = line_end_offset - line_len as u64 - line_delimiter_len as u64;
         event.insert(offset_key.as_str(), line_start_offset.to_string());
     }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -823,12 +823,12 @@ mod tests {
         let offset: u64 = 0;
 
         let meta = EventMetadata {
-            host_key: host_key,
-            hostname: hostname,
-            file_key: file_key,
-            offset_key: offset_key,
+            host_key,
+            hostname,
+            file_key,
+            offset_key,
         };
-        let log = create_event(line, offset, &file, &meta);
+        let log = create_event(line, offset, file, &meta);
 
         assert_eq!(log["file"], file.into());
         assert_eq!(log["host"], "Some.Machine".into());

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -515,7 +515,7 @@ impl Source {
                 }
             }
 
-            checkpoints.update(line.file_id, line.offset);
+            checkpoints.update(line.file_id, line.end_offset);
             event
         });
         let events = events.flat_map(move |event| {

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -197,7 +197,7 @@ components: sources: file: {
 			required:    false
 			type: string: {
 				default: null
-				examples: "offset"
+				examples: ["offset"]
 			}
 		}
 		oldest_first: {

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -190,6 +190,16 @@ components: sources: file: {
 				unit: "bytes"
 			}
 		}
+		offset_key: {
+			category:    "Context"
+			common:      false
+			description: "Enables adding the byte offset within the file of the start of each line to each event and sets the name of the log field used. Off by default, the offset is only added to the event if this is set."
+			required:    false
+			type: string: {
+				default: null
+				examples: "offset"
+			}
+		}
 		oldest_first: {
 			category:    "Reading"
 			common:      false


### PR DESCRIPTION
Motivation: If an application produces log lines faster than the resolution of the timestamp used additional information is needed to maintain ordering, and form part of a unique document id used in downstream services such as Elasticsearch.

Off by default, turned on by setting a value in config for `offset_key`.

This addresses issue #6633.
