### PR TITLE
feat(internal_metrics): Added ```vector_info```  internal metric, capturing build information

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -163,10 +163,18 @@ fn main() {
     let debug = tracker
         .get_env_var("DEBUG")
         .expect("Cargo-provided environment variables should always exist!");
+    let rust_version = tracker
+        .get_env_var("CARGO_PKG_RUST_VERSION")
+        .expect("Cargo-provided environment variables should always exist!");
     let build_desc = tracker.get_env_var("VECTOR_BUILD_DESC");
 
     // Gather up the constants and write them out to our build constants file.
     let mut constants = BuildConstants::new();
+    constants.add_required_constant(
+        "RUST_VERSION",
+        "The rust version from the package manifest.",
+        rust_version,
+    );
     constants.add_required_constant("PKG_NAME", "The full name of this package.", pkg_name);
     constants.add_required_constant(
         "PKG_VERSION",

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -19,13 +19,13 @@ impl InternalEvent for VectorStarted {
             build_id = built_info::VECTOR_BUILD_DESC.unwrap_or("none"),
         );
         gauge!(
-            "vector_info",
+            "build_info",
             1.0,
             "debug" => built_info::DEBUG,
             "version" => built_info::PKG_VERSION,
             "rust_version" => built_info::RUST_VERSION,
             "arch" => built_info::TARGET_ARCH,
-            "build_id" => built_info::VECTOR_BUILD_DESC.unwrap_or("none")
+            "revision" => built_info::VECTOR_BUILD_DESC.unwrap_or("")
         );
         counter!("started_total", 1);
     }

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -16,7 +16,7 @@ impl InternalEvent for VectorStarted {
             debug = built_info::DEBUG,
             version = built_info::PKG_VERSION,
             arch = built_info::TARGET_ARCH,
-            build_id = built_info::VECTOR_BUILD_DESC.unwrap_or("none"),
+            revision = built_info::VECTOR_BUILD_DESC.unwrap_or(""),
         );
         gauge!(
             "build_info",

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -1,4 +1,5 @@
 use metrics::counter;
+use metrics::gauge;
 use vector_core::internal_event::InternalEvent;
 
 use crate::{built_info, config};
@@ -16,6 +17,15 @@ impl InternalEvent for VectorStarted {
             version = built_info::PKG_VERSION,
             arch = built_info::TARGET_ARCH,
             build_id = built_info::VECTOR_BUILD_DESC.unwrap_or("none"),
+        );
+        gauge!(
+            "vector_info",
+            1.0,
+            "debug" => built_info::DEBUG,
+            "version" => built_info::PKG_VERSION,
+            "rust_version" => built_info::RUST_VERSION,
+            "arch" => built_info::TARGET_ARCH,
+            "build_id" => built_info::VECTOR_BUILD_DESC.unwrap_or("none")
         );
         counter!("started_total", 1);
     }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1112,7 +1112,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags & {
 				debug: {
-					description: "Level of debug info for Vector."
+					description: "Whether this is a debug build of Vector"
 					required:    true
 				}
 				version: {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1120,7 +1120,7 @@ components: sources: internal_metrics: {
 					required:    true
 				}
 				rust_version: {
-					description: "The rust version from the package manifest."
+					description: "The Rust version from the package manifest."
 					required:    true
 				}
 				arch: {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1106,6 +1106,12 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		vector_info: {
+			description:       "Has a fixed value of 1.0. Contains build information such as rust and vector versions."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
 		value_limit_reached_total: {
 			description: """
 				The total number of times new values for a key have been rejected because the

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1106,11 +1106,32 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		vector_info: {
+		build_info: {
 			description:       "Has a fixed value of 1.0. Contains build information such as rust and vector versions."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags:              _internal_metrics_tags
+			tags:              _internal_metrics_tags & {
+				debug: {
+					description: "Level of debug info for Vector."
+					required:    true
+				}
+				version: {
+					description: "Vector version."
+					required:    true
+				}
+				rust_version: {
+					description: "The rust version from the package manifest."
+					required:    true
+				}
+				arch: {
+					description: "The target architecture being compiled for. (e.g. x86_64)"
+					required:    true
+				}
+				revision: {
+					description: "Revision identifer, related to versioned releases."
+					required:    true
+				}
+			}
 		}
 		value_limit_reached_total: {
 			description: """

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1107,7 +1107,7 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		build_info: {
-			description:       "Has a fixed value of 1.0. Contains build information such as rust and vector versions."
+			description:       "Has a fixed value of 1.0. Contains build information such as Rust and Vector versions."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags & {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
