### PR TITLE
docs: Include breaking change for watch-config in 0.21

### DIFF
--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -26,7 +26,7 @@ Vector's 0.21.0 release includes **breaking changes**:
 11. [`kubernetes_logs` source rewritten to use `kube-rs`](#kubernetes-logs)
 12. [Published docker images no longer create implicit volumes](#docker-volume)
 13. [VRL now includes lexical scoping for blocks](#vrl-lexical-scoping)
-14. [CLI options: delimiters and wildcards](#cli-option-changes)
+14. [CLI options: delimiters, wildcards, and boolean options](#cli-option-changes)
 
 And **deprecations**:
 
@@ -354,7 +354,7 @@ count1 # returns ”3”
 count2 # returns a compile-time error, because ”count2” was defined in a nested block
 ```
 
-#### CLI options: delimiters and wildcards {#cli-option-changes}
+#### CLI options: delimiters, wildcards, and boolean options {#cli-option-changes}
 
 When using CLI options that can take multiple values, the provided values must
 be comma separated. For example:
@@ -368,6 +368,19 @@ must be quoted. For example:
 
 ```shell
 vector --config "*.toml"
+```
+
+The `--watch-config` option previously required a boolean value, which is no
+longer needed. For example, in earlier releases:
+
+```shell
+vector --watch-config=true
+```
+
+This should become:
+
+```shell
+vector --watch-config
 ```
 
 ### Iteration Sneak Preview


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
