### PR TITLE
fix(websocket sink, pulsar sink): Fix superfluous `flatten` attribute in `encoding` key

### DIFF
--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -48,7 +48,6 @@ pub struct PulsarSinkConfig {
     #[serde(alias = "address")]
     endpoint: String,
     topic: String,
-    #[serde(flatten)]
     pub encoding:
         EncodingConfigAdapter<EncodingConfig<StandardEncodings>, StandardEncodingsMigrator>,
     auth: Option<AuthConfig>,

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -17,7 +17,6 @@ use crate::{
 pub struct WebSocketSinkConfig {
     pub uri: String,
     pub tls: Option<TlsEnableableConfig>,
-    #[serde(flatten)]
     pub encoding:
         EncodingConfigAdapter<EncodingConfig<StandardEncodings>, StandardEncodingsMigrator>,
     pub ping_interval: Option<u64>,


### PR DESCRIPTION
Closes #13444.