### PR TITLE
docs(codecs): Correct sink codec highlight and document length_delimited framing

### DIFF
--- a/website/content/en/highlights/2022-07-07-sink-codecs.md
+++ b/website/content/en/highlights/2022-07-07-sink-codecs.md
@@ -16,9 +16,9 @@ now, rather than just specifying `encoding.codec`, you can now supply custom
 `framing` options. Additionally, the supported codecs (`encoding.codec`) for
 each sink was expanded to be a uniform set of codecs.
 
-For example, if you have a `socket` sink that you want to send [octet
-framed][octet_framing], JSON-encoded, messages, you can now do so with
-configuration like:
+For example, if you have a `socket` sink that you want to send
+[length-delimited][length_delimited] JSON-encoded, messages, you can now do so
+with configuration like:
 
 ```toml
 [sinks.socket]
@@ -30,7 +30,7 @@ encoding.codec = "json"
 ```
 
 This will encode messages flowing into this sink as JSON and frame them using
-[octet framing][octet_framing].
+[length-delimited][length_delimited] framing.
 
 [source_decoding]: /highlights/2021-10-06-source-codecs
-[octet_framing]: https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1
+[length_delimited]: https://docs.rs/tokio-util/0.7.3/tokio_util/codec/length_delimited/index.html

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -287,7 +287,7 @@ components: sinks: [Name=string]: {
 										enum: {
 											bytes:               "Byte frames are concatenated."
 											character_delimited: "Byte frames are delimited by a chosen character."
-											length_delimited:    "Byte frames whose messages are prefixed by a unsized big-endian 32-bit integer indicating the length."
+											length_delimited:    "Byte frames are prefixed by a unsized big-endian 32-bit integer indicating the length."
 											newline_delimited:   "Byte frames are delimited by a newline character."
 										}
 									}

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -287,7 +287,7 @@ components: sinks: [Name=string]: {
 										enum: {
 											bytes:               "Byte frames are concatenated."
 											character_delimited: "Byte frames are delimited by a chosen character."
-											length_delimited:    "Byte frames are encoded by adding a length header."
+											length_delimited:    "Byte frames whose messages are prefixed by a unsized big-endian 32-bit integer indicating the length."
 											newline_delimited:   "Byte frames are delimited by a newline character."
 										}
 									}

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -287,7 +287,7 @@ components: sinks: [Name=string]: {
 										enum: {
 											bytes:               "Byte frames are concatenated."
 											character_delimited: "Byte frames are delimited by a chosen character."
-											length_delimited:    "Byte frames are prefixed by a unsized big-endian 32-bit integer indicating the length."
+											length_delimited:    "Byte frames are prefixed by an unsized big-endian 32-bit integer indicating the length."
 											newline_delimited:   "Byte frames are delimited by a newline character."
 										}
 									}

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -86,7 +86,7 @@ components: sources: [Name=string]: {
 								enum: {
 									bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
 									character_delimited: "Byte frames which are delimited by a chosen character."
-									length_delimited:    "Byte frames whose messages are prefixed by a unsized big-endian 32-bit integer indicating the length."
+									length_delimited:    "Byte frames which are prefixed by a unsized big-endian 32-bit integer indicating the length."
 									newline_delimited:   "Byte frames which are delimited by a newline character."
 									octet_counting:      "Byte frames according to the [octet counting](\(urls.rfc_6587_3_4_1)) format."
 								}

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -86,7 +86,7 @@ components: sources: [Name=string]: {
 								enum: {
 									bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
 									character_delimited: "Byte frames which are delimited by a chosen character."
-									length_delimited:    "Byte frames which are prefixed by a unsized big-endian 32-bit integer indicating the length."
+									length_delimited:    "Byte frames which are prefixed by an unsized big-endian 32-bit integer indicating the length."
 									newline_delimited:   "Byte frames which are delimited by a newline character."
 									octet_counting:      "Byte frames according to the [octet counting](\(urls.rfc_6587_3_4_1)) format."
 								}

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -86,7 +86,7 @@ components: sources: [Name=string]: {
 								enum: {
 									bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
 									character_delimited: "Byte frames which are delimited by a chosen character."
-									length_delimited:    "Byte frames whose length is encoded in a header."
+									length_delimited:    "Byte frames whose messages are prefixed by a unsized big-endian 32-bit integer indicating the length."
 									newline_delimited:   "Byte frames which are delimited by a newline character."
 									octet_counting:      "Byte frames according to the [octet counting](\(urls.rfc_6587_3_4_1)) format."
 								}


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
