### PR TITLE
enhancement(loki sink): Adhere to InternalEvents spec

### DIFF
--- a/scripts/check-events
+++ b/scripts/check-events
@@ -229,7 +229,7 @@ class Event
         # Make sure EventsDropped events contain the required parameters
         handle.logs.each do |type, message, parameters|
           if type == 'error'
-            ['intentional', 'reason'].each do |parameter|
+            ['count', 'intentional', 'reason'].each do |parameter|
               unless parameters.include? parameter
                 append("Error log for EventsDropped event MUST include parameter \"#{parameter}\".")
               end

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -127,6 +127,7 @@ impl<'a, const INTENTIONAL: bool> InternalEvent for ComponentEventsDropped<'a, I
             debug!(
                 message,
                 intentional = INTENTIONAL,
+                count = self.count,
                 reason = self.reason,
                 internal_log_rate_limit = true,
             );
@@ -134,6 +135,7 @@ impl<'a, const INTENTIONAL: bool> InternalEvent for ComponentEventsDropped<'a, I
             error!(
                 message,
                 intentional = INTENTIONAL,
+                count = self.count,
                 reason = self.reason,
                 internal_log_rate_limit = true,
             );

--- a/src/internal_events/loki.rs
+++ b/src/internal_events/loki.rs
@@ -1,5 +1,7 @@
-// ## skip check-dropped-events ##
-
+use crate::{
+    emit,
+    internal_events::{ComponentEventsDropped, INTENTIONAL},
+};
 use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
