### PR TITLE
chore(host_metrics source): Simplify internal collection of metrics

### DIFF
--- a/src/api/schema/metrics/host.rs
+++ b/src/api/schema/metrics/host.rs
@@ -274,23 +274,31 @@ impl HostMetrics {
 impl HostMetrics {
     /// Memory metrics
     async fn memory(&self) -> MemoryMetrics {
-        MemoryMetrics(self.0.memory_metrics().await)
+        let mut buffer = self.0.buffer();
+        self.0.memory_metrics(&mut buffer).await;
+        MemoryMetrics(buffer.metrics)
     }
 
     /// Swap metrics
     async fn swap(&self) -> SwapMetrics {
-        SwapMetrics(self.0.swap_metrics().await)
+        let mut buffer = self.0.buffer();
+        self.0.swap_metrics(&mut buffer).await;
+        SwapMetrics(buffer.metrics)
     }
 
     /// CPU metrics
     async fn cpu(&self) -> CpuMetrics {
-        CpuMetrics(self.0.cpu_metrics().await)
+        let mut buffer = self.0.buffer();
+        self.0.cpu_metrics(&mut buffer).await;
+        CpuMetrics(buffer.metrics)
     }
 
     /// Load average metrics (*nix only)
     async fn load_average(&self) -> Option<LoadAverageMetrics> {
         if cfg!(unix) {
-            Some(LoadAverageMetrics(self.0.loadavg_metrics().await))
+            let mut buffer = self.0.buffer();
+            self.0.loadavg_metrics(&mut buffer).await;
+            Some(LoadAverageMetrics(buffer.metrics))
         } else {
             None
         }
@@ -298,17 +306,23 @@ impl HostMetrics {
 
     /// Network metrics
     async fn network(&self) -> NetworkMetrics {
-        NetworkMetrics(self.0.network_metrics().await)
+        let mut buffer = self.0.buffer();
+        self.0.network_metrics(&mut buffer).await;
+        NetworkMetrics(buffer.metrics)
     }
 
     /// Filesystem metrics
     async fn filesystem(&self) -> FileSystemMetrics {
-        FileSystemMetrics(self.0.filesystem_metrics().await)
+        let mut buffer = self.0.buffer();
+        self.0.filesystem_metrics(&mut buffer).await;
+        FileSystemMetrics(buffer.metrics)
     }
 
     /// Disk metrics
     async fn disk(&self) -> DiskMetrics {
-        DiskMetrics(self.0.disk_metrics().await)
+        let mut buffer = self.0.buffer();
+        self.0.disk_metrics(&mut buffer).await;
+        DiskMetrics(buffer.metrics)
     }
 }
 

--- a/src/sources/host_metrics/disk.rs
+++ b/src/sources/host_metrics/disk.rs
@@ -1,11 +1,9 @@
-use chrono::Utc;
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use heim::units::information::byte;
 use vector_common::btreemap;
 use vector_config::configurable_component;
 
 use super::{filter_result, FilterList, HostMetrics};
-use crate::event::metric::Metric;
 
 /// Options for the “disk” metrics collector.
 #[configurable_component]
@@ -17,10 +15,10 @@ pub struct DiskConfig {
 }
 
 impl HostMetrics {
-    pub async fn disk_metrics(&self) -> Vec<Metric> {
+    pub async fn disk_metrics(&self, output: &mut super::MetricsBuffer) {
         match heim::disk::io_counters().await {
             Ok(counters) => {
-                counters
+                for counter in counters
                     .filter_map(|result| {
                         filter_result(result, "Failed to load/parse disk I/O data.")
                     })
@@ -32,48 +30,37 @@ impl HostMetrics {
                             .then(|| counter)
                     })
                     .filter_map(|counter| async { counter })
-                    .map(|counter| {
-                        let timestamp = Utc::now();
-                        let tags = btreemap! {
-                            "device" => counter.device_name().to_string_lossy()
-                        };
-                        stream::iter(
-                            vec![
-                                self.counter(
-                                    "disk_read_bytes_total",
-                                    timestamp,
-                                    counter.read_bytes().get::<byte>() as f64,
-                                    tags.clone(),
-                                ),
-                                self.counter(
-                                    "disk_reads_completed_total",
-                                    timestamp,
-                                    counter.read_count() as f64,
-                                    tags.clone(),
-                                ),
-                                self.counter(
-                                    "disk_written_bytes_total",
-                                    timestamp,
-                                    counter.write_bytes().get::<byte>() as f64,
-                                    tags.clone(),
-                                ),
-                                self.counter(
-                                    "disk_writes_completed_total",
-                                    timestamp,
-                                    counter.write_count() as f64,
-                                    tags,
-                                ),
-                            ]
-                            .into_iter(),
-                        )
-                    })
-                    .flatten()
                     .collect::<Vec<_>>()
                     .await
+                {
+                    let tags = btreemap! {
+                        "device" => counter.device_name().to_string_lossy()
+                    };
+                    output.name = "disk";
+                    output.counter(
+                        "disk_read_bytes_total",
+                        counter.read_bytes().get::<byte>() as f64,
+                        tags.clone(),
+                    );
+                    output.counter(
+                        "disk_reads_completed_total",
+                        counter.read_count() as f64,
+                        tags.clone(),
+                    );
+                    output.counter(
+                        "disk_written_bytes_total",
+                        counter.write_bytes().get::<byte>() as f64,
+                        tags.clone(),
+                    );
+                    output.counter(
+                        "disk_writes_completed_total",
+                        counter.write_count() as f64,
+                        tags,
+                    );
+                }
             }
             Err(error) => {
                 error!(message = "Failed to load disk I/O info.", %error, internal_log_rate_secs = 60);
-                vec![]
             }
         }
     }
@@ -84,16 +71,19 @@ mod tests {
     use super::{
         super::{
             tests::{all_counters, assert_filtered_metrics, count_name, count_tag},
-            HostMetrics, HostMetricsConfig,
+            HostMetrics, HostMetricsConfig, MetricsBuffer,
         },
         DiskConfig,
     };
 
     #[tokio::test]
     async fn generates_disk_metrics() {
-        let metrics = HostMetrics::new(HostMetricsConfig::default())
-            .disk_metrics()
+        let mut buffer = MetricsBuffer::new(None);
+        HostMetrics::new(HostMetricsConfig::default())
+            .disk_metrics(&mut buffer)
             .await;
+        let metrics = buffer.metrics;
+
         // The Windows test runner doesn't generate any disk metrics on the VM.
         #[cfg(not(target_os = "windows"))]
         assert!(!metrics.is_empty());
@@ -121,13 +111,15 @@ mod tests {
 
     #[tokio::test]
     async fn filters_disk_metrics_on_device() {
-        assert_filtered_metrics("device", |devices| async {
+        assert_filtered_metrics("device", |devices| async move {
+            let mut buffer = MetricsBuffer::new(None);
             HostMetrics::new(HostMetricsConfig {
                 disk: DiskConfig { devices },
                 ..Default::default()
             })
-            .disk_metrics()
-            .await
+            .disk_metrics(&mut buffer)
+            .await;
+            buffer.metrics
         })
         .await;
     }

--- a/src/sources/host_metrics/memory.rs
+++ b/src/sources/host_metrics/memory.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use chrono::Utc;
 #[cfg(target_os = "linux")]
 use heim::memory::os::linux::MemoryExt;
 #[cfg(target_os = "macos")]
@@ -10,132 +9,110 @@ use heim::memory::os::SwapExt;
 use heim::units::information::byte;
 
 use super::HostMetrics;
-use crate::event::metric::Metric;
 
 impl HostMetrics {
-    pub async fn memory_metrics(&self) -> Vec<Metric> {
+    pub async fn memory_metrics(&self, output: &mut super::MetricsBuffer) {
+        output.name = "memory";
         match heim::memory::memory().await {
             Ok(memory) => {
-                let timestamp = Utc::now();
-                vec![
-                    self.gauge(
-                        "memory_total_bytes",
-                        timestamp,
-                        memory.total().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    self.gauge(
-                        "memory_free_bytes",
-                        timestamp,
-                        memory.free().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    self.gauge(
-                        "memory_available_bytes",
-                        timestamp,
-                        memory.available().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(any(target_os = "linux", target_os = "macos"))]
-                    self.gauge(
-                        "memory_active_bytes",
-                        timestamp,
-                        memory.active().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(target_os = "linux")]
-                    self.gauge(
-                        "memory_buffers_bytes",
-                        timestamp,
-                        memory.buffers().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(target_os = "linux")]
-                    self.gauge(
-                        "memory_cached_bytes",
-                        timestamp,
-                        memory.cached().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(target_os = "linux")]
-                    self.gauge(
-                        "memory_shared_bytes",
-                        timestamp,
-                        memory.shared().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(target_os = "linux")]
-                    self.gauge(
-                        "memory_used_bytes",
-                        timestamp,
-                        memory.used().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(target_os = "macos")]
-                    self.gauge(
-                        "memory_inactive_bytes",
-                        timestamp,
-                        memory.inactive().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(target_os = "macos")]
-                    self.gauge(
-                        "memory_wired_bytes",
-                        timestamp,
-                        memory.wire().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                ]
+                output.gauge(
+                    "memory_total_bytes",
+                    memory.total().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                output.gauge(
+                    "memory_free_bytes",
+                    memory.free().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                output.gauge(
+                    "memory_available_bytes",
+                    memory.available().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(any(target_os = "linux", target_os = "macos"))]
+                output.gauge(
+                    "memory_active_bytes",
+                    memory.active().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(target_os = "linux")]
+                output.gauge(
+                    "memory_buffers_bytes",
+                    memory.buffers().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(target_os = "linux")]
+                output.gauge(
+                    "memory_cached_bytes",
+                    memory.cached().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(target_os = "linux")]
+                output.gauge(
+                    "memory_shared_bytes",
+                    memory.shared().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(target_os = "linux")]
+                output.gauge(
+                    "memory_used_bytes",
+                    memory.used().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(target_os = "macos")]
+                output.gauge(
+                    "memory_inactive_bytes",
+                    memory.inactive().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(target_os = "macos")]
+                output.gauge(
+                    "memory_wired_bytes",
+                    memory.wire().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
             }
             Err(error) => {
                 error!(message = "Failed to load memory info.", %error, internal_log_rate_secs = 60);
-                vec![]
             }
         }
     }
 
-    pub async fn swap_metrics(&self) -> Vec<Metric> {
+    pub async fn swap_metrics(&self, output: &mut super::MetricsBuffer) {
+        output.name = "memory";
         match heim::memory::swap().await {
             Ok(swap) => {
-                let timestamp = Utc::now();
-                vec![
-                    self.gauge(
-                        "memory_swap_free_bytes",
-                        timestamp,
-                        swap.free().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    self.gauge(
-                        "memory_swap_total_bytes",
-                        timestamp,
-                        swap.total().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    self.gauge(
-                        "memory_swap_used_bytes",
-                        timestamp,
-                        swap.used().get::<byte>() as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(not(target_os = "windows"))]
-                    self.counter(
-                        "memory_swapped_in_bytes_total",
-                        timestamp,
-                        swap.sin().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,
-                        BTreeMap::new(),
-                    ),
-                    #[cfg(not(target_os = "windows"))]
-                    self.counter(
-                        "memory_swapped_out_bytes_total",
-                        timestamp,
-                        swap.sout().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,
-                        BTreeMap::new(),
-                    ),
-                ]
+                output.gauge(
+                    "memory_swap_free_bytes",
+                    swap.free().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                output.gauge(
+                    "memory_swap_total_bytes",
+                    swap.total().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                output.gauge(
+                    "memory_swap_used_bytes",
+                    swap.used().get::<byte>() as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(not(target_os = "windows"))]
+                output.counter(
+                    "memory_swapped_in_bytes_total",
+                    swap.sin().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,
+                    BTreeMap::new(),
+                );
+                #[cfg(not(target_os = "windows"))]
+                output.counter(
+                    "memory_swapped_out_bytes_total",
+                    swap.sout().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,
+                    BTreeMap::new(),
+                );
             }
             Err(error) => {
                 error!(message = "Failed to load swap info.", %error, internal_log_rate_secs = 60);
-                vec![]
             }
         }
     }


### PR DESCRIPTION
All of the metrics out of this source were collected into separate
`Vec`s and then pushed into the same result `Vec`. This change creates a
result buffer and pushes all the metrics into that result. This ends up
allowing for simpler code in a number of places.

As a result of the change, all of the metrics emitted by this source
will have the same timestamp on each collection representing the start
of the collection.