### PR TITLE
fix(buffers): Revert handle negative acknowledgements by stopping readers

### DIFF
--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use metrics::{counter, decrement_gauge, gauge, increment_gauge};
 use vector_common::internal_event::InternalEvent;
 
@@ -111,25 +109,6 @@ impl InternalEvent for BufferReadError {
             "error_code" => self.error_code,
             "error_type" => "reader_failed",
             "stage" => "processing",
-        );
-    }
-}
-
-pub(crate) struct BufferStopping {
-    pub data_dir: PathBuf,
-    pub record_id: u64,
-}
-
-impl InternalEvent for BufferStopping {
-    fn emit(self) {
-        let Self {
-            data_dir,
-            record_id,
-        } = self;
-        error!(
-            data_dir = ?data_dir,
-            record_id = %record_id,
-            "Disk buffer has received a negative acknowledgement, stopping processing. To correct, run: `vector buffer-advance --record-id {record_id} {data_dir:?}`",
         );
     }
 }

--- a/lib/vector-buffers/src/test/helpers.rs
+++ b/lib/vector-buffers/src/test/helpers.rs
@@ -100,8 +100,3 @@ pub(crate) async fn acknowledge(mut event: impl Finalizable) {
     // Finalizers are implicitly dropped here, sending the status update.
     tokio::task::yield_now().await;
 }
-
-pub(crate) async fn acknowledge_error(mut event: impl Finalizable) {
-    event.take_finalizers().update_status(EventStatus::Errored);
-    tokio::task::yield_now().await;
-}

--- a/lib/vector-buffers/src/topology/channel/receiver.rs
+++ b/lib/vector-buffers/src/topology/channel/receiver.rs
@@ -51,44 +51,25 @@ impl<T: Bufferable> From<disk_v2::Reader<T, ProductionFilesystem>> for ReceiverA
     }
 }
 
