### PR TITLE
chore(vrl): cleanup unused code (saved for LLVM runtime)

### DIFF
--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -5,7 +5,7 @@ use vrl::prelude::*;
 use vrl::state::TypeState;
 
 use crate::{
-    vrl_util::{self, add_index, evaluate_condition, index_from_args},
+    vrl_util::{self, add_index, evaluate_condition},
     Case, Condition, IndexHandle, TableRegistry, TableSearch,
 };
 
@@ -142,40 +142,6 @@ impl Function for FindEnrichmentTableRecords {
             enrichment_tables: registry.as_readonly(),
         }
         .as_expr())
-    }
-
-    fn compile_argument(
-        &self,
-        args: &[(&'static str, Option<FunctionArgument>)],
-        ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("table", Some(expr)) => {
-                let registry =
-                    ctx.get_external_context_mut::<TableRegistry>()
-                        .ok_or(Box::new(vrl_util::Error::TablesNotLoaded)
-                            as Box<dyn DiagnosticMessage>)?;
-
-                let tables = registry
-                    .table_ids()
-                    .into_iter()
-                    .map(Value::from)
-                    .collect::<Vec<_>>();
-
-                let table = expr
-                    .as_enum("table", tables)?
-                    .try_bytes_utf8_lossy()
-                    .expect("table is not valid utf8")
-                    .into_owned();
-
-                let record = index_from_args(table, registry, args)?;
-
-                Ok(Some(Box::new(record) as _))
-            }
-            _ => Ok(None),
-        }
     }
 }
 

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -4,18 +4,14 @@ use value::{kind::Collection, Kind, Value};
 use vrl::prelude::FunctionExpression;
 use vrl::state::TypeState;
 use vrl::{
-    function::{
-        ArgumentList, Compiled, CompiledArgument, Example, FunctionCompileContext, Parameter,
-    },
-    prelude::{
-        expression, DiagnosticMessage, FunctionArgument, Resolved, Result, TypeDef, VrlValueConvert,
-    },
+    function::{ArgumentList, Compiled, Example, FunctionCompileContext, Parameter},
+    prelude::{expression, DiagnosticMessage, Resolved, Result, TypeDef, VrlValueConvert},
     value::kind,
     Context, Expression, Function,
 };
 
 use crate::{
-    vrl_util::{self, add_index, evaluate_condition, index_from_args},
+    vrl_util::{self, add_index, evaluate_condition},
     Case, Condition, IndexHandle, TableRegistry, TableSearch,
 };
 
@@ -144,40 +140,6 @@ impl Function for GetEnrichmentTableRecord {
             enrichment_tables: registry.as_readonly(),
         }
         .as_expr())
