### PR TITLE
docs(aws_s3 sink): Fix permission for healthcheck

### DIFF
--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -368,7 +368,7 @@ components: sinks: aws_s3: components._aws & {
 
 			policies: [
 				{
-					_action: "HeadBucket"
+					_action: "ListBucket"
 					required_for: ["healthcheck"]
 				},
 				{


### PR DESCRIPTION
Should require `ListBucket`

Closes: #14166 

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
