### PR TITLE
chore(ci): Limit search in `check-events` script to `src`/`lib`

### DIFF
--- a/scripts/check-events
+++ b/scripts/check-events
@@ -308,7 +308,7 @@ $all_events = Hash::new { |hash, key| hash[key] = Event::new(key) }
 error_count = 0
 
 # Scan sources and build internal structures
-Find.find('.') do |path|
+Find.find('./src', './lib') do |path|
   if path.start_with? './'
     path = path[2..]
   end


### PR DESCRIPTION
Previously, the `check-events` script would scan all files in this project – including the `target` directory with lots of many small files that are not relevant to this script - and filter them in Ruby.

This PR at least reduces the scope to the `src` and `lib` directories.