### PR TITLE
fix: allow empty log schema keys

### DIFF
--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -195,49 +195,49 @@ impl SourceConfig for DatadogAgentConfig {
             .schema_definition(global_log_namespace.merge(self.log_namespace))
             .with_source_metadata(
                 self.get_component_name(),
-                "message",
+                Some("message"),
                 "message",
                 Kind::bytes(),
                 Some("message"),
             )
             .with_source_metadata(
                 self.get_component_name(),
-                "status",
+                Some("status"),
                 "status",
                 Kind::bytes(),
                 Some("severity"),
             )
             .with_source_metadata(
                 self.get_component_name(),
-                "timestamp",
+                Some("timestamp"),
                 "timestamp",
                 Kind::timestamp(),
                 Some("timestamp"),
             )
             .with_source_metadata(
                 self.get_component_name(),
-                "hostname",
+                Some("hostname"),
                 "hostname",
                 Kind::bytes(),
                 Some("host"),
             )
             .with_source_metadata(
                 self.get_component_name(),
-                "service",
+                Some("service"),
                 "service",
                 Kind::bytes(),
                 Some("service"),
             )
             .with_source_metadata(
                 self.get_component_name(),
-                "ddsource",
+                Some("ddsource"),
                 "ddsource",
                 Kind::bytes(),
                 Some("source"),
             )
             .with_source_metadata(
                 self.get_component_name(),
-                "ddtags",
+                Some("ddtags"),
                 "ddtags",
                 Kind::bytes(),
                 Some("tags"),


### PR DESCRIPTION
fixes: https://github.com/vectordotdev/vector/issues/14387

Some of the new "log namespace" code assumed that the global schema keys would always be valid, but previously you could set it to an invalid path (such as the empty string) which would prevent the data from being inserted. This is now also supported with the new code.