### PR TITLE
fix(codecs): Fix bug where Vector shuts down when a decoding error is returned to `FramedRead`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7561,8 +7561,7 @@ dependencies = [
 [[package]]
 name = "tokio-util"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+source = "git+https://github.com/vectordotdev/tokio?rev=3aa231cf6f33f74ca29077163879f0de9a207ad8#3aa231cf6f33f74ca29077163879f0de9a207ad8"
 dependencies = [
  "bytes 1.2.0",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,6 +358,8 @@ h2 = { git = "https://github.com/hyperium/h2.git", rev = "f6aa3be6719270cd7b4094
 # TODO remove this branch and instead use the openssl-src feature flag once it is available
 #    (see https://github.com/vectordotdev/vector/issues/13695)
 openssl-src = { git = "https://github.com/vectordotdev/openssl-src-rs.git", branch  = "enable_engine" }
+# The upgrade for `tokio-util` >= 0.6.9 is blocked on https://github.com/vectordotdev/vector/issues/11257.
+tokio-util = { git = "https://github.com/vectordotdev/tokio", version = "0.7", rev = "3aa231cf6f33f74ca29077163879f0de9a207ad8" }
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin


### PR DESCRIPTION
The bug in question: #11245.

This behavior has changed with the upgrade from `tokio_util` beyond `0.6.8`. See #11257 and https://github.com/tokio-rs/tokio/issues/3976.

The upgrade should have been blocked, but the `deny` script hasn't been enforced on CI: #13446.

The upgrade happened inadvertently in #12450.

Unfortunately, we can't easily roll back at the moment since some utilities have been built on top of the new features in `tokio_util`.