### PR TITLE
fix(prometheus_scrape source,prometheus_remote_write source): wait for mock endpoint in tests

### DIFF
--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -161,6 +161,7 @@ mod test {
         test_util::{
             self,
             components::{assert_source_compliance, HTTP_PUSH_SOURCE_TAGS},
+            wait_for_tcp,
         },
         tls::MaybeTlsSettings,
         SourceSender,
@@ -200,6 +201,7 @@ mod test {
                 .await
                 .unwrap();
             tokio::spawn(source);
+            wait_for_tcp(address).await;
 
             let sink = RemoteWriteConfig {
                 endpoint: format!("{}://localhost:{}/", proto, address.port()),

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -456,7 +456,7 @@ mod test {
             components::{
                 assert_source_compliance, run_and_assert_source_compliance, HTTP_PULL_SOURCE_TAGS,
             },
-            next_addr, start_topology,
+            next_addr, start_topology, wait_for_tcp,
         },
         Error,
     };
@@ -477,6 +477,7 @@ mod test {
         });
 
         tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+        wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
@@ -509,6 +510,7 @@ mod test {
         });
 
         tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+        wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
@@ -559,6 +561,7 @@ mod test {
         });
 
         tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+        wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
@@ -622,6 +625,7 @@ mod test {
         });
 
         tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+        wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics?key1=val1", in_addr)],
@@ -724,6 +728,7 @@ mod test {
                 error!(message = "Server error.", %error);
             }
         });
+        wait_for_tcp(in_addr).await;
 
         let mut config = config::Config::builder();
         config.add_source(

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -492,7 +492,7 @@ mod test {
 
         let events = run_and_assert_source_compliance(
             config,
-            Duration::from_secs(1),
+            Duration::from_secs(3),
             &HTTP_PULL_SOURCE_TAGS,
         )
         .await;
@@ -525,7 +525,7 @@ mod test {
 
         let events = run_and_assert_source_compliance(
             config,
-            Duration::from_secs(1),
+            Duration::from_secs(3),
             &HTTP_PULL_SOURCE_TAGS,
         )
         .await;
@@ -576,7 +576,7 @@ mod test {
 
         let events = run_and_assert_source_compliance(
             config,
-            Duration::from_secs(1),
+            Duration::from_secs(3),
             &HTTP_PULL_SOURCE_TAGS,
         )
         .await;
@@ -646,7 +646,7 @@ mod test {
 
         let events = run_and_assert_source_compliance(
             config,
-            Duration::from_secs(1),
+            Duration::from_secs(3),
             &HTTP_PULL_SOURCE_TAGS,
         )
         .await;
@@ -836,7 +836,7 @@ mod integration_tests {
 
         let events = run_and_assert_source_compliance(
             config,
-            Duration::from_secs(1),
+            Duration::from_secs(3),
             &HTTP_PULL_SOURCE_TAGS,
         )
         .await;


### PR DESCRIPTION
This is an attempt to fix the recent spate of Prometheus unit test failures on macOS. These don't seem to reproduce at all locally for most folks, but the macOS CI runners are shared and generally far more underpowered than local development environments, which seems to be the most likely cause of why they fail in CI but not locally.

At any rate, the changes made here are very much correct and not actually a stopgap or hack so this is still an improvement regardless of the current CI situation.