### PR TITLE
enhancement(throttle transform): Allow throttling by bytes

### DIFF
--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -7,6 +7,7 @@ use serde_with::serde_as;
 use snafu::Snafu;
 use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
+use vector_core::EstimatedJsonEncodedSizeOf;
 
 use crate::{
     conditions::{AnyCondition, Condition},
@@ -345,8 +346,8 @@ mode = "log_json_bytes"
         // 60 bytes after JSON serialization (message + timestamp)
         let event = Event::Log(LogEvent::from("test"));
 
-        tx.send(event.clone().into()).await.unwrap();
-        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
 
         let mut count = 0_u8;
         while count < 2 {
@@ -360,14 +361,14 @@ mode = "log_json_bytes"
 
         clock.advance(Duration::from_secs(2));
 
-        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
 
         // We should be back to pending, having the second event dropped
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
         clock.advance(Duration::from_secs(3));
 
-        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
 
         // The rate limiter should now be refreshed and allow an additional event through
         if let Some(_event) = out_stream.next().await {
@@ -412,8 +413,8 @@ mode = "log_message_bytes"
         // 60 bytes after JSON serialization (message + timestamp)
         let event = Event::Log(LogEvent::from("test"));
 
-        tx.send(event.clone().into()).await.unwrap();
-        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
 
         let mut count = 0_u8;
         while count < 2 {
@@ -427,14 +428,14 @@ mode = "log_message_bytes"
 
         clock.advance(Duration::from_secs(2));
 
-        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
 
         // We should be back to pending, having the second event dropped
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
         clock.advance(Duration::from_secs(3));
 
-        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone()).await.unwrap();
 
         // The rate limiter should now be refreshed and allow an additional event through
         if let Some(_event) = out_stream.next().await {

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -26,9 +26,9 @@ pub enum ThrottleMode {
     /// Throttle based on number of events
     Events,
     /// Throttle based on bytes of each event's estimated json bytes
-    EventBytes,
-    /// Throttle based on bytes of each event's message length
-    MessageLength,
+    EventJsonBytes,
+    /// Throttle based on bytes of each event's message length in bytes
+    MessageBytes,
 }
 
 /// Configuration for the `throttle` transform.
@@ -175,7 +175,17 @@ where
                                         .ok()
                                 });
 
-                                let throttle_count = match self.mode {
+                                let throttle_count = match self.mode.as_ref() {
+                                    Some(ThrottleMode::EventJsonBytes) => event.as_log().estimated_json_encoded_size_of(),
+                                    Some(ThrottleMode::MessageBytes) => {
+                                        event
+                                            .as_log()
+                                            .get("message")
+                                            .unwrap()
+                                            .to_string_lossy()
+                                            .into_owned()
+                                            .len()
+                                    },
                                     _ => 1,
                                 };
 
@@ -250,6 +260,7 @@ mod tests {
             r#"
 threshold = 2
 window_secs = 5
+mode = "events"
 "#,
         )
         .unwrap();
@@ -290,6 +301,140 @@ window_secs = 5
         clock.advance(Duration::from_secs(3));
 
         tx.send(LogEvent::default().into()).await.unwrap();
+
+        // The rate limiter should now be refreshed and allow an additional event through
+        if let Some(_event) = out_stream.next().await {
+        } else {
+            panic!("Unexpectedly received None in output stream");
+        }
+
+        // We should be back to pending, having nothing waiting for us
+        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+
+        tx.disconnect();
+
+        // And still nothing there
+        assert_eq!(Poll::Ready(None), futures::poll!(out_stream.next()));
+    }
+
+    #[tokio::test]
+    async fn throttle_json_bytes() {
+        let clock = clock::FakeRelativeClock::default();
+        let config = toml::from_str::<ThrottleConfig>(
+            r#"
+threshold = 120
+window_secs = 5
+mode = "event_json_bytes"
+"#,
+        )
+        .unwrap();
+
+        let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())
+            .map(Transform::event_task)
+            .unwrap();
+
+        let throttle = throttle.into_task();
+
+        let (mut tx, rx) = futures::channel::mpsc::channel(10);
+        let mut out_stream = throttle.transform_events(Box::pin(rx));
+
+        // tokio interval is always immediately ready, so we poll once to make sure
+        // we trip it/set the interval in the future
+        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+
+        // 60 bytes after JSON serialization (message + timestamp)
+        let event = Event::Log(LogEvent::from("test"));
+
+        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone().into()).await.unwrap();
+
+        let mut count = 0_u8;
+        while count < 2 {
+            if let Some(_event) = out_stream.next().await {
+                count += 1;
+            } else {
+                panic!("Unexpectedly received None in output stream");
+            }
+        }
+        assert_eq!(2, count);
+
+        clock.advance(Duration::from_secs(2));
+
+        tx.send(event.clone().into()).await.unwrap();
+
+        // We should be back to pending, having the second event dropped
+        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+
+        clock.advance(Duration::from_secs(3));
+
+        tx.send(event.clone().into()).await.unwrap();
+
+        // The rate limiter should now be refreshed and allow an additional event through
+        if let Some(_event) = out_stream.next().await {
+        } else {
+            panic!("Unexpectedly received None in output stream");
+        }
+
+        // We should be back to pending, having nothing waiting for us
+        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+
+        tx.disconnect();
+
+        // And still nothing there
+        assert_eq!(Poll::Ready(None), futures::poll!(out_stream.next()));
+    }
+
+    #[tokio::test]
+    async fn throttle_message_bytes() {
+        let clock = clock::FakeRelativeClock::default();
+        let config = toml::from_str::<ThrottleConfig>(
+            r#"
+threshold = 8
+window_secs = 5
+mode = "message_bytes"
+"#,
+        )
+        .unwrap();
+
+        let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())
+            .map(Transform::event_task)
+            .unwrap();
+
+        let throttle = throttle.into_task();
+
+        let (mut tx, rx) = futures::channel::mpsc::channel(10);
+        let mut out_stream = throttle.transform_events(Box::pin(rx));
+
+        // tokio interval is always immediately ready, so we poll once to make sure
+        // we trip it/set the interval in the future
+        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+
+        // 60 bytes after JSON serialization (message + timestamp)
+        let event = Event::Log(LogEvent::from("test"));
+
+        tx.send(event.clone().into()).await.unwrap();
+        tx.send(event.clone().into()).await.unwrap();
+
+        let mut count = 0_u8;
+        while count < 2 {
+            if let Some(_event) = out_stream.next().await {
+                count += 1;
+            } else {
+                panic!("Unexpectedly received None in output stream");
+            }
+        }
+        assert_eq!(2, count);
+
+        clock.advance(Duration::from_secs(2));
+
+        tx.send(event.clone().into()).await.unwrap();
+
+        // We should be back to pending, having the second event dropped
+        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+
+        clock.advance(Duration::from_secs(3));
+
+        tx.send(event.clone().into()).await.unwrap();
 
         // The rate limiter should now be refreshed and allow an additional event through
         if let Some(_event) = out_stream.next().await {

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -26,9 +26,9 @@ pub enum ThrottleMode {
     /// Throttle based on number of events
     Events,
     /// Throttle based on bytes of each event's estimated json bytes
-    EventJsonBytes,
+    LogJsonBytes,
     /// Throttle based on bytes of each event's message length in bytes
-    MessageBytes,
+    LogMessageBytes,
 }
 
 /// Configuration for the `throttle` transform.
@@ -176,8 +176,8 @@ where
                                 });
 
                                 let throttle_count = match self.mode.as_ref() {
-                                    Some(ThrottleMode::EventJsonBytes) => event.as_log().estimated_json_encoded_size_of(),
-                                    Some(ThrottleMode::MessageBytes) => {
+                                    Some(ThrottleMode::LogJsonBytes) => event.as_log().estimated_json_encoded_size_of(),
+                                    Some(ThrottleMode::LogMessageBytes) => {
                                         event
                                             .as_log()
                                             .get("message")
@@ -324,7 +324,7 @@ mode = "events"
             r#"
 threshold = 120
 window_secs = 5
-mode = "event_json_bytes"
+mode = "log_json_bytes"
 "#,
         )
         .unwrap();
@@ -391,7 +391,7 @@ mode = "event_json_bytes"
             r#"
 threshold = 8
 window_secs = 5
-mode = "message_bytes"
+mode = "log_message_bytes"
 "#,
         )
         .unwrap();

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -10,13 +10,12 @@ use vector_core::config::LogNamespace;
 
 use crate::{
     conditions::{AnyCondition, Condition},
-    config::{DataType, Input, Output, TransformConfig, TransformContext, log_schema},
+    config::{log_schema, DataType, Input, Output, TransformConfig, TransformContext},
     event::Event,
     internal_events::{TemplateRenderingError, ThrottleEventDiscarded},
     schema,
     template::Template,
     transforms::{TaskTransform, Transform},
-
 };
 
 /// Configuration for controlling how events will be throttled.

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -10,12 +10,13 @@ use vector_core::config::LogNamespace;
 
 use crate::{
     conditions::{AnyCondition, Condition},
-    config::{DataType, Input, Output, TransformConfig, TransformContext},
+    config::{DataType, Input, Output, TransformConfig, TransformContext, log_schema},
     event::Event,
     internal_events::{TemplateRenderingError, ThrottleEventDiscarded},
     schema,
     template::Template,
     transforms::{TaskTransform, Transform},
+
 };
 
 /// Configuration for controlling how events will be throttled.
@@ -180,7 +181,7 @@ where
                                     Some(ThrottleMode::LogMessageBytes) => {
                                         event
                                             .as_log()
-                                            .get("message")
+                                            .get(log_schema().message_key())
                                             .unwrap()
                                             .to_string_lossy()
                                             .into_owned()

--- a/website/cue/reference/components/transforms/base/throttle.cue
+++ b/website/cue/reference/components/transforms/base/throttle.cue
@@ -21,6 +21,18 @@ base: components: transforms: throttle: configuration: {
 			syntax: "template"
 		}
 	}
+	mode: {
+		description: "The throttling mode used to determine each event's contribution against `threshold`."
+		required: false
+		type: string: {
+			default: "events"
+			enum: {
+				"events": "Throttle by number of events."
+				"log_message_bytes": "Throttle by number of bytes in each event's `message` field (logs only)."
+				"log_json_bytes": "Throttle by number of estimated bytes for JSON representation of each event (logs only)."
+			}
+		}
+	}
 	threshold: {
 		description: """
 			The number of events allowed for a given bucket per configured `window_secs`.

--- a/website/cue/reference/components/transforms/base/throttle.cue
+++ b/website/cue/reference/components/transforms/base/throttle.cue
@@ -23,13 +23,13 @@ base: components: transforms: throttle: configuration: {
 	}
 	mode: {
 		description: "The throttling mode used to determine each event's contribution against `threshold`."
-		required: false
+		required:    false
 		type: string: {
 			default: "events"
 			enum: {
-				"events": "Throttle by number of events."
+				"events":            "Throttle by number of events."
 				"log_message_bytes": "Throttle by number of bytes in each event's `message` field (logs only)."
-				"log_json_bytes": "Throttle by number of estimated bytes for JSON representation of each event (logs only)."
+				"log_json_bytes":    "Throttle by number of estimated bytes for JSON representation of each event (logs only)."
 			}
 		}
 	}

--- a/website/cue/reference/components/transforms/base/throttle.cue
+++ b/website/cue/reference/components/transforms/base/throttle.cue
@@ -22,15 +22,12 @@ base: components: transforms: throttle: configuration: {
 		}
 	}
 	mode: {
-		description: "The throttling mode used to determine each event's contribution against `threshold`."
+		description: "The throttling mode to use."
 		required:    false
-		type: string: {
-			default: "events"
-			enum: {
-				"events":            "Throttle by number of events."
-				"log_message_bytes": "Throttle by number of bytes in each event's `message` field (logs only)."
-				"log_json_bytes":    "Throttle by number of estimated bytes for JSON representation of each event (logs only)."
-			}
+		type: string: enum: {
+			events:            "Throttle based on number of events"
+			log_json_bytes:    "Throttle based on bytes of each event's estimated json bytes"
+			log_message_bytes: "Throttle based on bytes of each event's message length in bytes"
 		}
 	}
 	threshold: {

--- a/website/cue/reference/components/transforms/throttle.cue
+++ b/website/cue/reference/components/transforms/throttle.cue
@@ -104,10 +104,11 @@ components: transforms: throttle: {
 				{
 					title: "Rate Limited Events"
 					body: """
-						The rate limiter will allow up to `threshold` number of events through and drop any further events
-						for that particular bucket when the rate limiter is at capacity. Any event passed when the rate
-						limiter is at capacity will be discarded and tracked by an `events_discarded_total` metric tagged
-						by the bucket's `key`.
+						The rate limiter will allow events through until `threshold` is reached, where each event's contribution
+						against `threshold` is determined by `mode`. The rate limiter will drop any further events for that
+						particular bucket when the rate limiter is at capacity. Any event passed when the rate limiter is at
+						capacity will be discarded and tracked by an `events_discarded_total` metric tagged by the bucket's
+						`key`.
 						"""
 				},
 			]


### PR DESCRIPTION
Implements #11854.

This is my first time programming in rust so some things may be strange. Feedback is greatly appreciated.

I started looking into updating the .cue files for documentation. I saw there are reusable components here, such as the `encoding` configuration I would like to use. However, this currently is only scoped to sinks. The fact that I am using it here in a transform is totally new. I'm not sure whether this is a sign that I am doing something in a very strange way, or if I should just update the necessary pieces to support the `encoding` feature within transforms. If someone can help me answer this, it would be a big help for me.