### PR TITLE
enhancement(buffers): Handle negative acknowledgements by stopping readers

### DIFF
--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -127,10 +127,9 @@ impl InternalEvent for BufferStopping {
             record_id,
         } = self;
         error!(
-            message = "Disk buffer has received a negative acknowledgement, stopping processing.",
             data_dir = ?data_dir,
             record_id = %record_id,
+            "Disk buffer has received a negative acknowledgement, stopping processing. To correct, run: `vector buffer-advance --record-id {record_id} {data_dir:?}`",
         );
-        info!("To correct this problem, run: `vector buffer-advance --record-id {record_id} {data_dir:?}`");
     }
 }

--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use metrics::{counter, decrement_gauge, gauge, increment_gauge};
 use vector_common::internal_event::InternalEvent;
 
@@ -110,5 +112,25 @@ impl InternalEvent for BufferReadError {
             "error_type" => "reader_failed",
             "stage" => "processing",
         );
+    }
+}
+
+pub(crate) struct BufferStopping {
+    pub data_dir: PathBuf,
+    pub record_id: u64,
+}
+
+impl InternalEvent for BufferStopping {
+    fn emit(self) {
+        let Self {
+            data_dir,
+            record_id,
+        } = self;
+        error!(
+            message = "Disk buffer has received a negative acknowledgement, stopping processing.",
+            data_dir = ?data_dir,
+            record_id = %record_id,
+        );
+        info!("To correct this problem, run: `vector buffer-advance --record-id {record_id} {data_dir:?}`");
     }
 }

--- a/lib/vector-buffers/src/test/helpers.rs
+++ b/lib/vector-buffers/src/test/helpers.rs
@@ -100,3 +100,8 @@ pub(crate) async fn acknowledge(mut event: impl Finalizable) {
     // Finalizers are implicitly dropped here, sending the status update.
     tokio::task::yield_now().await;
 }
+
+pub(crate) async fn acknowledge_error(mut event: impl Finalizable) {
+    event.take_finalizers().update_status(EventStatus::Errored);
+    tokio::task::yield_now().await;
+}

--- a/lib/vector-buffers/src/variants/disk_v1/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/reader.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
     marker::PhantomData,
     sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -57,7 +57,7 @@ pub struct Reader<T> {
     /// First uncompacted key
     pub(crate) compacted_offset: usize,
     /// First not deleted key
-    pub(crate) delete_offset: usize,
+    pub(crate) delete_offset: Arc<AtomicUsize>,
     /// Reader is notified by Writers through this Waker.
     /// Shared with Writers.
     pub(crate) read_waker: Arc<Notify>,
@@ -90,6 +90,14 @@ pub struct Reader<T> {
     pub(crate) usage_handle: BufferUsageHandle,
     pub(crate) phantom: PhantomData<T>,
     pub(crate) finalizer: OrderedFinalizer<u64>,
+    pub(super) reader_done: Arc<AtomicBool>,
+}
+
+/// Error that occurred during calls to [`Reader::next`]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReaderError {
+    /// The reader has been stopped due to an acknowledgement error.
+    Stopped,
 }
 
 impl<T> Reader<T>
