### PR TITLE
fix(kubernetes_logs): delaying applied new pod

### DIFF
--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -105,7 +105,8 @@ mod tests {
             .await
             .unwrap();
         tokio::spawn(custom_reflector(store_w, rx, Duration::from_secs(1)));
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        // Wait until the resource is added
+        tokio::time::sleep(Duration::from_secs(3)).await;
         assert_eq!(store.get(&ObjectRef::from_obj(&cm)).as_deref(), Some(&cm));
     }
 


### PR DESCRIPTION
if my guess described in problem #13467 is correct, then as a quick solution i suggest putting the event about the creation of a new pod in a delayed queue equal to the delayed queue for deleting a pod plus one second