### PR TITLE
fix(vrl parse_xml): Fix panic in parse_xml vrl function

### DIFF
--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -499,12 +499,12 @@ mod tests {
             tdef: type_def(),
         }
 
-        cdata_element {
-            args: func_args![ value: r#"<p><?xml?>[CDATA[]]Q</p>"# ],
+        header_inside_element {
+            args: func_args![ value: r#"<p><?xml?>text123</p>"# ],
             want: Ok(value!(
                 {
                     "p": {
-                        "text": "[CDATA[]]Q"
+                        "text": "text123"
                     }
                 }
             )),

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -295,7 +295,7 @@ fn process_node<'a>(node: Node, config: &ParseXmlConfig<'a>) -> Value {
             }
         }
 
-        for n in node.children().into_iter().filter(|n| !n.is_comment()) {
+        for n in node.children().into_iter().filter(|n| n.is_element() || n.is_text()) {
             let name = match n.node_type() {
                 NodeType::Element => n.tag_name().name().to_string(),
                 NodeType::Text => config.text_key.to_string(),

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -295,7 +295,11 @@ fn process_node<'a>(node: Node, config: &ParseXmlConfig<'a>) -> Value {
             }
         }
 
-        for n in node.children().into_iter().filter(|n| n.is_element() || n.is_text()) {
+        for n in node
+            .children()
+            .into_iter()
+            .filter(|n| n.is_element() || n.is_text())
+        {
             let name = match n.node_type() {
                 NodeType::Element => n.tag_name().name().to_string(),
                 NodeType::Text => config.text_key.to_string(),

--- a/lib/vrl/stdlib/src/parse_xml.rs
+++ b/lib/vrl/stdlib/src/parse_xml.rs
@@ -499,6 +499,18 @@ mod tests {
             tdef: type_def(),
         }
 
+        cdata_element {
+            args: func_args![ value: r#"<p><?xml?>[CDATA[]]Q</p>"# ],
+            want: Ok(value!(
+                {
+                    "p": {
+                        "text": "[CDATA[]]Q"
+                    }
+                }
+            )),
+            tdef: type_def(),
+        }
+
         mixed_types {
             args: func_args![ value: indoc!{r#"
                 <?xml version="1.0" encoding="ISO-8859-1"?>


### PR DESCRIPTION
In our company we found a potential panic in `parse_xml` which crashes vector.
XML payload causing panic
```xml
<p><?xml?>text123</p>
```

I added test case for this, but I am not sure about it.

According to spec this is incorrect xml
>  https://www.w3.org/TR/xml/#sec-prolog-dtd
>  xml declaration should be first element in the file

But `roxmltree` parses it without an error
Should we depend on this behavior? If not then test should be removed
