### PR TITLE
enhancement(vrl): In `parse_key_value` group duplicate keys into an array

### DIFF
--- a/website/cue/reference/remap.cue
+++ b/website/cue/reference/remap.cue
@@ -83,7 +83,7 @@ remap: #Remap & {
 			}
 			warnings: [
 				"All attributes are strings and will require manual type coercing.",
-				"Values of duplicate keys are gruped into an array.",
+				"Values of duplicate keys are grouped into an array.",
 			]
 		},
 		{

--- a/website/cue/reference/remap.cue
+++ b/website/cue/reference/remap.cue
@@ -83,6 +83,7 @@ remap: #Remap & {
 			}
 			warnings: [
 				"All attributes are strings and will require manual type coercing.",
+				"Values of duplicate keys are gruped into an array.",
 			]
 		},
 		{

--- a/website/cue/reference/remap/functions/parse_key_value.cue
+++ b/website/cue/reference/remap/functions/parse_key_value.cue
@@ -123,11 +123,11 @@ remap: functions: parse_key_value: {
 				)
 				"""#
 			return: {
-				at:		"info"
-				method:	"GET"
-				path:	"/index"
-				status:	"200"
-				tags: ["dev","dummy"]
+				at:     "info"
+				method: "GET"
+				path:   "/index"
+				status: "200"
+				tags: ["dev", "dummy"]
 			}
 		},
 	]

--- a/website/cue/reference/remap/functions/parse_key_value.cue
+++ b/website/cue/reference/remap/functions/parse_key_value.cue
@@ -10,7 +10,7 @@ remap: functions: parse_key_value: {
 		"""
 	notices: [
 		"""
-			All values are returned as strings. We recommend manually coercing values to desired types as you see fit.
+			All values are returned as strings or as an array of strings for duplicate keys. We recommend manually coercing values to desired types as you see fit.
 			""",
 	]
 
@@ -111,6 +111,23 @@ remap: functions: parse_key_value: {
 				service: "backend"
 				region:  "eu-east1"
 				beta:    true
+			}
+		},
+		{
+			title: "Parse duplicate keys"
+			source: #"""
+				parse_key_value!(
+					"at=info,method=GET,path=\"/index\",status=200,tags=dev,tags=dummy",
+					field_delimiter: ",",
+					key_value_delimiter: "=",
+				)
+				"""#
+			return: {
+				at:		"info",
+				method: "GET"
+				path:	"/index"
+				status:	"200"
+				tags: 	["dev","dummy"]
 			}
 		},
 	]

--- a/website/cue/reference/remap/functions/parse_key_value.cue
+++ b/website/cue/reference/remap/functions/parse_key_value.cue
@@ -123,11 +123,11 @@ remap: functions: parse_key_value: {
 				)
 				"""#
 			return: {
-				at:		"info",
-				method: "GET"
+				at:		"info"
+				method:	"GET"
 				path:	"/index"
 				status:	"200"
-				tags: 	["dev","dummy"]
+				tags: ["dev","dummy"]
 			}
 		},
 	]


### PR DESCRIPTION
Closes #8841

cc. @sim0nx

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