@@ -97,11 +105,16 @@ where
     T: Bufferable,
 {
     #[cfg_attr(test, instrument(skip(self), level = "debug"))]
-    pub async fn next(&mut self) -> Option<T> {
+    pub async fn next(&mut self) -> Result<Option<T>, ReaderError> {
         loop {
             // Check for any pending acknowledgements which may make a read eligible to finally be
             // deleted from the buffer entirely.
             self.try_flush();
+
+            // If we received a negative acknowledgement, stop returning results.
+            if self.reader_done.load(Ordering::Relaxed) {
+                return Err(ReaderError::Stopped);
+            }
 
             // If we have no buffered items, do a read from LevelDB.
             if self.buffer.is_empty() {
@@ -135,7 +148,7 @@ where
                         let (batch, receiver) = BatchNotifier::new_with_receiver();
                         item.add_batch_notifier(batch);
                         self.finalizer.add(count as u64, receiver);
-                        return Some(item);
+                        return Ok(Some(item));
                     }
                     Err(error) => {
                         error!(%error, "Error deserializing event.");
@@ -146,7 +159,7 @@ where
                 if Arc::strong_count(&self.db) == 1 {
                     // There are no writers left, and we've consumed all remaining items in the
                     // buffer, so we need to signal to this to caller by returning `None`.
-                    return None;
+                    return Ok(None);
                 }
 
                 // We have no more buffered reads, and we always make sure to do a read if our
@@ -261,7 +274,8 @@ impl<T> Reader<T> {
             // We adjust the delete offset/remaining acks here so that the next call to
             // `get_next_eligible_delete` has updated offsets so we can optimally drain as many
             // eligible deletes as possible in one go.
-            self.delete_offset = key.wrapping_add(event_count);
+            self.delete_offset
+                .store(key.wrapping_add(event_count), Ordering::Relaxed);
 
             total_records += 1;
             total_events += event_count;
@@ -272,7 +286,7 @@ impl<T> Reader<T> {
         // and update our buffer usage metrics.
         if total_records > 0 {
             debug!(
-                delete_offset = self.delete_offset,
+                delete_offset = self.delete_offset.load(Ordering::Relaxed),
                 "Deleting {} records from buffer: {} items, {} bytes.",
                 total_records,
                 total_events,
@@ -281,7 +295,7 @@ impl<T> Reader<T> {
             self.db.write(WriteOptions::new(), &delete_batch).unwrap();
 
             assert!(
-                self.delete_offset <= self.read_offset,
+                self.delete_offset.load(Ordering::Relaxed) <= self.read_offset,
                 "tried to ack beyond read offset"
             );
 
@@ -340,10 +354,12 @@ impl<T> Reader<T> {
             self.uncompacted_size = 0;
 
             debug!("Compacting disk buffer.");
-            self.db
-                .compact(&Key(self.compacted_offset), &Key(self.delete_offset));
+            self.db.compact(
+                &Key(self.compacted_offset),
+                &Key(self.delete_offset.load(Ordering::Relaxed)),
+            );
 
-            self.compacted_offset = self.delete_offset;
+            self.compacted_offset = self.delete_offset.load(Ordering::Relaxed);
             self.last_compaction = Instant::now();
         }
     }

--- a/lib/vector-buffers/src/variants/disk_v1/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/basic.rs
@@ -45,7 +45,7 @@ async fn basic_read_write_loop() {
 
             let read_task = tokio::spawn(async move {
                 let mut items = Vec::new();
-                while let Some(mut record) = reader.next().await {
+                while let Ok(Some(mut record)) = reader.next().await {
                     acknowledge(record.take_finalizers()).await;
                     items.push(record);
                 }
@@ -65,7 +65,7 @@ async fn basic_read_write_loop() {
             drive_reader_to_flush(&mut reader).await;
 
             let reader_position = reader.read_offset;
-            let delete_position = reader.delete_offset;
+            let delete_position = &reader.delete_offset;
             assert_eq!(
                 expected_position, writer_position,
                 "expected writer offset of {}, got {}",
@@ -77,9 +77,11 @@ async fn basic_read_write_loop() {
                 expected_position, reader_position
             );
             assert_eq!(
-                expected_position, delete_position,
+                expected_position,
+                delete_position.load(Ordering::Relaxed),
                 "expected delete offset of {}, got {}",
-                expected_position, delete_position
+                expected_position,
+                delete_position.load(Ordering::Relaxed)
             );
         }
     })
@@ -119,7 +121,7 @@ async fn basic_read_write_loop_multievents() {
 
             let read_task = tokio::spawn(async move {
                 let mut items = Vec::new();
-                while let Some(mut record) = reader.next().await {
+                while let Ok(Some(mut record)) = reader.next().await {
                     acknowledge(record.take_finalizers()).await;
                     items.push(record);
                 }
@@ -139,7 +141,7 @@ async fn basic_read_write_loop_multievents() {
             drive_reader_to_flush(&mut reader).await;
 
             let reader_position = reader.read_offset;
-            let delete_position = reader.delete_offset;
+            let delete_position = &reader.delete_offset;
             assert_eq!(
                 expected_position, writer_position,
                 "expected writer offset of {}, got {}",
@@ -151,9 +153,11 @@ async fn basic_read_write_loop_multievents() {
                 expected_position, reader_position
             );
             assert_eq!(
-                expected_position, delete_position,
+                expected_position,
+                delete_position.load(Ordering::Relaxed),
                 "expected delete offset of {}, got {}",
-                expected_position, delete_position
+                expected_position,
+                delete_position.load(Ordering::Relaxed),
             );
         }
     })
@@ -306,7 +310,11 @@ async fn ensure_buffer_metrics_accurate_with_poisoned_multievents() {
                 let expected_event_count = counts[count_idx] as usize;
                 count_idx += 1;
 
-                let record = reader.next().await.expect("record should be present");
+                let record = reader
+                    .next()
+                    .await
+                    .expect("read should not error")
+                    .expect("record should be present");
                 let actual_event_count = record.event_count();
                 assert_eq!(expected_event_count, actual_event_count);
 
@@ -321,7 +329,7 @@ async fn ensure_buffer_metrics_accurate_with_poisoned_multievents() {
             tokio::time::advance(FLUSH_INTERVAL.saturating_add(Duration::from_millis(1))).await;
 
             let final_read = reader.next().now_or_never();
-            assert_eq!(None, final_read);
+            assert_eq!(final_read, None);
 
             // At this point, we've read all four valid records, and since the undecodable record
             // was deleted when the buffer was initialized on the second load, our buffer metrics

--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -8,8 +8,13 @@ use vector_common::finalization::Finalizable;
 use super::{create_default_buffer_v2, read_next, read_next_some};
 use crate::{
     assert_buffer_is_empty, assert_buffer_records,
-    test::{acknowledge, install_tracing_helpers, with_temp_dir, MultiEventRecord, SizedRecord},
-    variants::disk_v2::{tests::create_default_buffer_v2_with_usage, writer::RecordWriter},
+    test::{
+        acknowledge, acknowledge_error, install_tracing_helpers, with_temp_dir, MultiEventRecord,
+        SizedRecord,
+    },
+    variants::disk_v2::{
+        reader::ReaderError, tests::create_default_buffer_v2_with_usage, writer::RecordWriter,
+    },
     EventCount,
 };
 
@@ -23,12 +28,7 @@ async fn basic_read_write_loop() {
             let (mut writer, mut reader, ledger) = create_default_buffer_v2(data_dir).await;
             assert_buffer_is_empty!(ledger);
 
-            let expected_items = (512..768)
-                .into_iter()
-                .cycle()
-                .take(10)
-                .map(SizedRecord::new)
-                .collect::<Vec<_>>();
+            let expected_items = make_items(10, SizedRecord::new);
             let input_items = expected_items.clone();
 
             // Now create a reader and writer task that will take a set of input messages, buffer
@@ -150,12 +150,7 @@ async fn initial_size_correct_with_multievents() {
             // Create a regular buffer, no customizations required.
             let (mut writer, _, _) = create_default_buffer_v2(data_dir.clone()).await;
 
-            let input_items = (512..768)
-                .into_iter()
-                .cycle()
-                .take(2000)
-                .map(MultiEventRecord::new)
-                .collect::<Vec<_>>();
+            let input_items = make_items(2000, MultiEventRecord::new);
             let expected_records = input_items.len();
             let expected_events = input_items
                 .iter()
@@ -231,4 +226,49 @@ async fn initial_size_correct_with_multievents() {
         }
     })
     .await;
+}
+
+#[tokio::test]
+async fn reader_stops_after_negative_acknowledgement() {
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let (mut writer, mut reader, ledger) = create_default_buffer_v2(data_dir).await;
+            assert_buffer_is_empty!(ledger);
+
+            // Now create a reader and writer task that will take a set of input messages, buffer
+            // them, read them out, and then make sure nothing was missed.
+            let write_task = tokio::spawn(async move {
+                for item in make_items(5, SizedRecord::new) {
+                    writer
+                        .write_record(item)
+                        .await
+                        .expect("write should not fail");
+                }
+                writer.flush().await.expect("writer flush should not fail");
+                writer.close();
+            });
+
+            let record = read_next(&mut reader).await.expect("First read failed");
+            acknowledge(record).await;
+
+            let record = read_next(&mut reader).await.expect("Second read failed");
+            acknowledge_error(record).await;
+
+            assert_eq!(reader.next().await, Err(ReaderError::Stopped));
+
+            write_task.await.expect("write task should not panic");
+        }
+    })
+    .await;
+}
+
+fn make_items<T>(count: usize, map: impl Fn(u32) -> T) -> Vec<T> {
+    (512..768)
+        .into_iter()
+        .cycle()
+        .take(count)
+        .map(map)
+        .collect()
 }

--- a/lib/vector-buffers/src/variants/disk_v2/v1_migration.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/v1_migration.rs
@@ -4,7 +4,8 @@ use vector_common::finalization::{EventStatus, Finalizable};
 
 use crate::{
     buffer_usage_data::BufferUsageHandle,
-    topology::{builder::IntoBuffer, channel::ReceiverAdapter},
+    topology::builder::IntoBuffer,
+    topology::channel::{Received, ReceiverAdapter},
     variants::{
         disk_v2::{build_disk_v2_buffer, get_disk_v2_data_dir_path},
         DiskV1Buffer,
@@ -72,7 +73,7 @@ where
     info!("Detected old `disk_v1`-based buffer for the `{}` sink. Automatically migrating to `disk_v2`.", id);
 
     let mut migrated_records = 0;
-    while let Some(mut old_record) = src_reader.next().await {
+    while let Received::Some(mut old_record) = src_reader.next().await {
         let old_record_event_count = old_record.event_count();
         let finalizers = ManuallyDrop::new(old_record.take_finalizers());
 


### PR DESCRIPTION
This changes the behavior of all sinks that can emit negative acknowledgements. If a sink that is
configured with a disk buffer receives an error or rejection, it will cause the buffer to stop
delivering new events to the sink and emit an error message. This can be resolved through the use of
an additional tool, integrated into vector, that is being developed separately.

Ref: #12145 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
