### PR TITLE
fix(vrl): extend parse_apache_log error format compatibility

### DIFF
--- a/lib/vrl/stdlib/src/log_util.rs
+++ b/lib/vrl/stdlib/src/log_util.rs
@@ -10,77 +10,100 @@ use vector_common::TimeZone;
 // - W3C specification: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
 // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#common
 #[cfg(any(feature = "parse_apache_log", feature = "parse_common_log"))]
-pub(crate) static REGEX_APACHE_COMMON_LOG: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
-        ^\s*                                    # Start with any number of whitespaces.
-        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<message>(                           # Match a request with...
-        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
-        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
-        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
-        |[[\\"][^"]]*?))\s*))"                  # ...Or match any character except `"`, but `\"`, and any amount of whitespaces.
-        )\s+                                    # Match at least one whitespace.
-        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
-        (-|(?P<size>\d+))                       # Match `-` or at least one digit.
-        \s*$                                    # Match any number of whitespaces (to be discarded).
-    "#)
-                                                                     .expect("failed compiling regex for common log")
+pub(crate) static REGEX_APACHE_COMMON_LOG: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        Regex::new(
+            r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+            ^\s*                                    # Start with any number of whitespaces.
+            (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+            (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
+            (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+            (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+            (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+            (?P<message>(                           # Match a request with...
+            (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
+            (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
+            (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
+            |[[\\"][^"]]*?))\s*))"                  # ...Or match any character except `"`, but `\"`, and any amount of whitespaces.
+            )\s+                                    # Match at least one whitespace.
+            (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
+            (-|(?P<size>\d+))                       # Match `-` or at least one digit.
+            \s*$                                    # Match any number of whitespaces (to be discarded).
+        "#)
+        .expect("failed compiling regex for common log")
+    ]
 });
 
 // - Apache HTTP Server docs: https://httpd.apache.org/docs/1.3/logs.html#combined
 #[cfg(feature = "parse_apache_log")]
-pub(crate) static REGEX_APACHE_COMBINED_LOG: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
-        ^\s*                                    # Start with any number of whitespaces.
-        (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
-        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<message>(                           # Match a request with...
-        (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
-        (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
-        (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
-        |[[\\"][^"]]*?))\s*))"                  # ...Or match any character except `"`, but `\"`, and any amount of whitespaces.
-        )\s+                                    # Match at least one whitespace.
-        (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
-        (-|(?P<size>\d+))\s+                    # Match `-` or at least one digit.
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<referrer>[[\\"][^"]]*?)             # Match any character except `"`, but `\"`
-        ")))                                    # Match the closing quote
-        \s+                                     # Match whitespace
-        (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
-        (?P<agent>[[\\"][^"]]*?)                # Match any character except `"`, but `\"`
-        ")))                                    # Match the closing quote
-        #\s*$                                   # Match any number of whitespaces (to be discarded).
-    "#)
-    .expect("failed compiling regex for combined log")
+pub(crate) static REGEX_APACHE_COMBINED_LOG: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        Regex::new(
+            r#"(?x)                                 # Ignore whitespace and comments in the regex expression.
+            ^\s*                                    # Start with any number of whitespaces.
+            (-|(?P<host>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+            (-|(?P<identity>.*?))\s+                # Match `-` or any character (non-greedily) and at least one whitespace.
+            (-|(?P<user>.*?))\s+                    # Match `-` or any character (non-greedily) and at least one whitespace.
+            (-|\[(-|(?P<timestamp>[^\[]*))\])\s+    # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+            (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+            (?P<message>(                           # Match a request with...
+            (?P<method>\w+)\s+                      # Match at least one word character and at least one whitespace.
+            (?P<path>[[\\"][^"]]*?)\s+              # Match any character except `"`, but `\"` (non-greedily) and at least one whitespace.
+            (?P<protocol>[[\\"][^"]]*?)\s*          # Match any character except `"`, but `\"` (non-greedily) and any number of whitespaces.
+            |[[\\"][^"]]*?))\s*))"                  # ...Or match any character except `"`, but `\"`, and any amount of whitespaces.
+            )\s+                                    # Match at least one whitespace.
+            (-|(?P<status>\d+))\s+                  # Match `-` or at least one digit and at least one whitespace.
+            (-|(?P<size>\d+))\s+                    # Match `-` or at least one digit.
+            (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+            (?P<referrer>[[\\"][^"]]*?)             # Match any character except `"`, but `\"`
+            ")))                                    # Match the closing quote
+            \s+                                     # Match whitespace
+            (-|"(-|(\s*                             # Match `-` or `"` followed by `-` or and any number of whitespaces...
+            (?P<agent>[[\\"][^"]]*?)                # Match any character except `"`, but `\"`
+            ")))                                    # Match the closing quote
+            #\s*$                                   # Match any number of whitespaces (to be discarded).
+        "#)
+        .expect("failed compiling regex for combined log")
+    ]
 });
 
-// It is possible to customise the format output by apache. This function just handles the default defined here.
-// https://github.com/mingrammer/flog/blob/9bc83b14408ca446e934c32e4a88a81a46e78d83/log.go#L16
+// It is possible to customise the format output by apache.
 #[cfg(feature = "parse_apache_log")]
-pub(crate) static REGEX_APACHE_ERROR_LOG: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?x)                                     # Ignore whitespace and comments in the regex expression.
-        ^\s*                                        # Start with any number of whitespaces.
-        (-|\[(-|(?P<timestamp>[^\[]*))\])\s+        # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-        (-|\[(-|(?P<module>[^:]*):                  # Match `-` or `[` followed by `-` or any character except `:`.
-        (?P<severity>[^\[]*))\])\s+                 # Match ary character except `]`, `]` and at least one whitespace.
-        (-|\[\s*pid\s*(-|(?P<pid>[^:]*)             # Match `-` or `[` followed by `pid`, `-` or any character except `:`.
-        (:\s*tid\s*(?P<thread>[^\[]*))?)\])\s       # Match `tid` followed by any character except `]`, `]` and at least one whitespace.
-        (-|\[\s*client\s*(-|(?P<client>.*:?):       # Match `-` or `[` followed by `client`, `-` or any character until the first or last `:` for the port.
-        (?P<port>[^\[]*))\])\s                      # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
-        (-|(?P<message>.*))                         # Match `-` or any character.
-        \s*$                                        # Match any number of whitespaces (to be discarded).
-    "#)
-    .expect("failed compiling regex for error log")
+pub(crate) static REGEX_APACHE_ERROR_LOG: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // Simple format
+        // https://github.com/mingrammer/flog/blob/9bc83b14408ca446e934c32e4a88a81a46e78d83/log.go#L16
+        Regex::new(
+            r#"(?x)                                     # Ignore whitespace and comments in the regex expression.
+            ^\s*                                        # Start with any number of whitespaces.
+            (-|\[(-|(?P<timestamp>[^\[]*))\])\s+        # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+            (-|\[(-|(?P<module>[^:]*):                  # Match `-` or `[` followed by `-` or any character except `:`.
+            (?P<severity>[^\[]*))\])\s+                 # Match ary character except `]`, `]` and at least one whitespace.
+            (-|\[\s*pid\s*(-|(?P<pid>[^:]*)             # Match `-` or `[` followed by `pid`, `-` or any character except `:`.
+            (:\s*tid\s*(?P<thread>[^\[]*))?)\])\s       # Match `tid` followed by any character except `]`, `]` and at least one whitespace.
+            (-|\[\s*client\s*(-|(?P<client>.*:?):       # Match `-` or `[` followed by `client`, `-` or any character until the first or last `:` for the port.
+            (?P<port>[^\[]*))\])\s                      # Match `-` or `[` followed by `-` or any character except `]`, `]` and at least one whitespace.
+            (-|(?P<message>.*))                         # Match `-` or any character.
+            \s*$                                        # Match any number of whitespaces (to be discarded).
+        "#)
+        .expect("failed compiling regex for error log"),
+
+        // threaded MPM format
+        // https://httpd.apache.org/docs/current/mod/core.html#errorlogformat
+        Regex::new(
+            r#"(?x)                                              # Ignore whitespace and comments in the regex expression.
+            ^\s*                                                 # Start with any number of whitespaces.
+            \[(?P<timestamp>[^\]]+)\]\s+                         # [%{u}t]
+            \[(-|(?P<module>[^:]+)):(?P<severity>[^\]]+)\]\s+    # [%-m:%l]
+            \[pid\s+(?P<pid>\d+)(:tid\s+(?P<thread>\d+))?\]\s+   # [pid %P:tid %T]
+            (?P<message1>[^\[]*?:\s+([^\[]*?:\s+)?)?             # %7F: %E:
+            (\[client\s+(?P<client>.+?):(?P<port>\d+)\]\s+)?     # [client\ %a]
+            (?P<message2>.*)                                     # %M
+            (, referer .*)?                                      # ,\ referer\ %{Referer}
+            \s*$                                                 # Match any number of whitespaces (to be discarded).
+        "#)
+        .expect("failed compiling regex for error log")
+    ]
 });
 
 // - Nginx HTTP Server docs: http://nginx.org/en/docs/http/ngx_http_log_module.html
@@ -194,4 +217,20 @@ pub(crate) fn log_fields(
         })
         .collect::<std::result::Result<BTreeMap<String, Value>, String>>()?
         .into())
+}
+
+/// Attempts to extract log fields from each of the list of regexes
+pub(crate) fn parse_message(
+    regexes: &Vec<Regex>,
+    message: &str,
+    timestamp_format: &str,
+    timezone: &TimeZone,
+    log_type: &str,
+) -> std::result::Result<Value, String> {
+    for regex in regexes {
+        if let Some(captures) = regex.captures(message) {
+            return log_fields(regex, &captures, timestamp_format, timezone);
+        }
+    }
+    Err(format!("failed parsing {} log line", log_type))
 }

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -333,6 +333,23 @@ mod tests {
             tz: vector_common::TimeZone::Named(chrono_tz::Tz::UTC),
         }
 
