### PR TITLE
docs(config): Add highlight for secrets management

### DIFF
--- a/website/content/en/highlights/2022-07-07-secrets-management.md
+++ b/website/content/en/highlights/2022-07-07-secrets-management.md
@@ -1,0 +1,62 @@
+---
+date: "2022-07-07"
+title: "Load secrets into Vector"
+description: "A new mechanism to load secrets into Vector from an external process"
+authors: ["jszwedko"]
+pr_numbers: [11985]
+release: "0.23.0"
+hide_on_release_notes: false
+badges:
+  type: enhancement
+---
+
+With this release, we have introduced a new mechanism to load secrets securely into Vector by calling an external
+process. This can be used, for example, to integrate with a service like [Vault](https://www.vaultproject.io/) to
+provide credentials.
+
+Previously the preferred mechanism was injection via environment variables, but there are some security concerns as
+these values can be read if a user on a host has access to read from the `/proc` filesystem for the Vector process.
+
+A secret backend can be configured like this:
+
+```toml
+[secret.backend_1]
+type = "exec" # exec is the only supported backend as of writing
+command = ["/path/to/cmd1"]
+```
+
+You can then specify where secrets should be read via `SECRET[<backend name>.<secret name>]` in the config like:
+
+```toml
+[sources.my_source_id]
+type = "aws_sqs"
+region = "us-east-1"
+queue_url = "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
+auth.access_key_id = "SECRET[backend_1.aws_access_key_id]"
+auth.secret_access_key = "SECRET[backend_1.aws_secret_access_key]"
+```
+
+Here `auth.access_key_id` and `auth.secret_access_key` will use secrets provided by the `backend_1` secret backend.
+
+When Vector starts, it will call the configured secret backend command, here `/path/to/cmd1`, with the needed secrets
+provided as JSON on stdin:
+
+```json
+{"version": "1.0", "secrets": ["aws_access_key_id", "aws_secret_access_key"]}
+```
+
+
+The command is then expected to write the secrets to stdout as JSON in the following format:
+
+```json
+{
+  "aws_access_key_id": {"value": "AKIAIOSFODNN7EXAMPLE", "error": null},
+  "aws_secret_access_key": {"value": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "error": null}
+}
+```
+
+Vector will then use the returned values when loading the configuration.
+
+If an `error` is returned, or the command exits non-zero, Vector will log any errors and stop.
+
+See the [documentation](/docs/reference/configuration/global-options/#secret) for additional details.

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -313,15 +313,36 @@ configuration: {
 			required: false
 			type: object: options: {
 				exec: {
-					required:    true
-					description: "Run a local command to retrieve secrets."
+					required: true
+					description: """
+						Run a local command to retrieve secrets.
+
+						The provided command will be run and provided a list of
+						secrets to fetch, determined from the configuration file, on stdin as JSON in the format:
+
+						```json
+						{"version": "1.0", "secrets": ["secret1", "secret2"]}
+						```
+
+						The executable is expected to respond with the values of these secrets on stdout, also as JSON, in the format:
+
+						```json
+						{
+							"secret1": {"value": "secret_value", "error": null},
+							"secret2": {"value": null, "error": "could not fetch the secret"}
+						}
+						```
+
+						If an `error` is returned for any secrets, or if the
+						command exits with a non-zero status code, Vector will
+						log the errors and exit.
+						"""
 					type: object: options: {
 						command: {
 							description: """
-								The command to be run, plus any arguments required. It shall comply with the
-								[Datadog Agent executable API](\(urls.datadog_agent_exec_api)).
+								The command to be run, plus any arguments required.
 								"""
-							required:    true
+							required: true
 							type: array: {
 								examples: [["/path/to/get-secret", "-s"], ["/path/to/vault-wrappper"]]
 								items: type: string: {}

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -333,9 +333,11 @@ configuration: {
 						}
 						```
 
-						If an `error` is returned for any secrets, or if the
-						command exits with a non-zero status code, Vector will
-						log the errors and exit.
+						If an `error` is returned for any secrets, or if the command exits with a non-zero status code,
+						Vector will log the errors and exit.
+
+						Secrets will be loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
+						configuration reload process.
 						"""
 					type: object: options: {
 						command: {


### PR DESCRIPTION
Also update the docs to include a full description of how it works
rather than linking to Datadog's docs as:

* the link was already broken
* it's possible the agent might diverge
* Non-Datadog user, Vector users, might be confused

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