-    }
-
-    fn compile_argument(
-        &self,
-        args: &[(&'static str, Option<FunctionArgument>)],
-        ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("table", Some(expr)) => {
-                let registry =
-                    ctx.get_external_context_mut::<TableRegistry>()
-                        .ok_or(Box::new(vrl_util::Error::TablesNotLoaded)
-                            as Box<dyn DiagnosticMessage>)?;
-
-                let tables = registry
-                    .table_ids()
-                    .into_iter()
-                    .map(Value::from)
-                    .collect::<Vec<_>>();
-
-                let table = expr
-                    .as_enum("table", tables)?
-                    .try_bytes_utf8_lossy()
-                    .expect("table is not bytes")
-                    .into_owned();
-
-                let record = index_from_args(table, registry, args)?;
-
-                Ok(Some(Box::new(record) as _))
-            }
-            _ => Ok(None),
-        }
     }
 }
 

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -10,7 +10,7 @@ use std::{
 use value::{kind::Collection, Value};
 
 use crate::{
-    expression::{container::Variant, Block, Container, Expr, Expression, FunctionArgument},
+    expression::{container::Variant, Block, Container, Expr, Expression},
     state::TypeState,
     value::{kind, Kind},
     CompileConfig, Span, TypeDef,
@@ -59,18 +59,6 @@ pub trait Function: Send + Sync + fmt::Debug {
     /// and argument type definition.
     fn parameters(&self) -> &'static [Parameter] {
         &[]
-    }
-
-    /// Implement this function if you need to manipulate and store any function parameters
-    /// at compile time.
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        _name: &str,
-        _expr: Option<&Expr>,
-    ) -> Result<Option<Box<dyn std::any::Any + Send + Sync>>, Box<dyn DiagnosticMessage>> {
-        Ok(None)
     }
 
     /// An optional closure definition for the function.
@@ -457,6 +445,7 @@ fn required<T>(argument: Option<T>) -> T {
 #[cfg(any(test, feature = "test"))]
 mod test_impls {
     use super::*;
+    use crate::expression::FunctionArgument;
     use crate::parser::Node;
 
     impl From<HashMap<&'static str, Value>> for ArgumentList {

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -99,32 +99,6 @@ impl Function for Del {
 
         Ok(Box::new(DelFn { query }))
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("target", Some(expr)) => {
-                let query = match expr {
-                    expression::Expr::Query(query) => query,
-                    _ => {
-                        return Err(Box::new(vrl::function::Error::UnexpectedExpression {
-                            keyword: "field",
-                            expected: "query",
-                            expr: expr.clone(),
-                        }))
-                    }
-                };
-
-                Ok(Some(Box::new(query.clone()) as _))
-            }
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/lib/vrl/stdlib/src/encode_percent.rs
+++ b/lib/vrl/stdlib/src/encode_percent.rs
@@ -130,26 +130,6 @@ impl Function for EncodePercent {
             },
         ]
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("ascii_set", Some(expr)) => {
-                let set = expr
-                    .as_enum("ascii_set", ascii_sets())?
-                    .try_bytes()
-                    .expect("ascii set not bytes");
-                Ok(Some(Box::new(set) as _))
-            }
-            ("ascii_set", None) => Ok(Some(Box::new(Bytes::from("NON_ALPHANUMERIC")) as _)),
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/lib/vrl/stdlib/src/exists.rs
+++ b/lib/vrl/stdlib/src/exists.rs
@@ -32,32 +32,6 @@ impl Function for Exists {
         ]
     }
 
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("field", Some(expr)) => {
-                let query = match expr {
-                    expression::Expr::Query(query) => query,
-                    _ => {
-                        return Err(Box::new(vrl::function::Error::UnexpectedExpression {
-                            keyword: "field",
-                            expected: "query",
-                            expr: expr.clone(),
-                        }))
-                    }
-                };
-
-                Ok(Some(Box::new(query.clone()) as _))
-            }
-            _ => Ok(None),
-        }
-    }
-
     fn compile(
         &self,
         _state: &state::TypeState,

--- a/lib/vrl/stdlib/src/is_json.rs
+++ b/lib/vrl/stdlib/src/is_json.rs
@@ -110,26 +110,6 @@ impl Function for IsJson {
             None => Ok(IsJsonFn { value }.as_expr()),
         }
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("variant", Some(expr)) => {
-                let variant = expr
-                    .as_enum("variant", variants())?
-                    .try_bytes()
-                    .map_err(|e| Box::new(e) as Box<dyn DiagnosticMessage>)?;
-
-                Ok(Some(Box::new(variant) as _))
-            }
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -30,16 +30,6 @@ fn log(
     Ok(Value::Null)
 }
 
-fn levels() -> Vec<Bytes> {
-    vec![
-        Bytes::from("trace"),
-        Bytes::from("debug"),
-        Bytes::from("info"),
-        Bytes::from("warn"),
-        Bytes::from("error"),
-    ]
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct Log;
 
@@ -113,46 +103,6 @@ impl Function for Log {
         }
         .as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        if name == "level" {
-            let level = match expr {
-                Some(expr) => match expr.as_value() {
-                    Some(value) => levels()
-                        .into_iter()
-                        .find(|level| Some(level) == value.as_bytes())
-                        .ok_or_else(|| vrl::function::Error::InvalidEnumVariant {
-                            keyword: "level",
-                            value,
-                            variants: levels().into_iter().map(Value::from).collect::<Vec<_>>(),
-                        })?,
-                    None => return Ok(None),
-                },
-                None => Bytes::from("info"),
-            };
-
-            let level = LogInfo {
-                level,
-                span: ctx.span(),
-            };
-            Ok(Some(Box::new(level) as Box<dyn std::any::Any + Send + Sync>))
-        } else {
-            Ok(None)
-        }
-    }
-}
-
-#[allow(unused)] // will be used by LLVM runtime
-#[derive(Debug)]
-struct LogInfo {
-    level: Bytes,
-    span: vrl::diagnostic::Span,
 }
 
 #[derive(Debug, Clone)]

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -73,37 +73,6 @@ impl Function for MatchAny {
 
         Ok(MatchAnyFn { value, regex_set }.as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("patterns", Some(expr)) => {
-                let patterns = expr
-                    .as_value()
-                    .and_then(|value| value.try_array().ok())
-                    .ok_or_else(|| vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "patterns",
-                        expr: expr.clone(),
-                    })?;
-                let mut re_strings = Vec::with_capacity(patterns.len());
-                for value in patterns {
-                    let re = value
-                        .try_regex()
-                        .map_err(|e| Box::new(e) as Box<dyn DiagnosticMessage>)?;
-                    re_strings.push(re.to_string());
-                }
-
-                let regex_set = RegexSet::new(re_strings).expect("regex were already valid");
-                Ok(Some(Box::new(regex_set) as _))
-            }
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -87,25 +87,6 @@ impl Function for ParseApacheLog {
         .as_expr())
     }
 
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("format", Some(expr)) => {
-                let format = expr
-                    .as_enum("format", variants())?
-                    .try_bytes()
-                    .expect("format not bytes");
-                Ok(Some(Box::new(format) as _))
-            }
-            _ => Ok(None),
-        }
-    }
-
     fn examples(&self) -> &'static [Example] {
         &[
             Example {

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -61,33 +61,6 @@ impl Function for ParseGrok {
 
         ParseGroks::compile(value, patterns, aliases)
     }
-
-    fn compile_argument(
-        &self,
-        args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("pattern", Some(expr)) => {
-                let pattern = expr.as_literal("pattern")?;
-                let patterns = vec![pattern];
-
-                let aliases = args.iter().find_map::<&FunctionArgument, _>(|(name, arg)| {
-                    if *name == "aliases" {
-                        arg.as_ref()
-                    } else {
-                        None
-                    }
-                });
-
-                ParseGroks::compile_pattern_argument(patterns, aliases)
-            }
-            ("aliases", Some(_)) => Ok(None),
-            _ => Ok(None),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -1,10 +1,8 @@
-use std::{collections::BTreeMap, fmt};
-
-use ::value::Value;
 use datadog_grok::{
     parse_grok,
     parse_grok_rules::{self, GrokRule},
 };
+use std::{collections::BTreeMap, fmt};
 use vrl::{
     diagnostic::{Label, Span},
     prelude::{expression::Expr, *},
@@ -91,49 +89,6 @@ impl ParseGroks {
 
         Ok(ParseGroksFn { value, grok_rules }.as_expr())
     }
-
-    pub(crate) fn compile_pattern_argument(
-        patterns: Vec<Value>,
-        aliases: Option<&FunctionArgument>,
-    ) -> CompiledArgument {
-        let aliases = aliases
-            .map(|aliases| {
-                aliases
-                    .as_value()
-                    .unwrap()
-                    .try_object()
-                    .unwrap()
-                    .into_iter()
-                    .map(|(key, expr)| {
-                        let alias = expr
-                            .try_bytes_utf8_lossy()
-                            .expect("should be a string")
-                            .into_owned();
-                        Ok((key, alias))
-                    })
-                    .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>(
-                    )
-                    .unwrap()
-            })
-            .unwrap_or_default();
-
-        let patterns = patterns
-            .into_iter()
-            .map(|value| {
-                let pattern = value
-                    .try_bytes_utf8_lossy()
-                    .expect("grok pattern not bytes")
-                    .into_owned();
-                Ok(pattern)
-            })
-            .collect::<std::result::Result<Vec<String>, vrl::function::Error>>()?;
-
-        // We use a datadog library here because it is a superset of grok.
-        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
-            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
-
-        Ok(Some(Box::new(grok_rules) as _))
-    }
 }
 
 impl Function for ParseGroks {
@@ -187,42 +142,6 @@ impl Function for ParseGroks {
                 }
             "#}),
         }]
-    }
-
-    fn compile_argument(
-        &self,
-        args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("patterns", Some(expr)) => {
-                let patterns = expr
-                    .as_value()
-                    .ok_or_else(|| vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "patterns",
-                        expr: expr.clone(),
-                    })?
-                    .try_array()
-                    .map_err(|_| vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "patterns",
-                        expr: expr.clone(),
-                    })?;
-
-                let aliases = args.iter().find_map::<&FunctionArgument, _>(|(name, arg)| {
-                    if *name == "aliases" {
-                        arg.as_ref()
-                    } else {
-                        None
-                    }
-                });
-
-                Self::compile_pattern_argument(patterns, aliases)
-            }
-            ("aliases", Some(_)) => Ok(None),
-            _ => Ok(None),
-        }
     }
 
     fn compile(

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -137,32 +137,6 @@ impl Function for ParseKeyValue {
         }
         .as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("whitespace", Some(expr)) => match expr.as_value() {
-                None => Ok(None),
-                Some(value) => Ok(Some(
-                    Whitespace::from_str(
-                        &value.try_bytes_utf8_lossy().expect("whitespace not bytes"),
-                    )
-                    .map(|whitespace| Box::new(whitespace) as Box<dyn std::any::Any + Send + Sync>)
-                    .map_err(|_| vrl::function::Error::InvalidEnumVariant {
-                        keyword: "whitespace",
-                        value,
-                        variants: Whitespace::all_value(),
-                    })?,
-                )),
-            },
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -96,25 +96,6 @@ impl Function for ParseNginxLog {
             },
         ]
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("format", Some(expr)) => {
-                let format = expr
-                    .as_enum("format", variants())?
-                    .try_bytes()
-                    .expect("format not bytes");
-                Ok(Some(Box::new(format) as _))
-            }
-            _ => Ok(None),
-        }
-    }
 }
 
 fn regex_for_format(format: &[u8]) -> &Regex {

--- a/lib/vrl/stdlib/src/parse_regex.rs
+++ b/lib/vrl/stdlib/src/parse_regex.rs
@@ -1,6 +1,6 @@
 use ::value::Value;
 use regex::Regex;
-use vrl::{function::Error, prelude::*};
+use vrl::prelude::*;
 
 use crate::util;
 
@@ -84,32 +84,6 @@ impl Function for ParseRegex {
             }"# }),
             },
         ]
