### PR TITLE
fix(enriching): fetch indexes if vector config is modified

### DIFF
--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -117,6 +117,11 @@ impl Difference {
         self.to_change.contains(key)
     }
 
+    /// Checks whether the given component is present as a change or addition.
+    pub fn is_added(&self, id: &ComponentKey) -> bool {
+        self.to_add.contains(id)
+    }
+
     /// Checks whether or not the given component is removed.
     pub fn is_removed(&self, key: &ComponentKey) -> bool {
         self.to_remove.contains(key)

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -117,7 +117,7 @@ impl Difference {
         self.to_change.contains(key)
     }
 
-    /// Checks whether the given component is present as a change or addition.
+    /// Checks whether the given component is present as an addition.
     pub fn is_added(&self, id: &ComponentKey) -> bool {
         self.to_add.contains(id)
     }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -76,7 +76,7 @@ pub(self) async fn load_enrichment_tables<'a>(
     'tables: for (name, table) in config.enrichment_tables.iter() {
         let table_name = name.to_string();
         if ENRICHMENT_TABLES.needs_reload(&table_name) {
-            let indexes = if !diff.enrichment_tables.contains_new(name) {
+            let indexes = if !diff.enrichment_tables.is_added(name) {
                 // If this is an existing enrichment table, we need to store the indexes to reapply
                 // them again post load.
                 Some(ENRICHMENT_TABLES.index_fields(&table_name))


### PR DESCRIPTION
Closes #13229 

When reloading the enrichment tables, Vector queries the existing enrichment tables for their indexes. Then the tables are loaded and these indexes are sent to the new tables.

It does this unless it is a new enrichment table - since that table will not have any indexes applied to it (due to it not having been loaded before). To determine if it is a new table the code was calling `!diff.enrichment_tables.contains_new`. It turns out that this function returns true if the table is new *or* has been modified. So if the table has been modified, the reload was thinking it was new and thus not passing the indexes on to the newly loaded table.

This resulted in Vector panicking when that index was queried.

This fix adds a new function that we can call to check if the table has actually been newly added to the config and returning false if it has been just modified.

----

This has highlighted a separate issue. The process that determines if a config entry has been modified serializes the objects to json and compares the json. Unfortunately, if the config contains a Map the order is non-deterministic. The result is when specifying a schema in the enrichment table config it can seem as though the enrichment table config has been modified, when in fact it has not been. (This is why it is only possible to reproduce this crash when a schema is specified for the table.)

I will raise a separate issue to look into this.

It is also worth further investigating what happens on reload if a new enrichment table and remap to query it is added to a config.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

