### PR TITLE
fix(config): Handle both expire_metrics settings when merging configs

### DIFF
--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -302,4 +302,18 @@ mod tests {
         metrics::counter!("test2", 3);
         assert_eq!(controller.capture_metrics().len(), 3);
     }
+
+    #[test]
+    fn expires_metrics_tags() {
+        let controller = init_metrics();
+        controller.set_expiry(Some(IDLE_TIMEOUT)).unwrap();
+
+        metrics::counter!("test4", 1, "tag" => "value1");
+        metrics::counter!("test4", 2, "tag" => "value2");
+        assert_eq!(controller.capture_metrics().len(), 4);
+
+        std::thread::sleep(Duration::from_secs_f64(IDLE_TIMEOUT * 2.0));
+        metrics::counter!("test4", 3, "tag" => "value1");
+        assert_eq!(controller.capture_metrics().len(), 3);
+    }
 }

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -334,6 +334,11 @@ impl ConfigBuilder {
 
         self.global.expire_metrics = self.global.expire_metrics.or(with.global.expire_metrics);
 
+        self.global.expire_metrics_secs = self
+            .global
+            .expire_metrics_secs
+            .or(with.global.expire_metrics_secs);
+
         self.schema.append(with.schema, &mut errors);
 
         self.schema.log_namespace = self.schema.log_namespace.or(with.schema.log_namespace);


### PR DESCRIPTION
The new `expire_metrics_secs` setting was not carried over when merging two configs, which is used during normal startup. This resulted in the new `expire_metrics_secs` setting being ignored in config files.

This also adds another expiry test I added while investigating.

Closes #14394 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
