### PR TITLE
fix(exec source): emit discarded error when channel is closed

### DIFF
--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -1,5 +1,9 @@
 use std::time::Duration;
 
+use crate::{
+    emit,
+    internal_events::{ComponentEventsDropped, UNINTENTIONAL},
+};
 use metrics::{counter, histogram};
 use tokio::time::error::Elapsed;
 use vector_common::internal_event::{error_stage, error_type};
@@ -53,6 +57,7 @@ impl InternalEvent for ExecFailedError<'_> {
             error_type = error_type::COMMAND_FAILED,
             error_code = %io_error_code(&self.error),
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -87,6 +92,7 @@ impl InternalEvent for ExecTimeoutError<'_> {
             error = %self.error,
             error_type = error_type::TIMED_OUT,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -128,6 +134,7 @@ impl InternalEvent for ExecCommandExecuted<'_> {
             command = %self.command,
             exit_status = %exit_status,
             elapsed_millis = %self.exec_duration.as_millis(),
+            internal_log_rate_limit = true,
         );
         counter!(
             "command_executed_total", 1,
@@ -201,6 +208,7 @@ impl InternalEvent for ExecFailedToSignalChildError<'_> {
             error_code = %self.error.to_error_code(),
             error_type = error_type::COMMAND_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -224,20 +232,18 @@ pub struct ExecChannelClosedError;
 
 impl InternalEvent for ExecChannelClosedError {
     fn emit(self) {
+        let reason = "Receive channel closed, unable to send.";
         error!(
-            message = %format!("Receive channel closed, unable to send."),
+            message = reason,
             error_type = error_type::COMMAND_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
             "error_type" => error_type::COMMAND_FAILED,
             "stage" => error_stage::RECEIVING,
         );
-        counter!(
-            "component_discarded_events_total", 1,
-            "error_type" => error_type::COMMAND_FAILED,
-            "stage" => error_stage::RECEIVING,
-        );
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
     }
 }

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -219,3 +219,25 @@ impl InternalEvent for ExecFailedToSignalChildError<'_> {
         );
     }
 }
+
+pub struct ExecChannelClosedError;
+
+impl InternalEvent for ExecChannelClosedError {
+    fn emit(self) {
+        error!(
+            message = %format!("Receive channel closed, unable to send."),
+            error_type = error_type::COMMAND_FAILED,
+            stage = error_stage::RECEIVING,
+        );
+        counter!(
+            "component_errors_total", 1,
+            "error_type" => error_type::COMMAND_FAILED,
+            "stage" => error_stage::RECEIVING,
+        );
+        counter!(
+            "component_discarded_events_total", 1,
+            "error_type" => error_type::COMMAND_FAILED,
+            "stage" => error_stage::RECEIVING,
+        );
+    }
+}

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -295,10 +295,7 @@ where
 
 /// Runs and returns a future and asserts that the provided test specification passes.
 #[track_caller]
-pub async fn assert_source_error<T>(
-    tags: &[&str],
-    f: impl Future<Output = T>,
-) -> T {
+pub async fn assert_source_error<T>(tags: &[&str], f: impl Future<Output = T>) -> T {
     init_test();
 
     let result = f.await;
@@ -307,7 +304,6 @@ pub async fn assert_source_error<T>(
 
     result
 }
-
 
 /// Runs source tests with timeout and asserts error path compliance.
 #[track_caller]

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -293,6 +293,22 @@ where
         .await
 }
 
+/// Runs and returns a future and asserts that the provided test specification passes.
+#[track_caller]
+pub async fn assert_source_error<T>(
+    tags: &[&str],
+    f: impl Future<Output = T>,
+) -> T {
+    init_test();
+
+    let result = f.await;
+
+    COMPONENT_TESTS_ERROR.assert(tags);
+
+    result
+}
+
+
 /// Runs source tests with timeout and asserts error path compliance.
 #[track_caller]
 pub async fn run_and_assert_source_error<SC>(


### PR DESCRIPTION
Ref #14451 

If the `Sender` is closed when the command thread tries to send it, that event is dropped. Before we were emitting a `trace`. I've updated this to emit an `Error` and update `component_discarded_events_total`.

I can't really think of a realistic situation where this error would occur, but it is a potential so we should emit.