### PR TITLE
chore(config): Restore `expire_metrics` back to original type

### DIFF
--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -259,7 +259,7 @@ impl Configurable for Duration {
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         let mut properties = IndexMap::default();
         properties.insert("secs".into(), generate_number_schema::<u64>());
-        properties.insert("nsecs".into(), generate_number_schema::<u64>());
+        properties.insert("nsecs".into(), generate_number_schema::<u32>());
 
         let mut required = BTreeSet::default();
         required.insert("secs".into());

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -6,8 +6,10 @@ use std::{
         NonZeroU8, NonZeroUsize,
     },
     path::PathBuf,
+    time::Duration,
 };
 
+use indexmap::IndexMap;
 use schemars::{gen::SchemaGenerator, schema::SchemaObject};
 use serde::Serialize;
 use vector_config_common::validation::Validation;
@@ -241,5 +243,30 @@ impl Configurable for PathBuf {
 
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
+    }
+}
+
+// The use of `Duration` is deprecated and will be removed in a future version
+impl Configurable for Duration {
+    fn referenceable_name() -> Option<&'static str> {
+        Some("stdlib::Duration")
+    }
+
+    fn description() -> Option<&'static str> {
+        Some("An duration of time.")
+    }
+
+    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+        let mut properties = IndexMap::default();
+        properties.insert("secs".into(), generate_number_schema::<u64>());
+        properties.insert("nsecs".into(), generate_number_schema::<u64>());
+
+        let mut required = BTreeSet::default();
+        required.insert("secs".into());
+        required.insert("nsecs".into());
+
+        Ok(crate::schema::generate_struct_schema(
+            properties, required, None,
+        ))
     }
 }

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -1,4 +1,4 @@
-use std::{fs::DirBuilder, path::PathBuf};
+use std::{fs::DirBuilder, path::PathBuf, time::Duration};
 
 use snafu::{ResultExt, Snafu};
 use vector_common::TimeZone;
@@ -83,7 +83,7 @@ pub struct GlobalOptions {
     /// a small amount of memory for each metric.
     #[configurable(deprecated)]
     #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
-    pub expire_metrics: Option<f64>,
+    pub expire_metrics: Option<Duration>,
 
     /// The amount of time, in seconds, that internal metrics will persist after having not been
     /// updated before they expire and are removed.

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -83,11 +83,11 @@ pub async fn start_validated(
         config.global.expire_metrics,
         config.global.expire_metrics_secs,
     ) {
-        (e @ Some(_), None) => {
+        (Some(e), None) => {
             warn!(
                 "DEPRECATED: `expire_metrics` setting is deprecated and will be removed in a future version. Use `expire_metrics_secs` instead."
             );
-            e
+            Some(e.as_secs_f64())
         }
         (Some(_), Some(_)) => {
             error!("Cannot set both `expire_metrics` and `expire_metrics_secs`.");

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -613,7 +613,7 @@ _values: {
 	unit: #Unit | null
 }
 
-#Unit: "bytes" | "events" | "milliseconds" | "requests" | "seconds" | "lines" | "concurrency"
+#Unit: "bytes" | "events" | "milliseconds" | "nanoseconds" | "requests" | "seconds" | "lines" | "concurrency"
 
 administration: _
 components:     _

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -41,15 +41,32 @@ configuration: {
 			common: false
 			description: """
 				If set, Vector will configure the internal metrics system to automatically
-				remove all metrics that have not been updated in the given number of seconds.
+				remove all metrics that have not been updated in the given time.
 				This value must be positive.
 				"""
-			warnings: ["Deprecated, please use `expire_metrics_secs` instead."]
 			required: false
-			type: float: {
-				default: null
-				examples: [60.0]
-				unit: "seconds"
+			warnings: ["Deprecated, please use `expire_metrics_secs` instead."]
+			type: object: options: {
+				secs: {
+					common:      true
+					required:    false
+					description: "The whole number of seconds after which to expire metrics."
+					type: uint: {
+						default: null
+						examples: [60]
+						unit: "seconds"
+					}
+				}
+				nsecs: {
+					common:      true
+					required:    false
+					description: "The fractional number of seconds after which to expire metrics."
+					type: uint: {
+						default: null
+						examples: [0]
+						unit: "nanoseconds"
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
This preserves the behavior present in version 0.24.0 to avoid breaking any configurations, while still marking the setting as deprecated.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
