### PR TITLE
enhancement(mongodb_metrics source): Rate limit internal errors

### DIFF
--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -48,6 +48,7 @@ impl<'a> InternalEvent for MongoDbMetricsRequestError<'a> {
             error = ?self.error,
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_secs = 10,
         );
         counter!(
             "component_errors_total", 1,
@@ -72,6 +73,7 @@ impl<'a> InternalEvent for MongoDbMetricsBsonParseError<'a> {
             error = ?self.error,
             error_type = error_type::PARSER_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_secs = 10,
         );
         counter!(
             "component_errors_total", 1,


### PR DESCRIPTION
Closes #14198

Both errors are prior to event creation in Vector and don't need to increment a dropped counter.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
