### PR TITLE
fix(prometheus_scrape source): Improve error messages for out of range values

### DIFF
--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -619,23 +619,50 @@ mod test {
     fn test_f64_to_u32() {
         let value = -1.0;
         let error = try_f64_to_u32(value).unwrap_err();
-        assert_eq!(error, ParserError::ValueOutOfRange { value });
+        assert_eq!(
+            error,
+            ParserError::ValueOutOfRange {
+                value,
+                max: u32::MAX.into()
+            }
+        );
 
         let value = u32::MAX as f64 + 1.0;
         let error = try_f64_to_u32(value).unwrap_err();
-        assert_eq!(error, ParserError::ValueOutOfRange { value });
+        assert_eq!(
+            error,
+            ParserError::ValueOutOfRange {
+                value,
+                max: u32::MAX.into()
+            }
+        );
 
         let value = f64::NAN;
         let error = try_f64_to_u32(value).unwrap_err();
-        assert!(matches!(error, ParserError::ValueOutOfRange { value } if value.is_nan()));
+        assert!(matches!(error, ParserError::ValueOutOfRange {
+                value,
+                max: _,
+            } if value.is_nan()));
 
         let value = f64::INFINITY;
         let error = try_f64_to_u32(value).unwrap_err();
-        assert_eq!(error, ParserError::ValueOutOfRange { value });
+        assert_eq!(
+            error,
+            ParserError::ValueOutOfRange {
+                value,
+                max: u32::MAX.into()
+            }
+        );
 
         let value = f64::NEG_INFINITY;
         let error = try_f64_to_u32(value).unwrap_err();
-        assert_eq!(error, ParserError::ValueOutOfRange { value });
+        assert_eq!(
+            error,
+            ParserError::ValueOutOfRange {
+                value,
+                max: u32::MAX.into()
+            }
+        );
 
         assert_eq!(try_f64_to_u32(0.0).unwrap(), 0);
         assert_eq!(try_f64_to_u32(u32::MAX as f64).unwrap(), u32::MAX);
@@ -645,19 +672,39 @@ mod test {
     fn test_f64_to_u64() {
         let value = -1.0;
         let error = try_f64_to_u64(value).unwrap_err();
-        assert_eq!(error, ParserError::ValueOutOfRange { value });
+        assert_eq!(
+            error,
+            ParserError::ValueOutOfRange {
+                value,
+                max: u64::MAX
+            }
+        );
 
         let value = f64::NAN;
         let error = try_f64_to_u64(value).unwrap_err();
-        assert!(matches!(error, ParserError::ValueOutOfRange { value } if value.is_nan()));
+        assert!(
+            matches!(error, ParserError::ValueOutOfRange { value, max: u64::MAX} if value.is_nan())
+        );
 
         let value = f64::INFINITY;
         let error = try_f64_to_u64(value).unwrap_err();
-        assert_eq!(error, ParserError::ValueOutOfRange { value });
+        assert_eq!(
+            error,
+            ParserError::ValueOutOfRange {
+                value,
+                max: u64::MAX
+            }
+        );
 
         let value = f64::NEG_INFINITY;
         let error = try_f64_to_u64(value).unwrap_err();
-        assert_eq!(error, ParserError::ValueOutOfRange { value });
+        assert_eq!(
+            error,
+            ParserError::ValueOutOfRange {
+                value,
+                max: u64::MAX
+            }
+        );
 
         assert_eq!(try_f64_to_u64(0.0).unwrap(), 0);
         assert_eq!(try_f64_to_u64(u64::MAX as f64).unwrap(), u64::MAX);

--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -53,8 +53,8 @@ pub enum ParserError {
         error: ErrorKind,
     },
 
-    #[snafu(display("expected value in range [0, {}], found: {}", u32::MAX, value))]
-    ValueOutOfRange { value: f64 },
+    #[snafu(display("expected value in range [0, {}], found: {}", max, value))]
+    ValueOutOfRange { value: f64, max: u64 },
 
     #[snafu(display("multiple metric kinds given for metric name `{}`", name))]
     MultipleMetricKinds { name: String },
@@ -242,7 +242,10 @@ fn try_f64_to_u32(f: f64) -> Result<u32, ParserError> {
     if 0.0 <= f && f <= u32::MAX as f64 {
         Ok(f as u32)
     } else {
-        Err(ParserError::ValueOutOfRange { value: f })
+        Err(ParserError::ValueOutOfRange {
+            value: f,
+            max: u32::MAX.into(),
+        })
     }
 }
 
@@ -250,7 +253,10 @@ fn try_f64_to_u64(f: f64) -> Result<u64, ParserError> {
     if 0.0 <= f && f <= u64::MAX as f64 {
         Ok(f as u64)
     } else {
-        Err(ParserError::ValueOutOfRange { value: f })
+        Err(ParserError::ValueOutOfRange {
+            value: f,
+            max: u64::MAX,
+        })
     }
 }
 


### PR DESCRIPTION
The error message was always saying u32 was the max even though it could be u64.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
