### PR TITLE
enhancement(splunk_hec_logs sink): Comply to `*EventsDropped` instrumentation spec in `splunk_hec_logs` sink

### DIFF
--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -12,7 +12,9 @@ mod sink {
     use vector_core::internal_event::InternalEvent;
 
     use crate::{
+        emit,
         event::metric::{MetricKind, MetricValue},
+        internal_events::{ComponentEventsDropped, UNINTENTIONAL},
         sinks::splunk_hec::common::acknowledgements::HecAckApiError,
     };
     use vector_common::internal_event::{error_stage, error_type};
@@ -24,8 +26,9 @@ mod sink {
 
     impl InternalEvent for SplunkEventEncodeError {
         fn emit(self) {
+            let reason = "Failed to encode Splunk HEC event as JSON.";
             error!(
-                message = "Error encoding Splunk HEC event to JSON.",
+                message = reason,
                 error = ?self.error,
                 error_code = "serializing_json",
                 error_type = error_type::ENCODER_FAILED,
@@ -38,6 +41,7 @@ mod sink {
                 "error_type" => error_type::ENCODER_FAILED,
                 "stage" => error_stage::PROCESSING,
             );
+            emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
         }
     }
 


### PR DESCRIPTION
Closes #14212.

Part of #13995.