+        error_line_threaded_mpms_valid {
+            args: func_args![value: r#"[Mon Dec 27 16:39:10.968303 2021] [proxy:error] [pid 23964] (113)No route to host: AH00957: HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed"#,
+                             timestamp_format: "%a %b %d %H:%M:%S.%f %Y",
+                             format: "error"
+                             ],
+            want: Ok(btreemap! {
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-12-27T23:39:10.000968303Z").unwrap().into()),
+                "message1" => "(113)No route to host: AH00957: ",
+                "message2" => "HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed",
+                "module" => "proxy",
+                "severity" => "error",
+                "pid" => 23964,
+            }),
+            tdef: TypeDef::object(kind_error()).fallible(),
+            tz: vector_common::TimeZone::default(),
+        }
+
         log_line_valid_empty {
             args: func_args![value: "- - - - - - -",
                              format: "common",

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -334,12 +334,11 @@ mod tests {
         }
 
         error_line_threaded_mpms_valid {
-            args: func_args![value: r#"[Mon Dec 27 16:39:10.968303 2021] [proxy:error] [pid 23964] (113)No route to host: AH00957: HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed"#,
-                             timestamp_format: "%a %b %d %H:%M:%S.%f %Y",
+            args: func_args![value: r#"[01/Mar/2021:12:00:19 +0000] [proxy:error] [pid 23964] (113)No route to host: AH00957: HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed"#,
                              format: "error"
                              ],
             want: Ok(btreemap! {
-                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-12-27T23:39:10.000968303Z").unwrap().into()),
+                "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2021-03-01T12:00:19Z").unwrap().into()),
                 "message1" => "(113)No route to host: AH00957: ",
                 "message2" => "HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed",
                 "module" => "proxy",

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -11,14 +11,13 @@ fn parse_common_log(bytes: Value, timestamp_format: Option<Value>, ctx: &Context
         None => "%d/%b/%Y:%T %z".to_owned(),
         Some(timestamp_format) => timestamp_format.try_bytes_utf8_lossy()?.to_string(),
     };
-    let captures = log_util::REGEX_APACHE_COMMON_LOG
-        .captures(&message)
-        .ok_or("failed parsing common log line")?;
-    log_util::log_fields(
-        &log_util::REGEX_APACHE_COMMON_LOG,
-        &captures,
+
+    log_util::parse_message(
+        &*log_util::REGEX_APACHE_COMMON_LOG,
+        &message,
         &timestamp_format,
         ctx.timezone(),
+        "common",
     )
     .map_err(Into::into)
 }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Closes: #10597

The reporter made a few observations:

1. There are error log formats that apache defines which the current regex doesn't support (it's noted in the code that the current implementation only supports the "simple" format , so perhaps this is somewhere between an enhancement and a bug I guess).

2. The error message when parsing fails for the input error format, is claiming it failed for a "common" format.

I attempted to address both.

For  \#1 I ended up using the reporter's supplied regex, as it looked correct to me and I'm not a regex whiz to where I could spot improvements on that.

Note that there may be other common|error|combined log formats that the current regexes don't support and I'm wondering if a full audit of all the formats that are possible is warranted:
https://httpd.apache.org/docs/current/mod/core.html#errorlogformat


Manual testing:
```
$ .input="[Mon Dec 27 16:39:10.968303 2021] [proxy:error] [pid 23964] (113)No route to host: AH00957: HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed"
"[Mon Dec 27 16:39:10.968303 2021] [proxy:error] [pid 23964] (113)No route to host: AH00957: HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed"

$ parse_apache_log!(.input, "error", "%a %b %d %H:%M:%S.%f %Y")
{ "message1": "(113)No route to host: AH00957: ", "message2": "HTTP: attempt to connect to 10.1.0.244:9000 (hostname.domain.com) failed", "module": "proxy", "pid": 23964, "severity": "error", "timestamp": t'2021-12-27T23:39:10.000968303Z' }
```