### PR TITLE
fix(docs): fix wrong default value for `suppress_timestamp` in `prometheus_exporter` sink

### DIFF
--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -128,7 +128,7 @@ components: sinks: prometheus_exporter: {
 			common:      false
 			description: "Whether or not to strip metric timestamp in the response."
 			required:    false
-			type: bool: default: true
+			type: bool: default: false
 		}
 	}
 


### PR DESCRIPTION
* the default for this option is `false`, not `true`

Ref: https://github.com/vectordotdev/vector/blob/5230fcdbb348376a35729a1a2ad7920b7243aa1c/src/sinks/prometheus/exporter.rs#L164-L166
