### PR TITLE
fix(mongodb_metrics source): Change bytes_written_from to i64

### DIFF
--- a/src/sources/mongodb_metrics/types.rs
+++ b/src/sources/mongodb_metrics/types.rs
@@ -326,7 +326,7 @@ pub struct CommandServerStatusWiredTigerCache {
     #[serde(rename = "bytes read into cache")]
     pub bytes_read_into: i32,
     #[serde(rename = "bytes written from cache")]
-    pub bytes_written_from: i32,
+    pub bytes_written_from: i64,
     #[serde(rename = "maximum bytes configured")]
     pub max_bytes: f64,
     #[serde(rename = "modified pages evicted")]


### PR DESCRIPTION
After monitoring MongoDB for a while, Vector will throw out errors like:

```
{ message: "invalid value: integer `2666800889`, expected i32" }
```

MongoDB returns `bytes written from cache` 64-bit integer, but we are trying to parse it as i32.

Signed-off-by: KernelErr <me@lirui.tech>