### PR TITLE
enhancement(demo_logs source): add assert_source_compliance to unit tests

### DIFF
--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -292,7 +292,7 @@ mod tests {
     use futures::{poll, Stream, StreamExt};
 
     use super::*;
-    use crate::{config::log_schema, event::Event, shutdown::ShutdownSignal, SourceSender};
+    use crate::{config::log_schema, event::Event, shutdown::ShutdownSignal, SourceSender, test_util::components::{assert_source_compliance, SOURCE_TAGS}};
 
     #[test]
     fn generate_config() {
@@ -308,17 +308,21 @@ mod tests {
             LogNamespace::Legacy,
         )
         .build();
-        demo_logs_source(
-            config.interval,
-            config.count,
-            config.format,
-            decoder,
-            ShutdownSignal::noop(),
-            tx,
-            LogNamespace::Legacy,
-        )
-        .await
-        .unwrap();
+
+        assert_source_compliance(&SOURCE_TAGS, async {
+            demo_logs_source(
+                config.interval,
+                config.count,
+                config.format,
+                decoder,
+                ShutdownSignal::noop(),
+                tx,
+                LogNamespace::Legacy,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
         rx
     }
 

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -292,7 +292,13 @@ mod tests {
     use futures::{poll, Stream, StreamExt};
 
     use super::*;
-    use crate::{config::log_schema, event::Event, shutdown::ShutdownSignal, SourceSender, test_util::components::{assert_source_compliance, SOURCE_TAGS}};
+    use crate::{
+        config::log_schema,
+        event::Event,
+        shutdown::ShutdownSignal,
+        test_util::components::{assert_source_compliance, SOURCE_TAGS},
+        SourceSender,
+    };
 
     #[test]
     fn generate_config() {


### PR DESCRIPTION
Ref #14374 

This wraps the unit tests with `assert_source_compliance` to ensure the source emits the correct events.

Note this works with unit tests rather than integration tests since integration tests aren't required due to the simplicity of the source.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
