### PR TITLE
chore(observability): Remove extraneous to_string

### DIFF
--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -28,15 +28,15 @@ pub struct SocketBytesReceived {
 
 impl InternalEvent for SocketBytesReceived {
     fn emit(self) {
-        let mode = self.mode.as_str();
+        let protocol = self.mode.as_str();
         trace!(
             message = "Bytes received.",
             byte_size = %self.byte_size,
-            mode,
+            protocol,
         );
         counter!(
             "component_received_bytes_total", self.byte_size as u64,
-            "mode" => mode,
+            "protocol" => protocol,
         );
     }
 }
@@ -72,15 +72,15 @@ pub struct SocketBytesSent {
 
 impl InternalEvent for SocketBytesSent {
     fn emit(self) {
-        let mode = self.mode.as_str();
+        let protocol = self.mode.as_str();
         trace!(
             message = "Bytes sent.",
             byte_size = %self.byte_size,
-            mode,
+            protocol,
         );
         counter!(
             "component_sent_bytes_total", self.byte_size as u64,
-            "mode" => mode,
+            "protocol" => protocol,
         );
     }
 }

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -32,7 +32,7 @@ impl InternalEvent for SocketBytesReceived {
         trace!(
             message = "Bytes received.",
             byte_size = %self.byte_size,
-            protocol,
+            %protocol,
         );
         counter!(
             "component_received_bytes_total", self.byte_size as u64,
@@ -55,7 +55,7 @@ impl InternalEvent for SocketEventsReceived {
             message = "Events received.",
             count = self.count,
             byte_size = self.byte_size,
-            mode,
+            %mode,
         );
         counter!("component_received_events_total", self.count as u64, "mode" => mode);
         counter!("component_received_event_bytes_total", self.byte_size as u64, "mode" => mode);
@@ -76,7 +76,7 @@ impl InternalEvent for SocketBytesSent {
         trace!(
             message = "Bytes sent.",
             byte_size = %self.byte_size,
-            protocol,
+            %protocol,
         );
         counter!(
             "component_sent_bytes_total", self.byte_size as u64,
@@ -115,7 +115,7 @@ impl<'a> InternalEvent for SocketReceiveError<'a> {
             error_code = "receiving_data",
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::RECEIVING,
-            mode,
+            %mode,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -28,15 +28,15 @@ pub struct SocketBytesReceived {
 
 impl InternalEvent for SocketBytesReceived {
     fn emit(self) {
-        let protocol = self.mode.as_str().to_string();
+        let mode = self.mode.as_str();
         trace!(
             message = "Bytes received.",
             byte_size = %self.byte_size,
-            protocol = protocol.as_str(),
+            mode,
         );
         counter!(
             "component_received_bytes_total", self.byte_size as u64,
-            "protocol" => protocol,
+            "mode" => mode,
         );
     }
 }
@@ -50,16 +50,17 @@ pub struct SocketEventsReceived {
 
 impl InternalEvent for SocketEventsReceived {
     fn emit(self) {
+        let mode = self.mode.as_str();
         trace!(
             message = "Events received.",
             count = self.count,
             byte_size = self.byte_size,
-            mode = self.mode.as_str()
+            mode,
         );
-        counter!("component_received_events_total", self.count as u64, "mode" => self.mode.as_str());
-        counter!("component_received_event_bytes_total", self.byte_size as u64, "mode" => self.mode.as_str());
+        counter!("component_received_events_total", self.count as u64, "mode" => mode);
+        counter!("component_received_event_bytes_total", self.byte_size as u64, "mode" => mode);
         // deprecated
-        counter!("events_in_total", self.count as u64, "mode" => self.mode.as_str());
+        counter!("events_in_total", self.count as u64, "mode" => mode);
     }
 }
 
@@ -71,15 +72,15 @@ pub struct SocketBytesSent {
 
 impl InternalEvent for SocketBytesSent {
     fn emit(self) {
-        let protocol = self.mode.as_str().to_string();
+        let mode = self.mode.as_str();
         trace!(
             message = "Bytes sent.",
             byte_size = %self.byte_size,
-            protocol = %protocol,
+            mode,
         );
         counter!(
             "component_sent_bytes_total", self.byte_size as u64,
-            "protocol" => protocol,
+            "mode" => mode,
         );
     }
 }
@@ -107,22 +108,23 @@ pub struct SocketReceiveError<'a> {
 
 impl<'a> InternalEvent for SocketReceiveError<'a> {
     fn emit(self) {
+        let mode = self.mode.as_str();
         error!(
             message = "Error receiving data.",
             error = %self.error,
             error_code = "receiving_data",
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::RECEIVING,
-            mode = %self.mode.as_str(),
+            mode,
         );
         counter!(
             "component_errors_total", 1,
             "error_code" => "receiving_data",
             "error_type" => error_type::CONNECTION_FAILED,
             "stage" => error_stage::RECEIVING,
-            "mode" => self.mode.as_str(),
+            "mode" => mode,
         );
         // deprecated
-        counter!("connection_errors_total", 1, "mode" => self.mode.as_str());
+        counter!("connection_errors_total", 1, "mode" => mode);
     }
 }


### PR DESCRIPTION
The socket sink/source related metrics had an extraneous `.to_string()` on some
of the constant strings used for modes, which causes an unnecessary memory
allocation.

Ref: https://github.com/vectordotdev/vector/pull/13739#discussion_r931898917
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
