### PR TITLE
feat(vrl): Adds `chunks` function

### DIFF
--- a/lib/value/src/value/convert.rs
+++ b/lib/value/src/value/convert.rs
@@ -264,6 +264,12 @@ impl<const N: usize> From<&[u8; N]> for Value {
     }
 }
 
+impl From<&[u8]> for Value {
+    fn from(data: &[u8]) -> Self {
+        Self::from(Bytes::copy_from_slice(data))
+    }
+}
+
 impl<T: Into<Self>> From<Vec<T>> for Value {
     fn from(set: Vec<T>) -> Self {
         set.into_iter()

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -76,6 +76,7 @@ default = [
     "assert_eq",
     "boolean",
     "ceil",
+    "chunks",
     "compact",
     "contains",
     "decode_base64",
@@ -213,6 +214,7 @@ assert = []
 assert_eq = ["vector-common/conversion"]
 boolean = []
 ceil = []
+chunks = []
 compact = []
 contains = []
 cryptography = ["dep:aes", "dep:ctr", "dep:cbc", "dep:cfb-mode", "dep:ofb"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -15,6 +15,7 @@ criterion_group!(
               assert_eq,
               r#bool,
               ceil,
+              chunks,
               compact,
               contains,
               decode_base64,
@@ -212,6 +213,15 @@ bench_function! {
     literal {
         args: func_args![value: 1234.56725, precision: 4],
         want: Ok(1234.5673),
+    }
+}
+
+bench_function! {
+    chunks => vrl_stdlib::Chunks;
+
+    literal {
+        args: func_args![value: "abcdefgh", chunk_size: 4],
+        want: Ok(value!(["abcd", "efgh"])),
     }
 }
 

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -72,11 +72,25 @@ impl Function for Chunks {
     }
 
     fn examples(&self) -> &'static [Example] {
-        &[Example {
-            title: "chunks by byte",
-            source: r#"chunks("abcdefgh", 4)"#,
-            result: Ok(["abcd", "efgh"]),
-        }]
+        &[
+            Example {
+                title: "chunks by byte",
+                source: r#"chunks("abcdefgh", 4)"#,
+                result: Ok(r#"["abcd", "efgh"]"#),
+            },
+            Example {
+                title: "chunk sizes respect unicode code point boundaries",
+                source: r#"chunks("ab你好", 4)"#,
+                result: Ok(r#"["ab", "你", "好"]"#),
+            },
+            Example {
+                title: "chunk size cannot be less than 4 bytes in length",
+                source: r#"chunks("hello world", 3)"#,
+                result: Err(
+                    r#"function call error for "chunks" at (0:24): "chunk_size" must be greater than or equal to 4 bytes"#,
+                ),
+            },
+        ]
     }
 
     fn compile(

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -85,7 +85,7 @@ impl Expression for ChunksFn {
     }
 
     fn type_def(&self, _state: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
-        TypeDef::array(Collection::from_unknown(Kind::bytes())).infallible()
+        TypeDef::array(Collection::from_unknown(Kind::bytes())).fallible()
     }
 }
 

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -2,14 +2,14 @@ use ::value::Value;
 use vrl::prelude::*;
 
 fn chunks(value: Value, chunk_size: Value) -> Resolved {
-    let chunk_size = chunk_size.try_integer()? as usize;
+    let chunk_size = chunk_size.try_integer()?;
     let bytes = value.try_bytes()?;
 
     if chunk_size < 1 {
         return Err(r#""chunk_size" must be at least 1 byte"#.into());
     }
 
-    Ok(bytes.chunks(chunk_size).collect::<Vec<_>>().into())
+    Ok(bytes.chunks(chunk_size as usize).collect::<Vec<_>>().into())
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -132,14 +132,6 @@ mod tests {
             tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
         }
 
-        minimum_chunk_size {
-            args: func_args![value: "",
-                             chunk_size: 0,
-            ],
-            want: Err(r#"invalid argument"#),
-            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
-        }
-
         mixed_ascii_unicode {
             args: func_args![value: "ab你好",
                              chunk_size: 4,

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -74,8 +74,8 @@ impl Function for Chunks {
     fn examples(&self) -> &'static [Example] {
         &[Example {
             title: "chunks by byte",
-            source: r#"chunks("foobar", 1)"#,
-            result: Ok("hi"),
+            source: r#"chunks("abcdefgh", 4)"#,
+            result: Ok(["abcd", "efgh"]),
         }]
     }
 

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -9,7 +9,11 @@ fn chunks(value: Value, chunk_size: Value) -> Resolved {
         return Err(r#""chunk_size" must be at least 1 byte"#.into());
     }
 
-    Ok(bytes.chunks(chunk_size as usize).collect::<Vec<_>>().into())
+    if let Ok(chunk_size) = usize::try_from(chunk_size) {
+        Ok(bytes.chunks(chunk_size).collect::<Vec<_>>().into())
+    } else {
+        Err(r#""chunk_size" must be a valid usize for this target architecture"#.into())
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -1,0 +1,151 @@
+use ::value::Value;
+use vrl::prelude::*;
+
+fn chunks(value: Value, chunk_size: Value) -> Resolved {
+    let chunk_size = chunk_size.try_integer()? as usize;
+    let bytes = value.try_bytes()?;
+
+    let data_length = bytes.len();
+    let mut chunked_data: Vec<&[u8]> = Vec::new();
+
+    let mut backtrack = 0;
+    let mut start = 0;
+    let mut end;
+
+    if chunk_size < 4 {
+        return Err(r#""chunk_size" must be greater than or equal to 4 bytes"#.into());
+    }
+
+    loop {
+        let is_last_chunk = (start < data_length) && (start + chunk_size >= data_length);
+
+        if is_last_chunk {
+            chunked_data.push(&bytes[start..]);
+            break;
+        }
+
+        end = start + chunk_size - backtrack;
+
+        if is_root_utf8_byte(&bytes[end]) {
+            chunked_data.push(&bytes[start..end]);
+            backtrack = 0;
+            start = end;
+        } else {
+            backtrack += 1;
+
+            if backtrack > 3 {
+                return Err("Bytes are not valid UTF-8".into());
+            }
+        }
+    }
+
+    Ok(chunked_data.into_iter().collect::<Vec<_>>().into())
+}
+
+fn is_root_utf8_byte(byte: &u8) -> bool {
+    byte >> 6 != 0b10
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Chunks;
+
+impl Function for Chunks {
+    fn identifier(&self) -> &'static str {
+        "chunks"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+            Parameter {
+                keyword: "chunk_size",
+                kind: kind::INTEGER,
+                required: true,
+            },
+        ]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "chunks by byte",
+            source: r#"chunks("foobar", 1)"#,
+            result: Ok("hi"),
+        }]
+    }
+
+    fn compile(
+        &self,
+        _state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        _ctx: &mut FunctionCompileContext,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        let chunk_size = arguments.required("chunk_size");
+
+        Ok(Box::new(ChunksFn { value, chunk_size }))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChunksFn {
+    value: Box<dyn Expression>,
+    chunk_size: Box<dyn Expression>,
+}
+
+impl Expression for ChunksFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let chunk_size = self.chunk_size.resolve(ctx)?;
+
+        chunks(value, chunk_size)
+    }
+
+    fn type_def(&self, _state: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
+        TypeDef::array(Collection::from_unknown(Kind::bytes())).infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        chunks => Chunks;
+
+        unicode {
+            args: func_args![value: "你好",
+                             chunk_size: 4
+            ],
+            want: Ok(value!(["你", "好"])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        minimum_chunk_size {
+            args: func_args![value: "",
+            chunk_size: 2
+            ],
+            want: Err(r#""chunk_size" must be greater than or equal to 4 bytes"#),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        mixed_ascii_unicode {
+            args: func_args![value: "ab你好",
+                             chunk_size: 4
+            ],
+            want: Ok(value!(["ab", "你", "好"])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        invalid_utf8 {
+            args: func_args![value: b"\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0",
+                             chunk_size: 8
+            ],
+            want: Err("Bytes are not valid UTF-8"),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -1,63 +1,15 @@
 use ::value::Value;
 use vrl::prelude::*;
 
-const MAX_UTF8_CODE_POINT_LENGTH_IN_BYTES: usize = 4;
-
-fn chunks(value: Value, chunk_size: Value, utf8: Value) -> Resolved {
+fn chunks(value: Value, chunk_size: Value) -> Resolved {
     let chunk_size = chunk_size.try_integer()? as usize;
     let bytes = value.try_bytes()?;
-    let utf8 = utf8.try_boolean()?;
-    let mut chunked_data: Vec<&[u8]> = Vec::new();
 
-    if utf8 {
-        let data_length = bytes.len();
+    if chunk_size < 1 {
+        return Err(r#""chunk_size" must be at least 1 byte"#.into());
+    }
 
-        let mut backtrack = 0;
-        let mut start = 0;
-        let mut end;
-
-        if chunk_size < MAX_UTF8_CODE_POINT_LENGTH_IN_BYTES {
-            return Err(r#""chunk_size" must be at least 4 bytes"#.into());
-        }
-
-        'chunks: loop {
-            let is_last_chunk = (start < data_length) && (start + chunk_size >= data_length);
-
-            if is_last_chunk {
-                chunked_data.push(&bytes[start..]);
-                break 'chunks;
-            }
-
-            'utf8_boundaries: loop {
-                end = start + chunk_size - backtrack;
-
-                if is_root_utf8_byte(&bytes[end]) {
-                    chunked_data.push(&bytes[start..end]);
-                    backtrack = 0;
-                    start = end;
-                    break 'utf8_boundaries;
-                } else {
-                    backtrack += 1;
-
-                    if backtrack >= MAX_UTF8_CODE_POINT_LENGTH_IN_BYTES {
-                        return Err("Bytes are not valid UTF-8".into());
-                    }
-                }
-            }
-        }
-    } else {
-        if chunk_size < 1 {
-            return Err(r#""chunk_size" must be at least 1 byte"#.into());
-        }
-
-        chunked_data = bytes.chunks(chunk_size).collect();
-    };
-
-    Ok(chunked_data.into())
-}
-
-fn is_root_utf8_byte(byte: &u8) -> bool {
-    byte >> 6 != 0b10
+    Ok(bytes.chunks(chunk_size).collect::<Vec<_>>().into())
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -80,48 +32,26 @@ impl Function for Chunks {
                 kind: kind::INTEGER,
                 required: true,
             },
-            Parameter {
-                keyword: "utf8",
-                kind: kind::BOOLEAN,
-                required: true,
-            },
         ]
     }
 
     fn examples(&self) -> &'static [Example] {
         &[
             Example {
-                title: "chunks by byte when utf8=true",
-                source: r#"chunks("abcdefgh", 4, true)"#,
+                title: "chunks by byte",
+                source: r#"chunks("abcdefgh", 4)"#,
                 result: Ok(r#"["abcd", "efgh"]"#),
             },
             Example {
-                title: "chunk sizes respect unicode code point boundaries when utf8=true",
-                source: r#"chunks("ab你好", 4, true)"#,
-                result: Ok(r#"["ab", "你", "好"]"#),
-            },
-            Example {
-                title: "chunk size cannot be less than 4 bytes when utf8=true",
-                source: r#"chunks("hello world", 3, true)"#,
-                result: Err(
-                    r#"function call error for "chunks" at (0:30): "chunk_size" must be at least 4 bytes"#,
-                ),
-            },
-            Example {
-                title: "chunk size can be less than 4 bytes when utf8=false",
-                source: r#"chunks("hello world", 3, false)"#,
-                result: Ok(r#"["hel","lo ","wor","ld"]"#),
-            },
-            Example {
                 title: "chunk size must be at least 1 byte",
-                source: r#"chunks("hello world", 0, false)"#,
+                source: r#"chunks("hello world", 0)"#,
                 result: Err(
-                    r#"function call error for "chunks" at (0:31): "chunk_size" must be at least 1 byte"#,
+                    r#"function call error for "chunks" at (0:24): "chunk_size" must be at least 1 byte"#,
                 ),
             },
             Example {
-                title: "chunk sizes do not respect unicode code point boundaries when utf8=false",
-                source: r#"chunks("ab你好", 4, false)"#,
+                title: "chunk sizes do not respect unicode code point boundaries",
+                source: r#"chunks("ab你好", 4)"#,
                 result: Ok(r#"["ab�","�好"]"#),
             },
         ]
@@ -135,13 +65,8 @@ impl Function for Chunks {
     ) -> Compiled {
         let value = arguments.required("value");
         let chunk_size = arguments.required("chunk_size");
-        let utf8 = arguments.required("utf8");
 
-        Ok(Box::new(ChunksFn {
-            value,
-            chunk_size,
-            utf8,
-        }))
+        Ok(Box::new(ChunksFn { value, chunk_size }))
     }
 }
 
@@ -149,16 +74,14 @@ impl Function for Chunks {
 struct ChunksFn {
     value: Box<dyn Expression>,
     chunk_size: Box<dyn Expression>,
-    utf8: Box<dyn Expression>,
 }
 
 impl Expression for ChunksFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         let value = self.value.resolve(ctx)?;
         let chunk_size = self.chunk_size.resolve(ctx)?;
-        let utf8 = self.utf8.resolve(ctx)?;
 
-        chunks(value, chunk_size, utf8)
+        chunks(value, chunk_size)
     }
 
     fn type_def(&self, _state: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
@@ -176,7 +99,6 @@ mod tests {
         chunks_data {
             args: func_args![value: "abcdefgh",
                              chunk_size: 4,
-                             utf8: true,
             ],
             want: Ok(value!(["abcd", "efgh"])),
             tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
@@ -184,37 +106,18 @@ mod tests {
 
         minimum_chunk_size {
             args: func_args![value: "",
-                             chunk_size: 2,
-                             utf8: true,
+                             chunk_size: 0,
             ],
-            want: Err(r#""chunk_size" must be at least 4 bytes"#),
+            want: Err(r#""chunk_size" must be at least 1 byte"#),
             tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
         }
 
-        mixed_ascii_unicode_with_utf8_true {
-            args: func_args![value: "ab你好",
-                             chunk_size: 4,
-                             utf8: true
-            ],
-            want: Ok(value!(["ab", "你", "好"])),
-            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
-        }
-
-        mixed_ascii_unicode_with_utf8_false {
+        mixed_ascii_unicode {
             args: func_args![value: "ab你好",
                              chunk_size: 4,
                              utf8: false
             ],
             want: Ok(value!([b"ab\xe4\xbd", b"\xa0\xe5\xa5\xbd"])),
-            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
-        }
-
-        invalid_utf8 {
-            args: func_args![value: b"\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0",
-                             chunk_size: 8,
-                             utf8: true
-            ],
-            want: Err("Bytes are not valid UTF-8"),
             tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
         }
     ];

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -14,7 +14,7 @@ fn chunks(value: Value, chunk_size: Value) -> Resolved {
         Ok(bytes.chunks(chunk_size).collect::<Vec<_>>().into())
     } else {
         Err(format!(
-            r#""chunk_size" is too large: must be at most {}"#,
+            r#""chunk_size" is too large: must be at most {} bytes"#,
             usize::MAX
         )
         .into())

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -1,6 +1,8 @@
 use ::value::Value;
 use vrl::prelude::*;
 
+const MAX_UTF8_CODE_POINT_LENGTH_IN_BYTES: usize = 4;
+
 fn chunks(value: Value, chunk_size: Value) -> Resolved {
     let chunk_size = chunk_size.try_integer()? as usize;
     let bytes = value.try_bytes()?;
@@ -12,7 +14,7 @@ fn chunks(value: Value, chunk_size: Value) -> Resolved {
     let mut start = 0;
     let mut end;
 
-    if chunk_size < 4 {
+    if chunk_size < MAX_UTF8_CODE_POINT_LENGTH_IN_BYTES {
         return Err(r#""chunk_size" must be greater than or equal to 4 bytes"#.into());
     }
 
@@ -33,7 +35,7 @@ fn chunks(value: Value, chunk_size: Value) -> Resolved {
         } else {
             backtrack += 1;
 
-            if backtrack > 3 {
+            if backtrack >= MAX_UTF8_CODE_POINT_LENGTH_IN_BYTES {
                 return Err("Bytes are not valid UTF-8".into());
             }
         }

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -2,8 +2,8 @@ use ::value::Value;
 use vrl::prelude::*;
 
 fn chunks(value: Value, chunk_size: Value) -> Resolved {
-    let chunk_size = chunk_size.try_integer()?;
     let bytes = value.try_bytes()?;
+    let chunk_size = chunk_size.try_integer()?;
 
     if chunk_size < 1 {
         return Err(r#""chunk_size" must be at least 1 byte"#.into());

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -12,7 +12,11 @@ fn chunks(value: Value, chunk_size: Value) -> Resolved {
     if let Ok(chunk_size) = usize::try_from(chunk_size) {
         Ok(bytes.chunks(chunk_size).collect::<Vec<_>>().into())
     } else {
-        Err(r#""chunk_size" must be a valid usize for this target architecture"#.into())
+        Err(format!(
+            r#""chunk_size" must be at least 1 byte and no greater than {} bytes"#,
+            usize::MAX
+        )
+        .into())
     }
 }
 

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -40,6 +40,8 @@ mod assert_eq;
 mod boolean;
 #[cfg(feature = "ceil")]
 mod ceil;
+#[cfg(feature = "chunks")]
+mod chunks;
 #[cfg(feature = "compact")]
 mod compact;
 #[cfg(feature = "contains")]
@@ -319,6 +321,8 @@ pub use assert_eq::AssertEq;
 pub use boolean::Boolean;
 #[cfg(feature = "ceil")]
 pub use ceil::Ceil;
+#[cfg(feature = "chunks")]
+pub use chunks::Chunks;
 #[cfg(feature = "compact")]
 pub use compact::Compact;
 #[cfg(feature = "contains")]
@@ -598,6 +602,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Boolean),
         #[cfg(feature = "ceil")]
         Box::new(Ceil),
+        #[cfg(feature = "chunks")]
+        Box::new(Chunks),
         #[cfg(feature = "compact")]
         Box::new(Compact),
         #[cfg(feature = "contains")]

--- a/lib/vrl/tests/tests/functions/chunks_chunk_size_at_least_1.vrl
+++ b/lib/vrl/tests/tests/functions/chunks_chunk_size_at_least_1.vrl
@@ -1,0 +1,16 @@
+# result:
+# error[E610]: function compilation error: error[E403] invalid argument
+#   ┌─ :2:1
+#   │
+# 2 │ chunks("hello world", 0)
+#   │ ^^^^^^^^^^^^^^^^^^^^^^^^
+#   │ │
+#   │ invalid argument "chunk_size"
+#   │ error: "chunk_size" must be at least 1 byte
+#   │ received: 0
+#   │
+#   = learn more about error code 403 at https://errors.vrl.dev/403
+#   = see language documentation at https://vrl.dev
+#   = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+chunks("hello world", 0)

--- a/lib/vrl/tests/tests/functions/chunks_fallible_given_expression.vrl
+++ b/lib/vrl/tests/tests/functions/chunks_fallible_given_expression.vrl
@@ -1,0 +1,17 @@
+# result:
+# error[E100]: unhandled error
+#   ┌─ :3:1
+#   │
+# 3 │ chunks("abcd", int!(floor(4.1)))
+#   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#   │ │
+#   │ expression can result in runtime error
+#   │ handle the error case to ensure runtime success
+#   │
+#   = see documentation about error handling at https://errors.vrl.dev/#handling
+#   = learn more about error code 100 at https://errors.vrl.dev/100
+#   = see language documentation at https://vrl.dev
+#   = try your code in the VRL REPL, learn more at https://vrl.dev/examples
+
+chunks("abcd", 4)
+chunks("abcd", int!(floor(4.1)))

--- a/website/cue/reference/remap/functions/chunks.cue
+++ b/website/cue/reference/remap/functions/chunks.cue
@@ -28,7 +28,8 @@ remap: functions: chunks: {
 	return: {
 		types: ["array"]
 		rules: [
-			"Returns an integer if `chunk_size` is `0` (this is the default). Returns a float otherwise.",
+			"`chunks` is considered fallible if the platform architecture's usize integer is smaller than 64 bits",
+			"`chunks` is considered fallible if the supplied `chunk_size` is an expression, and infallible if it's a literal integer.",
 		]
 	}
 

--- a/website/cue/reference/remap/functions/chunks.cue
+++ b/website/cue/reference/remap/functions/chunks.cue
@@ -1,0 +1,51 @@
+package metadata
+
+remap: functions: chunks: {
+	category: "Array"
+	description: """
+		Chunks `value` into slices of length `chunk_size` bytes
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The array of bytes to split."
+			required:    true
+			type: ["array", "string", "bytes"]
+		},
+		{
+			name:        "chunk_size"
+			description: "The desired length of each chunk in bytes."
+			required:    false
+			default:     0
+			type: ["integer"]
+		},
+	]
+	internal_failure_reasons: [
+		"`chunk_size` must be a valid usize for this target architecture",
+		"`chunk_size` must be at least 1 byte",
+	]
+	return: {
+		types: ["array"]
+		rules: [
+			"Returns an integer if `chunk_size` is `0` (this is the default). Returns a float otherwise.",
+		]
+	}
+
+	examples: [
+		{
+			title: "Split a string into chunks"
+			source: #"""
+				chunks("abcdefgh", 4)
+				"""#
+			return: ["abcd", "efgh"]
+		},
+		{
+			title: "Chunks do not respect unicode code point boundaries"
+			source: #"""
+				chunks("ab你好", 4)
+				"""#
+			return: ["ab�","�好"]
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/chunks.cue
+++ b/website/cue/reference/remap/functions/chunks.cue
@@ -11,7 +11,7 @@ remap: functions: chunks: {
 			name:        "value"
 			description: "The array of bytes to split."
 			required:    true
-			type: ["array", "string", "bytes"]
+			type: ["array", "string"]
 		},
 		{
 			name:        "chunk_size"

--- a/website/cue/reference/remap/functions/chunks.cue
+++ b/website/cue/reference/remap/functions/chunks.cue
@@ -15,20 +15,18 @@ remap: functions: chunks: {
 		},
 		{
 			name:        "chunk_size"
-			description: "The desired length of each chunk in bytes."
-			required:    false
-			default:     0
+			description: "The desired length of each chunk in bytes. This may be constrained by the host platform architecture."
+			required:    true
 			type: ["integer"]
 		},
 	]
 	internal_failure_reasons: [
-		"`chunk_size` must be a valid usize for this target architecture",
 		"`chunk_size` must be at least 1 byte",
+		"`chunk_size` is too large"
 	]
 	return: {
 		types: ["array"]
 		rules: [
-			"`chunks` is considered fallible if the platform architecture's usize integer is smaller than 64 bits",
 			"`chunks` is considered fallible if the supplied `chunk_size` is an expression, and infallible if it's a literal integer.",
 		]
 	}

--- a/website/cue/reference/remap/functions/chunks.cue
+++ b/website/cue/reference/remap/functions/chunks.cue
@@ -22,7 +22,7 @@ remap: functions: chunks: {
 	]
 	internal_failure_reasons: [
 		"`chunk_size` must be at least 1 byte",
-		"`chunk_size` is too large"
+		"`chunk_size` is too large",
 	]
 	return: {
 		types: ["array"]
@@ -44,7 +44,7 @@ remap: functions: chunks: {
 			source: #"""
 				chunks("ab你好", 4)
 				"""#
-			return: ["ab�","�好"]
+			return: ["ab�", "�好"]
 		},
 	]
 }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->


Issue: https://github.com/vectordotdev/vector/issues/13329

This adds a `chunks` method (chunks rather than chunk following the slice naming convention for [slice's chunks method](https://doc.rust-lang.org/std/primitive.slice.html#method.chunks)). This chunks data based on a given `chunk_size` in bytes. The result is an array of bytes of `chunk_size` in length.

______
👇 The below was true for the initial PR, which attempted to respect unicode code point boundaries. After [this comment](https://github.com/vectordotdev/vector/pull/13794#pullrequestreview-1065676560) that is no longer the aim of this PR.
______

~It attempts to respect unicode code point boundaries, but makes no guarantees about grapheme cluster boundaries: https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries~

~A quick overview is that valid UTF-8 code points are up to 4 bytes in length, the length of which is denoted by the first few bits in the first byte. See https://en.wikipedia.org/wiki/UTF-8#Encoding).~

~However, *user-perceived characters* can consist of several UTF-8 code points (see above link on Grapheme Cluster Boundaries). There is no simple algorithm for splitting text based on grapheme cluster boundaries because grapheme clusters are of arbitrary lengths.~

~Therefore, the algorithm used here only attempts to split text based on code point boundaries, which are at most 4 bytes in length, and not on grapheme cluster boundaries.~

Additional subtasks that I would like to complete:
- [x] Basic functionality - splitting bytes by `chunk_size`
- [x] Respects unicode code point boundaries 
- [x] Fix `fn examples` tests
- [x] ~Consider refactoring the main loop~
- [x] Add a `utf` configuration flag to treat it as utf or not (default: true)
- [x] Add documentation
    - [x] Mention the unicode code points limitation
    - [x] Mention the chunk_size limitation
- [x] ~~Add tests for data size (i.e. check that a 1MB limit actually does limit it to 1MB chunks)~~ I don't want to add 1MB+ to the repo, that would be silly