### PR TITLE
chore(docs): update wording around deprecation warnings in CLI to emphasize optionality

### DIFF
--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -41,9 +41,9 @@ When this happens, we will notify by:
   introduced in. This will include instructions on how to transition if applicable.
 - Adding a deprecation note to the [documentation site][configuration] alongside the configuration or feature being
   deprecated.
-- Output a log at the `WARN` level if Vector detects deprecated configuration or features being used on start-up, during
-  `vector validate`, or at runtime, when possible. This log message will lead with the text `DEPRECATED` to make it easy
-  to filter for.
+- When possible, output a log at the `WARN` level if Vector detects deprecated configuration or features being used
+  on start-up, during `vector validate`, or at runtime. This log message will lead with the text `DEPRECATED` to
+  make it easy to filter for.
 
 ### Migration
 


### PR DESCRIPTION
A user on Discord pointed out that they were confused that they were not seeing warning logs in the CLI when using a deprecated configuration option, despite the deprecation documentation saying it should be there.

This boiled down to the wording about "when possible" being buried at the end. This change simply moves it to the very beginning to emphasize that there may not always be a log message about deprecated option usage.