### PR TITLE
fix(config): Fix type of global `expire_metrics` setting

### DIFF
--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -1,4 +1,4 @@
-use std::{fs::DirBuilder, path::PathBuf, time::Duration};
+use std::{fs::DirBuilder, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -29,7 +29,7 @@ pub(crate) enum DataDirError {
 }
 
 // If this is modified, make sure those changes are reflected in the `ConfigBuilder::append` function!
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
 pub struct GlobalOptions {
     #[serde(default = "crate::default_data_dir")]
@@ -47,7 +47,7 @@ pub struct GlobalOptions {
     )]
     pub acknowledgements: AcknowledgementsConfig,
     #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
-    pub expire_metrics: Option<Duration>,
+    pub expire_metrics: Option<f64>,
 }
 
 impl GlobalOptions {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -79,9 +79,13 @@ pub async fn start_validated(
 ) -> Option<(RunningTopology, mpsc::UnboundedReceiver<()>)> {
     let (abort_tx, abort_rx) = mpsc::unbounded_channel();
 
-    crate::metrics::Controller::get()
+    if let Err(error) = crate::metrics::Controller::get()
         .expect("Metrics must be initialized")
-        .set_expiry(config.global.expire_metrics);
+        .set_expiry(config.global.expire_metrics)
+    {
+        error!(message="Invalid metrics expiry.", %error);
+        return None;
+    }
 
     let mut running_topology = RunningTopology::new(config, abort_tx);
 

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -42,12 +42,12 @@ configuration: {
 			description: """
 				If set, Vector will configure the internal metrics system to automatically
 				remove all metrics that have not been updated in the given number of seconds.
-                This value must be positive.
+				This value must be positive.
 				"""
 			required: false
 			type: float: {
 				default: null
-				examples: [60]
+				examples: [60.0]
 				unit: "seconds"
 			}
 		}

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -42,9 +42,10 @@ configuration: {
 			description: """
 				If set, Vector will configure the internal metrics system to automatically
 				remove all metrics that have not been updated in the given number of seconds.
+                This value must be positive.
 				"""
 			required: false
-			type: uint: {
+			type: float: {
 				default: null
 				examples: [60]
 				unit: "seconds"


### PR DESCRIPTION
The global configuration was set to type `Option<Duration>` thinking that could
deserialize integers or floating point values. It turns out that this needs
structured data, and so is very inconvenient for users to configure. Change it
to an `Option<f64>` to improve this pain point.

Closes #14188 

*Note:* This setting should have been named `expire_metrics_secs` to match other such durations. This would technically be a breaking change but it's already broken, so should we fix the naming as well?