### PR TITLE
revert(observability): Convert internal metric counts back to absolute

### DIFF
--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -279,7 +279,6 @@ impl Metric {
     #[allow(clippy::cast_precision_loss)]
     pub(crate) fn from_metric_kv(
         key: &metrics::Key,
-        kind: MetricKind,
         value: MetricValue,
         timestamp: DateTime<Utc>,
     ) -> Self {
@@ -288,7 +287,7 @@ impl Metric {
             .map(|label| (String::from(label.key()), String::from(label.value())))
             .collect::<MetricTags>();
 
-        Self::new(key.name().to_string(), kind, value)
+        Self::new(key.name().to_string(), MetricKind::Absolute, value)
             .with_namespace(Some("vector"))
             .with_timestamp(Some(timestamp))
             .with_tags((!labels.is_empty()).then(|| labels))

--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -14,7 +14,7 @@ use snafu::Snafu;
 
 pub use self::ddsketch::{AgentDDSketch, BinMap, Config};
 use self::{label_filter::VectorLabelFilter, recorder::Registry, recorder::VectorRecorder};
-use crate::event::{Metric, MetricKind, MetricValue};
+use crate::event::{Metric, MetricValue};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -181,13 +181,11 @@ impl Controller {
         let value = (metrics.len() + 2) as f64;
         metrics.push(Metric::from_metric_kv(
             &CARDINALITY_KEY,
-            MetricKind::Absolute,
             MetricValue::Gauge { value },
             timestamp,
         ));
         metrics.push(Metric::from_metric_kv(
             &CARDINALITY_COUNTER_KEY,
-            MetricKind::Absolute,
             MetricValue::Counter { value },
             timestamp,
         ));

--- a/lib/vector-core/src/metrics/recorder.rs
+++ b/lib/vector-core/src/metrics/recorder.rs
@@ -11,7 +11,7 @@ use once_cell::unsync::OnceCell;
 use quanta::Clock;
 
 use super::storage::VectorStorage;
-use crate::event::{Metric, MetricKind, MetricValue};
+use crate::event::{Metric, MetricValue};
 
 thread_local!(static LOCAL_REGISTRY: OnceCell<Registry> = OnceCell::new());
 
@@ -54,13 +54,9 @@ impl Registry {
             }) {
                 // NOTE this will truncate if the value is greater than 2**52.
                 #[allow(clippy::cast_precision_loss)]
-                let value = counter.get_inner().swap(0, Ordering::Relaxed) as f64;
-                metrics.push(Metric::from_metric_kv(
-                    &key,
-                    MetricKind::Incremental,
-                    MetricValue::Counter { value },
-                    timestamp,
-                ));
+                let value = counter.get_inner().load(Ordering::Relaxed) as f64;
+                let value = MetricValue::Counter { value };
+                metrics.push(Metric::from_metric_kv(&key, value, timestamp));
             }
         }
         for (key, gauge) in self.registry.get_gauge_handles() {
@@ -68,12 +64,8 @@ impl Registry {
                 recency.should_store_gauge(&key, gauge.get_generation(), &self.registry)
             }) {
                 let value = gauge.get_inner().load(Ordering::Relaxed);
-                metrics.push(Metric::from_metric_kv(
-                    &key,
-                    MetricKind::Absolute,
-                    MetricValue::Gauge { value },
-                    timestamp,
-                ));
+                let value = MetricValue::Gauge { value };
+                metrics.push(Metric::from_metric_kv(&key, value, timestamp));
             }
         }
         for (key, histogram) in self.registry.get_histogram_handles() {
@@ -81,12 +73,7 @@ impl Registry {
                 recency.should_store_histogram(&key, histogram.get_generation(), &self.registry)
             }) {
                 let value = histogram.get_inner().make_metric();
-                metrics.push(Metric::from_metric_kv(
-                    &key,
-                    MetricKind::Absolute,
-                    value,
-                    timestamp,
-                ));
+                metrics.push(Metric::from_metric_kv(&key, value, timestamp));
             }
         }
         metrics


### PR DESCRIPTION
Revert "enhancement(observability): Convert internal metric counters to incremental (#13883)"

This reverts commit 579d49882775d00b5297a41adb5faaac2ba2898a.

The above change broke metrics exposed in `vector top` and the API, as they
assumed the values were absolute. Also, the current setup does not work in the
presence of multiple consumers pulling from the metrics registry, as the
increments will be split across the consumers with none seeing the whole value.

Closes #14228 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
