### PR TITLE
enhancement(observability): Add initial registered internal event implementation

### DIFF
--- a/lib/vector-common/src/internal_event/bytes_sent.rs
+++ b/lib/vector-common/src/internal_event/bytes_sent.rs
@@ -1,7 +1,9 @@
-use metrics::counter;
+use std::borrow::Cow;
+
+use metrics::{counter, register_counter, Counter};
 use tracing::trace;
 
-use crate::internal_event::InternalEvent;
+use super::{ByteSize, InternalEvent, InternalEventHandle, RegisterInternalEvent};
 
 #[derive(Debug)]
 pub struct BytesSent<'a> {
@@ -18,5 +20,37 @@ impl<'a> InternalEvent for BytesSent<'a> {
 
     fn name(&self) -> Option<&'static str> {
         Some("BytesSent")
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct RegisteredBytesSent {
+    pub protocol: Cow<'static, str>,
+}
+
+impl RegisterInternalEvent for RegisteredBytesSent {
+    type Handle = BytesSentHandle;
+    fn register(self) -> Self::Handle {
+        let bytes_sent =
+            register_counter!("component_sent_bytes_total", "protocol" => self.protocol.clone());
+        BytesSentHandle {
+            bytes_sent,
+            protocol: self.protocol,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[allow(clippy::module_name_repetitions)]
+pub struct BytesSentHandle {
+    bytes_sent: Counter,
+    protocol: Cow<'static, str>,
+}
+
+impl InternalEventHandle for BytesSentHandle {
+    type Data = ByteSize;
+    fn emit(&self, byte_size: ByteSize) {
+        trace!(message = "Bytes sent.", byte_size = %byte_size.0, protocol = %self.protocol);
+        self.bytes_sent.increment(byte_size.0 as u64);
     }
 }

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -2,7 +2,7 @@ mod bytes_sent;
 mod events_received;
 mod events_sent;
 
-pub use bytes_sent::BytesSent;
+pub use bytes_sent::{BytesSent, RegisteredBytesSent};
 pub use events_received::{EventsReceived, OldEventsReceived};
 pub use events_sent::{EventsSent, DEFAULT_OUTPUT};
 
@@ -85,6 +85,8 @@ pub fn register<E: RegisterInternalEvent>(event: E) -> E::Handle {
 pub fn register<E: RegisterInternalEvent>(event: E) -> E::Handle {
     event.register()
 }
+
+pub struct ByteSize(pub usize);
 
 pub fn emit_registered<E, H, D>(event: E, data: D)
 where

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -93,3 +93,11 @@ pub type Registered<T> = <T as RegisterInternalEvent>::Handle;
 pub struct ByteSize(pub usize);
 
 pub struct Protocol(pub SharedString);
+
+impl Protocol {
+    pub const HTTP: Protocol = Protocol(SharedString::const_str("http"));
+    pub const HTTPS: Protocol = Protocol(SharedString::const_str("https"));
+    pub const NONE: Protocol = Protocol(SharedString::const_str("none"));
+    pub const TCP: Protocol = Protocol(SharedString::const_str("tcp"));
+    pub const UDP: Protocol = Protocol(SharedString::const_str("udp"));
+}

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -7,12 +7,29 @@ pub use events_received::{EventsReceived, OldEventsReceived};
 pub use events_sent::{EventsSent, DEFAULT_OUTPUT};
 
 pub trait InternalEvent: Sized {
-    fn emit(self) {}
+    fn emit(self);
 
     // Optional for backwards compat until all events implement this
     fn name(&self) -> Option<&'static str> {
         None
     }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub trait RegisterInternalEvent: Sized {
+    type Handle: InternalEventHandle;
+
+    fn register(self) -> Self::Handle;
+
+    fn name(&self) -> Option<&'static str> {
+        None
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub trait InternalEventHandle: Sized {
+    type Data: Sized;
+    fn emit(&self, data: Self::Data);
 }
 
 // Sets the name of an event if it doesn't have one
@@ -21,10 +38,7 @@ pub struct DefaultName<E> {
     pub event: E,
 }
 
-impl<E> InternalEvent for DefaultName<E>
-where
-    E: InternalEvent,
-{
+impl<E: InternalEvent> InternalEvent for DefaultName<E> {
     fn emit(self) {
         self.event.emit();
     }
@@ -34,16 +48,50 @@ where
     }
 }
 
+impl<E: RegisterInternalEvent> RegisterInternalEvent for DefaultName<E> {
+    type Handle = E::Handle;
+
+    fn register(self) -> Self::Handle {
+        self.event.register()
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        Some(self.event.name().unwrap_or(self.name))
+    }
+}
+
 #[cfg(any(test, feature = "test"))]
 pub fn emit(event: impl InternalEvent) {
-    let name = event.name();
-    event.emit();
-    if let Some(name) = name {
+    if let Some(name) = event.name() {
         super::event_test_util::record_internal_event(name);
     }
+    event.emit();
 }
 
 #[cfg(not(any(test, feature = "test")))]
 pub fn emit(event: impl InternalEvent) {
     event.emit();
 }
+
+#[cfg(any(test, feature = "test"))]
+pub fn register<E: RegisterInternalEvent>(event: E) -> E::Handle {
+    if let Some(name) = event.name() {
+        super::event_test_util::record_internal_event(name);
+    }
+    event.register()
+}
+
+#[cfg(not(any(test, feature = "test")))]
+pub fn register<E: RegisterInternalEvent>(event: E) -> E::Handle {
+    event.register()
+}
+
+pub fn emit_registered<E, H, D>(event: E, data: D)
+where
+    E: RegisterInternalEvent<Handle = H>,
+    H: InternalEventHandle<Data = D>,
+{
+    event.register().emit(data);
+}
+
+pub type Registered<T> = <T as RegisterInternalEvent>::Handle;

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -2,7 +2,9 @@ mod bytes_sent;
 mod events_received;
 mod events_sent;
 
-pub use bytes_sent::{BytesSent, RegisteredBytesSent};
+pub use metrics::SharedString;
+
+pub use bytes_sent::BytesSent;
 pub use events_received::{EventsReceived, OldEventsReceived};
 pub use events_sent::{EventsSent, DEFAULT_OUTPUT};
 
@@ -86,14 +88,8 @@ pub fn register<E: RegisterInternalEvent>(event: E) -> E::Handle {
     event.register()
 }
 
+pub type Registered<T> = <T as RegisterInternalEvent>::Handle;
+
 pub struct ByteSize(pub usize);
 
-pub fn emit_registered<E, H, D>(event: E, data: D)
-where
-    E: RegisterInternalEvent<Handle = H>,
-    H: InternalEventHandle<Data = D>,
-{
-    event.register().emit(data);
-}
-
-pub type Registered<T> = <T as RegisterInternalEvent>::Handle;
+pub struct Protocol(pub SharedString);

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -19,7 +19,7 @@ pub trait DriverResponse {
 
     // TODO, remove the default implementation once all sinks have
     // implemented this function.
-    fn bytes_sent(&self) -> Option<BytesSent> {
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
         None
     }
 }
@@ -175,8 +175,11 @@ where
                 trace!(message = "Service call succeeded.", request_id);
                 finalizers.update_status(response.event_status());
                 if response.event_status() == EventStatus::Delivered {
-                    if let Some(bytes_sent) = response.bytes_sent() {
-                        emit(bytes_sent);
+                    if let Some((byte_size, protocol)) = response.bytes_sent() {
+                        emit(BytesSent {
+                            byte_size,
+                            protocol,
+                        });
                     }
                     emit(response.events_sent());
                 }

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -178,7 +178,7 @@ where
                     if let Some((byte_size, protocol)) = response.bytes_sent() {
                         emit(BytesSent {
                             byte_size,
-                            protocol,
+                            protocol: protocol.to_string().into(),
                         });
                     }
                     emit(response.events_sent());

--- a/scripts/check-events
+++ b/scripts/check-events
@@ -34,8 +34,8 @@ end
 
 # A class to hold error reports and common functionality
 class Event
-  attr_accessor :path, :uses, :impl_internal_event
-  attr_reader :name, :reports
+  attr_accessor :path, :uses, :impl_internal_event, :impl_register_event, :impl_event_handle
+  attr_reader :name, :reports, :logs
   attr_writer :members
 
   def initialize(name)
@@ -48,6 +48,8 @@ class Event
     @logs = []
     @uses = 0
     @impl_internal_event = false
+    @impl_register_event = false
+    @impl_event_handle = false
   end
 
   def add_metric(type, name, tags)
@@ -57,8 +59,47 @@ class Event
     end
   end
 
+  # Scan for counter names and tags
+  def scan_metrics(block)
+    block.scan(/ (counter|gauge|histogram)!\((?:\n\s+)?"([^"]+)",(.+?)\)[;\n]/ms) \
+    do |type, name, tags|
+      tags = Hash[tags.scan(/"([^"]+)" => (.+?)(?:,|$)/)]
+      add_metric(type, name, tags)
+    end
+  end
+
+  # Scan for registered counter names and tags
+  def scan_register_metrics(block)
+    # This is a _slightly_ different regex than the above, couldn't figure a way to unify them
+    block.scan(/ register_(counter|gauge|histogram)!\((?:\n\s+)?"([^"]+)"(,.+?)?\)[;,]\n/ms) \
+    do |type, name, tags|
+      tags = tags || ''
+      tags = Hash[tags.scan(/"([^"]+)" => (.+?)(?:,|$)/)]
+      add_metric(type, name, tags)
+    end
+  end
+
   def add_log(type, message, parameters)
     @logs.append([type, message, parameters])
+  end
+
+  # Scan for log outputs and their parameters
+  def scan_logs(block)
+    block.scan(/
+               (trace|debug|info|warn|error)! # The log type
+                \(\s*(?:message\s*=\s*)? # Skip any leading "message =" bit
+                (?:"([^({)][^("]+)"|([^,]+)) # The log message text
+                ([^;]*?) # Match the parameter list
+                \)(?:;|\n\s*}) # Normally would end with simply ");", but some are missing the semicolon
+               /mx) \
+    do |type, raw_message, var_message, parameters|
+      parameters = parameters.scan(/([a-z0-9_]+) *= .|[?%]([a-z0-9_.]+)/) \
+                     .map { |assignment, simple| assignment or simple }
+
+      message = raw_message.nil? ? var_message : raw_message
+
+      add_log(type, message, parameters)
+    end
   end
 
   # The event signature is used to check for duplicates and is
@@ -82,6 +123,10 @@ class Event
   end
 
   def valid?
+    valid_with_handle? self
+  end
+
+  def valid_with_handle?(handle)
     @reports.clear
 
     if @uses == 0
@@ -90,7 +135,7 @@ class Event
 
     EVENT_CLASSES.each do |suffix, (required_message, counters, additional_tags)|
       if @name.end_with? suffix
-        @logs.each do |type, message, parameters|
+        handle.logs.each do |type, message, parameters|
           if type != 'trace'
             @reports.append('Log type MUST be \"trace!\".')
           end
@@ -110,17 +155,17 @@ class Event
       end
     end
 
-    has_errors = @logs.one? { |type, _, _| type == 'error' }
+    has_errors = handle.logs.one? { |type, _, _| type == 'error' }
 
     # Make sure Error events output an error
     if has_errors or @name.end_with? 'Error'
       append('Error events MUST be named "___Error".') unless @name.end_with? 'Error'
-      logs_should_have('error')
+      handle.logs_should_have('error')
       counters_must_include('component_errors_total', ['error_type', 'stage'])
     end
 
     # Make sure error events contain the right parameters
-    @logs.each do |type, message, parameters|
+    handle.logs.each do |type, message, parameters|
       if type == 'error'
         ['error_type', 'stage'].each do |parameter|
           unless parameters.include? parameter
@@ -161,16 +206,16 @@ class Event
     @reports.empty?
   end
 
+  def logs_should_have(level)
+    if @logs.find_index { |type, message, parameters| type == level }.nil?
+      @reports.append("This event MUST log with level #{level}.")
+    end
+  end
+
   private
 
     def append(report)
       @reports.append(report)
-    end
-
-    def logs_should_have(level)
-      if @logs.find_index { |type, message, parameters| type == level }.nil?
-        @reports.append("This event MUST log with level #{level}.")
-      end
     end
 
     def counters_must_include(name, required_tags)
@@ -200,7 +245,8 @@ Find.find('.') do |path|
   if path.end_with? '.rs'
     text = File.read(path)
 
-    text.scan(/\b(?:emit!|internal_event::emit)\((?:[a-z][a-z0-9_:]+)?([A-Z][A-Za-z0-9]+)/) do |event_name,|
+    text.scan(/\b(?:emit!?|register!?)\((?:[a-z][a-z0-9_:]+)?([A-Z][A-Za-z0-9]+)/) \
+    do |event_name,|
       $all_events[event_name].uses += 1
     end
 
@@ -222,37 +268,33 @@ Find.find('.') do |path|
     if (path.start_with? 'src/internal_events/' or path.start_with? 'lib/vector-common/src/internal_event/')
       # Scan internal event structs for member names
       text.scan(/[\n ]struct (\S+?)(?:<.+?>)?(?: {\n(.+?)\n\s*}|;)\n/m) do |struct_name, members|
-        $all_events[struct_name].path = path
+        event = $all_events[struct_name]
+        event.path = path
         if members
           members = members.scan(/ ([A-Za-z0-9_]+): +(.+?),/).map { |member, type| [member, type] }
-          $all_events[struct_name].members = members.to_h
+          event.members = members.to_h
         end
       end
 
       # Scan internal event implementation blocks for logs and metrics
-      text.scan(/^(\s*)impl(?:<.+?>)? InternalEvent for ([A-Za-z0-9_]+)(?:<.+?>)? {\n(.+?)\n\1}$/m) do |_space, event_name, block|
-        $all_events[event_name].impl_internal_event = true
+      text.scan(/^(\s*)impl(?:<.+?>)? (InternalEvent|RegisterInternalEvent|InternalEventHandle) for ([A-Za-z0-9_]+)(?:<.+?>)? {\n(.+?)\n\1}$/m) \
+      do |_space, trait, event_name, block|
+        event = $all_events[event_name]
 
-        # Scan for counter names and tags
-        block.scan(/ (counter|gauge|histogram)!\((?:\n\s+)?"([^"]+)",(.+?)\)[;\n]/m) do |type, name, tags|
-          tags = Hash[tags.scan(/"([^"]+)" => (.+?)(?:,|$)/)]
-          $all_events[event_name].add_metric(type, name, tags)
-        end
-
-        # Scan for log outputs and their parameters
-        block.scan(/
-                    (trace|debug|info|warn|error)! # The log type
-                    \(\s*(?:message\s*=\s*)? # Skip any leading "message =" bit
-                    (?:"([^({)][^("]+)"|([^,]+)) # The log message text
-                    ([^;]*?) # Match the parameter list
-                    \)(?:;|\n\s*}) # Normally would end with simply ");", but some are missing the semicolon
-                   /mx) do |type, raw_message, var_message, parameters|
-          parameters = parameters.scan(/([a-z0-9_]+) *= .|[?%]([a-z0-9_.]+)/) \
-                         .map { |assignment, simple| assignment or simple }
-
-          message = raw_message.nil? ? var_message : raw_message
-
-          $all_events[event_name].add_log(type, message, parameters)
+        if trait == 'InternalEvent'
+          # Look-aside internal events that defer their implementation to a registered event.
+          if ! block.include? '.register('
+            event.impl_internal_event = true
+            event.scan_metrics(block)
+            event.scan_logs(block)
+          end
+        elsif trait == 'RegisterInternalEvent'
+          # Extract the handle type name to join them together
+          event.impl_register_event = block[/type Handle = ([A-Za-z0-9]+);/, 1]
+          event.scan_register_metrics(block)
+        elsif trait == 'InternalEventHandle'
+          event.impl_event_handle = true
+          event.scan_logs(block)
         end
       end
     end
@@ -262,15 +304,33 @@ end
 $duplicates = Hash::new { |hash, key| hash[key] = [] }
 
 $all_events.each do |name, event|
-  if event.impl_internal_event
+  # Check for duplicated signatures
+  if event.impl_internal_event or event.impl_register_event or event.impl_event_handle
     signature = event.signature
     if signature
       $duplicates[event.signature].append(name)
     end
+  end
+
+  # Check events for validity
+  if event.impl_internal_event
     unless event.valid?
       puts "#{event.path}: Errors in event #{event.name}:"
       event.reports.each { |report| puts "    #{report}" }
       error_count += 1
+    end
+  elsif event.impl_register_event
+    handle = $all_events[event.impl_register_event]
+    if handle
+      unless event.valid_with_handle? handle
+        puts "#{event.path}: Errors in event #{event.name}:"
+        event.reports.each { |report| puts "    #{report}" }
+        error_count += 1
+      end
+    else
+      puts "Registered event #{event.name} references non-exitent handle #{event.impl_register_event}"
+      error_count += 1
+      next
     end
   end
 end

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -271,7 +271,7 @@ pub(crate) use self::{
 #[macro_export]
 macro_rules! emit {
     ($event:expr) => {
-        vector_core::internal_event::emit(vector_core::internal_event::DefaultName {
+        vector_common::internal_event::emit(vector_common::internal_event::DefaultName {
             event: $event,
             name: stringify!($event),
         })
@@ -282,6 +282,25 @@ macro_rules! emit {
 #[macro_export]
 macro_rules! emit {
     ($event:expr) => {
-        vector_core::internal_event::emit($event)
+        vector_common::internal_event::emit($event)
+    };
+}
+
+#[cfg(test)]
+#[macro_export]
+macro_rules! register {
+    ($event:expr) => {
+        vector_common::internal_event::register(vector_common::internal_event::DefaultName {
+            event: $event,
+            name: stringify!($event),
+        })
+    };
+}
+
+#[cfg(not(test))]
+#[macro_export]
+macro_rules! register {
+    ($event:expr) => {
+        vector_common::internal_event::register($event)
     };
 }

--- a/src/sinks/azure_common/service.rs
+++ b/src/sinks/azure_common/service.rs
@@ -10,7 +10,7 @@ use futures::{future::BoxFuture, TryFutureExt};
 use tower::Service;
 use tracing::Instrument;
 use vector_common::internal_event::{
-    ByteSize, InternalEventHandle, Registered, RegisteredBytesSent,
+    ByteSize, BytesSent, InternalEventHandle, Protocol, Registered,
 };
 
 use crate::{
@@ -21,14 +21,12 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct AzureBlobService {
     client: Arc<ContainerClient>,
-    bytes_sent: Registered<RegisteredBytesSent>,
+    bytes_sent: Registered<BytesSent>,
 }
 
 impl AzureBlobService {
     pub fn new(client: Arc<ContainerClient>) -> AzureBlobService {
-        let bytes_sent = register!(RegisteredBytesSent {
-            protocol: "https".into()
-        });
+        let bytes_sent = register!(BytesSent::from(Protocol("https".into())));
         AzureBlobService { client, bytes_sent }
     }
 }

--- a/src/sinks/azure_common/service.rs
+++ b/src/sinks/azure_common/service.rs
@@ -9,21 +9,27 @@ use azure_storage_blobs::prelude::*;
 use futures::{future::BoxFuture, TryFutureExt};
 use tower::Service;
 use tracing::Instrument;
+use vector_common::internal_event::{
+    ByteSize, InternalEventHandle, Registered, RegisteredBytesSent,
+};
 
 use crate::{
     internal_events::azure_blob::{AzureBlobHttpError, AzureBlobResponseError},
     sinks::azure_common::config::{AzureBlobRequest, AzureBlobResponse},
 };
-use vector_common::internal_event::BytesSent;
 
 #[derive(Clone)]
 pub(crate) struct AzureBlobService {
-    pub(self) client: Arc<ContainerClient>,
+    client: Arc<ContainerClient>,
+    bytes_sent: Registered<RegisteredBytesSent>,
 }
 
 impl AzureBlobService {
-    pub const fn new(client: Arc<ContainerClient>) -> AzureBlobService {
-        AzureBlobService { client }
+    pub fn new(client: Arc<ContainerClient>) -> AzureBlobService {
+        let bytes_sent = register!(RegisteredBytesSent {
+            protocol: "https".into()
+        });
+        AzureBlobService { client, bytes_sent }
     }
 }
 
@@ -37,10 +43,12 @@ impl Service<AzureBlobRequest> for AzureBlobService {
     }
 
     fn call(&mut self, request: AzureBlobRequest) -> Self::Future {
-        let client =
-            Arc::clone(&self.client).as_blob_client(request.metadata.partition_key.as_str());
+        let this = self.clone();
 
         Box::pin(async move {
+            let client = this
+                .client
+                .as_blob_client(request.metadata.partition_key.as_str());
             let byte_size = request.blob_data.len();
             let blob = client
                 .put_block_blob(request.blob_data)
@@ -62,12 +70,7 @@ impl Service<AzureBlobRequest> for AzureBlobService {
                         }),
                     };
                 })
-                .inspect_ok(|_| {
-                    emit!(BytesSent {
-                        byte_size,
-                        protocol: "https",
-                    });
-                })
+                .inspect_ok(|_| this.bytes_sent.emit(ByteSize(byte_size)))
                 .instrument(info_span!("request").or_current())
                 .await;
 

--- a/src/sinks/azure_common/service.rs
+++ b/src/sinks/azure_common/service.rs
@@ -26,7 +26,7 @@ pub(crate) struct AzureBlobService {
 
 impl AzureBlobService {
     pub fn new(client: Arc<ContainerClient>) -> AzureBlobService {
-        let bytes_sent = register!(BytesSent::from(Protocol("https".into())));
+        let bytes_sent = register!(BytesSent::from(Protocol::HTTPS));
         AzureBlobService { client, bytes_sent }
     }
 }

--- a/src/sinks/console/sink.rs
+++ b/src/sinks/console/sink.rs
@@ -5,7 +5,7 @@ use futures::{stream::BoxStream, StreamExt};
 use tokio::{io, io::AsyncWriteExt};
 use tokio_util::codec::Encoder as _;
 use vector_core::{
-    internal_event::{ByteSize, EventsSent, InternalEventHandle as _, RegisteredBytesSent},
+    internal_event::{ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol},
     ByteSizeOf,
 };
 
@@ -27,9 +27,7 @@ where
     T: io::AsyncWrite + Send + Sync + Unpin,
 {
     async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let bytes_sent = register!(RegisteredBytesSent {
-            protocol: "console".into(),
-        });
+        let bytes_sent = register!(BytesSent::from(Protocol("console".into(),)));
         while let Some(mut event) = input.next().await {
             let event_byte_size = event.size_of();
             self.transformer.transform(&mut event);

--- a/src/sinks/console/sink.rs
+++ b/src/sinks/console/sink.rs
@@ -5,7 +5,7 @@ use futures::{stream::BoxStream, StreamExt};
 use tokio::{io, io::AsyncWriteExt};
 use tokio_util::codec::Encoder as _;
 use vector_core::{
-    internal_event::{BytesSent, EventsSent},
+    internal_event::{ByteSize, EventsSent, InternalEventHandle as _, RegisteredBytesSent},
     ByteSizeOf,
 };
 
@@ -27,6 +27,9 @@ where
     T: io::AsyncWrite + Send + Sync + Unpin,
 {
     async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+        let bytes_sent = register!(RegisteredBytesSent {
+            protocol: "console".into(),
+        });
         while let Some(mut event) = input.next().await {
             let event_byte_size = event.size_of();
             self.transformer.transform(&mut event);
@@ -54,10 +57,7 @@ where
                         count: 1,
                         output: None,
                     });
-                    emit!(BytesSent {
-                        byte_size: bytes.len(),
-                        protocol: "console"
-                    });
+                    bytes_sent.emit(ByteSize(bytes.len()));
                 }
             }
         }

--- a/src/sinks/datadog/events/service.rs
+++ b/src/sinks/datadog/events/service.rs
@@ -8,7 +8,6 @@ use futures::{
 use http::Request;
 use hyper::Body;
 use tower::{Service, ServiceExt};
-use vector_common::internal_event::BytesSent;
 use vector_core::{internal_event::EventsSent, stream::DriverResponse};
 
 use crate::{
@@ -41,11 +40,8 @@ impl DriverResponse for DatadogEventsResponse {
         }
     }
 
-    fn bytes_sent(&self) -> Option<BytesSent> {
-        Some(BytesSent {
-            byte_size: self.raw_byte_size,
-            protocol: &self.protocol,
-        })
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
+        Some((self.raw_byte_size, &self.protocol))
     }
 }
 

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -12,7 +12,6 @@ use http::{
 use hyper::Body;
 use tower::Service;
 use tracing::Instrument;
-use vector_common::internal_event::BytesSent;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
     internal_event::EventsSent,
@@ -76,11 +75,8 @@ impl DriverResponse for LogApiResponse {
         }
     }
 
-    fn bytes_sent(&self) -> Option<BytesSent> {
-        Some(BytesSent {
-            byte_size: self.raw_byte_size,
-            protocol: &self.protocol,
-        })
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
+        Some((self.raw_byte_size, &self.protocol))
     }
 }
 

--- a/src/sinks/datadog/metrics/service.rs
+++ b/src/sinks/datadog/metrics/service.rs
@@ -10,7 +10,6 @@ use http::{
 use hyper::Body;
 use snafu::ResultExt;
 use tower::Service;
-use vector_common::internal_event::BytesSent;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
     internal_event::EventsSent,
@@ -141,11 +140,8 @@ impl DriverResponse for DatadogMetricsResponse {
         }
     }
 
-    fn bytes_sent(&self) -> Option<BytesSent> {
-        Some(BytesSent {
-            byte_size: self.raw_byte_size,
-            protocol: &self.protocol,
-        })
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
+        Some((self.raw_byte_size, &self.protocol))
     }
 }
 

--- a/src/sinks/datadog/traces/service.rs
+++ b/src/sinks/datadog/traces/service.rs
@@ -9,7 +9,6 @@ use http::{Request, StatusCode, Uri};
 use hyper::Body;
 use snafu::ResultExt;
 use tower::Service;
-use vector_common::internal_event::BytesSent;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
     internal_event::EventsSent,
@@ -109,11 +108,8 @@ impl DriverResponse for TraceApiResponse {
         }
     }
 
-    fn bytes_sent(&self) -> Option<BytesSent> {
-        Some(BytesSent {
-            byte_size: self.uncompressed_size,
-            protocol: &self.protocol,
-        })
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
+        Some((self.uncompressed_size, &self.protocol))
     }
 }
 

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -8,7 +8,6 @@ use http::{
 };
 use hyper::Body;
 use tower::Service;
-use vector_common::internal_event::BytesSent;
 use vector_core::{internal_event::EventsSent, stream::DriverResponse};
 
 use crate::{
@@ -88,11 +87,8 @@ impl DriverResponse for GcsResponse {
         }
     }
 
-    fn bytes_sent(&self) -> Option<BytesSent> {
-        Some(BytesSent {
-            byte_size: self.metadata.request_encoded_size(),
-            protocol: self.protocol,
-        })
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
+        Some((self.metadata.request_encoded_size(), self.protocol))
     }
 }
 

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -10,7 +10,7 @@ use rdkafka::{
 };
 use tower::Service;
 use vector_core::{
-    internal_event::{BytesSent, EventsSent},
+    internal_event::{ByteSize, EventsSent, InternalEventHandle, Registered, RegisteredBytesSent},
     stream::DriverResponse,
 };
 
@@ -57,15 +57,20 @@ impl Finalizable for KafkaRequest {
     }
 }
 
+#[derive(Clone)]
 pub struct KafkaService {
     kafka_producer: FutureProducer<KafkaStatisticsContext>,
+    bytes_sent: Registered<RegisteredBytesSent>,
 }
 
 impl KafkaService {
-    pub(crate) const fn new(
-        kafka_producer: FutureProducer<KafkaStatisticsContext>,
-    ) -> KafkaService {
-        KafkaService { kafka_producer }
+    pub(crate) fn new(kafka_producer: FutureProducer<KafkaStatisticsContext>) -> KafkaService {
+        KafkaService {
+            kafka_producer,
+            bytes_sent: register!(RegisteredBytesSent {
+                protocol: "kafka".into()
+            }),
+        }
     }
 }
 
@@ -79,7 +84,7 @@ impl Service<KafkaRequest> for KafkaService {
     }
 
     fn call(&mut self, request: KafkaRequest) -> Self::Future {
-        let kafka_producer = self.kafka_producer.clone();
+        let this = self.clone();
 
         Box::pin(async move {
             let mut record =
@@ -95,13 +100,11 @@ impl Service<KafkaRequest> for KafkaService {
             }
 
             //rdkafka will internally retry forever if the queue is full
-            let result = match kafka_producer.send(record, Timeout::Never).await {
+            let result = match this.kafka_producer.send(record, Timeout::Never).await {
                 Ok((_partition, _offset)) => {
-                    emit!(BytesSent {
-                        byte_size: request.body.len()
-                            + request.metadata.key.map(|x| x.len()).unwrap_or(0),
-                        protocol: "kafka"
-                    });
+                    this.bytes_sent.emit(ByteSize(
+                        request.body.len() + request.metadata.key.map(|x| x.len()).unwrap_or(0),
+                    ));
                     Ok(KafkaResponse {
                         event_byte_size: request.event_byte_size,
                     })

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -10,7 +10,9 @@ use rdkafka::{
 };
 use tower::Service;
 use vector_core::{
-    internal_event::{ByteSize, EventsSent, InternalEventHandle, Registered, RegisteredBytesSent},
+    internal_event::{
+        ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol, Registered,
+    },
     stream::DriverResponse,
 };
 
@@ -60,16 +62,14 @@ impl Finalizable for KafkaRequest {
 #[derive(Clone)]
 pub struct KafkaService {
     kafka_producer: FutureProducer<KafkaStatisticsContext>,
-    bytes_sent: Registered<RegisteredBytesSent>,
+    bytes_sent: Registered<BytesSent>,
 }
 
 impl KafkaService {
     pub(crate) fn new(kafka_producer: FutureProducer<KafkaStatisticsContext>) -> KafkaService {
         KafkaService {
             kafka_producer,
-            bytes_sent: register!(RegisteredBytesSent {
-                protocol: "kafka".into()
-            }),
+            bytes_sent: register!(BytesSent::from(Protocol("kafka".into()))),
         }
     }
 }

--- a/src/sinks/loki/service.rs
+++ b/src/sinks/loki/service.rs
@@ -6,7 +6,6 @@ use http::StatusCode;
 use snafu::Snafu;
 use tower::Service;
 use tracing::Instrument;
-use vector_common::internal_event::BytesSent;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
     internal_event::EventsSent,
@@ -65,11 +64,8 @@ impl DriverResponse for LokiResponse {
         }
     }
 
-    fn bytes_sent(&self) -> Option<BytesSent> {
-        Some(BytesSent {
-            byte_size: self.metadata.request_encoded_size(),
-            protocol: self.protocol,
-        })
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
+        Some((self.metadata.request_encoded_size(), self.protocol))
     }
 }
 

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -122,6 +122,7 @@ pub enum HealthcheckError {
 /// Configurable sinks in Vector.
 #[configurable_component]
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Sinks {
     /// Apex Logs.

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -6,7 +6,9 @@ use codecs::JsonSerializerConfig;
 use futures::{stream::BoxStream, FutureExt, StreamExt, TryFutureExt};
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
-use vector_common::internal_event::{BytesSent, EventsSent};
+use vector_common::internal_event::{
+    ByteSize, EventsSent, InternalEventHandle, RegisteredBytesSent,
+};
 use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
@@ -172,6 +174,10 @@ impl NatsSink {
 #[async_trait]
 impl StreamSink<Event> for NatsSink {
     async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+        let bytes_sent = register!(RegisteredBytesSent {
+            protocol: "tcp".into()
+        });
+
         while let Some(mut event) = input.next().await {
             let finalizers = event.take_finalizers();
 
@@ -213,10 +219,7 @@ impl StreamSink<Event> for NatsSink {
                         count: 1,
                         output: None
                     });
-                    emit!(BytesSent {
-                        byte_size: bytes.len(),
-                        protocol: "tcp"
-                    });
+                    bytes_sent.emit(ByteSize(bytes.len()));
                 }
             }
         }

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -174,7 +174,7 @@ impl NatsSink {
 #[async_trait]
 impl StreamSink<Event> for NatsSink {
     async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let bytes_sent = register!(BytesSent::from(Protocol("tcp".into())));
+        let bytes_sent = register!(BytesSent::from(Protocol::TCP));
 
         while let Some(mut event) = input.next().await {
             let finalizers = event.take_finalizers();

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -7,7 +7,7 @@ use futures::{stream::BoxStream, FutureExt, StreamExt, TryFutureExt};
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
 use vector_common::internal_event::{
-    ByteSize, EventsSent, InternalEventHandle, RegisteredBytesSent,
+    ByteSize, BytesSent, EventsSent, InternalEventHandle, Protocol,
 };
 use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
@@ -174,9 +174,7 @@ impl NatsSink {
 #[async_trait]
 impl StreamSink<Event> for NatsSink {
     async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let bytes_sent = register!(RegisteredBytesSent {
-            protocol: "tcp".into()
-        });
+        let bytes_sent = register!(BytesSent::from(Protocol("tcp".into())));
 
         while let Some(mut event) = input.next().await {
             let finalizers = event.take_finalizers();

--- a/src/sinks/new_relic/service.rs
+++ b/src/sinks/new_relic/service.rs
@@ -13,7 +13,6 @@ use http::{
 use hyper::Body;
 use tower::Service;
 use tracing::Instrument;
-use vector_common::internal_event::BytesSent;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
     internal_event::EventsSent,
@@ -61,11 +60,8 @@ impl DriverResponse for NewRelicApiResponse {
         }
     }
 
-    fn bytes_sent(&self) -> Option<BytesSent> {
-        Some(BytesSent {
-            byte_size: self.metadata.request_encoded_size(),
-            protocol: self.protocol,
-        })
+    fn bytes_sent(&self) -> Option<(usize, &str)> {
+        Some((self.metadata.request_encoded_size(), self.protocol))
     }
 }
 

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -22,7 +22,9 @@ use stream_cancel::{Trigger, Tripwire};
 use tracing::{Instrument, Span};
 use vector_config::configurable_component;
 use vector_core::{
-    internal_event::{ByteSize, EventsSent, InternalEventHandle, Registered, RegisteredBytesSent},
+    internal_event::{
+        ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol, Registered,
+    },
     ByteSizeOf,
 };
 
@@ -386,7 +388,7 @@ fn handle(
     buckets: &[f64],
     quantiles: &[f64],
     metrics: &IndexMap<MetricRef, (Metric, MetricMetadata)>,
-    bytes_sent: &Registered<RegisteredBytesSent>,
+    bytes_sent: &Registered<BytesSent>,
 ) -> Response<Body> {
     let mut response = Response::new(Body::empty());
 
@@ -432,9 +434,7 @@ impl PrometheusExporter {
             return;
         }
 
-        let bytes_sent = register!(RegisteredBytesSent {
-            protocol: "http".into()
-        });
+        let bytes_sent = register!(BytesSent::from(Protocol("http".into())));
 
         let span = Span::current();
         let metrics = Arc::clone(&self.metrics);

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -22,7 +22,7 @@ use stream_cancel::{Trigger, Tripwire};
 use tracing::{Instrument, Span};
 use vector_config::configurable_component;
 use vector_core::{
-    internal_event::{BytesSent, EventsSent},
+    internal_event::{ByteSize, EventsSent, InternalEventHandle, Registered, RegisteredBytesSent},
     ByteSizeOf,
 };
 
@@ -386,6 +386,7 @@ fn handle(
     buckets: &[f64],
     quantiles: &[f64],
     metrics: &IndexMap<MetricRef, (Metric, MetricMetadata)>,
+    bytes_sent: &Registered<RegisteredBytesSent>,
 ) -> Response<Body> {
     let mut response = Response::new(Body::empty());
 
@@ -407,10 +408,7 @@ fn handle(
                 HeaderValue::from_static("text/plain; version=0.0.4"),
             );
 
-            emit!(BytesSent {
-                byte_size: body_size,
-                protocol: "http",
-            });
+            bytes_sent.emit(ByteSize(body_size));
         }
         _ => {
             *response.status_mut() = StatusCode::NOT_FOUND;
@@ -434,6 +432,10 @@ impl PrometheusExporter {
             return;
         }
 
+        let bytes_sent = register!(RegisteredBytesSent {
+            protocol: "http".into()
+        });
+
         let span = Span::current();
         let metrics = Arc::clone(&self.metrics);
         let default_namespace = self.config.default_namespace.clone();
@@ -446,6 +448,7 @@ impl PrometheusExporter {
             let default_namespace = default_namespace.clone();
             let buckets = buckets.clone();
             let quantiles = quantiles.clone();
+            let bytes_sent = bytes_sent.clone();
 
             async move {
                 Ok::<_, Infallible>(service_fn(move |req| {
@@ -464,6 +467,7 @@ impl PrometheusExporter {
                             &buckets,
                             &quantiles,
                             &metrics,
+                            &bytes_sent,
                         );
 
                         emit!(EventsSent {

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -434,7 +434,7 @@ impl PrometheusExporter {
             return;
         }
 
-        let bytes_sent = register!(BytesSent::from(Protocol("http".into())));
+        let bytes_sent = register!(BytesSent::from(Protocol::HTTP));
 
         let span = Span::current();
         let metrics = Arc::clone(&self.metrics);

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -16,7 +16,7 @@ use pulsar::{
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
 use vector_common::internal_event::{
-    ByteSize, EventsSent, InternalEventHandle, Registered, RegisteredBytesSent,
+    ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol, Registered,
 };
 use vector_config::configurable_component;
 use vector_core::config::log_schema;
@@ -134,7 +134,7 @@ struct PulsarSink {
             ),
         >,
     >,
-    bytes_sent: Registered<RegisteredBytesSent>,
+    bytes_sent: Registered<BytesSent>,
 }
 
 inventory::submit! {
@@ -258,9 +258,7 @@ impl PulsarSink {
             encoder,
             state: PulsarSinkState::Ready(Box::new(producer)),
             in_flight: FuturesUnordered::new(),
-            bytes_sent: register!(RegisteredBytesSent {
-                protocol: "tcp".into(),
-            }),
+            bytes_sent: register!(BytesSent::from(Protocol("tcp".into()))),
         })
     }
 

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -258,7 +258,7 @@ impl PulsarSink {
             encoder,
             state: PulsarSinkState::Ready(Box::new(producer)),
             in_flight: FuturesUnordered::new(),
-            bytes_sent: register!(BytesSent::from(Protocol("tcp".into()))),
+            bytes_sent: register!(BytesSent::from(Protocol::TCP)),
         })
     }
 

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -15,7 +15,9 @@ use pulsar::{
 };
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
-use vector_common::internal_event::{BytesSent, EventsSent};
+use vector_common::internal_event::{
+    ByteSize, EventsSent, InternalEventHandle, Registered, RegisteredBytesSent,
+};
 use vector_config::configurable_component;
 use vector_core::config::log_schema;
 
@@ -132,6 +134,7 @@ struct PulsarSink {
             ),
         >,
     >,
+    bytes_sent: Registered<RegisteredBytesSent>,
 }
 
 inventory::submit! {
@@ -255,6 +258,9 @@ impl PulsarSink {
             encoder,
             state: PulsarSinkState::Ready(Box::new(producer)),
             in_flight: FuturesUnordered::new(),
+            bytes_sent: register!(RegisteredBytesSent {
+                protocol: "tcp".into(),
+            }),
         })
     }
 
@@ -351,10 +357,8 @@ impl Sink<Event> for PulsarSink {
                         output: None,
                     });
 
-                    emit!(BytesSent {
-                        byte_size: metadata.request_encoded_size(),
-                        protocol: "tcp",
-                    });
+                    this.bytes_sent
+                        .emit(ByteSize(metadata.request_encoded_size()));
                 }
                 Some((Err(error), _, finalizers)) => {
                     finalizers.update_status(EventStatus::Errored);

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -6,7 +6,9 @@ use redis::{aio::ConnectionManager, RedisError, RedisResult};
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
 use tower::{Service, ServiceBuilder};
-use vector_common::internal_event::BytesSent;
+use vector_common::internal_event::{
+    ByteSize, InternalEventHandle, Registered, RegisteredBytesSent,
+};
 use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
@@ -226,7 +228,13 @@ impl RedisSinkConfig {
 
         let buffer = VecBuffer::new(batch.size);
 
-        let redis = RedisSink { conn, data_type };
+        let redis = RedisSink {
+            conn,
+            data_type,
+            bytes_sent: register!(RegisteredBytesSent {
+                protocol: "tcp".into(),
+            }),
+        };
 
         let svc = ServiceBuilder::new()
             .settings(request, RedisRetryLogic)
@@ -337,6 +345,7 @@ impl RetryLogic for RedisRetryLogic {
 pub struct RedisSink {
     conn: ConnectionManager,
     data_type: DataType,
+    bytes_sent: Registered<RegisteredBytesSent>,
 }
 
 impl Service<Vec<RedisKvEntry>> for RedisSink {
@@ -384,15 +393,13 @@ impl Service<Vec<RedisKvEntry>> for RedisSink {
             }
         }
 
+        let bytes_sent = self.bytes_sent.clone();
         Box::pin(async move {
             let result: RedisPipeResult = pipe.query_async(&mut conn).await;
             match &result {
                 Ok(res) => {
                     if res.is_successful() {
-                        emit!(BytesSent {
-                            byte_size,
-                            protocol: "tcp",
-                        });
+                        bytes_sent.emit(ByteSize(byte_size));
                     } else {
                         warn!("Batch sending was not all successful and will be retried.")
                     }

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -7,7 +7,7 @@ use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
 use tower::{Service, ServiceBuilder};
 use vector_common::internal_event::{
-    ByteSize, InternalEventHandle, Registered, RegisteredBytesSent,
+    ByteSize, BytesSent, InternalEventHandle, Protocol, Registered,
 };
 use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
@@ -231,9 +231,7 @@ impl RedisSinkConfig {
         let redis = RedisSink {
             conn,
             data_type,
-            bytes_sent: register!(RegisteredBytesSent {
-                protocol: "tcp".into(),
-            }),
+            bytes_sent: register!(BytesSent::from(Protocol("tcp".into(),))),
         };
 
         let svc = ServiceBuilder::new()
@@ -345,7 +343,7 @@ impl RetryLogic for RedisRetryLogic {
 pub struct RedisSink {
     conn: ConnectionManager,
     data_type: DataType,
-    bytes_sent: Registered<RegisteredBytesSent>,
+    bytes_sent: Registered<BytesSent>,
 }
 
 impl Service<Vec<RedisKvEntry>> for RedisSink {

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -231,7 +231,7 @@ impl RedisSinkConfig {
         let redis = RedisSink {
             conn,
             data_type,
-            bytes_sent: register!(BytesSent::from(Protocol("tcp".into(),))),
+            bytes_sent: register!(BytesSent::from(Protocol::TCP)),
         };
 
         let svc = ServiceBuilder::new()

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -315,7 +315,7 @@ mod test {
     use crate::{
         event::Metric,
         test_util::{
-            components::{run_and_assert_sink_compliance, SINK_TAGS},
+            components::{assert_sink_compliance, SINK_TAGS},
             *,
         },
     };
@@ -509,9 +509,6 @@ mod test {
             acknowledgements: Default::default(),
         };
 
-        let context = SinkContext::new_test();
-        let (sink, _healthcheck) = config.build(context).await.unwrap();
-
         let events = vec![
             Event::Metric(
                 Metric::new(
@@ -536,18 +533,26 @@ mod test {
         ];
         let (mut tx, rx) = mpsc::channel(0);
 
-        let socket = UdpSocket::bind(addr).await.unwrap();
-        tokio::spawn(async move {
-            let mut stream = UdpFramed::new(socket, BytesCodec::new())
-                .map_err(|error| error!(message = "Error reading line.", %error))
-                .map_ok(|(bytes, _addr)| bytes.freeze());
+        let context = SinkContext::new_test();
+        assert_sink_compliance(&SINK_TAGS, async move {
+            let (sink, _healthcheck) = config.build(context).await.unwrap();
 
-            while let Some(Ok(item)) = stream.next().await {
-                tx.send(item).await.unwrap();
-            }
-        });
+            let socket = UdpSocket::bind(addr).await.unwrap();
+            tokio::spawn(async move {
+                let mut stream = UdpFramed::new(socket, BytesCodec::new())
+                    .map_err(|error| error!(message = "Error reading line.", %error))
+                    .map_ok(|(bytes, _addr)| bytes.freeze());
 
-        run_and_assert_sink_compliance(sink, stream::iter(events), &SINK_TAGS).await;
+                while let Some(Ok(item)) = stream.next().await {
+                    tx.send(item).await.unwrap();
+                }
+            });
+
+            sink.run(stream::iter(events).map(Into::into))
+                .await
+                .expect("Running sink failed")
+        })
+        .await;
 
         let messages = collect_n(rx, 1).await;
         assert_eq!(

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -187,7 +187,7 @@ impl UdpService {
         Self {
             connector,
             state: UdpServiceState::Disconnected,
-            bytes_sent: register!(BytesSent::from(Protocol("udp".into()))),
+            bytes_sent: register!(BytesSent::from(Protocol::UDP)),
         }
     }
 }
@@ -272,7 +272,7 @@ where
             connector,
             transformer,
             encoder,
-            bytes_sent: register!(BytesSent::from(Protocol("udp".into()))),
+            bytes_sent: register!(BytesSent::from(Protocol::UDP)),
         }
     }
 }

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -11,7 +11,9 @@ use futures::{future::BoxFuture, ready, stream::BoxStream, FutureExt, StreamExt}
 use snafu::{ResultExt, Snafu};
 use tokio::{net::UdpSocket, sync::oneshot, time::sleep};
 use tokio_util::codec::Encoder;
-use vector_common::internal_event::BytesSent;
+use vector_common::internal_event::{
+    ByteSize, InternalEventHandle, Registered, RegisteredBytesSent,
+};
 use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
 
@@ -177,13 +179,17 @@ enum UdpServiceState {
 pub struct UdpService {
     connector: UdpConnector,
     state: UdpServiceState,
+    bytes_sent: Registered<RegisteredBytesSent>,
 }
 
 impl UdpService {
-    const fn new(connector: UdpConnector) -> Self {
+    fn new(connector: UdpConnector) -> Self {
         Self {
             connector,
             state: UdpServiceState::Disconnected,
+            bytes_sent: register!(RegisteredBytesSent {
+                protocol: "udp".into()
+            }),
         }
     }
 }
@@ -222,6 +228,7 @@ impl tower::Service<BytesMut> for UdpService {
     fn call(&mut self, msg: BytesMut) -> Self::Future {
         let (sender, receiver) = oneshot::channel();
         let byte_size = msg.len();
+        let bytes_sent = self.bytes_sent.clone();
 
         let mut socket =
             match std::mem::replace(&mut self.state, UdpServiceState::Sending(receiver)) {
@@ -240,10 +247,7 @@ impl tower::Service<BytesMut> for UdpService {
                 // emitting the `BytesSent` event, and related metrics... and practically, those sinks don't compress
                 // anyways, so the metrics are correct as-is... they just may not be correct in the future if
                 // compression support was added, etc.
-                emit!(BytesSent {
-                    byte_size,
-                    protocol: "udp",
-                });
+                bytes_sent.emit(ByteSize(byte_size));
             }
 
             result
@@ -258,17 +262,21 @@ where
     connector: UdpConnector,
     transformer: Transformer,
     encoder: E,
+    bytes_sent: Registered<RegisteredBytesSent>,
 }
 
 impl<E> UdpSink<E>
 where
     E: Encoder<Event, Error = codecs::encoding::Error> + Clone + Send + Sync,
 {
-    const fn new(connector: UdpConnector, transformer: Transformer, encoder: E) -> Self {
+    fn new(connector: UdpConnector, transformer: Transformer, encoder: E) -> Self {
         Self {
             connector,
             transformer,
             encoder,
+            bytes_sent: register!(RegisteredBytesSent {
+                protocol: "udp".into()
+            }),
         }
     }
 }
@@ -303,10 +311,7 @@ where
                             byte_size,
                         });
 
-                        emit!(BytesSent {
-                            byte_size: bytes.len(),
-                            protocol: "udp",
-                        });
+                        self.bytes_sent.emit(ByteSize(bytes.len()));
                         finalizers.update_status(EventStatus::Delivered);
                     }
                     Err(error) => {

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -12,7 +12,7 @@ use snafu::{ResultExt, Snafu};
 use tokio::{net::UdpSocket, sync::oneshot, time::sleep};
 use tokio_util::codec::Encoder;
 use vector_common::internal_event::{
-    ByteSize, InternalEventHandle, Registered, RegisteredBytesSent,
+    ByteSize, BytesSent, InternalEventHandle, Protocol, Registered,
 };
 use vector_config::configurable_component;
 use vector_core::ByteSizeOf;
@@ -179,7 +179,7 @@ enum UdpServiceState {
 pub struct UdpService {
     connector: UdpConnector,
     state: UdpServiceState,
-    bytes_sent: Registered<RegisteredBytesSent>,
+    bytes_sent: Registered<BytesSent>,
 }
 
 impl UdpService {
@@ -187,9 +187,7 @@ impl UdpService {
         Self {
             connector,
             state: UdpServiceState::Disconnected,
-            bytes_sent: register!(RegisteredBytesSent {
-                protocol: "udp".into()
-            }),
+            bytes_sent: register!(BytesSent::from(Protocol("udp".into()))),
         }
     }
 }
@@ -262,7 +260,7 @@ where
     connector: UdpConnector,
     transformer: Transformer,
     encoder: E,
-    bytes_sent: Registered<RegisteredBytesSent>,
+    bytes_sent: Registered<BytesSent>,
 }
 
 impl<E> UdpSink<E>
@@ -274,9 +272,7 @@ where
             connector,
             transformer,
             encoder,
-            bytes_sent: register!(RegisteredBytesSent {
-                protocol: "udp".into()
-            }),
+            bytes_sent: register!(BytesSent::from(Protocol("udp".into()))),
         }
     }
 }

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -30,7 +30,7 @@ use tokio_tungstenite::{
 };
 use tokio_util::codec::Encoder as _;
 use vector_core::{
-    internal_event::{ByteSize, EventsSent, InternalEventHandle, RegisteredBytesSent},
+    internal_event::{ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol},
     ByteSizeOf,
 };
 
@@ -248,9 +248,7 @@ impl WebSocketSink {
         }
         let mut last_pong = Instant::now();
 
-        let bytes_sent = register!(RegisteredBytesSent {
-            protocol: "websocket".into(),
-        });
+        let bytes_sent = register!(BytesSent::from(Protocol("websocket".into(),)));
 
         loop {
             let result = tokio::select! {


### PR DESCRIPTION
This adds the new `RegisteredBytesSent` event and puts it into use in all sinks
except for the new-style stream sinks. That change is blocked by a complication
in how the driver handles emitting the `BytesSent` event centrally.

Ref: #13691 