### PR TITLE
chore(core): Simplify lookup path coalesce segments

### DIFF
--- a/lib/lookup/src/lookup_v2/borrowed.rs
+++ b/lib/lookup/src/lookup_v2/borrowed.rs
@@ -1,4 +1,4 @@
-use crate::lookup_v2::{OwnedSegment, Path};
+use crate::lookup_v2::{Path};
 use std::borrow::Cow;
 use std::iter::Cloned;
 use std::slice::Iter;
@@ -45,20 +45,6 @@ impl<'a> From<&'a String> for BorrowedSegment<'a> {
 impl From<isize> for BorrowedSegment<'_> {
     fn from(index: isize) -> Self {
         BorrowedSegment::index(index)
-    }
-}
-
-impl<'a, 'b: 'a> From<&'b OwnedSegment> for BorrowedSegment<'a> {
-    fn from(segment: &'b OwnedSegment) -> Self {
-        match segment {
-            OwnedSegment::Field(field) => BorrowedSegment::Field(field.as_str().into()),
-            OwnedSegment::Index(value) => BorrowedSegment::Index(*value),
-            OwnedSegment::Invalid => BorrowedSegment::Invalid,
-            OwnedSegment::CoalesceField(field) => {
-                BorrowedSegment::CoalesceField(field.as_str().into())
-            }
-            OwnedSegment::CoalesceEnd(field) => BorrowedSegment::CoalesceEnd(field.as_str().into()),
-        }
     }
 }
 

--- a/lib/lookup/src/lookup_v2/borrowed.rs
+++ b/lib/lookup/src/lookup_v2/borrowed.rs
@@ -1,4 +1,4 @@
-use crate::lookup_v2::{Path};
+use crate::lookup_v2::Path;
 use std::borrow::Cow;
 use std::iter::Cloned;
 use std::slice::Iter;

--- a/lib/lookup/src/lookup_v2/jit.rs
+++ b/lib/lookup/src/lookup_v2/jit.rs
@@ -427,98 +427,78 @@ mod test {
             (
                 ".(a|b)",
                 owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b")
+                    vec!["a", "b"]
                 ),
             ),
             (
                 "(a|b)",
                 owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b")
+                    vec!["a", "b"]
                 ),
             ),
             (
                 "( a | b )",
                 owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b")
+                    vec!["a", "b"]
                 ),
             ),
             (
                 ".(a|b)[1]",
                 owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b"),
+                    vec!["a", "b"],
                     1
                 ),
             ),
             (
                 ".(a|b).foo",
                 owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b"),
+                    vec!["a", "b"],
                     "foo"
                 ),
             ),
             (
                 ".(a|b|c)",
                 owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_field("b"),
-                    OwnedSegment::coalesce_end("c")
+                    vec!["a", "b", "c"]
                 ),
             ),
             (
                 "[1](a|b)",
                 owned_path!(
                     1,
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b")
+                    vec!["a", "b"]
                 ),
             ),
             (
                 "[1].(a|b)",
                 owned_path!(
                     1,
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b")
+                    vec!["a", "b"]
                 ),
             ),
             (
                 "foo.(a|b)",
                 owned_path!(
                     "foo",
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b")
+                    vec!["a", "b"]
                 ),
             ),
             (
                 "(\"a\"|b)",
-                owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b")
-                ),
+                owned_path!(vec!["a", "b"]),
             ),
             (
                 "(a|\"b.c\")",
-                owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b.c")
-                ),
+                owned_path!(vec!["a", "b.c"]),
             ),
             (
                 "(a|\"b\\\"c\")",
-                owned_path!(
-                    OwnedSegment::coalesce_field("a"),
-                    OwnedSegment::coalesce_end("b\"c")
-                ),
+                owned_path!(vec!["a", "b\"c"]),
             ),
             (
                 "(\"b\\\"c\"|a)",
                 owned_path!(
-                    OwnedSegment::coalesce_field("b\"c"),
-                    OwnedSegment::coalesce_end("a")
+                    vec!["b\"c", "a"]
                 ),
             ),
             ("(a)", owned_path!(OwnedSegment::Invalid)),

