### PR TITLE
chore(vrl): Call `parse_groks` in implementation of `parse_grok`

### DIFF
--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -1,58 +1,9 @@
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use std::collections::BTreeMap;
 
-use ::value::Value;
-use vrl::{
-    diagnostic::{Label, Span},
-    prelude::*,
-};
+use datadog_grok::parse_grok_rules;
+use vrl::prelude::*;
 
-fn parse_grok(value: Value, pattern: Arc<grok::Pattern>) -> Resolved {
-    let bytes = value.try_bytes_utf8_lossy()?;
-    match pattern.match_against(&bytes) {
-        Some(matches) => {
-            let mut result = BTreeMap::new();
-
-            for (name, value) in matches.iter() {
-                result.insert(name.to_string(), Value::from(value));
-            }
-
-            Ok(Value::from(result))
-        }
-        None => Err("unable to parse input with grok pattern".into()),
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum Error {
-    InvalidGrokPattern(grok::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::InvalidGrokPattern(err) => err.fmt(f),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl DiagnosticMessage for Error {
-    fn code(&self) -> usize {
-        109
-    }
-
-    fn labels(&self) -> Vec<Label> {
-        match self {
-            Error::InvalidGrokPattern(err) => {
-                vec![Label::primary(
-                    format!("grok pattern error: {}", err),
-                    Span::default(),
-                )]
-            }
-        }
-    }
-}
+use crate::parse_groks::{Error, ParseGroksFn};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseGrok;
@@ -73,6 +24,11 @@ impl Function for ParseGrok {
                 keyword: "pattern",
                 kind: kind::BYTES,
                 required: true,
+            },
+            Parameter {
+                keyword: "aliases",
+                kind: kind::OBJECT,
+                required: false,
             },
         ]
     }
@@ -110,66 +66,95 @@ impl Function for ParseGrok {
             .try_bytes_utf8_lossy()
             .expect("grok pattern not bytes")
             .into_owned();
+        let patterns = [pattern];
 
-        let mut grok = grok::Grok::with_default_patterns();
-        let pattern =
-            Arc::new(grok.compile(&pattern, true).map_err(|e| {
-                Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
-            })?);
+        let aliases = arguments
+            .optional_object("aliases")?
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(key, expr)| {
+                let alias = expr
+                    .as_value()
+                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "aliases",
+                        expr,
+                    })
+                    .map(|e| {
+                        e.try_bytes_utf8_lossy()
+                            .expect("should be a string")
+                            .into_owned()
+                    })?;
+                Ok((key, alias))
+            })
+            .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>()?;
 