@@ -8,6 +10,7 @@ pub struct LokiEventUnlabeled;
 
 impl InternalEvent for LokiEventUnlabeled {
     fn emit(self) {
+        // Deprecated
         counter!("processing_errors_total", 1,
                 "error_type" => "unlabeled_event");
     }
@@ -15,39 +18,41 @@ impl InternalEvent for LokiEventUnlabeled {
 
 #[derive(Debug)]
 pub struct LokiOutOfOrderEventDropped {
-    pub count: usize,
+    pub count: u64,
 }
 
 impl InternalEvent for LokiOutOfOrderEventDropped {
     fn emit(self) {
-        debug!(
-            message = "Received out-of-order events; dropping events.",
-            count = %self.count,
-            internal_log_rate_limit = true,
-        );
-        counter!("events_discarded_total", self.count as u64,
-                "reason" => "out_of_order"); // deprecated
-        counter!("processing_errors_total", 1,
-                "error_type" => "out_of_order"); // deprecated
-        counter!("component_discarded_events_total", self.count as u64,
+        emit!(ComponentEventsDropped::<INTENTIONAL> {
+            count: self.count,
+            reason: "out_of_order",
+        });
+
+        // Deprecated
+        counter!("events_discarded_total", self.count,
                 "reason" => "out_of_order");
+        counter!("processing_errors_total", 1,
+                "error_type" => "out_of_order");
     }
 }
 
 #[derive(Debug)]
 pub struct LokiOutOfOrderEventRewritten {
-    pub count: usize,
+    pub count: u64,
 }
 
 impl InternalEvent for LokiOutOfOrderEventRewritten {
     fn emit(self) {
         debug!(
-            message = "Received out-of-order events, rewriting timestamps.",
-            count = %self.count,
+            message = "Timestamps rewritten",
+            count = self.count,
+            reason = "out_of_order",
             internal_log_rate_limit = true,
         );
+        counter!("rewritten_timestamp_events_total", self.count);
+
+        // Deprecated
         counter!("processing_errors_total", 1,
-                "error_type" => "out_of_order"); // deprecated
-        counter!("rewritten_timestamp_events_total", self.count as u64);
+                "error_type" => "out_of_order");
     }
 }

--- a/src/internal_events/loki.rs
+++ b/src/internal_events/loki.rs
@@ -44,7 +44,7 @@ pub struct LokiOutOfOrderEventRewritten {
 impl InternalEvent for LokiOutOfOrderEventRewritten {
     fn emit(self) {
         debug!(
-            message = "Timestamps rewritten",
+            message = "Timestamps rewritten.",
             count = self.count,
             reason = "out_of_order",
             internal_log_rate_limit = true,

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -315,7 +315,7 @@ async fn out_of_order_drop() {
         .map(|e| Event::Log(LogEvent::from(e)))
         .collect::<Vec<_>>();
 
-    let base = chrono::Utc::now() - Duration::seconds(20);
+    let base = Utc::now() - Duration::seconds(20);
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(
@@ -344,7 +344,7 @@ async fn out_of_order_accept() {
         .map(|e| Event::Log(LogEvent::from(e)))
         .collect::<Vec<_>>();
 
-    let base = chrono::Utc::now() - Duration::seconds(20);
+    let base = Utc::now() - Duration::seconds(20);
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(
@@ -375,7 +375,7 @@ async fn out_of_order_rewrite() {
         .map(|e| Event::Log(LogEvent::from(e)))
         .collect::<Vec<_>>();
 
-    let base = chrono::Utc::now() - Duration::seconds(20);
+    let base = Utc::now() - Duration::seconds(20);
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(
@@ -415,7 +415,7 @@ async fn out_of_order_per_partition() {
         .map(|e| Event::Log(LogEvent::from(e)))
         .collect::<Vec<_>>();
 
-    let base = chrono::Utc::now() - Duration::seconds(30);
+    let base = Utc::now() - Duration::seconds(30);
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(

--- a/src/sinks/loki/mod.rs
+++ b/src/sinks/loki/mod.rs
@@ -1,9 +1,9 @@
 //! Loki sink
 //!
 //! This sink provides downstream support for `Loki` via
-//! the v1 http json endpoint.
+//! the `/loki/api/v1/push` endpoint.
 //!
-//! <https://github.com/grafana/loki/tree/v1.6.1/docs>
+//! <https://grafana.com/docs/loki/v2.6.x/api/>
 //!
 //! This sink uses `PartitionBatching` to partition events
 //! by streams. There must be at least one valid set of labels.

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use snafu::Snafu;
 use tokio_util::codec::Encoder as _;
 use vector_core::{
-    event::{self, Event, EventFinalizers, Finalizable, Value},
+    event::{Event, EventFinalizers, Finalizable, Value},
     partition::Partitioner,
     sink::StreamSink,
     stream::BatcherSettings,
@@ -204,7 +204,7 @@ impl EventEncoder {
         let schema = log_schema();
         let timestamp_key = schema.timestamp_key();
         let timestamp = match event.as_log().get(timestamp_key) {
-            Some(event::Value::Timestamp(ts)) => ts.timestamp_nanos(),
+            Some(Value::Timestamp(ts)) => ts.timestamp_nanos(),
             _ => chrono::Utc::now().timestamp_nanos(),
         };
 
@@ -264,12 +264,12 @@ impl FilteredRecord {
 }
 
 impl ByteSizeOf for FilteredRecord {
-    fn allocated_bytes(&self) -> usize {
-        self.inner.allocated_bytes()
-    }
-
     fn size_of(&self) -> usize {
         self.inner.size_of()
+    }
+
+    fn allocated_bytes(&self) -> usize {
+        self.inner.allocated_bytes()
     }
 }
 

--- a/src/sinks/loki/tests.rs
+++ b/src/sinks/loki/tests.rs
@@ -12,7 +12,7 @@ use crate::{
 
 #[test]
 fn generate_config() {
-    crate::test_util::test_generate_config::<LokiConfig>();
+    test_util::test_generate_config::<LokiConfig>();
 }
 
 #[tokio::test]


### PR DESCRIPTION
- chore(loki sink): Remove duplicate code from healthcheck
- chore(loki sink): Misc cleanup and comments
- enhancement(loki sink): Adhere to errors and dropped events spec

Closes #14208

Adds the required `count` property to dropped events logs, and checks for it in the `check-events` script.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
