### PR TITLE
chore(tests): Remove vector v1 tests

### DIFF
--- a/lib/vector-config/tests/smoke.rs
+++ b/lib/vector-config/tests/smoke.rs
@@ -336,36 +336,6 @@ fn default_advanced_sink_endpoint() -> String {
     String::from("https://zalgohtml5.io")
 }
 
-pub mod vector_v1 {
-    use vector_config::configurable_component;
-
-    use crate::SocketListenAddr;
-
-    /// Configuration for version one of the `vector` source.
-    #[configurable_component]
-    #[derive(Clone, Debug)]
-    #[serde(deny_unknown_fields)]
-    pub(crate) struct VectorConfig {
-        /// The address to listen for connections on.
-        ///
-        /// It _must_ include a port.
-        address: SocketListenAddr,
-
-        /// The timeout, in seconds, before a connection is forcefully closed during shutdown.
-        #[serde(default = "default_shutdown_timeout_secs")]
-        shutdown_timeout_secs: u64,
-
-        /// The size, in bytes, of the receive buffer used for each connection.
-        ///
-        /// This should not typically needed to be changed.
-        receive_buffer_bytes: Option<usize>,
-    }
-
-    const fn default_shutdown_timeout_secs() -> u64 {
-        30
-    }
-}
-
 pub mod vector_v2 {
     use std::net::SocketAddr;
 
@@ -401,26 +371,6 @@ pub mod vector_v2 {
     }
 }
 
-/// Marker type for the version one of the configuration for the `vector` source.
-#[configurable_component]
-#[derive(Clone, Debug)]
-enum V1 {
-    /// Marker value for version one.
-    #[serde(rename = "1")]
-    V1,
-}
-
-/// Configuration for version two of the `vector` source.
-#[configurable_component]
-#[derive(Clone, Debug)]
-pub struct VectorConfigV1 {
-    /// Version of the configuration.
-    version: V1,
-
-    #[serde(flatten)]
-    config: self::vector_v1::VectorConfig,
-}
-
 /// Marker type for the version two of the configuration for the `vector` source.
 #[configurable_component]
 #[derive(Clone, Debug)]
@@ -446,9 +396,6 @@ pub struct VectorConfigV2 {
 #[derive(Clone, Debug)]
 #[serde(untagged)]
 pub enum VectorSourceConfig {
-    /// Configuration for version one.
-    V1(#[configurable(derived)] VectorConfigV1),
-
     /// Configuration for version two.
     V2(#[configurable(derived)] VectorConfigV2),
 }

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -473,16 +473,6 @@ fn timely_shutdown_syslog_unix() {
 }
 
 #[test]
-fn timely_shutdown_vector_v1() {
-    test_timely_shutdown(source_vector(
-        r#"
-    type = "vector"
-    version = "1"
-    address = "${VECTOR_TEST_ADDRESS}""#,
-    ));
-}
-
-#[test]
 fn timely_shutdown_vector_v2() {
     test_timely_shutdown(source_vector(
         r#"


### PR DESCRIPTION
The `timely_shutdown_vector_v1` test is causing CI breakage, and the other is just unworkable as it stands.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