--- a/lib/lookup/src/lookup_v2/jit.rs
+++ b/lib/lookup/src/lookup_v2/jit.rs
@@ -424,83 +424,19 @@ mod test {
                 owned_path!("foo", "a\"a", "b\\b", "bar"),
             ),
             (r#"."🤖""#, owned_path!("🤖")),
-            (
-                ".(a|b)",
-                owned_path!(
-                    vec!["a", "b"]
-                ),
-            ),
-            (
-                "(a|b)",
-                owned_path!(
-                    vec!["a", "b"]
-                ),
-            ),
-            (
-                "( a | b )",
-                owned_path!(
-                    vec!["a", "b"]
-                ),
-            ),
-            (
-                ".(a|b)[1]",
-                owned_path!(
-                    vec!["a", "b"],
-                    1
-                ),
-            ),
-            (
-                ".(a|b).foo",
-                owned_path!(
-                    vec!["a", "b"],
-                    "foo"
-                ),
-            ),
-            (
-                ".(a|b|c)",
-                owned_path!(
-                    vec!["a", "b", "c"]
-                ),
-            ),
-            (
-                "[1](a|b)",
-                owned_path!(
-                    1,
-                    vec!["a", "b"]
-                ),
-            ),
-            (
-                "[1].(a|b)",
-                owned_path!(
-                    1,
-                    vec!["a", "b"]
-                ),
-            ),
-            (
-                "foo.(a|b)",
-                owned_path!(
-                    "foo",
-                    vec!["a", "b"]
-                ),
-            ),
-            (
-                "(\"a\"|b)",
-                owned_path!(vec!["a", "b"]),
-            ),
-            (
-                "(a|\"b.c\")",
-                owned_path!(vec!["a", "b.c"]),
-            ),
-            (
-                "(a|\"b\\\"c\")",
-                owned_path!(vec!["a", "b\"c"]),
-            ),
-            (
-                "(\"b\\\"c\"|a)",
-                owned_path!(
-                    vec!["b\"c", "a"]
-                ),
-            ),
+            (".(a|b)", owned_path!(vec!["a", "b"])),
+            ("(a|b)", owned_path!(vec!["a", "b"])),
+            ("( a | b )", owned_path!(vec!["a", "b"])),
+            (".(a|b)[1]", owned_path!(vec!["a", "b"], 1)),
+            (".(a|b).foo", owned_path!(vec!["a", "b"], "foo")),
+            (".(a|b|c)", owned_path!(vec!["a", "b", "c"])),
+            ("[1](a|b)", owned_path!(1, vec!["a", "b"])),
+            ("[1].(a|b)", owned_path!(1, vec!["a", "b"])),
+            ("foo.(a|b)", owned_path!("foo", vec!["a", "b"])),
+            ("(\"a\"|b)", owned_path!(vec!["a", "b"])),
+            ("(a|\"b.c\")", owned_path!(vec!["a", "b.c"])),
+            ("(a|\"b\\\"c\")", owned_path!(vec!["a", "b\"c"])),
+            ("(\"b\\\"c\"|a)", owned_path!(vec!["b\"c", "a"])),
             ("(a)", owned_path!(OwnedSegment::Invalid)),
         ];
 

