### PR TITLE
fix(setup): add the correct bin directory to $PATH

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -203,7 +203,7 @@ install_from_archive() {
     printf " ✓\n"
 
     if [ "$modify_path" = "yes" ]; then
-      local _path="export PATH=$PATH:$prefix"
+      local _path="export PATH=$PATH:$prefix/bin"
       add_to_path "${HOME}/.zprofile" "${_path}"
       add_to_path "${HOME}/.profile" "${_path}"
     fi


### PR DESCRIPTION
|When using the `curl sh.vector.dev | bash`-based installation method, the installer script can modify the user's `$PATH` to add the binary directory so that `vector` is available on the path.

Normally, this should be `~/.vector/bin` so that `vector` is on the path, but the installer script currently only adds `~/.vector` to `$PATH`. This PR simply tweaks that to add the right binary subdirectory to land at the expected behavior.