### PR TITLE
docs(releasing): Add note to 0.23.0 about libc/libc++ changes

### DIFF
--- a/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
@@ -302,16 +302,19 @@ Additionally, the following sinks support setting a framing method: `aws_s3`, `a
 
 #### Support for older OSes dropped {#old-oses}
 
-Due to changes to the [tool we use for cross-compiling Vector](https://github.com/cross-rs/cross), support for operating
-systems with old versions of `libstdc++` were dropped for the `x86-uknown_linux-gnu` target. Vector now requires that
-the host system has `libstdc++` >= 3.4.21 with support for ABI version 1.3.8.
+Due to changes to the [tool we use for cross-compiling Vector](https://github.com/cross-rs/cross),
+support for operating systems with old versions of `libc` and `libstdc++` were dropped for the
+`x86-uknown_linux-gnu` target. Vector now requires that the host system has `libc` >= 2.18 and
+`libstdc++` >= 3.4.21 with support for ABI version 1.3.8.
 
 Known OSes that this affects:
 
 - Amazon Linux 1
 - Ubuntu 14.04
+- CentOS 7
 
-We will be looking at options to re-add support for these OSes in the future.
+We will be looking at options to [re-add support for these
+OSes](http://github.com/vectordotdev/vector/issues/13183) in the future.
 
 #### `kubernetes_logs` source now requires rights to list and watch nodes {#kubernetes-logs-list-watch-nodes}
 

--- a/website/cue/reference/releases/0.23.0.cue
+++ b/website/cue/reference/releases/0.23.0.cue
@@ -491,6 +491,28 @@ releases: "0.23.0": {
 				"""
 			pr_numbers: [12433]
 		},
+		{
+			type:     "chore"
+			breaking: true
+			scopes: ["releasing"]
+			breaking: true
+			description: """
+				Due to changes to the [tool we use for cross-compiling Vector](https://github.com/cross-rs/cross),
+				support for operating systems with old versions of `libc` and `libstdc++` were dropped for the
+				`x86-uknown_linux-gnu` target. Vector now requires that the host system has `libc` >= 2.18 and
+				`libstdc++` >= 3.4.21 with support for ABI version 1.3.8.
+
+				Known OSes that this affects:
+
+				- Amazon Linux 1
+				- Ubuntu 14.04
+				- CentOS 7
+
+				We will be looking at options to [re-add support for these
+				OSes](http://github.com/vectordotdev/vector/issues/13183) in the future.
+				"""
+			pr_numbers: []
+		},
 	]
 
 	commits: [


### PR DESCRIPTION
This was noted in the upgrade guide, but not in the changelog (as observed by
https://github.com/vectordotdev/vector/issues/10807#issuecomment-1195962669).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
