### PR TITLE
chore(vector source): Remove unused `shutdown_timeout_secs` option

### DIFF
--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -110,10 +110,6 @@ pub struct VectorConfig {
     /// It _must_ include a port.
     pub address: SocketAddr,
 
-    /// The timeout, in seconds, before a connection is forcefully closed during shutdown.
-    #[serde(default = "default_shutdown_timeout_secs")]
-    pub shutdown_timeout_secs: u64,
-
     #[configurable(derived)]
     #[serde(default)]
     tls: Option<TlsEnableableConfig>,
@@ -123,16 +119,11 @@ pub struct VectorConfig {
     acknowledgements: AcknowledgementsConfig,
 }
 
-const fn default_shutdown_timeout_secs() -> u64 {
-    30
-}
-
 impl GenerateConfig for VectorConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
             version: None,
             address: "0.0.0.0:6000".parse().unwrap(),
-            shutdown_timeout_secs: default_shutdown_timeout_secs(),
             tls: None,
             acknowledgements: Default::default(),
         })

--- a/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
@@ -12,9 +12,10 @@ badges:
 Vector's 0.25.0 release includes **breaking changes**:
 
 1. [Removal of VRL's modulo operator](#modulo-removal)
-1. [Removal of the `new_relic_logs` sink](#new-relic-logs-sink-removal)
-1. [`internal_metrics` defaults to setting `host` tag](#internal-metrics-host-tag)
-1. [Removal of the `vector` source and sink v1 protocol](#vector-v1-removal)
+2. [Removal of the `new_relic_logs` sink](#new-relic-logs-sink-removal)
+3. [`internal_metrics` defaults to setting `host` tag](#internal-metrics-host-tag)
+4. [Removal of the `vector` source and sink v1 protocol](#vector-v1-removal)
+5. [Removal of `shutdown_timeout_secs` from `vector` source](#shutdown-timeout-secs)
 
 and **deprecations**:
 
@@ -97,6 +98,11 @@ configuration. The `version` field is still accepted in configurations, but only
 `2` is accepted.
 
 [deprecate-vector-v1] https://vector.dev/highlights/2022-02-08-0-20-0-upgrade-guide/#deprecate-v1
+
+#### Removal of `shutdown_timeout_secs` from `vector` source {#shutdown-timeout-secs}
+
+The `shutdown_timeout_secs` config for the `vector` v2 source didn't actually do anything, so
+it was removed.
 
 ### Deprecation Notices
 

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -63,15 +63,6 @@ components: sources: vector: {
 				examples: ["0.0.0.0:\(_port)"]
 			}
 		}
-		shutdown_timeout_secs: {
-			common:      false
-			description: "The timeout before a connection is forcefully closed during shutdown."
-			required:    false
-			type: uint: {
-				default: 30
-				unit:    "seconds"
-			}
-		}
 		version: {
 			description: "Source API version. Specifying this version ensures that Vector does not silently break backward compatibility."
 			common:      true


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/13562