### PR TITLE
chore(dev): Allow loading YAML configs with `run-vector` script

### DIFF
--- a/scripts/features
+++ b/scripts/features
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import sys, tomlkit, yaml
+import os, sys, tomlkit, yaml
 from yaml.loader import SafeLoader
 
 try:
@@ -8,10 +8,11 @@ except:
   print("usage: {} CONFIG.toml".format(sys.argv[0]))
   exit(1)
 
-if filename.lower().endswith('.yaml'):
+_, ext = os.path.splitext(filename.lower())
+if ext in ['.yaml', '.yml']:
   with open(filename) as fh:
     config = yaml.load(fh, Loader=SafeLoader)
-elif filename.lower().endswith('.toml'):
+elif ext == '.toml':
   with open(filename, 'rb') as fh:
     config = tomlkit.load(fh)
 else:

--- a/scripts/features
+++ b/scripts/features
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-import sys, tomlkit
+import sys, tomlkit, yaml
+from yaml.loader import SafeLoader
 
 try:
   _, filename = sys.argv
@@ -7,8 +8,15 @@ except:
   print("usage: {} CONFIG.toml".format(sys.argv[0]))
   exit(1)
 
-with open(filename, 'rb') as fh:
-  config = tomlkit.load(fh)
+if filename.lower().endswith('.yaml'):
+  with open(filename) as fh:
+    config = yaml.load(fh, Loader=SafeLoader)
+elif filename.lower().endswith('.toml'):
+  with open(filename, 'rb') as fh:
+    config = tomlkit.load(fh)
+else:
+  print("{}: Unknown config filename extension.".format(sys.argv[0]))
+  exit(1)
 
 base_features = set()
 


### PR DESCRIPTION
The `features` script that extracts cargo features from a configuration file was hard-coded to accept only TOML configuration files. Since we are seeing more YAML configuration files, this also needs to account for that file format.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
