### PR TITLE
docs(config): Remove tls.enabled flag from components that don't support it

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -413,6 +413,7 @@ components: {
 			can_verify_certificate: bool
 			if Args.mode == "connect" {
 				can_verify_hostname: bool
+				enabled_by_scheme:   bool
 			}
 			enabled_default: bool
 		}
@@ -671,6 +672,7 @@ components: {
 					can_verify_certificate: bool | *true
 					can_verify_hostname:    bool | *false
 					enabled_default:        bool
+					enabled_by_scheme:      bool
 				}
 				let Args = _args
 
@@ -678,11 +680,15 @@ components: {
 				description: "Configures the TLS options for outgoing connections."
 				required:    false
 				type: object: options: {
-					enabled: {
-						common:      true
-						description: "Enable TLS during connections to the remote."
-						required:    false
-						type: bool: default: Args.enabled_default
+					if Args.enabled_by_scheme != _|_ {
+						if !Args.enabled_by_scheme {
+							enabled: {
+								common:      true
+								description: "Enable TLS during connections to the remote."
+								required:    false
+								type: bool: default: Args.enabled_default
+							}
+						}
 					}
 
 					ca_file: {

--- a/website/cue/reference/components/sinks/apex.cue
+++ b/website/cue/reference/components/sinks/apex.cue
@@ -37,7 +37,8 @@ components: sinks: apex: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        true
+				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.apex

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -45,7 +45,8 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.aws_cloudwatch_logs

--- a/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -35,7 +35,8 @@ components: sinks: aws_cloudwatch_metrics: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.aws_cloudwatch_metrics

--- a/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
@@ -45,7 +45,8 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.aws_kinesis_firehose

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -45,7 +45,8 @@ components: sinks: aws_kinesis_streams: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.aws_kinesis_data_streams

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -45,7 +45,8 @@ components: sinks: aws_s3: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.aws_s3

--- a/website/cue/reference/components/sinks/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/aws_sqs.cue
@@ -38,7 +38,8 @@ components: sinks: aws_sqs: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.aws_sqs

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -37,7 +37,8 @@ components: sinks: axiom: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.axiom

--- a/website/cue/reference/components/sinks/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/azure_monitor_logs.cue
@@ -33,7 +33,8 @@ components: sinks: azure_monitor_logs: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.azure_monitor_logs

--- a/website/cue/reference/components/sinks/clickhouse.cue
+++ b/website/cue/reference/components/sinks/clickhouse.cue
@@ -42,6 +42,7 @@ components: sinks: clickhouse: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.clickhouse

--- a/website/cue/reference/components/sinks/datadog_archives.cue
+++ b/website/cue/reference/components/sinks/datadog_archives.cue
@@ -28,7 +28,8 @@ components: sinks: datadog_archives: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 		}
 	}

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -23,7 +23,8 @@ components: sinks: datadog_events: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.datadog_events

--- a/website/cue/reference/components/sinks/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/datadog_logs.cue
@@ -36,6 +36,7 @@ components: sinks: datadog_logs: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.datadog_logs

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -32,6 +32,7 @@ components: sinks: datadog_metrics: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.datadog_metrics

--- a/website/cue/reference/components/sinks/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/datadog_traces.cue
@@ -38,6 +38,7 @@ components: sinks: datadog_traces: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.datadog_traces

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -42,6 +42,7 @@ components: sinks: elasticsearch: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.elasticsearch

--- a/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
@@ -41,7 +41,8 @@ components: sinks: gcp_chronicle_unstructured: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.gcp_chronicle

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -46,7 +46,8 @@ components: sinks: gcp_cloud_storage: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.gcp_cloud_storage

--- a/website/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/gcp_pubsub.cue
@@ -40,7 +40,8 @@ components: sinks: gcp_pubsub: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.gcp_pubsub

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -37,7 +37,8 @@ components: sinks: gcp_stackdriver_logs: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.gcp_operations_logs

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -37,7 +37,8 @@ components: sinks: gcp_stackdriver_metrics: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.gcp_cloud_monitoring

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -46,6 +46,7 @@ components: sinks: http: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: {

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -49,7 +49,8 @@ components: sinks: _humio: {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.humio

--- a/website/cue/reference/components/sinks/influxdb.cue
+++ b/website/cue/reference/components/sinks/influxdb.cue
@@ -9,6 +9,7 @@ components: sinks: _influxdb: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.influxdb

--- a/website/cue/reference/components/sinks/kafka.cue
+++ b/website/cue/reference/components/sinks/kafka.cue
@@ -42,6 +42,7 @@ components: sinks: kafka: {
 				can_verify_certificate: false
 				can_verify_hostname:    false
 				enabled_default:        false
+				enabled_by_scheme:      false
 			}
 			to: components._kafka.features.send.to
 		}

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -46,6 +46,7 @@ components: sinks: loki: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.loki

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -30,6 +30,7 @@ components: sinks: nats: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.nats

--- a/website/cue/reference/components/sinks/papertrail.cue
+++ b/website/cue/reference/components/sinks/papertrail.cue
@@ -32,6 +32,7 @@ components: sinks: papertrail: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true
+				enabled_by_scheme:      false
 			}
 			to: {
 				service: services.papertrail

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -40,6 +40,7 @@ components: sinks: prometheus_remote_write: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.prometheus_remote_write

--- a/website/cue/reference/components/sinks/socket.cue
+++ b/website/cue/reference/components/sinks/socket.cue
@@ -36,6 +36,7 @@ components: sinks: socket: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      false
 			}
 			to: {
 				service: services.socket_receiver

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -46,6 +46,7 @@ components: sinks: splunk_hec_logs: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.splunk

--- a/website/cue/reference/components/sinks/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_metrics.cue
@@ -39,6 +39,7 @@ components: sinks: splunk_hec_metrics: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.splunk

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -42,6 +42,7 @@ components: sinks: vector: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.vector

--- a/website/cue/reference/components/sinks/websocket.cue
+++ b/website/cue/reference/components/sinks/websocket.cue
@@ -30,6 +30,7 @@ components: sinks: websocket: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 			to: {
 				service: services.websocket

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -11,7 +11,8 @@ components: sources: aws_s3: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			checkpoint: enabled: false
 			proxy: enabled:      true

--- a/website/cue/reference/components/sources/aws_sqs.cue
+++ b/website/cue/reference/components/sources/aws_sqs.cue
@@ -10,7 +10,8 @@ components: sources: aws_sqs: components._aws & {
 				enabled:                true
 				can_verify_certificate: true
 				can_verify_hostname:    true
-				enabled_default:        false
+				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			checkpoint: enabled: false
 			proxy: enabled:      true

--- a/website/cue/reference/components/sources/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/gcp_pubsub.cue
@@ -11,6 +11,7 @@ components: sources: gcp_pubsub: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        true
+				enabled_by_scheme:      true
 			}
 			checkpoint: enabled: false
 			proxy: enabled:      true

--- a/website/cue/reference/components/sources/kafka.cue
+++ b/website/cue/reference/components/sources/kafka.cue
@@ -12,6 +12,7 @@ components: sources: kafka: {
 				can_verify_certificate: false
 				can_verify_hostname:    false
 				enabled_default:        false
+				enabled_by_scheme:      false
 			}
 			from: components._kafka.features.collect.from
 		}

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -36,6 +36,7 @@ components: sources: prometheus_scrape: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
+				enabled_by_scheme:      true
 			}
 		}
 		multiline: enabled: false


### PR DESCRIPTION
Whether some components use TLS or not is controlled by the scheme from the configured endpoint.

Fixes: #12343

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
