### PR TITLE
chore(dev): Restore the `-rdynamic` linker flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,3 +18,9 @@ rustflags = "-Lnative=/lib/native-libs"
 
 [target.armv7-unknown-linux-musleabihf]
 rustflags = "-Lnative=/lib/native-libs"
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-rdynamic"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-rdynamic"]


### PR DESCRIPTION
In order for dynamically loaded Lua modules to work, they need to be able to link against the symbols provided by the Lua libraries. These symbols are not exposed unless `vector` is linked with the `-rdynamic` flag. This flag was removed by #13074 (Fix application of `rustflags`) and here we are restoring just this flag for linking.

Closes #14271 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
