### PR TITLE
fix(http sink): Expand input type support to match codec's

### DIFF
--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -226,7 +226,7 @@ impl SinkConfig for HttpSinkConfig {
     }
 
     fn input(&self) -> Input {
-        Input::new(self.encoding.config().1.input_type() & DataType::Log)
+        Input::new(self.encoding.config().1.input_type())
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -16,7 +16,7 @@ use vector_config::configurable_component;
 
 use crate::{
     codecs::{Encoder, EncodingConfigWithFraming, SinkType, Transformer},
-    config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     event::Event,
     http::{Auth, HttpClient, MaybeAuth},
     sinks::util::{

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -70,7 +70,7 @@ components: sinks: http: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
+		notices: ["Input type support can depend on configured `encoding.codec`"]
 	}
 
 	configuration: {
@@ -103,9 +103,16 @@ components: sinks: http: {
 	}
 
 	input: {
-		logs:    true
-		metrics: null
-		traces:  false
+		logs: true
+		metrics: {
+			counter:      true
+			distribution: true
+			gauge:        true
+			histogram:    true
+			summary:      true
+			set:          true
+		}
+		traces: true
 	}
 
 	telemetry: metrics: {


### PR DESCRIPTION
We had previously released the widened input type support in Vector in 0.22.0 but narrowed it in
ahead of 0.23.0 thinking that we never released the widened support.

We still need to figure out a better way to model this in the docs: where the input type varies depending on the configured codec.

Fixes: #14319

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
