### PR TITLE
chore(releasing): Pin to cross 0.2.4

### DIFF
--- a/scripts/cross/aarch64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/aarch64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/cross/aarch64-unknown-linux-musl.dockerfile
+++ b/scripts/cross/aarch64-unknown-linux-musl.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/cross/armv7-unknown-linux-gnueabihf.dockerfile
+++ b/scripts/cross/armv7-unknown-linux-gnueabihf.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/cross/armv7-unknown-linux-musleabihf.dockerfile
+++ b/scripts/cross/armv7-unknown-linux-musleabihf.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main
+FROM ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/cross/powerpc-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/powerpc-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/powerpc-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/powerpc-unknown-linux-gnu:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/cross/powerpc64le-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/powerpc64le-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/powerpc64le-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/powerpc64le-unknown-linux-gnu:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/cross/x86_64-unknown-linux-musl.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-musl.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.4
 
 COPY bootstrap-ubuntu.sh .
 RUN ./bootstrap-ubuntu.sh

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -4,10 +4,10 @@ set -e -o verbose
 rustup show # causes installation of version from rust-toolchain.toml
 rustup default "$(rustup show active-toolchain | awk '{print $1;}')"
 if [[ "$(cargo-deb --version)" != "1.29.2" ]] ; then
-  rustup run stable cargo install cargo-deb --version 1.29.2 --force
+  rustup run stable cargo install cargo-deb --version 1.29.2 --force --locked
 fi
-if [[ "$(cross --version | grep cross)" != "cross 0.2.1" ]] ; then
-  rustup run stable cargo install cross --version 0.2.1 --force
+if [[ "$(cross --version | grep cross)" != "cross 0.2.4" ]] ; then
+  rustup run stable cargo install cross --version 0.2.4 --force --locked
 fi
 if [[ "$(cargo-nextest --version)" != "cargo-nextest 0.9.25" ]] ; then
   rustup run stable cargo install cargo-nextest --version 0.9.25 --force --locked


### PR DESCRIPTION
There appears to be a change in `main` that is causing the binaries to
be built requiring a newer version of glibc (2.29).

Opened cross issue here: https://github.com/cross-rs/cross/issues/960

Fixes: #13600

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
