### PR TITLE
enhancement(aws_cloudwatch_logs sink): Adhere to InternalEvents spec

### DIFF
--- a/src/internal_events/aws_cloudwatch_logs.rs
+++ b/src/internal_events/aws_cloudwatch_logs.rs
@@ -15,8 +15,9 @@ pub struct AwsCloudwatchLogsMessageSizeError {
 
 impl InternalEvent for AwsCloudwatchLogsMessageSizeError {
     fn emit(self) {
+        let reason = "Encoded event is too long.";
         error!(
-            message = "Encoded event is too long.",
+            message = reason,
             size = self.size as u64,
             max_size = self.max_size as u64,
             error_code = "message_too_long",
@@ -29,9 +30,6 @@ impl InternalEvent for AwsCloudwatchLogsMessageSizeError {
             "error_type" => error_type::ENCODER_FAILED,
             "stage" => error_stage::PROCESSING,
         );
-        emit!(ComponentEventsDropped::<UNINTENTIONAL> {
-            count: 1,
-            reason: "Encoded event is too long.",
-        });
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
     }
 }

--- a/src/internal_events/aws_cloudwatch_logs.rs
+++ b/src/internal_events/aws_cloudwatch_logs.rs
@@ -1,10 +1,11 @@
-// ## skip check-dropped-events ##
-
 use metrics::counter;
 use vector_common::internal_event::{error_stage, error_type};
 use vector_core::internal_event::InternalEvent;
 
-use super::prelude::io_error_code;
+use crate::{
+    emit,
+    internal_events::{ComponentEventsDropped, UNINTENTIONAL},
+};
 
 #[derive(Debug)]
 pub struct AwsCloudwatchLogsMessageSizeError {
@@ -28,42 +29,9 @@ impl InternalEvent for AwsCloudwatchLogsMessageSizeError {
             "error_type" => error_type::ENCODER_FAILED,
             "stage" => error_stage::PROCESSING,
         );
-        counter!(
-            "component_discarded_events_total", 1,
-            "error_code" => "message_too_long",
-            "error_type" => error_type::ENCODER_FAILED,
-            "stage" => error_stage::PROCESSING,
-        );
-    }
-}
-
-#[derive(Debug)]
-pub struct AwsCloudwatchLogsEncoderError {
-    pub error: codecs::encoding::Error,
-}
-
-impl InternalEvent for AwsCloudwatchLogsEncoderError {
-    fn emit(self) {
-        let error_code = io_error_code(&std::io::ErrorKind::InvalidData.into());
-        error!(
-            message = "Error when encoding event.",
-            error = %self.error,
-            error_type = error_type::ENCODER_FAILED,
-            stage = error_stage::PROCESSING,
-            error_code = error_code,
-            internal_log_rate_limit = true,
-        );
-        counter!(
-            "component_errors_total", 1,
-            "error_type" => error_type::ENCODER_FAILED,
-            "error_code" => error_code,
-            "stage" => error_stage::PROCESSING,
-        );
-        counter!(
-            "component_discarded_events_total", 1,
-            "error_type" => error_type::ENCODER_FAILED,
-            "error_code" => error_code,
-            "stage" => error_stage::PROCESSING,
-        );
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+            count: 1,
+            reason: "Encoded event is too long.",
+        });
     }
 }

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -108,7 +108,7 @@ async fn cloudwatch_insert_log_events_sorted() {
 
     let (sink, _) = config.build(SinkContext::new_test()).await.unwrap();
 
-    let timestamp = chrono::Utc::now() - chrono::Duration::days(1);
+    let timestamp = chrono::Utc::now() - Duration::days(1);
 
     let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
 
@@ -117,7 +117,7 @@ async fn cloudwatch_insert_log_events_sorted() {
     let mut doit = false;
     let events = events.map(move |mut events| {
         if doit {
-            let timestamp = chrono::Utc::now() - chrono::Duration::days(1);
+            let timestamp = chrono::Utc::now() - Duration::days(1);
 
             events.iter_logs_mut().for_each(|log| {
                 log.insert(log_schema().timestamp_key(), Value::Timestamp(timestamp));
@@ -183,7 +183,7 @@ async fn cloudwatch_insert_out_of_range_timestamp() {
     let mut events = Vec::new();
     let mut lines = Vec::new();
 
-    let mut add_event = |offset: chrono::Duration| {
+    let mut add_event = |offset: Duration| {
         let line = input_lines.next().unwrap();
         let mut event = LogEvent::from(line.clone());
         event.insert(log_schema().timestamp_key(), now + offset);

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -241,12 +241,10 @@ impl Client {
                 .log_group_name(group_name)
                 .log_stream_name(stream_name)
                 .build()
-                .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?
+                .map_err(|err| SdkError::ConstructionFailure(err.into()))?
                 .make_operation(cw_client.conf())
                 .await
-                .map_err(|err| {
-                    aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
-                })?;
+                .map_err(|err| SdkError::ConstructionFailure(err.into()))?;
 
             let (req, parts) = op.into_request_response();
             let (mut body, props) = req.into_parts();
@@ -254,12 +252,10 @@ impl Client {
                 let owned_header = header.clone();
                 let owned_value = value.clone();
                 body.headers_mut().insert(
-                    http::header::HeaderName::from_bytes(owned_header.as_bytes()).map_err(
-                        |err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()),
-                    )?,
-                    http::HeaderValue::from_str(owned_value.as_str()).map_err(|err| {
-                        aws_smithy_http::result::SdkError::ConstructionFailure(err.into())
-                    })?,
+                    http::header::HeaderName::from_bytes(owned_header.as_bytes())
+                        .map_err(|err| SdkError::ConstructionFailure(err.into()))?,
+                    http::HeaderValue::from_str(owned_value.as_str())
+                        .map_err(|err| SdkError::ConstructionFailure(err.into()))?,
                 );
             }
             client

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -11,7 +11,7 @@ use crate::{
     codecs::{Encoder, Transformer},
     config::LogSchema,
     event::{Event, Value},
-    internal_events::{AwsCloudwatchLogsEncoderError, AwsCloudwatchLogsMessageSizeError},
+    internal_events::AwsCloudwatchLogsMessageSizeError,
     sinks::aws_cloudwatch_logs::CloudwatchKey,
     template::Template,
 };
@@ -80,8 +80,8 @@ impl CloudwatchRequestBuilder {
         let event_byte_size = event.size_of();
         self.transformer.transform(&mut event);
         let mut message_bytes = BytesMut::new();
-        if let Err(error) = self.encoder.encode(event, &mut message_bytes) {
-            emit!(AwsCloudwatchLogsEncoderError { error });
+        if self.encoder.encode(event, &mut message_bytes).is_err() {
+            // The encoder handles internal event emission for Error and EventsDropped.
             return None;
         }
         let message = String::from_utf8_lossy(&message_bytes).to_string();


### PR DESCRIPTION
- enhancement(aws_cloudwatch_logs sink): Use shared EventsDropped and remove duplicate internal event
- enhancement(aws_cloudwatch_logs sink): Adhere to InternalEvents spec

Closes #14201

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
