### PR TITLE
chore(metrics): Eliminate histogram bucket loop

### DIFF
--- a/lib/vector-core/src/metrics/handle.rs
+++ b/lib/vector-core/src/metrics/handle.rs
@@ -141,6 +141,7 @@ impl Histogram {
         let log = value.max(Self::MIN_BUCKET).log2().ceil();
         // Offset it based on the minimum bucket's exponent. The result will be non-negative thanks
         // to the `.max` above, so we can coerce it directly to `usize`.
+        #[allow(clippy::cast_possible_truncation)] // The log will always be smaller than `usize`.
         let index = (log - Self::MIN_BUCKET_EXP) as usize;
         // Now bound the value for values larger than the largest bucket.
         index.min(Self::BUCKETS - 1)


### PR DESCRIPTION
The internal metrics histogram buckets are all divided on constant power-of-two borders. As such,
the right bucket number can be computed with a relatively simple log_2 calculation and bounding
instead of the existing loop-and-test.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
