### PR TITLE
enhancement(prometheus_exporter sink): Add acknowledgements support

### DIFF
--- a/lib/vector-common/src/finalization.rs
+++ b/lib/vector-common/src/finalization.rs
@@ -217,20 +217,26 @@ impl BatchNotifier {
         }
     }
 
+    /// Creates a new `BatchNotifier` and attaches it to a group of events.
+    ///
+    /// The receiver used to await the finalization status of the batch is returned.
+    pub fn apply_to<T: AddBatchNotifier>(items: &mut [T]) -> BatchStatusReceiver {
+        let (batch, receiver) = Self::new_with_receiver();
+        for item in items {
+            item.add_batch_notifier(batch.clone());
+        }
+        receiver
+    }
+
     /// Optionally creates a new `BatchNotifier` and attaches it to a group of events.
     ///
-    /// If `enabled`, the receiver used to await the finalization status of the batch is returned. Otherwise, `None` is returned.
+    /// If `enabled`, the receiver used to await the finalization status of the batch is
+    /// returned. Otherwise, `None` is returned.
     pub fn maybe_apply_to<T: AddBatchNotifier>(
         enabled: bool,
         items: &mut [T],
     ) -> Option<BatchStatusReceiver> {
-        enabled.then(|| {
-            let (batch, receiver) = Self::new_with_receiver();
-            for item in items {
-                item.add_batch_notifier(batch.clone());
-            }
-            receiver
-        })
+        enabled.then(|| Self::apply_to(items))
     }
 
     /// Updates the status of the notifier.

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -751,6 +751,7 @@ mod test {
                 distributions_as_summaries: false,
                 flush_period_secs: Duration::from_secs(1),
                 suppress_timestamp: false,
+                acknowledgements: Default::default(),
             },
         );
 

--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -16,7 +16,7 @@ components: sinks: prometheus_exporter: {
 	}
 
 	features: {
-		acknowledgements: false
+		acknowledgements: true
 		healthcheck: enabled: false
 		exposes: {
 			tls: {


### PR DESCRIPTION
This trivially handles end-to-end acknowledgements by marking events as
delivered when they are added to the aggregation buffer. As there are no error
branches in this path, all events are thus marked as delivered.

In discussion, we concluded this was the most prudent path, as acknowledging events only after they have been scraped could lead to some very long acknowledgement times, which would create somewhat artificial backpressure. I am open to alternative models, though.

Closes #13742 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
