### PR TITLE
enhancement(vector sink): Comply to `*EventsDropped` instrumentation spec in `vector` sink

### DIFF
--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -308,15 +308,13 @@ impl Service<PartitionInnerBuffer<Vec<Metric>, String>> for CloudWatchMetricsSvc
     type Error = SdkError<PutMetricDataError>;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller
-
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, items: PartitionInnerBuffer<Vec<Metric>, String>) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller
-
         let (items, namespace) = items.into_parts();
         let metric_data = self.encode_events(items);
         if metric_data.is_empty() {

--- a/src/sinks/aws_kinesis_firehose/service.rs
+++ b/src/sinks/aws_kinesis_firehose/service.rs
@@ -38,15 +38,13 @@ impl Service<Vec<KinesisRequest>> for KinesisService {
     type Error = SdkError<PutRecordBatchError>;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller
-
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, requests: Vec<KinesisRequest>) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller
-
         let events_byte_size = requests.iter().map(|req| req.event_byte_size).sum();
         let count = requests.len();
 

--- a/src/sinks/aws_kinesis_streams/service.rs
+++ b/src/sinks/aws_kinesis_streams/service.rs
@@ -39,15 +39,13 @@ impl Service<Vec<KinesisRequest>> for KinesisService {
     type Error = SdkError<PutRecordsError>;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller
-
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, requests: Vec<KinesisRequest>) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller
-
         let events_byte_size = requests.iter().map(|req| req.event_byte_size).sum();
         let count = requests.len();
 

--- a/src/sinks/aws_sqs/service.rs
+++ b/src/sinks/aws_sqs/service.rs
@@ -26,15 +26,13 @@ impl Service<SendMessageEntry> for SqsService {
     type Error = SdkError<SendMessageError>;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller
-
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, entry: SendMessageEntry) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller
-
         let byte_size = entry.size_of();
         let client = self.client.clone();
 

--- a/src/sinks/azure_common/service.rs
+++ b/src/sinks/azure_common/service.rs
@@ -27,13 +27,13 @@ impl Service<AzureBlobRequest> for AzureBlobService {
     type Error = Box<dyn std::error::Error + std::marker::Send + std::marker::Sync>;
     type Future = BoxFuture<'static, StdResult<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<StdResult<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, request: AzureBlobRequest) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller
         let this = self.clone();
 
         Box::pin(async move {

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -152,13 +152,13 @@ impl Service<ElasticsearchRequest> for ElasticsearchService {
     type Error = crate::Error;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller.
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, req: ElasticsearchRequest) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller.
         let mut http_service = self.batch_service.clone();
         Box::pin(async move {
             http_service.ready().await?;

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -96,15 +96,13 @@ impl Service<GcsRequest> for GcsService {
     type Error = HttpError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller.
-
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, request: GcsRequest) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller.
-
         let settings = request.settings;
         let metadata = request.metadata;
 

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -342,12 +342,12 @@ impl Service<Vec<RedisKvEntry>> for RedisSink {
     type Error = RedisError;
     type Future = BoxFuture<'static, RedisPipeResult>;
 
-    // Emission of Error internal event is handled upstream by the caller
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    // Emission of Error internal event is handled upstream by the caller
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, kvs: Vec<RedisKvEntry>) -> Self::Future {
         let count = kvs.len();
         let mut byte_size = 0;

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -83,15 +83,13 @@ impl Service<S3Request> for S3Service {
     type Error = SdkError<PutObjectError>;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        // Emission of Error internal event is handled upstream by the caller
-
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, request: S3Request) -> Self::Future {
-        // Emission of Error internal event is handled upstream by the caller
-
         let options = request.options;
 
         let content_encoding = request.content_encoding;

--- a/src/sinks/vector/service.rs
+++ b/src/sinks/vector/service.rs
@@ -8,6 +8,7 @@ use hyper_proxy::ProxyConnector;
 use prost::Message;
 use proto_event::EventWrapper;
 use tonic::{body::BoxBody, IntoRequest};
+use tower::Service;
 use vector_core::{
     event::proto as proto_event, internal_event::CountByteSize, stream::DriverResponse,
 };
@@ -79,11 +80,12 @@ impl VectorService {
     }
 }
 
-impl tower::Service<VectorRequest> for VectorService {
+impl Service<VectorRequest> for VectorService {
     type Response = VectorResponse;
     type Error = Error;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Readiness check of the client is done through the `push_events()`
         // call happening inside `call()`. That check blocks until the client is
@@ -93,6 +95,7 @@ impl tower::Service<VectorRequest> for VectorService {
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, list: VectorRequest) -> Self::Future {
         let mut service = self.clone();
         let events_count = list.events.len();
@@ -131,15 +134,17 @@ pub struct HyperSvc {
     client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
 }
 
-impl tower::Service<hyper::Request<BoxBody>> for HyperSvc {
+impl Service<hyper::Request<BoxBody>> for HyperSvc {
     type Response = hyper::Response<hyper::Body>;
     type Error = hyper::Error;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
+    // Emission of an internal event in case of errors is handled upstream by the caller.
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
+    // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, mut req: hyper::Request<BoxBody>) -> Self::Future {
         let uri = Uri::builder()
             .scheme(self.uri.scheme().unwrap().clone())


### PR DESCRIPTION
Closes #14215.

Part of #13995.

Emitting an error when the sink fails is handled in the service driver: https://github.com/vectordotdev/vector/blob/5149fef19f249b9990803c68c3b3a615abc063ac/lib/vector-core/src/stream/driver.rs#L123