-    }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("pattern", Some(expr)) => {
-                let regex: regex::Regex = match expr {
-                    expression::Expr::Literal(expression::Literal::Regex(regex)) => {
-                        Ok((**regex).clone())
-                    }
-                    expr => Err(Error::UnexpectedExpression {
-                        keyword: "pattern",
-                        expected: "regex",
-                        expr: expr.clone(),
-                    }),
-                }?;
-
-                Ok(Some(Box::new(regex) as _))
-            }
-            _ => Ok(None),
-        }
     }
 }
 

--- a/lib/vrl/stdlib/src/parse_regex_all.rs
+++ b/lib/vrl/stdlib/src/parse_regex_all.rs
@@ -1,6 +1,6 @@
 use ::value::Value;
 use regex::Regex;
-use vrl::{function::Error, prelude::*};
+use vrl::prelude::*;
 
 use crate::util;
 
@@ -89,32 +89,6 @@ impl Function for ParseRegexAll {
                 "2": "peas"}]"# }),
             },
         ]
-    }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("pattern", Some(expr)) => {
-                let regex: regex::Regex = match expr {
-                    expression::Expr::Literal(expression::Literal::Regex(regex)) => {
-                        Ok((**regex).clone())
-                    }
-                    expr => Err(Error::UnexpectedExpression {
-                        keyword: "pattern",
-                        expected: "regex",
-                        expr: expr.clone(),
-                    }),
-                }?;
-
-                Ok(Some(Box::new(regex) as _))
-            }
-            _ => Ok(None),
-        }
     }
 }
 

