### PR TITLE
feat(vrl): Adds `keys()` and `values()` function

### DIFF
--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -129,6 +129,7 @@ default = [
     "is_string",
     "is_timestamp",
     "join",
+    "keys",
     "length",
     "log",
     "map_keys",
@@ -207,6 +208,7 @@ default = [
     "unnest",
     "upcase",
     "uuid_v4",
+    "values"
 ]
 
 append = []
@@ -270,6 +272,7 @@ is_regex = ["dep:regex"]
 is_string = []
 is_timestamp = ["dep:chrono"]
 join = []
+keys = []
 length = []
 log = ["dep:tracing", "value/json"]
 map_keys = []
@@ -348,6 +351,7 @@ unique = ["dep:indexmap"]
 unnest = ["dep:lookup_lib"]
 upcase = []
 uuid_v4 = ["dep:bytes", "dep:uuid"]
+values = []
 
 [lib]
 bench = false

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -943,7 +943,7 @@ bench_function! {
 
     literal {
         args: func_args![value: value!({"key1": "val1", "key2": "val2"})],
-        want: Ok(["key1", "key2"]),
+        want: Ok(value!(["key1", "key2"])),
     }
 }
 
@@ -2527,6 +2527,6 @@ bench_function! {
 
     literal {
         args: func_args![value: value!({"key1": "val1", "key2": "val2"})],
-        want: Ok(["val1", "val2"]),
+        want: Ok(value!(["val1", "val2"])),
     }
 }

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -68,6 +68,7 @@ criterion_group!(
               is_string,
               is_timestamp,
               join,
+              keys,
               length,
               log,
               r#match,
@@ -142,6 +143,7 @@ criterion_group!(
               // TODO: value is dynamic so we cannot assert equality
               //uuidv4,
               upcase,
+              values,
 );
 criterion_main!(benches);
 
@@ -933,6 +935,15 @@ bench_function! {
     literal {
         args: func_args![value: value!(["hello", "world"]), separator: " "],
         want: Ok("hello world"),
+    }
+}
+
+bench_function! {
+    keys => vrl_stdlib::Keys;
+
+    literal {
+        args: func_args![value: value!({"key1": "val1", "key2": "val2"})],
+        want: Ok(["key1", "key2"]),
     }
 }
 
@@ -2508,5 +2519,14 @@ bench_function! {
     literal {
         args: func_args![value: "foo"],
         want: Ok("FOO")
+    }
+}
+
+bench_function! {
+    values => vrl_stdlib::Values;
+
+    literal {
+        args: func_args![value: value!({"key1": "val1", "key2": "val2"})],
+        want: Ok(["val1", "val2"]),
     }
 }

--- a/lib/vrl/stdlib/src/keys.rs
+++ b/lib/vrl/stdlib/src/keys.rs
@@ -38,9 +38,9 @@ impl Function for Keys {
                 result: Ok(r#"["key1", "key2"]"#),
             },
             Example {
-                title: "get keys",
-                source: r#"keys({"key3": "val3", "key4": "val4"})"#,
-                result: Ok(r#"["key3", "key4"]"#),
+                title: "get keys from a nested object",
+                source: r#"keys({"key1": "val1", "key2": {"nestedkey1": "val3", "nestedkey2": "val4"}})"#,
+                result: Ok(r#"["key1", "key2"]"#),
             },
         ]
     }

--- a/lib/vrl/stdlib/src/keys.rs
+++ b/lib/vrl/stdlib/src/keys.rs
@@ -44,6 +44,7 @@ impl Function for Keys {
             },
         ]
     }
+
     fn compile(
         &self,
         _state: &TypeState,

--- a/lib/vrl/stdlib/src/keys.rs
+++ b/lib/vrl/stdlib/src/keys.rs
@@ -1,0 +1,68 @@
+use ::value::Value;
+use vrl::prelude::*;
+use vrl::Function;
+use vrl::function::Example;
+use vrl::state::TypeState;
+use vrl::function::FunctionCompileContext;
+use vrl::function::ArgumentList;
+use vrl::function::Compiled;
+use vrl::Expression;
+
+fn keys(value: Value) -> Resolved {
+    let mut vec: Vec<Value> = Vec::new();
+    let value_btree = value.try_object()?;
+    
+    for (k, _v) in value_btree {
+        vec.push(Value::Bytes(Bytes::from(k.clone())))
+    }
+    Ok(Value::Array(vec))
+}
+
+
+#[derive(Debug)]
+ pub struct Keys;
+
+ impl Function for Keys {
+    fn identifier(&self) -> &'static str {
+        "keys"
+    }
+    
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::OBJECT,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        unimplemented!();
+    }
+    fn compile(
+        &self,
+        _state: &TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        Ok(KeysFn{ value }.as_expr())
+    }
+
+ }
+
+ #[derive(Debug, Clone)]
+ struct KeysFn {
+    value: Box<dyn Expression>,
+}
+
+ impl FunctionExpression for KeysFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        keys(self.value.resolve(ctx)?)
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+
+        TypeDef::array(Collection::empty().with_unknown(Kind::bytes())).infallible()
+         
+    }
+ }

