### PR TITLE
fix(docker_logs source): add assert_source_compliance calls to integration tests

### DIFF
--- a/scripts/integration/docker-compose.docker-logs.yml
+++ b/scripts/integration/docker-compose.docker-logs.yml
@@ -17,7 +17,7 @@ services:
       - "--features"
       - "docker-logs-integration-tests"
       - "--lib"
-      - "::docker_::"
+      - "${FILTER:-::docker_logs::}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}:/code

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -1106,12 +1106,16 @@ mod integration_tests {
     use super::*;
     use crate::{
         event::Event,
-        test_util::{collect_n, collect_ready, trace_init},
+        test_util::{
+            collect_n, collect_ready,
+            components::{assert_source_compliance, SOURCE_TAGS},
+            trace_init,
+        },
         SourceSender,
     };
 
     /// None if docker is not present on the system
-    fn source_with<'a, L: Into<Option<&'a str>>>(
+    async fn source_with<'a, L: Into<Option<&'a str>>>(
         names: &[&str],
         label: L,
     ) -> impl Stream<Item = Event> {
@@ -1120,18 +1124,21 @@ mod integration_tests {
             include_labels: Some(label.into().map(|l| vec![l.to_owned()]).unwrap_or_default()),
             ..DockerLogsConfig::default()
         })
+        .await
     }
 
-    fn source_with_config(config: DockerLogsConfig) -> impl Stream<Item = Event> {
+    async fn source_with_config(config: DockerLogsConfig) -> impl Stream<Item = Event> + Unpin {
         let (sender, recv) = SourceSender::new_test();
-        tokio::spawn(async move {
-            config
-                .build(SourceContext::new_test(sender, None))
-                .await
-                .unwrap()
-                .await
-                .unwrap();
-        });
+        //assert_source_compliance(&FILE_SOURCE_TAGS, async {
+        let source = config
+            .build(SourceContext::new_test(sender, None))
+            .await
+            .unwrap();
+
+        tokio::spawn(async move { source.await.unwrap() });
+        //})
+        //.await;
+
         recv
     }
 
@@ -1325,7 +1332,7 @@ mod integration_tests {
         log: &'static str,
         docker: &Docker,
     ) -> String {
-        let out = source_with(&[name], None);
+        let out = source_with(&[name], None).await;
         let docker = docker.clone();
 
         let id = eternal_container(name, label, log, &docker).await;
@@ -1355,7 +1362,7 @@ mod integration_tests {
         let message = "log container_with_tty";
         let name = "container_with_tty";
 
-        let out = source_with(&[name], None);
+        let out = source_with(&[name], None).await;
 
         let docker = docker(None, None).unwrap();
 
@@ -1377,7 +1384,7 @@ mod integration_tests {
         let name = "vector_test_newly_started";
         let label = "vector_test_label_newly_started";
 
-        let out = source_with(&[name], None);
+        let out = source_with(&[name], None).await;
 
         let docker = docker(None, None).unwrap();
 
@@ -1405,7 +1412,7 @@ mod integration_tests {
         let message = "10";
         let name = "vector_test_restart";
 
-        let out = source_with(&[name], None);
+        let out = source_with(&[name], None).await;
 
         let docker = docker(None, None).unwrap();
 
@@ -1431,7 +1438,7 @@ mod integration_tests {
         let name0 = "vector_test_include_container_0";
         let name1 = "vector_test_include_container_1";
 
-        let out = source_with(&[name1], None);
+        let out = source_with(&[name1], None).await;
 
         let docker = docker(None, None).unwrap();
 
@@ -1464,7 +1471,8 @@ mod integration_tests {
             include_containers: Some(vec![prefix.to_owned()]),
             exclude_containers: Some(vec![excluded0.to_owned()]),
             ..DockerLogsConfig::default()
-        });
+        })
+        .await;
 
         let id0 = container_log_n(1, &excluded0, None, "will not be read", &docker).await;
         let id1 = container_log_n(1, &included0, None, will_be_read, &docker).await;
@@ -1496,7 +1504,7 @@ mod integration_tests {
         let name1 = "vector_test_include_labels_1";
         let label = "vector_test_include_label";
 
-        let out = source_with(&[name0, name1], label);
+        let out = source_with(&[name0, name1], label).await;
 
         let docker = docker(None, None).unwrap();
 
@@ -1522,7 +1530,7 @@ mod integration_tests {
 
         let docker = docker(None, None).unwrap();
         let id = running_container(name, Some(label), message, &docker).await;
-        let out = source_with(&[name], None);
+        let out = source_with(&[name], None).await;
 
         let events = collect_n(out, 1).await;
         let _ = container_kill(&id, &docker).await;
@@ -1545,26 +1553,29 @@ mod integration_tests {
     async fn include_image() {
         trace_init();
 
-        let message = "15";
-        let name = "vector_test_include_image";
-        let config = DockerLogsConfig {
-            include_containers: Some(vec![name.to_owned()]),
-            include_images: Some(vec!["busybox".to_owned()]),
-            ..DockerLogsConfig::default()
-        };
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "15";
+            let name = "vector_test_include_image";
+            let config = DockerLogsConfig {
+                include_containers: Some(vec![name.to_owned()]),
+                include_images: Some(vec!["busybox".to_owned()]),
+                ..DockerLogsConfig::default()
+            };
 
-        let out = source_with_config(config);
+            let out = source_with_config(config).await;
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let id = container_log_n(1, name, None, message, &docker).await;
-        let events = collect_n(out, 1).await;
-        container_remove(&id, &docker).await;
+            let id = container_log_n(1, name, None, message, &docker).await;
+            let events = collect_n(out, 1).await;
+            container_remove(&id, &docker).await;
 
-        assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
-            message.into()
-        );
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key()],
+                message.into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -1578,7 +1589,7 @@ mod integration_tests {
             ..DockerLogsConfig::default()
         };
 
-        let exclude_out = source_with_config(config_ex);
+        let exclude_out = source_with_config(config_ex).await;
 
         let docker = docker(None, None).unwrap();
 
@@ -1592,143 +1603,154 @@ mod integration_tests {
     async fn not_include_running_image() {
         trace_init();
 
-        let message = "17";
-        let name = "vector_test_not_include_running_image";
-        let config_ex = DockerLogsConfig {
-            include_images: Some(vec!["some_image".to_owned()]),
-            ..DockerLogsConfig::default()
-        };
-        let config_in = DockerLogsConfig {
-            include_containers: Some(vec![name.to_owned()]),
-            include_images: Some(vec!["busybox".to_owned()]),
-            ..DockerLogsConfig::default()
-        };
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "17";
+            let name = "vector_test_not_include_running_image";
+            let config_ex = DockerLogsConfig {
+                include_images: Some(vec!["some_image".to_owned()]),
+                ..DockerLogsConfig::default()
+            };
+            let config_in = DockerLogsConfig {
+                include_containers: Some(vec![name.to_owned()]),
+                include_images: Some(vec!["busybox".to_owned()]),
+                ..DockerLogsConfig::default()
+            };
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let id = running_container(name, None, message, &docker).await;
-        let exclude_out = source_with_config(config_ex);
-        let include_out = source_with_config(config_in);
+            let id = running_container(name, None, message, &docker).await;
+            let exclude_out = source_with_config(config_ex).await;
+            let include_out = source_with_config(config_in).await;
 
-        let _ = collect_n(include_out, 1).await;
-        let _ = container_kill(&id, &docker).await;
-        container_remove(&id, &docker).await;
+            let _ = collect_n(include_out, 1).await;
+            let _ = container_kill(&id, &docker).await;
+            container_remove(&id, &docker).await;
 
-        assert!(is_empty(exclude_out));
+            assert!(is_empty(exclude_out));
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn flat_labels() {
         trace_init();
 
-        let message = "18";
-        let name = "vector_test_flat_labels";
-        let label = "vector.test.label.flat.labels";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "18";
+            let name = "vector_test_flat_labels";
+            let label = "vector.test.label.flat.labels";
 
-        let docker = docker(None, None).unwrap();
-        let id = running_container(name, Some(label), message, &docker).await;
-        let out = source_with(&[name], None);
+            let docker = docker(None, None).unwrap();
+            let id = running_container(name, Some(label), message, &docker).await;
+            let out = source_with(&[name], None).await;
 
-        let events = collect_n(out, 1).await;
-        let _ = container_kill(&id, &docker).await;
-        container_remove(&id, &docker).await;
+            let events = collect_n(out, 1).await;
+            let _ = container_kill(&id, &docker).await;
+            container_remove(&id, &docker).await;
 
-        let log = events[0].as_log();
-        assert_eq!(log[log_schema().message_key()], message.into());
-        assert_eq!(log[super::CONTAINER], id.into());
-        assert!(log.get(super::CREATED_AT).is_some());
-        assert_eq!(log[super::IMAGE], "busybox".into());
-        assert!(log
-            .get("label")
-            .unwrap()
-            .as_object()
-            .unwrap()
-            .get(label)
-            .is_some());
-        assert_eq!(events[0].as_log()[&super::NAME], name.into());
-        assert_eq!(
-            events[0].as_log()[log_schema().source_type_key()],
-            "docker".into()
-        );
+            let log = events[0].as_log();
+            assert_eq!(log[log_schema().message_key()], message.into());
+            assert_eq!(log[super::CONTAINER], id.into());
+            assert!(log.get(super::CREATED_AT).is_some());
+            assert_eq!(log[super::IMAGE], "busybox".into());
+            assert!(log
+                .get("label")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get(label)
+                .is_some());
+            assert_eq!(events[0].as_log()[&super::NAME], name.into());
+            assert_eq!(
+                events[0].as_log()[log_schema().source_type_key()],
+                "docker".into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn log_longer_than_16kb() {
         trace_init();
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let mut message = String::with_capacity(20 * 1024);
+            for _ in 0..message.capacity() {
+                message.push('0');
+            }
+            let name = "vector_test_log_longer_than_16kb";
 
-        let mut message = String::with_capacity(20 * 1024);
-        for _ in 0..message.capacity() {
-            message.push('0');
-        }
-        let name = "vector_test_log_longer_than_16kb";
+            let out = source_with(&[name], None).await;
 
-        let out = source_with(&[name], None);
+            let docker = docker(None, None).unwrap();
 
-        let docker = docker(None, None).unwrap();
+            let id = container_log_n(1, name, None, message.as_str(), &docker).await;
+            let events = collect_n(out, 1).await;
+            container_remove(&id, &docker).await;
 
-        let id = container_log_n(1, name, None, message.as_str(), &docker).await;
-        let events = collect_n(out, 1).await;
-        container_remove(&id, &docker).await;
-
-        let log = events[0].as_log();
-        assert_eq!(log[log_schema().message_key()], message.into());
+            let log = events[0].as_log();
+            assert_eq!(log[log_schema().message_key()], message.into());
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn merge_multiline() {
-        trace_init();
+        assert_source_compliance(&SOURCE_TAGS, async {
+            trace_init();
 
-        let emitted_messages = vec![
-            "java.lang.Exception",
-            "    at com.foo.bar(bar.java:123)",
-            "    at com.foo.baz(baz.java:456)",
-        ];
-        let expected_messages = vec![concat!(
-            "java.lang.Exception\n",
-            "    at com.foo.bar(bar.java:123)\n",
-            "    at com.foo.baz(baz.java:456)",
-        )];
-        let name = "vector_test_merge_multiline";
-        let config = DockerLogsConfig {
-            include_containers: Some(vec![name.to_owned()]),
-            include_images: Some(vec!["busybox".to_owned()]),
-            multiline: Some(MultilineConfig {
-                start_pattern: "^[^\\s]".to_owned(),
-                condition_pattern: "^[\\s]+at".to_owned(),
-                mode: line_agg::Mode::ContinueThrough,
-                timeout_ms: 10,
-            }),
-            ..DockerLogsConfig::default()
-        };
+            let emitted_messages = vec![
+                "java.lang.Exception",
+                "    at com.foo.bar(bar.java:123)",
+                "    at com.foo.baz(baz.java:456)",
+            ];
+            let expected_messages = vec![concat!(
+                "java.lang.Exception\n",
+                "    at com.foo.bar(bar.java:123)\n",
+                "    at com.foo.baz(baz.java:456)",
+            )];
+            let name = "vector_test_merge_multiline";
+            let config = DockerLogsConfig {
+                include_containers: Some(vec![name.to_owned()]),
+                include_images: Some(vec!["busybox".to_owned()]),
+                multiline: Some(MultilineConfig {
+                    start_pattern: "^[^\\s]".to_owned(),
+                    condition_pattern: "^[\\s]+at".to_owned(),
+                    mode: line_agg::Mode::ContinueThrough,
+                    timeout_ms: 10,
+                }),
+                ..DockerLogsConfig::default()
+            };
 
-        let out = source_with_config(config);
+            let out = source_with_config(config).await;
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let command = emitted_messages
-            .into_iter()
-            .map(|message| format!("echo {:?}", message))
-            .collect::<Box<_>>()
-            .join(" && ");
+            let command = emitted_messages
+                .into_iter()
+                .map(|message| format!("echo {:?}", message))
+                .collect::<Box<_>>()
+                .join(" && ");
 
-        let id = cmd_container(name, None, vec!["sh", "-c", &command], &docker, false).await;
-        if let Err(error) = container_run(&id, &docker).await {
+            let id = cmd_container(name, None, vec!["sh", "-c", &command], &docker, false).await;
+            if let Err(error) = container_run(&id, &docker).await {
+                container_remove(&id, &docker).await;
+                panic!("Container failed to start with error: {:?}", error);
+            }
+            let events = collect_n(out, expected_messages.len()).await;
             container_remove(&id, &docker).await;
-            panic!("Container failed to start with error: {:?}", error);
-        }
-        let events = collect_n(out, expected_messages.len()).await;
-        container_remove(&id, &docker).await;
 
-        let actual_messages = events
-            .into_iter()
-            .map(|event| {
-                event
-                    .into_log()
-                    .remove(crate::config::log_schema().message_key())
-                    .unwrap()
-                    .to_string_lossy()
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(actual_messages, expected_messages);
+            let actual_messages = events
+                .into_iter()
+                .map(|event| {
+                    event
+                        .into_log()
+                        .remove(crate::config::log_schema().message_key())
+                        .unwrap()
+                        .to_string_lossy()
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(actual_messages, expected_messages);
+        })
+        .await;
     }
 }

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -1129,15 +1129,12 @@ mod integration_tests {
 
     async fn source_with_config(config: DockerLogsConfig) -> impl Stream<Item = Event> + Unpin {
         let (sender, recv) = SourceSender::new_test();
-        //assert_source_compliance(&FILE_SOURCE_TAGS, async {
         let source = config
             .build(SourceContext::new_test(sender, None))
             .await
             .unwrap();
 
         tokio::spawn(async move { source.await.unwrap() });
-        //})
-        //.await;
 
         recv
     }

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -1359,194 +1359,215 @@ mod integration_tests {
     async fn container_with_tty() {
         trace_init();
 
-        let message = "log container_with_tty";
-        let name = "container_with_tty";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "log container_with_tty";
+            let name = "container_with_tty";
 
-        let out = source_with(&[name], None).await;
+            let out = source_with(&[name], None).await;
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let id = container_with_optional_tty_log_n(1, name, None, message, &docker, true).await;
-        let events = collect_n(out, 1).await;
-        container_remove(&id, &docker).await;
+            let id = container_with_optional_tty_log_n(1, name, None, message, &docker, true).await;
+            let events = collect_n(out, 1).await;
+            container_remove(&id, &docker).await;
 
-        assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
-            message.into()
-        );
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key()],
+                message.into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn newly_started() {
         trace_init();
 
-        let message = "9";
-        let name = "vector_test_newly_started";
-        let label = "vector_test_label_newly_started";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "9";
+            let name = "vector_test_newly_started";
+            let label = "vector_test_label_newly_started";
 
-        let out = source_with(&[name], None).await;
+            let out = source_with(&[name], None).await;
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let id = container_log_n(1, name, Some(label), message, &docker).await;
-        let events = collect_n(out, 1).await;
-        container_remove(&id, &docker).await;
+            let id = container_log_n(1, name, Some(label), message, &docker).await;
+            let events = collect_n(out, 1).await;
+            container_remove(&id, &docker).await;
 
-        let log = events[0].as_log();
-        assert_eq!(log[log_schema().message_key()], message.into());
-        assert_eq!(log[super::CONTAINER], id.into());
-        assert!(log.get(super::CREATED_AT).is_some());
-        assert_eq!(log[super::IMAGE], "busybox".into());
-        assert!(log.get(format!("label.{}", label).as_str()).is_some());
-        assert_eq!(events[0].as_log()[&super::NAME], name.into());
-        assert_eq!(
-            events[0].as_log()[log_schema().source_type_key()],
-            "docker".into()
-        );
+            let log = events[0].as_log();
+            assert_eq!(log[log_schema().message_key()], message.into());
+            assert_eq!(log[super::CONTAINER], id.into());
+            assert!(log.get(super::CREATED_AT).is_some());
+            assert_eq!(log[super::IMAGE], "busybox".into());
+            assert!(log.get(format!("label.{}", label).as_str()).is_some());
+            assert_eq!(events[0].as_log()[&super::NAME], name.into());
+            assert_eq!(
+                events[0].as_log()[log_schema().source_type_key()],
+                "docker".into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn restart() {
         trace_init();
 
-        let message = "10";
-        let name = "vector_test_restart";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "10";
+            let name = "vector_test_restart";
 
-        let out = source_with(&[name], None).await;
+            let out = source_with(&[name], None).await;
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let id = container_log_n(2, name, None, message, &docker).await;
-        let events = collect_n(out, 2).await;
-        container_remove(&id, &docker).await;
+            let id = container_log_n(2, name, None, message, &docker).await;
+            let events = collect_n(out, 2).await;
+            container_remove(&id, &docker).await;
 
-        assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
-            message.into()
-        );
-        assert_eq!(
-            events[1].as_log()[log_schema().message_key()],
-            message.into()
-        );
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key()],
+                message.into()
+            );
+            assert_eq!(
+                events[1].as_log()[log_schema().message_key()],
+                message.into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn include_containers() {
         trace_init();
 
-        let message = "11";
-        let name0 = "vector_test_include_container_0";
-        let name1 = "vector_test_include_container_1";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "11";
+            let name0 = "vector_test_include_container_0";
+            let name1 = "vector_test_include_container_1";
 
-        let out = source_with(&[name1], None).await;
+            let out = source_with(&[name1], None).await;
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let id0 = container_log_n(1, name0, None, "11", &docker).await;
-        let id1 = container_log_n(1, name1, None, message, &docker).await;
-        let events = collect_n(out, 1).await;
-        container_remove(&id0, &docker).await;
-        container_remove(&id1, &docker).await;
+            let id0 = container_log_n(1, name0, None, "11", &docker).await;
+            let id1 = container_log_n(1, name1, None, message, &docker).await;
+            let events = collect_n(out, 1).await;
+            container_remove(&id0, &docker).await;
+            container_remove(&id1, &docker).await;
 
-        assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
-            message.into()
-        );
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key()],
+                message.into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn exclude_containers() {
         trace_init();
 
-        let will_be_read = "12";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let will_be_read = "12";
 
-        let prefix = "vector_test_exclude_containers";
-        let included0 = format!("{}_{}", prefix, "include0");
-        let included1 = format!("{}_{}", prefix, "include1");
-        let excluded0 = format!("{}_{}", prefix, "excluded0");
+            let prefix = "vector_test_exclude_containers";
+            let included0 = format!("{}_{}", prefix, "include0");
+            let included1 = format!("{}_{}", prefix, "include1");
+            let excluded0 = format!("{}_{}", prefix, "excluded0");
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let out = source_with_config(DockerLogsConfig {
-            include_containers: Some(vec![prefix.to_owned()]),
-            exclude_containers: Some(vec![excluded0.to_owned()]),
-            ..DockerLogsConfig::default()
+            let out = source_with_config(DockerLogsConfig {
+                include_containers: Some(vec![prefix.to_owned()]),
+                exclude_containers: Some(vec![excluded0.to_owned()]),
+                ..DockerLogsConfig::default()
+            })
+            .await;
+
+            let id0 = container_log_n(1, &excluded0, None, "will not be read", &docker).await;
+            let id1 = container_log_n(1, &included0, None, will_be_read, &docker).await;
+            let id2 = container_log_n(1, &included1, None, will_be_read, &docker).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            let events = collect_ready(out).await;
+            container_remove(&id0, &docker).await;
+            container_remove(&id1, &docker).await;
+            container_remove(&id2, &docker).await;
+
+            assert_eq!(events.len(), 2);
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key()],
+                will_be_read.into()
+            );
+
+            assert_eq!(
+                events[1].as_log()[log_schema().message_key()],
+                will_be_read.into()
+            );
         })
         .await;
-
-        let id0 = container_log_n(1, &excluded0, None, "will not be read", &docker).await;
-        let id1 = container_log_n(1, &included0, None, will_be_read, &docker).await;
-        let id2 = container_log_n(1, &included1, None, will_be_read, &docker).await;
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        let events = collect_ready(out).await;
-        container_remove(&id0, &docker).await;
-        container_remove(&id1, &docker).await;
-        container_remove(&id2, &docker).await;
-
-        assert_eq!(events.len(), 2);
-        assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
-            will_be_read.into()
-        );
-
-        assert_eq!(
-            events[1].as_log()[log_schema().message_key()],
-            will_be_read.into()
-        );
     }
 
     #[tokio::test]
     async fn include_labels() {
         trace_init();
 
-        let message = "13";
-        let name0 = "vector_test_include_labels_0";
-        let name1 = "vector_test_include_labels_1";
-        let label = "vector_test_include_label";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "13";
+            let name0 = "vector_test_include_labels_0";
+            let name1 = "vector_test_include_labels_1";
+            let label = "vector_test_include_label";
 
-        let out = source_with(&[name0, name1], label).await;
+            let out = source_with(&[name0, name1], label).await;
 
-        let docker = docker(None, None).unwrap();
+            let docker = docker(None, None).unwrap();
 
-        let id0 = container_log_n(1, name0, None, "13", &docker).await;
-        let id1 = container_log_n(1, name1, Some(label), message, &docker).await;
-        let events = collect_n(out, 1).await;
-        container_remove(&id0, &docker).await;
-        container_remove(&id1, &docker).await;
+            let id0 = container_log_n(1, name0, None, "13", &docker).await;
+            let id1 = container_log_n(1, name1, Some(label), message, &docker).await;
+            let events = collect_n(out, 1).await;
+            container_remove(&id0, &docker).await;
+            container_remove(&id1, &docker).await;
 
-        assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
-            message.into()
-        );
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key()],
+                message.into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn currently_running() {
         trace_init();
 
-        let message = "14";
-        let name = "vector_test_currently_running";
-        let label = "vector_test_label_currently_running";
+        assert_source_compliance(&SOURCE_TAGS, async {
+            let message = "14";
+            let name = "vector_test_currently_running";
+            let label = "vector_test_label_currently_running";
 
-        let docker = docker(None, None).unwrap();
-        let id = running_container(name, Some(label), message, &docker).await;
-        let out = source_with(&[name], None).await;
+            let docker = docker(None, None).unwrap();
+            let id = running_container(name, Some(label), message, &docker).await;
+            let out = source_with(&[name], None).await;
 
-        let events = collect_n(out, 1).await;
-        let _ = container_kill(&id, &docker).await;
-        container_remove(&id, &docker).await;
+            let events = collect_n(out, 1).await;
+            let _ = container_kill(&id, &docker).await;
+            container_remove(&id, &docker).await;
 
-        let log = events[0].as_log();
-        assert_eq!(log[log_schema().message_key()], message.into());
-        assert_eq!(log[super::CONTAINER], id.into());
-        assert!(log.get(super::CREATED_AT).is_some());
-        assert_eq!(log[super::IMAGE], "busybox".into());
-        assert!(log.get(format!("label.{}", label).as_str()).is_some());
-        assert_eq!(events[0].as_log()[&super::NAME], name.into());
-        assert_eq!(
-            events[0].as_log()[log_schema().source_type_key()],
-            "docker".into()
-        );
+            let log = events[0].as_log();
+            assert_eq!(log[log_schema().message_key()], message.into());
+            assert_eq!(log[super::CONTAINER], id.into());
+            assert!(log.get(super::CREATED_AT).is_some());
+            assert_eq!(log[super::IMAGE], "busybox".into());
+            assert!(log.get(format!("label.{}", label).as_str()).is_some());
+            assert_eq!(events[0].as_log()[&super::NAME], name.into());
+            assert_eq!(
+                events[0].as_log()[log_schema().source_type_key()],
+                "docker".into()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -1581,6 +1602,9 @@ mod integration_tests {
     #[tokio::test]
     async fn not_include_image() {
         trace_init();
+
+        // No assert_source_compliance here since we aren't including the image
+        // no events are collected.
 
         let message = "16";
         let name = "vector_test_not_include_image";


### PR DESCRIPTION
Ref #14411 

This adds `assert_source_compliance` calls to the integration tests for the docker logs source.

There is also a fix to the docker-compose file. It appears the integration tests weren't running at all without this.