### PR TITLE
enhancement(distribution): add `--prefix` option for installation script

### DIFF
--- a/website/content/en/docs/setup/installation/_index.md
+++ b/website/content/en/docs/setup/installation/_index.md
@@ -6,7 +6,7 @@ short: Installation
 
 Vector compiles to a single static binary, which makes it easy to install.
 
-On *nix systems Vector's only dependency is [`libc`][libc]. Your operating system should generally provide this
+On \*nix systems Vector's only dependency is [`libc`][libc]. Your operating system should generally provide this
 dependency.
 
 ## Using static musl builds
@@ -18,16 +18,24 @@ artifacts can be useful in stripped-down environments that don't provide a built
 {{< warning title="musl performance issues" >}}
 Please note that musl, as of this writing, has a significantly worse performance profile than [glibc] when Vector is
 running in multiple threads (Vector defaults to the number of available cores). We recommend that you use [glibc] when
-available *unless* you're running Vector on a single CPU.
+available _unless_ you're running Vector on a single CPU.
 
 [glibc]: https://www.gnu.org/software/libc
+
 {{< /warning >}}
 
 ## Installation script
 
-These light-weight scripts detect your platform and determine the best method for installing Vector:
+This light-weight script detects your platform and determine the best method for installing Vector:
 
 {{< easy-install-scripts >}}
+
+You can use the `--prefix` option to specify a custom installation directory. This is
+especially useful in automated environments (for example Dockerfiles).
+
+The following command adds the required binaries to `$PATH` without modifying your profiles.
+
+{{< docker-example-install-scripts >}}
 
 ## Other installation methods
 

--- a/website/cue/reference/administration/example_docker_install_commands.cue
+++ b/website/cue/reference/administration/example_docker_install_commands.cue
@@ -1,0 +1,16 @@
+// One-liner installation commands. Currently displayed only on the main page.
+package metadata
+
+#Command: {
+	title:   string
+	command: string
+}
+
+administration: {
+	example_docker_install_commands: [#Command, ...#Command] & [
+		{
+			title:   "Docker example"
+			command: "RUN apk add --no-cache curl bash && \\ \n    curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y --prefix /usr/local"
+		},
+	]
+}

--- a/website/cue/reference/administration/example_docker_install_commands.cue
+++ b/website/cue/reference/administration/example_docker_install_commands.cue
@@ -7,10 +7,8 @@ package metadata
 }
 
 administration: {
-	example_docker_install_commands: [#Command, ...#Command] & [
-		{
-			title:   "Docker example"
-			command: "RUN apk add --no-cache curl bash && \\ \n    curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y --prefix /usr/local"
-		},
-	]
+	example_docker_install_commands: [#Command, ...#Command] & [{
+		title:   "Docker example"
+		command: "RUN apk add --no-cache curl bash && \\ \n    curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y --prefix /usr/local"
+	}]
 }

--- a/website/layouts/shortcodes/docker-example-install-scripts.html
+++ b/website/layouts/shortcodes/docker-example-install-scripts.html
@@ -1,0 +1,25 @@
+{{ $commands := site.Data.docs.administration.example_docker_install_commands }}
+{{ $defaultCommand := (index $commands 0).title }}
+<div x-data="{ command: '{{ $defaultCommand }}' }" class="no-prose">
+  <div class="flex space-x-5" role="tablist" aria-orientation="horizontal">
+    {{ range $commands }}
+    <button
+      @click="command = '{{ .title }}'"
+      :class="{ 'text-secondary dark:text-primary font-bold': command === '{{ .title }}' }"
+      role="tab"
+      tabindex="0"
+      class="text-sm font-light tracking-tight text-gray-500 cursor-pointer md:text-base lg:text-lg dark:text-gray-400"
+    >
+      {{ .title }}
+    </button>
+    {{ end }}
+  </div>
+
+  {{ range $commands }}
+  <div x-show="command === '{{ .title }}'">
+    <div class="p-1 mt-3 overflow-x-scroll bg-black rounded-md">
+      {{ highlight .command "bash" "" }}
+    </div>
+  </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
This change adds a `--prefix` option so that users using the install script can manually    specify a custom installation directory and save them from having to copying the `vector`    binary to their $PATH in some situations.

Also added docs to the "Installation script" section for example usage.

Fixes #13486.