### PR TITLE
chore(config): initial integration of configuration schema for sinks (part two)

### DIFF
--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -17,7 +17,7 @@ enum KafkaError {
 #[derive(Clone, Copy, Debug, Derivative)]
 #[derivative(Default)]
 #[serde(rename_all = "lowercase")]
-pub(crate) enum KafkaCompression {
+pub enum KafkaCompression {
     /// No compression.
     #[derivative(Default)]
     None,
@@ -38,7 +38,7 @@ pub(crate) enum KafkaCompression {
 /// Kafka authentication configuration.
 #[configurable_component]
 #[derive(Clone, Debug, Default)]
-pub(crate) struct KafkaAuthConfig {
+pub struct KafkaAuthConfig {
     #[configurable(derived)]
     pub(crate) sasl: Option<KafkaSaslConfig>,
 
@@ -49,7 +49,7 @@ pub(crate) struct KafkaAuthConfig {
 /// Configuration for SASL authentication when interacting with Kafka.
 #[configurable_component]
 #[derive(Clone, Debug, Default)]
-pub(crate) struct KafkaSaslConfig {
+pub struct KafkaSaslConfig {
     /// Enables SASL authentication.
     ///
     /// Only `PLAIN` and `SCRAM`-based mechanisms are supported when configuring SASL authentication via `sasl.*`. For

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use rdkafka::{consumer::ConsumerContext, ClientConfig, ClientContext, Statistics};
-use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use vector_config::configurable_component;
 
@@ -13,15 +12,26 @@ enum KafkaError {
     InvalidPath { path: PathBuf },
 }
 
-#[derive(Clone, Copy, Debug, Derivative, Deserialize, Serialize)]
+/// Supported compression types for Kafka.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Derivative)]
 #[derivative(Default)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum KafkaCompression {
+    /// No compression.
     #[derivative(Default)]
     None,
+
+    /// Gzip.
     Gzip,
+
+    /// Snappy.
     Snappy,
+
+    /// LZ4.
     Lz4,
+
+    /// Zstandard.
     Zstd,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,9 @@ pub mod gcp;
 pub(crate) mod graph;
 pub mod heartbeat;
 pub mod http;
+#[allow(unreachable_pub)]
 #[cfg(any(feature = "sources-kafka", feature = "sinks-kafka"))]
-pub(crate) mod kafka;
+pub mod kafka;
 #[allow(unreachable_pub)]
 pub mod kubernetes;
 pub mod line_agg;

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -23,7 +23,7 @@ pub(crate) const QUEUED_MIN_MESSAGES: u64 = 100000;
 #[configurable_component(sink)]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct KafkaSinkConfig {
+pub struct KafkaSinkConfig {
     /// A comma-separated list of the initial Kafka brokers to connect to.
     ///
     /// Each value must be in the form of `<host>` or `<host>:<port>`, and separated by a comma.

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use codecs::JsonSerializerConfig;
 use futures::FutureExt;
 use rdkafka::ClientConfig;
-use serde::{Deserialize, Serialize};
+use vector_config::configurable_component;
 
 use crate::{
     codecs::EncodingConfig,
@@ -19,28 +19,66 @@ use crate::{
 
 pub(crate) const QUEUED_MIN_MESSAGES: u64 = 100000;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Configuration for the `kafka` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct KafkaSinkConfig {
+    /// A comma-separated list of the initial Kafka brokers to connect to.
+    ///
+    /// Each value must be in the form of `<host>` or `<host>:<port>`, and separated by a comma.
     pub bootstrap_servers: String,
+
+    /// The Kafka topic name to write events to.
+    #[configurable(metadata(templateable))]
     pub topic: String,
+
+    /// The log field name or tags key to use for the topic key.
+    ///
+    /// If the field does not exist in the log or in tags, a blank value will be used. If unspecified, the key is not sent.
+    ///
+    /// Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key.
     pub key_field: Option<String>,
+
+    #[configurable(derived)]
     pub encoding: EncodingConfig,
-    /// These batching options will **not** override librdkafka_options values.
+
+    // These batching options will **not** override librdkafka_options values.
+    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<NoDefaultsBatchSettings>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub compression: KafkaCompression,
+
+    #[configurable(derived)]
     #[serde(flatten)]
     pub auth: KafkaAuthConfig,
+
+    /// Default timeout, in milliseconds, for network requests.
     #[serde(default = "default_socket_timeout_ms")]
     pub socket_timeout_ms: u64,
+
+    /// Local message timeout, in milliseconds.
     #[serde(default = "default_message_timeout_ms")]
     pub message_timeout_ms: u64,
+
+    /// A map of advanced options to pass directly to the underlying `librdkafka` client.
+    ///
+    /// For more information on configuration options, see [Configuration properties][config_props_docs].
+    ///
+    /// [config_props_docs]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
     #[serde(default)]
     pub librdkafka_options: HashMap<String, String>,
+
+    /// The log field name to use for the Kafka headers.
+    ///
+    /// If omitted, no headers will be written.
     #[serde(alias = "headers_field")] // accidentally released as `headers_field` in 0.18
     pub headers_key: Option<String>,
+
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -4,8 +4,8 @@ use bytes::Bytes;
 use futures::{FutureExt, SinkExt};
 use http::{Request, StatusCode, Uri};
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 use serde_json::json;
+use vector_config::configurable_component;
 
 use crate::{
     codecs::Transformer,
@@ -26,33 +26,53 @@ static HOST: Lazy<Uri> = Lazy::new(|| Uri::from_static("https://logs.logdna.com"
 
 const PATH: &str = "/logs/ingest";
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Configuration for the `logdna` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug)]
 pub(super) struct LogdnaConfig {
+    /// The Ingestion API key.
     api_key: String,
-    // Deprecated name
+
+    /// The endpoint to send logs to.
     #[serde(alias = "host")]
     endpoint: Option<UriSerde>,
 
+    /// The hostname that will be attached to each batch of events.
+    #[configurable(metadata(templateable))]
     hostname: Template,
+
+    /// The MAC address that will be attached to each batch of events.
     mac: Option<String>,
+
+    /// The IP address that will be attached to each batch of events.
     ip: Option<String>,
+
+    /// The tags that will be attached to each batch of events.
+    #[configurable(metadata(templateable))]
     tags: Option<Vec<Template>>,
 
+    #[configurable(derived)]
     #[serde(
         default,
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     pub encoding: Transformer,
 
+    /// The default app that will be set for events that do not contain a `file` or `app` field.
     default_app: Option<String>,
+
+    /// The default environment that will be set for events that do not contain an `env` field.
     default_env: Option<String>,
 
+    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
+    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -29,7 +29,7 @@ const PATH: &str = "/logs/ingest";
 /// Configuration for the `logdna` sink.
 #[configurable_component(sink)]
 #[derive(Clone, Debug)]
-pub(super) struct LogdnaConfig {
+pub struct LogdnaConfig {
     /// The Ingestion API key.
     api_key: String,
 

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use futures::future::FutureExt;
 use serde::{Deserialize, Serialize};
+use vector_config::configurable_component;
 
 use super::{healthcheck::healthcheck, sink::LokiSink};
 use crate::{
@@ -16,27 +17,62 @@ use crate::{
     tls::{TlsConfig, TlsSettings},
 };
 
+/// Configuration for the `loki` sink.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LokiConfig {
+    /// The base URL of the Loki instance.
+    ///
+    /// Vector will append `/loki/api/v1/push` to this.
     pub endpoint: UriSerde,
+
     pub encoding: EncodingConfig,
+
+    /// The tenant ID to send.
+    ///
+    /// By default, this is not required since a proxy should set this header.
+    ///
+    /// When running Loki locally, a tenant ID is not required.
     pub tenant_id: Option<Template>,
+
+    /// A set of labels that are attached to each batch of events.
+    ///
+    /// Both keys and values are templatable, which enables you to attach dynamic labels to events
+    ///
+    /// Labels can be suffixed with a “*” to allow the expansion of objects into multiple labels,
+    /// see “How it works” for more information.
+    ///
+    /// Note: If the set of labels has high cardinality, this can cause drastic performance issues
+    /// with Loki. To prevent this from happening, reduce the number of unique label keys and
+    /// values.
     pub labels: HashMap<Template, Template>,
+
+    /// Whether or not to delete fields from the event when they are used as labels.
     #[serde(default = "crate::serde::default_false")]
     pub remove_label_fields: bool,
+
+    /// Whether or not to remove the timestamp from the event payload.
+    ///
+    /// The timestamp will still be sent as event metadata for Loki to use for indexing.
     #[serde(default = "crate::serde::default_true")]
     pub remove_timestamp: bool,
+
     #[serde(default)]
     pub compression: Compression,
+
     #[serde(default)]
     pub out_of_order_action: OutOfOrderAction,
+
     pub auth: Option<Auth>,
+
     #[serde(default)]
     pub request: TowerRequestConfig,
+
     #[serde(default)]
     pub batch: BatchConfig<LokiDefaultBatchSettings>,
+
     pub tls: Option<TlsConfig>,
+
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -54,13 +90,32 @@ impl SinkBatchSettings for LokiDefaultBatchSettings {
     const TIMEOUT_SECS: f64 = 1.0;
 }
 
-#[derive(Copy, Clone, Debug, Derivative, Deserialize, Serialize)]
+/// Out-of-order event behavior.
+///
+/// Some sources may generate events with timestamps that aren’t in chronological order. While the
+/// sink will sort events before sending them to Loki, there is the chance another event comes in
+/// that is out-of-order with respective the latest events sent to Loki. Prior to Loki 2.4.0, this
+/// was not supported and would result in an error during the push request.
+///
+/// If you're using Loki 2.4.0 or newer, `Accept` is the preferred action, which lets Loki handle
+/// any necessary sorting/reordering. If you're using an earlier version, then you must use `Drop`
+/// or `RewriteTimestamp` depending on which option makes the most sense for your use case.
+#[configurable_component]
+#[derive(Copy, Clone, Debug, Derivative)]
 #[derivative(Default)]
 #[serde(rename_all = "snake_case")]
 pub enum OutOfOrderAction {
+    /// Drop the event.
     #[derivative(Default)]
     Drop,
+
+    /// Rewrite the timestamp of the event to the timestamp of the latest event seen by the sink.
     RewriteTimestamp,
+
+    /// Accept the event.
+    ///
+    /// This sends the event to Loki normally, and requires Loki 2.4.0 or newer. Older versions do
+    /// not support out-of-order events and will throw an error when
     Accept,
 }
 

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -244,10 +244,11 @@ pub enum Sinks {
     #[cfg(feature = "sinks-logdna")]
     Logdna(#[configurable(derived)] logdna::LogdnaConfig),
 
+    /*
     /// Loki.
     #[cfg(feature = "sinks-loki")]
     Loki(#[configurable(derived)] loki::LokiConfig),
-
+    */
     /// NATS.
     #[cfg(feature = "sinks-nats")]
     Nats(#[configurable(derived)] self::nats::NatsSinkConfig),
@@ -264,10 +265,11 @@ pub enum Sinks {
     #[cfg(feature = "sinks-papertrail")]
     Papertrail(#[configurable(derived)] papertrail::PapertrailConfig),
 
+    /*
     /// Prometheus Exporter.
     #[cfg(feature = "sinks-prometheus")]
     PrometheusExporter(#[configurable(derived)] prometheus::exporter::PrometheusExporterConfig),
-
+    */
     /// Prometheus Remote Write.
     #[cfg(feature = "sinks-prometheus")]
     PrometheusRemoteWrite(#[configurable(derived)] prometheus::remote_write::RemoteWriteConfig),

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -232,7 +232,6 @@ pub enum Sinks {
     #[cfg(any(feature = "sinks-influxdb", feature = "prometheus-integration-tests"))]
     InfluxdbLogs(#[configurable(derived)] influxdb::logs::InfluxDbLogsConfig),
 
-    /*
     /// InfluxDB Metrics.
     #[cfg(any(feature = "sinks-influxdb", feature = "prometheus-integration-tests"))]
     InfluxdbMetrics(#[configurable(derived)] influxdb::metrics::InfluxDbConfig),
@@ -260,12 +259,11 @@ pub enum Sinks {
     /// New Relic Logs.
     #[cfg(feature = "sinks-new_relic_logs")]
     NewrelicLogs(#[configurable(derived)] new_relic_logs::NewRelicLogsConfig),
-    */
+
     /// Papertrail.
     #[cfg(feature = "sinks-papertrail")]
     Papertrail(#[configurable(derived)] papertrail::PapertrailConfig),
 
-    /*
     /// Prometheus Exporter.
     #[cfg(feature = "sinks-prometheus")]
     PrometheusExporter(#[configurable(derived)] prometheus::exporter::PrometheusExporterConfig),
@@ -273,7 +271,7 @@ pub enum Sinks {
     /// Prometheus Remote Write.
     #[cfg(feature = "sinks-prometheus")]
     PrometheusRemoteWrite(#[configurable(derived)] prometheus::remote_write::RemoteWriteConfig),
-    */
+
     /// Apache Pulsar.
     #[cfg(feature = "sinks-pulsar")]
     Pulsar(#[configurable(derived)] pulsar::PulsarSinkConfig),
@@ -281,7 +279,7 @@ pub enum Sinks {
     /// Redis.
     #[cfg(feature = "sinks-redis")]
     Redis(#[configurable(derived)] redis::RedisSinkConfig),
-    /*
+
     /// Sematext Logs.
     #[cfg(feature = "sinks-sematext")]
     SematextLogs(#[configurable(derived)] sematext::logs::SematextLogsConfig),
@@ -313,5 +311,4 @@ pub enum Sinks {
     /// Websocket.
     #[cfg(feature = "sinks-websocket")]
     Websocket(#[configurable(derived)] websocket::WebSocketSinkConfig),
-    */
 }

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 use bytes::BytesMut;
 use codecs::JsonSerializerConfig;
 use futures::{stream::BoxStream, FutureExt, StreamExt, TryFutureExt};
-use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
 use vector_common::internal_event::{BytesSent, EventsSent};
+use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
 use crate::{
@@ -42,21 +42,39 @@ enum BuildError {
  * Code dealing with the SinkConfig struct.
  */
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Configuration for the `nats` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct NatsSinkConfig {
+    #[configurable(derived)]
     encoding: EncodingConfig,
+
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
+
+    /// A name assigned to the NATS connection.
     #[serde(default = "default_name", alias = "name")]
     connection_name: String,
+
+    /// The NATS subject to publish messages to.
+    #[configurable(metadata(templateable))]
     subject: String,
+
+    /// The NATS URL to connect to.
+    ///
+    /// The URL must take the form of `nats://server:port`.
     url: String,
+
+    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
+
+    #[configurable(derived)]
     auth: Option<NatsAuthConfig>,
 }
 

--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -2,8 +2,8 @@ use std::{fmt::Debug, sync::Arc};
 
 use futures::FutureExt;
 use http::Uri;
-use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
+use vector_config::configurable_component;
 
 use super::{
     healthcheck, NewRelicApiResponse, NewRelicApiService, NewRelicEncoder, NewRelicSink,
@@ -20,22 +20,34 @@ use crate::{
     tls::TlsSettings,
 };
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Copy, Derivative)]
+/// New Relic region.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
 pub enum NewRelicRegion {
+    /// US region.
     #[derivative(Default)]
     Us,
+
+    /// EU region.
     Eu,
 }
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Copy, Derivative)]
+/// New Relic API endpoint.
+#[configurable_component]
+#[derive(Clone, Copy, Derivative, Debug, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
 pub enum NewRelicApi {
+    /// Events API.
     #[derivative(Default)]
     Events,
+
+    /// Metrics API.
     Metrics,
+
+    /// Logs API.
     Logs,
 }
 
@@ -61,30 +73,50 @@ impl RetryLogic for NewRelicApiRetry {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+/// Configuration for the `new_relic` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct NewRelicConfig {
+    /// A valid New Relic license key.
     pub license_key: String,
+
+    /// The New Relic account ID.
     pub account_id: String,
+
+    #[configurable(derived)]
     pub region: Option<NewRelicRegion>,
+
+    #[configurable(derived)]
     pub api: NewRelicApi,
+
+    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     pub compression: Compression,
+
+    #[configurable(derived)]
     #[serde(
         default,
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     pub encoding: Transformer,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<NewRelicDefaultBatchSettings>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
+
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     acknowledgements: AcknowledgementsConfig,
+
     #[serde(skip)]
     pub override_uri: Option<Uri>,
 }

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -56,8 +56,8 @@ impl SinkBatchSettings for NewRelicLogsDefaultBatchSettings {
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Default)]
 pub struct NewRelicLogsConfig {
-    /// A valid New Relic license key.
-    pub license_key: String,
+    /// A valid New Relic license key (if applicable).
+    pub license_key: Option<String>,
 
     /// A valid New Relic insert key (if applicable).
     pub insert_key: Option<String>,

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -1,8 +1,8 @@
 use codecs::{CharacterDelimitedEncoderConfig, JsonSerializerConfig};
 use http::Uri;
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
 use snafu::Snafu;
+use vector_config::configurable_component;
 
 use crate::{
     codecs::{EncodingConfigWithFraming, Transformer},
@@ -28,12 +28,17 @@ enum BuildError {
     MissingAuthParam,
 }
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Clone, Derivative)]
+/// New Relic region.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[derivative(Default)]
 pub enum NewRelicLogsRegion {
+    /// US region.
     #[derivative(Default)]
     Us,
+
+    /// EU region.
     Eu,
 }
 
@@ -46,24 +51,40 @@ impl SinkBatchSettings for NewRelicLogsDefaultBatchSettings {
     const TIMEOUT_SECS: f64 = 1.0;
 }
 
-#[derive(Deserialize, Serialize, Debug, Derivative, Clone)]
+/// Configuration for the `new_relic_logs` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug, Derivative)]
 #[derivative(Default)]
 pub struct NewRelicLogsConfig {
-    pub license_key: Option<String>,
+    /// A valid New Relic license key.
+    pub license_key: String,
+
+    /// A valid New Relic insert key (if applicable).
     pub insert_key: Option<String>,
+
+    #[configurable(derived)]
     pub region: Option<NewRelicLogsRegion>,
+
+    #[configurable(derived)]
     #[serde(
         default,
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     pub encoding: Transformer,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<NewRelicLogsDefaultBatchSettings>,
 
+    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
+
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -56,24 +56,69 @@ enum BuildError {
     FlushPeriodTooShort { min: u64 },
 }
 
+/// Configuration for the `prometheus_exporter` sink.
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrometheusExporterConfig {
+    /// The default namespace for any metrics sent.
+    ///
+    /// This namespace is only used if a metric has no existing namespace. When a namespace is
+    /// present, it is used as a prefix to the metric name, and separated with a period (`.`).
+    ///
+    /// It should follow the Prometheus [naming conventions][prom_naming_docs].
+    ///
+    /// [prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
     #[serde(alias = "namespace")]
     pub default_namespace: Option<String>,
+
+    /// The address to expose for scraping.
+    ///
+    /// The metrics are exposed at the typical Prometheus exporter path, `/metrics`.
     #[serde(default = "default_address")]
     pub address: SocketAddr,
+
     pub tls: Option<TlsEnableableConfig>,
+
+    /// Default buckets to use for aggregating [distribution][dist_metric_docs] metrics into histograms.
+    ///
+    /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_histogram_buckets")]
     pub buckets: Vec<f64>,
+
+    /// Quantiles to use for aggregating [distribution][dist_metric_docs] metrics into a summary.
+    ///
+    /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_summary_quantiles")]
     pub quantiles: Vec<f64>,
+
+    /// Whether or not to render [distributions][dist_metric_docs] as an [aggregated histogram][prom_agg_hist_docs] or  [aggregated summary][prom_agg_summ_docs].
+    ///
+    /// While Vector supports distributions as a lossless way to represent a set of samples for a
+    /// metric, Prometheus clients (the application being scraped, which is this sink) must
+    /// aggregate locally into either an aggregated histogram or aggregated summary.
+    ///
+    /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
+    /// [prom_agg_hist_docs]: https://prometheus.io/docs/concepts/metric_types/#histogram
+    /// [prom_agg_summ_docs]: https://prometheus.io/docs/concepts/metric_types/#summary
     #[serde(default = "default_distributions_as_summaries")]
     pub distributions_as_summaries: bool,
+
+    /// The interval, in seconds, on which metrics are flushed.
+    ///
+    /// On the flush interval, if a metric has not been seen since the last flush interval, it is
+    /// considered expired and is removed.
+    ///
+    /// Be sure to configure this value higher than your client’s scrape interval.
     #[serde(default = "default_flush_period_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     pub flush_period_secs: Duration,
+
+    /// Suppresses timestamps on the Prometheus output.
+    ///
+    /// This can sometimes be useful when the source of metrics leads to their timestamps being too
+    /// far in the past for Prometheus to allow them, such as when aggregating metrics over long
+    /// time periods, or when replaying old metrics from a disk buffer.
     #[serde(default)]
     pub suppress_timestamp: bool,
 }

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -4,8 +4,8 @@ use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, stream, FutureExt, SinkExt};
 use http::Uri;
 use prost::Message;
-use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
+use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
 use super::collector::{self, MetricCollector as _};
@@ -43,28 +43,57 @@ enum Errors {
     SetMetricInvalid,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// Configuration for the `prometheus_remote_write` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RemoteWriteConfig {
+    /// The endpoint to send data to.
     pub endpoint: String,
 
+    /// The default namespace for any metrics sent.
+    ///
+    /// This namespace is only used if a metric has no existing namespace. When a namespace is
+    /// present, it is used as a prefix to the metric name, and separated with a period (`.`).
+    ///
+    /// It should follow the Prometheus [naming conventions][prom_naming_docs].
+    ///
+    /// [prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
     pub default_namespace: Option<String>,
 
+    /// Default buckets to use for aggregating [distribution][dist_metric_docs] metrics into histograms.
+    ///
+    /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_histogram_buckets")]
     pub buckets: Vec<f64>,
+
+    /// Quantiles to use for aggregating [distribution][dist_metric_docs] metrics into a summary.
+    ///
+    /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_summary_quantiles")]
     pub quantiles: Vec<f64>,
 
+    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<PrometheusRemoteWriteDefaultBatchSettings>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
+    /// The tenant ID to send.
+    ///
+    /// If set, a header named `X-Scope-OrgID` will be added to outgoing requests with the value of this setting.
+    ///
+    /// This may be used by Cortex or other remote services to identify the tenant making the request.
+    #[configurable(metadata(templateable))]
     #[serde(default)]
     pub tenant_id: Option<Template>,
 
+    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
+    #[configurable(derived)]
     pub auth: Option<Auth>,
 }
 

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use futures::stream::{BoxStream, StreamExt};
 use indoc::indoc;
-use serde::{Deserialize, Serialize};
+use vector_config::configurable_component;
 
 use super::Region;
 use crate::{
@@ -20,26 +20,36 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Configuration for the `sematext_logs` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug)]
 pub struct SematextLogsConfig {
+    #[configurable(derived)]
     region: Option<Region>,
-    // Deprecated name
+
+    /// The endpoint to send data to.
     #[serde(alias = "host")]
     endpoint: Option<String>,
+
+    /// The token that will be used to write to Sematext.
     token: String,
 
+    #[configurable(derived)]
     #[serde(
         skip_serializing_if = "crate::serde::skip_serializing_if_default",
         default
     )]
     pub encoding: Transformer,
 
+    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
+    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -5,8 +5,8 @@ use futures::{future::BoxFuture, stream, FutureExt, SinkExt};
 use http::{StatusCode, Uri};
 use hyper::{Body, Request};
 use indoc::indoc;
-use serde::{Deserialize, Serialize};
 use tower::Service;
+use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
 use super::Region;
@@ -47,16 +47,34 @@ impl SinkBatchSettings for SematextMetricsDefaultBatchSettings {
     const TIMEOUT_SECS: f64 = 1.0;
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// Configuration for the `sematext_metrics` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug, Default)]
 pub struct SematextMetricsConfig {
+    /// Sets the default namespace for any metrics sent.
+    ///
+    /// This namespace is only used if a metric has no existing namespace. When a namespace is
+    /// present, it is used as a prefix to the metric name, and separated with a period (`.`).
     pub default_namespace: String,
+
+    #[configurable(derived)]
     pub region: Option<Region>,
+
+    /// The endpoint to send data to.
     pub endpoint: Option<String>,
+
+    /// The token that will be used to write to Sematext.
     pub token: String,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub(self) batch: BatchConfig<SematextMetricsDefaultBatchSettings>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
+
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/sematext/mod.rs
+++ b/src/sinks/sematext/mod.rs
@@ -3,11 +3,16 @@ pub mod metrics;
 
 pub use self::{logs::SematextLogsConfig, metrics::SematextMetricsConfig};
 
-use serde::{Deserialize, Serialize};
+use vector_config::configurable_component;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Sematext region.
+#[configurable_component]
+#[derive(Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Region {
+    /// US region.
     Us,
+
+    /// EU region.
     Eu,
 }

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -2,7 +2,7 @@ use codecs::{
     encoding::{Framer, FramingConfig},
     TextSerializerConfig,
 };
-use serde::{Deserialize, Serialize};
+use vector_config::configurable_component;
 
 #[cfg(unix)]
 use crate::sinks::util::unix::UnixSinkConfig;
@@ -15,41 +15,60 @@ use crate::{
     sinks::util::{tcp::TcpSinkConfig, udp::UdpSinkConfig},
 };
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Configuration for the `socket` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug)]
 pub struct SocketSinkConfig {
     #[serde(flatten)]
     pub mode: Mode,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Socket mode.
+#[configurable_component]
+#[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum Mode {
-    Tcp(TcpMode),
-    Udp(UdpMode),
+    /// TCP.
+    Tcp(#[configurable(transparent)] TcpMode),
+
+    /// UDP.
+    Udp(#[configurable(transparent)] UdpMode),
+
+    /// Unix Domain Socket.
     #[cfg(unix)]
-    Unix(UnixMode),
+    Unix(#[configurable(transparent)] UnixMode),
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// TCP configuration.
+#[configurable_component]
+#[derive(Clone, Debug)]
 pub struct TcpMode {
     #[serde(flatten)]
     config: TcpSinkConfig,
+
     #[serde(flatten)]
     encoding: EncodingConfigWithFraming,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// UDP configuration.
+#[configurable_component]
+#[derive(Clone, Debug)]
 pub struct UdpMode {
     #[serde(flatten)]
     config: UdpSinkConfig,
+
+    #[configurable(derived)]
     encoding: EncodingConfig,
 }
 
+/// Unix Domain Socket configuration.
 #[cfg(unix)]
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[configurable_component]
+#[derive(Clone, Debug)]
 pub struct UnixMode {
     #[serde(flatten)]
     config: UnixSinkConfig,
+
     #[serde(flatten)]
     encoding: EncodingConfigWithFraming,
 }

--- a/src/sinks/splunk_hec/common/acknowledgements.rs
+++ b/src/sinks/splunk_hec/common/acknowledgements.rs
@@ -8,6 +8,7 @@ use std::{
 use hyper::Body;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc::Receiver, oneshot::Sender};
+use vector_config::configurable_component;
 use vector_core::event::EventStatus;
 
 use super::service::{HttpRequestBuilder, MetadataFields};
@@ -20,13 +21,27 @@ use crate::{
     },
 };
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+/// Splunk HEC acknowledgement configuration.
+#[configurable_component]
+#[derive(Clone, Debug)]
 #[serde(default)]
 pub struct HecClientAcknowledgementsConfig {
+    /// Controls if the sink will integrate with [Splunk HEC indexer acknowledgements][splunk_indexer_ack_docs] for end-to-end acknowledgements.
+    ///
+    /// [splunk_indexer_ack_docs]: https://docs.splunk.com/Documentation/Splunk/8.2.3/Data/AboutHECIDXAck
     pub indexer_acknowledgements_enabled: bool,
+
+    /// The amount of time, in seconds, to wait in between queries to the Splunk HEC indexer acknowledgement endpoint.
     pub query_interval: NonZeroU8,
+
+    /// The maximum number of times an acknowledgement ID will be queried for its status.
     pub retry_limit: NonZeroU8,
+
+    /// The maximum number of pending acknowledgements from events sent to the Splunk HEC collector.
+    ///
+    /// Once reached, the sink will begin applying backpressure.
     pub max_pending_acks: NonZeroU64,
+
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/splunk_hec/common/mod.rs
+++ b/src/sinks/splunk_hec/common/mod.rs
@@ -4,18 +4,35 @@ pub mod response;
 pub mod service;
 pub mod util;
 
-use serde::{Deserialize, Serialize};
 pub use util::*;
+use vector_config::configurable_component;
 
 pub(super) const SOURCE_FIELD: &str = "source";
 pub(super) const SOURCETYPE_FIELD: &str = "sourcetype";
 pub(super) const INDEX_FIELD: &str = "index";
 pub(super) const HOST_FIELD: &str = "host";
 
-#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
+/// Splunk HEC endpoint configuration.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum EndpointTarget {
+    /// Events are sent to the [raw endpoint][raw_endpoint_docs].
+    ///
+    /// When the raw endpoint is used, configured [event metadata][event_metadata_docs] is sent as
+    /// query parameters on the request, except for the `timestamp` field.
+    ///
+    /// [raw_endpoint_docs]: https://docs.splunk.com/Documentation/Splunk/8.0.0/RESTREF/RESTinput#services.2Fcollector.2Fraw
+    /// [event_metadata_docs]: https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
     Raw,
+
+    /// Events are sent to the [event endpoint][event_endpoint_docs].
+    ///
+    /// When the event endpoint is used, configured [event metadata][event_metadata_docs] is sent
+    /// directly with each event.
+    ///
+    /// [event_endpoint_docs]: https://docs.splunk.com/Documentation/Splunk/8.0.0/RESTREF/RESTinput#services.2Fcollector.2Fevent
+    /// [event_metadata_docs]: https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
     Event,
 }
 

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use futures_util::FutureExt;
-use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
+use vector_config::configurable_component;
 use vector_core::sink::VectorSink;
 
 use super::{request_builder::HecMetricsRequestBuilder, sink::HecMetricsSink};
@@ -25,26 +25,70 @@ use crate::{
     tls::TlsConfig,
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// Configuration of the `splunk_hec_metrics` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct HecMetricsSinkConfig {
+    /// Sets the default namespace for any metrics sent.
+    ///
+    /// This namespace is only used if a metric has no existing namespace. When a namespace is
+    /// present, it is used as a prefix to the metric name, and separated with a period (`.`).
     pub default_namespace: Option<String>,
-    // Deprecated name
+
+    /// Default Splunk HEC token.
+    ///
+    /// If an event has a token set in its metadata, it will prevail over the one set here.
     #[serde(alias = "token")]
     pub default_token: String,
+
+    /// The base URL of the Splunk instance.
     pub endpoint: String,
-    #[serde(default = "crate::sinks::splunk_hec::common::host_key")]
+
+    /// Overrides the name of the log field used to grab the hostname to send to Splunk HEC.
+    ///
+    /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
+    ///
+    /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+    #[serde(default = "host_key")]
     pub host_key: String,
+
+    /// The name of the index where to send the events to.
+    ///
+    /// If not specified, the default index is used.
+    #[configurable(metadata(templateable))]
     pub index: Option<Template>,
+
+    /// The sourcetype of events sent to this sink.
+    ///
+    /// If unset, Splunk will default to `httpevent`.
+    #[configurable(metadata(templateable))]
     pub sourcetype: Option<Template>,
+
+    /// The source of events sent to this sink.
+    ///
+    /// This is typically the filename the logs originated from.
+    ///
+    /// If unset, the Splunk collector will set it.
+    #[configurable(metadata(templateable))]
     pub source: Option<Template>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<SplunkHecDefaultBatchSettings>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
+
+    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub acknowledgements: HecClientAcknowledgementsConfig,
 }

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::{stream::BoxStream, task::noop_waker_ref, SinkExt, StreamExt};
 use futures_util::{future::ready, stream};
-use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tokio::{
     io::{AsyncRead, ReadBuf},
@@ -19,6 +18,7 @@ use tokio::{
 };
 use tokio_util::codec::Encoder;
 use vector_common::internal_event::{BytesSent, EventsSent};
+use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
 use crate::{
@@ -53,11 +53,24 @@ enum TcpError {
     SendError { source: tokio::io::Error },
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// A TCP sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 pub struct TcpSinkConfig {
+    /// The address to connect to.
+    ///
+    /// The address _must_ include a port.
     address: String,
+
+    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
+
+    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
+
+    /// The size, in bytes, of the socket's send buffer.
+    ///
+    /// If set, the value of the setting is passed via the `SO_SNDBUF` option.
     send_buffer_bytes: Option<usize>,
 }
 

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -8,11 +8,11 @@ use std::{
 use async_trait::async_trait;
 use bytes::BytesMut;
 use futures::{future::BoxFuture, ready, stream::BoxStream, FutureExt, StreamExt};
-use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tokio::{net::UdpSocket, sync::oneshot, time::sleep};
 use tokio_util::codec::Encoder;
 use vector_common::internal_event::BytesSent;
+use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
 use super::SinkBuildError;
@@ -47,9 +47,18 @@ pub enum UdpError {
     ServiceChannelRecvError { source: oneshot::error::RecvError },
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// A UDP sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 pub struct UdpSinkConfig {
+    /// The address to connect to.
+    ///
+    /// The address _must_ include a port.
     address: String,
+
+    /// The size, in bytes, of the socket's send buffer.
+    ///
+    /// If set, the value of the setting is passed via the `SO_SNDBUF` option.
     send_buffer_bytes: Option<usize>,
 }
 

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -3,10 +3,10 @@ use std::{path::PathBuf, pin::Pin, time::Duration};
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::{stream::BoxStream, SinkExt, StreamExt};
-use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tokio::{net::UnixStream, time::sleep};
 use tokio_util::codec::Encoder;
+use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
 use crate::{
@@ -33,8 +33,13 @@ pub enum UnixError {
     ConnectError { source: tokio::io::Error },
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// A Unix Domain Socket sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 pub struct UnixSinkConfig {
+    /// The Unix socket path.
+    ///
+    /// This should be an absolute path.
     pub path: PathBuf,
 }
 

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -1,45 +1,64 @@
 pub mod v1;
 pub mod v2;
 
-use serde::{Deserialize, Serialize};
+use vector_config::configurable_component;
 
 use crate::config::{
     AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, SinkDescription,
 };
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Marker type for the version one of the configuration for the `vector` sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 enum V1 {
+    /// Marker value for version one.
     #[serde(rename = "1")]
     V1,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Configuration for version one of the `vector` sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfigV1 {
+    /// Version of the configuration.
     version: V1,
+
     #[serde(flatten)]
     config: v1::VectorConfig,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Marker type for the version two of the configuration for the `vector` sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 enum V2 {
+    /// Marker value for version two.
     #[serde(rename = "2")]
     V2,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Configuration for version two of the `vector` sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfigV2 {
+    /// Version of the configuration.
     version: Option<V2>,
+
     #[serde(flatten)]
     config: v2::VectorConfig,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Configurable for the `vector` sink.
+#[configurable_component(source)]
+#[derive(Clone, Debug)]
 #[serde(untagged)]
 pub enum VectorConfig {
-    V1(VectorConfigV1),
-    V2(VectorConfigV2),
+    /// Configuration for version one.
+    V1(#[configurable(derived)] VectorConfigV1),
+
+    /// Configuration for version two.
+    V2(#[configurable(derived)] VectorConfigV2),
 }
 
 inventory::submit! {

--- a/src/sinks/vector/v1.rs
+++ b/src/sinks/vector/v1.rs
@@ -1,8 +1,8 @@
 use bytes::{BufMut, BytesMut};
 use prost::Message;
-use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use tokio_util::codec::Encoder;
+use vector_config::configurable_component;
 use vector_core::event::{proto, Event};
 
 use crate::{
@@ -12,12 +12,25 @@ use crate::{
     tls::TlsEnableableConfig,
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// Configuration for version one of the `vector` sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfig {
+    /// The downstream Vector address to connect to.
+    ///
+    /// The address _must_ include a port.
     address: String,
+
+    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
+
+    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
+
+    /// The size, in bytes, of the socket's send buffer.
+    ///
+    /// If set, the value of the setting is passed via the `SO_SNDBUF` option.
     send_buffer_bytes: Option<usize>,
 }
 

--- a/src/sinks/vector/v2/config.rs
+++ b/src/sinks/vector/v2/config.rs
@@ -2,9 +2,9 @@ use http::Uri;
 use hyper::client::HttpConnector;
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
-use serde::{Deserialize, Serialize};
 use tonic::body::BoxBody;
 use tower::ServiceBuilder;
+use vector_config::configurable_component;
 
 use crate::{
     config::{
@@ -26,18 +26,37 @@ use crate::{
     tls::{tls_connector_builder, MaybeTlsSettings, TlsEnableableConfig},
 };
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// Configuration for version two of the `vector` sink.
+#[configurable_component]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct VectorConfig {
+    /// The downstream Vector address to connect to.
+    ///
+    /// The address _must_ include a port.
     address: String,
+
+    /// Whether or not to compress requests.
+    ///
+    /// If set to `true`, requests will be compressed with [`gzip`][gzip_docs].
+    ///
+    /// [gzip_docs]: https://en.wikipedia.org/wiki/Gzip
     #[serde(default)]
     compression: bool,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeEventBasedDefaultBatchSettings>,
+
+    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
+
+    #[configurable(derived)]
     #[serde(default)]
     tls: Option<TlsEnableableConfig>,
+
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -1,6 +1,6 @@
 use codecs::JsonSerializerConfig;
-use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
+use vector_config::configurable_component;
 
 use crate::{
     codecs::EncodingConfig,
@@ -12,13 +12,30 @@ use crate::{
     tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Configuration for the `websocket` sink.
+#[configurable_component(sink)]
+#[derive(Clone, Debug)]
 pub struct WebSocketSinkConfig {
+    /// The WebSocket URI to connect to.
+    ///
+    /// This should include the protocol and host, but can also include the port, path, and any other valid part of a URI.
     pub uri: String,
+
+    #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
+
+    #[configurable(derived)]
     pub encoding: EncodingConfig,
+
+    /// The interval, in seconds, between sending PINGs to the remote peer.
     pub ping_interval: Option<u64>,
+
+    /// The timeout, in seconds, while waiting for a PONG response from the remote peer.
+    ///
+    /// If a response is not received in this time, the connection is reestablished.
     pub ping_timeout: Option<u64>,
+
+    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",


### PR DESCRIPTION
(part of the work required for https://github.com/vectordotdev/vector/issues/12223)

This PR is the initial implementation of the configuration schema framework, specifically for sinks. It represents the second major chunk of conversion work for sinks.

It does not change how we load configurations, or anything about our use of `inventory`/`typetag`/`SourceOuter`/etc. That work will be the final step after all components have been minimally instrumented/converted to support having their configuration schema generated.

# Reviewer Notes

In general, the majority of this PR is indeed the instrumenting of many sinks and porting over the Cue documentation to the code. There are still **two** sinks -- `loki` and `prometheus_exporter` -- that have yet to be converted as they require some work to `vector_config` to support the structure of their configuration type. I've opted to leave that work for one more final PR as the work will be a little more tedious and heavier, relatively speaking, on the `vector-config` side than the sinks themselves.

Other than that, I've strived to port over the existing Cue documentation in a faithful manner, but there are a number of small divergences:

- making the documentation of common fields consistent across sinks
- fixing spelling/grammatical issues, changing from passive to active voice, etc