### PR TITLE
fix(datadog agent source): traces are missing k8s tags

### DIFF
--- a/proto/dd_trace.proto
+++ b/proto/dd_trace.proto
@@ -31,6 +31,9 @@ message TracerPayload {
 	string tracerVersion = 4;
 	string runtimeID = 5;
 	repeated TraceChunk chunks = 6;
+	map<string, string> tags = 7;
+	string env = 8;
+	string hostname = 9;
 	string appVersion = 10;
 }
 

--- a/src/sinks/datadog/traces/request_builder.rs
+++ b/src/sinks/datadog/traces/request_builder.rs
@@ -272,7 +272,7 @@ impl DatadogTracesEncoder {
                 .and_then(|v| v.as_boolean())
                 .unwrap_or(false),
             spans,
-            tags,
+            tags: tags.clone(),
         };
 
         dd_proto::TracerPayload {
@@ -297,6 +297,15 @@ impl DatadogTracesEncoder {
                 .map(|v| v.to_string_lossy())
                 .unwrap_or_default(),
             chunks: vec![chunk],
+            tags,
+            env: trace
+                .get("env")
+                .map(|v| v.to_string_lossy())
+                .unwrap_or_default(),
+            hostname: trace
+                .get("hostname")
+                .map(|v| v.to_string_lossy())
+                .unwrap_or_default(),
             app_version: trace
                 .get("app_version")
                 .map(|v| v.to_string_lossy())

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1003,6 +1003,9 @@ async fn decode_traces() {
             tracer_version: "v577".to_string(),
             runtime_id: "123abc".to_string(),
             chunks: vec![chunk],
+            env: "env".to_string(),
+            tags: BTreeMap::from_iter([("another".to_string(), "tag".to_string())].into_iter()),
+            hostname: "hostname".to_string(),
             app_version: "v314".to_string(),
         };
 
@@ -1109,6 +1112,18 @@ async fn decode_traces() {
             let trace_v2 = events[2].as_trace();
             assert_eq!(trace_v2.as_map()["host"], "a_hostname".into());
             assert_eq!(trace_v2.as_map()["env"], "env".into());
+
+            assert_eq!(
+                trace_v2.as_map()["tags"],
+                Value::Object(BTreeMap::from_iter(
+                    [
+                        ("a".to_string(), "tag".into()),
+                        ("another".to_string(), "tag".into())
+                    ]
+                    .into_iter()
+                ))
+            );
+
             assert_eq!(trace_v2.as_map()["language_name"], "plop".into());
             assert_eq!(trace_v2.as_map()["language_version"], "v33".into());
             assert_eq!(trace_v2.as_map()["container_id"], "an_id".into());

--- a/src/sources/datadog_agent/traces.rs
+++ b/src/sources/datadog_agent/traces.rs
@@ -175,9 +175,9 @@ fn convert_dd_tracer_payload(payload: ddtrace_proto::TracerPayload) -> Vec<Trace
             trace_event.insert("priority", trace.priority as i64);
             trace_event.insert("origin", trace.origin);
             trace_event.insert("dropped", trace.dropped_trace);
-            let mut span_tags = convert_tags(trace.tags);
-            span_tags.extend(tags.clone());
-            trace_event.insert("tags", Value::from(span_tags));
+            let mut trace_tags = convert_tags(trace.tags);
+            trace_tags.extend(tags.clone());
+            trace_event.insert("tags", Value::from(trace_tags));
             trace_event.insert(
                 "spans",
                 trace

--- a/src/sources/datadog_agent/traces.rs
+++ b/src/sources/datadog_agent/traces.rs
@@ -166,6 +166,7 @@ fn handle_dd_trace_payload_v1(
 }
 
 fn convert_dd_tracer_payload(payload: ddtrace_proto::TracerPayload) -> Vec<TraceEvent> {
+    let tags = convert_tags(payload.tags);
     payload
         .chunks
         .into_iter()
@@ -174,7 +175,9 @@ fn convert_dd_tracer_payload(payload: ddtrace_proto::TracerPayload) -> Vec<Trace
             trace_event.insert("priority", trace.priority as i64);
             trace_event.insert("origin", trace.origin);
             trace_event.insert("dropped", trace.dropped_trace);
-            trace_event.insert("tags", Value::from(convert_tags(trace.tags)));
+            let mut span_tags = convert_tags(trace.tags);
+            span_tags.extend(tags.clone());
+            trace_event.insert("tags", Value::from(span_tags));
             trace_event.insert(
                 "spans",
                 trace


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Fix for https://datadoghq.atlassian.net/jira/software/c/projects/OBPS/boards/1533?modal=detail&selectedIssue=OBPS-8

NOTE: I am posting a review because I believe the code change is correct, however while trying to test the fix against the expected behavior from the JIRA issue, I am not seeing the `kube_namespace` tag. What I'm wondering is perhaps the helm values to generate the reproduction attempt are not correct ?

This is the data generated before applying the fix, note tags is empty:

```
{"agent_version":"7.38.2","app_version":"","container_id":"b6fbf7915a1d6229310bf6fe4979f4374bb761ba0b3b709171606b8fcb8c84a3","dropped":false,"env":"none","error_tps":0.0,"host":"minikube","language_name":"python","language_version":"3.10.6","origin":"","payload_version":"v2","priority":10,"runtime_id":"","source_type":"datadog_agent","spans":[{"duration":2006000177,"error":0,"meta":{"_dd.p.dm":"-0","env":"kyle-dev","foo":"bar","runtime-id":"c9d84d4c769d468e9dccefce7ed9df64"},"meta_struct":{},"metrics":{"_dd.agent_psr":1.0,"_dd.top_level":1.0,"_dd.tracer_kr":1.0,"_sampling_priority_v1":10.0,"_top_level":1.0,"numeric":1.234,"system.pid":1.0},"name":"operations.of.interest","parent_id":0,"resource":"operations.of.interest","service":"trace-test-app","span_id":-6107765803375370716,"start":"2022-08-19T16:33:24.266050920Z","trace_id":2253901555132370018,"type":""},{"duration":1002889326,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_10","parent_id":-6107765803375370716,"resource":"child_10","service":"trace-test-app","span_id":-2587723803608368797,"start":"2022-08-19T16:33:24.266112917Z","trace_id":2253901555132370018,"type":""},{"duration":902735174,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_9","parent_id":-2587723803608368797,"resource":"child_9","service":"trace-test-app","span_id":306519629396597955,"start":"2022-08-19T16:33:24.366259733Z","trace_id":2253901555132370018,"type":""},{"duration":802478288,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_8","parent_id":306519629396597955,"resource":"child_8","service":"trace-test-app","span_id":-5139904333599832880,"start":"2022-08-19T16:33:24.466509187Z","trace_id":2253901555132370018,"type":""},{"duration":702174776,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_7","parent_id":-5139904333599832880,"resource":"child_7","service":"trace-test-app","span_id":1721564378901907814,"start":"2022-08-19T16:33:24.566805265Z","trace_id":2253901555132370018,"type":""},{"duration":601860373,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_6","parent_id":1721564378901907814,"resource":"child_6","service":"trace-test-app","span_id":4481787344958267175,"start":"2022-08-19T16:33:24.667111298Z","trace_id":2253901555132370018,"type":""},{"duration":501561183,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_5","parent_id":4481787344958267175,"resource":"child_5","service":"trace-test-app","span_id":8063141245157009874,"start":"2022-08-19T16:33:24.767402112Z","trace_id":2253901555132370018,"type":""},{"duration":401253531,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_4","parent_id":8063141245157009874,"resource":"child_4","service":"trace-test-app","span_id":8983523852437125472,"start":"2022-08-19T16:33:24.867701211Z","trace_id":2253901555132370018,"type":""},{"duration":300946592,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_3","parent_id":8983523852437125472,"resource":"child_3","service":"trace-test-app","span_id":8554661248515984163,"start":"2022-08-19T16:33:24.967998872Z","trace_id":2253901555132370018,"type":""},{"duration":200663690,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_2","parent_id":8554661248515984163,"resource":"child_2","service":"trace-test-app","span_id":-7621930164763221294,"start":"2022-08-19T16:33:25.068267233Z","trace_id":2253901555132370018,"type":""},{"duration":100290870,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_1","parent_id":-7621930164763221294,"resource":"child_1","service":"trace-test-app","span_id":-6916840659356501010,"start":"2022-08-19T16:33:25.168550409Z","trace_id":2253901555132370018,"type":""},{"duration":1003002878,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_10","parent_id":-6107765803375370716,"resource":"child_10","service":"trace-test-app","span_id":5440692843100769798,"start":"2022-08-19T16:33:25.269038785Z","trace_id":2253901555132370018,"type":""},{"duration":902648461,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_9","parent_id":5440692843100769798,"resource":"child_9","service":"trace-test-app","span_id":4919828010497591832,"start":"2022-08-19T16:33:25.369385050Z","trace_id":2253901555132370018,"type":""},{"duration":802229376,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_8","parent_id":4919828010497591832,"resource":"child_8","service":"trace-test-app","span_id":6518126025715400943,"start":"2022-08-19T16:33:25.469795851Z","trace_id":2253901555132370018,"type":""},{"duration":701914884,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_7","parent_id":6518126025715400943,"resource":"child_7","service":"trace-test-app","span_id":2660755495603096849,"start":"2022-08-19T16:33:25.570101967Z","trace_id":2253901555132370018,"type":""},{"duration":601629806,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_6","parent_id":2660755495603096849,"resource":"child_6","service":"trace-test-app","span_id":8508481092719184809,"start":"2022-08-19T16:33:25.670378705Z","trace_id":2253901555132370018,"type":""},{"duration":501326598,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_5","parent_id":8508481092719184809,"resource":"child_5","service":"trace-test-app","span_id":3842800624263910630,"start":"2022-08-19T16:33:25.770673622Z","trace_id":2253901555132370018,"type":""},{"duration":401058363,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_4","parent_id":3842800624263910630,"resource":"child_4","service":"trace-test-app","span_id":513985671297343760,"start":"2022-08-19T16:33:25.870933143Z","trace_id":2253901555132370018,"type":""},{"duration":300804531,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_3","parent_id":513985671297343760,"resource":"child_3","service":"trace-test-app","span_id":-5734719498552859052,"start":"2022-08-19T16:33:25.971177020Z","trace_id":2253901555132370018,"type":""},{"duration":200536487,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_2","parent_id":-5734719498552859052,"resource":"child_2","service":"trace-test-app","span_id":-4677596164760598843,"start":"2022-08-19T16:33:26.071432189Z","trace_id":2253901555132370018,"type":""},{"duration":100227348,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_1","parent_id":-4677596164760598843,"resource":"child_1","service":"trace-test-app","span_id":-3768142066537271840,"start":"2022-08-19T16:33:26.171673517Z","trace_id":2253901555132370018,"type":""}],"tags":{},"target_tps":0.0,"tracer_version":"1.3.2"}

```

This is what is generated AFTER applying the fix. Tags is populated but does not contain `kube_namespace` :

```
{"agent_version":"7.38.2","app_version":"","container_id":"f78c83379a25031bf9df82c146979467b5f9221eb81ed93639b4411c6820119a","dropped":false,"env":"none","error_tps":0.0,"host":"minikube","language_name":"python","language_version":"3.10.6","origin":"","payload_version":"v2","priority":10,"runtime_id":"","source_type":"datadog_agent","spans":[{"duration":2005419304,"error":0,"meta":{"_dd.p.dm":"-0","env":"kyle-dev","foo":"bar","runtime-id":"620c7cd0ab8a40349596580d6bdc0714"},"meta_struct":{},"metrics":{"_dd.agent_psr":1.0,"_dd.top_level":1.0,"_dd.tracer_kr":1.0,"_sampling_priority_v1":10.0,"_top_level":1.0,"numeric":1.234,"system.pid":1.0},"name":"operations.of.interest","parent_id":0,"resource":"operations.of.interest","service":"trace-test-app","span_id":1491502377508621798,"start":"2022-08-19T21:06:15.959613644Z","trace_id":7418521323492190345,"type":""},{"duration":1002228262,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_10","parent_id":1491502377508621798,"resource":"child_10","service":"trace-test-app","span_id":-2579806706580065589,"start":"2022-08-19T21:06:15.959658733Z","trace_id":7418521323492190345,"type":""},{"duration":902053670,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_9","parent_id":-2579806706580065589,"resource":"child_9","service":"trace-test-app","span_id":6465527413316804763,"start":"2022-08-19T21:06:16.059830325Z","trace_id":7418521323492190345,"type":""},{"duration":801810158,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_8","parent_id":6465527413316804763,"resource":"child_8","service":"trace-test-app","span_id":6076332043157296987,"start":"2022-08-19T21:06:16.160070685Z","trace_id":7418521323492190345,"type":""},{"duration":701441601,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_7","parent_id":6076332043157296987,"resource":"child_7","service":"trace-test-app","span_id":-2981644028006488695,"start":"2022-08-19T21:06:16.260435808Z","trace_id":7418521323492190345,"type":""},{"duration":601216979,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_6","parent_id":-2981644028006488695,"resource":"child_6","service":"trace-test-app","span_id":9220250912372806739,"start":"2022-08-19T21:06:16.360657235Z","trace_id":7418521323492190345,"type":""},{"duration":500972878,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_5","parent_id":9220250912372806739,"resource":"child_5","service":"trace-test-app","span_id":-4402715213628500990,"start":"2022-08-19T21:06:16.460897615Z","trace_id":7418521323492190345,"type":""},{"duration":400794232,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_4","parent_id":-4402715213628500990,"resource":"child_4","service":"trace-test-app","span_id":-2804409136150614560,"start":"2022-08-19T21:06:16.561072594Z","trace_id":7418521323492190345,"type":""},{"duration":300641997,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_3","parent_id":-2804409136150614560,"resource":"child_3","service":"trace-test-app","span_id":8063055723000467104,"start":"2022-08-19T21:06:16.661221290Z","trace_id":7418521323492190345,"type":""},{"duration":200408725,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_2","parent_id":8063055723000467104,"resource":"child_2","service":"trace-test-app","span_id":-1406621037598608465,"start":"2022-08-19T21:06:16.761449436Z","trace_id":7418521323492190345,"type":""},{"duration":100181463,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_1","parent_id":-1406621037598608465,"resource":"child_1","service":"trace-test-app","span_id":6062256858220833225,"start":"2022-08-19T21:06:16.861622628Z","trace_id":7418521323492190345,"type":""},{"duration":1003117282,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_10","parent_id":1491502377508621798,"resource":"child_10","service":"trace-test-app","span_id":2062796391759032903,"start":"2022-08-19T21:06:16.961906811Z","trace_id":7418521323492190345,"type":""},{"duration":902829555,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_9","parent_id":2062796391759032903,"resource":"child_9","service":"trace-test-app","span_id":-7857784996802692785,"start":"2022-08-19T21:06:17.062186686Z","trace_id":7418521323492190345,"type":""},{"duration":802546822,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_8","parent_id":-7857784996802692785,"resource":"child_8","service":"trace-test-app","span_id":-7460762880212443626,"start":"2022-08-19T21:06:17.162461684Z","trace_id":7418521323492190345,"type":""},{"duration":702162276,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_7","parent_id":-7460762880212443626,"resource":"child_7","service":"trace-test-app","span_id":5385210746748223412,"start":"2022-08-19T21:06:17.262838587Z","trace_id":7418521323492190345,"type":""},{"duration":601805839,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_6","parent_id":5385210746748223412,"resource":"child_6","service":"trace-test-app","span_id":4969061107372491345,"start":"2022-08-19T21:06:17.363187353Z","trace_id":7418521323492190345,"type":""},{"duration":501457276,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_5","parent_id":4969061107372491345,"resource":"child_5","service":"trace-test-app","span_id":7804882170459906048,"start":"2022-08-19T21:06:17.463528660Z","trace_id":7418521323492190345,"type":""},{"duration":401167164,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_4","parent_id":7804882170459906048,"resource":"child_4","service":"trace-test-app","span_id":-1707520329008186136,"start":"2022-08-19T21:06:17.563811176Z","trace_id":7418521323492190345,"type":""},{"duration":300883527,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_3","parent_id":-1707520329008186136,"resource":"child_3","service":"trace-test-app","span_id":6331092101375770867,"start":"2022-08-19T21:06:17.664086279Z","trace_id":7418521323492190345,"type":""},{"duration":200575471,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_2","parent_id":6331092101375770867,"resource":"child_2","service":"trace-test-app","span_id":1746862045376443916,"start":"2022-08-19T21:06:17.764382181Z","trace_id":7418521323492190345,"type":""},{"duration":100234492,"error":0,"meta":{"env":"kyle-dev","foo":"bar"},"meta_struct":{},"metrics":{},"name":"child_1","parent_id":1746862045376443916,"resource":"child_1","service":"trace-test-app","span_id":-2785034574615421208,"start":"2022-08-19T21:06:17.864660004Z","trace_id":7418521323492190345,"type":""}],"tags":{"_dd.tags.container":"image_name:tracer/tracer,short_image:tracer,image_tag:latest,docker_image:tracer/tracer:latest,container_id:f78c83379a25031bf9df82c146979467b5f9221eb81ed93639b4411c6820119a,container_name:k8s_tracer_tracer-847mg_default_b9575c6b-1757-42e7-a323-7add4edca567_0"},"target_tps":0.0,"tracer_version":"1.3.2"}
```

Zeroing in on `tags`:

```
"tags: {"_dd.tags.container":"image_name:tracer/tracer,short_image:tracer,image_tag:latest,docker_image:tracer/tracer:latest,container_id:f78c83379a25031bf9df82c146979467b5f9221eb81ed93639b4411c6820119a,container_name:k8s_tracer_tracer-847mg_default_b9575c6b-1757-42e7-a323-7add4edca567_0"},"target_tps":0.0,"tracer_version":"1.3.2"}
```

EDIT: 

It eventually worked (see https://github.com/vectordotdev/vector/pull/14049#issuecomment-1226016621)

Also see this guide that was written as a result of working on this issue, for how to reproduce/verify:

https://github.com/vectordotdev/vector/wiki/Guide:-Routing-traces-from-the-Datadog-Agent-to-Vector-within-Kubernetes