### PR TITLE
chore(enterprise): Change default enterprise reporting interval seconds to 1

### DIFF
--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -118,9 +118,9 @@ const fn default_enable_logs_reporting() -> bool {
     true
 }
 
-/// By default, report to Datadog every 5 seconds.
+/// By default, scrape internal metrics and report to Datadog every 1 seconds.
 const fn default_reporting_interval_secs() -> f64 {
-    5.0
+    1.0
 }
 
 /// By default, keep retrying (recoverable) failed reporting


### PR DESCRIPTION
Closes OP-502

This PR
- Changes the default `reporting_interval_secs` to `1` second. This affects how often the `internal_metrics` and `host_metrics` sources scrape for data.

Opening as a draft to view soak results.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
