### PR TITLE
docs(codecs): Document support for GELF codec

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -55,7 +55,7 @@ _values: {
 // * `removed` - The component has been removed.
 #DevelopmentStatus: "beta" | "stable" | "deprecated" | "removed"
 
-#EncodingCodec: "json" | "logfmt" | "text" | "native" | "native_json" | "avro"
+#EncodingCodec: "json" | "logfmt" | "text" | "native" | "native_json" | "avro" | "gelf"
 
 #Endpoint: {
 	description: string

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -193,6 +193,9 @@ components: sinks: [Name=string]: {
 											if codec == "json" {
 												json: "JSON encoded event."
 											}
+											if codec == "gelf" {
+												gelf: "[GELF](https://docs.graylog.org/docs/gelf) encoded event."
+											}
 											if codec == "avro" {
 												avro: "Avro encoded event with a given schema."
 											}

--- a/website/cue/reference/components/sinks/socket.cue
+++ b/website/cue/reference/components/sinks/socket.cue
@@ -22,7 +22,7 @@ components: sinks: socket: {
 				codec: {
 					enabled: true
 					framing: true
-					enum: ["json", "text"]
+					enum: ["json", "text", "gelf"]
 				}
 			}
 			send_buffer_bytes: {

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -168,6 +168,7 @@ components: sources: [Name=string]: {
 								enum: {
 									bytes:       "Events containing the byte frame as-is."
 									json:        "Events being parsed from a JSON string."
+									gelf:        "Events being parsed from a [GELF](https://docs.graylog.org/docs/gelf) message."
 									syslog:      "Events being parsed from a Syslog message."
 									native:      "Events being parsed from Vector's [native protobuf format](\(urls.native_proto_schema)) ([EXPERIMENTAL](/highlights/2022-03-31-native-event-codecs))."
 									native_json: "Events being parsed from Vector's [native JSON format](\(urls.native_json_schema)) ([EXPERIMENTAL](/highlights/2022-03-31-native-event-codecs))."


### PR DESCRIPTION
Technically it is supported on all sinks, but so far the pattern has been to only document codecs
that are typically used for a given sink so I just documented it on the `socket` sink which is
likely to be the only one this codec is used with.

Fixes: #14230

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
