### PR TITLE
chore(new_relic sink): Adhere to InternalEvents spec

### DIFF
--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -158,7 +158,6 @@ impl SinkConfig for NewRelicConfig {
 
         let sink = NewRelicSink {
             service,
-
             transformer: self.encoding.clone(),
             encoder: NewRelicEncoder,
             credentials,

--- a/src/sinks/new_relic/mod.rs
+++ b/src/sinks/new_relic/mod.rs
@@ -1,5 +1,3 @@
-use crate::config::SinkDescription;
-
 mod config;
 mod encoding;
 mod healthcheck;
@@ -17,7 +15,3 @@ pub use super::{Healthcheck, VectorSink};
 
 #[cfg(test)]
 pub mod tests;
-
-inventory::submit! {
-    SinkDescription::new::<NewRelicConfig>("new_relic")
-}

--- a/src/sinks/new_relic/model.rs
+++ b/src/sinks/new_relic/model.rs
@@ -57,7 +57,7 @@ impl TryFrom<Vec<Event>> for MetricsApiModel {
 
         for buf_event in buf_events {
             if let Event::Metric(metric) = buf_event {
-                // Future improvement: put metric type. If type = count, NR metric model requiere an interval.ms field, that is not provided by the Vector Metric model.
+                // Future improvement: put metric type. If type = count, NR metric model requires an interval.ms field, that is not provided by the Vector Metric model.
                 match metric.value() {
                     MetricValue::Gauge { value } => {
                         metric_array.push((


### PR DESCRIPTION
Closes #14209

Events are handled by the new sink framework, use the new shared `SinkRequestBuildError`

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
