### PR TITLE
chore: point tonic at temporary fork that incorporates a fix to remove the compression feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.7.2"
-source = "git+https://github.com/StephenWakely/tonic.git#9ea03c2c44ad6bf76e4141e6fb40870b9b30ab63"
+source = "git+https://github.com/StephenWakely/tonic.git?rev=b05b565a284874970afa5e49ca5ffc893d940ac1#b05b565a284874970afa5e49ca5ffc893d940ac1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.7.2"
-source = "git+https://github.com/StephenWakely/tonic.git#9ea03c2c44ad6bf76e4141e6fb40870b9b30ab63"
+source = "git+https://github.com/StephenWakely/tonic.git?rev=b05b565a284874970afa5e49ca5ffc893d940ac1#b05b565a284874970afa5e49ca5ffc893d940ac1"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8573,7 +8573,7 @@ dependencies = [
  "tokio-tungstenite 0.17.1",
  "tokio-util 0.7.1",
  "toml",
- "tonic 0.7.2 (git+https://github.com/StephenWakely/tonic.git)",
+ "tonic 0.7.2 (git+https://github.com/StephenWakely/tonic.git?rev=b05b565a284874970afa5e49ca5ffc893d940ac1)",
  "tonic-build",
  "tower",
  "tower-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.7.2"
-source = "git+https://github.com/StephenWakely/tonic.git?branch=stephen/compression_feature#b05b565a284874970afa5e49ca5ffc893d940ac1"
+source = "git+https://github.com/StephenWakely/tonic.git#9ea03c2c44ad6bf76e4141e6fb40870b9b30ab63"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.7.2"
-source = "git+https://github.com/StephenWakely/tonic.git?branch=stephen/compression_feature#b05b565a284874970afa5e49ca5ffc893d940ac1"
+source = "git+https://github.com/StephenWakely/tonic.git#9ea03c2c44ad6bf76e4141e6fb40870b9b30ab63"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8573,7 +8573,7 @@ dependencies = [
  "tokio-tungstenite 0.17.1",
  "tokio-util 0.7.1",
  "toml",
- "tonic 0.7.2 (git+https://github.com/StephenWakely/tonic.git?branch=stephen/compression_feature)",
+ "tonic 0.7.2 (git+https://github.com/StephenWakely/tonic.git)",
  "tonic-build",
  "tower",
  "tower-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,7 +1730,7 @@ checksum = "06c5fd425783d81668ed68ec98408a80498fb4ae2fd607797539e1a9dfa3618f"
 dependencies = [
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-core 0.1.28",
 ]
 
@@ -1752,7 +1752,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.34",
  "tracing-core 0.1.28",
  "tracing-subscriber 0.3.14",
@@ -7694,6 +7694,37 @@ dependencies = [
  "axum",
  "base64",
  "bytes 1.1.0",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.1",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing 0.1.34",
+ "tracing-futures 0.2.5",
+]
+
+[[package]]
+name = "tonic"
+version = "0.7.2"
+source = "git+https://github.com/StephenWakely/tonic.git?branch=stephen/compression_feature#b05b565a284874970afa5e49ca5ffc893d940ac1"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes 1.1.0",
  "flate2",
  "futures-core",
  "futures-util",
@@ -7722,8 +7753,7 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
+source = "git+https://github.com/StephenWakely/tonic.git?branch=stephen/compression_feature#b05b565a284874970afa5e49ca5ffc893d940ac1"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8543,7 +8573,7 @@ dependencies = [
  "tokio-tungstenite 0.17.1",
  "tokio-util 0.7.1",
  "toml",
- "tonic",
+ "tonic 0.7.2 (git+https://github.com/StephenWakely/tonic.git?branch=stephen/compression_feature)",
  "tonic-build",
  "tower",
  "tower-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ tikv-jemallocator = { version = "0.5.0", default-features = false, optional = tr
 tokio-postgres = { version = "0.7.6", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 tokio-tungstenite = {version = "0.17.1", default-features = false, features = ["connect"], optional = true}
 toml = { version = "0.5.9", default-features = false }
-tonic = { version = "0.7.2", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "compression"] }
+tonic = { git = "https://github.com/StephenWakely/tonic.git", branch = "stephen/compression_feature", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
 trust-dns-proto = { version = "0.21.0", default-features = false, features = ["dnssec"], optional = true }
 typetag = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
@@ -321,7 +321,7 @@ nix = { version = "0.24.1", default-features = false, features = ["socket", "sig
 
 [build-dependencies]
 prost-build = { version = "0.10.4", default-features = false, optional = true }
-tonic-build = { version = "0.7", default-features = false, features = ["transport", "prost", "compression"], optional = true }
+tonic-build = { git = "https://github.com/StephenWakely/tonic.git", branch = "stephen/compression_feature", default-features = false, features = ["transport", "prost"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,11 @@ tikv-jemallocator = { version = "0.5.0", default-features = false, optional = tr
 tokio-postgres = { version = "0.7.6", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 tokio-tungstenite = {version = "0.17.1", default-features = false, features = ["connect"], optional = true}
 toml = { version = "0.5.9", default-features = false }
-tonic = { git = "https://github.com/StephenWakely/tonic.git", branch = "stephen/compression_feature", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
+# This is pinning to version 0.7.2 of tonic that also has this commit (https://github.com/hyperium/tonic/pull/1004) cherry-picked
+# since we are running into issues where turning on the compression feature causes the `tokio-console` feature not
+# compiling. Turning it off causes the `sinks_datadog_metrics` feature not to compile. This branch fixes those issues.
+# This should be reverted when version 0.7.3 of tonic is released.
+tonic = { git = "https://github.com/StephenWakely/tonic.git", sha="b05b565a284874970afa5e49ca5ffc893d940ac1", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
 trust-dns-proto = { version = "0.21.0", default-features = false, features = ["dnssec"], optional = true }
 typetag = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
@@ -321,7 +325,7 @@ nix = { version = "0.24.1", default-features = false, features = ["socket", "sig
 
 [build-dependencies]
 prost-build = { version = "0.10.4", default-features = false, optional = true }
-tonic-build = { git = "https://github.com/StephenWakely/tonic.git", branch = "stephen/compression_feature", default-features = false, features = ["transport", "prost"], optional = true }
+tonic-build = { git = "https://github.com/StephenWakely/tonic.git", sha="b05b565a284874970afa5e49ca5ffc893d940ac1", default-features = false, features = ["transport", "prost"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ toml = { version = "0.5.9", default-features = false }
 # since we are running into issues where turning on the compression feature causes the `tokio-console` feature not
 # compiling. Turning it off causes the `sinks_datadog_metrics` feature not to compile. This branch fixes those issues.
 # This should be reverted when version 0.7.3 of tonic is released.
-tonic = { git = "https://github.com/StephenWakely/tonic.git", sha="b05b565a284874970afa5e49ca5ffc893d940ac1", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
+tonic = { git = "https://github.com/StephenWakely/tonic.git", rev="b05b565a284874970afa5e49ca5ffc893d940ac1", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
 trust-dns-proto = { version = "0.21.0", default-features = false, features = ["dnssec"], optional = true }
 typetag = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
@@ -325,7 +325,7 @@ nix = { version = "0.24.1", default-features = false, features = ["socket", "sig
 
 [build-dependencies]
 prost-build = { version = "0.10.4", default-features = false, optional = true }
-tonic-build = { git = "https://github.com/StephenWakely/tonic.git", sha="b05b565a284874970afa5e49ca5ffc893d940ac1", default-features = false, features = ["transport", "prost"], optional = true }
+tonic-build = { git = "https://github.com/StephenWakely/tonic.git", rev="b05b565a284874970afa5e49ca5ffc893d940ac1", default-features = false, features = ["transport", "prost"], optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/sinks/vector/v2/service.rs
+++ b/src/sinks/vector/v2/service.rs
@@ -7,7 +7,7 @@ use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
 use prost::Message;
 use proto_event::EventWrapper;
-use tonic::{body::BoxBody, IntoRequest, codec::CompressionEncoding};
+use tonic::{body::BoxBody, codec::CompressionEncoding, IntoRequest};
 use vector_core::{
     buffers::Ackable, event::proto as proto_event, internal_event::EventsSent,
     stream::DriverResponse,

--- a/src/sinks/vector/v2/service.rs
+++ b/src/sinks/vector/v2/service.rs
@@ -7,7 +7,7 @@ use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
 use prost::Message;
 use proto_event::EventWrapper;
-use tonic::{body::BoxBody, IntoRequest};
+use tonic::{body::BoxBody, IntoRequest, codec::CompressionEncoding};
 use vector_core::{
     buffers::Ackable, event::proto as proto_event, internal_event::EventsSent,
     stream::DriverResponse,
@@ -79,7 +79,7 @@ impl VectorService {
         });
 
         if compression {
-            proto_client = proto_client.send_gzip();
+            proto_client = proto_client.send_compressed(CompressionEncoding::Gzip);
         }
         Self {
             client: proto_client,

--- a/src/sources/vector/v2.rs
+++ b/src/sources/vector/v2.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use futures::TryFutureExt;
 use tokio::net::TcpStream;
 use tonic::{
+    codec::CompressionEncoding,
     transport::{server::Connected, Certificate},
     Request, Response, Status,
 };
@@ -135,7 +136,7 @@ impl VectorConfig {
             pipeline: cx.out,
             acknowledgements,
         })
-        .accept_gzip();
+        .accept_compressed(CompressionEncoding::Gzip);
 
         let source =
             run_grpc_server(self.address, tls_settings, service, cx.shutdown).map_err(|error| {


### PR DESCRIPTION
This PR points `tonic` at a [fork](https://github.com/StephenWakely/tonic/tree/stephen/compression_feature) that cherry picks a [fix](https://github.com/StephenWakely/tonic/commit/b05b565a284874970afa5e49ca5ffc893d940ac1)  into the 0.7.2 release.

This is needed to help move the [open telemetry logs source](https://github.com/vectordotdev/vector/pull/13320) moving forward as per [this comment](https://github.com/vectordotdev/vector/pull/13320#issuecomment-1174848554).

It is worth noting that @prognant has another idea how to move the PR forward, so if his idea works this PR won't be necessary.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
