### PR TITLE
fix(codecs): deny unknown fields on transformer config

### DIFF
--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -362,7 +362,7 @@ mod tests {
     fn deny_unknown_fields() {
         // We're only checking this explicitly because of our custom deserializer arrangement to
         // make it possible to throw the exclusivity error during deserialization, to ensure that we
-        // enforce this on the top-level `Transformer`g type even though it has to be applied at the
+        // enforce this on the top-level `Transformer` type even though it has to be applied at the
         // intermediate deserialization stage, on `TransformerInner`.
         let config: std::result::Result<Transformer, _> = toml::from_str(indoc! {r#"
             onlyfields = ["Doop"]

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -36,6 +36,7 @@ impl<'de> Deserialize<'de> for Transformer {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct TransformerInner {
             #[serde(default)]
             only_fields: Option<Vec<OwnedPath>>,
@@ -353,6 +354,18 @@ mod tests {
         let config: std::result::Result<Transformer, _> = toml::from_str(indoc! {r#"
             except_fields = ["Doop"]
             only_fields = ["Doop"]
+        "#});
+        assert!(config.is_err())
+    }
+
+    #[test]
+    fn deny_unknown_fields() {
+        // We're only checking this explicitly because of our custom deserializer arrangement to
+        // make it possible to throw the exclusivity error during deserialization, to ensure that we
+        // enforce this on the top-level `Transformer`g type even though it has to be applied at the
+        // intermediate deserialization stage, on `TransformerInner`.
+        let config: std::result::Result<Transformer, _> = toml::from_str(indoc! {r#"
+            onlyfields = ["Doop"]
         "#});
         assert!(config.is_err())
     }


### PR DESCRIPTION
In #13783, a user reported that despite specifying an invalid configuration field (`onlyfields` vs `only_fields`), Vector still loaded their configuration without issue, leading to a scenario where the intended behavior (only allow specify fields) did not occur, as they believe the configuration was valid.

We've simply added the `#[serde(deny_unknown_fields)]` annotation to detect this scenario, as well as a unit test to ensure we've correctly fixed the issue. There's certainly precedent to potentially use `deny_unknown_fields` by default with an escape hatch for necessary situations, but I figured it was easy enough to fix in this isolated case.

Closes #13783.