### PR TITLE
chore(core): remove unnecessary mutability from `ArgumentList`

### DIFF
--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -92,7 +92,7 @@ impl Function for FindEnrichmentTableRecords {
         &self,
         _state: &TypeState,
         ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let registry = ctx
             .get_external_context_mut::<TableRegistry>()

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -90,7 +90,7 @@ impl Function for GetEnrichmentTableRecord {
         &self,
         _state: &TypeState,
         ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let registry = ctx
             .get_external_context_mut::<TableRegistry>()

--- a/lib/vector-vrl-functions/src/get_secret.rs
+++ b/lib/vector-vrl-functions/src/get_secret.rs
@@ -40,7 +40,7 @@ impl Function for GetSecret {
         &self,
         _state: &TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let key = arguments.required("key");
         Ok(GetSecretFn { key }.as_expr())

--- a/lib/vector-vrl-functions/src/remove_secret.rs
+++ b/lib/vector-vrl-functions/src/remove_secret.rs
@@ -37,7 +37,7 @@ impl Function for RemoveSecret {
         &self,
         _state: &TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let key = arguments.required("key");
         Ok(RemoveSecretFn { key }.as_expr())

--- a/lib/vector-vrl-functions/src/set_secret.rs
+++ b/lib/vector-vrl-functions/src/set_secret.rs
@@ -50,7 +50,7 @@ impl Function for SetSecret {
         &self,
         _state: &TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let key = arguments.required("key");
         let secret = arguments.required("secret");

--- a/lib/vector-vrl-functions/src/set_semantic_meaning.rs
+++ b/lib/vector-vrl-functions/src/set_semantic_meaning.rs
@@ -57,7 +57,7 @@ impl Function for SetSemanticMeaning {
         &self,
         state: &TypeState,
         ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let span = ctx.span();
         let query = arguments.required_query("target")?;

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -210,17 +210,19 @@ pub struct ArgumentList {
 }
 
 impl ArgumentList {
-    pub fn optional(&mut self, keyword: &'static str) -> Option<Box<dyn Expression>> {
+    #[must_use]
+    pub fn optional(&self, keyword: &'static str) -> Option<Box<dyn Expression>> {
         self.optional_expr(keyword).map(|v| Box::new(v) as _)
     }
 
-    pub fn required(&mut self, keyword: &'static str) -> Box<dyn Expression> {
+    #[must_use]
+    pub fn required(&self, keyword: &'static str) -> Box<dyn Expression> {
         Box::new(self.required_expr(keyword)) as _
     }
 
     #[cfg(feature = "expr-literal")]
     pub fn optional_literal(
-        &mut self,
+        &self,
         keyword: &'static str,
     ) -> Result<Option<crate::expression::Literal>, Error> {
         self.optional_expr(keyword)
@@ -247,14 +249,14 @@ impl ArgumentList {
 
     #[cfg(not(feature = "expr-literal"))]
     pub fn optional_literal(
-        &mut self,
+        &self,
         _: &'static str,
     ) -> Result<Option<crate::expression::Noop>, Error> {
         Ok(Some(crate::expression::Noop))
     }
 
     /// Returns the argument if it is a literal, an object or an array.
-    pub fn optional_value(&mut self, keyword: &'static str) -> Result<Option<Value>, Error> {
+    pub fn optional_value(&self, keyword: &'static str) -> Result<Option<Value>, Error> {
         self.optional_expr(keyword)
             .map(|expr| {
                 expr.try_into().map_err(|err| Error::UnexpectedExpression {
@@ -268,7 +270,7 @@ impl ArgumentList {
 
     #[cfg(feature = "expr-literal")]
     pub fn required_literal(
-        &mut self,
+        &self,
         keyword: &'static str,
     ) -> Result<crate::expression::Literal, Error> {
         Ok(required(self.optional_literal(keyword)?))
@@ -283,7 +285,7 @@ impl ArgumentList {
     }
 
     pub fn optional_enum(
-        &mut self,
+        &self,
         keyword: &'static str,
         variants: &[Value],
     ) -> Result<Option<Value>, Error> {
@@ -303,17 +305,13 @@ impl ArgumentList {
             .transpose()
     }
 
-    pub fn required_enum(
-        &mut self,
-        keyword: &'static str,
-        variants: &[Value],
-    ) -> Result<Value, Error> {
+    pub fn required_enum(&self, keyword: &'static str, variants: &[Value]) -> Result<Value, Error> {
         Ok(required(self.optional_enum(keyword, variants)?))
     }
 
     #[cfg(feature = "expr-query")]
     pub fn optional_query(
-        &mut self,
+        &self,
         keyword: &'static str,
     ) -> Result<Option<crate::expression::Query>, Error> {
         self.optional_expr(keyword)
@@ -329,14 +327,11 @@ impl ArgumentList {
     }
 
     #[cfg(feature = "expr-query")]
-    pub fn required_query(
-        &mut self,
-        keyword: &'static str,
-    ) -> Result<crate::expression::Query, Error> {
+    pub fn required_query(&self, keyword: &'static str) -> Result<crate::expression::Query, Error> {
         Ok(required(self.optional_query(keyword)?))
     }
 
-    pub fn optional_regex(&mut self, keyword: &'static str) -> Result<Option<regex::Regex>, Error> {
+    pub fn optional_regex(&self, keyword: &'static str) -> Result<Option<regex::Regex>, Error> {
         self.optional_expr(keyword)
             .map(|expr| match expr {
                 #[cfg(feature = "expr-literal")]
@@ -350,12 +345,12 @@ impl ArgumentList {
             .transpose()
     }
 
-    pub fn required_regex(&mut self, keyword: &'static str) -> Result<regex::Regex, Error> {
+    pub fn required_regex(&self, keyword: &'static str) -> Result<regex::Regex, Error> {
         Ok(required(self.optional_regex(keyword)?))
     }
 
     pub fn optional_object(
-        &mut self,
+        &self,
         keyword: &'static str,
     ) -> Result<Option<BTreeMap<String, Expr>>, Error> {
         self.optional_expr(keyword)
@@ -372,14 +367,11 @@ impl ArgumentList {
             .transpose()
     }
 
-    pub fn required_object(
-        &mut self,
-        keyword: &'static str,
-    ) -> Result<BTreeMap<String, Expr>, Error> {
+    pub fn required_object(&self, keyword: &'static str) -> Result<BTreeMap<String, Expr>, Error> {
         Ok(required(self.optional_object(keyword)?))
     }
 
-    pub fn optional_array(&mut self, keyword: &'static str) -> Result<Option<Vec<Expr>>, Error> {
+    pub fn optional_array(&self, keyword: &'static str) -> Result<Option<Vec<Expr>>, Error> {
         self.optional_expr(keyword)
             .map(|expr| match expr {
                 Expr::Container(Container {
@@ -394,7 +386,7 @@ impl ArgumentList {
             .transpose()
     }
 
-    pub fn required_array(&mut self, keyword: &'static str) -> Result<Vec<Expr>, Error> {
+    pub fn required_array(&self, keyword: &'static str) -> Result<Vec<Expr>, Error> {
         Ok(required(self.optional_array(keyword)?))
     }
 
@@ -424,11 +416,12 @@ impl ArgumentList {
         self.closure = Some(closure);
     }
 
-    pub(crate) fn optional_expr(&mut self, keyword: &'static str) -> Option<Expr> {
+    pub(crate) fn optional_expr(&self, keyword: &'static str) -> Option<Expr> {
         self.arguments.get(keyword).cloned()
     }
 
-    pub fn required_expr(&mut self, keyword: &'static str) -> Expr {
+    #[must_use]
+    pub fn required_expr(&self, keyword: &'static str) -> Expr {
         required(self.optional_expr(keyword))
     }
 }

--- a/lib/vrl/stdlib/src/append.rs
+++ b/lib/vrl/stdlib/src/append.rs
@@ -44,7 +44,7 @@ impl Function for Append {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let items = arguments.required("items");

--- a/lib/vrl/stdlib/src/array.rs
+++ b/lib/vrl/stdlib/src/array.rs
@@ -46,7 +46,7 @@ impl Function for Array {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/assert.rs
+++ b/lib/vrl/stdlib/src/assert.rs
@@ -71,7 +71,7 @@ impl Function for Assert {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let condition = arguments.required("condition");
         let message = arguments.optional("message");

--- a/lib/vrl/stdlib/src/assert_eq.rs
+++ b/lib/vrl/stdlib/src/assert_eq.rs
@@ -74,7 +74,7 @@ impl Function for AssertEq {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let left = arguments.required("left");
         let right = arguments.required("right");

--- a/lib/vrl/stdlib/src/boolean.rs
+++ b/lib/vrl/stdlib/src/boolean.rs
@@ -46,7 +46,7 @@ impl Function for Boolean {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ceil.rs
+++ b/lib/vrl/stdlib/src/ceil.rs
@@ -51,7 +51,7 @@ impl Function for Ceil {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let precision = arguments.optional("precision");

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -63,7 +63,7 @@ impl Function for Chunks {
         &self,
         _state: &TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let chunk_size = arguments.required("chunk_size");

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -125,7 +125,7 @@ impl Function for Compact {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let recursive = arguments.optional("recursive");

--- a/lib/vrl/stdlib/src/contains.rs
+++ b/lib/vrl/stdlib/src/contains.rs
@@ -55,7 +55,7 @@ impl Function for Contains {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");

--- a/lib/vrl/stdlib/src/decode_base64.rs
+++ b/lib/vrl/stdlib/src/decode_base64.rs
@@ -52,7 +52,7 @@ impl Function for DecodeBase64 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let charset = arguments.optional("charset");

--- a/lib/vrl/stdlib/src/decode_percent.rs
+++ b/lib/vrl/stdlib/src/decode_percent.rs
@@ -31,7 +31,7 @@ impl Function for DecodePercent {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/decrypt.rs
+++ b/lib/vrl/stdlib/src/decrypt.rs
@@ -129,7 +129,7 @@ impl Function for Decrypt {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let ciphertext = arguments.required("ciphertext");
         let algorithm = arguments.required("algorithm");

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -86,7 +86,7 @@ impl Function for Del {
         &self,
         _state: &state::TypeState,
         ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let query = arguments.required_query("target")?;
 

--- a/lib/vrl/stdlib/src/downcase.rs
+++ b/lib/vrl/stdlib/src/downcase.rs
@@ -26,7 +26,7 @@ impl Function for Downcase {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/encode_base64.rs
+++ b/lib/vrl/stdlib/src/encode_base64.rs
@@ -55,7 +55,7 @@ impl Function for EncodeBase64 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let padding = arguments.optional("padding");

--- a/lib/vrl/stdlib/src/encode_json.rs
+++ b/lib/vrl/stdlib/src/encode_json.rs
@@ -30,7 +30,7 @@ impl Function for EncodeJson {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -74,7 +74,7 @@ impl Function for EncodeKeyValue {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let fields = arguments.optional("fields_ordering");

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -30,7 +30,7 @@ impl Function for EncodeLogfmt {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         // The encode_logfmt function is just an alias for `encode_key_value` with the following
         // parameters for the delimiters.

--- a/lib/vrl/stdlib/src/encode_percent.rs
+++ b/lib/vrl/stdlib/src/encode_percent.rs
@@ -104,7 +104,7 @@ impl Function for EncodePercent {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let ascii_set = arguments

--- a/lib/vrl/stdlib/src/encrypt.rs
+++ b/lib/vrl/stdlib/src/encrypt.rs
@@ -188,7 +188,7 @@ impl Function for Encrypt {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let plaintext = arguments.required("plaintext");
         let algorithm = arguments.required("algorithm");

--- a/lib/vrl/stdlib/src/ends_with.rs
+++ b/lib/vrl/stdlib/src/ends_with.rs
@@ -55,7 +55,7 @@ impl Function for EndsWith {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");

--- a/lib/vrl/stdlib/src/exists.rs
+++ b/lib/vrl/stdlib/src/exists.rs
@@ -36,7 +36,7 @@ impl Function for Exists {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let query = arguments.required_query("field")?;
 

--- a/lib/vrl/stdlib/src/filter.rs
+++ b/lib/vrl/stdlib/src/filter.rs
@@ -74,7 +74,7 @@ impl Function for Filter {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let closure = arguments.required_closure()?;

--- a/lib/vrl/stdlib/src/find.rs
+++ b/lib/vrl/stdlib/src/find.rs
@@ -51,7 +51,7 @@ impl Function for Find {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");

--- a/lib/vrl/stdlib/src/flatten.rs
+++ b/lib/vrl/stdlib/src/flatten.rs
@@ -72,7 +72,7 @@ impl Function for Flatten {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let separator = arguments
             .optional("separator")

--- a/lib/vrl/stdlib/src/float.rs
+++ b/lib/vrl/stdlib/src/float.rs
@@ -45,7 +45,7 @@ impl Function for Float {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/floor.rs
+++ b/lib/vrl/stdlib/src/floor.rs
@@ -50,7 +50,7 @@ impl Function for Floor {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let precision = arguments.optional("precision");

--- a/lib/vrl/stdlib/src/for_each.rs
+++ b/lib/vrl/stdlib/src/for_each.rs
@@ -51,7 +51,7 @@ impl Function for ForEach {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let closure = arguments.required_closure()?;

--- a/lib/vrl/stdlib/src/format_int.rs
+++ b/lib/vrl/stdlib/src/format_int.rs
@@ -51,7 +51,7 @@ impl Function for FormatInt {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let base = arguments.optional("base");

--- a/lib/vrl/stdlib/src/format_number.rs
+++ b/lib/vrl/stdlib/src/format_number.rs
@@ -118,7 +118,7 @@ impl Function for FormatNumber {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let scale = arguments.optional("scale");

--- a/lib/vrl/stdlib/src/format_timestamp.rs
+++ b/lib/vrl/stdlib/src/format_timestamp.rs
@@ -40,7 +40,7 @@ impl Function for FormatTimestamp {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments.required("format");

--- a/lib/vrl/stdlib/src/get.rs
+++ b/lib/vrl/stdlib/src/get.rs
@@ -128,7 +128,7 @@ impl Function for Get {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let path = arguments.required("path");

--- a/lib/vrl/stdlib/src/get_env_var.rs
+++ b/lib/vrl/stdlib/src/get_env_var.rs
@@ -36,7 +36,7 @@ impl Function for GetEnvVar {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let name = arguments.required("name");
 

--- a/lib/vrl/stdlib/src/includes.rs
+++ b/lib/vrl/stdlib/src/includes.rs
@@ -49,7 +49,7 @@ impl Function for Includes {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let item = arguments.required("item");

--- a/lib/vrl/stdlib/src/integer.rs
+++ b/lib/vrl/stdlib/src/integer.rs
@@ -45,7 +45,7 @@ impl Function for Integer {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ip_aton.rs
+++ b/lib/vrl/stdlib/src/ip_aton.rs
@@ -39,7 +39,7 @@ impl Function for IpAton {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ip_cidr_contains.rs
+++ b/lib/vrl/stdlib/src/ip_cidr_contains.rs
@@ -71,7 +71,7 @@ impl Function for IpCidrContains {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let cidr = arguments.required("cidr");
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/ip_ntoa.rs
+++ b/lib/vrl/stdlib/src/ip_ntoa.rs
@@ -40,7 +40,7 @@ impl Function for IpNtoa {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ip_ntop.rs
+++ b/lib/vrl/stdlib/src/ip_ntop.rs
@@ -54,7 +54,7 @@ impl Function for IpNtop {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ip_pton.rs
+++ b/lib/vrl/stdlib/src/ip_pton.rs
@@ -53,7 +53,7 @@ impl Function for IpPton {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ip_subnet.rs
+++ b/lib/vrl/stdlib/src/ip_subnet.rs
@@ -75,7 +75,7 @@ impl Function for IpSubnet {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let subnet = arguments.required("subnet");

--- a/lib/vrl/stdlib/src/ip_to_ipv6.rs
+++ b/lib/vrl/stdlib/src/ip_to_ipv6.rs
@@ -42,7 +42,7 @@ impl Function for IpToIpv6 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
+++ b/lib/vrl/stdlib/src/ipv6_to_ipv4.rs
@@ -45,7 +45,7 @@ impl Function for Ipv6ToIpV4 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         Ok(Ipv6ToIpV4Fn { value }.as_expr())

--- a/lib/vrl/stdlib/src/is_array.rs
+++ b/lib/vrl/stdlib/src/is_array.rs
@@ -40,7 +40,7 @@ impl Function for IsArray {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_boolean.rs
+++ b/lib/vrl/stdlib/src/is_boolean.rs
@@ -40,7 +40,7 @@ impl Function for IsBoolean {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_empty.rs
+++ b/lib/vrl/stdlib/src/is_empty.rs
@@ -65,7 +65,7 @@ impl Function for IsEmpty {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_float.rs
+++ b/lib/vrl/stdlib/src/is_float.rs
@@ -40,7 +40,7 @@ impl Function for IsFloat {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_integer.rs
+++ b/lib/vrl/stdlib/src/is_integer.rs
@@ -40,7 +40,7 @@ impl Function for IsInteger {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_ipv4.rs
+++ b/lib/vrl/stdlib/src/is_ipv4.rs
@@ -49,7 +49,7 @@ impl Function for IsIpv4 {
         &self,
         _state: &TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_ipv6.rs
+++ b/lib/vrl/stdlib/src/is_ipv6.rs
@@ -49,7 +49,7 @@ impl Function for IsIpv6 {
         &self,
         _state: &TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_json.rs
+++ b/lib/vrl/stdlib/src/is_json.rs
@@ -95,7 +95,7 @@ impl Function for IsJson {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let variant = arguments.optional_enum("variant", &variants())?;

--- a/lib/vrl/stdlib/src/is_null.rs
+++ b/lib/vrl/stdlib/src/is_null.rs
@@ -40,7 +40,7 @@ impl Function for IsNull {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_nullish.rs
+++ b/lib/vrl/stdlib/src/is_nullish.rs
@@ -35,7 +35,7 @@ impl Function for IsNullish {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         Ok(IsNullishFn { value }.as_expr())

--- a/lib/vrl/stdlib/src/is_object.rs
+++ b/lib/vrl/stdlib/src/is_object.rs
@@ -40,7 +40,7 @@ impl Function for IsObject {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_regex.rs
+++ b/lib/vrl/stdlib/src/is_regex.rs
@@ -40,7 +40,7 @@ impl Function for IsRegex {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_string.rs
+++ b/lib/vrl/stdlib/src/is_string.rs
@@ -40,7 +40,7 @@ impl Function for IsString {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/is_timestamp.rs
+++ b/lib/vrl/stdlib/src/is_timestamp.rs
@@ -40,7 +40,7 @@ impl Function for IsTimestamp {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/join.rs
+++ b/lib/vrl/stdlib/src/join.rs
@@ -45,7 +45,7 @@ impl Function for Join {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let separator = arguments.optional("separator");

--- a/lib/vrl/stdlib/src/length.rs
+++ b/lib/vrl/stdlib/src/length.rs
@@ -56,7 +56,7 @@ impl Function for Length {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/log.rs
+++ b/lib/vrl/stdlib/src/log.rs
@@ -77,7 +77,7 @@ impl Function for Log {
         &self,
         _state: &state::TypeState,
         ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let levels = vec![
             "trace".into(),

--- a/lib/vrl/stdlib/src/map_keys.rs
+++ b/lib/vrl/stdlib/src/map_keys.rs
@@ -68,7 +68,7 @@ impl Function for MapKeys {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let recursive = arguments.optional("recursive");

--- a/lib/vrl/stdlib/src/map_values.rs
+++ b/lib/vrl/stdlib/src/map_values.rs
@@ -67,7 +67,7 @@ impl Function for MapValues {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let recursive = arguments.optional("recursive");

--- a/lib/vrl/stdlib/src/match.rs
+++ b/lib/vrl/stdlib/src/match.rs
@@ -49,7 +49,7 @@ impl Function for Match {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");

--- a/lib/vrl/stdlib/src/match_any.rs
+++ b/lib/vrl/stdlib/src/match_any.rs
@@ -49,7 +49,7 @@ impl Function for MatchAny {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let patterns = arguments.required_array("patterns")?;

--- a/lib/vrl/stdlib/src/match_array.rs
+++ b/lib/vrl/stdlib/src/match_array.rs
@@ -47,7 +47,7 @@ impl Function for MatchArray {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");

--- a/lib/vrl/stdlib/src/match_datadog_query.rs
+++ b/lib/vrl/stdlib/src/match_datadog_query.rs
@@ -47,7 +47,7 @@ impl Function for MatchDatadogQuery {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let query_value = arguments.required_literal("query")?.to_value();

--- a/lib/vrl/stdlib/src/md5.rs
+++ b/lib/vrl/stdlib/src/md5.rs
@@ -35,7 +35,7 @@ impl Function for Md5 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/merge.rs
+++ b/lib/vrl/stdlib/src/merge.rs
@@ -43,7 +43,7 @@ impl Function for Merge {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let to = arguments.required("to");
         let from = arguments.required("from");

--- a/lib/vrl/stdlib/src/mod_func.rs
+++ b/lib/vrl/stdlib/src/mod_func.rs
@@ -41,7 +41,7 @@ impl Function for Mod {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let modulus = arguments.required("modulus");

--- a/lib/vrl/stdlib/src/object.rs
+++ b/lib/vrl/stdlib/src/object.rs
@@ -45,7 +45,7 @@ impl Function for Object {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_apache_log.rs
+++ b/lib/vrl/stdlib/src/parse_apache_log.rs
@@ -69,7 +69,7 @@ impl Function for ParseApacheLog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments

--- a/lib/vrl/stdlib/src/parse_aws_alb_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_alb_log.rs
@@ -38,7 +38,7 @@ impl Function for ParseAwsAlbLog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -88,7 +88,7 @@ impl Function for ParseAwsCloudWatchLogSubscriptionMessage {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
+++ b/lib/vrl/stdlib/src/parse_aws_vpc_flow_log.rs
@@ -64,7 +64,7 @@ impl Function for ParseAwsVpcFlowLog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments.optional("format");

--- a/lib/vrl/stdlib/src/parse_common_log.rs
+++ b/lib/vrl/stdlib/src/parse_common_log.rs
@@ -49,7 +49,7 @@ impl Function for ParseCommonLog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let timestamp_format = arguments.optional("timestamp_format");

--- a/lib/vrl/stdlib/src/parse_csv.rs
+++ b/lib/vrl/stdlib/src/parse_csv.rs
@@ -51,7 +51,7 @@ impl Function for ParseCsv {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let delimiter = arguments.optional("delimiter").unwrap_or(expr!(","));

--- a/lib/vrl/stdlib/src/parse_duration.rs
+++ b/lib/vrl/stdlib/src/parse_duration.rs
@@ -82,7 +82,7 @@ impl Function for ParseDuration {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let unit = arguments.required("unit");

--- a/lib/vrl/stdlib/src/parse_glog.rs
+++ b/lib/vrl/stdlib/src/parse_glog.rs
@@ -100,7 +100,7 @@ impl Function for ParseGlog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -101,7 +101,7 @@ impl Function for ParseGrok {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -100,7 +100,7 @@ impl Function for ParseGroks {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_int.rs
+++ b/lib/vrl/stdlib/src/parse_int.rs
@@ -80,7 +80,7 @@ impl Function for ParseInt {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let base = arguments.optional("base");

--- a/lib/vrl/stdlib/src/parse_json.rs
+++ b/lib/vrl/stdlib/src/parse_json.rs
@@ -176,7 +176,7 @@ impl Function for ParseJson {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let max_depth = arguments.optional("max_depth");

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -104,7 +104,7 @@ impl Function for ParseKeyValue {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_klog.rs
+++ b/lib/vrl/stdlib/src/parse_klog.rs
@@ -101,7 +101,7 @@ impl Function for ParseKlog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_linux_authorization.rs
+++ b/lib/vrl/stdlib/src/parse_linux_authorization.rs
@@ -37,7 +37,7 @@ impl Function for ParseLinuxAuthorization {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_logfmt.rs
+++ b/lib/vrl/stdlib/src/parse_logfmt.rs
@@ -37,7 +37,7 @@ impl Function for ParseLogFmt {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_nginx_log.rs
+++ b/lib/vrl/stdlib/src/parse_nginx_log.rs
@@ -60,7 +60,7 @@ impl Function for ParseNginxLog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments

--- a/lib/vrl/stdlib/src/parse_query_string.rs
+++ b/lib/vrl/stdlib/src/parse_query_string.rs
@@ -56,7 +56,7 @@ impl Function for ParseQueryString {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         Ok(ParseQueryStringFn { value }.as_expr())

--- a/lib/vrl/stdlib/src/parse_regex.rs
+++ b/lib/vrl/stdlib/src/parse_regex.rs
@@ -46,7 +46,7 @@ impl Function for ParseRegex {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern")?;

--- a/lib/vrl/stdlib/src/parse_regex_all.rs
+++ b/lib/vrl/stdlib/src/parse_regex_all.rs
@@ -46,7 +46,7 @@ impl Function for ParseRegexAll {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required_regex("pattern")?;

--- a/lib/vrl/stdlib/src/parse_ruby_hash.rs
+++ b/lib/vrl/stdlib/src/parse_ruby_hash.rs
@@ -48,7 +48,7 @@ impl Function for ParseRubyHash {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         Ok(ParseRubyHashFn { value }.as_expr())

--- a/lib/vrl/stdlib/src/parse_syslog.rs
+++ b/lib/vrl/stdlib/src/parse_syslog.rs
@@ -59,7 +59,7 @@ impl Function for ParseSyslog {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_timestamp.rs
+++ b/lib/vrl/stdlib/src/parse_timestamp.rs
@@ -36,7 +36,7 @@ impl Function for ParseTimestamp {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let format = arguments.required("format");

--- a/lib/vrl/stdlib/src/parse_tokens.rs
+++ b/lib/vrl/stdlib/src/parse_tokens.rs
@@ -37,7 +37,7 @@ impl Function for ParseTokens {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_url.rs
+++ b/lib/vrl/stdlib/src/parse_url.rs
@@ -68,7 +68,7 @@ impl Function for ParseUrl {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let default_known_ports = arguments

--- a/lib/vrl/stdlib/src/parse_user_agent.rs
+++ b/lib/vrl/stdlib/src/parse_user_agent.rs
@@ -89,7 +89,7 @@ impl Function for ParseUserAgent {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -115,7 +115,7 @@ impl Function for ParseXml {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/push.rs
+++ b/lib/vrl/stdlib/src/push.rs
@@ -49,7 +49,7 @@ impl Function for Push {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let item = arguments.required("item");

--- a/lib/vrl/stdlib/src/random_bytes.rs
+++ b/lib/vrl/stdlib/src/random_bytes.rs
@@ -43,7 +43,7 @@ impl Function for RandomBytes {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let length = arguments.required("length");
 

--- a/lib/vrl/stdlib/src/redact.rs
+++ b/lib/vrl/stdlib/src/redact.rs
@@ -62,7 +62,7 @@ impl Function for Redact {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/remove.rs
+++ b/lib/vrl/stdlib/src/remove.rs
@@ -145,7 +145,7 @@ impl Function for Remove {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let path = arguments.required("path");

--- a/lib/vrl/stdlib/src/replace.rs
+++ b/lib/vrl/stdlib/src/replace.rs
@@ -101,7 +101,7 @@ impl Function for Replace {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");

--- a/lib/vrl/stdlib/src/reverse_dns.rs
+++ b/lib/vrl/stdlib/src/reverse_dns.rs
@@ -42,7 +42,7 @@ impl Function for ReverseDns {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/round.rs
+++ b/lib/vrl/stdlib/src/round.rs
@@ -67,7 +67,7 @@ impl Function for Round {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let precision = arguments.optional("precision").unwrap_or(expr!(0));

--- a/lib/vrl/stdlib/src/set.rs
+++ b/lib/vrl/stdlib/src/set.rs
@@ -124,7 +124,7 @@ impl Function for Set {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let path = arguments.required("path");

--- a/lib/vrl/stdlib/src/sha1.rs
+++ b/lib/vrl/stdlib/src/sha1.rs
@@ -35,7 +35,7 @@ impl Function for Sha1 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/sha2.rs
+++ b/lib/vrl/stdlib/src/sha2.rs
@@ -69,7 +69,7 @@ impl Function for Sha2 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let variant = arguments

--- a/lib/vrl/stdlib/src/sha3.rs
+++ b/lib/vrl/stdlib/src/sha3.rs
@@ -65,7 +65,7 @@ impl Function for Sha3 {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let variant = arguments

--- a/lib/vrl/stdlib/src/slice.rs
+++ b/lib/vrl/stdlib/src/slice.rs
@@ -92,7 +92,7 @@ impl Function for Slice {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let start = arguments.required("start");

--- a/lib/vrl/stdlib/src/split.rs
+++ b/lib/vrl/stdlib/src/split.rs
@@ -77,7 +77,7 @@ impl Function for Split {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let pattern = arguments.required("pattern");

--- a/lib/vrl/stdlib/src/starts_with.rs
+++ b/lib/vrl/stdlib/src/starts_with.rs
@@ -120,7 +120,7 @@ impl Function for StartsWith {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let substring = arguments.required("substring");

--- a/lib/vrl/stdlib/src/string.rs
+++ b/lib/vrl/stdlib/src/string.rs
@@ -45,7 +45,7 @@ impl Function for String {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
+++ b/lib/vrl/stdlib/src/strip_ansi_escape_codes.rs
@@ -35,7 +35,7 @@ impl Function for StripAnsiEscapeCodes {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/strip_whitespace.rs
+++ b/lib/vrl/stdlib/src/strip_whitespace.rs
@@ -40,7 +40,7 @@ impl Function for StripWhitespace {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/strlen.rs
+++ b/lib/vrl/stdlib/src/strlen.rs
@@ -35,7 +35,7 @@ impl Function for Strlen {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/tag_types_externally.rs
+++ b/lib/vrl/stdlib/src/tag_types_externally.rs
@@ -49,7 +49,7 @@ impl Function for TagTypesExternally {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/tally.rs
+++ b/lib/vrl/stdlib/src/tally.rs
@@ -41,7 +41,7 @@ impl Function for Tally {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/tally_value.rs
+++ b/lib/vrl/stdlib/src/tally_value.rs
@@ -26,7 +26,7 @@ impl Function for TallyValue {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let array = arguments.required("array");
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/timestamp.rs
+++ b/lib/vrl/stdlib/src/timestamp.rs
@@ -45,7 +45,7 @@ impl Function for Timestamp {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_bool.rs
+++ b/lib/vrl/stdlib/src/to_bool.rs
@@ -152,7 +152,7 @@ impl Function for ToBool {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_float.rs
+++ b/lib/vrl/stdlib/src/to_float.rs
@@ -107,7 +107,7 @@ impl Function for ToFloat {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_int.rs
+++ b/lib/vrl/stdlib/src/to_int.rs
@@ -106,7 +106,7 @@ impl Function for ToInt {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_regex.rs
+++ b/lib/vrl/stdlib/src/to_regex.rs
@@ -38,7 +38,7 @@ impl Function for ToRegex {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         warn!("`to_regex` is an expensive function that could impact throughput.");
         let value = arguments.required("value");

--- a/lib/vrl/stdlib/src/to_string.rs
+++ b/lib/vrl/stdlib/src/to_string.rs
@@ -97,7 +97,7 @@ impl Function for ToString {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_syslog_facility.rs
+++ b/lib/vrl/stdlib/src/to_syslog_facility.rs
@@ -71,7 +71,7 @@ impl Function for ToSyslogFacility {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_syslog_level.rs
+++ b/lib/vrl/stdlib/src/to_syslog_level.rs
@@ -55,7 +55,7 @@ impl Function for ToSyslogLevel {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_syslog_severity.rs
+++ b/lib/vrl/stdlib/src/to_syslog_severity.rs
@@ -55,7 +55,7 @@ impl Function for ToSyslogSeverity {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_timestamp.rs
@@ -184,7 +184,7 @@ impl Function for ToTimestamp {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/to_unix_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_unix_timestamp.rs
@@ -60,7 +60,7 @@ impl Function for ToUnixTimestamp {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/truncate.rs
+++ b/lib/vrl/stdlib/src/truncate.rs
@@ -76,7 +76,7 @@ impl Function for Truncate {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let limit = arguments.required("limit");

--- a/lib/vrl/stdlib/src/type_def.rs
+++ b/lib/vrl/stdlib/src/type_def.rs
@@ -45,7 +45,7 @@ impl Function for TypeDef {
         &self,
         state: &TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
         let type_def = value.type_def(state);

--- a/lib/vrl/stdlib/src/unique.rs
+++ b/lib/vrl/stdlib/src/unique.rs
@@ -28,7 +28,7 @@ impl Function for Unique {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 

--- a/lib/vrl/stdlib/src/unnest.rs
+++ b/lib/vrl/stdlib/src/unnest.rs
@@ -99,7 +99,7 @@ impl Function for Unnest {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let path = arguments.required_query("path")?;
         Ok(UnnestFn { path }.as_expr())

--- a/lib/vrl/stdlib/src/upcase.rs
+++ b/lib/vrl/stdlib/src/upcase.rs
@@ -34,7 +34,7 @@ impl Function for Upcase {
         &self,
         _state: &state::TypeState,
         _ctx: &mut FunctionCompileContext,
-        mut arguments: ArgumentList,
+        arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
 


### PR DESCRIPTION
These functions didn't need to be mutable. Clippy required refactoring >100 files, so I'm pulling this out of another PR to make it easier to review.