### PR TITLE
fix(kubernetes_logs) problem with fail to annotate when pod names are reused

### DIFF
--- a/src/kubernetes/meta_cache.rs
+++ b/src/kubernetes/meta_cache.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+
+use kube::core::ObjectMeta;
+
+pub struct Cacher {
+    pub cache: HashMap<MetaDescribe, bool>
+}
+
+impl Cacher {
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new()
+        }
+    }
+    pub fn store(&mut self, meta_desc: MetaDescribe, active: bool) {
+        self.cache.insert(meta_desc, active);
+    }
+    pub fn is_active(&self, meta_descr: &MetaDescribe) -> bool {
+        match self.cache.get(&meta_descr) {
+            Some(cache_value) => cache_value.to_owned(),
+            None => false,
+        }
+    }
+
+}
+#[derive(PartialEq, Eq, Hash)]
+pub struct MetaDescribe {
+    name: String,
+    namespace: String,
+}
+
+impl MetaDescribe {
+    pub fn new<T: Into<String>>(name: T, namespace: T) -> Self {
+        Self {
+            name: name.into(),
+            namespace: namespace.into(),
+        }
+    }
+
+    pub fn from_meta(meta: &ObjectMeta) -> Self {
+        let meta = meta.clone();
+        let name = meta.name.unwrap_or_default();
+        let namespace = meta.namespace.unwrap_or_default();
+        Self {
+            name,
+            namespace,
+        }
+
+    }
+}

--- a/src/kubernetes/mod.rs
+++ b/src/kubernetes/mod.rs
@@ -8,5 +8,6 @@
 
 pub mod pod_manager_logic;
 pub mod reflector;
+pub mod meta_cache;
 
 pub use reflector::custom_reflector;

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -41,7 +41,7 @@ use crate::{
         KubernetesLogsEventNodeAnnotationError, KubernetesLogsEventsReceived,
         KubernetesLogsPodInfo, StreamClosedError,
     },
-    kubernetes::{custom_reflector, pod_deletion_logic::Cacher},
+    kubernetes::{custom_reflector, meta_cache::MetaCache},
     shutdown::ShutdownSignal,
     sources,
     transforms::{FunctionTransform, OutputBuffer},
@@ -349,7 +349,7 @@ impl Source {
         );
         let pod_store_w = reflector::store::Writer::default();
         let pod_state = pod_store_w.as_reader();
-        let pod_cacher = Cacher::new();
+        let pod_cacher = MetaCache::new();
 
         reflectors.push(tokio::spawn(custom_reflector(
             pod_store_w,
@@ -370,7 +370,7 @@ impl Source {
         );
         let ns_store_w = reflector::store::Writer::default();
         let ns_state = ns_store_w.as_reader();
-        let ns_cacher = Cacher::new();
+        let ns_cacher = MetaCache::new();
 
         reflectors.push(tokio::spawn(custom_reflector(
             ns_store_w,
@@ -391,7 +391,7 @@ impl Source {
         );
         let node_store_w = reflector::store::Writer::default();
         let node_state = node_store_w.as_reader();
-        let node_cacher = Cacher::new();
+        let node_cacher = MetaCache::new();
 
         reflectors.push(tokio::spawn(custom_reflector(
             node_store_w,

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -41,7 +41,7 @@ use crate::{
         KubernetesLogsEventNodeAnnotationError, KubernetesLogsEventsReceived,
         KubernetesLogsPodInfo, StreamClosedError,
     },
-    kubernetes::custom_reflector,
+    kubernetes::{custom_reflector, pod_deletion_logic::Cacher},
     shutdown::ShutdownSignal,
     sources,
     transforms::{FunctionTransform, OutputBuffer},
@@ -338,6 +338,7 @@ impl Source {
         let mut reflectors = Vec::new();
 
         let pods = Api::<Pod>::all(client.clone());
+
         let pod_watcher = watcher(
             pods,
             ListParams {
@@ -348,9 +349,11 @@ impl Source {
         );
         let pod_store_w = reflector::store::Writer::default();
         let pod_state = pod_store_w.as_reader();
+        let pod_cacher = Cacher::new();
 
         reflectors.push(tokio::spawn(custom_reflector(
             pod_store_w,
+            pod_cacher,
             pod_watcher,
             delay_deletion,
         )));
@@ -367,9 +370,11 @@ impl Source {
         );
         let ns_store_w = reflector::store::Writer::default();
         let ns_state = ns_store_w.as_reader();
+        let ns_cacher = Cacher::new();
 
         reflectors.push(tokio::spawn(custom_reflector(
             ns_store_w,
+            ns_cacher,
             ns_watcher,
             delay_deletion,
         )));
@@ -386,9 +391,11 @@ impl Source {
         );
         let node_store_w = reflector::store::Writer::default();
         let node_state = node_store_w.as_reader();
+        let node_cacher = Cacher::new();
 
         reflectors.push(tokio::spawn(custom_reflector(
             node_store_w,
+            node_cacher,
             node_watcher,
             delay_deletion,
         )));


### PR DESCRIPTION
Hello, it's me again, with another PR :)

I added some logic, that cached minimum information which can be obtained from Meta of Resource.

It's just a map with Name/Namespace and boolean.
It store information about all applied resource and mark it as active
When the Delete event occurred, it search information about Resource in cache, and if founded, mark it as not active and delayed to deletion. 
If a time not expired and occurred new Create event with the same meta information (name and namespace), then information in cache is changed back to active. 
And after that, when the time is expired and invoked logic, that must deleted object, it check cache again, and if state is active, then it skip deletion, and if not, then finally deleted resource.

I will be glad to new reviews