### PR TITLE
docs: Add release note about expiring internal metrics

### DIFF
--- a/website/cue/reference/releases/0.24.0.cue
+++ b/website/cue/reference/releases/0.24.0.cue
@@ -398,9 +398,9 @@ releases: "0.24.0": {
 			type: "enhancement"
 			scopes: ["observability"]
 			description: """
-				Vector's internal metrics store, which is exposed via the `internal_metrics_secs`
+				Vector's internal metrics store, which is exposed via the `internal_metrics`
 				source, now allows for expiration of metrics via a new configurable global
-				`expire_metrics_secs` configuration option. When set, the store will drop metrics that
+				`expire_metrics` configuration option. When set, the store will drop metrics that
 				haven't been seen in the configured duration. This can be used to expire metrics
 				from the `kubernetes_logs` source, and others, which tag their internal metrics with
 				high cardinality, but ephemeral, tags like `file`.

--- a/website/cue/reference/releases/0.24.0.cue
+++ b/website/cue/reference/releases/0.24.0.cue
@@ -33,7 +33,10 @@ releases: "0.24.0": {
 		- A new `opentelemetry` source to receive input from OpenTelemetry collectors and SDKs. Only
 		  logs are supported in this release, but support for metrics and traces are in-flight.
 		  An `opentelemetry` sink will follow.
-		- Support for expiring high cardinality internal metrics through `expire_metrics_secs`.
+		- Support for expiring high cardinality internal metrics through the global `expire_metrics`
+		  (will be replaced by `expire_metrics_secs` in 0.24.1). This can alleviate issues with
+		  Vector using increased memory over time. For now it is opt-in, but we may make this the
+		  default in the future.
 
 		Note that this release has a backwards incompatible data model change that users of the
 		`vector` sink and disk buffers should be aware of while upgrading. See the [note in the

--- a/website/cue/reference/releases/0.24.0.cue
+++ b/website/cue/reference/releases/0.24.0.cue
@@ -33,7 +33,7 @@ releases: "0.24.0": {
 		- A new `opentelemetry` source to receive input from OpenTelemetry collectors and SDKs. Only
 		  logs are supported in this release, but support for metrics and traces are in-flight.
 		  An `opentelemetry` sink will follow.
-		- Support for expiring high cardinality internal metrics through `expire_metrics`.
+		- Support for expiring high cardinality internal metrics through `expire_metrics_secs`.
 
 		Note that this release has a backwards incompatible data model change that users of the
 		`vector` sink and disk buffers should be aware of while upgrading. See the [note in the
@@ -395,9 +395,9 @@ releases: "0.24.0": {
 			type: "enhancement"
 			scopes: ["observability"]
 			description: """
-				Vector's internal metrics store, which is exposed via the `internal_metrics`
+				Vector's internal metrics store, which is exposed via the `internal_metrics_secs`
 				source, now allows for expiration of metrics via a new configurable global
-				`expire_metrics` configuration option. When set, the store will drop metrics that
+				`expire_metrics_secs` configuration option. When set, the store will drop metrics that
 				haven't been seen in the configured duration. This can be used to expire metrics
 				from the `kubernetes_logs` source, and others, which tag their internal metrics with
 				high cardinality, but ephemeral, tags like `file`.

--- a/website/cue/reference/releases/0.24.0.cue
+++ b/website/cue/reference/releases/0.24.0.cue
@@ -33,6 +33,7 @@ releases: "0.24.0": {
 		- A new `opentelemetry` source to receive input from OpenTelemetry collectors and SDKs. Only
 		  logs are supported in this release, but support for metrics and traces are in-flight.
 		  An `opentelemetry` sink will follow.
+		- Support for expiring high cardinality internal metrics through `expire_metrics`.
 
 		Note that this release has a backwards incompatible data model change that users of the
 		`vector` sink and disk buffers should be aware of while upgrading. See the [note in the


### PR DESCRIPTION
This is worth highlighting in the release notes.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
