### PR TITLE
fix(vrl): Do not include empty matches for `grok` pattern

### DIFF
--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -289,7 +289,6 @@ mod test {
                               patterns: vec!["(%{TIMESTAMP_ISO8601:timestamp}|%{LOGLEVEL:level})"]],
             want: Ok(Value::from(btreemap! {
                 "timestamp" => "2020-10-02T23:22:12.223222Z",
-                "level" => "",
             })),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }


### PR DESCRIPTION
Closes #13534.