--- a/lib/vrl/stdlib/src/keys.rs
+++ b/lib/vrl/stdlib/src/keys.rs
@@ -1,32 +1,31 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::Function;
-use vrl::function::Example;
-use vrl::state::TypeState;
-use vrl::function::FunctionCompileContext;
 use vrl::function::ArgumentList;
 use vrl::function::Compiled;
+use vrl::function::Example;
+use vrl::function::FunctionCompileContext;
+use vrl::prelude::*;
+use vrl::state::TypeState;
 use vrl::Expression;
+use vrl::Function;
 
 fn keys(value: Value) -> Resolved {
     let mut vec: Vec<Value> = Vec::new();
     let value_btree = value.try_object()?;
-    
+
     for (k, _v) in value_btree {
         vec.push(Value::Bytes(Bytes::from(k.clone())))
     }
     Ok(Value::Array(vec))
 }
 
-
 #[derive(Debug)]
- pub struct Keys;
+pub struct Keys;
 
- impl Function for Keys {
+impl Function for Keys {
     fn identifier(&self) -> &'static str {
         "keys"
     }
-    
+
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
@@ -36,7 +35,18 @@ fn keys(value: Value) -> Resolved {
     }
 
     fn examples(&self) -> &'static [Example] {
-        unimplemented!();
+        &[
+            Example {
+                title: "get keys",
+                source: r#"keys({"key1": "val1", "key2": "val2"})"#,
+                result: Ok(r#"["key1", "key2"]"#),
+            },
+            Example {
+                title: "get keys",
+                source: r#"keys({"key3": "val3", "key4": "val4"})"#,
+                result: Ok(r#"["key3", "key4"]"#),
+            },
+        ]
     }
     fn compile(
         &self,
@@ -45,24 +55,21 @@ fn keys(value: Value) -> Resolved {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        Ok(KeysFn{ value }.as_expr())
+        Ok(KeysFn { value }.as_expr())
     }
+}
 
- }
-
- #[derive(Debug, Clone)]
- struct KeysFn {
+#[derive(Debug, Clone)]
+struct KeysFn {
     value: Box<dyn Expression>,
 }
 
- impl FunctionExpression for KeysFn {
+impl FunctionExpression for KeysFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         keys(self.value.resolve(ctx)?)
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-
         TypeDef::array(Collection::empty().with_unknown(Kind::bytes())).infallible()
-         
     }
- }
+}

--- a/lib/vrl/stdlib/src/keys.rs
+++ b/lib/vrl/stdlib/src/keys.rs
@@ -9,13 +9,9 @@ use vrl::Expression;
 use vrl::Function;
 
 fn keys(value: Value) -> Resolved {
-    let mut vec: Vec<Value> = Vec::new();
-    let value_btree = value.try_object()?;
-
-    for (k, _v) in value_btree {
-        vec.push(Value::Bytes(Bytes::from(k.clone())))
-    }
-    Ok(Value::Array(vec))
+    let object = value.try_object()?;
+    let keys = object.into_keys().map(Value::from);
+    Ok(Value::Array(keys.collect()))
 }
 
 #[derive(Debug)]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -146,6 +146,8 @@ mod is_string;
 mod is_timestamp;
 #[cfg(feature = "join")]
 mod join;
+#[cfg(feature = "keys")]
+mod keys;
 #[cfg(feature = "length")]
 mod length;
 #[cfg(feature = "log")]
