### PR TITLE
feat(file sink): support Zstandard-compressed output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8546,6 +8546,7 @@ dependencies = [
  "warp",
  "windows-service",
  "wiremock",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,6 +343,7 @@ tower-test = "0.4.0"
 value = { path = "lib/value", features = ["test"] }
 vector-core = { path = "lib/vector-core", default-features = false, features = ["vrl", "test"] }
 wiremock = "0.5.14"
+zstd = { version = "0.10.0", default-features = false }
 
 [patch.crates-io]
 # A patch for lib/vector-core/buffers, addresses Issue 7514

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -136,6 +136,7 @@ components: sinks: [Name=string]: {
 					description: """
 						The compression strategy used to compress the encoded event data before transmission.
 
+						The default compression level of the chosen algorithm is used.
 						Some cloud storage API clients and browsers will handle decompression transparently,
 						so files may not always appear to be compressed depending how they are accessed.
 						"""
@@ -148,7 +149,7 @@ components: sinks: [Name=string]: {
 									none: "No compression."
 								}
 								if algo == "gzip" {
-									gzip: "[Gzip](\(urls.gzip)) standard DEFLATE compression."
+									gzip: "[Gzip](\(urls.gzip)) standard DEFLATE compression. Compression level is `6` unless otherwise specified."
 								}
 								if algo == "snappy" {
 									snappy: "[Snappy](\(urls.snappy)) compression."
@@ -157,7 +158,7 @@ components: sinks: [Name=string]: {
 									lz4: "[lz4](\(urls.lz4)) compression."
 								}
 								if algo == "zstd" {
-									zstd: "[zstd](\(urls.zstd)) compression."
+									zstd: "[zstd](\(urls.zstd)) compression. Compression level is `3` unless otherwise specified. Dictionaries are not supported."
 								}
 							}
 						}

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -20,7 +20,7 @@ components: sinks: file: {
 			compression: {
 				enabled: true
 				default: "none"
-				algorithms: ["none", "gzip"]
+				algorithms: ["none", "gzip", "zstd"]
 				levels: ["none", "fast", "default", "best", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 			}
 			encoding: {
@@ -53,7 +53,7 @@ components: sinks: file: {
 			}
 		}
 		path: {
-			description: "File name to write events to."
+			description: "File name to write events to. Compression format extension must be explicit."
 			required:    true
 			type: string: {
 				examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log"]


### PR DESCRIPTION


This is part of #2302

I'm a bit uncomfortable with raising `zstd` to a true dependency, but the `lines_from_zstd_file` test function is always built. I put in the current version `0.10` from Cargo.lock.

todos:
- [x] bump to 0.11 or later, without default features
- [x] show zstd-commandline compatibility
- [x] perhaps gate this & `flate2` under dev-dependencies, since they are used for tests only?
- [x] explicitly say we don't special zstd feature like `dictionary`