### PR TITLE
chore: Require TEST_DATADOG_API_KEY for Datadog integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -102,6 +102,9 @@ jobs:
         if: always()
       - run: make test-integration-${{ matrix.test }}-cleanup
         if: ${{ always() }}
+        env:
+          TEST_DATADOG_API_KEY: ${{ secrets.CI_TEST_DATADOG_API_KEY }}
+          SPLUNK_VERSION: ${{ matrix.env.SPLUNK_VERSION }}
 
   test-integration-check:
     name: test-integration-check

--- a/scripts/integration/docker-compose.datadog-agent.yml
+++ b/scripts/integration/docker-compose.datadog-agent.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - backend
     environment:
-      - DD_API_KEY=${TEST_DATADOG_API_KEY}
+      - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
       - DD_APM_ENABLED=false
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_LOGS_DD_URL=runner:8080
@@ -23,7 +23,7 @@ services:
     networks:
       - backend
     environment:
-      - DD_API_KEY=${TEST_DATADOG_API_KEY}
+      - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
       - DD_APM_ENABLED=true
       - DD_APM_DD_URL=http://runner:8081
       - DD_HEALTH_PORT=8183

--- a/scripts/integration/docker-compose.datadog-logs.yml
+++ b/scripts/integration/docker-compose.datadog-logs.yml
@@ -19,7 +19,7 @@ services:
       - "--lib"
       - "::datadog::logs::"
     environment:
-      - TEST_DATADOG_API_KEY
+      - TEST_DATADOG_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
     volumes:
       - ${PWD}:/code
       - target:/code/target

--- a/scripts/integration/docker-compose.datadog-metrics.yml
+++ b/scripts/integration/docker-compose.datadog-metrics.yml
@@ -19,7 +19,7 @@ services:
       - "--lib"
       - "::datadog::metrics::"
     environment:
-      - TEST_DATADOG_API_KEY
+      - TEST_DATADOG_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
     volumes:
       - ${PWD}:/code
       - target:/code/target

--- a/scripts/integration/docker-compose.datadog-traces.yml
+++ b/scripts/integration/docker-compose.datadog-traces.yml
@@ -19,7 +19,7 @@ services:
       - "--lib"
       - "::datadog::traces::"
     environment:
-      - TEST_DATADOG_API_KEY
+      - TEST_DATADOG_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
     volumes:
       - ${PWD}:/code
       - target:/code/target

--- a/src/sinks/datadog/logs/integration_tests.rs
+++ b/src/sinks/datadog/logs/integration_tests.rs
@@ -19,6 +19,7 @@ async fn to_real_v2_endpoint() {
     "#};
     let api_key = std::env::var("TEST_DATADOG_API_KEY")
         .expect("couldn't find the Datatog api key in environment variables");
+    assert_eq!(!api_key.is_empty(), "$TEST_DATADOG_API_KEY required");
     let config = config.replace("atoken", &api_key);
     let (config, cx) = load_sink::<DatadogLogsConfig>(config.as_str()).unwrap();
 

--- a/src/sinks/datadog/logs/integration_tests.rs
+++ b/src/sinks/datadog/logs/integration_tests.rs
@@ -19,7 +19,7 @@ async fn to_real_v2_endpoint() {
     "#};
     let api_key = std::env::var("TEST_DATADOG_API_KEY")
         .expect("couldn't find the Datatog api key in environment variables");
-    assert_eq!(!api_key.is_empty(), "$TEST_DATADOG_API_KEY required");
+    assert!(!api_key.is_empty(), "$TEST_DATADOG_API_KEY required");
     let config = config.replace("atoken", &api_key);
     let (config, cx) = load_sink::<DatadogLogsConfig>(config.as_str()).unwrap();
 

--- a/src/sinks/datadog/metrics/integration_tests.rs
+++ b/src/sinks/datadog/metrics/integration_tests.rs
@@ -176,6 +176,7 @@ async fn real_endpoint() {
         default_namespace = "fake.test.integration"
     "#};
         let api_key = std::env::var("TEST_DATADOG_API_KEY").unwrap();
+        assert_eq!(!api_key.is_empty(), "$TEST_DATADOG_API_KEY required");
         let config = config.replace("${TEST_DATADOG_API_KEY}", &api_key);
         let (config, cx) = load_sink::<DatadogMetricsConfig>(config.as_str()).unwrap();
 

--- a/src/sinks/datadog/metrics/integration_tests.rs
+++ b/src/sinks/datadog/metrics/integration_tests.rs
@@ -176,7 +176,7 @@ async fn real_endpoint() {
         default_namespace = "fake.test.integration"
     "#};
         let api_key = std::env::var("TEST_DATADOG_API_KEY").unwrap();
-        assert_eq!(!api_key.is_empty(), "$TEST_DATADOG_API_KEY required");
+        assert!(!api_key.is_empty(), "$TEST_DATADOG_API_KEY required");
         let config = config.replace("${TEST_DATADOG_API_KEY}", &api_key);
         let (config, cx) = load_sink::<DatadogMetricsConfig>(config.as_str()).unwrap();
 

--- a/src/sinks/datadog/traces/integration_tests.rs
+++ b/src/sinks/datadog/traces/integration_tests.rs
@@ -24,6 +24,7 @@ async fn to_real_traces_endpoint() {
     "#};
         let api_key = std::env::var("TEST_DATADOG_API_KEY")
             .expect("couldn't find the Datatog api key in environment variables");
+        assert_eq!(!api_key.is_empty(), "TEST_DATADOG_API_KEY required");
         let config = config.replace("atoken", &api_key);
         let (config, cx) = load_sink::<DatadogTracesConfig>(config.as_str()).unwrap();
 

--- a/src/sinks/datadog/traces/integration_tests.rs
+++ b/src/sinks/datadog/traces/integration_tests.rs
@@ -24,7 +24,7 @@ async fn to_real_traces_endpoint() {
     "#};
         let api_key = std::env::var("TEST_DATADOG_API_KEY")
             .expect("couldn't find the Datatog api key in environment variables");
-        assert_eq!(!api_key.is_empty(), "TEST_DATADOG_API_KEY required");
+        assert!(!api_key.is_empty(), "TEST_DATADOG_API_KEY required");
         let config = config.replace("atoken", &api_key);
         let (config, cx) = load_sink::<DatadogTracesConfig>(config.as_str()).unwrap();
 


### PR DESCRIPTION
Will fail faster and more clearly than retrying forever.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
