### PR TITLE
chore(sinks): Make acknowledgement configuration non-optional

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -218,7 +218,9 @@ implement since errors are specific to the component.
 *All components* that can drop events MUST emit a `ComponentEventsDropped`
 event in accordance with the [EventsDropped event] requirements.
 
-## Health checks
+## Sink Operational Requirements
+
+### Health checks
 
 All sink components SHOULD define a health check. These checks are executed at
 boot and as part of `vector validate`. This health check SHOULD, as closely as
@@ -231,6 +233,22 @@ sink might fail if AWS is unhealthy, but the check itself should not query for
 AWS's status.
 
 See the [development documentation][health checks] for more context guidance.
+
+### Finalization
+
+All sink components MUST defer finalization of events until after those events have been
+delivered. This finalization controls when the events are removed from any source disk buffer. To do
+this, the sink must extract the finalizers from events before they are delivered and ensure they are
+not dropped until after delivery is completed.
+
+## Acknowledgements
+
+Further to the above, all sink components MUST support acknowledgements. This requires both a
+configuration option named `acknowledgements` conforming to the `AcknowledgementsConfig` type, as
+well as updating the status of all finalizers deferred above after delivery of the events is
+completed. This update is automatically handled for all sinks that use the newer `StreamSink`
+framework.  Additionally, unit tests for the sink SHOULD ensure through unit tests that delivered
+batches have their status updated properly for both normal delivery and delivery errors.
 
 [Configuration Specification]: configuration.md
 [Error event]: instrumentation.md#Error

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -154,6 +154,8 @@ pub struct AcknowledgementsConfig {
 }
 
 impl AcknowledgementsConfig {
+    pub const DEFAULT: Self = Self { enabled: None };
+
     #[must_use]
     pub fn merge_default(&self, other: &Self) -> Self {
         let enabled = self.enabled.or(other.enabled);

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -328,8 +328,8 @@ mod test {
             Input::all()
         }
 
-        fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-            None
+        fn acknowledgements(&self) -> &AcknowledgementsConfig {
+            &AcknowledgementsConfig::DEFAULT
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -158,24 +158,12 @@ impl Config {
     }
 
     pub fn propagate_acknowledgements(&mut self) -> Result<(), Vec<String>> {
-        if self.global.acknowledgements.enabled() {
-            for (name, sink) in &self.sinks {
-                if sink.inner.acknowledgements().is_none() {
-                    warn!(
-                        message = "Acknowledgements are globally enabled but sink does not support them.",
-                        sink = %name,
-                    );
-                }
-            }
-        }
-
         let inputs: Vec<_> = self
             .sinks
             .iter()
             .filter(|(_, sink)| {
                 sink.inner
                     .acknowledgements()
-                    .unwrap_or(&self.global.acknowledgements)
                     .merge_default(&self.global.acknowledgements)
                     .enabled()
             })

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -144,7 +144,7 @@ pub trait SinkConfig: core::fmt::Debug + Send + Sync {
         Vec::new()
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig>;
+    fn acknowledgements(&self) -> &AcknowledgementsConfig;
 }
 
 #[derive(Debug, Clone)]

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -114,8 +114,8 @@ impl SinkConfig for UnitTestSinkConfig {
         Input::all()
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
     }
 }
 

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -198,8 +198,8 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
         "aws_cloudwatch_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/aws_cloudwatch_metrics.rs
+++ b/src/sinks/aws_cloudwatch_metrics.rs
@@ -143,8 +143,8 @@ impl SinkConfig for CloudWatchMetricsSinkConfig {
         "aws_cloudwatch_metrics"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/aws_kinesis_firehose/config.rs
+++ b/src/sinks/aws_kinesis_firehose/config.rs
@@ -191,8 +191,8 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
         "aws_kinesis_firehose"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -205,8 +205,8 @@ impl SinkConfig for KinesisSinkConfig {
         "aws_kinesis_streams"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -161,8 +161,8 @@ impl SinkConfig for S3SinkConfig {
         "aws_s3"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/aws_sqs/config.rs
+++ b/src/sinks/aws_sqs/config.rs
@@ -128,8 +128,8 @@ impl SinkConfig for SqsSinkConfig {
         "aws_sqs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -97,8 +97,8 @@ impl SinkConfig for AxiomConfig {
         "axiom"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -157,8 +157,8 @@ impl SinkConfig for AzureBlobSinkConfig {
         "azure_blob"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -168,8 +168,8 @@ impl SinkConfig for AzureMonitorLogsConfig {
         "azure_monitor_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/blackhole/config.rs
+++ b/src/sinks/blackhole/config.rs
@@ -55,8 +55,8 @@ impl SinkConfig for BlackholeConfig {
         "blackhole"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/clickhouse.rs
+++ b/src/sinks/clickhouse.rs
@@ -118,8 +118,8 @@ impl SinkConfig for ClickhouseConfig {
         "clickhouse"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -90,8 +90,8 @@ impl SinkConfig for ConsoleSinkConfig {
         "console"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -134,8 +134,8 @@ impl SinkConfig for DatadogEventsConfig {
         "datadog_events"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -209,8 +209,8 @@ impl SinkConfig for DatadogLogsConfig {
         "datadog_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -171,8 +171,8 @@ impl SinkConfig for DatadogMetricsConfig {
         "datadog_metrics"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -211,8 +211,8 @@ impl SinkConfig for DatadogTracesConfig {
         "datadog_traces"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -839,8 +839,8 @@ impl SinkConfig for DatadogArchivesSinkConfig {
         "datadog_archives"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -418,8 +418,8 @@ impl SinkConfig for ElasticsearchConfig {
         "elasticsearch"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -170,8 +170,8 @@ impl SinkConfig for FileSinkConfig {
         "file"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -167,8 +167,8 @@ impl SinkConfig for ChronicleUnstructuredConfig {
         NAME
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -215,8 +215,8 @@ impl SinkConfig for GcsSinkConfig {
         NAME
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -138,8 +138,8 @@ impl SinkConfig for PubsubConfig {
         "gcp_pubsub"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -226,8 +226,8 @@ impl SinkConfig for StackdriverConfig {
         "gcp_stackdriver_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -134,8 +134,8 @@ impl SinkConfig for StackdriverConfig {
         "gcp_stackdriver_metrics"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -120,8 +120,8 @@ impl SinkConfig for HoneycombConfig {
         "honeycomb"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -241,8 +241,8 @@ impl SinkConfig for HttpSinkConfig {
         "http"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -167,8 +167,8 @@ impl SinkConfig for HumioLogsConfig {
         "humio_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -173,8 +173,8 @@ impl SinkConfig for HumioMetricsConfig {
         "humio_metrics"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -182,8 +182,8 @@ impl SinkConfig for InfluxDbLogsConfig {
         "influxdb_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -143,8 +143,8 @@ impl SinkConfig for InfluxDbConfig {
         "influxdb_metrics"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -232,8 +232,8 @@ impl SinkConfig for KafkaSinkConfig {
         "kafka"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -128,8 +128,8 @@ impl SinkConfig for LogdnaConfig {
         "logdna"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -178,8 +178,8 @@ impl SinkConfig for LokiConfig {
         "loki"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -121,8 +121,8 @@ impl SinkConfig for NatsSinkConfig {
         "nats"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -178,8 +178,8 @@ impl SinkConfig for NewRelicConfig {
         "new_relic"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/new_relic_logs.rs
+++ b/src/sinks/new_relic_logs.rs
@@ -122,8 +122,8 @@ impl SinkConfig for NewRelicLogsConfig {
         "new_relic_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -117,8 +117,8 @@ impl SinkConfig for PapertrailConfig {
         "papertrail"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -207,8 +207,8 @@ impl SinkConfig for PrometheusExporterConfig {
         vec![Resource::tcp(self.address)]
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 
@@ -239,7 +239,7 @@ impl SinkConfig for PrometheusCompatConfig {
         self.config.resources()
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
         self.config.acknowledgements()
     }
 }

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -183,8 +183,8 @@ impl SinkConfig for RemoteWriteConfig {
         "prometheus_remote_write"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -186,8 +186,8 @@ impl SinkConfig for PulsarSinkConfig {
         "pulsar"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -197,8 +197,8 @@ impl SinkConfig for RedisSinkConfig {
         "redis"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -123,8 +123,8 @@ impl SinkConfig for SematextLogsConfig {
         "sematext_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -149,8 +149,8 @@ impl SinkConfig for SematextMetricsConfig {
         "sematext_metrics"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -162,8 +162,8 @@ impl SinkConfig for SocketSinkConfig {
         "socket"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -168,8 +168,8 @@ impl SinkConfig for HecLogsSinkConfig {
         "splunk_hec_logs"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements.inner)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements.inner
     }
 }
 
@@ -262,7 +262,7 @@ impl SinkConfig for HecSinkCompatConfig {
         "splunk_hec"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
         self.config.acknowledgements()
     }
 }

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -136,8 +136,8 @@ impl SinkConfig for HecMetricsSinkConfig {
         "splunk_hec_metrics"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements.inner)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements.inner
     }
 }
 

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -170,8 +170,8 @@ impl SinkConfig for StatsdSinkConfig {
         "statsd"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -197,8 +197,8 @@ impl SinkConfig for TestConfig {
         unimplemented!("not intended for use in real configs")
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
     }
 }
 

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -97,11 +97,11 @@ impl SinkConfig for VectorConfig {
         "vector"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(match self {
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        match self {
             Self::V1(v1) => &v1.config.acknowledgements,
             Self::V2(v2) => &v2.config.acknowledgements,
-        })
+        }
     }
 }
 

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -79,8 +79,8 @@ impl SinkConfig for WebSocketSinkConfig {
         "websocket"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        Some(&self.acknowledgements)
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
     }
 }
 

--- a/src/test_util/mock/sinks/basic.rs
+++ b/src/test_util/mock/sinks/basic.rs
@@ -103,8 +103,8 @@ impl SinkConfig for BasicSinkConfig {
         "basic_sink"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
     }
 }
 

--- a/src/test_util/mock/sinks/error.rs
+++ b/src/test_util/mock/sinks/error.rs
@@ -44,8 +44,8 @@ impl SinkConfig for ErrorSinkConfig {
         "error_sink"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
     }
 }
 

--- a/src/test_util/mock/sinks/panic.rs
+++ b/src/test_util/mock/sinks/panic.rs
@@ -44,8 +44,8 @@ impl SinkConfig for PanicSinkConfig {
         "panic_sink"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
     }
 }
 

--- a/src/topology/test/backpressure.rs
+++ b/src/topology/test/backpressure.rs
@@ -265,8 +265,8 @@ mod test_sink {
             "test-backpressure-sink"
         }
 
-        fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-            None
+        fn acknowledgements(&self) -> &AcknowledgementsConfig {
+            &AcknowledgementsConfig::DEFAULT
         }
     }
 }

--- a/src/topology/test/compliance.rs
+++ b/src/topology/test/compliance.rs
@@ -116,8 +116,8 @@ impl SinkConfig for OneshotSinkConfig {
         "oneshot"
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
     }
 
     async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -424,8 +424,8 @@ impl SinkConfig for MockSinkConfig {
         unimplemented!("not intended for use in real configs")
     }
 
-    fn acknowledgements(&self) -> Option<&AcknowledgementsConfig> {
-        None
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
     }
 }
 


### PR DESCRIPTION
This finishes the cleanup of end-to-end acknowledgements, making handling of
acknowledgements non-optional in all sinks, at least at a configuration level.

I would like to take this a step further and move the `acknowledgements` configuration up out of the individual sinks and into `struct SinkOuter`. This is blocked by the configuration of the `splunk_hec` sink that overloads its own configuration on top of this item. As such, I think this is as far as I can push this clean up without introducing a breaking change for that sink.

Closes #13664 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
