### PR TITLE
add compact option to del

### DIFF
--- a/website/cue/reference/remap/functions/del.cue
+++ b/website/cue/reference/remap/functions/del.cue
@@ -16,10 +16,14 @@ remap: functions: del: {
 			type: ["path"]
 		},
 		{
-			name:        "compact"
-			description: "If compact is true, after deletion, if an empty object or array is left behind, it should be removed as well, cascading up to the root. This only applies to the path being deleted, and any parent paths."
-			required:    false
-			default:     false
+			name: "compact"
+			description: """
+				If compact is true, after deletion, if an empty object or array is left
+				behind, it should be removed as well, cascading up to the root. This only
+				applies to the path being deleted, and any parent paths.
+				"""
+			required: false
+			default:  false
 			type: ["boolean"]
 		},
 	]

--- a/website/cue/reference/remap/functions/del.cue
+++ b/website/cue/reference/remap/functions/del.cue
@@ -15,6 +15,13 @@ remap: functions: del: {
 			required:    true
 			type: ["path"]
 		},
+		{
+			name:        "compact"
+			description: "If compact is true, after deletion, if an empty object or array is left behind, it should be removed as well, cascading up to the root."
+			required:    false
+			default: false,
+			type: ["boolean"]
+		},
 	]
 	internal_failure_reasons: []
 	notices: [

--- a/website/cue/reference/remap/functions/del.cue
+++ b/website/cue/reference/remap/functions/del.cue
@@ -17,7 +17,7 @@ remap: functions: del: {
 		},
 		{
 			name:        "compact"
-			description: "If compact is true, after deletion, if an empty object or array is left behind, it should be removed as well, cascading up to the root."
+			description: "If compact is true, after deletion, if an empty object or array is left behind, it should be removed as well, cascading up to the root. This only applies to the path being deleted, and any parent paths."
 			required:    false
 			default:     false
 			type: ["boolean"]

--- a/website/cue/reference/remap/functions/del.cue
+++ b/website/cue/reference/remap/functions/del.cue
@@ -19,7 +19,7 @@ remap: functions: del: {
 			name:        "compact"
 			description: "If compact is true, after deletion, if an empty object or array is left behind, it should be removed as well, cascading up to the root."
 			required:    false
-			default: false,
+			default:     false
 			type: ["boolean"]
 		},
 	]


### PR DESCRIPTION
This adds a `compact` option to the `del` function, which deletes empty objects / arrays.
