### PR TITLE
chore(pulsar sink): Fix integration test for partition key

### DIFF
--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -22,6 +22,7 @@ use pulsar::{
 };
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
+use value::Value;
 use vector_common::{
     internal_event::{
         ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol, Registered,
@@ -299,7 +300,10 @@ impl Sink<Event> for PulsarSink {
         );
 
         let key_value: Option<String> = match (event.maybe_as_log(), &self.partition_key_field) {
-            (Some(log), Some(field)) => log.get(field.as_str()).map(|x| x.to_string()),
+            (Some(log), Some(field)) => log.get(field.as_str()).map(|x| match x {
+                Value::Bytes(x) => String::from_utf8_lossy(x).to_string(),
+                x => x.to_string(),
+            }),
             _ => None,
         };
 


### PR DESCRIPTION
`Display` on `Value` quotes `Bytes`, which we don't want.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
