### PR TITLE
chore(external docs): Making the example `endpoint` valid format

### DIFF
--- a/website/cue/reference/components/sinks/datadog.cue
+++ b/website/cue/reference/components/sinks/datadog.cue
@@ -32,7 +32,7 @@ components: sinks: _datadog: {
 			required:      false
 			type: string: {
 				default: null
-				examples: ["127.0.0.1:8080", "example.com:12345"]
+				examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
 			}
 		}
 		region: {


### PR DESCRIPTION
Without the "http://" prefix, vector does not start.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
