### PR TITLE
chore(core): Allow configurable names for "source" metadata

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -220,17 +220,18 @@ impl LogNamespace {
         &self,
         source_name: &'a str,
         log: &mut LogEvent,
-        key: impl Path<'a>,
+        legacy_key: impl Path<'a>,
+        metadata_key: impl Path<'a>,
         value: impl Into<Value>,
     ) {
         match self {
             LogNamespace::Vector => {
                 log.metadata_mut()
                     .value_mut()
-                    .insert(path!(source_name).concat(key), value);
+                    .insert(path!(source_name).concat(metadata_key), value);
             }
             LogNamespace::Legacy => {
-                log.try_insert(key, value);
+                log.try_insert(legacy_key, value);
             }
         }
     }

--- a/src/sources/datadog_agent/logs.rs
+++ b/src/sources/datadog_agent/logs.rs
@@ -112,11 +112,13 @@ pub(crate) fn decode_log_body(
                                 source_name,
                                 log,
                                 path!("status"),
+                                path!("status"),
                                 status.clone(),
                             );
                             namespace.insert_source_metadata(
                                 source_name,
                                 log,
+                                path!("timestamp"),
                                 path!("timestamp"),
                                 timestamp,
                             );
@@ -124,11 +126,13 @@ pub(crate) fn decode_log_body(
                                 source_name,
                                 log,
                                 path!("hostname"),
+                                path!("hostname"),
                                 hostname.clone(),
                             );
                             namespace.insert_source_metadata(
                                 source_name,
                                 log,
+                                path!("service"),
                                 path!("service"),
                                 service.clone(),
                             );
@@ -136,11 +140,13 @@ pub(crate) fn decode_log_body(
                                 source_name,
                                 log,
                                 path!("ddsource"),
+                                path!("ddsource"),
                                 ddsource.clone(),
                             );
                             namespace.insert_source_metadata(
                                 source_name,
                                 log,
+                                path!("ddtags"),
                                 path!("ddtags"),
                                 ddtags.clone(),
                             );


### PR DESCRIPTION
Some sources need to use a configurable metadata field name when using the `Legacy` namespace, but a hard-coded name when using the `Vector` namespace. Now both names are passed into the `LogNamespace::insert_source_metadata` function.