### PR TITLE
docs: fix markdown in internal docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -190,8 +190,8 @@ When deprecating functionality in Vector, see [DEPRECATION.md](DEPRECATION.md).
 As discussed in the [`README`](README.md), you should continue to the following
 documents:
 
-2. **[DEVELOPING.md](DEVELOPING.md)** - Everything necessary to develop
-3. **[DOCUMENTING.md](DOCUMENTING.md)** - Preparing your change for Vector users
+1. **[DEVELOPING.md](DEVELOPING.md)** - Everything necessary to develop
+2. **[DOCUMENTING.md](DOCUMENTING.md)** - Preparing your change for Vector users
 3. **[DEPRECATION.md](DEPRECATION.md)** - Deprecating functionality in Vector
 
 ## Legal

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -23,9 +23,9 @@ introduced in a release without being announced in a prior release.
 
 Examples of possible deprecations in Vector:
 
-* Removal or rename of a configuration option
-* Removal or rename of a metric
-* Removal of a feature
+- Removal or rename of a configuration option
+- Removal or rename of a metric
+- Removal of a feature
 
 ## Lifecycle of a deprecation
 
@@ -37,11 +37,11 @@ A configuration option or feature in Vector is marked as deprecated.
 
 When this happens, we will notify by:
 
-* Listing the deprecation in the Deprecations section of the upgrade guide for the release the deprecation was
+- Listing the deprecation in the Deprecations section of the upgrade guide for the release the deprecation was
   introduced in. This will include instructions on how to transition if applicable.
-* Adding a deprecation note to the [documentation site][configuration] alongside the configuration or feature being
+- Adding a deprecation note to the [documentation site][configuration] alongside the configuration or feature being
   deprecated.
-* Output a log at the `WARN` level if Vector detects deprecated configuration or features being used on start-up, during
+- Output a log at the `WARN` level if Vector detects deprecated configuration or features being used on start-up, during
   `vector validate`, or at runtime, when possible. This log message will lead with the text `DEPRECATED` to make it easy
   to filter for.
 
@@ -56,7 +56,7 @@ A deprecated configuration option or feature in Vector is removed.
 
 When this happens, we will notify by:
 
-* Listing the removal in the Breaking Changes section of upgrade guide for that release. This will include directions on
+- Listing the removal in the Breaking Changes section of upgrade guide for that release. This will include directions on
   how to transition if applicable.
 
 When possible, Vector will error at start-up when a removed configuration option or feature is used.
@@ -67,17 +67,17 @@ When possible, Vector will error at start-up when a removed configuration option
 
 When introducing a deprecation into Vector, the pull request introducing the deprecation should:
 
-* Add a note to the Deprecations section of the upgrade guide for the next release with a description and
+- Add a note to the Deprecations section of the upgrade guide for the next release with a description and
   directions for transitioning if applicable.
-* Add a deprecation note to the docs. Typically this means adding `deprecation: "description of the deprecation"`
-  to the `cue` data for the option or feature. If the `cue` schema does not support `deprecation`  for whatever you
+- Add a deprecation note to the docs. Typically this means adding `deprecation: "description of the deprecation"`
+  to the `cue` data for the option or feature. If the `cue` schema does not support `deprecation` for whatever you
   are deprecating yet, add it to the schema and open an issue to have it rendered on the website.
-* Add a log message to Vector that is logged at the `WARN` level starting with the word `DEPRECATION` if Vector detects
+- Add a log message to Vector that is logged at the `WARN` level starting with the word `DEPRECATION` if Vector detects
   the deprecated configuration or feature being used (when possible).
 
 When removing a deprecation in a subsequent release, the pull request should:
 
-* Indicate that it is a breaking change by including `!` in the title after the type/scope
-* Remove the deprecation from the documentation
-* Add a note to the Breaking Changes section of the upgrade guide for the next release with a description and directions
+- Indicate that it is a breaking change by including `!` in the title after the type/scope
+- Remove the deprecation from the documentation
+- Add a note to the Breaking Changes section of the upgrade guide for the next release with a description and directions
   for transitioning if applicable.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -191,7 +191,6 @@ make fmt
 
 #### Logging style
 
