### PR TITLE
docs(config): Only render `client_metadata_key` if available

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -414,6 +414,9 @@ components: {
 			if Args.mode == "connect" {
 				can_verify_hostname: bool
 			}
+			if Args.mode == "accept" {
+				can_add_client_metadata: bool | *false
+			}
 			enabled_default: bool
 		}
 	}
@@ -593,8 +596,9 @@ components: {
 
 			_tls_accept: {
 				_args: {
-					can_verify_certificate: bool | *true
-					enabled_default:        bool
+					can_verify_certificate:  bool | *true
+					can_add_client_metadata: bool | *false
+					enabled_default:         bool
 				}
 				let Args = _args
 
@@ -618,13 +622,15 @@ components: {
 							examples: ["/path/to/certificate_authority.crt"]
 						}
 					}
-					client_metadata_key: {
-						common:      false
-						description: "The key name added to each event with the client certificate's metadata."
-						required:    false
-						type: string: {
-							default: null
-							examples: ["client_cert"]
+					if Args.can_add_client_metadata {
+						client_metadata_key: {
+							common:      false
+							description: "The key name added to each event with the client certificate's metadata."
+							required:    false
+							type: string: {
+								default: null
+								examples: ["client_cert"]
+							}
 						}
 					}
 					crt_file: {

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -259,8 +259,9 @@ components: sources: [Name=string]: {
 
 			if features.receive.tls.enabled {
 				tls: configuration._tls_accept & {_args: {
-					can_verify_certificate: features.receive.tls.can_verify_certificate
-					enabled_default:        features.receive.tls.enabled_default
+					can_verify_certificate:  features.receive.tls.can_verify_certificate
+					can_add_client_metadata: features.receive.tls.can_add_client_metadata
+					enabled_default:         features.receive.tls.enabled_default
 				}}
 			}
 		}

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -37,9 +37,10 @@ components: sources: socket: {
 			}
 			keepalive: enabled: true
 			tls: {
-				enabled:                true
-				can_verify_certificate: true
-				enabled_default:        false
+				enabled:                 true
+				can_verify_certificate:  true
+				can_add_client_metadata: true
+				enabled_default:         false
 			}
 		}
 	}


### PR DESCRIPTION
Only socket-based sources support this so far.

Fixes: #13914

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
