### PR TITLE
chore(dev): Standardize on a common maximum line length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100
 
 [website/layouts/**/*.html]
 insert_final_newline = false


### PR DESCRIPTION
This should probably get buy-in from more than just one team. I don't actually care what the number is here, as long as it's not something silly like 256. It would just be good to standardize on _something_ to avoid re-wrapping lines introducing changes where there aren't actually any.