--- a/lib/vrl/stdlib/src/parse_user_agent.rs
+++ b/lib/vrl/stdlib/src/parse_user_agent.rs
@@ -8,7 +8,7 @@ use std::{
 use ::value::Value;
 use once_cell::sync::Lazy;
 use uaparser::UserAgentParser as UAParser;
-use vrl::{function::Error, prelude::*};
+use vrl::prelude::*;
 use woothee::parser::Parser as WootheeParser;
 
 static UA_PARSER: Lazy<UAParser> = Lazy::new(|| {
@@ -141,80 +141,6 @@ impl Function for ParseUserAgent {
         }
         .as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match name {
-            "mode" => {
-                let mode = expr
-                    .and_then(|expr| {
-                        expr.as_value().map(|value| {
-                            let s = value.try_bytes_utf8_lossy().expect("mode not bytes");
-                            Mode::from_str(&s).map_err(|_| Error::InvalidEnumVariant {
-                                keyword: "mode",
-                                value,
-                                variants: Mode::all_value(),
-                            })
-                        })
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-
-                let parser = match mode {
-                    Mode::Fast => {
-                        let parser = WootheeParser::new();
-                        ParserMode {
-                            fun: Box::new(move |s: &str| {
-                                parser.parse_user_agent(s).partial_schema()
-                            }),
-                        }
-                    }
-                    Mode::Reliable => {
-                        let fast = WootheeParser::new();
-                        let slow = &UA_PARSER;
-
-                        ParserMode {
-                            fun: Box::new(move |s: &str| {
-                                let ua = fast.parse_user_agent(s);
-                                let ua = if ua.browser.family.is_none() || ua.os.family.is_none() {
-                                    let better_ua = slow.parse_user_agent(s);
-                                    better_ua.or(ua)
-                                } else {
-                                    ua
-                                };
-                                ua.partial_schema()
-                            }),
-                        }
-                    }
-                    Mode::Enriched => {
-                        let fast = WootheeParser::new();
-                        let slow = &UA_PARSER;
-
-                        ParserMode {
-                            fun: Box::new(move |s: &str| {
-                                slow.parse_user_agent(s)
-                                    .or(fast.parse_user_agent(s))
-                                    .full_schema()
-                            }),
-                        }
-                    }
-                };
-
-                Ok(Some(Box::new(parser) as _))
-            }
-            _ => Ok(None),
-        }
-    }
-}
-
-#[allow(dead_code)] // will be used by LLVM runtime
-struct ParserMode {
-    fun: Box<dyn Fn(&str) -> Value + Send + Sync>,
 }
 
 #[derive(Clone)]

--- a/lib/vrl/stdlib/src/redact.rs
+++ b/lib/vrl/stdlib/src/redact.rs
@@ -98,45 +98,6 @@ impl Function for Redact {
         }
         .as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("filters", Some(expr)) => {
-                let filters = expr.as_value().ok_or_else(|| {
-                    vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "filters",
-                        expr: expr.clone(),
-                    }
-                })?;
-                let filters = filters
-                    .try_array()
-                    .map_err(|_| vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "filters",
-                        expr: expr.clone(),
-                    })?
-                    .into_iter()
-                    .map(|value| {
-                        value.clone().try_into().map_err(|error| {
-                            vrl::function::Error::InvalidArgument {
-                                keyword: "filters",
-                                value,
-                                error,
-                            }
-                        })
-                    })
-                    .collect::<std::result::Result<Vec<Filter>, vrl::function::Error>>()?;
-
-                Ok(Some(Box::new(filters) as _))
-            }
-            _ => Ok(None),
-        }
-    }
 }
 
 //-----------------------------------------------------------------------------

