### PR TITLE
fix(ci): report filename when check-events errors

### DIFF
--- a/scripts/check-events
+++ b/scripts/check-events
@@ -330,6 +330,7 @@ Find.find('.') do |path|
         reports.append('Message must start with a capital.') unless message.match(/^[[:upper:]]/)
         reports.append('Message must end with a period.') unless message.match(/\.$/)
         unless reports.empty?
+          puts "Error(s) in file #{path}"
           reports.each { |report| puts "  #{report}" }
           error_count += 1
         end


### PR DESCRIPTION
Since [this commit](https://github.com/vectordotdev/vector/commit/3e0ca6bdf0f4f4bb3bc66ddfc14c6b961f83dbd2) the `check-events` script is not reporting the file path in which there is an error. This PR brings it back.

Signed-off-by: Jeremie Drouet <jeremie.drouet@datadoghq.com>
