### PR TITLE
fix(elasticsearch sink, sematext sink): Fix index template being excluded via `only_fields`/`except_fields` transform

### DIFF
--- a/src/sinks/elasticsearch/sink.rs
+++ b/src/sinks/elasticsearch/sink.rs
@@ -60,12 +60,9 @@ where
 
         let mode = self.mode;
         let id_key_field = self.id_key_field;
+        let transformer = self.transformer.clone();
 
         let sink = input
-            .map(|mut event| {
-                self.transformer.transform(&mut event);
-                event
-            })
             .scan(self.metric_to_log, |metric_to_log, event| {
                 future::ready(Some(match event {
                     Event::Metric(metric) => metric_to_log.transform_one(metric),
@@ -74,7 +71,9 @@ where
                 }))
             })
             .filter_map(|x| async move { x })
-            .filter_map(move |log| future::ready(process_log(log, &mode, &id_key_field)))
+            .filter_map(move |log| {
+                future::ready(process_log(log, &mode, &id_key_field, &transformer))
+            })
             .batched(self.batch_settings.into_byte_size_config())
             .request_builder(request_builder_concurrency_limit, self.request_builder)
             .filter_map(|request| async move {
@@ -96,6 +95,7 @@ pub fn process_log(
     mut log: LogEvent,
     mode: &ElasticsearchCommonMode,
     id_key_field: &Option<String>,
+    transformer: &Transformer,
 ) -> Option<ProcessedEvent> {
     let index = mode.index(&log)?;
     let bulk_action = mode.bulk_action(&log)?;
@@ -111,6 +111,11 @@ pub fn process_log(
         Some(String::from_utf8_lossy(&key).into_owned())
     } else {
         None
+    };
+    let log = {
+        let mut event = Event::from(log);
+        transformer.transform(&mut event);
+        event.into_log()
     };
     Some(ProcessedEvent {
         index,

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -41,7 +41,7 @@ async fn sets_create_action_when_configured() {
         .request_builder
         .encoder
         .encode_input(
-            vec![process_log(log, &es.mode, &None).unwrap()],
+            vec![process_log(log, &es.mode, &None, &config.encoding).unwrap()],
             &mut encoded,
         )
         .unwrap();
@@ -89,7 +89,7 @@ async fn encode_datastream_mode() {
         .request_builder
         .encoder
         .encode_input(
-            vec![process_log(log, &es.mode, &None).unwrap()],
+            vec![process_log(log, &es.mode, &None, &config.encoding).unwrap()],
             &mut encoded,
         )
         .unwrap();
@@ -134,7 +134,7 @@ async fn encode_datastream_mode_no_routing() {
         .request_builder
         .encoder
         .encode_input(
-            vec![process_log(log, &es.mode, &None).unwrap()],
+            vec![process_log(log, &es.mode, &None, &config.encoding).unwrap()],
             &mut encoded,
         )
         .unwrap();
@@ -169,7 +169,7 @@ async fn handle_metrics() {
     es.request_builder
         .encoder
         .encode_input(
-            vec![process_log(log, &es.mode, &None).unwrap()],
+            vec![process_log(log, &es.mode, &None, &config.encoding).unwrap()],
             &mut encoded,
         )
         .unwrap();
@@ -258,7 +258,7 @@ async fn encode_datastream_mode_no_sync() {
         .request_builder
         .encoder
         .encode_input(
-            vec![process_log(log, &es.mode, &None).unwrap()],
+            vec![process_log(log, &es.mode, &None, &config.encoding).unwrap()],
             &mut encoded,
         )
         .unwrap();
@@ -271,7 +271,7 @@ async fn encode_datastream_mode_no_sync() {
 }
 
 #[tokio::test]
-async fn allows_using_excepted_fields() {
+async fn allows_using_except_fields() {
     let config = ElasticsearchConfig {
         bulk: Some(BulkConfig {
             action: None,
@@ -297,13 +297,47 @@ async fn allows_using_excepted_fields() {
         .request_builder
         .encoder
         .encode_input(
-            vec![process_log(log, &es.mode, &None).unwrap()],
+            vec![process_log(log, &es.mode, &None, &config.encoding).unwrap()],
             &mut encoded,
         )
         .unwrap();
 
     let expected = r#"{"index":{"_index":"purple","_type":"_doc"}}
 {"foo":"bar","message":"hello there"}
+"#;
+    assert_eq!(std::str::from_utf8(&encoded).unwrap(), expected);
+    assert_eq!(encoded.len(), encoded_size);
+}
+
+#[tokio::test]
+async fn allows_using_only_fields() {
+    let config = ElasticsearchConfig {
+        bulk: Some(BulkConfig {
+            action: None,
+            index: Some(String::from("{{ idx }}")),
+        }),
+        encoding: Transformer::new(Some(vec!["foo".to_string().into()]), None, None).unwrap(),
+        endpoint: String::from("https://example.com"),
+        ..Default::default()
+    };
+    let es = ElasticsearchCommon::parse_config(&config).await.unwrap();
+
+    let mut log = LogEvent::from("hello there");
+    log.insert("foo", "bar");
+    log.insert("idx", "purple");
+
+    let mut encoded = vec![];
+    let encoded_size = es
+        .request_builder
+        .encoder
+        .encode_input(
+            vec![process_log(log, &es.mode, &None, &config.encoding).unwrap()],
+            &mut encoded,
+        )
+        .unwrap();
+
+    let expected = r#"{"index":{"_index":"purple","_type":"_doc"}}
+{"foo":"bar"}
 "#;
     assert_eq!(std::str::from_utf8(&encoded).unwrap(), expected);
     assert_eq!(encoded.len(), encoded_size);


### PR DESCRIPTION
Closes #13728.