--- a/lib/lookup/src/lookup_v2/mod.rs
+++ b/lib/lookup/src/lookup_v2/mod.rs
@@ -36,8 +36,7 @@ macro_rules! owned_path {
 /// Use if you want to pre-parse paths so it can be used multiple times.
 /// The return value (when borrowed) implements `Path` so it can be used directly.
 pub fn parse_path(path: &str) -> OwnedPath {
-    JitPath::new(path)
-        .to_owned_path()
+    JitPath::new(path).to_owned_path()
 }
 
 /// A path is simply the data describing how to look up a value.
@@ -66,10 +65,12 @@ pub trait Path<'a>: Clone {
             match segment {
                 BorrowedSegment::Invalid => return OwnedPath::invalid(),
                 BorrowedSegment::Index(i) => owned_path.push(OwnedSegment::Index(i)),
-                BorrowedSegment::Field(field) => owned_path.push(OwnedSegment::Field(field.to_string())),
+                BorrowedSegment::Field(field) => {
+                    owned_path.push(OwnedSegment::Field(field.to_string()))
+                }
                 BorrowedSegment::CoalesceField(field) => {
                     coalesce.push(field.to_string());
-                },
+                }
                 BorrowedSegment::CoalesceEnd(field) => {
                     coalesce.push(field.to_string());
                     owned_path.push(OwnedSegment::Coalesce(std::mem::take(&mut coalesce)));

--- a/lib/lookup/src/lookup_v2/mod.rs
+++ b/lib/lookup/src/lookup_v2/mod.rs
@@ -36,11 +36,8 @@ macro_rules! owned_path {
 /// Use if you want to pre-parse paths so it can be used multiple times.
 /// The return value (when borrowed) implements `Path` so it can be used directly.
 pub fn parse_path(path: &str) -> OwnedPath {
-    let segments = JitPath::new(path)
-        .segment_iter()
-        .map(|segment| segment.into())
-        .collect();
-    OwnedPath { segments }
+    JitPath::new(path)
+        .to_owned_path()
 }
 
 /// A path is simply the data describing how to look up a value.
@@ -60,6 +57,26 @@ pub trait Path<'a>: Clone {
 
     fn eq(&self, other: impl Path<'a>) -> bool {
         self.segment_iter().eq(other.segment_iter())
+    }
+
+    fn to_owned_path(&self) -> OwnedPath {
+        let mut owned_path = OwnedPath::root();
+        let mut coalesce = vec![];
+        for segment in self.segment_iter() {
+            match segment {
+                BorrowedSegment::Invalid => return OwnedPath::invalid(),
+                BorrowedSegment::Index(i) => owned_path.push(OwnedSegment::Index(i)),
+                BorrowedSegment::Field(field) => owned_path.push(OwnedSegment::Field(field.to_string())),
+                BorrowedSegment::CoalesceField(field) => {
+                    coalesce.push(field.to_string());
+                },
+                BorrowedSegment::CoalesceEnd(field) => {
+                    coalesce.push(field.to_string());
+                    owned_path.push(OwnedSegment::Coalesce(std::mem::take(&mut coalesce)));
+                }
+            }
+        }
+        owned_path
     }
 }
 

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -1,6 +1,6 @@
 use crate::lookup_v2::{parse_path, BorrowedSegment, Path};
-use vector_config::configurable_component;
 use std::fmt::Write;
+use vector_config::configurable_component;
 
 /// A lookup path.
 #[configurable_component]
@@ -95,7 +95,11 @@ impl From<OwnedPath> for String {
                             coalesce_i += 1;
                             output.push_str(&field_output);
                         }
-                        let _ = write!(output, "{})", serialize_field(last.as_ref(), (coalesce_i != 0).then(|| "|")));
+                        let _ = write!(
+                            output,
+                            "{})",
+                            serialize_field(last.as_ref(), (coalesce_i != 0).then(|| "|"))
+                        );
                         output
                     }
                 })

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -44,7 +44,7 @@ impl OwnedPath {
 
     pub fn invalid() -> Self {
         Self {
-            segments: vec![OwnedSegment::Invalid]
+            segments: vec![OwnedSegment::Invalid],
         }
     }
 }
