### PR TITLE
enhancement(observability): Adhere TemplateRenderingError to EventsDropped spec

### DIFF
--- a/src/internal_events/template.rs
+++ b/src/internal_events/template.rs
@@ -16,17 +16,25 @@ impl<'a> InternalEvent for TemplateRenderingError<'a> {
             use std::fmt::Write;
             let _ = write!(msg, " for \"{}\"", field);
         }
-        if self.drop_event {
-            msg.push_str("; discarding event");
-        }
         msg.push('.');
-        error!(
-            message = %msg,
-            error = %self.error,
-            error_type = error_type::TEMPLATE_FAILED,
-            stage = error_stage::PROCESSING,
-            internal_log_rate_secs = 30,
-        );
+        if self.drop_event {
+            error!(
+                message = %msg,
+                error = %self.error,
+                error_type = error_type::TEMPLATE_FAILED,
+                stage = error_stage::PROCESSING,
+            )
+        } else {
+            error!(
+                message = "Events dropped.",
+                count = 1,
+                error = %self.error,
+                error_type = error_type::TEMPLATE_FAILED,
+                intentional = "false",
+                reason = %msg,
+                stage = error_stage::PROCESSING,
+            );
+        }
         counter!(
             "component_errors_total", 1,
             "error_type" => error_type::TEMPLATE_FAILED,
@@ -39,6 +47,7 @@ impl<'a> InternalEvent for TemplateRenderingError<'a> {
             counter!(
                 "component_discarded_events_total", 1,
                 "error_type" => error_type::TEMPLATE_FAILED,
+                "intentional" => "false",
                 "stage" => error_stage::PROCESSING,
             );
             // deprecated

--- a/src/internal_events/template.rs
+++ b/src/internal_events/template.rs
@@ -19,13 +19,6 @@ impl<'a> InternalEvent for TemplateRenderingError<'a> {
         msg.push('.');
         if self.drop_event {
             error!(
-                message = %msg,
-                error = %self.error,
-                error_type = error_type::TEMPLATE_FAILED,
-                stage = error_stage::PROCESSING,
-            )
-        } else {
-            error!(
                 message = "Events dropped.",
                 count = 1,
                 error = %self.error,
@@ -34,6 +27,13 @@ impl<'a> InternalEvent for TemplateRenderingError<'a> {
                 reason = %msg,
                 stage = error_stage::PROCESSING,
             );
+        } else {
+            error!(
+                message = %msg,
+                error = %self.error,
+                error_type = error_type::TEMPLATE_FAILED,
+                stage = error_stage::PROCESSING,
+            )
         }
         counter!(
             "component_errors_total", 1,


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Part of #14019.
Part of #13995.

Depending on configuration some templating errors cause dropped events, this intends to adhere the `TemplateRenderingError` event to the `EventsDropped` spec this is the case.
This PR will affect any component using the `TemplateRenderingError` event.
