### PR TITLE
docs(host_metrics source): Fix description of load1/5/15 metrics

### DIFF
--- a/website/cue/reference/components/sources/host_metrics.cue
+++ b/website/cue/reference/components/sources/host_metrics.cue
@@ -464,9 +464,9 @@ components: sources: host_metrics: {
 		filesystem_used_ratio:  _host & _filesystem_bytes & {description: "The ratio between used and total bytes on the named filesystem."}
 
 		// Host load
-		load1:  _host & _loadavg & {description: "System load averaged over the last 1 second."}
-		load5:  _host & _loadavg & {description: "System load averaged over the last 5 seconds."}
-		load15: _host & _loadavg & {description: "System load averaged over the last 15 seconds."}
+		load1:  _host & _loadavg & {description: "System load averaged over the last 1 minute."}
+		load5:  _host & _loadavg & {description: "System load averaged over the last 5 minutes."}
+		load15: _host & _loadavg & {description: "System load averaged over the last 15 minutes."}
 
 		// Host time
 		uptime:    _host & _host_metric & {description: "The number of seconds since the last boot."}


### PR DESCRIPTION
The load averages are calculated over a period of minutes, not seconds as the reference currently states.

Closes #14521 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
