### PR TITLE
fix(log_to_metric transform): add metric timestamp if source log lacks one

### DIFF
--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, convert::TryFrom, num::ParseFloatError};
 
+use chrono::Utc;
 use indexmap::IndexMap;
 use vector_config::configurable_component;
 
@@ -289,7 +290,8 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
     let timestamp = log
         .get(log_schema().timestamp_key())
         .and_then(Value::as_timestamp)
-        .cloned();
+        .cloned()
+        .or_else(|| Some(Utc::now()));
     let metadata = event.metadata().clone();
 
     let field = config.field();


### PR DESCRIPTION
Fixes #13860.