### PR TITLE
docs: Add de-dot example for map_keys VRL func

### DIFF
--- a/website/cue/reference/remap/functions/map_keys.cue
+++ b/website/cue/reference/remap/functions/map_keys.cue
@@ -67,5 +67,21 @@ remap: functions: map_keys: {
 				"""#
 			return: {"FOO": "foo", "BAR": "bar"}
 		},
+		{
+			title: "De-dot keys"
+			input: log: {
+				labels: {
+					"app.kubernetes.io/name": "mysql"
+				}
+			}
+			source: #"""
+				map_keys(., recursive: true) -> |key| { replace(key, ".", "_") }
+				"""#
+			return: {
+				labels: {
+					"app_kubernetes_io/name": "mysql"
+				}
+			}
+		}
 	]
 }


### PR DESCRIPTION
Adds an example for de-dotting keys with VRL, which is commonly needed when using the `elasticsearch` sink.

NOTE: the input for the example is not rendered on the website at this time, see #14306
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
