### PR TITLE
chore(external docs): announce deprecation of renamed components in 0.24.0

### DIFF
--- a/website/content/en/highlights/2022-08-16-0-24-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-08-16-0-24-0-upgrade-guide.md
@@ -17,9 +17,11 @@ Vector's 0.24.0 release includes **breaking changes**:
 4. [`ndjson` on sink `encoding` is now `json` encoding + `newline_delimited` framing](#sink-encoding-json)
 5. [VRL type definition updates](#vrl-type-def)
 
+
 and **deprecations**:
 
 1. [`internal_metrics` source cardinality metric change]
+2. [Imminent removal of deprecated names for a select set of sources and sinks](#deprecated-sources-sinks)
 
 We cover them below to help you upgrade quickly:
 
@@ -167,3 +169,30 @@ metric described above is now deprecated and will be removed in a future version
 See the
 [documentation](/docs/reference/configuration/sources/internal_metrics/#internal_metrics_cardinality)
 for additional details.
+
+#### Imminent removal of deprecated names for a select set of sources, transforms, and sinks {#deprecated-components}
+
+In 0.22.0, we had announced the removal of certain deprecated transforms. Continuing that work, we
+are deprecating the original names for a select set of sources, transforms, and sinks. These
+components have since been renamed to better align with the actual name of the product/technology,
+or to better differentiate them from related components.
+
+The following component type names will be **removed* in 0.25.0:
+
+Sources:
+
+- `generator` (now `demo_logs`)
+- `docker` (now `docker_logs`)
+- `logplex` (now `heroku_logs`)
+- `prometheus` (now `prometheus_scrape`)
+
+Transforms:
+
+- `swimlanes` (now `route`)
+- `sampler` (now `sample`)
+
+Sinks:
+
+- `new_relic_logs` (now `new_relic`)
+- `prometheus` (now `prometheus_exporter`)
+- `splunk_hec` (now `spelunk_hec_logs`)


### PR DESCRIPTION
As stated in the title.