### PR TITLE
enhancement(observability): Convert internal metric counters to incremental

### DIFF
--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -270,6 +270,7 @@ impl Metric {
     #[allow(clippy::cast_precision_loss)]
     pub(crate) fn from_metric_kv(
         key: &metrics::Key,
+        kind: MetricKind,
         value: MetricValue,
         timestamp: DateTime<Utc>,
     ) -> Self {
@@ -278,7 +279,7 @@ impl Metric {
             .map(|label| (String::from(label.key()), String::from(label.value())))
             .collect::<MetricTags>();
 
-        Self::new(key.name().to_string(), MetricKind::Absolute, value)
+        Self::new(key.name().to_string(), kind, value)
             .with_namespace(Some("vector"))
             .with_timestamp(Some(timestamp))
             .with_tags((!labels.is_empty()).then(|| labels))

--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -14,7 +14,7 @@ use snafu::Snafu;
 
 pub use self::ddsketch::{AgentDDSketch, BinMap, Config};
 use self::{label_filter::VectorLabelFilter, recorder::Registry, recorder::VectorRecorder};
-use crate::event::{Metric, MetricValue};
+use crate::event::{Metric, MetricKind, MetricValue};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -169,11 +169,13 @@ impl Controller {
         let value = (metrics.len() + 2) as f64;
         metrics.push(Metric::from_metric_kv(
             &CARDINALITY_KEY,
+            MetricKind::Absolute,
             MetricValue::Gauge { value },
             timestamp,
         ));
         metrics.push(Metric::from_metric_kv(
             &CARDINALITY_COUNTER_KEY,
+            MetricKind::Absolute,
             MetricValue::Counter { value },
             timestamp,
         ));


### PR DESCRIPTION
Currently, internal metric counters are accumulated from incremental values but
then emitted as absolute values containing the sum total of all the increments
to that point. Those absolute values are then turned back into increments by
many of the metric sinks by reading the value twice (initially), which then
loses the initial increments.

This change converts these internal counters to incremental values, preserving
this incremental nature through the pipe. Those sinks that require absolute
metrics (ie `prometheus_exporter`) will convert them as needed, this preserving
the best of both worlds.

Closes #13863 

This is stacked on #13872 and so will be rebased once that is merged.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
