### PR TITLE
docs(installation msi): Fix powershell script

### DIFF
--- a/website/content/en/docs/setup/installation/package-managers/msi.md
+++ b/website/content/en/docs/setup/installation/package-managers/msi.md
@@ -9,9 +9,8 @@ MSI is the file format and command line utility for the [Windows Installer][inst
 ## Installation
 
 ```powershell
-powershell Invoke-WebRequest https://packages.timber.io/vector/{{% version %}}/vector-x86_64.msi \
-  -OutFile vector-{{% version %}}-x86_64.msi && \
-  msiexec /i vector-{{% version %}}-x86_64.msi /quiet
+powershell Invoke-WebRequest https://packages.timber.io/vector/{{% version %}}/vector-x64.msi -OutFile vector-{{% version %}}-x64.msi
+msiexec /i vector-{{% version %}}-x64.msi
 ```
 
 ## Management


### PR DESCRIPTION
The current MSI filename has been changed from `vector-x86_64.msi` to `vector-x64.msi`. And quiet mode is not an element way to install programs.

Signed-off-by: KernelErr <me@lirui.tech>