### PR TITLE
fix(elasticsearch sink): add Accept-Encoding header for compression

### DIFF
--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -94,7 +94,9 @@ impl HttpRequestBuilder {
         builder = builder.header("Content-Type", "application/x-ndjson");
 
         if let Some(ce) = self.compression.content_encoding() {
-            builder = builder.header("Content-Encoding", ce);
+            builder = builder
+                .header("Content-Encoding", ce)
+                .header("Accept-Encoding", ce);
         }
 
         for (header, value) in &self.http_request_config.headers {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Closes: #8439

An HTTP header `Accept-Encoding` was missing when compression enabled in the elasticsearch sink.