### PR TITLE
fix(elasticsearch sink): fix error msg spelling

### DIFF
--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -171,7 +171,7 @@ fn get_event_status(response: &Response<Bytes>) -> EventStatus {
         let body = String::from_utf8_lossy(response.body());
         if body.contains("\"errors\":true") {
             emit!(ElasticsearchResponseError::new(
-                "Response containerd errors.",
+                "Response contained errors.",
                 response
             ));
             EventStatus::Rejected


### PR DESCRIPTION
Unless I am mistaken ElasticSearch has little to do with containerd.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

