### PR TITLE
chore(dev): Lower `cargo deny` log level

### DIFF
--- a/scripts/check-deny.sh
+++ b/scripts/check-deny.sh
@@ -11,4 +11,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -x
 
 cargo install --locked cargo-deny
-cargo deny --all-features check all
+cargo deny --log-level error --all-features check all


### PR DESCRIPTION
So that it doesn't output all of the warnings, making it more difficult to find the errors. We may
make more of these warnings failures in the future (e.g. the licences per
https://github.com/vectordotdev/vector/issues/12190).

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
