### PR TITLE
feat(top): add component filtering to vector top command

### DIFF
--- a/src/top/mod.rs
+++ b/src/top/mod.rs
@@ -26,4 +26,8 @@ pub struct Opts {
     /// Whether to reconnect if the underlying Vector API connection drops. By default, top will attempt to reconnect if the connection drops.
     #[clap(short, long)]
     no_reconnect: bool,
+
+    /// Show only specified component with provided id. Multiple component id must be comma-separated.
+    #[clap(short, long, value_delimiter = ',')]
+    component_id: Option<Vec<String>>,
 }


### PR DESCRIPTION
Resolves (probable partially) https://github.com/vectordotdev/vector/issues/14282

In this PR I have added to the `vector top` ability to filter the requested components via command-line filter. E.g. `vector top -c demo_logs,display` will return only two components.

## Implementation details
### Where to filter
I have researched the codebase a little bit and found at least to ways, where the filter can be applied: during the requesting data from via GraphQL, and on the `vector top` side after receiving metric events.

I chose the second way with filtering on the `top` side because:
- We need anyway some kind of filtering for reacting on `ComponentAdded` event
- For me it was easier to implement

Sure, we can try to implement some fancy mechanism on the server side and subscribe only on specific events set but for me it looks like much more difficult to do.

### Why it partially resolves #14282 ?
Because right now it does not support specifying component id patterns (like `demo_*_logs`). It should be done in another PR and I have no desire to implement it right now.