### PR TITLE
fix(docker-logs source): old messages that are dropped should be a component_error

### DIFF
--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -1,9 +1,8 @@
 use bollard::errors::Error;
 use chrono::ParseError;
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct DockerLogsEventsReceived<'a> {
@@ -210,6 +209,5 @@ impl InternalEvent for DockerLogsReceivedOldLogError<'_> {
             "stage" => error_stage::RECEIVING,
             "container_id" => self.container_id.to_owned(),
         );
-
     }
 }

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -197,7 +197,7 @@ pub struct DockerLogsReceivedOldLogError<'a> {
 impl InternalEvent for DockerLogsReceivedOldLogError<'_> {
     fn emit(self) {
         error!(
-            message = "Received older log.",
+            message = "Received out of order log message.",
             error_type = error_type::CONDITION_FAILED,
             stage = error_stage::RECEIVING,
             container_id = ?self.container_id,

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -12,7 +12,7 @@ pub struct DockerLogsEventsReceived<'a> {
     pub container_name: &'a str,
 }
 
-impl<'a> InternalEvent for DockerLogsEventsReceived<'a> {
+impl InternalEvent for DockerLogsEventsReceived<'_> {
     fn emit(self) {
         trace!(
             message = "Events received.",
@@ -42,7 +42,7 @@ pub struct DockerLogsContainerEventReceived<'a> {
     pub action: &'a str,
 }
 
-impl<'a> InternalEvent for DockerLogsContainerEventReceived<'a> {
+impl InternalEvent for DockerLogsContainerEventReceived<'_> {
     fn emit(self) {
         debug!(
             message = "Received one container event.",
@@ -58,7 +58,7 @@ pub struct DockerLogsContainerWatch<'a> {
     pub container_id: &'a str,
 }
 
-impl<'a> InternalEvent for DockerLogsContainerWatch<'a> {
+impl InternalEvent for DockerLogsContainerWatch<'_> {
     fn emit(self) {
         info!(
             message = "Started watching for container logs.",
@@ -73,7 +73,7 @@ pub struct DockerLogsContainerUnwatch<'a> {
     pub container_id: &'a str,
 }
 
-impl<'a> InternalEvent for DockerLogsContainerUnwatch<'a> {
+impl InternalEvent for DockerLogsContainerUnwatch<'_> {
     fn emit(self) {
         info!(
             message = "Stopped watching for container logs.",
@@ -89,7 +89,7 @@ pub struct DockerLogsCommunicationError<'a> {
     pub container_id: Option<&'a str>,
 }
 
-impl<'a> InternalEvent for DockerLogsCommunicationError<'a> {
+impl InternalEvent for DockerLogsCommunicationError<'_> {
     fn emit(self) {
         error!(
             message = "Error in communication with Docker daemon.",
@@ -115,7 +115,7 @@ pub struct DockerLogsContainerMetadataFetchError<'a> {
     pub container_id: &'a str,
 }
 
-impl<'a> InternalEvent for DockerLogsContainerMetadataFetchError<'a> {
+impl InternalEvent for DockerLogsContainerMetadataFetchError<'_> {
     fn emit(self) {
         error!(
             message = "Failed to fetch container metadata.",
@@ -142,7 +142,7 @@ pub struct DockerLogsTimestampParseError<'a> {
     pub container_id: &'a str,
 }
 
-impl<'a> InternalEvent for DockerLogsTimestampParseError<'a> {
+impl InternalEvent for DockerLogsTimestampParseError<'_> {
     fn emit(self) {
         error!(
             message = "Failed to parse timestamp as RFC3339 timestamp.",
@@ -169,7 +169,7 @@ pub struct DockerLogsLoggingDriverUnsupportedError<'a> {
     pub error: Error,
 }
 
-impl<'a> InternalEvent for DockerLogsLoggingDriverUnsupportedError<'a> {
+impl InternalEvent for DockerLogsLoggingDriverUnsupportedError<'_> {
     fn emit(self) {
         error!(
             message = "Docker engine is not using either the `jsonfile` or `journald` logging driver. Please enable one of these logging drivers to get logs from the Docker daemon.",
@@ -186,5 +186,30 @@ impl<'a> InternalEvent for DockerLogsLoggingDriverUnsupportedError<'a> {
         );
         // deprecated
         counter!("logging_driver_errors_total", 1);
+    }
+}
+
+#[derive(Debug)]
+pub struct DockerLogsReceivedOldLogError<'a> {
+    pub timestamp_str: &'a str,
+    pub container_id: &'a str,
+}
+
+impl InternalEvent for DockerLogsReceivedOldLogError<'_> {
+    fn emit(self) {
+        error!(
+            message = "Received older log.",
+            error_type = error_type::CONDITION_FAILED,
+            stage = error_stage::RECEIVING,
+            container_id = ?self.container_id,
+            timestamp = ?self.timestamp_str,
+        );
+        counter!(
+            "component_errors_total", 1,
+            "error_type" => error_type::CONDITION_FAILED,
+            "stage" => error_stage::RECEIVING,
+            "container_id" => self.container_id.to_owned(),
+        );
+
     }
 }

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -189,12 +189,12 @@ impl InternalEvent for DockerLogsLoggingDriverUnsupportedError<'_> {
 }
 
 #[derive(Debug)]
-pub struct DockerLogsReceivedOldLogError<'a> {
+pub struct DockerLogsReceivedOutOfOrderError<'a> {
     pub timestamp_str: &'a str,
     pub container_id: &'a str,
 }
 
-impl InternalEvent for DockerLogsReceivedOldLogError<'_> {
+impl InternalEvent for DockerLogsReceivedOutOfOrderError<'_> {
     fn emit(self) {
         error!(
             message = "Received out of order log message.",

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -33,7 +33,7 @@ use crate::{
         DockerLogsCommunicationError, DockerLogsContainerEventReceived,
         DockerLogsContainerMetadataFetchError, DockerLogsContainerUnwatch,
         DockerLogsContainerWatch, DockerLogsEventsReceived,
-        DockerLogsLoggingDriverUnsupportedError, DockerLogsReceivedOldLogError,
+        DockerLogsLoggingDriverUnsupportedError, DockerLogsReceivedOutOfOrderError,
         DockerLogsTimestampParseError, StreamClosedError,
     },
     line_agg::{self, LineAgg},
@@ -867,7 +867,7 @@ impl ContainerLogInfo {
                     }
                     // Received log is older than the previously received entry.
                     _ => {
-                        emit!(DockerLogsReceivedOldLogError {
+                        emit!(DockerLogsReceivedOutOfOrderError {
                             container_id: self.id.as_str(),
                             timestamp_str,
                         });

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -855,14 +855,17 @@ impl ContainerLogInfo {
             Ok(timestamp) => {
                 // Timestamp check
                 match self.last_log.as_ref() {
-                    // Received log has not already been processed
+                    // Received log has not already been processed.
                     Some(&(ref last, gen))
                         if *last < timestamp || (*last == timestamp && gen == self.generation) =>
                     {
                         // noop
                     }
-                    // Received log is not from before of creation
-                    None if self.created <= timestamp.with_timezone(&Utc) => (),
+                    // Received log is after the time the container was created.
+                    None if self.created <= timestamp.with_timezone(&Utc) => {
+                        // noop
+                    }
+                    // Received log is older than the previously received entry.
                     _ => {
                         emit!(DockerLogsReceivedOldLogError {
                             container_id: self.id.as_str(),

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -33,7 +33,8 @@ use crate::{
         DockerLogsCommunicationError, DockerLogsContainerEventReceived,
         DockerLogsContainerMetadataFetchError, DockerLogsContainerUnwatch,
         DockerLogsContainerWatch, DockerLogsEventsReceived,
-        DockerLogsLoggingDriverUnsupportedError, DockerLogsTimestampParseError, StreamClosedError,
+        DockerLogsLoggingDriverUnsupportedError, DockerLogsReceivedOldLogError,
+        DockerLogsTimestampParseError, StreamClosedError,
     },
     line_agg::{self, LineAgg},
     shutdown::ShutdownSignal,
@@ -863,10 +864,10 @@ impl ContainerLogInfo {
                     // Received log is not from before of creation
                     None if self.created <= timestamp.with_timezone(&Utc) => (),
                     _ => {
-                        trace!(
-                            message = "Received older log.",
-                            timestamp = %timestamp_str
-                        );
+                        emit!(DockerLogsReceivedOldLogError {
+                            container_id: self.id.as_str(),
+                            timestamp_str,
+                        });
                         return None;
                     }
                 }


### PR DESCRIPTION
Ref #14411 

When receiving a message from docker that is older than the previous one, this message was being dropped and a `trace` message was emitted.

I would argue that this should be a component error, and this PR makes it so. 

It's not 100% clear to me under what circumstances this error would occur, so I am open to arguments as to why this should remain a trace - in which case I will update to add a comment with that reason.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
