### PR TITLE
chore(core): Reimplement finalizer stream using `async-stream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8544,6 +8544,7 @@ dependencies = [
 name = "vector_common"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "bytes 1.1.0",
  "chrono",
  "chrono-tz",

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -43,6 +43,7 @@ tokenize = [
 ]
 
 [dependencies]
+async-stream = "0.3.3"
 bytes = { version = "1.1.0", default-features = false, optional = true }
 chrono-tz = "0.6.1"
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -59,11 +59,11 @@ serde = { version = "1.0.138", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false }
 snafu = { version = "0.7", optional = true }
 stream-cancel = { version = "0.8.1", default-features = false }
-tokio = { version = "1.19.2", default-features = false, features = ["time"] }
+tokio = { version = "1.19.2", default-features = false, features = ["macros", "time"] }
 tracing = { version = "0.1.34", default-features = false }
 value = { path = "../value", features = ["json"] }
 vector_config = { path = "../vector-config" }
 
 [dev-dependencies]
 futures = { version = "0.3.21", default-features = false, features = ["async-await", "std"] }
-tokio = { version = "1.19.2", default-features = false, features = ["macros", "rt", "time"] }
+tokio = { version = "1.19.2", default-features = false, features = ["rt", "time"] }


### PR DESCRIPTION
The (un)ordered finalizer framework was initially implemented as an
async loop that was spawned as a separate task. It was later converted
to return a stream of finalizers to allow callers to use that stream
within the same task as the source. This was a manual implementation of
the `Stream` trait.

This change converts that manual implementation back to the same form as
the original implementation using the `async_stream::stream` macro. This
is being done to prepare for the reintegration of the "flush" mechanism
required by the kafka source rebalance fix (#10434).

(Review note: unified diff mode is likely useless for this PR)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
