### PR TITLE
fix(datadog_archives) fix typo in error msg

### DIFF
--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -209,7 +209,7 @@ impl DatadogArchivesSinkConfig {
                 let azure_config = self
                     .azure_blob
                     .as_ref()
-                    .expect("azire blob config wasn't provided");
+                    .expect("azure blob config wasn't provided");
                 let client = azure_common::config::build_client(
                     Some(azure_config.connection_string.clone()),
                     None,


### PR DESCRIPTION
Fix a tiny typo in the datadog_archives sink for a missing Azure config
