### PR TITLE
chore: Fix outdated test in `parse_grok`

### DIFF
--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -136,7 +136,6 @@ mod test {
             args: func_args![ value: "2020-10-02T23:22:12.223222Z",
                               pattern: "(%{TIMESTAMP_ISO8601:timestamp}|%{LOGLEVEL:level})"],
             want: Ok(Value::from(btreemap! {
-                "level" => "",
                 "timestamp" => "2020-10-02T23:22:12.223222Z",
             })),
             tdef: TypeDef::object(Collection::any()).fallible(),


### PR DESCRIPTION
Fixes a conflict that was a result of merging #13721 and #13635.