### PR TITLE
feat(vrl): add methods to check if a string is an IPv4 or IPv6 address

### DIFF
--- a/lib/vrl/compiler/src/test_util.rs
+++ b/lib/vrl/compiler/src/test_util.rs
@@ -104,7 +104,7 @@ macro_rules! test_function {
                         let got_value = expression.resolve(&mut ctx)
                             .map_err(|e| format!("{:#}", anyhow::anyhow!(e)));
 
-                        assert_eq!(got_value, want);
+                        assert!(got_value == want, "assertion failed for `{}` case:\n  got:    {:?}\n  wanted: {:?}", stringify!($case), got_value, want);
                         let got_tdef = expression.type_def((&local, &external));
 
                         assert_eq!(got_tdef, $tdef);

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -117,6 +117,8 @@ default = [
     "is_empty",
     "is_float",
     "is_integer",
+    "is_ipv4",
+    "is_ipv6",
     "is_json",
     "is_null",
     "is_nullish",
@@ -254,6 +256,8 @@ is_boolean = []
 is_empty = []
 is_float = []
 is_integer = []
+is_ipv4 = []
+is_ipv6 = []
 is_json = ["dep:serde", "dep:serde_json", "value/json"]
 is_null = []
 is_nullish = []

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -57,6 +57,8 @@ criterion_group!(
               is_empty,
               is_float,
               is_integer,
+              is_ipv4,
+              is_ipv6,
               is_json,
               is_null,
               is_nullish,
@@ -749,6 +751,54 @@ bench_function! {
 
     object {
         args: func_args![value: value!({"foo": "bar"})],
+        want: Ok(false),
+    }
+}
+
+bench_function! {
+    is_ipv4 => vrl_stdlib::IsIpv4;
+
+    not_string {
+        args: func_args![value: 42],
+        want: Ok(false),
+    }
+
+    ipv4 {
+        args: func_args![value: "192.168.0.1"],
+        want: Ok(true),
+    }
+
+    invalid_ipv4 {
+        args: func_args![value: "192.168.0.299"],
+        want: Ok(false),
+    }
+
+    ipv6 {
+        args: func_args![value: "2404:6800:4003:c02::64"],
+        want: Ok(false),
+    }
+}
+
+bench_function! {
+    is_ipv6 => vrl_stdlib::IsIpv6;
+
+    not_string {
+        args: func_args![value: 42],
+        want: Ok(false),
+    }
+
+    ipv4 {
+        args: func_args![value: "192.168.0.1"],
+        want: Ok(false),
+    }
+
+    ipv6 {
+        args: func_args![value: "2404:6800:4003:c02::64"],
+        want: Ok(true),
+    }
+
+    invalid_ipv6 {
+        args: func_args![value: "2404:6800:goat:c02::64"],
         want: Ok(false),
     }
 }

--- a/lib/vrl/stdlib/src/is_ipv4.rs
+++ b/lib/vrl/stdlib/src/is_ipv4.rs
@@ -1,0 +1,111 @@
+use std::net::Ipv4Addr;
+
+use ::value::Value;
+use vrl::prelude::*;
+
+fn is_ipv4(value: Value) -> Resolved {
+    let value_str = value.try_bytes_utf8_lossy()?;
+    Ok(value_str.parse::<Ipv4Addr>().is_ok().into())
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct IsIpv4;
+
+impl Function for IsIpv4 {
+    fn identifier(&self) -> &'static str {
+        "is_ipv4"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "random string",
+                source: r#"is_ipv4("foobar")"#,
+                result: Ok("false"),
+            },
+            Example {
+                title: "IPv4 address",
+                source: r#"is_ipv4("1.1.1.1")"#,
+                result: Ok("true"),
+            },
+            Example {
+                title: "IPv6 address",
+                source: r#"is_ipv4("2001:0db8:85a3:0000:0000:8a2e:0370:7334")"#,
+                result: Ok("false"),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        _ctx: &mut FunctionCompileContext,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(Box::new(IsIpv4Fn { value }))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct IsIpv4Fn {
+    value: Box<dyn Expression>,
+}
+
+impl Expression for IsIpv4Fn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        self.value.resolve(ctx).and_then(is_ipv4)
+    }
+
+    fn type_def(&self, _: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
+        TypeDef::boolean().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        is_ipv4 => IsIpv4;
+
+        not_string {
+            args: func_args![value: value!(42)],
+            want: Err("expected string, got integer"),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        random_string {
+            args: func_args![value: value!("foobar")],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        ipv4_address_valid {
+            args: func_args![value: value!("1.1.1.1")],
+            want: Ok(value!(true)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        ipv4_address_invalid {
+            args: func_args![value: value!("1.1.1.314")],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        ipv6_address {
+            args: func_args![value: value!("2001:0db8:85a3:0000:0000:8a2e:0370:7334")],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/is_ipv6.rs
+++ b/lib/vrl/stdlib/src/is_ipv6.rs
@@ -1,0 +1,111 @@
+use std::net::Ipv6Addr;
+
+use ::value::Value;
+use vrl::prelude::*;
+
+fn is_ipv6(value: Value) -> Resolved {
+    let value_str = value.try_bytes_utf8_lossy()?;
+    Ok(value_str.parse::<Ipv6Addr>().is_ok().into())
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct IsIpv6;
+
+impl Function for IsIpv6 {
+    fn identifier(&self) -> &'static str {
+        "is_ipv6"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "random string",
+                source: r#"is_ipv6("foobar")"#,
+                result: Ok("false"),
+            },
+            Example {
+                title: "IPv4 address",
+                source: r#"is_ipv6("1.1.1.1")"#,
+                result: Ok("false"),
+            },
+            Example {
+                title: "IPv6 address",
+                source: r#"is_ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334")"#,
+                result: Ok("true"),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: (&mut state::LocalEnv, &mut state::ExternalEnv),
+        _ctx: &mut FunctionCompileContext,
+        mut arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(Box::new(IsIpv6Fn { value }))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct IsIpv6Fn {
+    value: Box<dyn Expression>,
+}
+
+impl Expression for IsIpv6Fn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        self.value.resolve(ctx).and_then(is_ipv6)
+    }
+
+    fn type_def(&self, _: (&state::LocalEnv, &state::ExternalEnv)) -> TypeDef {
+        TypeDef::boolean().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        is_ipv6 => IsIpv6;
+
+        not_string {
+            args: func_args![value: value!(42)],
+            want: Err("expected string, got integer"),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        random_string {
+            args: func_args![value: value!("foobar")],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        ipv4_address {
+            args: func_args![value: value!("1.1.1.1")],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        ipv6_address_valid {
+            args: func_args![value: value!("2001:0db8:85a3:0000:0000:8a2e:0370:7334")],
+            want: Ok(value!(true)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+
+        ipv6_address_invalid {
+            args: func_args![value: value!("2001:0db8:85a3:zzzz:0000:8a2e:0370:7334")],
+            want: Ok(value!(false)),
+            tdef: TypeDef::boolean().infallible(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -124,6 +124,10 @@ mod is_empty;
 mod is_float;
 #[cfg(feature = "is_integer")]
 mod is_integer;
+#[cfg(feature = "is_ipv4")]
+mod is_ipv4;
+#[cfg(feature = "is_ipv6")]
+mod is_ipv6;
 #[cfg(feature = "is_json")]
 mod is_json;
 #[cfg(feature = "is_null")]
@@ -399,6 +403,10 @@ pub use is_empty::IsEmpty;
 pub use is_float::IsFloat;
 #[cfg(feature = "is_integer")]
 pub use is_integer::IsInteger;
+#[cfg(feature = "is_ipv4")]
+pub use is_ipv4::IsIpv4;
+#[cfg(feature = "is_ipv6")]
+pub use is_ipv6::IsIpv6;
 #[cfg(feature = "is_json")]
 pub use is_json::IsJson;
 #[cfg(feature = "is_null")]
@@ -674,6 +682,10 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(IsFloat),
         #[cfg(feature = "is_integer")]
         Box::new(IsInteger),
+        #[cfg(feature = "is_ipv4")]
+        Box::new(IsIpv4),
+        #[cfg(feature = "is_ipv6")]
+        Box::new(IsIpv6),
         #[cfg(feature = "is_json")]
         Box::new(IsJson),
         #[cfg(feature = "is_null")]

--- a/website/cue/reference/remap/functions/is_ipv4.cue
+++ b/website/cue/reference/remap/functions/is_ipv4.cue
@@ -1,0 +1,53 @@
+package metadata
+
+remap: functions: is_ipv4: {
+	category: "IP"
+	description: """
+		Check if the string is a valid IPv4 address or not.
+
+		An [IPv4-mapped][https://datatracker.ietf.org/doc/html/rfc6890] or
+		[IPv4-compatible][https://datatracker.ietf.org/doc/html/rfc6890] IPv6 address is not considered
+		valid for the purpose of this function.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The IP address to check"
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["boolean"]
+		rules: [
+			#"Returns `true` if `value` is a valid IPv4 address."#,
+			#"Returns `false` if `value` is anything else."#,
+		]
+	}
+
+	examples: [
+		{
+			title: "Valid IPv4 address"
+			source: """
+				is_ipv4("10.0.102.37")
+				"""
+			return: true
+		},
+		{
+			title: "Valid IPv6 address"
+			source: """
+				is_ipv4("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+				"""
+			return: false
+		},
+		{
+			title: "Arbitrary string"
+			source: """
+				is_ipv4("foobar")
+				"""
+			return: false
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/is_ipv6.cue
+++ b/website/cue/reference/remap/functions/is_ipv6.cue
@@ -1,0 +1,49 @@
+package metadata
+
+remap: functions: is_ipv6: {
+	category: "IP"
+	description: """
+		Check if the string is a valid IPv6 address or not.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The IP address to check"
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: []
+	return: {
+		types: ["boolean"]
+		rules: [
+			#"Returns `true` if `value` is a valid IPv6 address."#,
+			#"Returns `false` if `value` is anything else."#,
+		]
+	}
+
+	examples: [
+		{
+			title: "Valid IPv6 address"
+			source: """
+				is_ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+				"""
+			return: true
+		},
+		{
+			title: "Valid IPv4 address"
+			source: """
+				is_ipv6("10.0.102.37")
+				"""
+			return: false
+		},
+		{
+			title: "Arbitrary string"
+			source: """
+				is_ipv6("foobar")
+				"""
+			return: false
+		},
+	]
+}


### PR DESCRIPTION
As stated in the title.

Fixes #13849.