### PR TITLE
chore(ci): try and tighten up component feature check scripts

### DIFF
--- a/scripts/check-component-features
+++ b/scripts/check-component-features
@@ -19,9 +19,9 @@ features=$(
 )
 
 # Prime the pump to build most of the artifacts
-cargo check --workspace --all-targets --no-default-features
-cargo check --workspace --all-targets --no-default-features --features default
-cargo check --workspace --all-targets --no-default-features --features all-integration-tests
+cargo check --bin vector --no-default-features
+cargo check --bin vector --no-default-features --features default
+cargo check --bin vector --no-default-features --features all-integration-tests
 
 # The feature builds already run in parallel below, don't overload
 export CARGO_BUILD_JOBS=1

--- a/scripts/check-one-feature
+++ b/scripts/check-one-feature
@@ -12,21 +12,36 @@ fi
 feature=$1
 shift
 
-if [ ! -d target ]
+# We assume that `target` is the normal target directory.
+base_target_dir="target"
+
+# Check to see if we have the nightly toolchain installed, and if so, do a deeper check to see if
+# there's a custom target directory configured.
+if cargo +nightly 2>&1 >/dev/null; then
+  overridden_base_target_dir=$(cargo +nightly -Zunstable-options config get | grep "build.target-dir" | sed 's/build.target-dir = //' | sed 's/\"//g' || true)
+  if [ ! -z "$overridden_base_target_dir" ]; then
+    base_target_dir=$overridden_base_target_dir
+  fi
+fi
+
+# Make sure that `cargo check` has been run so that we have something to bootstrap our per-feature
+# target directory from.
+if [ ! -d $base_target_dir/debug ]
 then
-  echo $0: 'Run `cargo check` first to prime the `target` directory.'
+  echo "$0: Run \`cargo check\` first to prime the \`${base_target_dir}\` directory."
   exit 1
 fi
 
-target=$PWD/target-feature-$feature
+target=$PWD/$base_target_dir/component-features/feature-$feature
+mkdir -p $target
 log=$target/.logfile
 trap 'rm --force --recursive $target' EXIT
 
-cp --archive --link target $target
-rm --force $target/debug/.cargo-lock
+cp --archive --link $base_target_dir/debug $target
+rm --force $base_target_dir/debug/.cargo-lock
 
 echo "===== Feature: $feature ====="
-if cargo check --workspace --all-targets \
+if cargo check --bin vector \
 	--no-default-features \
 	--features $feature \
 	--target-dir $target \


### PR DESCRIPTION
This PR tries to achieve a few things:

- handle cases where users may have a custom target directory configured via a Cargo configuration override
- nest the per-feature target directories under the base target directory to avoid thrashing IDEs/etc by having it not existing a path covered by `.gitignore`, but also to follow the precedent set by other tooling (i.e. `nextest` does `target/nextest/...`)
- only copy the `debug` target subdirectory as, mentioned above, other tooling may create their own specific target subdirectories, and we're needlessly copying them when running this locally (compared to a clean CI environment)
- avoid using `--workspace` on the `cargo check` calls, as this will pull in crates defined in the workspace even if they would not otherwise be compiled based on the given feature flag being tested
- scope down to just the `vector` binary target, as the feature flags being tested only matter to the `vector` crate/binary anyways