### PR TITLE
fix(config): Rename global `expire_metrics` to `expire_metrics_secs`

### DIFF
--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -48,6 +48,8 @@ pub struct GlobalOptions {
     pub acknowledgements: AcknowledgementsConfig,
     #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
     pub expire_metrics: Option<f64>,
+    #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
+    pub expire_metrics_secs: Option<f64>,
 }
 
 impl GlobalOptions {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -85,7 +85,7 @@ pub async fn start_validated(
     ) {
         (e @ Some(_), None) => {
             warn!(
-                "Global `expire_metrics` setting is deprecated and will be removed in a future version. Use `expire_metrics_secs` instead."
+                "DEPRECATED: `expire_metrics` setting is deprecated and will be removed in a future version. Use `expire_metrics_secs` instead."
             );
             e
         }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -79,11 +79,28 @@ pub async fn start_validated(
 ) -> Option<(RunningTopology, mpsc::UnboundedReceiver<()>)> {
     let (abort_tx, abort_rx) = mpsc::unbounded_channel();
 
+    let expire_metrics = match (
+        config.global.expire_metrics,
+        config.global.expire_metrics_secs,
+    ) {
+        (e @ Some(_), None) => {
+            warn!(
+                "Global `expire_metrics` setting is deprecated and will be removed in a future version. Use `expire_metrics_secs` instead."
+            );
+            e
+        }
+        (Some(_), Some(_)) => {
+            error!("Cannot set both `expire_metrics` and `expire_metrics_secs`.");
+            return None;
+        }
+        (None, e) => e,
+    };
+
     if let Err(error) = crate::metrics::Controller::get()
         .expect("Metrics must be initialized")
-        .set_expiry(config.global.expire_metrics)
+        .set_expiry(expire_metrics)
     {
-        error!(message="Invalid metrics expiry.", %error);
+        error!(message = "Invalid metrics expiry.", %error);
         return None;
     }
 

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -37,6 +37,22 @@ configuration: {
 			}
 		}
 
+		expire_metrics: {
+			common: false
+			description: """
+				If set, Vector will configure the internal metrics system to automatically
+				remove all metrics that have not been updated in the given number of seconds.
+				This value must be positive.
+				"""
+			warnings: ["Deprecated, please use `expire_metrics_secs` instead."]
+			required: false
+			type: float: {
+				default: null
+				examples: [60.0]
+				unit: "seconds"
+			}
+		}
+
 		expire_metrics_secs: {
 			common: false
 			description: """

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -37,7 +37,7 @@ configuration: {
 			}
 		}
 
-		expire_metrics: {
+		expire_metrics_secs: {
 			common: false
 			description: """
 				If set, Vector will configure the internal metrics system to automatically


### PR DESCRIPTION
All configuration that represents a number of seconds should be named `_secs`,
but the global `expire_metrics` setting did not reflect that pattern. This
renames the setting and adds a deprecation warning for the old setting, which
will be removed in a later version.

Ref: https://github.com/vectordotdev/vector/pull/14224#pullrequestreview-1092276407
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
