### PR TITLE
chore: remove duplicate integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,6 @@ test-enterprise: ## Runs enterprise related behavioral tests
 .PHONY: test-integration
 test-integration: ## Runs all integration tests
 test-integration: test-integration-apex test-integration-aws test-integration-axiom test-integration-azure test-integration-clickhouse test-integration-docker-logs test-integration-elasticsearch
-test-integration: test-integration-azure test-integration-clickhouse test-integration-docker-logs test-integration-elasticsearch
 test-integration: test-integration-eventstoredb test-integration-fluent test-integration-gcp test-integration-humio test-integration-http-scrape test-integration-influxdb
 test-integration: test-integration-kafka test-integration-logstash test-integration-loki test-integration-mongodb test-integration-nats
 test-integration: test-integration-nginx test-integration-opentelemetry test-integration-postgres test-integration-prometheus test-integration-pulsar


### PR DESCRIPTION
Some duplicates have crept into the list of integration tests in the Makefile.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

