### PR TITLE
docs: Adds link to directions for installing cue

### DIFF
--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -50,8 +50,8 @@ suitable for complex data definitions.
 
 Vector has some CUE-related CI checks that are run whenever changes are made to
 the `docs` directory. This includes checks to make sure that the CUE sources are
-properly formatted. To run CUE's autoformatting, run this command from the
-`vector` root:
+properly formatted. To run CUE's autoformatting, first [install cue](https://cuelang.org/docs/install/),
+then run this command from the `vector` root:
 
 ```bash
 cue fmt ./docs/**/*.cue


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Adds a link to install cue. I wasn't aware when attempting to contribute that cue was a separate dependency.