### PR TITLE
chore(ci): make integration tests trigger when label is added

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,6 +21,7 @@ on:
       - "Makefile"
       - "rust-toolchain"
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   # For pull requests, cancel running workflows, for master, run all


### PR DESCRIPTION
This PR attempts to make the integration tests trigger when the integration tests _label_ is added to an existing PR. If the label is missed when the PR is created, it takes a separate commit to trigger it to re-evaluate the PR and see the label exists, thus triggering the actual integration tests.

Github Actions, by default, only pays attention to [some of the activity types](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) for the overall `pull_request` event type. We've set the activity types to be those defaults plus the `labeled` activity type, which I assume will do what we want: the activity types don't appear to be otherwise documented.