### PR TITLE
docs: updated highlights regarding u64 bucket counts.

### DIFF
--- a/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-23-0-23-0-upgrade-guide.md
@@ -19,6 +19,7 @@ Vector's 0.23.0 release includes **breaking changes**:
 6. [VRL conditions are now checked for mutations at compile time](#read_only_check)
 7. [`syslog` source and VRL's `parse_syslog` structured data fields made consistent](#parse-syslog)
 8. [VRL VM beta runtime removed](#vrl-vm-removed)
+9. [Metric bucket counts are now u64](#metric-buckets)
 
 We cover them below to help you upgrade quickly:
 
@@ -218,3 +219,22 @@ The experimental VM runtime for VRL-based components has been removed. The
 stable AST runtime remains in place, and is now nearly identical in performance
 to the VM runtime. If you have `runtime = "vm"` configured in your config, you
 need to remove it to avoid Vector from erroring on startup.
+
+#### [Metric bucket counts are now u64] {#metric-buckets}
+
+The field storing metric bucket counts for Histogram metrics has now been upgraded
+to use 64 bits from 32 bits. This allows for much larger bucket sizes to be used. To
+facilitate this we have updated the proto files that determine how an event is
+persisted. Newer versions of Vector will be able to read older versions of metrics,
+but older versions of Vector may not be able to read newer versions of metrics.
+
+This has two potential implications that you should consider.
+
+1. Disk buffers should be backed up if you want to be able to roll back to an older
+   Vector version since new disk buffer entries may not be readable by older Vector
+   versions. The disk buffers location can be found under the
+   [Vector data directory](https://vector.dev/docs/reference/configuration/global-options/#data_dir).
+
+2. When upgrading Vector to Vector instances make sure you upgrade the consumers first
+   followed by the producers to ensure newer versions of Vector aren't sending data
+   to older versions.


### PR DESCRIPTION
Ref #12043

This adds a highlight about upgrading to v23 regarding the u32 -> u64 bucket size metric change. #13318 

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

