### PR TITLE
chore(sinks): Regularize the emitted events in socket sinks

### DIFF
--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -67,7 +67,6 @@ impl InternalEvent for SocketEventsReceived {
 pub struct SocketBytesSent {
     pub mode: SocketMode,
     pub byte_size: usize,
-    //pub endpoint: &'a str,
 }
 
 impl InternalEvent for SocketBytesSent {
@@ -77,12 +76,10 @@ impl InternalEvent for SocketBytesSent {
             message = "Bytes sent.",
             byte_size = %self.byte_size,
             protocol = %protocol,
-            //endpoint = %self.endpoint,
         );
         counter!(
             "component_sent_bytes_total", self.byte_size as u64,
             "protocol" => protocol,
-            //"endpoint" => self.endpoint.to_string(),
         );
     }
 }

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -64,6 +64,30 @@ impl InternalEvent for SocketEventsReceived {
 }
 
 #[derive(Debug)]
+pub struct SocketBytesSent {
+    pub mode: SocketMode,
+    pub byte_size: usize,
+    //pub endpoint: &'a str,
+}
+
+impl InternalEvent for SocketBytesSent {
+    fn emit(self) {
+        let protocol = self.mode.as_str().to_string();
+        trace!(
+            message = "Bytes sent.",
+            byte_size = %self.byte_size,
+            protocol = %protocol,
+            //endpoint = %self.endpoint,
+        );
+        counter!(
+            "component_sent_bytes_total", self.byte_size as u64,
+            "protocol" => protocol,
+            //"endpoint" => self.endpoint.to_string(),
+        );
+    }
+}
+
+#[derive(Debug)]
 pub struct SocketEventsSent {
     pub mode: SocketMode,
     pub count: u64,


### PR DESCRIPTION
By emitting the `BytesSent` event in `BytesSink`, we can avoid the premature emit in the TCP socket code and the duplicated events there too.

Closes #13528

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
