### PR TITLE
fix(dnstap source): recoverable parse errors should be a warning

### DIFF
--- a/src/internal_events/dnstap.rs
+++ b/src/internal_events/dnstap.rs
@@ -28,15 +28,15 @@ impl<'a> InternalEvent for DnstapParseError<'a> {
 }
 
 #[derive(Debug)]
-pub(crate) struct DnstapParseWarning<'a> {
-    pub error: &'a str,
+pub(crate) struct DnstapParseWarning<E> {
+    pub error: E,
 }
 
-impl<'a> InternalEvent for DnstapParseWarning<'a> {
+impl<E: std::fmt::Display> InternalEvent for DnstapParseWarning<E> {
     fn emit(self) {
         warn!(
             message = "Recoverable error occurred while parsing dnstap data.",
-            error = ?self.error,
+            error = %self.error,
             stage = error_stage::PROCESSING,
             error_type = error_type::PARSER_FAILED,
             internal_log_rate_secs = 10,

--- a/src/internal_events/dnstap.rs
+++ b/src/internal_events/dnstap.rs
@@ -26,3 +26,20 @@ impl<'a> InternalEvent for DnstapParseError<'a> {
         counter!("parse_errors_total", 1);
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct DnstapParseWarning<'a> {
+    pub error: &'a str,
+}
+
+impl<'a> InternalEvent for DnstapParseWarning<'a> {
+    fn emit(self) {
+        warn!(
+            message = "Recoverable error occurred while parsing dnstap data.",
+            error = ?self.error,
+            stage = error_stage::PROCESSING,
+            error_type = error_type::PARSER_FAILED,
+            internal_log_rate_secs = 10,
+        );
+    }
+}

--- a/src/internal_events/dnstap.rs
+++ b/src/internal_events/dnstap.rs
@@ -4,15 +4,15 @@ use vector_core::internal_event::InternalEvent;
 use vector_common::internal_event::{error_stage, error_type};
 
 #[derive(Debug)]
-pub(crate) struct DnstapParseError<'a> {
-    pub error: &'a str,
+pub(crate) struct DnstapParseError<E> {
+    pub error: E,
 }
 
-impl<'a> InternalEvent for DnstapParseError<'a> {
+impl<E: std::fmt::Display> InternalEvent for DnstapParseError<E> {
     fn emit(self) {
         error!(
             message = "Error occurred while parsing dnstap data.",
-            error = ?self.error,
+            error = %self.error,
             stage = error_stage::PROCESSING,
             error_type = error_type::PARSER_FAILED,
             internal_log_rate_secs = 10,

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -210,7 +210,7 @@ impl FrameHandler for DnstapFrameHandler {
             match parse_dnstap_data(&self.schema, &mut log_event, frame) {
                 Err(err) => {
                     emit!(DnstapParseError {
-                        error: format!("Dnstap protobuf decode error {:?}.", err).as_str()
+                        error: format!("Dnstap protobuf decode error {:?}.", err)
                     });
                     None
                 }
@@ -221,6 +221,7 @@ impl FrameHandler for DnstapFrameHandler {
             }
         }
     }
+
     fn socket_path(&self) -> PathBuf {
         self.socket_path.clone()
     }

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -153,9 +153,7 @@ impl<'a> DnstapParser<'a> {
             if dnstap_data_type == "Message" {
                 if let Some(message) = proto_msg.message {
                     if let Err(err) = self.parse_dnstap_message(message) {
-                        emit!(DnstapParseWarning {
-                            error: err.to_string().as_str()
-                        });
+                        emit!(DnstapParseWarning { error: &err });
                         need_raw_data = true;
                         self.insert(
                             self.event_schema.dnstap_root_data_schema().error(),
@@ -166,7 +164,7 @@ impl<'a> DnstapParser<'a> {
             }
         } else {
             emit!(DnstapParseWarning {
-                error: format!("Unknown dnstap data type: {}", dnstap_data_type_id).as_str()
+                error: format!("Unknown dnstap data type: {}", dnstap_data_type_id)
             });
             need_raw_data = true;
         }

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -17,7 +17,7 @@ use trust_dns_proto::{
 
 use crate::{
     event::{LogEvent, Value},
-    internal_events::DnstapParseError,
+    internal_events::DnstapParseWarning,
     Error, Result,
 };
 
@@ -153,7 +153,7 @@ impl<'a> DnstapParser<'a> {
             if dnstap_data_type == "Message" {
                 if let Some(message) = proto_msg.message {
                     if let Err(err) = self.parse_dnstap_message(message) {
-                        emit!(DnstapParseError {
+                        emit!(DnstapParseWarning {
                             error: err.to_string().as_str()
                         });
                         need_raw_data = true;
@@ -165,7 +165,7 @@ impl<'a> DnstapParser<'a> {
                 }
             }
         } else {
-            emit!(DnstapParseError {
+            emit!(DnstapParseWarning {
                 error: format!("Unknown dnstap data type: {}", dnstap_data_type_id).as_str()
             });
             need_raw_data = true;


### PR DESCRIPTION
When parsing a dnstap message, if there is an error parsing the message or if the message has an invalid `data_type_id` (anything other than 1), the entire message is inserted as raw data. The parser inserts the entire message into the event as raw data and returns a success.

Currently when this happens an `error` is logged and `component_errors_total` is incremented.

This PR changes this so that it just logs a warning and does not increment `component_errors_total` (should it still increment this?).

Now, the only time an error is raised is if there is an error decoding the raw bytes of the `dnstap` protobuf message. In this case the parse function returns an `Err` which then logs the `error`. The message is then dropped.
 


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
