### PR TITLE
chore(honeycomb sink): Use HTTP_SINK_TAGS for compliance

### DIFF
--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -150,7 +150,7 @@ impl HttpSink for HoneycombConfig {
         }
     }
 
-    async fn build_request(&self, events: Self::Output) -> crate::Result<http::Request<Bytes>> {
+    async fn build_request(&self, events: Self::Output) -> crate::Result<Request<Bytes>> {
         let uri = self.build_uri();
         let request = Request::post(uri).header("X-Honeycomb-Team", self.api_key.clone());
         let body = crate::serde::json::to_bytes(&events).unwrap().freeze();
@@ -163,8 +163,7 @@ impl HoneycombConfig {
     fn build_uri(&self) -> Uri {
         let uri = format!("{}/{}", self.endpoint, self.dataset);
 
-        uri.parse::<http::Uri>()
-            .expect("This should be a valid uri")
+        uri.parse::<Uri>().expect("This should be a valid uri")
     }
 }
 
@@ -213,7 +212,7 @@ mod test {
     use crate::{
         config::{GenerateConfig, SinkConfig, SinkContext},
         test_util::{
-            components::{run_and_assert_sink_compliance, SINK_TAGS},
+            components::{run_and_assert_sink_compliance, HTTP_SINK_TAGS},
             http::{always_200_response, spawn_blackhole_http_server},
         },
     };
@@ -222,7 +221,7 @@ mod test {
 
     #[test]
     fn generate_config() {
-        crate::test_util::test_generate_config::<super::HoneycombConfig>();
+        crate::test_util::test_generate_config::<HoneycombConfig>();
     }
 
     #[tokio::test]
@@ -238,6 +237,6 @@ mod test {
         let (sink, _healthcheck) = config.build(context).await.unwrap();
 
         let event = Event::Log(LogEvent::from("simple message"));
-        run_and_assert_sink_compliance(sink, stream::once(ready(event)), &SINK_TAGS).await;
+        run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
     }
 }


### PR DESCRIPTION
Closes #14152

It _seems_ like the errors are handled by shared code, and nothing needs to be added here. There are no integration tests for this sink.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
