### PR TITLE
fix(kafka sink): add panic on Fatal error received from `librdkafka`

### DIFF
--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -5,7 +5,7 @@ use futures::future::BoxFuture;
 use rdkafka::{
     error::KafkaError,
     message::OwnedHeaders,
-    producer::{FutureProducer, FutureRecord},
+    producer::{FutureProducer, FutureRecord, Producer},
     util::Timeout,
 };
 use tower::Service;
@@ -109,7 +109,14 @@ impl Service<KafkaRequest> for KafkaService {
                         event_byte_size: request.event_byte_size,
                     })
                 }
-                Err((kafka_err, _original_record)) => Err(kafka_err),
+                Err((kafka_err, _original_record)) => match kafka_err {
+                    KafkaError::MessageProduction(rdkafka::types::RDKafkaErrorCode::Fatal) => {
+                        let (_, error_description) = this.kafka_producer.client()
+                        .fatal_error().unwrap_or((rdkafka::types::RDKafkaErrorCode::Fatal, String::new()));
+                        panic!("Unrecoverable error in Kafka sink: {}, {}", kafka_err, error_description)
+                    }
+                    _ => Err(kafka_err),
+                },
             }
         })
     }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
This is my attempt to fix #14290.
The fatal error is unrecoverable and requires the librdkafka producer to be reinitialized. I think failing fast is a good solution in this situation. So, just panic and let the vector restart after that.