-
 - Always use the [Tracing crate](https://tracing.rs/tracing/)'s key/value style for log events.
 - Events should be capitalized and end with a period, `.`.
 - Never use `e` or `err` - always spell out `error` to enrich logs and make it
@@ -345,26 +344,26 @@ You can run these tests within a PR as described in the [CI section](#ci).
 
 #### Faster builds With `sccache`
 
-Vector is a large project with a plethora of dependencies.  Changing to a different branch, or
+Vector is a large project with a plethora of dependencies. Changing to a different branch, or
 running `cargo clean`, can sometimes necessitate rebuilding many of those dependencies, which has an
-impact on productivity.  One way to reduce some of this cycle time is to use `sccache`, which caches
+impact on productivity. One way to reduce some of this cycle time is to use `sccache`, which caches
 compilation assets to avoid recompiling them over and over.
 
 `sccache` works by being configured to sit in front of `rustc`, taking compilation requests from
-Cargo and checking the cache to see if it already has the cached compilation unit.  It handles
+Cargo and checking the cache to see if it already has the cached compilation unit. It handles
 making sure that different compiler flags, versions of Rust, etc, are taken into consideration
 before using a cached asset.
 
 In order to use `sccache`, you must first [install](https://github.com/mozilla/sccache#installation)
-it.  There are pre-built binaries for all major platforms to get you going quickly. The
+it. There are pre-built binaries for all major platforms to get you going quickly. The
 [usage](https://github.com/mozilla/sccache#usage) documentation also explains how to set up your
-environment to actually use it.  We recommend using the `$HOME/.cargo/config` approach as this can help
+environment to actually use it. We recommend using the `$HOME/.cargo/config` approach as this can help
 speed up all of your Rust development work, and not just developing on Vector.
 
 While `sccache` was originally designed to cache compilation assets in cloud storage, maximizing
 reusability amongst CI workers, `sccache` actually supports storing assets locally by default.
 Local mode works well for local development as it is much easier to delete the cache directory if
-you ever encounter issues with the cached assets.  It also involves no extra infrastructure or
+you ever encounter issues with the cached assets. It also involves no extra infrastructure or
 spending.
 
 #### Testing specific components
@@ -587,7 +586,7 @@ is required too, see Vector [docs](https://vector.dev) for more details.
 Notes:
 
 > - `minikube` had a bug in the versions `1.12.x` that affected our test
->   process - see https://github.com/kubernetes/minikube/issues/8799.
+>   process - see <https://github.com/kubernetes/minikube/issues/8799>.
 >   Use version `1.13.0+` that has this bug fixed.
 > - `minikube` has troubles running on ZFS systems. If you're using ZFS, we
 >   suggest using a cloud cluster or [`minik8s`](https://microk8s.io/) with local

--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -21,20 +21,19 @@ documentation in tandem with code changes.
 
 <!-- /MarkdownTOC -->
 
-
 ## Responsibilities
 
 As a Vector contributor you _are_ responsible for coupling the following user
 experience related changes with your code:
 
-* Reference docs changes located in the [`/website/cue` folder](../website/cue) (generally configuration changes)
-* Existing guide changes located in the [`/website/content` folder](../website/content)
-* If relevant, [highlighting](../website/content/en/highlights) your change for future release notes
+- Reference docs changes located in the [`/website/cue` folder](../website/cue) (generally configuration changes)
+- Existing guide changes located in the [`/website/content` folder](../website/content)
+- If relevant, [highlighting](../website/content/en/highlights) your change for future release notes
 
 By default, you are _not_ responsible for:
 
-* Writing new guides related to your change (unless assigned)
-* Writing a blog post on your change (unless assigned)
+- Writing new guides related to your change (unless assigned)
+- Writing a blog post on your change (unless assigned)
 
 ## Reference documentation
 
@@ -62,7 +61,7 @@ CI failures.
 
 ### Validating
 
-In addition to proper formatting, the CUE sources need to be *valid*, that is,
+In addition to proper formatting, the CUE sources need to be _valid_, that is,
 the provided data needs to conform to various CUE schemas. To check the validity
 of the CUE sources:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # Vector Internal Documentation
 
-***This folder contains _internal_ documentation for Vector contributors. If
-you're a Vector user, please visit https://vector.dev/docs, which is powered by
-the [website](../website) directory.***
+**_This folder contains internal documentation for Vector contributors. If
+you're a Vector user, please visit <https://vector.dev/docs>, which is powered by
+the [website](../website) directory._**
 
 ## Getting started
 
@@ -19,17 +19,16 @@ development of Vector and ensuring your change gets approved in a timely manner.
 Vector team members have additional responsibilities beyond outside
 contributors:
 
-* **[REVIEWING.md](REVIEWING.md)** - Code review expectations and guidelines.
-* **[USER_EXPERIENCE_DESIGN.md](USER_EXPERIENCE_DESIGN.md)** - User experience
-   principles and guidelines.
+- **[REVIEWING.md](REVIEWING.md)** - Code review expectations and guidelines.
+- **[USER_EXPERIENCE_DESIGN.md](USER_EXPERIENCE_DESIGN.md)** - User experience
+  principles and guidelines.
 
 ## Project policies
 
 Vector's policies are located in the root directory:
 
-* **[CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)**
-* **[PRIVACY.md](../PRIVACY.md)**
-* **[RELEASES.md](../RELEASES.md)**
-* **[SECURITY.md](../SECURITY.md)**
-* **[VERSIONING.md](../VERSIONING.md)**
-
+- **[CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)**
+- **[PRIVACY.md](../PRIVACY.md)**
+- **[RELEASES.md](../RELEASES.md)**
+- **[SECURITY.md](../SECURITY.md)**
+- **[VERSIONING.md](../VERSIONING.md)**

--- a/docs/USER_EXPERIENCE_DESIGN.md
+++ b/docs/USER_EXPERIENCE_DESIGN.md
@@ -262,4 +262,4 @@ As a user experience design committee member, you are responsible for:
 - Reviewing and approving user-facing changes in pull requests.
 - Updating and evolving guides to reflect new Vector changes.
 
-[Hicks Law]: https://en.wikipedia.org/wiki/Hick%27s_law
+[hicks law]: https://en.wikipedia.org/wiki/Hick%27s_law

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -36,7 +36,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
 
 #### BufferCreated
 
-*All buffers* MUST emit a `BufferCreated` event upon creation. To avoid stale metrics, this event MUST be regularly emitted at an interval.
+_All buffers_ MUST emit a `BufferCreated` event upon creation. To avoid stale metrics, this event MUST be regularly emitted at an interval.
 
 - Properties
   - `max_size_bytes` - the max size of the buffer in bytes if relevant
@@ -47,7 +47,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
 
 #### BufferEventsReceived
 
-*All buffers* MUST emit a `BufferEventsReceived` event after receiving one or more Vector events. *All buffers- MUST emit a `BufferEventsReceived` event upon startup if there are existing events in the buffer.
+_All buffers_ MUST emit a `BufferEventsReceived` event after receiving one or more Vector events. \*All buffers- MUST emit a `BufferEventsReceived` event upon startup if there are existing events in the buffer.
 
 - Properties
   - `count` - the number of received events
@@ -60,7 +60,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
 
 #### BufferEventsSent
 
-*All buffers* MUST emit a `BufferEventsSent` event after sending one or more Vector events.
+_All buffers_ MUST emit a `BufferEventsSent` event after sending one or more Vector events.
 
 - Properties
   - `count` - the number of sent events
@@ -75,7 +75,7 @@ Vector buffers MUST be instrumented for optimal observability and monitoring.
 
 **Extends the [Error event].**
 
-*All buffers* MUST emit error events in accordance with the [Error event]
+_All buffers_ MUST emit error events in accordance with the [Error event]
 requirements.
 
 This specification does not list a standard set of errors that components must
@@ -85,9 +85,9 @@ implement since errors are specific to the buffer and operation.
 
 **Extends the [EventsDropped event].**
 
-*All buffers* that can drop events MUST emit a `BufferEventsDropped` event in
+_All buffers_ that can drop events MUST emit a `BufferEventsDropped` event in
 accordance with the [EventsDropped event] requirements.
 
-[Error event]: instrumentation.md#Error
-[EventsDropped event]: instrumentation.md#EventsDropped
-[Instrumentation Specification]: instrumentation.md
+[error event]: instrumentation.md#Error
+[eventsdropped event]: instrumentation.md#EventsDropped
+[instrumentation specification]: instrumentation.md

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -110,7 +110,7 @@ of these events:
 
 #### ComponentEventsReceived
 
-*All components* MUST emit a `ComponentEventsReceived` event that represents
+_All components_ MUST emit a `ComponentEventsReceived` event that represents
 the reception of Vector events from an upstream component.
 
 - Emission
@@ -130,11 +130,11 @@ the reception of Vector events from an upstream component.
 
 #### ComponentEventsSent
 
-*All components* MUST emit an `ComponentEventsSent` event that represents the
+_All components_ MUST emit an `ComponentEventsSent` event that represents the
 emission of Vector events to the next downstream component(s).
 
 - Emission
-  - MUST emit immediately after *successful* transmission of Vector events.
+  - MUST emit immediately after _successful_ transmission of Vector events.
     MUST NOT emit if the transmission was unsuccessful.
   - MUST NOT emit for pull-based sinks since they do not send events. For
     example, the `prometheus_exporter` sink MUST NOT emit this event.
@@ -158,7 +158,7 @@ emission of Vector events to the next downstream component(s).
 
 **Extends the [Error event].**
 
-*All components* MUST emit error events in accordance with the [Error event]
+_All components_ MUST emit error events in accordance with the [Error event]
 requirements.
 
 This specification does not list a standard set of errors that components must
@@ -168,20 +168,20 @@ implement since errors are specific to the component.
 
 **Extends the [EventsDropped event].**
 
-*All components* that can drop events MUST emit a `ComponentEventsDropped`
+_All components_ that can drop events MUST emit a `ComponentEventsDropped`
 event in accordance with the [EventsDropped event] requirements.
 
 #### SinkNetworkBytesSent
 
-*Sinks* MUST emit a `SinkNetworkBytesSent` that represents the egress of
-*raw network bytes*.
+_Sinks_ MUST emit a `SinkNetworkBytesSent` that represents the egress of
+_raw network bytes_.
 
 - Emission
   - MUST emit immediately after egress of raw network bytes regardless
     of whether the transmission was successful or not.
     - This includes pull-based sinks, such as the `prometheus_exporter` sink,
       and SHOULD reflect the bytes sent to the client when requested (pulled).
-  - MUST emit *after* processing of the bytes (encryption, compression,
+  - MUST emit _after_ processing of the bytes (encryption, compression,
     filtering, etc.)
 - Properties
   - `byte_size` - The number of raw network bytes sent after processing.
@@ -199,12 +199,12 @@ event in accordance with the [EventsDropped event] requirements.
 
 #### SourceNetworkBytesReceived
 
-*Sources* MUST emit a `SourceNetworkBytesReceived` event that represents the
-ingress of *raw network bytes*.
+_Sources_ MUST emit a `SourceNetworkBytesReceived` event that represents the
+ingress of _raw network bytes_.
 
 - Emission
   - MUST emit immediately after ingress of raw network bytes.
-  - MUST emit *before* processing of the bytes (decryption, decompression,
+  - MUST emit _before_ processing of the bytes (decryption, decompression,
     filtering, etc.).
     - This includes pull-based sources that issue requests to ingest bytes.
 - Properties
@@ -251,14 +251,14 @@ Further to the above, all sink components MUST support acknowledgements. This re
 configuration option named `acknowledgements` conforming to the `AcknowledgementsConfig` type, as
 well as updating the status of all finalizers deferred above after delivery of the events is
 completed. This update is automatically handled for all sinks that use the newer `StreamSink`
-framework.  Additionally, unit tests for the sink SHOULD ensure through unit tests that delivered
+framework. Additionally, unit tests for the sink SHOULD ensure through unit tests that delivered
 batches have their status updated properly for both normal delivery and delivery errors.
 
-[Configuration Specification]: configuration.md
-[Error event]: instrumentation.md#Error
-[EventsDropped event]: instrumentation.md#EventsDropped
+[configuration specification]: configuration.md
+[error event]: instrumentation.md#Error
+[eventsdropped event]: instrumentation.md#EventsDropped
 [high user experience expectations]: https://github.com/vectordotdev/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md
 [health checks]: ../DEVELOPING.md#sink-healthchecks
-[Instrumentation Specification]: instrumentation.md
+[instrumentation specification]: instrumentation.md
 [logical boundaries of components]: ../USER_EXPERIENCE_DESIGN.md#logical-boundaries
-[RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119
+[rfc 2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/docs/specs/configuration.md
+++ b/docs/specs/configuration.md
@@ -111,5 +111,5 @@ buffer.disk.max_bytes = 1_000_000_000
 
 [component specification]: component.md
 [external tagging]: https://docs.rs/serde_tagged/0.2.0/serde_tagged/ser/external/index.html
-[JSON types]: http://json-schema.org/understanding-json-schema/reference/type.html
+[json types]: http://json-schema.org/understanding-json-schema/reference/type.html
 [user_experience]: ../USER_EXPERIENCE_DESIGN.md

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -135,13 +135,12 @@ not result in data loss if the retry succeeds.**
   - If `intentional` is `false`, MUST log at the `error` level.
   - SHOULD NOT be rate limited.
 
-
 [camelcase]: https://en.wikipedia.org/wiki/Camel_case
-[`EventsDropped`]: #EventsDropped
-[Issue 10658]: https://github.com/vectordotdev/vector/issues/10658
-[Prometheus metric naming standards]: https://prometheus.io/docs/practices/naming/
+[`eventsdropped`]: #EventsDropped
+[issue 10658]: https://github.com/vectordotdev/vector/issues/10658
+[prometheus metric naming standards]: https://prometheus.io/docs/practices/naming/
 [pull request #8383]: https://github.com/vectordotdev/vector/pull/8383/
-[RFC 2064]: https://github.com/vectordotdev/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
-[RFC 9480]: https://github.com/vectordotdev/vector/blob/master/rfcs/2021-10-22-9480-processing-arrays-of-events.md
+[rfc 2064]: https://github.com/vectordotdev/vector/blob/master/rfcs/2020-03-17-2064-event-driven-observability.md
+[rfc 9480]: https://github.com/vectordotdev/vector/blob/master/rfcs/2021-10-22-9480-processing-arrays-of-events.md
 [single base unit]: https://en.wikipedia.org/wiki/SI_base_unit
 [snakecase]: https://en.wikipedia.org/wiki/Snake_case

--- a/docs/specs/target.md
+++ b/docs/specs/target.md
@@ -95,7 +95,7 @@ requirements, the following requirements define support for this architecture:
 - Architecture
   - MUST deploy as a service with reserved/dedicated resources.
   - SHOULD deploy with a persistent disk that is available between deployments by default,
-     MUST be overridable by the user if they do not want a persistent disk.
+    MUST be overridable by the user if they do not want a persistent disk.
   - MUST deploy with Vector's [default aggregator configuration][default_aggregator_configuration].
   - Configured Vector ports, including non-default user configured ports,
     SHOULD be automatically accessible within the Cluster or VPC.
@@ -104,14 +104,14 @@ requirements, the following requirements define support for this architecture:
     mechanisms.
 - Sizing
   - MUST have dedicated/reserved resources that cannot be stolen by other services, preventing
-     the "noisy neighbor" problem to the degree possible.
+    the "noisy neighbor" problem to the degree possible.
   - The Vector service SHOULD NOT be artificially limited with resource
     limiters such as cgroups.
   - SHOULD require 8 vCPUs by default, MUST be overridable by the user.
   - SHOULD require 2 GiB of memory per vCPU (16 GiB in this case) by default,
-     MUST be overridable by the user.
+    MUST be overridable by the user.
   - SHOULD request 36 GiB of disk space per vCPU by default (288 GiB in this case),
-     MUST be overridable by the user.
+    MUST be overridable by the user.
 
 The following are additional requirements for Orchestration Platform installation
 targets:
@@ -121,11 +121,11 @@ targets:
   - SHOULD deploy across multiple availability zones by default, MUST be overridable by the user.
 - Scaling
   - SHOULD provide facilities for provisioning a load balancer to enable horizontal scaling
-     out of the box. MUST be overridable by the user.
+    out of the box. MUST be overridable by the user.
     - Cloud-managed load balancers (i.e., AWS NLB) SHOULD be supported in addition to
-        self-managed load balancers (i.e., HAProxy).
+      self-managed load balancers (i.e., HAProxy).
     - Cloud-managed load balancers SHOULD be prioritized by default over self-managed
-        load balancers.
+      load balancers.
     - Network load balancers (layer-4) SHOULD be prioritized over HTTP load balancers (layer-7)
   - Autoscaling SHOULD be enabled by default, driven by an average of 85%
     CPU utilization and a stabilization period of 5 minutes.
@@ -178,6 +178,6 @@ targets as there is little added benefit.
 [high_availability]: https://vector.dev/docs/setup/going-to-prod/high-availability/
 [reduce_decisions]: https://github.com/vectordotdev/vector/blob/master/docs/USER_EXPERIENCE_DESIGN.md#be-opinionated--reduce-decisions
 [reference_architectures]: https://vector.dev/docs/setup/going-to-prod/arch/
-[RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119
+[rfc 2119]: https://datatracker.ietf.org/doc/html/rfc2119
 [terminology_document]: https://vector.dev/docs/reference/glossary/
 [unified_architecture]: https://vector.dev/docs/setup/going-to-prod/arch/unified/


### PR DESCRIPTION
Found via `markdownlint *.md --disable MD013 MD024`.