--- a/lib/vrl/stdlib/src/sha2.rs
+++ b/lib/vrl/stdlib/src/sha2.rs
@@ -80,27 +80,6 @@ impl Function for Sha2 {
 
         Ok(Sha2Fn { value, variant }.as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("variant", Some(expr)) => {
-                let variant = expr
-                    .as_enum("variant", variants())?
-                    .try_bytes()
-                    .expect("variant not bytes");
-
-                Ok(Some(Box::new(variant) as _))
-            }
-            ("variant", None) => Ok(Some(Box::new(Bytes::from("SHA-512/256")) as _)),
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/lib/vrl/stdlib/src/sha3.rs
+++ b/lib/vrl/stdlib/src/sha3.rs
@@ -76,27 +76,6 @@ impl Function for Sha3 {
 
         Ok(Sha3Fn { value, variant }.as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("variant", Some(expr)) => {
-                let variant = expr
-                    .as_enum("variant", variants())?
-                    .try_bytes()
-                    .expect("variant not bytes");
-
-                Ok(Some(Box::new(variant) as _))
-            }
-            ("variant", None) => Ok(Some(Box::new(Bytes::from("SHA3-512")) as _)),
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/lib/vrl/stdlib/src/to_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_timestamp.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use ::value::Value;
 use chrono::{TimeZone as _, Utc};
 use vector_common::{conversion::Conversion, TimeZone};
-use vrl::{function::Error, prelude::*};
+use vrl::prelude::*;
 
 fn to_timestamp(value: Value, unit: Unit) -> Resolved {
     use Value::{Bytes, Float, Integer, Timestamp};
@@ -197,33 +197,6 @@ impl Function for ToTimestamp {
             .unwrap_or_default();
 
         Ok(ToTimestampFn { value, unit }.as_expr())
-    }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("unit", Some(expr)) => match expr.as_value() {
-                None => Ok(None),
-                Some(value) => {
-                    let s = value.try_bytes_utf8_lossy().expect("unit not bytes");
-                    Ok(Some(
-                        Unit::from_str(&s)
-                            .map(|unit| Box::new(unit) as Box<dyn std::any::Any + Send + Sync>)
-                            .map_err(|_| Error::InvalidEnumVariant {
-                                keyword: "unit",
-                                value,
-                                variants: Unit::all_value(),
-                            })?,
-                    ))
-                }
-            },
-            _ => Ok(None),
-        }
     }
 }
 

--- a/lib/vrl/stdlib/src/to_unix_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_unix_timestamp.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use ::value::Value;
-use vrl::{function::Error, prelude::*};
+use vrl::prelude::*;
 
 fn to_unix_timestamp(value: Value, unit: Unit) -> Resolved {
     let ts = value.try_timestamp()?;
@@ -73,33 +73,6 @@ impl Function for ToUnixTimestamp {
             .unwrap_or_default();
 
         Ok(ToUnixTimestampFn { value, unit }.as_expr())
-    }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("unit", Some(expr)) => match expr.as_value() {
-                None => Ok(None),
-                Some(value) => {
-                    let s = value.try_bytes_utf8_lossy().expect("unit not bytes");
-                    Ok(Some(
-                        Unit::from_str(&s)
-                            .map(|unit| Box::new(unit) as Box<dyn std::any::Any + Send + Sync>)
-                            .map_err(|_| Error::InvalidEnumVariant {
-                                keyword: "unit",
-                                value,
-                                variants: Unit::all_value(),
-                            })?,
-                    ))
-                }
-            },
-            _ => Ok(None),
-        }
     }
 }
 

--- a/lib/vrl/stdlib/src/unnest.rs
+++ b/lib/vrl/stdlib/src/unnest.rs
@@ -106,32 +106,6 @@ impl Function for Unnest {
 
         Ok(UnnestFn { path, root }.as_expr())
     }
-
-    fn compile_argument(
-        &self,
-        _args: &[(&'static str, Option<FunctionArgument>)],
-        _ctx: &mut FunctionCompileContext,
-        name: &str,
-        expr: Option<&expression::Expr>,
-    ) -> CompiledArgument {
-        match (name, expr) {
-            ("path", Some(expr)) => {
-                let query = match expr {
-                    expression::Expr::Query(query) => query,
-                    _ => {
-                        return Err(Box::new(vrl::function::Error::UnexpectedExpression {
-                            keyword: "path",
-                            expected: "query",
-                            expr: expr.clone(),
-                        }))
-                    }
-                };
-
-                Ok(Some(Box::new(query.clone()) as _))
-            }
-            _ => Ok(None),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This is a continuation of the cleanup from https://github.com/vectordotdev/vector/pull/12888

Some code was originally preserved even though it was unused because the LLVM runtime may have used it. Now that it seems like the LLVM runtime won't exist anytime soon, that is also being cleaned up.