### PR TITLE
enhancement(vrl): Optimize error in VRL `??` operator

### DIFF
--- a/lib/vrl/compiler/src/context.rs
+++ b/lib/vrl/compiler/src/context.rs
@@ -6,6 +6,12 @@ pub struct Context<'a> {
     target: &'a mut dyn Target,
     state: &'a mut Runtime,
     timezone: &'a TimeZone,
+    /// If this value is `true`, the error can be discarded since it's not read by the parent
+    /// expression.
+    ///
+    /// This allows for some optimizations to construct cheaper `Err` values, e.g. in the left hand
+    /// side of the `??` operator.
+    discard_error: bool,
 }
 
 impl<'a> Context<'a> {
@@ -15,6 +21,7 @@ impl<'a> Context<'a> {
             target,
             state,
             timezone,
+            discard_error: false,
         }
     }
 
@@ -40,9 +47,20 @@ impl<'a> Context<'a> {
         self.state
     }
 
-    /// Get a reference to the [`TimeZone`]
+    /// Get a reference to the [`TimeZone`].
     #[must_use]
     pub fn timezone(&self) -> &TimeZone {
         self.timezone
+    }
+
+    /// Probe if errors should be discarded in this `Context`.
+    #[must_use]
+    pub fn discard_error(&self) -> bool {
+        self.discard_error
+    }
+
+    /// Set if errors should be discarded in this `Context`.
+    pub fn set_discard_error(&mut self, discard_error: bool) {
+        self.discard_error = discard_error;
     }
 }

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -83,7 +83,15 @@ impl Expression for Op {
         use value::Value::{Boolean, Null};
 
         match self.opcode {
-            Err => return self.lhs.resolve(ctx).or_else(|_| self.rhs.resolve(ctx)),
+            Err => {
+                return {
+                    let discard_error = ctx.discard_error();
+                    ctx.set_discard_error(true);
+                    let lhs_resolved = self.lhs.resolve(ctx);
+                    ctx.set_discard_error(discard_error);
+                    lhs_resolved.or_else(|_| self.rhs.resolve(ctx))
+                }
+            }
             Or => {
                 return self
                     .lhs

--- a/lib/vrl/stdlib/src/string.rs
+++ b/lib/vrl/stdlib/src/string.rs
@@ -1,10 +1,16 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-fn string(value: Value) -> Resolved {
+fn string(value: Value, discard_error: bool) -> Resolved {
     match value {
         v @ Value::Bytes(_) => Ok(v),
-        v => Err(format!("expected string, got {}", v.kind()).into()),
+        v => {
+            if discard_error {
+                Err("".into())
+            } else {
+                Err(format!("expected string, got {}", v.kind()).into())
+            }
+        }
     }
 }
 
@@ -60,7 +66,7 @@ struct StringFn {
 
 impl Expression for StringFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
-        string(self.value.resolve(ctx)?)
+        string(self.value.resolve(ctx)?, ctx.discard_error())
     }
 
     fn type_def(&self, state: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {


### PR DESCRIPTION
When using the `??` operator, the expression on the left hand side can discard its error, since it's never read.