### PR TITLE
fix(honeycomb sink): Fixes timestamp field to match Honeycomb spec

### DIFF
--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -130,7 +130,7 @@ impl HttpEventEncoder<serde_json::Value> for HoneycombEventEncoder {
         };
 
         let data = json!({
-            "timestamp": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
+            "time": timestamp.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
             "data": log.convert_to_fields(),
         });
 


### PR DESCRIPTION
Honeycomb uses "[time](https://docs.honeycomb.io/api/events/#batched-events-body)" for the batch api endpoint in sending Honeycomb events to represent the timestamp of the event, not "timestamp".  This change will allow Honeycomb to correctly pick up the timestamp field. 
