### PR TITLE
chore(internal docs): Clarify dropped events for sources

### DIFF
--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -112,6 +112,10 @@ An `<Namespace>EventsDropped` event MUST be emitted when events are dropped.
 If events are dropped due to an error, then the error event should drive the
 emission of this event, meeting the below requirements.
 
+This event MUST NOT be emitted before events have been created in Vector. For
+example a source failing to decode incoming data would simply emit the
+`ComponentError` event but would not emit the `ComponentEventsDropped` event.
+
 **You MUST NOT emit this event for retriable operations that can recover and
 prevent data loss. For example, a failed HTTP request that will be retried does
 not result in data loss if the retry succeeds.**


### PR DESCRIPTION
That sources shouldn't emit that they discarded events if they haven't created the events yet.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
