### PR TITLE
docs: Add template for otel source, and correct cue docs

### DIFF
--- a/website/content/en/docs/reference/configuration/sources/opentelemetry.md
+++ b/website/content/en/docs/reference/configuration/sources/opentelemetry.md
@@ -1,0 +1,14 @@
+---
+title: OpenTelemetry
+description: Receive [OpenTelemetry](https://opentelemetry.io/) data directly from a SDK or an OpenTelemetry Collector.
+kind: source
+layout: component
+tags: ["opentelemetry", "component", "source", "logs"]
+---
+
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -1,7 +1,7 @@
 package metadata
 
 components: sources: opentelemetry: {
-	_port: 6788
+	_port: 4317
 
 	title: "OpenTelemetry"
 
@@ -12,7 +12,7 @@ components: sources: opentelemetry: {
 	classes: {
 		commonly_used: false
 		delivery:      "at_least_once"
-		deployment_roles: ["aggregator"]
+		deployment_roles: ["daemon", "aggregator"]
 		development:   "beta"
 		egress_method: "stream"
 		stateful:      false
@@ -32,8 +32,6 @@ components: sources: opentelemetry: {
 					ssl: "optional"
 				}
 			}
-			receive_buffer_bytes: enabled: false
-			keepalive: enabled:            true
 			tls: {
 				enabled:                true
 				can_verify_certificate: true
@@ -171,13 +169,6 @@ components: sources: opentelemetry: {
 					}
 				}
 			}
-		}
-		metrics: {
-			counter:      output._passthrough_counter
-			distribution: output._passthrough_distribution
-			gauge:        output._passthrough_gauge
-			histogram:    output._passthrough_histogram
-			set:          output._passthrough_set
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