@@ -310,6 +312,8 @@ mod unnest;
 mod upcase;
 #[cfg(feature = "uuid_v4")]
 mod uuid_v4;
+#[cfg(feature = "values")]
+mod values;
 
 // -----------------------------------------------------------------------------
 
@@ -429,6 +433,8 @@ pub use is_string::IsString;
 pub use is_timestamp::IsTimestamp;
 #[cfg(feature = "join")]
 pub use join::Join;
+#[cfg(feature = "keys")]
+pub use keys::Keys;
 #[cfg(feature = "length")]
 pub use length::Length;
 #[cfg(feature = "log")]
@@ -583,6 +589,8 @@ pub use unnest::Unnest;
 pub use upcase::Upcase;
 #[cfg(feature = "uuid_v4")]
 pub use uuid_v4::UuidV4;
+#[cfg(feature = "values")]
+pub use values::Values;
 
 #[cfg(feature = "array")]
 pub use crate::array::Array;
@@ -712,6 +720,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(IsTimestamp),
         #[cfg(feature = "join")]
         Box::new(Join),
+        #[cfg(feature = "keys")]
+        Box::new(Keys),
         #[cfg(feature = "length")]
         Box::new(Length),
         #[cfg(feature = "log")]
@@ -872,5 +882,7 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Upcase),
         #[cfg(feature = "uuid_v4")]
         Box::new(UuidV4),
+        #[cfg(feature = "values")]
+        Box::new(Values),
     ]
 }

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -67,8 +67,13 @@ impl FunctionExpression for ValuesFn {
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {
         // get all the kinds, iterate over it and union all the unknown kinds with reduced_kind()
-        let merged_kind = self.value.type_def(state).kind().as_object().unwrap().reduced_kind();
+        let merged_kind = self
+            .value
+            .type_def(state)
+            .kind()
+            .as_object()
+            .unwrap()
+            .reduced_kind();
         TypeDef::array(Collection::empty().with_unknown(merged_kind)).infallible()
-
     }
 }

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -1,32 +1,31 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::Function;
-use vrl::function::Example;
-use vrl::state::TypeState;
-use vrl::function::FunctionCompileContext;
 use vrl::function::ArgumentList;
 use vrl::function::Compiled;
+use vrl::function::Example;
+use vrl::function::FunctionCompileContext;
+use vrl::prelude::*;
+use vrl::state::TypeState;
 use vrl::Expression;
+use vrl::Function;
 
 fn values(value: Value) -> Resolved {
     let mut vec: Vec<Value> = Vec::new();
     let value_btree = value.try_object()?;
-    
+
     for (_k, v) in value_btree {
         vec.push(v)
     }
     Ok(Value::Array(vec))
 }
 
-
 #[derive(Debug)]
- pub struct Values;
+pub struct Values;
 
