### PR TITLE
revert(sources): Revert halting stream sources on error acknowledgements

### DIFF
--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -450,27 +450,4 @@ mod source {
             emit!(PathGlobbingError { path, error });
         }
     }
-
-    pub struct FileNegativeAcknowledgementError<'a> {
-        pub filename: &'a str,
-    }
-
-    impl InternalEvent for FileNegativeAcknowledgementError<'_> {
-        fn emit(self) {
-            error!(
-                message = "Event received a negative acknowledgment, file has been stopped.",
-                error_code = "negative_acknowledgement",
-                error_type = error_type::ACKNOWLEDGMENT_FAILED,
-                stage = error_stage::SENDING,
-                filename = self.filename,
-                internal_log_rate_secs = 10,
-            );
-            counter!(
-                "component_errors_total", 1,
-                "error_code" => "negative_acknowledgment",
-                "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
-                "stage" => error_stage::SENDING,
-            );
-        }
-    }
 }

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -27,25 +27,3 @@ impl InternalEvent for JournaldInvalidRecordError {
         counter!("invalid_record_bytes_total", self.text.len() as u64); // deprecated
     }
 }
-
-pub struct JournaldNegativeAcknowledgmentError<'a> {
-    pub cursor: &'a str,
-}
-
-impl InternalEvent for JournaldNegativeAcknowledgmentError<'_> {
-    fn emit(self) {
-        error!(
-            message = "Event received a negative acknowledgment, journal has been stopped.",
-            error_code = "negative_acknowledgement",
-            error_type = error_type::ACKNOWLEDGMENT_FAILED,
-            stage = error_stage::SENDING,
-            cursor = self.cursor,
-        );
-        counter!(
-            "component_errors_total", 1,
-            "error_code" => "negative_acknowledgment",
-            "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
-            "stage" => error_stage::SENDING,
-        );
-    }
-}

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -173,29 +173,3 @@ impl InternalEvent for KafkaHeaderExtractionError<'_> {
         counter!("kafka_header_extraction_failures_total", 1);
     }
 }
-
-pub struct KafkaNegativeAcknowledgmentError<'a> {
-    pub topic: &'a str,
-    pub partition: i32,
-    pub offset: i64,
-}
-
-impl InternalEvent for KafkaNegativeAcknowledgmentError<'_> {
-    fn emit(self) {
-        error!(
-            message = "Event received a negative acknowledgment, topic has been stopped.",
-            error_code = "negative_acknowledgement",
-            error_type = error_type::ACKNOWLEDGMENT_FAILED,
-            stage = error_stage::SENDING,
-            topic = self.topic,
-            partition = self.partition,
-            offset = self.offset,
-        );
-        counter!(
-            "component_errors_total", 1,
-            "error_code" => "negative_acknowledgment",
-            "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
-            "stage" => error_stage::SENDING,
-        );
-    }
-}

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -127,14 +127,16 @@ impl SourceSender {
     }
 
     #[cfg(test)]