-        Ok(Box::new(ParseGrokFn { value, pattern }))
+        // we use a datadog library here because it is a superset of grok
+        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
+            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
+
+        Ok(Box::new(ParseGroksFn { value, grok_rules }))
     }
 
     fn compile_argument(
         &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
+        args: &[(&'static str, Option<FunctionArgument>)],
         _ctx: &mut FunctionCompileContext,
         name: &str,
         expr: Option<&expression::Expr>,
     ) -> CompiledArgument {
         match (name, expr) {
             ("pattern", Some(expr)) => {
+                let aliases: Option<&FunctionArgument> = args.iter().find_map(|(name, arg)| {
+                    if *name == "aliases" {
+                        arg.as_ref()
+                    } else {
+                        None
+                    }
+                });
+
                 let pattern = expr
                     .as_literal("pattern")?
                     .try_bytes_utf8_lossy()
                     .expect("grok pattern not bytes")
                     .into_owned();
+                let patterns = [pattern];
 
-                let mut grok = grok::Grok::with_default_patterns();
-                let pattern = Arc::new(grok.compile(&pattern, true).map_err(|e| {
-                    Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
-                })?);
+                let aliases = aliases
+                .map(|aliases| {
+                    aliases
+                        .as_value()
+                        .unwrap()
+                        .try_object()
+                        .unwrap()
+                        .into_iter()
+                        .map(|(key, expr)| {
+                            let alias = expr
+                                .try_bytes_utf8_lossy()
+                                .expect("should be a string")
+                                .into_owned();
+                            Ok((key, alias))
+                        })
+                    .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>().unwrap()
+                })
+                .unwrap_or_default();
 
-                Ok(Some(Box::new(pattern) as _))
+                // We use a datadog library here because it is a superset of grok.
+                let grok_rules =
+                    parse_grok_rules::parse_grok_rules(&patterns, aliases).map_err(|e| {
+                        Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
+                    })?;
+
+                Ok(Some(Box::new(grok_rules) as _))
             }
+            ("aliases", Some(_)) => Ok(None),
             _ => Ok(None),
         }
     }
 }
 
-#[derive(Clone, Debug)]
-struct ParseGrokFn {
-    value: Box<dyn Expression>,
-
-    // Wrapping pattern in an Arc, as cloning the pattern could otherwise be expensive.
-    pattern: Arc<grok::Pattern>,
-}
-
-impl Expression for ParseGrokFn {
-    fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?;
-        let pattern = self.pattern.clone();
-
-        parse_grok(value, pattern)
-    }
-
-    fn type_def(&self, _: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
-        TypeDef::object(Collection::any()).fallible()
-    }
-}
-
 #[cfg(test)]
 mod test {
+    use ::value::Value;
     use vector_common::btreemap;
 
     use super::*;
@@ -180,21 +165,21 @@ mod test {
         invalid_grok {
             args: func_args![ value: "foo",
                               pattern: "%{NOG}"],
-            want: Err("The given pattern definition name \"NOG\" could not be found in the definition map"),
+            want: Err("failed to parse grok expression '\\A%{NOG}\\z': The given pattern definition name \"NOG\" could not be found in the definition map"),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 
         error {
             args: func_args![ value: "an ungrokkable message",
                               pattern: "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"],
-            want: Err("unable to parse input with grok pattern"),
+            want: Err("unable to parse grok: value does not match any rule"),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 
         error2 {
             args: func_args![ value: "2020-10-02T23:22:12.223222Z an ungrokkable message",
                               pattern: "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"],
-            want: Err("unable to parse input with grok pattern"),
+            want: Err("unable to parse grok: value does not match any rule"),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 
@@ -213,6 +198,7 @@ mod test {
             args: func_args![ value: "2020-10-02T23:22:12.223222Z",
                               pattern: "(%{TIMESTAMP_ISO8601:timestamp}|%{LOGLEVEL:level})"],
             want: Ok(Value::from(btreemap! {
+                "level" => "",
                 "timestamp" => "2020-10-02T23:22:12.223222Z",
             })),
             tdef: TypeDef::object(Collection::any()).fallible(),

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -35,9 +35,8 @@ impl Function for ParseGrok {
             title: "parse grok pattern",
             source: indoc! {r#"
                 value = "2020-10-02T23:22:12.223222Z info Hello world"
-                pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
 
-                parse_grok!(value, pattern)
+                parse_grok!(value, "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}")
             "#},
             result: Ok(indoc! {r#"
                 {

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -1,9 +1,6 @@
-use std::collections::BTreeMap;
-
-use datadog_grok::parse_grok_rules;
 use vrl::prelude::*;
 
-use crate::parse_groks::{Error, ParseGroksFn};
+use crate::parse_groks::ParseGroks;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseGrok;
@@ -58,41 +55,12 @@ impl Function for ParseGrok {
         _ctx: &mut FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
-        let value = arguments.required("value");
+        let value = arguments.required_expr("value");
+        let pattern = arguments.required_expr("pattern");
+        let patterns = vec![pattern];
+        let aliases = arguments.optional_object("aliases")?.unwrap_or_default();
 
-        let pattern = arguments
-            .required_literal("pattern")?
-            .to_value()
-            .try_bytes_utf8_lossy()
-            .expect("grok pattern not bytes")
-            .into_owned();
-        let patterns = [pattern];
-
-        let aliases = arguments
-            .optional_object("aliases")?
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(key, expr)| {
-                let alias = expr
-                    .as_value()
-                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "aliases",
-                        expr,
-                    })
-                    .map(|e| {
-                        e.try_bytes_utf8_lossy()
-                            .expect("should be a string")
-                            .into_owned()
-                    })?;
-                Ok((key, alias))
-            })
-            .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>()?;
-
-        // we use a datadog library here because it is a superset of grok
-        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
-            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
-
-        Ok(Box::new(ParseGroksFn { value, grok_rules }))
+        ParseGroks::compile(value, patterns, aliases)
     }
 
     fn compile_argument(
@@ -104,7 +72,10 @@ impl Function for ParseGrok {
     ) -> CompiledArgument {
         match (name, expr) {
             ("pattern", Some(expr)) => {
-                let aliases: Option<&FunctionArgument> = args.iter().find_map(|(name, arg)| {
+                let pattern = expr.as_literal("pattern")?;
+                let patterns = vec![pattern];
+
+                let aliases = args.iter().find_map::<&FunctionArgument, _>(|(name, arg)| {
                     if *name == "aliases" {
                         arg.as_ref()
                     } else {
@@ -112,39 +83,7 @@ impl Function for ParseGrok {
                     }
                 });
 
-                let pattern = expr
-                    .as_literal("pattern")?
-                    .try_bytes_utf8_lossy()
-                    .expect("grok pattern not bytes")
-                    .into_owned();
-                let patterns = [pattern];
-
-                let aliases = aliases
-                .map(|aliases| {
-                    aliases
-                        .as_value()
-                        .unwrap()
-                        .try_object()
-                        .unwrap()
-                        .into_iter()
-                        .map(|(key, expr)| {
-                            let alias = expr
-                                .try_bytes_utf8_lossy()
-                                .expect("should be a string")
-                                .into_owned();
-                            Ok((key, alias))
-                        })
-                    .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>().unwrap()
-                })
-                .unwrap_or_default();
-
-                // We use a datadog library here because it is a superset of grok.
-                let grok_rules =
-                    parse_grok_rules::parse_grok_rules(&patterns, aliases).map_err(|e| {
-                        Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
-                    })?;
-
-                Ok(Some(Box::new(grok_rules) as _))
+                ParseGroks::compile_pattern_argument(patterns, aliases)
             }
             ("aliases", Some(_)) => Ok(None),
             _ => Ok(None),

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -1,12 +1,13 @@
 use std::{collections::BTreeMap, fmt};
 
+use ::value::Value;
 use datadog_grok::{
     parse_grok,
     parse_grok_rules::{self, GrokRule},
 };
 use vrl::{
     diagnostic::{Label, Span},
-    prelude::*,
+    prelude::{expression::Expr, *},
 };
 
 #[derive(Debug)]
@@ -43,6 +44,97 @@ impl DiagnosticMessage for Error {
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseGroks;
+
+impl ParseGroks {
+    pub(crate) fn compile(
+        value: Expr,
+        patterns: Vec<Expr>,
+        aliases: BTreeMap<String, Expr>,
+    ) -> Compiled {
+        let patterns = patterns
+            .into_iter()
+            .map(|expr| {
+                let pattern = expr
+                    .as_value()
+                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "patterns",
+                        expr,
+                    })?
+                    .try_bytes_utf8_lossy()
+                    .expect("grok pattern not bytes")
+                    .into_owned();
+                Ok(pattern)
+            })
+            .collect::<std::result::Result<Vec<String>, vrl::function::Error>>()?;
+
+        let aliases = aliases
+            .into_iter()
+            .map(|(key, expr)| {
+                let alias = expr
+                    .as_value()
+                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "aliases",
+                        expr,
+                    })
+                    .map(|e| {
+                        e.try_bytes_utf8_lossy()
+                            .expect("should be a string")
+                            .into_owned()
+                    })?;
+                Ok((key, alias))
+            })
+            .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>()?;
+
+        // we use a datadog library here because it is a superset of grok
+        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
+            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
+
+        Ok(Box::new(ParseGroksFn { value, grok_rules }))
+    }
+
+    pub(crate) fn compile_pattern_argument(
+        patterns: Vec<Value>,
+        aliases: Option<&FunctionArgument>,
+    ) -> CompiledArgument {
+        let aliases = aliases
+            .map(|aliases| {
+                aliases
+                    .as_value()
+                    .unwrap()
+                    .try_object()
+                    .unwrap()
+                    .into_iter()
+                    .map(|(key, expr)| {
+                        let alias = expr
+                            .try_bytes_utf8_lossy()
+                            .expect("should be a string")
+                            .into_owned();
+                        Ok((key, alias))
+                    })
+                    .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>(
+                    )
+                    .unwrap()
+            })
+            .unwrap_or_default();
+
+        let patterns = patterns
+            .into_iter()
+            .map(|value| {
+                let pattern = value
+                    .try_bytes_utf8_lossy()
+                    .expect("grok pattern not bytes")
+                    .into_owned();
+                Ok(pattern)
+            })
+            .collect::<std::result::Result<Vec<String>, vrl::function::Error>>()?;
+
+        // We use a datadog library here because it is a superset of grok.
+        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
+            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
+
+        Ok(Some(Box::new(grok_rules) as _))
+    }
+}
 
 impl Function for ParseGroks {
     fn identifier(&self) -> &'static str {
@@ -106,7 +198,19 @@ impl Function for ParseGroks {
     ) -> CompiledArgument {
         match (name, expr) {
             ("patterns", Some(expr)) => {
-                let aliases: Option<&FunctionArgument> = args.iter().find_map(|(name, arg)| {
+                let patterns = expr
+                    .as_value()
+                    .ok_or_else(|| vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "patterns",
+                        expr: expr.clone(),
+                    })?
+                    .try_array()
+                    .map_err(|_| vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "patterns",
+                        expr: expr.clone(),
+                    })?;
+
+                let aliases = args.iter().find_map::<&FunctionArgument, _>(|(name, arg)| {
                     if *name == "aliases" {
                         arg.as_ref()
                     } else {
@@ -114,54 +218,7 @@ impl Function for ParseGroks {
                     }
                 });
 
-                let patterns = expr.as_value().ok_or_else(|| {
-                    vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "patterns",
-                        expr: expr.clone(),
-                    }
-                })?;
-                let patterns = patterns
-                    .try_array()
-                    .map_err(|_| vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "patterns",
-                        expr: expr.clone(),
-                    })?
-                    .into_iter()
-                    .map(|value| {
-                        let pattern = value
-                            .try_bytes_utf8_lossy()
-                            .expect("grok pattern not bytes")
-                            .into_owned();
-                        Ok(pattern)
-                    })
-                    .collect::<std::result::Result<Vec<String>, vrl::function::Error>>()?;
-
-                let aliases = aliases
-                .map(|aliases| {
-                    aliases
-                        .as_value()
-                        .unwrap()
-                        .try_object()
-                        .unwrap()
-                        .into_iter()
-                        .map(|(key, expr)| {
-                            let alias = expr
-                                .try_bytes_utf8_lossy()
-                                .expect("should be a string")
-                                .into_owned();
-                            Ok((key, alias))
-                        })
-                    .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>().unwrap()
-                })
-                .unwrap_or_default();
-
-                // We use a datadog library here because it is a superset of grok.
-                let grok_rules =
-                    parse_grok_rules::parse_grok_rules(&patterns, aliases).map_err(|e| {
-                        Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
-                    })?;
-
-                Ok(Some(Box::new(grok_rules) as _))
+                Self::compile_pattern_argument(patterns, aliases)
             }
             ("aliases", Some(_)) => Ok(None),
             _ => Ok(None),
@@ -174,56 +231,17 @@ impl Function for ParseGroks {
         _ctx: &mut FunctionCompileContext,
         mut arguments: ArgumentList,
     ) -> Compiled {
-        let value = arguments.required("value");
+        let value = arguments.required_expr("value");
+        let patterns = arguments.required_array("patterns")?;
+        let aliases = arguments.optional_object("aliases")?.unwrap_or_default();
 
-        let patterns = arguments
-            .required_array("patterns")?
-            .into_iter()
-            .map(|expr| {
-                let pattern = expr
-                    .as_value()
-                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "patterns",
-                        expr,
-                    })?
-                    .try_bytes_utf8_lossy()
-                    .expect("grok pattern not bytes")
-                    .into_owned();
-                Ok(pattern)
-            })
-            .collect::<std::result::Result<Vec<String>, vrl::function::Error>>()?;
-
-        let aliases = arguments
-            .optional_object("aliases")?
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(key, expr)| {
-                let alias = expr
-                    .as_value()
-                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "aliases",
-                        expr,
-                    })
-                    .map(|e| {
-                        e.try_bytes_utf8_lossy()
-                            .expect("should be a string")
-                            .into_owned()
-                    })?;
-                Ok((key, alias))
-            })
-            .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>()?;
-
-        // we use a datadog library here because it is a superset of grok
-        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
-            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
-
-        Ok(Box::new(ParseGroksFn { value, grok_rules }))
+        Self::compile(value, patterns, aliases)
     }
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct ParseGroksFn {
-    pub(crate) value: Box<dyn Expression>,
+    pub(crate) value: Expr,
     pub(crate) grok_rules: Vec<GrokRule>,
 }
 

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -163,6 +163,7 @@ impl Function for ParseGroks {
 
                 Ok(Some(Box::new(grok_rules) as _))
             }
+            ("aliases", Some(_)) => Ok(None),
             _ => Ok(None),
         }
     }
@@ -216,17 +217,17 @@ impl Function for ParseGroks {
         let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
             .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
 
-        Ok(Box::new(ParseGrokFn { value, grok_rules }))
+        Ok(Box::new(ParseGroksFn { value, grok_rules }))
     }
 }
 
 #[derive(Clone, Debug)]
-struct ParseGrokFn {
-    value: Box<dyn Expression>,
-    grok_rules: Vec<GrokRule>,
+pub(crate) struct ParseGroksFn {
+    pub(crate) value: Box<dyn Expression>,
+    pub(crate) grok_rules: Vec<GrokRule>,
 }
 
-impl Expression for ParseGrokFn {
+impl Expression for ParseGroksFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let bytes = value.try_bytes_utf8_lossy()?;


### PR DESCRIPTION
Closes #12612.

(And therefore also introduces the same bug as #13534 in `parse_groks` to `parse_grok`).

#10287 is also somewhat related to this.