### PR TITLE
chore(docs): Update v0.23 upgrade guide

### DIFF
--- a/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
@@ -349,7 +349,7 @@ rules:
 
 Incoming events from the `datadog_agent` source contain a name that is `.` (period) delimited where the first element is the namespace eg "system.fs.inodes.total". Before this release, the metric event outputted by the `datadog_agent` source contained an empty namespace, and the name contained the full unparsed name from the Datadog Agent. In this release, the namespace is parsed out of the name. Taking the prior example, the event name becomes "fs.inodes.todal" and the namespace is "system".
 
-This was introduced in order to handle interactions with the `datadog_agent` source and the `datadog_agent` sink.
+This was introduced in order to better handle metrics sent from the `datadog_agent` source to the `datadog_metrics` sink, where previously they would be lacking a namespace and so would have one added by the sink if `default_namespace` was set.
 
 The result is that configurations with VRL expressions that expect the namespace to be in the name will need to be adapted to either remove the namespace from the name, or join the namespace and the name, for example:
 

--- a/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
@@ -353,8 +353,10 @@ This was introduced in order to handle interactions with the `datadog_agent` sou
 
 The result is that configurations with VRL expressions that expect the namespace to be in the name will need to be adapted to either remove the namespace from the name, or join the namespace and the name, for example:
 
-```
-full_metric_name = join([.namespace, .name], ".")
+```toml
+full_metric_name = """
+join([.namespace, .name], ".")
+"""
 ```
 
 ### Deprecations

--- a/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
@@ -22,6 +22,7 @@ Vector's 0.23.0 release includes **breaking changes**:
 9. [New `framing` and `encoding` options for sinks](#sinks-framing-encoding-options)
 10. [Support for older OSes dropped](#old-oses)
 11. [`kubernetes_logs` source now requires rights to list and watch nodes](#kubernetes-logs-list-watch-nodes)
+12. [`datadog_agent` source metrics now contain a namespace parsed from the event name](#datadog-agent-source-metric-namespace)
 
 and **deprecations**:
 
@@ -342,6 +343,18 @@ rules:
     verbs:
       - list
       - watch
+```
+
+#### `datadog_agent` source metrics now contain a namespace parsed from the event name {#datadog-agent-source-metric-namespace}
+
+Incoming events from the `datadog_agent` source contain a name that is `.` (period) delimited where the first element is the namespace eg "system.fs.inodes.total". Before this release, the metric event outputted by the `datadog_agent` source contained an empty namespace, and the name contained the full unparsed name from the Datadog Agent. In this release, the namespace is parsed out of the name. Taking the prior example, the event name becomes "fs.inodes.todal" and the namespace is "system".
+
+This was introduced in order to handle interactions with the `datadog_agent` source and the `datadog_agent` sink.
+
+The result is that configurations with VRL expressions that expect the namespace to be in the name will need to be adapted to either remove the namespace from the name, or join the namespace and the name, for example:
+
+```
+full_metric_name = join([.namespace, .name], ".")
 ```
 
 ### Deprecations


### PR DESCRIPTION
Include breaking change from #13176

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
