### PR TITLE
chore: update environment with rustup cache, podman compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ cargo-timing*.html
 *.pyc
 *.iml
 *.tmp
+*~
 **/*.rs.bk
 .DS_Store
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ define ENVIRONMENT_EXEC
 			--mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
 			--mount type=volume,source=vector-target,target=/git/vectordotdev/vector/target \
 			--mount type=volume,source=vector-cargo-cache,target=/root/.cargo \
+			--mount type=volume,source=vector-rustup-cache,target=/root/.rustup \
 			$(ENVIRONMENT_UPSTREAM)
 endef
 
@@ -157,7 +158,7 @@ environment-prepare: ## Prepare the Vector dev shell using $CONTAINER_TOOL.
 
 .PHONY: environment-clean
 environment-clean: ## Clean the Vector dev shell using $CONTAINER_TOOL.
-	@$(CONTAINER_TOOL) volume rm -f vector-target vector-cargo-cache
+	@$(CONTAINER_TOOL) volume rm -f vector-target vector-cargo-cache vector-rustup-cache
 	@$(CONTAINER_TOOL) rmi $(ENVIRONMENT_UPSTREAM) || true
 
 .PHONY: environment-push

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ FORMATTING_END = \033[0m
 # "One weird trick!" https://www.gnu.org/software/make/manual/make.html#Syntax-of-Functions
 EMPTY:=
 SPACE:= ${EMPTY} ${EMPTY}
+COMMA:= ,
 
 help:
 	@printf -- "${FORMATTING_BEGIN_BLUE}                                      __   __  __${FORMATTING_END}\n"
@@ -119,7 +120,7 @@ define ENVIRONMENT_EXEC
 			--env INSIDE_ENVIRONMENT=true \
 			--network host \
 			--mount type=bind,source=${CURRENT_DIR},target=/git/vectordotdev/vector \
-			--mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
+			$(if $(findstring docker,$(CONTAINER_TOOL)),--mount type=bind$(COMMA)source=/var/run/docker.sock$(COMMA)target=/var/run/docker.sock,) \
 			--mount type=volume,source=vector-target,target=/git/vectordotdev/vector/target \
 			--mount type=volume,source=vector-cargo-cache,target=/root/.cargo \
 			--mount type=volume,source=vector-rustup-cache,target=/root/.rustup \

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -56,6 +56,14 @@ This is ideal for users who want it to "Just work" and just want to start contri
 export CONTAINER_TOOL="podman"
 ```
 
+If your Linux environment runs SELinux in Enforcing mode, you will need to relabel the vector source code checkout with `container_home_t` context. Otherwise the container environment cannot read/write the code:
+
+```bash
+cd your/checkout/of/vector/
+sudo semanage fcontext -a "${PWD}(/.*)?" -t container_file_t
+sudo restorecon . -R
+```
+
 By default, `make environment` style tasks will do a `docker pull` from Github's container repository, you can **optionally** build your own environment while you make your morning coffee ☕:
 
 ```bash

--- a/scripts/environment/Dockerfile
+++ b/scripts/environment/Dockerfile
@@ -29,6 +29,7 @@ RUN ./scripts/environment/prepare.sh && ./scripts/environment/setup-helm.sh
 VOLUME /vector
 VOLUME /vector/target
 VOLUME /root/.cargo
+VOLUME /root/.rustup
 
 # Prepare for use
 COPY ./scripts/environment/entrypoint.sh /

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 set -e -o verbose
 
+git config --global --add safe.directory /git/vectordotdev/vector
+
 rustup show # causes installation of version from rust-toolchain.toml
 rustup default "$(rustup show active-toolchain | awk '{print $1;}')"
 if [[ "$(cargo-deb --version)" != "1.29.2" ]] ; then


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

This is based on my set up on Fedora 36. I have verified that `CONTAINER_TOOL=docker` (using fedora package `moby-engine`), and `CONTAINER_TOOL=podman` can spawn a shell, where `make check` finishes.