### PR TITLE
chore: Remove unneeded OldEventsReceived

### DIFF
--- a/lib/vector-common/src/internal_event/events_received.rs
+++ b/lib/vector-common/src/internal_event/events_received.rs
@@ -25,29 +25,3 @@ impl InternalEvent for EventsReceived {
         counter!("events_in_total", self.count as u64);
     }
 }
-
-// This should have a better name, but this event is deprecated.
-// Use `EventsReceived` once the deprecated counter below is removed.
-#[allow(clippy::module_name_repetitions)]
-#[derive(Debug)]
-pub struct OldEventsReceived {
-    pub byte_size: usize,
-    pub count: usize,
-}
-
-impl InternalEvent for OldEventsReceived {
-    fn emit(self) {
-        trace!(
-            message = "Events received.",
-            count = self.count,
-            byte_size = self.byte_size,
-        );
-        counter!("component_received_events_total", self.count as u64);
-        counter!(
-            "component_received_event_bytes_total",
-            self.byte_size as u64
-        );
-        // deprecated
-        counter!("events_in_total", self.count as u64);
-    }
-}

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -7,7 +7,7 @@ pub use metrics::SharedString;
 
 pub use bytes_received::BytesReceived;
 pub use bytes_sent::BytesSent;
-pub use events_received::{EventsReceived, OldEventsReceived};
+pub use events_received::EventsReceived;
 pub use events_sent::{EventsSent, DEFAULT_OUTPUT};
 
 pub trait InternalEvent: Sized {

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -2,8 +2,8 @@ use std::time::Instant;
 
 use crate::emit;
 use metrics::{counter, histogram};
+pub use vector_core::internal_event::EventsReceived;
 use vector_core::internal_event::InternalEvent;
-pub use vector_core::internal_event::{EventsReceived, OldEventsReceived};
 
 use super::prelude::{error_stage, error_type};
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -29,7 +29,7 @@ use crate::{
     config::{log_schema, AcknowledgementsConfig, SourceContext},
     event::{BatchNotifier, BatchStatus, LogEvent},
     internal_events::{
-        OldEventsReceived, SqsMessageDeleteBatchError, SqsMessageDeletePartialError,
+        EventsReceived, SqsMessageDeleteBatchError, SqsMessageDeletePartialError,
         SqsMessageDeleteSucceeded, SqsMessageProcessingError, SqsMessageProcessingSucceeded,
         SqsMessageReceiveError, SqsMessageReceiveSucceeded, SqsS3EventRecordInvalidEventIgnored,
         StreamClosedError,
@@ -516,7 +516,7 @@ impl IngestorProcess {
                 }
             }
 
-            emit!(OldEventsReceived {
+            emit!(EventsReceived {
                 count: 1,
                 byte_size: log.size_of()
             });

--- a/src/sources/eventstoredb_metrics/mod.rs
+++ b/src/sources/eventstoredb_metrics/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     config::{self, Output, SourceConfig, SourceContext},
     http::HttpClient,
     internal_events::{
-        EventStoreDbMetricsHttpError, EventStoreDbStatsParsingError, OldEventsReceived,
+        EventStoreDbMetricsHttpError, EventStoreDbStatsParsingError, EventsReceived,
         StreamClosedError,
     },
     tls::TlsSettings,
@@ -123,7 +123,7 @@ fn eventstoredb(
                                 let count = metrics.len();
                                 let byte_size = metrics.size_of();
 
-                                emit!(OldEventsReceived { count, byte_size });
+                                emit!(EventsReceived { count, byte_size });
 
                                 if let Err(error) = cx.out.send_batch(metrics).await {
                                     emit!(StreamClosedError { count, error });

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -18,7 +18,7 @@ use vector_core::ByteSizeOf;
 use crate::{
     codecs::{Decoder, DecodingConfig},
     config::log_schema,
-    internal_events::{OldEventsReceived, StreamClosedError},
+    internal_events::{EventsReceived, StreamClosedError},
     shutdown::ShutdownSignal,
     SourceSender,
 };
@@ -122,7 +122,7 @@ async fn process_stream(
             match result {
                 Ok((events, byte_size)) => {
                     bytes_received.emit(ByteSize(byte_size));
-                    emit!(OldEventsReceived {
+                    emit!(EventsReceived {
                         byte_size: events.size_of(),
                         count: events.len()
                     });

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -39,8 +39,9 @@ use crate::{
     config::{log_schema, AcknowledgementsConfig, DataType, Output, SourceConfig, SourceContext},
     event::{BatchNotifier, BatchStatus, BatchStatusReceiver, LogEvent, Value},
     internal_events::{
-        JournaldCheckpointFileOpenError, JournaldCheckpointSetError, JournaldInvalidRecordError,
-        JournaldReadError, JournaldStartJournalctlError, OldEventsReceived, StreamClosedError,
+        EventsReceived, JournaldCheckpointFileOpenError, JournaldCheckpointSetError,
+        JournaldInvalidRecordError, JournaldReadError, JournaldStartJournalctlError,
+        StreamClosedError,
     },
     serde::bool_or_struct,
     shutdown::ShutdownSignal,
@@ -447,7 +448,7 @@ impl<'a> Batch<'a> {
 
         if !self.events.is_empty() {
             let count = self.events.len();
-            emit!(OldEventsReceived {
+            emit!(EventsReceived {
                 count,
                 byte_size: self.events.size_of(),
             });


### PR DESCRIPTION
EventsReceived emitted the a superset of OldEventsReceived's metrics and logs, this should have zero impact on users.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