- impl Function for Values {
+impl Function for Values {
     fn identifier(&self) -> &'static str {
         "values"
     }
-    
+
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
@@ -36,7 +35,18 @@ fn values(value: Value) -> Resolved {
     }
 
     fn examples(&self) -> &'static [Example] {
-        unimplemented!();
+        &[
+            Example {
+                title: "get keys",
+                source: r#"keys({"key1": "val1", "key2": "val2"})"#,
+                result: Ok(r#"["val1", "val2"]"#),
+            },
+            Example {
+                title: "get keys",
+                source: r#"keys({"key3": "val3", "key4": "val4"})"#,
+                result: Ok(r#"["val3", "val4"]"#),
+            },
+        ]
     }
     fn compile(
         &self,
@@ -45,24 +55,21 @@ fn values(value: Value) -> Resolved {
         arguments: ArgumentList,
     ) -> Compiled {
         let value = arguments.required("value");
-        Ok(ValuesFn{ value }.as_expr())
+        Ok(ValuesFn { value }.as_expr())
     }
+}
 
- }
-
- #[derive(Debug, Clone)]
- struct ValuesFn {
+#[derive(Debug, Clone)]
+struct ValuesFn {
     value: Box<dyn Expression>,
 }
 
- impl FunctionExpression for ValuesFn {
+impl FunctionExpression for ValuesFn {
     fn resolve(&self, ctx: &mut Context) -> Resolved {
         values(self.value.resolve(ctx)?)
     }
 
     fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-
         TypeDef::array(Collection::empty().with_unknown(Kind::bytes())).infallible()
-         
     }
- }
+}

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -38,9 +38,9 @@ impl Function for Values {
                 result: Ok(r#"["val1", "val2"]"#),
             },
             Example {
-                title: "get values",
-                source: r#"values({"key3": "val3", "key4": "val4"})"#,
-                result: Ok(r#"["val3", "val4"]"#),
+                title: "get values from a nested object",
+                source: r#"values({"key1": "val1", "key2": {"nestedkey1": "val3", "nestedkey2": "val4"}})"#,
+                result: Ok(r#"["val1", { "nestedkey1": "val3", "nestedkey2": "val4" }]"#),
             },
         ]
     }
@@ -67,7 +67,7 @@ impl FunctionExpression for ValuesFn {
     }
 
     fn type_def(&self, state: &state::TypeState) -> TypeDef {
-        // get all the kinds, iterate over it and union all the unknown kinds with reduced_kind()
+        // The type of all possible values is merged together to get a more specific value than just `TypeDef::any()`
         let merged_kind = self
             .value
             .type_def(state)

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -65,7 +65,10 @@ impl FunctionExpression for ValuesFn {
         values(self.value.resolve(ctx)?)
     }
 
-    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
-        TypeDef::array(Collection::empty().with_unknown(Kind::bytes())).infallible()
+    fn type_def(&self, state: &state::TypeState) -> TypeDef {
+        // get all the kinds, iterate over it and union all the unknown kinds with reduced_kind()
+        let merged_kind = self.value.type_def(state).kind().as_object().unwrap().reduced_kind();
+        TypeDef::array(Collection::empty().with_unknown(merged_kind)).infallible()
+
     }
 }

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -9,13 +9,9 @@ use vrl::Expression;
 use vrl::Function;
 
 fn values(value: Value) -> Resolved {
-    let mut vec: Vec<Value> = Vec::new();
-    let value_btree = value.try_object()?;
-
-    for (_k, v) in value_btree {
-        vec.push(v)
-    }
-    Ok(Value::Array(vec))
+    let object = value.try_object()?;
+    let values = object.into_values();
+    Ok(Value::Array(values.collect()))
 }
 
 #[derive(Debug)]
@@ -37,13 +33,13 @@ impl Function for Values {
     fn examples(&self) -> &'static [Example] {
         &[
             Example {
-                title: "get keys",
-                source: r#"keys({"key1": "val1", "key2": "val2"})"#,
+                title: "get values",
+                source: r#"values({"key1": "val1", "key2": "val2"})"#,
                 result: Ok(r#"["val1", "val2"]"#),
             },
             Example {
-                title: "get keys",
-                source: r#"keys({"key3": "val3", "key4": "val4"})"#,
+                title: "get values",
+                source: r#"values({"key3": "val3", "key4": "val4"})"#,
                 result: Ok(r#"["val3", "val4"]"#),
             },
         ]

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -44,6 +44,7 @@ impl Function for Values {
             },
         ]
     }
+
     fn compile(
         &self,
         _state: &TypeState,

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -1,0 +1,68 @@
+use ::value::Value;
+use vrl::prelude::*;
+use vrl::Function;
+use vrl::function::Example;
+use vrl::state::TypeState;
+use vrl::function::FunctionCompileContext;
+use vrl::function::ArgumentList;
+use vrl::function::Compiled;
+use vrl::Expression;
+
+fn values(value: Value) -> Resolved {
+    let mut vec: Vec<Value> = Vec::new();
+    let value_btree = value.try_object()?;
+    
+    for (_k, v) in value_btree {
+        vec.push(v)
+    }
+    Ok(Value::Array(vec))
+}
+
+
+#[derive(Debug)]
+ pub struct Values;
+
+ impl Function for Values {
+    fn identifier(&self) -> &'static str {
+        "values"
+    }
+    
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::OBJECT,
+            required: true,
+        }]
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        unimplemented!();
+    }
+    fn compile(
+        &self,
+        _state: &TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        Ok(ValuesFn{ value }.as_expr())
+    }
+
+ }
+
+ #[derive(Debug, Clone)]
+ struct ValuesFn {
+    value: Box<dyn Expression>,
+}
+
+ impl FunctionExpression for ValuesFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        values(self.value.resolve(ctx)?)
+    }
+
+    fn type_def(&self, _state: &state::TypeState) -> TypeDef {
+
+        TypeDef::array(Collection::empty().with_unknown(Kind::bytes())).infallible()
+         
+    }
+ }

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -23,7 +23,7 @@ remap: functions: keys: {
 	}
 	examples: [
 		{
-			title: "Get keys from key value object"
+			title: "Get keys from the object."
 			input: log: {
 				"key1": "val1"
 				"key2": "val2"

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -1,0 +1,33 @@
+package metadata
+
+remap: functions: values: {
+	category: "Type"
+	description: """
+		Returns the `values` from the object passed into the function
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The value that you need to ensure is an object containing keys and values."
+			required:    true
+			type: ["any"]
+		},
+	]
+	return: {
+		types: ["array"]
+		rules: [
+			#"Returns an array for all the values"#,
+		]
+	}
+	examples: [
+		{
+			title: "Get keys from key value object"
+			input: log: value:
+			source: #"""
+				values({"key1": "val1", "key2": "val2"})
+				"""#
+			return: ["val1", "val2"]
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -18,7 +18,7 @@ remap: functions: keys: {
 	return: {
 		types: ["array"]
 		rules: [
-			#"Returns an array for all the keys"#,
+			#"Returns an array of all the keys"#,
 		]
 	}
 	examples: [

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: values: {
 	category: "Type"
 	description: """
-		Returns the `values` from the object passed into the function
+		Returns the `keys` from the object passed into the function
 		"""
 
 	arguments: [
@@ -17,7 +17,7 @@ remap: functions: values: {
 	return: {
 		types: ["array"]
 		rules: [
-			#"Returns an array for all the values"#,
+			#"Returns an array for all the keys"#,
 		]
 	}
 	examples: [
@@ -27,7 +27,7 @@ remap: functions: values: {
 			source: #"""
 				values({"key1": "val1", "key2": "val2"})
 				"""#
-			return: ["val1", "val2"]
+			return: ["key1", "key2"]
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -29,7 +29,7 @@ remap: functions: keys: {
 				"key2": "val2"
 			}
 			source: #"""
-				keys(.)
+				values({"key1": "val1", "key2": "val2"})
 				"""#
 			return: ["key1", "key2"]
 		},

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -9,7 +9,7 @@ remap: functions: keys: {
 	arguments: [
 		{
 			name:        "value"
-			description: "The key, value object to extract keys from."
+			description: "The object to extract keys from."
 			required:    true
 			type: ["object"]
 		},

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -1,19 +1,20 @@
 package metadata
 
-remap: functions: values: {
-	category: "Type"
-	description: """
-		Returns the `keys` from the object passed into the function
-		"""
+remap: functions: keys: {
+	category: "Enumerate"
+	description: #"""
+		Returns the keys from the object passed into the function.
+		"""#
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is an object containing keys and values."
+			description: "The key, value object to extract keys from."
 			required:    true
-			type: ["any"]
+			type: ["object"]
 		},
 	]
+	internal_failure_reasons: []
 	return: {
 		types: ["array"]
 		rules: [
@@ -23,9 +24,12 @@ remap: functions: values: {
 	examples: [
 		{
 			title: "Get keys from key value object"
-			input: log: value:
+			input: log: {
+				"key1": "val1"
+				"key2": "val2"
+			}
 			source: #"""
-				values({"key1": "val1", "key2": "val2"})
+				keys(.)
 				"""#
 			return: ["key1", "key2"]
 		},

--- a/website/cue/reference/remap/functions/keys.cue
+++ b/website/cue/reference/remap/functions/keys.cue
@@ -29,7 +29,7 @@ remap: functions: keys: {
 				"key2": "val2"
 			}
 			source: #"""
-				values({"key1": "val1", "key2": "val2"})
+				keys({"key1": "val1", "key2": "val2"})
 				"""#
 			return: ["key1", "key2"]
 		},

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -1,0 +1,38 @@
+package metadata
+
+remap: functions: float: {
+	category: "Type"
+	description: """
+		Returns the `value` if it's a float and errors otherwise. This enables the type checker to guarantee that the
+		returned value is a float and can be used in any function that expects one.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The value that you need to ensure is a float."
+			required:    true
+			type: ["any"]
+		},
+	]
+	internal_failure_reasons: [
+		"`value` isn't a float.",
+	]
+	return: {
+		types: ["float"]
+		rules: [
+			#"Returns the `value` if it's a float."#,
+			#"Raises an error if not a float."#,
+		]
+	}
+	examples: [
+		{
+			title: "Declare a float type"
+			input: log: value: 42.0
+			source: #"""
+				float!(.value)
+				"""#
+			return: input.log.value
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -9,7 +9,7 @@ remap: functions: values: {
 	arguments: [
 		{
 			name:        "value"
-			description: "The key, value object to extract values from."
+			description: "The object to extract values from."
 			required:    true
 			type: ["object"]
 		},

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -25,8 +25,8 @@ remap: functions: values: {
 		{
 			title: "Get values from key value object"
 			input: log: {
-				"key3": "val3"
-				"key4": "val4"
+				"key1": "val1"
+				"key2": "val2"
 			}
 			source: #"""
 				values({"key1": "val1", "key2": "val2"})

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -1,38 +1,33 @@
 package metadata
 
-remap: functions: float: {
+remap: functions: values: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's a float and errors otherwise. This enables the type checker to guarantee that the
-		returned value is a float and can be used in any function that expects one.
+		Returns the `values` from the object passed into the function
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is a float."
+			description: "The value that you need to ensure is an object containing keys and values."
 			required:    true
 			type: ["any"]
 		},
 	]
-	internal_failure_reasons: [
-		"`value` isn't a float.",
-	]
 	return: {
-		types: ["float"]
+		types: ["array"]
 		rules: [
-			#"Returns the `value` if it's a float."#,
-			#"Raises an error if not a float."#,
+			#"Returns an array for all the values"#,
 		]
 	}
 	examples: [
 		{
-			title: "Declare a float type"
-			input: log: value: 42.0
+			title: "Get values from key value object"
+			input: log: value:
 			source: #"""
-				float!(.value)
+				values({"key1": "val1", "key2": "val2"})
 				"""#
-			return: input.log.value
+			return: ["val1", "val2"]
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -23,7 +23,7 @@ remap: functions: values: {
 	}
 	examples: [
 		{
-			title: "Get values from key value object"
+			title: "Get values from the object."
 			input: log: {
 				"key1": "val1"
 				"key2": "val2"

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -29,9 +29,9 @@ remap: functions: values: {
 				"key4": "val4"
 			}
 			source: #"""
-				values(.)
+				values({"key1": "val1", "key2": "val2"})
 				"""#
-			return: ["val3", "val4"]
+			return: ["val1", "val2"]
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -1,33 +1,37 @@
 package metadata
 
 remap: functions: values: {
-	category: "Type"
-	description: """
-		Returns the `values` from the object passed into the function
-		"""
+	category: "Enumerate"
+	description: #"""
+		Returns the values from the object passed into the function.
+		"""#
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is an object containing keys and values."
+			description: "The key, value object to extract values from."
 			required:    true
-			type: ["any"]
+			type: ["object"]
 		},
 	]
+	internal_failure_reasons: []
 	return: {
 		types: ["array"]
 		rules: [
-			#"Returns an array for all the values"#,
+			#"Returns an array for all the values."#,
 		]
 	}
 	examples: [
 		{
 			title: "Get values from key value object"
-			input: log: value:
+			input: log: {
+				"key3": "val3"
+				"key4": "val4"
+			}
 			source: #"""
-				values({"key1": "val1", "key2": "val2"})
+				values(.)
 				"""#
-			return: ["val1", "val2"]
+			return: ["val3", "val4"]
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/values.cue
+++ b/website/cue/reference/remap/functions/values.cue
@@ -18,7 +18,7 @@ remap: functions: values: {
 	return: {
 		types: ["array"]
 		rules: [
-			#"Returns an array for all the values."#,
+			#"Returns an array of all the values."#,
 		]
 	}
 	examples: [


### PR DESCRIPTION
Issue: https://github.com/vectordotdev/vector/issues/11888

This adds a `values` method and a `keys` method to print out only the keys or values of a given iterable vrl `Value` input.
Examples is yet to be implemented, future iteration is needed and feedback is welcome.

Testing:
To be determined
