### PR TITLE
chore(observability): Don't include name field for SinkRequestBuildError

### DIFF
--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -150,13 +150,15 @@ impl<'a, const INTENTIONAL: bool> InternalEvent for ComponentEventsDropped<'a, I
 
 #[derive(Debug)]
 pub struct SinkRequestBuildError<E> {
+    // This event had a `name` field which would contain the type of sink,
+    // emitted logs contain this already due to `tracing` spans.
     pub error: E,
 }
 
 impl<E: std::fmt::Display> InternalEvent for SinkRequestBuildError<E> {
     fn emit(self) {
         error!(
-            message = format!("Failed to build request"),
+            message = format!("Failed to build request."),
             error = %self.error,
             error_type = error_type::ENCODER_FAILED,
             stage = error_stage::PROCESSING,

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -150,13 +150,14 @@ impl<'a, const INTENTIONAL: bool> InternalEvent for ComponentEventsDropped<'a, I
 
 #[derive(Debug)]
 pub struct SinkRequestBuildError<E> {
-    // This event had a `name` field which would contain the type of sink,
-    // emitted logs contain this already due to `tracing` spans.
     pub error: E,
 }
 
 impl<E: std::fmt::Display> InternalEvent for SinkRequestBuildError<E> {
     fn emit(self) {
+        // Providing the name of the sink with the build error is not necessary because the emitted log
+        // message contains the sink name in `component_type` field thanks to `tracing` spans. For example:
+        // "<timestamp> ERROR sink{component_kind="sink" component_id=sink0 component_type=aws_s3 component_name=sink0}: vector::internal_events::common: Failed to build request."
         error!(
             message = format!("Failed to build request."),
             error = %self.error,

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -150,14 +150,13 @@ impl<'a, const INTENTIONAL: bool> InternalEvent for ComponentEventsDropped<'a, I
 
 #[derive(Debug)]
 pub struct SinkRequestBuildError<E> {
-    pub name: &'static str,
     pub error: E,
 }
 
 impl<E: std::fmt::Display> InternalEvent for SinkRequestBuildError<E> {
     fn emit(self) {
         error!(
-            message = format!("Failed to build request for {}", self.name),
+            message = format!("Failed to build request"),
             error = %self.error,
             error_type = error_type::ENCODER_FAILED,
             stage = error_stage::PROCESSING,

--- a/src/sinks/aws_kinesis_firehose/sink.rs
+++ b/src/sinks/aws_kinesis_firehose/sink.rs
@@ -3,16 +3,12 @@ use std::{fmt, num::NonZeroUsize};
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt};
 use tower::Service;
-use vector_config::NamedComponent;
 use vector_core::{
     sink::StreamSink,
     stream::{BatcherSettings, DriverResponse},
 };
 
-use super::{
-    config::KinesisFirehoseSinkConfig,
-    request_builder::{KinesisRequest, KinesisRequestBuilder},
-};
+use super::request_builder::{KinesisRequest, KinesisRequestBuilder};
 use crate::{event::Event, internal_events::SinkRequestBuildError, sinks::util::SinkBuilderExt};
 
 #[derive(Debug, Clone)]
@@ -43,10 +39,7 @@ where
             .filter_map(|request| async move {
                 match request {
                     Err(error) => {
-                        emit!(SinkRequestBuildError {
-                            name: KinesisFirehoseSinkConfig::NAME,
-                            error,
-                        });
+                        emit!(SinkRequestBuildError { error });
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/aws_kinesis_streams/sink.rs
+++ b/src/sinks/aws_kinesis_streams/sink.rs
@@ -4,10 +4,8 @@ use async_trait::async_trait;
 use futures::{future, stream::BoxStream, StreamExt};
 use rand::random;
 use tower::Service;
-use vector_config::NamedComponent;
 use vector_core::stream::{BatcherSettings, DriverResponse};
 
-use super::KinesisSinkConfig;
 use crate::{
     event::{Event, LogEvent},
     internal_events::SinkRequestBuildError,
@@ -51,10 +49,7 @@ where
             .filter_map(|request| async move {
                 match request {
                     Err(error) => {
-                        emit!(SinkRequestBuildError {
-                            name: KinesisSinkConfig::NAME,
-                            error,
-                        });
+                        emit!(SinkRequestBuildError { error });
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/aws_sqs/sink.rs
+++ b/src/sinks/aws_sqs/sink.rs
@@ -3,7 +3,6 @@ use std::num::NonZeroUsize;
 use aws_sdk_sqs::Client as SqsClient;
 use futures::stream::BoxStream;
 use futures_util::StreamExt;
-use vector_config::NamedComponent;
 use vector_core::sink::StreamSink;
 
 use super::{config::SqsSinkConfig, request_builder::SqsRequestBuilder, service::SqsService};
@@ -55,10 +54,7 @@ impl SqsSink {
             .request_builder(request_builder_concurrency_limit, self.request_builder)
             .filter_map(|req| async move {
                 req.map_err(|error| {
-                    emit!(SinkRequestBuildError {
-                        name: SqsSinkConfig::NAME,
-                        error,
-                    });
+                    emit!(SinkRequestBuildError { error });
                 })
                 .ok()
             })

--- a/src/sinks/datadog/events/sink.rs
+++ b/src/sinks/datadog/events/sink.rs
@@ -3,7 +3,6 @@ use std::{fmt, num::NonZeroUsize};
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt};
 use tower::Service;
-use vector_config::NamedComponent;
 use vector_core::stream::DriverResponse;
 
 use crate::{
@@ -11,10 +10,7 @@ use crate::{
     event::Event,
     internal_events::{ParserMissingFieldError, SinkRequestBuildError, DROP_EVENT},
     sinks::{
-        datadog::events::{
-            request_builder::{DatadogEventsRequest, DatadogEventsRequestBuilder},
-            DatadogEventsConfig,
-        },
+        datadog::events::request_builder::{DatadogEventsRequest, DatadogEventsRequestBuilder},
         util::{SinkBuilderExt, StreamSink},
     },
 };
@@ -39,10 +35,7 @@ where
             .filter_map(|request| async move {
                 match request {
                     Err(error) => {
-                        emit!(SinkRequestBuildError {
-                            name: DatadogEventsConfig::NAME,
-                            error
-                        });
+                        emit!(SinkRequestBuildError { error });
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/datadog/logs/mod.rs
+++ b/src/sinks/datadog/logs/mod.rs
@@ -29,5 +29,3 @@ mod service;
 mod sink;
 
 pub(crate) use config::DatadogLogsConfig;
-
-pub(crate) const NAME: &str = "datadog_logs";

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -16,7 +16,7 @@ use vector_core::{
     ByteSizeOf,
 };
 
-use super::{config::MAX_PAYLOAD_BYTES, service::LogApiRequest, NAME};
+use super::{config::MAX_PAYLOAD_BYTES, service::LogApiRequest};
 use crate::{
     codecs::{Encoder, Transformer},
     internal_events::SinkRequestBuildError,
@@ -391,7 +391,7 @@ where
                 .filter_map(|request| async move {
                     match request {
                         Err(error) => {
-                            emit!(SinkRequestBuildError { name: NAME, error });
+                            emit!(SinkRequestBuildError { error });
                             None
                         }
                         Ok(req) => Some(req),
@@ -414,7 +414,7 @@ where
                 .filter_map(|request| async move {
                     match request {
                         Err(error) => {
-                            emit!(SinkRequestBuildError { name: NAME, error });
+                            emit!(SinkRequestBuildError { error });
                             None
                         }
                         Ok(req) => Some(req),

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -6,7 +6,6 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use snafu::Snafu;
 use tokio_util::codec::Encoder as _;
-use vector_config::NamedComponent;
 use vector_core::{
     event::{Event, EventFinalizers, Finalizable, Value},
     partition::Partitioner,
@@ -417,10 +416,7 @@ impl LokiSink {
             .filter_map(|request| async move {
                 match request {
                     Err(error) => {
-                        emit!(SinkRequestBuildError {
-                            name: LokiConfig::NAME,
-                            error,
-                        });
+                        emit!(SinkRequestBuildError { error });
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/new_relic/sink.rs
+++ b/src/sinks/new_relic/sink.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{BoxStream, StreamExt};
 use tower::Service;
-use vector_config::NamedComponent;
 use vector_core::{
     event::{EventFinalizers, Finalizable},
     stream::{BatcherSettings, DriverResponse},
@@ -18,7 +17,6 @@ use crate::{
     codecs::Transformer,
     event::Event,
     internal_events::SinkRequestBuildError,
-    sinks::new_relic::NewRelicConfig,
     sinks::util::{
         builder::SinkBuilderExt,
         metadata::{RequestMetadata, RequestMetadataBuilder},
@@ -166,10 +164,7 @@ where
                 |request: Result<NewRelicApiRequest, NewRelicSinkError>| async move {
                     match request {
                         Err(error) => {
-                            emit!(SinkRequestBuildError {
-                                name: NewRelicConfig::NAME,
-                                error
-                            });
+                            emit!(SinkRequestBuildError { error });
                             None
                         }
                         Ok(req) => Some(req),

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -45,7 +45,7 @@ const CREATED_AT: &str = "container_created_at";
 const NAME: &str = "container_name";
 const STREAM: &str = "stream";
 const CONTAINER: &str = "container_id";
-// Prevent short hostname from being wrongly regconized as a container's short ID.
+// Prevent short hostname from being wrongly recognized as a container's short ID.
 const MIN_HOSTNAME_LENGTH: usize = 6;
 
 static STDERR: Lazy<Bytes> = Lazy::new(|| "stderr".into());
@@ -705,7 +705,7 @@ impl EventStreamBuilder {
     }
 
     fn finish(self, result: Result<ContainerLogInfo, (ContainerId, ErrorPersistence)>) {
-        // This can legaly fail when shutting down, and any other
+        // This can legally fail when shutting down, and any other
         // reason should have been logged in the main future.
         let _ = self.main_send.send(result);
     }

--- a/src/sources/http_scrape/integration_tests.rs
+++ b/src/sources/http_scrape/integration_tests.rs
@@ -10,12 +10,12 @@ use crate::{
     http::Auth,
     serde::default_decoding,
     serde::default_framing_message_based,
-    sources::http_scrape::scrape::NAME,
     tls,
     tls::TlsConfig,
     SourceSender,
 };
 use codecs::decoding::DeserializerConfig;
+use vector_config::NamedComponent;
 use vector_core::config::log_schema;
 
 use super::{
@@ -39,7 +39,7 @@ fn dufs_https_address() -> String {
 
 /// The error path should not yield any events and must emit the required error internal events.
 /// Consider extracting this function into test_util , if it is always true that if the error
-/// internal event metric is fired that no events would be outputed by the source.
+/// internal event metric is fired that no events would be outputted by the source.
 pub(crate) async fn run_error(config: HttpScrapeConfig) {
     let events =
         run_and_assert_source_error(config, Duration::from_secs(3), &COMPONENT_ERROR_TAGS).await;
@@ -81,7 +81,10 @@ async fn scraped_logs_bytes() {
     .await;
     // panics if not log event
     let log = events[0].as_log();
-    assert_eq!(log[log_schema().source_type_key()], NAME.into());
+    assert_eq!(
+        log[log_schema().source_type_key()],
+        HttpScrapeConfig::NAME.into()
+    );
 }
 
 /// Logs (json) should be scraped and decoded successfully.
@@ -101,7 +104,10 @@ async fn scraped_logs_json() {
     .await;
     // panics if not log event
     let log = events[0].as_log();
-    assert_eq!(log[log_schema().source_type_key()], NAME.into());
+    assert_eq!(
+        log[log_schema().source_type_key()],
+        HttpScrapeConfig::NAME.into()
+    );
 }
 
 /// Metrics should be scraped and decoded successfully.
@@ -124,7 +130,7 @@ async fn scraped_metrics_native_json() {
     let metric = events[0].as_metric();
     assert_eq!(
         metric.tags().unwrap()[log_schema().source_type_key()],
-        NAME.to_string()
+        HttpScrapeConfig::NAME.to_string()
     );
 }
 
@@ -145,7 +151,10 @@ async fn scraped_trace_native_json() {
     .await;
 
     let trace = events[0].as_trace();
-    assert_eq!(trace.as_map()[log_schema().source_type_key()], NAME.into());
+    assert_eq!(
+        trace.as_map()[log_schema().source_type_key()],
+        HttpScrapeConfig::NAME.into()
+    );
 }
 
 /// Passing no authentication for the auth-gated endpoint should yield errors.

--- a/src/sources/http_scrape/scrape.rs
+++ b/src/sources/http_scrape/scrape.rs
@@ -27,14 +27,11 @@ use codecs::{
     decoding::{DeserializerConfig, FramingConfig},
     StreamDecodingError,
 };
-use vector_config::configurable_component;
+use vector_config::{configurable_component, NamedComponent};
 use vector_core::{
     config::{log_schema, LogNamespace, Output},
     event::Event,
 };
-
-/// The name of this source
-pub(crate) const NAME: &str = "http_scrape";
 
 /// Configuration for the `http_scrape` source.
 #[configurable_component(source("http_scrape"))]
@@ -199,7 +196,7 @@ impl HttpScrapeContext {
                         log,
                         log_schema().source_type_key(),
                         "source_type",
-                        NAME,
+                        HttpScrapeConfig::NAME,
                     );
                     self.log_namespace.insert_vector_metadata(
                         log,
@@ -209,10 +206,16 @@ impl HttpScrapeContext {
                     );
                 }
                 Event::Metric(ref mut metric) => {
-                    metric.insert_tag(log_schema().source_type_key().to_string(), NAME.to_string());
+                    metric.insert_tag(
+                        log_schema().source_type_key().to_string(),
+                        HttpScrapeConfig::NAME.to_string(),
+                    );
                 }
                 Event::Trace(ref mut trace) => {
-                    trace.insert(log_schema().source_type_key(), Bytes::from(NAME));
+                    trace.insert(
+                        log_schema().source_type_key(),
+                        Bytes::from(HttpScrapeConfig::NAME),
+                    );
                 }
             }
         }


### PR DESCRIPTION
- chore(observability): Don't include name field for SinkRequestBuildError
- chore: Fix typos and use NamedComponent for http_scrape

The `name` field duplicates the info included at the beginning of the log, removing it saves us some work.

```text
2022-09-21T20:11:11.005652Z ERROR sink{component_kind="sink" component_id=sink0 component_type=aws_s3 component_name=sink0}: vector::internal_events::common: Failed to build request for <NAME> error=<ERROR> error_type="encoder_failed" stage="processing" internal_log_rate_limit=true
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