@@ -76,7 +76,8 @@ impl From<OwnedPath> for String {
                     }
                     OwnedSegment::Coalesce(fields) => {
                         let mut output = String::new();
-                        let (last, fields) = fields.split_last().expect("coalesce must not be empty");
+                        let (last, fields) =
+                            fields.split_last().expect("coalesce must not be empty");
                         for field in fields {
                             let field_output = serialize_field(
                                 field.as_ref(),
@@ -175,7 +176,11 @@ impl OwnedSegment {
 
 impl From<Vec<&'static str>> for OwnedSegment {
     fn from(fields: Vec<&'static str>) -> Self {
-        fields.into_iter().map(ToString::to_string).collect::<Vec<_>>().into()
+        fields
+            .into_iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .into()
     }
 }
 
@@ -241,10 +246,12 @@ impl<'a> Iterator for OwnedSegmentSliceIter<'a> {
             OwnedSegment::Coalesce(fields) => {
                 let coalesce_segment;
                 if self.coalesce_i == fields.len() - 1 {
-                    coalesce_segment = BorrowedSegment::CoalesceEnd(fields[self.coalesce_i].as_str().into());
+                    coalesce_segment =
+                        BorrowedSegment::CoalesceEnd(fields[self.coalesce_i].as_str().into());
                     self.coalesce_i = 0;
                 } else {
-                    coalesce_segment = BorrowedSegment::CoalesceField(fields[self.coalesce_i].as_str().into());
+                    coalesce_segment =
+                        BorrowedSegment::CoalesceField(fields[self.coalesce_i].as_str().into());
                     self.coalesce_i += 1;
                 }
                 coalesce_segment

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -37,6 +37,16 @@ impl OwnedPath {
     pub fn single_field(field: &str) -> Self {
         vec![OwnedSegment::field(field)].into()
     }
+
+    pub fn push(&mut self, segment: OwnedSegment) {
+        self.segments.push(segment);
+    }
+
+    pub fn invalid() -> Self {
+        Self {
+            segments: vec![OwnedSegment::Invalid]
+        }
+    }
 }
 
 impl From<String> for OwnedPath {
@@ -60,32 +70,35 @@ impl From<OwnedPath> for String {
                     OwnedSegment::Field(field) => {
                         serialize_field(field.as_ref(), (i != 0).then(|| "."))
                     }
-
-                    OwnedSegment::CoalesceField(field) => {
-                        let output = serialize_field(
-                            field.as_ref(),
-                            Some(if coalesce_i == 0 {
-                                if i == 0 {
-                                    "("
-                                } else {
-                                    ".("
-                                }
-                            } else {
-                                "|"
-                            }),
-                        );
-                        coalesce_i += 1;
-                        output
-                    }
                     OwnedSegment::Index(index) => format!("[{}]", index),
                     OwnedSegment::Invalid => {
                         (if i == 0 { "<invalid>" } else { ".<invalid>" }).to_owned()
                     }
-                    OwnedSegment::CoalesceEnd(field) => {
-                        format!(
+                    OwnedSegment::Coalesce(fields) => {
+                        let mut output = String::new();
+                        let (last, fields) = fields.split_last().expect("coalesce must not be empty");
+                        for field in fields {
+                            let field_output = serialize_field(
+                                field.as_ref(),
+                                Some(if coalesce_i == 0 {
+                                    if i == 0 {
+                                        "("
+                                    } else {
+                                        ".("
+                                    }
+                                } else {
+                                    "|"
+                                }),
+                            );
+                            coalesce_i += 1;
+                            output.push_str(&field_output);
+                        }
+
+                        output.push_str(&format!(
                             "{})",
-                            serialize_field(field.as_ref(), (coalesce_i != 0).then(|| "|"))
-                        )
+                            serialize_field(last.as_ref(), (coalesce_i != 0).then(|| "|"))
+                        ));
+                        output
                     }
                 })
                 .collect::<Vec<_>>()
@@ -129,24 +142,11 @@ impl From<Vec<OwnedSegment>> for OwnedPath {
     }
 }
 
-impl<const N: usize> From<[OwnedSegment; N]> for OwnedPath {
-    fn from(segments: [OwnedSegment; N]) -> Self {
-        OwnedPath::from(Vec::from(segments))
-    }
-}
-
-impl<'a, const N: usize> From<[BorrowedSegment<'a>; N]> for OwnedPath {
-    fn from(segments: [BorrowedSegment<'a>; N]) -> Self {
-        OwnedPath::from(segments.map(OwnedSegment::from))
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OwnedSegment {
     Field(String),
     Index(isize),
-    CoalesceField(String),
-    CoalesceEnd(String),
+    Coalesce(Vec<String>),
     Invalid,
 }
 
@@ -158,12 +158,8 @@ impl OwnedSegment {
         OwnedSegment::Index(value)
     }
 
-    pub fn coalesce_field(field: impl Into<String>) -> OwnedSegment {
-        OwnedSegment::CoalesceField(field.into())
-    }
-
-    pub fn coalesce_end(field: impl Into<String>) -> OwnedSegment {
-        OwnedSegment::CoalesceEnd(field.into())
+    pub fn coalesce(fields: Vec<String>) -> OwnedSegment {
+        OwnedSegment::Coalesce(fields)
     }
 
     pub fn is_field(&self) -> bool {
@@ -177,15 +173,15 @@ impl OwnedSegment {
     }
 }
 
-impl<'a> From<BorrowedSegment<'a>> for OwnedSegment {
-    fn from(x: BorrowedSegment<'a>) -> Self {
-        match x {
-            BorrowedSegment::Field(value) => OwnedSegment::Field(value.to_string()),
-            BorrowedSegment::Index(value) => OwnedSegment::Index(value),
-            BorrowedSegment::Invalid => OwnedSegment::Invalid,
-            BorrowedSegment::CoalesceField(field) => OwnedSegment::CoalesceField(field.to_string()),
-            BorrowedSegment::CoalesceEnd(field) => OwnedSegment::CoalesceEnd(field.to_string()),
-        }
+impl From<Vec<&'static str>> for OwnedSegment {
+    fn from(fields: Vec<&'static str>) -> Self {
+        fields.into_iter().map(ToString::to_string).collect::<Vec<_>>().into()
+    }
+}
+
+impl From<Vec<String>> for OwnedSegment {
+    fn from(fields: Vec<String>) -> Self {
+        OwnedSegment::Coalesce(fields)
     }
 }
 
@@ -214,6 +210,7 @@ impl<'a> Path<'a> for &'a Vec<OwnedSegment> {
         OwnedSegmentSliceIter {
             segments: self.as_slice(),
             index: 0,
+            coalesce_i: 0,
         }
     }
 }
@@ -230,14 +227,32 @@ impl<'a> Path<'a> for &'a OwnedPath {
 pub struct OwnedSegmentSliceIter<'a> {
     segments: &'a [OwnedSegment],
     index: usize,
+    coalesce_i: usize,
 }
 
 impl<'a> Iterator for OwnedSegmentSliceIter<'a> {
     type Item = BorrowedSegment<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let output = self.segments.get(self.index).map(|x| x.into());
-        self.index += 1;
+        let output = self.segments.get(self.index).map(|segment| match segment {
+            OwnedSegment::Field(field) => BorrowedSegment::Field(field.as_str().into()),
+            OwnedSegment::Invalid => BorrowedSegment::Invalid,
+            OwnedSegment::Index(i) => BorrowedSegment::Index(*i),
+            OwnedSegment::Coalesce(fields) => {
+                let coalesce_segment;
+                if self.coalesce_i == fields.len() - 1 {
+                    coalesce_segment = BorrowedSegment::CoalesceEnd(fields[self.coalesce_i].as_str().into());
+                    self.coalesce_i = 0;
+                } else {
+                    coalesce_segment = BorrowedSegment::CoalesceField(fields[self.coalesce_i].as_str().into());
+                    self.coalesce_i += 1;
+                }
+                coalesce_segment
+            }
+        });
+        if self.coalesce_i == 0 {
+            self.index += 1;
+        }
         output
     }
 }
@@ -261,14 +276,14 @@ mod test {
                 r#"ec2.metadata."availability-zone""#,
             ),
             ("@timestamp", "@timestamp"),
-            ("foo[", "foo.<invalid>"),
+            ("foo[", "<invalid>"),
             ("foo$", "<invalid>"),
             (r#""$peci@l chars""#, r#""$peci@l chars""#),
-            ("foo.foo bar", "foo.<invalid>"),
+            ("foo.foo bar", "<invalid>"),
             (r#"foo."foo bar".bar"#, r#"foo."foo bar".bar"#),
             ("[1]", "[1]"),
             ("[42]", "[42]"),
-            ("foo.[42]", "foo.<invalid>"),
+            ("foo.[42]", "<invalid>"),
             ("[42].foo", "[42].foo"),
             ("[-1]", "[-1]"),
             ("[-42]", "[-42]"),

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -1,5 +1,6 @@
 use crate::lookup_v2::{parse_path, BorrowedSegment, Path};
 use vector_config::configurable_component;
+use std::fmt::Write;
 
 /// A lookup path.
 #[configurable_component]
@@ -94,11 +95,7 @@ impl From<OwnedPath> for String {
                             coalesce_i += 1;
                             output.push_str(&field_output);
                         }
-
-                        output.push_str(&format!(
-                            "{})",
-                            serialize_field(last.as_ref(), (coalesce_i != 0).then(|| "|"))
-                        ));
+                        let _ = write!(output, "{})", serialize_field(last.as_ref(), (coalesce_i != 0).then(|| "|")));
                         output
                     }
                 })


### PR DESCRIPTION
This is some cleanup that was pulled out of https://github.com/vectordotdev/vector/pull/14011 to help simplify the implementation there.

This unifies `OwnedSegment::CoalesceField` and `OwnedSegment::CoalesceEnd` into a single `OwnedSegment::Coalesce`. It was originally split to more closely model `BorrowedSegment`, which needs it for performance reasons (to prevent allocations). `OwnedSegment`'s however are not expected to be parsed / created at runtime and having a single coalesce segment is easier to work with.

I'd also eventually like to remove `OwnedSegment::Invalid`, but that will come later.