### PR TITLE
docs(sources, sinks): Fix documentation of tls.enabled

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -700,14 +700,12 @@ components: {
 				description: "Configures the TLS options for outgoing connections."
 				required:    false
 				type: object: options: {
-					if Args.enabled_by_scheme != _|_ {
-						if !Args.enabled_by_scheme {
-							enabled: {
-								common:      true
-								description: "Enable TLS during connections to the remote."
-								required:    false
-								type: bool: default: Args.enabled_default
-							}
+					if !Args.enabled_by_scheme {
+						enabled: {
+							common:      true
+							description: "Enable TLS during connections to the remote."
+							required:    false
+							type: bool: default: Args.enabled_default
 						}
 					}
 

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -518,6 +518,7 @@ components: sinks: [Name=string]: {
 					can_verify_certificate: features.send.tls.can_verify_certificate
 					can_verify_hostname:    features.send.tls.can_verify_hostname
 					enabled_default:        features.send.tls.enabled_default
+					enabled_by_scheme:      features.send.tls.enabled_by_scheme
 				}}
 			}
 		}

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -214,6 +214,7 @@ components: sources: [Name=string]: {
 						can_verify_certificate: features.collect.tls.can_verify_certificate
 						can_verify_hostname:    features.collect.tls.can_verify_hostname
 						enabled_default:        features.collect.tls.enabled_default
+						enabled_by_scheme:      features.collect.tls.enabled_by_scheme
 					}}
 				}
 			}
@@ -263,6 +264,7 @@ components: sources: [Name=string]: {
 					can_verify_certificate:  features.receive.tls.can_verify_certificate
 					can_add_client_metadata: features.receive.tls.can_add_client_metadata
 					enabled_default:         features.receive.tls.enabled_default
+					enabled_by_scheme:       false
 				}}
 			}
 		}

--- a/website/cue/reference/components/sources/http_scrape.cue
+++ b/website/cue/reference/components/sources/http_scrape.cue
@@ -36,7 +36,7 @@ components: sources: http_scrape: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
-				enabled_by_scheme:      false
+				enabled_by_scheme:      true
 			}
 		}
 		multiline: enabled: false

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -80,6 +80,7 @@ components: sources: nginx_metrics: {
 			can_verify_certificate: true
 			can_verify_hostname:    true
 			enabled_default:        false
+			enabled_by_scheme:      true
 		}}
 		auth: configuration._http_auth & {_args: {
 			password_example: "${HTTP_PASSWORD}"


### PR DESCRIPTION
This wasn't being correctly propagated in a few places.

Also fixed `enabled_by_scheme` for the `http_scrape` source.

Fixes: #14238

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
