### PR TITLE
chore: Clarify EventsDropped spec

### DIFF
--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -127,7 +127,7 @@ not result in data loss if the retry succeeds.**
 - Metrics
   - MUST increment the `<namespace>_discarded_events_total` counter by the
     number of events discarded.
-  - MUST include the listed properties as tags except the `reason` property.
+  - MUST NOT include `count` and `reason` from the `reason` property as tags.
 - Logs
   - MUST log a `Events dropped` message.
   - MUST include the defined properties as key-value pairs.


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

I'm not entirely sold on the phrasing, but it's not specified that `count` doesn't need to be included in the _counter_ unless we want to consider that obvious.
