### PR TITLE
fix(datadog_agent source): fix datadog agent integration test

### DIFF
--- a/src/sources/datadog/agent/mod.rs
+++ b/src/sources/datadog/agent/mod.rs
@@ -118,7 +118,7 @@ impl GenerateConfig for DatadogAgentConfig {
             disable_metrics: false,
             disable_traces: false,
             multiple_outputs: false,
-            log_namespace: Some(true),
+            log_namespace: Some(false),
         })
         .unwrap()
     }


### PR DESCRIPTION
Integration tests used the `generate_config` function for the config, which defaulted to using the new log namespacing feature, but the test assertions assumed it was not using this feature, so it was switched off.