### PR TITLE
chore: Install protoc for soak builder too

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -114,7 +114,7 @@ fi
 
 # Protoc. No guard because we want to override Ubuntu's old version in
 # case it is already installed by a dependency.
-PROTOC_VERSION=3.19.4
+PROTOC_VERSION=3.19.4 # also update soaks/Dockerfile
 PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
 curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \
      --output "$TEMP/$PROTOC_ZIP"

--- a/soaks/Dockerfile.builder
+++ b/soaks/Dockerfile.builder
@@ -8,5 +8,16 @@ RUN apt-get update && \
 # Build mold, a fast linker
 RUN git clone https://github.com/rui314/mold.git && cd mold && git checkout v1.2.1 && make -j"$(nproc)" && make install
 
+# also update scripts/cross/bootstrap-ubuntu.sh
+ENV PROTOC_VERSION=3.19.4
+ENV PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+
+RUN \
+  curl -fsSL https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \
+    --output "$TEMP/$PROTOC_ZIP" && \
+  unzip "$TEMP/$PROTOC_ZIP" bin/protoc -d "$TEMP" && \
+  chmod +x "$TEMP"/bin/protoc && \
+  mv --force --verbose "$TEMP"/bin/protoc /usr/bin/protoc
+
 # Smoke test
 RUN ["/usr/local/bin/mold", "--version"]


### PR DESCRIPTION
Required to upgrade to prost 0.11 which drops support for building protoc. Opening as a separate PR
to be able to upgrade the builder image used by the prost 0.11 upgrade PR.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
