### PR TITLE
docs(vector sink): Re-add `tls.enabled` option

### DIFF
--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -42,7 +42,7 @@ components: sinks: vector: {
 				can_verify_certificate: true
 				can_verify_hostname:    true
 				enabled_default:        false
-				enabled_by_scheme:      true
+				enabled_by_scheme:      false // sink allows both scheme or `enabled` to be used
 			}
 			to: {
 				service: services.vector


### PR DESCRIPTION
This sink supports both `tls.enabled` _or_ including `https` in the `address` field.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
