### PR TITLE
fix(internal events): Double emission of `Error` event in sink framework code.

### DIFF
--- a/lib/vector-common/src/internal_event/service.rs
+++ b/lib/vector-common/src/internal_event/service.rs
@@ -26,30 +26,3 @@ impl<E: std::fmt::Debug> InternalEvent for PollReadyError<E> {
         Some("ServicePollReadyError")
     }
 }
-
-#[derive(Debug)]
-pub struct CallError<E> {
-    pub error: E,
-    pub request_id: usize,
-}
-
-impl<E: std::fmt::Debug> InternalEvent for CallError<E> {
-    fn emit(self) {
-        error!(
-            message = "Service call failed.",
-            request_id = self.request_id,
-            error = ?self.error,
-            error_type = error_type::REQUEST_FAILED,
-            stage = error_stage::SENDING,
-        );
-        counter!(
-            "component_errors_total", 1,
-            "error_type" => error_type::REQUEST_FAILED,
-            "stage" => error_stage::SENDING,
-        );
-    }
-
-    fn name(&self) -> Option<&'static str> {
-        Some("ServiceCallError")
-    }
-}

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -168,7 +168,8 @@ where
     ) {
         match result {
             Err(error) => {
-                emit(service::CallError { error, request_id });
+                // `Error` and `EventsDropped` internal events are emitted in the sink retry logic.
+                error!(message = "Service call failed.", ?error, request_id);
                 finalizers.update_status(EventStatus::Rejected);
             }
             Ok(response) => {


### PR DESCRIPTION
I missed that the `SinkSendError` (and `ComponentEventsDropped`) event gets emitted on the retry logic, which means we don't need to emit internal events here! That's what happens when too much time elapses between submitting PRs and merging them :grimacing: 

Reverted back to the error! log print that was here before my change.



Fixes this unit test failure:

```
failures:
    sinks::datadog::logs::tests::handles_failure_v2

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 269 filtered out; finished in 0.03s


--- TRY 4 STDERR:        vector sinks::datadog::logs::tests::handles_failure_v2 ---
thread 'sinks::datadog::logs::tests::handles_failure_v2' panicked at 'Failed to assert compliance, errors:
  - Multiple (2) events matching `Error`: (`ServiceCallError`, `SinkSendError`). Hint! Don't use the `assert_x_` test helpers on round-trip tests (tests that run more than a single component).
', src/test_util/components.rs:470:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```