-    pub fn new_test_error_after(n: usize) -> (Self, impl Stream<Item = Event> + Unpin) {
+    pub fn new_test_errors(
+        error_at: impl Fn(usize) -> bool,
+    ) -> (Self, impl Stream<Item = Event> + Unpin) {
         let (pipe, recv) = Self::new_with_buffer(TEST_BUFFER_SIZE);
         // In a source test pipeline, there is no sink to acknowledge
         // events, so we have to add a map to the receiver to handle the
         // finalization.
         let mut count: usize = 0;
         let recv = recv.into_stream().flat_map(move |mut events| {
-            let status = if count == n {
+            let status = if error_at(count) {
                 EventStatus::Errored
             } else {
                 EventStatus::Delivered

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -19,6 +19,7 @@ mod errors;
 pub use errors::{ClosedError, StreamSendError};
 
 pub(crate) const CHUNK_SIZE: usize = 1000;
+
 #[cfg(test)]
 const TEST_BUFFER_SIZE: usize = 100;
 
@@ -103,7 +104,7 @@ impl SourceSender {
 
     #[cfg(test)]
     pub fn new_test() -> (Self, impl Stream<Item = Event> + Unpin) {
-        let (pipe, recv) = Self::new_with_buffer(TEST_BUFFER_SIZE);
+        let (pipe, recv) = Self::new_with_buffer(4096);
         let recv = recv.into_stream().flat_map(into_event_stream);
         (pipe, recv)
     }

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -104,7 +104,7 @@ impl SourceSender {
 
     #[cfg(test)]
     pub fn new_test() -> (Self, impl Stream<Item = Event> + Unpin) {
-        let (pipe, recv) = Self::new_with_buffer(4096);
+        let (pipe, recv) = Self::new_with_buffer(TEST_BUFFER_SIZE);
         let recv = recv.into_stream().flat_map(into_event_stream);
         (pipe, recv)
     }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1042,16 +1042,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_file_key_acknowledged() {
-        file_file_key(Acks).await
+    async fn file_key_acknowledged() {
+        file_key(Acks).await
     }
 
     #[tokio::test]
-    async fn file_file_key_nonacknowledged() {
-        file_file_key(NoAcks).await
+    async fn file_key_nonacknowledged() {
+        file_key(NoAcks).await
     }
 
-    async fn file_file_key(acks: AckingMode) {
+    async fn file_key(acks: AckingMode) {
         // Default
         {
             let dir = tempdir().unwrap();

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,6 +1,4 @@
-use std::{
-    collections::HashSet, convert::TryInto, path::PathBuf, sync::Arc, sync::Mutex, time::Duration,
-};
+use std::{convert::TryInto, path::PathBuf, time::Duration};
 
 use bytes::Bytes;
 use chrono::Utc;
@@ -23,16 +21,13 @@ use crate::{
     encoding_transcode::{Decoder, Encoder},
     event::{BatchNotifier, BatchStatus, LogEvent},
     internal_events::{
-        FileBytesReceived, FileEventsReceived, FileNegativeAcknowledgementError, FileOpen,
-        FileSourceInternalEventsEmitter,
+        FileBytesReceived, FileEventsReceived, FileOpen, FileSourceInternalEventsEmitter,
     },
     line_agg::{self, LineAgg},
     serde::bool_or_struct,
     shutdown::ShutdownSignal,
     SourceSender,
 };
-
-const POISONED_FAILED_LOCK: &str = "Poisoned lock on failed files set";
 
 #[derive(Debug, Snafu)]
 enum BuildError {
@@ -275,7 +270,6 @@ const fn default_lines() -> usize {
 
 #[derive(Debug)]
 pub(crate) struct FinalizerEntry {
-    pub(crate) file_name: String,
     pub(crate) file_id: FileFingerprint,
     pub(crate) offset: u64,
 }
@@ -433,14 +427,6 @@ pub fn file_source(
     let message_start_indicator = config.message_start_indicator.clone();
     let multi_line_timeout = config.multi_line_timeout;
 
-    // The `failed_files` set contains `FileFingerprint`s, provided by
-    // the file server, of all files that have received a negative
-    // acknowledgements. This set is shared between the finalizer
-    // task, which both holds back checkpointer updates if an
-    // identifier is present and adds entries on negative
-    // acknowledgements, and the main file server handling task, which
-    // holds back further events from files in the set.
-    let failed_files: Arc<Mutex<HashSet<FileFingerprint>>> = Default::default();
     let (finalizer, shutdown_checkpointer) = if acknowledgements {
         // The shutdown sent in to the finalizer is the global
         // shutdown handle used to tell it to stop accepting new batch
@@ -452,21 +438,10 @@ pub fn file_source(
         // checkpoints until all the acks have come in.
         let (send_shutdown, shutdown2) = oneshot::channel::<()>();
         let checkpoints = checkpointer.view();
-        let failed_files = Arc::clone(&failed_files);
         tokio::spawn(async move {
             while let Some((status, entry)) = ack_stream.next().await {
-                // Don't update the checkpointer on file streams after failed acks
-                let mut failed_files = failed_files.lock().expect(POISONED_FAILED_LOCK);
-                // Hold back updates for failed files
-                if !failed_files.contains(&entry.file_id) {
-                    if status == BatchStatus::Delivered {
-                        checkpoints.update(entry.file_id, entry.offset);
-                    } else {
-                        emit!(FileNegativeAcknowledgementError {
-                            filename: &entry.file_name,
-                        });
-                        failed_files.insert(entry.file_id);
-                    }
+                if status == BatchStatus::Delivered {
+                    checkpoints.update(entry.file_id, entry.offset);
                 }
             }
             send_shutdown.send(())
@@ -494,21 +469,13 @@ pub fn file_source(
                     byte_size: line.text.len(),
                     file: &line.filename,
                 });
-                let failed = failed_files
-                    .lock()
-                    .expect(POISONED_FAILED_LOCK)
-                    .contains(&line.file_id);
-                // Drop the incoming data if the file received a negative acknowledgement.
-                (!failed).then(|| {
-                    // transcode each line from the file's encoding charset to utf8
-                    if let Some(d) = &mut encoding_decoder {
-                        line.text = d.decode_to_utf8(line.text);
-                    }
-                    line
-                })
-            })
-            .map(futures::stream::iter)
-            .flatten();
+                // transcode each line from the file's encoding charset to utf8
+                line.text = match encoding_decoder.as_mut() {
+                    Some(d) => d.decode_to_utf8(line.text),
+                    None => line.text,
+                };
+                line
+            });
 
         let messages: Box<dyn Stream<Item = Line> + Send + std::marker::Unpin> =
             if let Some(ref multiline_config) = multiline_config {
@@ -545,7 +512,6 @@ pub fn file_source(
                 let (batch, receiver) = BatchNotifier::new_with_receiver();
                 event = event.with_batch_notifier(&batch);
                 let entry = FinalizerEntry {
-                    file_name: line.filename,
                     file_id: line.file_id,
                     offset: line.end_offset,
                 };
@@ -664,18 +630,15 @@ fn create_event(line: Bytes, offset: u64, file: &str, meta: &EventMetadata) -> L
 #[cfg(test)]
 mod tests {
     use std::{
-        cmp::{max, min},
         collections::HashSet,
         fs::{self, File},
         future::Future,
-        io::{Read, Seek, Write},
-        path::Path,
+        io::{Seek, Write},
     };
 
     use encoding_rs::UTF_16LE;
     use pretty_assertions::assert_eq;
-    use serde::Deserialize;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::tempdir;
     use tokio::time::{sleep, timeout, Duration};
 
     use super::*;
@@ -692,7 +655,7 @@ mod tests {
         crate::test_util::test_generate_config::<FileConfig>();
     }
 
-    fn test_default_file_config(dir: &TempDir) -> file::FileConfig {
+    fn test_default_file_config(dir: &tempfile::TempDir) -> file::FileConfig {
         file::FileConfig {
             fingerprint: FingerprintConfig::Checksum {
                 bytes: Some(8),
@@ -818,7 +781,7 @@ mod tests {
         };
         let log = create_event(line, offset, file, &meta);
 
-        assert_eq!(log["file"], file.into());
+        assert_eq!(log["file"], "some_file.rs".into());
         assert_eq!(log["host"], "Some.Machine".into());
         assert_eq!(log["offset"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
@@ -1079,16 +1042,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_key_acknowledged() {
-        file_key(Acks).await
+    async fn file_file_key_acknowledged() {
+        file_file_key(Acks).await
     }
 
     #[tokio::test]
-    async fn file_key_nonacknowledged() {
-        file_key(NoAcks).await
+    async fn file_file_key_nonacknowledged() {
+        file_file_key(NoAcks).await
     }
 
-    async fn file_key(acks: AckingMode) {
+    async fn file_file_key(acks: AckingMode) {
         // Default
         {
             let dir = tempdir().unwrap();
@@ -1274,95 +1237,6 @@ mod tests {
         let received = run_file_source(&config, false, Unfinalized, sleep_500_millis()).await;
         let lines = extract_messages_string(received);
         assert_eq!(lines, vec!["the line"]);
-    }
-
-    #[tokio::test]
-    async fn file_start_position_negative_acknowledgement() {
-        let dir = tempdir().unwrap();
-        let config = file::FileConfig {
-            include: vec![dir.path().join("*")],
-            ..test_default_file_config(&dir)
-        };
-
-        let path = dir.path().join("file");
-        let orig: Vec<String> = (0..10).map(|n| format!("line #{:03}", n)).collect();
-        let line_len = orig[0].len() as u64 + 1;
-
-        // First time server runs it picks up existing lines.
-        let received =
-            run_file_source(&config, false, Nack(2), slow_write(&path, &orig, 100, 1)).await;
-        let lines = extract_messages_string(received);
-        let checkpoints = read_checkpoints(&dir);
-        assert_eq!(checkpoints.len(), 1);
-        assert_eq!(checkpoints[0].position, line_len * 2);
-        assert_eq!(&lines, &orig[0..3]);
-    }
-
-    #[tokio::test]
-    async fn file_start_position_negative_acknowledgement_multi_file() {
-        let dir = tempdir().unwrap();
-        let config = file::FileConfig {
-            include: vec![dir.path().join("*")],
-            ..test_default_file_config(&dir)
-        };
-
-        let path = dir.path().join("file");
-        let orig: Vec<String> = (0..10).map(|n| format!("line #{:03}", n)).collect();
-        let line_len = orig[0].len() as u64 + 1;
-
-        // First time server runs it picks up existing lines.
-        let received =
-            run_file_source(&config, false, Nack(2), slow_write(&path, &orig, 100, 2)).await;
-        let lines = extract_messages_string(received);
-        let checkpoints = read_checkpoints(&dir);
-        assert_eq!(checkpoints.len(), 2);
-        assert_eq!(
-            min(checkpoints[0].position, checkpoints[1].position),
-            line_len * 2
-        );
-        assert_eq!(
-            max(checkpoints[0].position, checkpoints[1].position),
-            line_len * 5
-        );
-        assert_eq!(lines.len(), 8);
-        assert_eq!(&lines[..3], &orig[..3]);
-        assert_eq!(&lines[3..], &orig[5..]);
-    }
-
-    async fn slow_write(filename: &Path, lines: &[String], millis: u64, files: usize) {
-        let duration = Duration::from_millis(millis);
-        for lines in lines.chunks(lines.len() / files) {
-            let mut file = File::create(filename).unwrap();
-            for line in lines {
-                writeln!(&mut file, "{}", line).unwrap();
-                sleep(duration).await;
-            }
-        }
-        sleep_500_millis().await;
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct Checkpoint {
-        // fingerprint: JsonValue,
-        // modified: String,
-        position: u64,
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct Checkpoints {
-        version: String,
-        checkpoints: Vec<Checkpoint>,
-    }
-
-    fn read_checkpoints(dir: &TempDir) -> Vec<Checkpoint> {
-        let mut filename = dir.path().to_path_buf();
-        filename.push(file_source::CHECKPOINT_FILE_NAME);
-        let mut file = File::open(filename).unwrap();
-        let mut buf = String::new();
-        file.read_to_string(&mut buf).unwrap();
-        let checkpoints: Checkpoints = serde_json::from_str(&buf).unwrap();
-        assert_eq!(&checkpoints.version, "1");
-        checkpoints.checkpoints
     }
 
     #[tokio::test]
@@ -1918,7 +1792,6 @@ mod tests {
         NoAcks,      // No acknowledgement handling and no finalization
         Unfinalized, // Acknowledgement handling but no finalization
         Acks,        // Full acknowledgements and proper finalization
-        Nack(usize), // Error acknowledgement after N events
     }
     use AckingMode::*;
 
@@ -1929,50 +1802,40 @@ mod tests {
         inner: impl Future<Output = ()>,
     ) -> Vec<Event> {
         assert_source_compliance(&FILE_SOURCE_TAGS, async move {
-            let (tx, rx) = match acking_mode {
-                Acks => {
-                    let (tx, rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
-                    (tx, rx.boxed())
-                }
-                NoAcks | Unfinalized => {
-                    let (tx, rx) = SourceSender::new_test();
-                    (tx, rx.boxed())
-                }
-                Nack(after) => {
-                    let (tx, rx) = SourceSender::new_test_error_after(after);
-                    (tx, rx.boxed())
-                }
+            let (tx, rx) = if acking_mode == Acks {
+                let (tx, rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+                (tx, rx.boxed())
+            } else {
+                let (tx, rx) = SourceSender::new_test();
+                (tx, rx.boxed())
             };
 
             let (trigger_shutdown, shutdown, shutdown_done) = ShutdownSignal::new_wired();
             let data_dir = config.data_dir.clone().unwrap();
             let acks = !matches!(acking_mode, NoAcks);
 
-            // Run the collector concurrent to the file source, to execute finalizers.
-            let collector = if acking_mode == Unfinalized {
-                tokio::spawn(
-                rx.take_until(tokio::time::sleep(Duration::from_secs(5)))
-                    .collect::<Vec<_>>())
-            } else {
-                tokio::spawn(async {
-                    timeout(Duration::from_secs(5), rx.collect::<Vec<_>>())
-                        .await
-                        .expect(
-                            "Unclosed channel: may indicate file-server could not shutdown gracefully.",
-                        )
-                })
-            };
             tokio::spawn(file::file_source(config, data_dir, shutdown, tx, acks));
 
             inner.await;
 
             drop(trigger_shutdown);
 
+            let result = if acking_mode == Unfinalized {
+                rx.take_until(tokio::time::sleep(Duration::from_secs(5)))
+                    .collect::<Vec<_>>()
+                    .await
+            } else {
+                timeout(Duration::from_secs(5), rx.collect::<Vec<_>>())
+                    .await
+                    .expect(
+                        "Unclosed channel: may indicate file-server could not shutdown gracefully.",
+                    )
+            };
             if wait_shutdown {
                 shutdown_done.await;
             }
 
-            collector.await.expect("Collector task failed")
+            result
         })
         .await
     }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     io::Cursor,
     sync::Arc,
 };
@@ -30,8 +30,8 @@ use crate::{
     config::{log_schema, AcknowledgementsConfig, LogSchema, Output, SourceConfig, SourceContext},
     event::{BatchNotifier, BatchStatus, Event, Value},
     internal_events::{
-        KafkaBytesReceived, KafkaEventsReceived, KafkaNegativeAcknowledgmentError,
-        KafkaOffsetUpdateError, KafkaReadError, StreamClosedError,
+        KafkaBytesReceived, KafkaEventsReceived, KafkaOffsetUpdateError, KafkaReadError,
+        StreamClosedError,
     },
     kafka::{KafkaAuthConfig, KafkaStatisticsContext},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
@@ -241,13 +241,17 @@ async fn kafka_source(
     let mut stream = consumer.stream();
     let keys = Keys::from(log_schema(), &config);
 
-    let mut topics = Topics::new(&config);
-
     loop {
         tokio::select! {
             _ = &mut shutdown => break,
             entry = ack_stream.next() => if let Some((status, entry)) = entry {
-                handle_ack(&mut topics, status, entry, &consumer);
+                if status == BatchStatus::Delivered {
+                    if let Err(error) =
+                        consumer.store_offset(&entry.topic, entry.partition, entry.offset)
+                    {
+                        emit!(KafkaOffsetUpdateError { error });
+                    }
+                }
             },
             message = stream.next() => match message {
                 None => break,  // WHY?
@@ -260,7 +264,7 @@ async fn kafka_source(
                         partition: msg.partition(),
                     });
 
-                    parse_message(msg, &decoder, keys, &finalizer, &mut out, &consumer, &topics).await;
+                    parse_message(msg, decoder.clone(), keys, &finalizer, &mut out, &consumer).await;
                 }
             },
         }
@@ -269,72 +273,15 @@ async fn kafka_source(
     Ok(())
 }
 
-struct Topics {
-    subscribed: HashSet<String>,
-    failed: HashSet<String>,
-}
-
-impl Topics {
-    fn new(config: &KafkaSourceConfig) -> Self {
-        Self {
-            subscribed: config.topics.iter().cloned().collect(),
-            failed: Default::default(),
-        }
-    }
-}
-
-fn handle_ack(
-    topics: &mut Topics,
-    status: BatchStatus,
-    entry: FinalizerEntry,
-    consumer: &StreamConsumer<KafkaStatisticsContext>,
-) {
-    if !topics.failed.contains(&entry.topic) {
-        if status == BatchStatus::Delivered {
-            if let Err(error) = consumer.store_offset(&entry.topic, entry.partition, entry.offset) {
-                emit!(KafkaOffsetUpdateError { error });
-            }
-        } else {
-            emit!(KafkaNegativeAcknowledgmentError {
-                topic: &entry.topic,
-                partition: entry.partition,
-                offset: entry.offset,
-            });
-            // Try to unsubscribe from the named topic. Note that the
-            // subscribed topics list could be missing the named topic
-            // for two reasons:
-            // 1. Multiple batches of events from the same topic could
-            // be flight and all receive a negative acknowledgement,
-            // in which case it will only be present for the first
-            // response.
-            // 2. The topic list may contain wildcards, in which case
-            // there may not be an exact match for the topic name.
-            if topics.subscribed.remove(&entry.topic) {
-                let topics: Vec<&str> = topics.subscribed.iter().map(|s| s.as_str()).collect();
-                // There is no direct way to unsubscribe from a named
-                // topic, as the unsubscribe library function drops
-                // all topics. The subscribe function, however,
-                // replaces the list of subscriptions, from which we
-                // have removed the topic above.  Ignore any errors,
-                // as we drop output from the topic below anyways.
-                let _ = consumer.subscribe(&topics);
-            }
-            // Don't update the offset after a failed ack
-            topics.failed.insert(entry.topic);
-        }
-    }
-}
-
 async fn parse_message(
     msg: BorrowedMessage<'_>,
-    decoder: &Decoder,
+    decoder: Decoder,
     keys: Keys<'_>,
     finalizer: &Option<OrderedFinalizer<FinalizerEntry>>,
     out: &mut SourceSender,
     consumer: &Arc<StreamConsumer<KafkaStatisticsContext>>,
-    topics: &Topics,
 ) {
-    if let Some((count, mut stream)) = parse_stream(&msg, decoder, keys, topics) {
+    if let Some((count, mut stream)) = parse_stream(&msg, decoder, keys) {
         match finalizer {
             Some(finalizer) => {
                 let (batch, receiver) = BatchNotifier::new_with_receiver();
@@ -370,21 +317,16 @@ async fn parse_message(
 // Turn the received message into a stream of parsed events.
 fn parse_stream<'a>(
     msg: &BorrowedMessage<'a>,
-    decoder: &Decoder,
+    decoder: Decoder,
     keys: Keys<'a>,
-    topics: &Topics,
 ) -> Option<(usize, impl Stream<Item = Event> + 'a)> {
-    if topics.failed.contains(msg.topic()) {
-        return None;
-    }
-
     let payload = msg.payload()?; // skip messages with empty payload
 
     let rmsg = ReceivedMessage::from(msg);
 
     let payload = Cursor::new(Bytes::copy_from_slice(payload));
 
-    let mut stream = FramedRead::new(payload, decoder.clone());
+    let mut stream = FramedRead::new(payload, decoder);
     let (count, _) = stream.size_hint();
     let stream = stream! {
         while let Some(result) = stream.next().await {
@@ -677,6 +619,7 @@ mod integration_test {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn handles_negative_acknowledgements() {
         send_receive(true, 2).await;
     }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -94,6 +94,7 @@ enum BuildError {
 }
 
 /// Configurable sources in Vector.
+#[allow(clippy::large_enum_variant)]
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]


### PR DESCRIPTION
We are moving forward on handling processing and delivery errors by alternate
means that will no longer require sources to reject events. This halting
behavior is surprising to users and causes situations that are difficult to
recover from without complicated manual adjustments. As such, we are going to
revert this series in order to prevent regressions.

This partially reverts the following commits:

fix(kafka source): Fix handling of negative acknowledgements (#12901)

2dfa85b69def8492b4e5081bbfcc755107737957

fix(journald source): Fix handling of negative acknowledgements (#12913)

da11de593a7b3802c923c732725054e9ab2ee07f

fix(file source): Fix handling of negative acknowledgements (#12936)

4c584221536be94bfb90ef2385c5628577c55ec0

Ref: https://github.com/vectordotdev/vector/issues/12217#issuecomment-1228093795