-pub(crate) enum Received<T> {
-    None,
-    Some(T),
-    Stopped,
-}
-
-impl<T> From<Option<T>> for Received<T> {
-    fn from(that: Option<T>) -> Self {
-        match that {
-            None => Self::None,
-            Some(that) => Self::Some(that),
-        }
-    }
-}
-
 impl<T> ReceiverAdapter<T>
 where
     T: Bufferable,
 {
-    pub(crate) async fn next(&mut self) -> Received<T> {
+    pub(crate) async fn next(&mut self) -> Option<T> {
         match self {
-            ReceiverAdapter::InMemory(rx) => rx.next().await.into(),
-            ReceiverAdapter::DiskV1(reader) => match reader.next().await {
-                Ok(result) => result.into(),
-                Err(_) => Received::Stopped,
-            },
+            ReceiverAdapter::InMemory(rx) => rx.next().await,
+            ReceiverAdapter::DiskV1(reader) => reader.next().await,
             ReceiverAdapter::DiskV2(reader) => loop {
                 match reader.next().await {
-                    Ok(result) => break result.into(),
-                    Err(e) => match (e.is_stopped(), e.as_recoverable_error()) {
-                        (true, _) => break Received::Stopped,
-                        (false, Some(re)) => {
+                    Ok(result) => break result,
+                    Err(e) => match e.as_recoverable_error() {
+                        Some(re) => {
                             // If we've hit a recoverable error, we'll emit an event to indicate as much but we'll still
                             // keep trying to read the next available record.
                             emit(re);
                             continue;
                         }
-                        (false, None) => panic!("Reader encountered unrecoverable error: {:?}", e),
+                        None => panic!("Reader encountered unrecoverable error: {:?}", e),
                     },
                 }
             },
@@ -109,7 +90,6 @@ pub struct BufferReceiver<T: Bufferable> {
     base: ReceiverAdapter<T>,
     overflow: Option<Box<BufferReceiver<T>>>,
     instrumentation: Option<BufferUsageHandle>,
-    stopped: bool,
 }
 
 impl<T: Bufferable> BufferReceiver<T> {
@@ -119,7 +99,6 @@ impl<T: Bufferable> BufferReceiver<T> {
             base,
             overflow: None,
             instrumentation: None,
-            stopped: false,
         }
     }
 
@@ -129,7 +108,6 @@ impl<T: Bufferable> BufferReceiver<T> {
             base,
             overflow: Some(Box::new(overflow)),
             instrumentation: None,
-            stopped: false,
         }
     }
 
@@ -149,12 +127,6 @@ impl<T: Bufferable> BufferReceiver<T> {
 
     #[async_recursion]
     pub async fn next(&mut self) -> Option<T> {
-        // If the base receiver indicated it has been stopped by a negative acknowledgement, then
-        // stop receiving from the overflow as well.
-        if self.stopped {
-            return None;
-        }
-
         // We want to poll both our base and overflow receivers without waiting for one or the
         // other to entirely drain before checking the other.  This ensures that we're fairly
         // servicing both receivers, and avoiding stalls in one or the other.
@@ -167,24 +139,13 @@ impl<T: Bufferable> BufferReceiver<T> {
 
         let (item, from_base) = match overflow {
             None => match self.base.next().await {
-                Received::Some(item) => (item, true),
-                Received::None => return None,
-                Received::Stopped => {
-                    self.stopped = true;
-                    return None;
-                }
+                Some(item) => (item, true),
+                None => return None,
             },
             Some(mut overflow) => {
                 select! {
                     Some(item) = overflow.next() => (item, false),
-                    next = self.base.next() => match next {
-                        Received::Some(item) => (item, true),
-                        Received::None => return None,
-                        Received::Stopped => {
-                            self.stopped = true;
-                            return None;
-                        }
-                    },
+                    Some(item) = self.base.next() => (item, true),
                     else => return None,
                 }
             }

--- a/lib/vector-buffers/src/variants/disk_v1/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/mod.rs
@@ -14,7 +14,7 @@ use std::{
     num::NonZeroU64,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -29,16 +29,12 @@ use leveldb::{
 };
 use snafu::{ResultExt, Snafu};
 use tokio::{sync::Notify, time::Instant};
-use vector_common::{
-    finalization::BatchStatus, finalizer::OrderedFinalizer, internal_event::emit,
-    shutdown::ShutdownSignal,
-};
+use vector_common::{finalizer::OrderedFinalizer, shutdown::ShutdownSignal};
 
 use self::key::Key;
 pub use self::{reader::Reader, writer::Writer};
 use crate::{
     buffer_usage_data::BufferUsageHandle,
-    internal_events::BufferStopping,
     topology::{
         acks::OrderedAcknowledgements,
         builder::IntoBuffer,
@@ -392,34 +388,16 @@ fn build<T: Bufferable>(
     let read_waker = Arc::new(Notify::new());
     let write_waker = Arc::new(Notify::new());
     let ack_counter = Arc::new(AtomicUsize::new(0));
-    let reader_done = Arc::new(AtomicBool::new(false));
-    let delete_offset = Arc::new(AtomicUsize::new(delete_offset));
-
     let (finalizer, mut stream) = OrderedFinalizer::<u64>::new(ShutdownSignal::noop());
     {
         let ack_counter = Arc::clone(&ack_counter);
         let read_waker = Arc::clone(&read_waker);
-        let reader_done = Arc::clone(&reader_done);
-        let delete_offset = Arc::clone(&delete_offset);
-        let data_dir = path.into();
         tokio::spawn(async move {
-            while let Some((status, amount)) = stream.next().await {
-                match status {
-                    BatchStatus::Delivered => {
-                        let amount = amount.try_into().expect("too many records on 32-bit");
-                        ack_counter.fetch_add(amount, Ordering::Relaxed);
-                        read_waker.notify_one();
-                    }
-                    BatchStatus::Errored | BatchStatus::Rejected => {
-                        emit(BufferStopping {
-                            data_dir,
-                            record_id: delete_offset.load(Ordering::Relaxed) as u64,
-                        });
-                        break;
-                    }
-                }
+            while let Some((_status, amount)) = stream.next().await {
+                let amount = amount.try_into().expect("too many records on 32-bit");
+                ack_counter.fetch_add(amount, Ordering::Relaxed);
+                read_waker.notify_one();
             }
-            reader_done.store(true, Ordering::Relaxed);
         });
     }
 
@@ -456,7 +434,6 @@ fn build<T: Bufferable>(
         usage_handle,
         phantom: PhantomData,
         finalizer,
-        reader_done,
     };
 
     Ok((writer, reader))

--- a/lib/vector-buffers/src/variants/disk_v1/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/reader.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
     marker::PhantomData,
     sync::{
-        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -57,7 +57,7 @@ pub struct Reader<T> {
     /// First uncompacted key
     pub(crate) compacted_offset: usize,
     /// First not deleted key
-    pub(crate) delete_offset: Arc<AtomicUsize>,
+    pub(crate) delete_offset: usize,
     /// Reader is notified by Writers through this Waker.
     /// Shared with Writers.
     pub(crate) read_waker: Arc<Notify>,
@@ -90,14 +90,6 @@ pub struct Reader<T> {
     pub(crate) usage_handle: BufferUsageHandle,
     pub(crate) phantom: PhantomData<T>,
     pub(crate) finalizer: OrderedFinalizer<u64>,
-    pub(super) reader_done: Arc<AtomicBool>,
-}
-
-/// Error that occurred during calls to [`Reader::next`]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ReaderError {
-    /// The reader has been stopped due to an acknowledgement error.
-    Stopped,
 }
 
 impl<T> Reader<T>
@@ -105,16 +97,11 @@ where
     T: Bufferable,
 {
     #[cfg_attr(test, instrument(skip(self), level = "debug"))]
-    pub async fn next(&mut self) -> Result<Option<T>, ReaderError> {
+    pub async fn next(&mut self) -> Option<T> {
         loop {
             // Check for any pending acknowledgements which may make a read eligible to finally be
             // deleted from the buffer entirely.
             self.try_flush();
-
-            // If we received a negative acknowledgement, stop returning results.
-            if self.reader_done.load(Ordering::Relaxed) {
-                return Err(ReaderError::Stopped);
-            }
 
             // If we have no buffered items, do a read from LevelDB.
             if self.buffer.is_empty() {
@@ -148,7 +135,7 @@ where
                         let (batch, receiver) = BatchNotifier::new_with_receiver();
                         item.add_batch_notifier(batch);
                         self.finalizer.add(count as u64, receiver);
-                        return Ok(Some(item));
+                        return Some(item);
                     }
                     Err(error) => {
                         error!(%error, "Error deserializing event.");
@@ -159,7 +146,7 @@ where
                 if Arc::strong_count(&self.db) == 1 {
                     // There are no writers left, and we've consumed all remaining items in the
                     // buffer, so we need to signal to this to caller by returning `None`.
-                    return Ok(None);
+                    return None;
                 }
 
                 // We have no more buffered reads, and we always make sure to do a read if our
@@ -274,8 +261,7 @@ impl<T> Reader<T> {
             // We adjust the delete offset/remaining acks here so that the next call to
             // `get_next_eligible_delete` has updated offsets so we can optimally drain as many
             // eligible deletes as possible in one go.
-            self.delete_offset
-                .store(key.wrapping_add(event_count), Ordering::Relaxed);
+            self.delete_offset = key.wrapping_add(event_count);
 
             total_records += 1;
             total_events += event_count;
@@ -286,7 +272,7 @@ impl<T> Reader<T> {
         // and update our buffer usage metrics.
         if total_records > 0 {
             debug!(
-                delete_offset = self.delete_offset.load(Ordering::Relaxed),
+                delete_offset = self.delete_offset,
                 "Deleting {} records from buffer: {} items, {} bytes.",
                 total_records,
                 total_events,
@@ -295,7 +281,7 @@ impl<T> Reader<T> {
             self.db.write(WriteOptions::new(), &delete_batch).unwrap();
 
             assert!(
-                self.delete_offset.load(Ordering::Relaxed) <= self.read_offset,
+                self.delete_offset <= self.read_offset,
                 "tried to ack beyond read offset"
             );
 
@@ -354,12 +340,10 @@ impl<T> Reader<T> {
             self.uncompacted_size = 0;
 
             debug!("Compacting disk buffer.");
-            self.db.compact(
-                &Key(self.compacted_offset),
-                &Key(self.delete_offset.load(Ordering::Relaxed)),
-            );
+            self.db
+                .compact(&Key(self.compacted_offset), &Key(self.delete_offset));
 
-            self.compacted_offset = self.delete_offset.load(Ordering::Relaxed);
+            self.compacted_offset = self.delete_offset;
             self.last_compaction = Instant::now();
         }
     }

--- a/lib/vector-buffers/src/variants/disk_v1/tests/acknowledgements.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/acknowledgements.rs
@@ -5,13 +5,10 @@ use super::{create_default_buffer_v1, read_next};
 use crate::{
     assert_reader_v1_delete_position, assert_reader_writer_v1_positions,
     test::{
-        acknowledge, acknowledge_error, install_tracing_helpers, with_temp_dir, MultiEventRecord,
+        acknowledge, install_tracing_helpers, with_temp_dir, MultiEventRecord,
         PoisonPillMultiEventRecord, SizedRecord,
     },
-    variants::disk_v1::{
-        reader::{ReaderError, FLUSH_INTERVAL},
-        tests::drive_reader_to_flush,
-    },
+    variants::disk_v1::{reader::FLUSH_INTERVAL, tests::drive_reader_to_flush},
     EventCount,
 };
 
@@ -249,46 +246,4 @@ async fn acking_when_undecodable_records_present() {
 
         tokio::time::resume();
     }
-}
-
-#[tokio::test]
-async fn negative_acknowledgement_stops_reader() {
-    let _a = install_tracing_helpers();
-    with_temp_dir(|dir| {
-        let data_dir = dir.to_path_buf();
-
-        async move {
-            // Create a regular buffer, no customizations required.
-            let (mut writer, mut reader) = create_default_buffer_v1(data_dir);
-            assert_reader_writer_v1_positions!(reader, writer, 0, 0);
-
-            // Write in some records to read back
-            for _ in 1..5 {
-                let record = SizedRecord::new(360);
-                assert_eq!(record.event_count(), 1); // Math below depends on this
-                writer.send(SizedRecord::new(360)).await;
-            }
-            writer.flush();
-            tokio::time::pause();
-
-            // Read out the first one and acknowledge it, checking the delete offset.
-            let read_record = read_next(&mut reader).await;
-            assert_reader_v1_delete_position!(reader, 0);
-            acknowledge(read_record).await;
-            tokio::time::advance(FLUSH_INTERVAL).await;
-            // assert_reader_v1_delete_position!(reader, 1); // advancement happens after next read
-
-            // Read out the second one and nack it, this should *not* advance the delete offset.
-            let read_record = read_next(&mut reader).await;
-            assert_reader_v1_delete_position!(reader, 1);
-            acknowledge_error(read_record).await;
-            tokio::time::advance(FLUSH_INTERVAL).await;
-            assert_reader_v1_delete_position!(reader, 1);
-
-            assert_eq!(reader.next().await, Err(ReaderError::Stopped));
-            tokio::time::advance(FLUSH_INTERVAL).await;
-            assert_reader_v1_delete_position!(reader, 1);
-        }
-    })
-    .await;
 }

--- a/lib/vector-buffers/src/variants/disk_v1/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v1/tests/mod.rs
@@ -130,14 +130,11 @@ macro_rules! assert_reader_writer_v1_positions {
 #[macro_export]
 macro_rules! assert_reader_v1_delete_position {
     ($reader:expr, $expected_reader:expr) => {{
-        use std::sync::atomic::Ordering;
-        let delete_offset = &$reader.delete_offset;
+        let delete_offset = $reader.delete_offset;
         assert_eq!(
-            delete_offset.load(Ordering::Relaxed),
-            $expected_reader,
+            delete_offset, $expected_reader,
             "expected delete offset of {}, got {} instead",
-            $expected_reader,
-            delete_offset.load(Ordering::Relaxed),
+            $expected_reader, delete_offset
         );
     }};
 }
@@ -201,9 +198,5 @@ pub(crate) async fn read_next<T>(reader: &mut Reader<T>) -> T
 where
     T: Bufferable,
 {
-    reader
-        .next()
-        .await
-        .expect("read should not fail")
-        .expect("read should not be none")
+    reader.next().await.expect("read should not fail")
 }

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -14,10 +14,7 @@ use futures::StreamExt;
 use rkyv::{with::Atomic, Archive, Serialize};
 use snafu::{ResultExt, Snafu};
 use tokio::{fs, io::AsyncWriteExt, sync::Notify};
-use vector_common::{
-    finalization::BatchStatus, finalizer::OrderedFinalizer, internal_event::emit,
-    shutdown::ShutdownSignal,
-};
+use vector_common::{finalizer::OrderedFinalizer, shutdown::ShutdownSignal};
 
 use super::{
     backed_archive::BackedArchive,
@@ -26,7 +23,7 @@ use super::{
     ser::SerializeError,
     Filesystem,
 };
-use crate::{buffer_usage_data::BufferUsageHandle, internal_events::BufferStopping};
+use crate::buffer_usage_data::BufferUsageHandle;
 
 pub const LEDGER_LEN: usize = align16(mem::size_of::<ArchivedLedgerState>());
 
@@ -235,8 +232,6 @@ where
     last_flush: AtomicCell<Instant>,
     // Tracks usage data about the buffer.
     usage_handle: BufferUsageHandle,
-    // Tracks when a negative acknowledgement has been received
-    reader_done: AtomicBool,
 }
 
 impl<FS> Ledger<FS>
@@ -416,16 +411,6 @@ where
     /// Returns `true` if the writer was marked as done.
     pub fn is_writer_done(&self) -> bool {
         self.writer_done.load(Ordering::Acquire)
-    }
-
-    /// Marks the reader as finished.
-    fn stop_reader(&self) {
-        self.reader_done.store(true, Ordering::Release);
-    }
-
-    /// Returns `true` if the reader was marked as done.
-    pub(super) fn is_reader_done(&self) -> bool {
-        self.reader_done.load(Ordering::Acquire)
     }
 
     /// Increments the pending acknowledgement counter by the given amount.
@@ -665,7 +650,6 @@ where
             unacked_reader_file_id_offset: AtomicU16::new(0),
             last_flush: AtomicCell::new(Instant::now()),
             usage_handle,
-            reader_done: AtomicBool::new(false),
         };
         ledger.update_buffer_size().await?;
 
@@ -722,24 +706,11 @@ where
     #[must_use]
     pub(super) fn spawn_finalizer(self: Arc<Self>) -> OrderedFinalizer<u64> {
         let (finalizer, mut stream) = OrderedFinalizer::new(ShutdownSignal::noop());
-        let data_dir = self.config.data_dir.clone();
         tokio::spawn(async move {
-            while let Some((status, amount)) = stream.next().await {
-                match status {
-                    BatchStatus::Delivered => {
-                        self.increment_pending_acks(amount);
-                        self.notify_writer_waiters();
-                    }
-                    BatchStatus::Errored | BatchStatus::Rejected => {
-                        emit(BufferStopping {
-                            data_dir,
-                            record_id: self.state().get_last_reader_record_id(),
-                        });
-                        break;
-                    }
-                }
+            while let Some((_status, amount)) = stream.next().await {
+                self.increment_pending_acks(amount);
+                self.notify_writer_waiters();
             }
-            self.stop_reader();
         });
         finalizer
     }

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -123,9 +123,6 @@ where
     /// writing logic of the buffer, or a record that does not use a symmetrical encoding scheme,
     /// which is also not supported.
     EmptyRecord,
-
-    /// The reader has been stopped due to an acknowledgement error.
-    Stopped,
 }
 
 impl<T> ReaderError<T>
@@ -135,38 +132,35 @@ where
     fn is_bad_read(&self) -> bool {
         matches!(
             self,
-            Self::Checksum { .. } | Self::Deserialization { .. } | Self::PartialWrite
+            ReaderError::Checksum { .. }
+                | ReaderError::Deserialization { .. }
+                | ReaderError::PartialWrite
         )
-    }
-
-    pub(crate) fn is_stopped(&self) -> bool {
-        matches!(self, Self::Stopped)
     }
 
     fn as_error_code(&self) -> &'static str {
         match self {
-            Self::Io { .. } => "io_error",
-            Self::Deserialization { .. } => "deser_failed",
-            Self::Checksum { .. } => "checksum_mismatch",
-            Self::Decode { .. } => "decode_failed",
-            Self::Incompatible { .. } => "incompatible_record_version",
-            Self::PartialWrite => "partial_write",
-            Self::EmptyRecord => "empty_record",
-            Self::Stopped => "reader_stopped",
+            ReaderError::Io { .. } => "io_error",
+            ReaderError::Deserialization { .. } => "deser_failed",
+            ReaderError::Checksum { .. } => "checksum_mismatch",
+            ReaderError::Decode { .. } => "decode_failed",
+            ReaderError::Incompatible { .. } => "incompatible_record_version",
+            ReaderError::PartialWrite => "partial_write",
+            ReaderError::EmptyRecord => "empty_record",
         }
     }
 
-    pub(crate) fn as_recoverable_error(&self) -> Option<BufferReadError> {
+    pub fn as_recoverable_error(&self) -> Option<BufferReadError> {
         let error = self.to_string();
         let error_code = self.as_error_code();
 
         match self {
-            Self::Io { .. } | Self::EmptyRecord | Self::Stopped => None,
-            Self::Deserialization { .. }
-            | Self::Checksum { .. }
-            | Self::Decode { .. }
-            | Self::Incompatible { .. }
-            | Self::PartialWrite => Some(BufferReadError { error_code, error }),
+            ReaderError::Io { .. } | ReaderError::EmptyRecord => None,
+            ReaderError::Deserialization { .. }
+            | ReaderError::Checksum { .. }
+            | ReaderError::Decode { .. }
+            | ReaderError::Incompatible { .. }
+            | ReaderError::PartialWrite => Some(BufferReadError { error_code, error }),
         }
     }
 }
@@ -946,10 +940,6 @@ where
                 .await
                 .context(IoSnafu)?;
             force_check_pending_data_files = false;
-
-            if self.ledger.is_reader_done() {
-                return Err(ReaderError::Stopped);
-            }
 
             // If the writer has marked themselves as done, and the buffer has been emptied, then
             // we're done and can return.  We have to look at something besides simply the writer

--- a/lib/vector-buffers/src/variants/disk_v2/v1_migration.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/v1_migration.rs
@@ -4,8 +4,7 @@ use vector_common::finalization::{EventStatus, Finalizable};
 
 use crate::{
     buffer_usage_data::BufferUsageHandle,
-    topology::builder::IntoBuffer,
-    topology::channel::{Received, ReceiverAdapter},
+    topology::{builder::IntoBuffer, channel::ReceiverAdapter},
     variants::{
         disk_v2::{build_disk_v2_buffer, get_disk_v2_data_dir_path},
         DiskV1Buffer,
@@ -73,7 +72,7 @@ where
     info!("Detected old `disk_v1`-based buffer for the `{}` sink. Automatically migrating to `disk_v2`.", id);
 
     let mut migrated_records = 0;
-    while let Received::Some(mut old_record) = src_reader.next().await {
+    while let Some(mut old_record) = src_reader.next().await {
         let old_record_event_count = old_record.event_count();
         let finalizers = ManuallyDrop::new(old_record.take_finalizers());
 


### PR DESCRIPTION
This reverts commit 000fe8bb918a5409b8b7df0d43c436648c611d32.

After discussing the user experience impacts of this change, we have decided to reverse course on
this implementation in favor of the ability to redirect events or batches with errors to alternate
destinations.

Epic: #12145 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
