### PR TITLE
feat(aws): add auth.region option when assuming role

### DIFF
--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -44,7 +44,10 @@ pub enum AwsAuthentication {
         /// Timeout for assuming the role, in seconds.
         load_timeout_secs: Option<u64>,
 
-        /// Region to send STS requests through
+        /// The AWS region to send STS requests to.
+        ///
+        /// If not set, this will default to the configured region
+        /// for the service itself.
         region: Option<String>,
     },
 

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -199,7 +199,7 @@ mod tests {
             AwsAuthentication::Role {
                 assume_role,
                 load_timeout_secs,
-                region
+                region,
             } => {
                 assert_eq!(&assume_role, "auth.root");
                 assert_eq!(load_timeout_secs, Some(10));

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -43,6 +43,9 @@ pub enum AwsAuthentication {
 
         /// Timeout for assuming the role, in seconds.
         load_timeout_secs: Option<u64>,
+
+        /// Region to send STS requests through
+        region: Option<String>,
     },
 
     /// Default authentication strategy which tries a variety of substrategies in a one-after-the-other fashion.
@@ -56,7 +59,7 @@ pub enum AwsAuthentication {
 impl AwsAuthentication {
     pub async fn credentials_provider(
         &self,
-        region: Region,
+        service_region: Region,
     ) -> crate::Result<SharedCredentialsProvider> {
         match self {
             Self::Static {
@@ -73,15 +76,17 @@ impl AwsAuthentication {
             AwsAuthentication::Role {
                 assume_role,
                 load_timeout_secs,
+                region,
             } => {
+                let auth_region = region.clone().map(Region::new).unwrap_or(service_region);
                 let provider = AssumeRoleProviderBuilder::new(assume_role)
-                    .region(region.clone())
-                    .build(default_credentials_provider(region, *load_timeout_secs).await);
+                    .region(auth_region.clone())
+                    .build(default_credentials_provider(auth_region, *load_timeout_secs).await);
 
                 Ok(SharedCredentialsProvider::new(provider))
             }
             AwsAuthentication::Default { load_timeout_secs } => Ok(SharedCredentialsProvider::new(
-                default_credentials_provider(region, *load_timeout_secs).await,
+                default_credentials_provider(service_region, *load_timeout_secs).await,
             )),
         }
     }
@@ -182,6 +187,7 @@ mod tests {
             assume_role = "root"
             auth.assume_role = "auth.root"
             auth.load_timeout_secs = 10
+            auth.region = "us-west-2"
         "#,
         )
         .unwrap();
@@ -190,9 +196,11 @@ mod tests {
             AwsAuthentication::Role {
                 assume_role,
                 load_timeout_secs,
+                region
             } => {
                 assert_eq!(&assume_role, "auth.root");
                 assert_eq!(load_timeout_secs, Some(10));
+                assert_eq!(region.unwrap(), "us-west-2");
             }
             _ => panic!(),
         }

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -42,7 +42,7 @@ components: _aws: {
 					region: {
 						category:    "Auth",
 						common: 	 false
-						description: "The [AWS region](\(urls.aws_regions)) to call STS against"
+						description: "The [AWS region](\(urls.aws_regions)) to send STS requests to. If not set, this will default to the configured region for the service itself."
 						required: 	 false
 						type: string: {
 							default: null

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -40,10 +40,10 @@ components: _aws: {
 						}
 					}
 					region: {
-						category:    "Auth",
-						common: 	 false
+						category:    "Auth"
+						common:      false
 						description: "The [AWS region](\(urls.aws_regions)) to send STS requests to. If not set, this will default to the configured region for the service itself."
-						required: 	 false
+						required:    false
 						type: string: {
 							default: null
 							examples: ["us-west-2"]

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -39,6 +39,16 @@ components: _aws: {
 							examples: ["arn:aws:iam::123456789098:role/my_role"]
 						}
 					}
+					region: {
+						category:    "Auth",
+						common: 	 false
+						description: "The [AWS region](\(urls.aws_regions)) to call STS against"
+						required: 	 false
+						type: string: {
+							default: null
+							examples: ["us-west-2"]
+						}
+					}
 					load_timeout_secs: {
 						category:    "Auth"
 						common:      false


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Issue:  https://github.com/vectordotdev/vector/issues/13829

Allow a user to optionally specify the `auth.region` without changing the underlying sink behavior.  If a user does not specify `auth.region` then there should be no change to functionality.

If a user does specify `auth.region` only the credential providers will reference that region.

Very open to comments/changes etc.
