### PR TITLE
enhancement(sinks): Add support for acknowledgements to all socket sinks

### DIFF
--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -39,6 +39,14 @@ pub struct PapertrailConfig {
     /// The value to use as the `process` in Papertrail.
     #[configurable(metadata(templateable))]
     process: Option<Template>,
+
+    #[configurable(derived)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
 }
 
 inventory::submit! {
@@ -110,7 +118,7 @@ impl SinkConfig for PapertrailConfig {
     }
 
     fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+        Some(&self.acknowledgements)
     }
 }
 

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -50,6 +50,14 @@ pub struct StatsdSinkConfig {
 
     #[serde(flatten)]
     pub mode: Mode,
+
+    #[configurable(derived)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
 }
 
 /// Socket mode.
@@ -105,6 +113,7 @@ impl GenerateConfig for StatsdSinkConfig {
                 batch: Default::default(),
                 udp: UdpSinkConfig::from_address(default_address().to_string()),
             }),
+            acknowledgements: Default::default(),
         })
         .unwrap()
     }
@@ -162,7 +171,7 @@ impl SinkConfig for StatsdSinkConfig {
     }
 
     fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+        Some(&self.acknowledgements)
     }
 }
 
@@ -497,6 +506,7 @@ mod test {
                 batch,
                 udp: UdpSinkConfig::from_address(addr.to_string()),
             }),
+            acknowledgements: Default::default(),
         };
 
         let context = SinkContext::new_test();

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -19,7 +19,7 @@ use super::SinkBuildError;
 use crate::{
     codecs::Transformer,
     dns,
-    event::{Event, Finalizable},
+    event::{Event, EventStatus, Finalizable},
     internal_events::{
         SocketEventsSent, SocketMode, UdpSendIncompleteError, UdpSocketConnectionError,
         UdpSocketConnectionEstablished, UdpSocketError,
@@ -307,14 +307,14 @@ where
                             byte_size: bytes.len(),
                             protocol: "udp",
                         });
+                        finalizers.update_status(EventStatus::Delivered);
                     }
                     Err(error) => {
                         emit!(UdpSocketError { error });
+                        finalizers.update_status(EventStatus::Errored);
                         break;
                     }
-                };
-
-                drop(finalizers); // Ensure we don't acknowledge until after the send
+                }
             }
         }
 

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -98,10 +98,10 @@ impl SinkConfig for VectorConfig {
     }
 
     fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        match self {
-            Self::V1(_) => None,
-            Self::V2(v2) => Some(&v2.config.acknowledgements),
-        }
+        Some(match self {
+            Self::V1(v1) => &v1.config.acknowledgements,
+            Self::V2(v2) => &v2.config.acknowledgements,
+        })
     }
 }
 

--- a/src/sinks/vector/v1.rs
+++ b/src/sinks/vector/v1.rs
@@ -6,7 +6,7 @@ use vector_config::configurable_component;
 use vector_core::event::{proto, Event};
 
 use crate::{
-    config::GenerateConfig,
+    config::{AcknowledgementsConfig, GenerateConfig},
     sinks::{util::tcp::TcpSinkConfig, Healthcheck, VectorSink},
     tcp::TcpKeepaliveConfig,
     tls::TlsEnableableConfig,
@@ -32,6 +32,14 @@ pub struct VectorConfig {
     ///
     /// If set, the value of the setting is passed via the `SO_SNDBUF` option.
     send_buffer_bytes: Option<usize>,
+
+    #[configurable(derived)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
+    pub(super) acknowledgements: AcknowledgementsConfig,
 }
 
 impl VectorConfig {
@@ -44,17 +52,19 @@ impl VectorConfig {
         keepalive: Option<TcpKeepaliveConfig>,
         tls: Option<TlsEnableableConfig>,
         send_buffer_bytes: Option<usize>,
+        acknowledgements: AcknowledgementsConfig,
     ) -> Self {
         Self {
             address,
             keepalive,
             tls,
             send_buffer_bytes,
+            acknowledgements,
         }
     }
 
-    pub const fn from_address(address: String) -> Self {
-        Self::new(address, None, None, None)
+    pub const fn from_address(address: String, acknowledgements: AcknowledgementsConfig) -> Self {
+        Self::new(address, None, None, None, acknowledgements)
     }
 }
 
@@ -68,7 +78,14 @@ enum BuildError {
 
 impl GenerateConfig for VectorConfig {
     fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::new("127.0.0.1:5000".to_string(), None, None, None)).unwrap()
+        toml::Value::try_from(Self::new(
+            "127.0.0.1:5000".to_string(),
+            None,
+            None,
+            None,
+            Default::default(),
+        ))
+        .unwrap()
     }
 }
 

--- a/src/sources/vector/v1.rs
+++ b/src/sources/vector/v1.rs
@@ -254,7 +254,7 @@ mod test {
             stream_test(
                 addr,
                 VectorConfig::from_address(addr.into()),
-                SinkConfig::from_address(format!("localhost:{}", addr.port())),
+                SinkConfig::from_address(format!("localhost:{}", addr.port()), Default::default()),
             )
             .await;
         })
@@ -276,7 +276,10 @@ mod test {
                     config
                 },
                 {
-                    let mut config = SinkConfig::from_address(format!("localhost:{}", addr.port()));
+                    let mut config = SinkConfig::from_address(
+                        format!("localhost:{}", addr.port()),
+                        Default::default(),
+                    );
                     config.set_tls(Some(TlsEnableableConfig {
                         enabled: Some(true),
                         options: TlsConfig {

--- a/src/topology/test/crash.rs
+++ b/src/topology/test/crash.rs
@@ -25,7 +25,7 @@ async fn test_source_error() {
     config.add_sink(
         "out",
         &["in", "error"],
-        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
+        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string(), Default::default()),
     );
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
@@ -67,7 +67,7 @@ async fn test_source_panic() {
     config.add_sink(
         "out",
         &["in", "panic"],
-        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
+        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string(), Default::default()),
     );
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
@@ -112,7 +112,7 @@ async fn test_sink_error() {
     config.add_sink(
         "out",
         &["in1"],
-        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
+        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string(), Default::default()),
     );
     config.add_sink("error", &["in2"], error_sink());
 
@@ -158,7 +158,7 @@ async fn test_sink_panic() {
     config.add_sink(
         "out",
         &["in1"],
-        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string()),
+        SocketSinkConfig::make_basic_tcp_config(out_addr.to_string(), Default::default()),
     );
     config.add_sink("panic", &["in2"], panic_sink());
 

--- a/website/cue/reference/components/sinks/papertrail.cue
+++ b/website/cue/reference/components/sinks/papertrail.cue
@@ -13,7 +13,7 @@ components: sinks: papertrail: {
 	}
 
 	features: {
-		acknowledgements: false
+		acknowledgements: true
 		healthcheck: enabled: true
 		send: {
 			compression: enabled: false

--- a/website/cue/reference/components/sinks/socket.cue
+++ b/website/cue/reference/components/sinks/socket.cue
@@ -13,7 +13,7 @@ components: sinks: socket: {
 	}
 
 	features: {
-		acknowledgements: false
+		acknowledgements: true
 		healthcheck: enabled: true
 		send: {
 			compression: enabled: false


### PR DESCRIPTION
The bulk of the work here is in the common code layer, which was already mostly set up to handle these relatively trivial "acknowledgements" for the socket sinks. Since these sinks have no acknowledgement protocol, the support amounts to ensuring events send and propagating send errors into the event status.

Closes #13397

This is stacked on #13739

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
