### PR TITLE
fix(http sink): cert verification with proxy enabled

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -139,7 +139,7 @@ pub fn build_proxy_connector(
     tls_settings: MaybeTlsSettings,
     proxy_config: &ProxyConfig,
 ) -> Result<ProxyConnector<HttpsConnector<HttpConnector>>, HttpError> {
-    // Create dedicated TLS connector for the proxied connection with user tls settings.
+    // Create dedicated TLS connector for the proxied connection with user TLS settings.
     let tls = tls_connector_builder(&tls_settings)
         .context(BuildTlsConnectorSnafu)?
         .build();

--- a/src/http.rs
+++ b/src/http.rs
@@ -139,8 +139,12 @@ pub fn build_proxy_connector(
     tls_settings: MaybeTlsSettings,
     proxy_config: &ProxyConfig,
 ) -> Result<ProxyConnector<HttpsConnector<HttpConnector>>, HttpError> {
+    let tls = tls_connector_builder(&tls_settings.clone())
+        .context(BuildTlsConnectorSnafu)?
+        .build();
     let https = build_tls_connector(tls_settings)?;
     let mut proxy = ProxyConnector::new(https).unwrap();
+    proxy.set_tls(Some(tls));
     proxy_config
         .configure(&mut proxy)
         .context(MakeProxyConnectorSnafu)?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -139,13 +139,13 @@ pub fn build_proxy_connector(
     tls_settings: MaybeTlsSettings,
     proxy_config: &ProxyConfig,
 ) -> Result<ProxyConnector<HttpsConnector<HttpConnector>>, HttpError> {
-    // Create dedicated TLS connector with user tls settings.
+    // Create dedicated TLS connector for the proxied connection with user tls settings.
     let tls = tls_connector_builder(&tls_settings)
         .context(BuildTlsConnectorSnafu)?
         .build();
     let https = build_tls_connector(tls_settings)?;
     let mut proxy = ProxyConnector::new(https).unwrap();
-    // Make proxy connector aware of user TLS settings:
+    // Make proxy connector aware of user TLS settings by setting the TLS connector:
     // https://github.com/vectordotdev/vector/issues/13683
     proxy.set_tls(Some(tls));
     proxy_config

--- a/src/http.rs
+++ b/src/http.rs
@@ -139,11 +139,14 @@ pub fn build_proxy_connector(
     tls_settings: MaybeTlsSettings,
     proxy_config: &ProxyConfig,
 ) -> Result<ProxyConnector<HttpsConnector<HttpConnector>>, HttpError> {
-    let tls = tls_connector_builder(&tls_settings.clone())
+    // Create dedicated TLS connector with user tls settings.
+    let tls = tls_connector_builder(&tls_settings)
         .context(BuildTlsConnectorSnafu)?
         .build();
     let https = build_tls_connector(tls_settings)?;
     let mut proxy = ProxyConnector::new(https).unwrap();
+    // Make proxy connector aware of user TLS settings:
+    // https://github.com/vectordotdev/vector/issues/13683
     proxy.set_tls(Some(tls));
     proxy_config
         .configure(&mut proxy)


### PR DESCRIPTION
As described in #13683, when enabling the proxy for the http sink, the hyper ProxyConnector is not configured properly with the user supplied tls settings. Therefore, certificate verification using a private PKI or client cert authentication are broken.