### PR TITLE
fix(check-events script): Allow `ComponentEventsDropped` to be emitted in events that are named `<namespace>EventsDropped`

### DIFF
--- a/scripts/check-events
+++ b/scripts/check-events
@@ -45,6 +45,7 @@ class Event
   def initialize(name)
     @path = nil
     @skip_dropped_events = false
+    @emits_component_events_dropped = false
     @name = name
     @reports = []
     @members = {}
@@ -104,6 +105,13 @@ class Event
       message = raw_message.nil? ? var_message : raw_message
 
       add_log(type, message, parameters)
+    end
+  end
+
+  # Scan for the emission of ComponentEventsDropped.
+  def scan_component_dropped_events(block)
+    if block.match(/emit!\(\s*ComponentEventsDropped\s*\{/)
+      @emits_component_events_dropped = true
     end
   end
 
@@ -198,25 +206,35 @@ class Event
     # Validate <Namespace>EventsDropped events
     if is_events_dropped_event && !@skip_dropped_events
 
-      # Name check
-      append('EventsDropped events MUST be named "___EventsDropped".') unless @name.end_with? 'EventsDropped'
-      # Outputs an error log
-      handle.logs_should_have('error')
-      # Metric check
-      counters_must_include_exclude_tags(METRIC_NAME_EVENTS_DROPPED, ['intentional'], ['reason', 'count'])
+      # Don't run the checks on event structs which themselves emit ComponentEventsDropped,
+      # as the ComponentEventsDropped event is already checked.
+      # Instead, verify that component_discarded_events_total is not being over-incremented.
+      if @emits_component_events_dropped
+        if @counters.include? METRIC_NAME_EVENTS_DROPPED
+          @reports.append("Event emitting ComponentEventsDropped should not also increment counter `#{METRIC_NAME_EVENTS_DROPPED}`")
+        end
+      else
 
-      # Make sure EventsDropped events contain the required parameters
-      handle.logs.each do |type, message, parameters|
-        if type == 'error'
-          ['intentional', 'reason'].each do |parameter|
-            unless parameters.include? parameter
-              @reports.append("Error log for EventsDropped event MUST include parameter \"#{parameter}\".")
+        # Name check
+        append('EventsDropped events MUST be named "___EventsDropped".') unless @name.end_with? 'EventsDropped'
+        # Outputs an error log
+        handle.logs_should_have('error')
+        # Metric check
+        counters_must_include_exclude_tags(METRIC_NAME_EVENTS_DROPPED, ['intentional'], ['reason', 'count'])
+
+        # Make sure EventsDropped events contain the required parameters
+        handle.logs.each do |type, message, parameters|
+          if type == 'error'
+            ['intentional', 'reason'].each do |parameter|
+              unless parameters.include? parameter
+                @reports.append("Error log for EventsDropped event MUST include parameter \"#{parameter}\".")
+              end
             end
-          end
 
-          ['intentional'].each do |parameter|
-            if parameters.include? parameter and !@counters[METRIC_NAME_EVENTS_DROPPED].include? parameter
-              @reports.append("Counter \"#{METRIC_NAME_EVENTS_DROPPED}\" must include \"#{parameter}\" to match error log.")
+            ['intentional'].each do |parameter|
+              if parameters.include? parameter and !@counters[METRIC_NAME_EVENTS_DROPPED].include? parameter
+                @reports.append("Counter \"#{METRIC_NAME_EVENTS_DROPPED}\" must include \"#{parameter}\" to match error log.")
+              end
             end
           end
         end
@@ -337,6 +355,7 @@ Find.find('.') do |path|
             event.impl_internal_event = true
             event.scan_metrics(block)
             event.scan_logs(block)
+            event.scan_component_dropped_events(block)
           end
         elsif trait == 'RegisterInternalEvent'
           # Extract the handle type name to join them together

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -120,11 +120,22 @@ pub struct ComponentEventsDropped {
 
 impl InternalEvent for ComponentEventsDropped {
     fn emit(self) {
-        error!(
-            message = "Events dropped.",
-            intentional = self.intentional,
-            reason = self.reason,
-        );
+        let message = "Events dropped";
+        if self.intentional {
+            debug!(
+                message,
+                intentional = self.intentional,
+                reason = self.reason,
+                internal_log_rate_secs = 10,
+            );
+        } else {
+            error!(
+                message,
+                intentional = self.intentional,
+                reason = self.reason,
+                internal_log_rate_secs = 10,
+            );
+        }
         counter!(
             "component_discarded_events_total",
             self.count,


### PR DESCRIPTION
Fixes: #14266.
Closes: #14261.

Tested by adding the following event:

```Rust
#[derive(Debug)]
pub struct FooEventsDropped {
    pub count: u64,
    pub intentional: bool,
    pub reason: &'static str,
}

impl InternalEvent for FooEventsDropped {
    fn emit(self) {
        error!(message = "Hi.",);
        emit!(ComponentEventsDropped {
            count: self.count,
            intentional: self.intentional,
            reason: self.reason,
        });
    }
}
```


```
$ make check-events                                                                                                                                                                                                                                                                                           
./scripts/check-events                                                                                                                                                                                                                                                                                                                                
src/internal_events/common.rs: Errors in event FooEventsDropped:                                                                                                                                                                                                                                                                                      
    Event has no uses.                                                                                                                                                                                                                                                                                                                                
1 error(s)                                                                                                                                                                                                                                                                                                                                            
make: *** [Makefile:479: check-events] Error 1     
```