### PR TITLE
fix(buffers): fix minimum size value for `buffer.max_size` in docs

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -86,7 +86,7 @@ components: sinks: [Name=string]: {
 					}
 					max_size: {
 						description: """
-							The maximum size of the buffer on the disk. Must be at least 256 megabytes (268435456 bytes).
+							The maximum size of the buffer on the disk. Must be at least ~256 megabytes (268435488 bytes).
 							"""
 						required:      true
 						relevant_when: "type = \"disk\""


### PR DESCRIPTION
A user on Discord pointed out that while the docs for the minimum size of `buffer.max_size` specify a value of 268435456 (256MB exactly: 256 * 1024 * 1024), the true limit is actually 268435488, which is 256MB _plus_ the ledger size.

We changed this in #13356 to be as precise as possible with tracking bytes used on disk by the buffer, and respecting `buffer.max_size`, where before, we only considered the size of buffer data files themselves.