### PR TITLE
feature(prometheus_exporter sink): Emit address when building server.

### DIFF
--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -444,11 +444,11 @@ impl PrometheusExporter {
 
         tokio::spawn(async move {
             let tls = MaybeTlsSettings::from_config(&tls, true)
-                .map_err(|error| error!("Server TLS error: {}", error))?;
+                .map_err(|error| error!("Server TLS error: {}.", error))?;
             let listener = tls
                 .bind(&address)
                 .await
-                .map_err(|error| error!("Server bind error: {}", error))?;
+                .map_err(|error| error!("Server bind error: {}.", error))?;
 
             info!(message = "Building HTTP server.", address = %address);
 
@@ -457,7 +457,7 @@ impl PrometheusExporter {
                 .with_graceful_shutdown(tripwire.then(crate::shutdown::tripwire_handler))
                 .instrument(span)
                 .await
-                .map_err(|error| error!("Server error: {}", error))?;
+                .map_err(|error| error!("Server error: {}.", error))?;
 
             Ok::<(), ()>(())
         });

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -443,22 +443,21 @@ impl PrometheusExporter {
         let address = self.config.address;
 
         tokio::spawn(async move {
-            #[allow(clippy::print_stderr)]
             let tls = MaybeTlsSettings::from_config(&tls, true)
-                .map_err(|error| eprintln!("Server TLS error: {}", error))?;
-            #[allow(clippy::print_stderr)]
+                .map_err(|error| error!("Server TLS error: {}", error))?;
             let listener = tls
                 .bind(&address)
                 .await
-                .map_err(|error| eprintln!("Server bind error: {}", error))?;
+                .map_err(|error| error!("Server bind error: {}", error))?;
 
-            #[allow(clippy::print_stderr)]
+            info!(message = "Building HTTP server.", address = %address);
+
             Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
                 .serve(new_service)
                 .with_graceful_shutdown(tripwire.then(crate::shutdown::tripwire_handler))
                 .instrument(span)
                 .await
-                .map_err(|error| eprintln!("Server error: {}", error))?;
+                .map_err(|error| error!("Server error: {}", error))?;
 
             Ok::<(), ()>(())
         });


### PR DESCRIPTION
Replaces `eprintln!` with `error!`, and emits an `info` log (like our other HTTP servers) that contains the address the component will be listening on.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
