### PR TITLE
chore: Create std locks in const context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,7 +3693,6 @@ version = "0.1.0"
 dependencies = [
  "k8s-openapi",
  "log",
- "once_cell",
  "serde_json",
  "tempfile",
  "tokio",

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -9,7 +9,6 @@ license = "MPL-2.0"
 
 [dependencies]
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_19"] }
-once_cell = "1"
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/lib/k8s-test-framework/src/lock.rs
+++ b/lib/k8s-test-framework/src/lock.rs
@@ -1,14 +1,12 @@
 use std::sync::{Mutex, MutexGuard};
 
-use once_cell::sync::OnceCell;
-
 /// A shared lock to use commonly among the tests.
 /// The goal is to guarantee that only one test is executing concurrently, since
 /// tests use a shared resource - a k8s cluster - and will conflict with each
 /// other unless they're executing sequentially.
 pub fn lock() -> MutexGuard<'static, ()> {
-    static INSTANCE: OnceCell<Mutex<()>> = OnceCell::new();
-    match INSTANCE.get_or_init(|| Mutex::new(())).lock() {
+    static INSTANCE: Mutex<()> = Mutex::new(());
+    match INSTANCE.lock() {
         Ok(guard) => guard,
         // Ignore poison error.
         Err(err) => err.into_inner(),

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -16,7 +16,6 @@ pub use config_builder::*;
 use glob::glob;
 use loader::process::Process;
 pub use loader::*;
-use once_cell::sync::Lazy;
 pub use secret::*;
 pub use source::*;
 
@@ -25,7 +24,7 @@ use super::{
 };
 use crate::signal;
 
-pub static CONFIG_PATHS: Lazy<Mutex<Vec<ConfigPath>>> = Lazy::new(Mutex::default);
+pub static CONFIG_PATHS: Mutex<Vec<ConfigPath>> = Mutex::new(Vec::new());
 
 pub(super) fn read_dir<P: AsRef<Path> + Debug>(path: P) -> Result<ReadDir, Vec<String>> {
     path.as_ref()

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -121,7 +121,7 @@ fn get_early_buffer() -> MutexGuard<'static, Option<Vec<LogEvent>>> {
 ///
 /// Checks if [`BUFFER`] is set or if a trace sender exists
 fn should_process_tracing_event() -> bool {
-    maybe_get_trace_sender().is_some()
+    get_early_buffer().is_some() || maybe_get_trace_sender().is_some()
 }
 
 /// Attempts to buffer an event into the early buffer.

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -36,7 +36,7 @@ use crate::event::LogEvent;
 /// This means that callers must subscribe during the configuration phase of their components, and not in the core loop
 /// of the component, as the topology can only report when a component has been spawned, but not necessarily always
 /// when it has started doing, or waiting, for input.
-static BUFFER: OnceCell<Mutex<Option<Vec<LogEvent>>>> = OnceCell::new();
+static BUFFER: Mutex<Option<Vec<LogEvent>>> = Mutex::new(Some(Vec::new()));
 
 /// SHOULD_BUFFER controls whether or not internal log events should be buffered or sent directly to the trace broadcast
 /// channel.
@@ -44,7 +44,8 @@ static SHOULD_BUFFER: AtomicBool = AtomicBool::new(true);
 
 /// SUBSCRIBERS contains a list of callers interested in internal log events who will be notified when early buffering
 /// is disabled, by receiving a copy of all buffered internal log events.
-static SUBSCRIBERS: OnceCell<Mutex<Option<Vec<oneshot::Sender<Vec<LogEvent>>>>>> = OnceCell::new();
+static SUBSCRIBERS: Mutex<Option<Vec<oneshot::Sender<Vec<LogEvent>>>>> =
+    Mutex::new(Some(Vec::new()));
 
 /// SENDER holds the sender/receiver handle that will receive a copy of all the internal log events *after* the topology
 /// has been initialized.
@@ -55,7 +56,6 @@ fn metrics_layer_enabled() -> bool {
 }
 
 pub fn init(color: bool, json: bool, levels: &str) {
-    let _ = BUFFER.set(Mutex::new(Some(Vec::new())));
     let fmt_filter = tracing_subscriber::filter::Targets::from_str(levels).expect(
         "logging filter targets were not formatted correctly or did not specify a valid level",
     );
@@ -112,8 +112,6 @@ pub fn reset_early_buffer() -> Option<Vec<LogEvent>> {
 /// Gets a  mutable reference to the early buffer.
 fn get_early_buffer() -> MutexGuard<'static, Option<Vec<LogEvent>>> {
     BUFFER
-        .get()
-        .expect("Internal logs buffer not initialized")
         .lock()
         .expect("Couldn't acquire lock on internal logs buffer")
 }
@@ -123,7 +121,7 @@ fn get_early_buffer() -> MutexGuard<'static, Option<Vec<LogEvent>>> {
 ///
 /// Checks if [`BUFFER`] is set or if a trace sender exists
 fn should_process_tracing_event() -> bool {
-    BUFFER.get().is_some() || maybe_get_trace_sender().is_some()
+    maybe_get_trace_sender().is_some()
 }
 
 /// Attempts to buffer an event into the early buffer.
@@ -179,10 +177,7 @@ fn get_trace_receiver() -> broadcast::Receiver<LogEvent> {
 
 /// Gets a mutable reference to the list of waiting subscribers, if it exists.
 fn get_trace_subscriber_list() -> MutexGuard<'static, Option<Vec<oneshot::Sender<Vec<LogEvent>>>>> {
-    SUBSCRIBERS
-        .get_or_init(|| Mutex::new(Some(Vec::new())))
-        .lock()
-        .expect("poisoned locks are dumb")
+    SUBSCRIBERS.lock().expect("poisoned locks are dumb")
 }
 
 /// Attempts to register for early buffered events.


### PR DESCRIPTION
As of Rust 1.63, the std locks can be created in `const` context, meaning they
can be used directly in `static` expressions (so long as the contained
initializer is also `const`, of course). This change drops several `OnceCell`s
used just to initialize such locks.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
