### PR TITLE
chore(config): fix invalid enum schemas + provide more enum metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "value",
  "vector-common",
  "vector-config",
+ "vector-config-common",
  "vector-config-macros",
  "vector-core",
 ]
@@ -9112,6 +9113,7 @@ dependencies = [
  "vector-buffers",
  "vector-common",
  "vector-config",
+ "vector-config-common",
  "vector-config-macros",
  "vrl",
 ]
@@ -9199,6 +9201,7 @@ dependencies = [
  "value",
  "vector-common",
  "vector-config",
+ "vector-config-common",
  "vector-config-macros",
  "vrl-core",
  "vrl-diagnostic",

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { version = "0.1", default-features = false }
 value = { path = "../value", default-features = false }
 vector-common = { path = "../vector-common", default-features = false }
 vector-config = { path = "../vector-config", default-features = false }
+vector-config-common = { path = "../vector-config-common", default-features = false }
 vector-config-macros = { path = "../vector-config-macros", default-features = false }
 vector-core = { path = "../vector-core", default-features = false }
 

--- a/lib/vector-common/src/datetime.rs
+++ b/lib/vector-common/src/datetime.rs
@@ -3,10 +3,26 @@ use std::fmt::Debug;
 use chrono::{DateTime, Local, ParseError, TimeZone as _, Utc};
 use chrono_tz::Tz;
 use derivative::Derivative;
-use vector_config::configurable_component;
+use vector_config::{
+    schema::{
+        apply_metadata, generate_const_string_schema, generate_one_of_schema,
+        get_or_generate_schema,
+    },
+    schemars::{gen::SchemaGenerator, schema::SchemaObject},
+    Configurable, GenerateError, Metadata,
+};
 
 /// Timezone reference.
-#[configurable_component(no_deser, no_ser)]
+///
+/// This can refer to any valid timezone as defined in the [TZ database][tzdb], or "local" which
+/// refers to the system local timezone.
+///
+/// [tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#[cfg_attr(
+    feature = "serde",
+    derive(::serde::Deserialize, ::serde::Serialize),
+    serde(try_from = "String", into = "String")
+)]
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 #[derivative(Default)]
 pub enum TimeZone {
@@ -19,7 +35,7 @@ pub enum TimeZone {
     /// Must be a valid name in the [TZ database][tzdb].
     ///
     /// [tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    Named(#[configurable(transparent)] Tz),
+    Named(Tz),
 }
 
 /// This is a wrapper trait to allow `TimeZone` types to be passed generically.
@@ -54,41 +70,55 @@ pub(super) fn datetime_to_utc<TZ: chrono::TimeZone>(ts: &DateTime<TZ>) -> DateTi
     Utc.timestamp(ts.timestamp(), ts.timestamp_subsec_nanos())
 }
 
-#[cfg(feature = "serde")]
-pub mod ser_de {
-    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-
-    use super::TimeZone;
-
-    impl Serialize for TimeZone {
-        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            match self {
-                Self::Local => serializer.serialize_str("local"),
-                Self::Named(tz) => serializer.serialize_str(tz.name()),
-            }
+impl From<TimeZone> for String {
+    fn from(tz: TimeZone) -> Self {
+        match tz {
+            TimeZone::Local => "local".to_string(),
+            TimeZone::Named(tz) => tz.name().to_string(),
         }
     }
+}
 
-    impl<'de> Deserialize<'de> for TimeZone {
-        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-            deserializer.deserialize_str(TimeZoneVisitor)
+impl TryFrom<String> for TimeZone {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match TimeZone::parse(&value) {
+            Some(tz) => Ok(tz),
+            None => Err("No such time zone".to_string()),
         }
     }
+}
 
-    struct TimeZoneVisitor;
+// TODO: Consider an approach for generating schema of "fixed string value, or remainder" structure
+// used by this type.
+impl Configurable for TimeZone {
+    fn referenceable_name() -> Option<&'static str> {
+        Some(std::any::type_name::<Self>())
+    }
 
-    impl<'de> de::Visitor<'de> for TimeZoneVisitor {
-        type Value = TimeZone;
+    fn metadata() -> vector_config::Metadata<Self> {
+        let mut metadata = vector_config::Metadata::default();
+        metadata.set_title("Timezone reference.");
+        metadata.set_description(r#"This can refer to any valid timezone as defined in the [TZ database][tzdb], or "local" which refers to the system local timezone.
 
-        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "a time zone name")
-        }
+[tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"#);
+        metadata
+    }
 
-        fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
-            match TimeZone::parse(s) {
-                Some(tz) => Ok(tz),
-                None => Err(de::Error::custom("No such time zone")),
-            }
-        }
+    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+        let mut local_schema = generate_const_string_schema("local".to_string());
+        let local_metadata = Metadata::<()>::with_description("System local timezone.");
+        apply_metadata(&mut local_schema, local_metadata);
+
+        let mut tz_metadata = Metadata::with_title("A named timezone.");
+        tz_metadata.set_description(
+            r#"Must be a valid name in the [TZ database][tzdb].
+
+[tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"#,
+        );
+        let tz_schema = get_or_generate_schema::<Tz>(gen, tz_metadata)?;
+
+        Ok(generate_one_of_schema(&[local_schema, tz_schema]))
     }
 }

--- a/lib/vector-config-macros/src/ast/variant.rs
+++ b/lib/vector-config-macros/src/ast/variant.rs
@@ -1,4 +1,5 @@
 use darling::{error::Accumulator, util::Flag, FromAttributes};
+use proc_macro2::Ident;
 use serde_derive_internals::ast as serde_ast;
 use syn::spanned::Spanned;
 use vector_config_common::attributes::CustomAttribute;
@@ -48,6 +49,11 @@ impl<'a> Variant<'a> {
             tagging,
         };
         accumulator.finish_with(variant)
+    }
+
+    /// Ident of the variant.
+    pub fn ident(&self) -> &Ident {
+        &self.original.ident
     }
 
     /// Style of the variant.

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -62,6 +62,7 @@ value = { path = "../value", default-features = false, features = ["lua", "toml"
 vector-buffers = { path = "../vector-buffers", default-features = false }
 vector-common = { path = "../vector-common" }
 vector-config = { path = "../vector-config" }
+vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }
 # Rename to "vrl" once we use a release with stable `-Z namespaced-features`:
 # https://doc.rust-lang.org/cargo/reference/unstable.html#namespaced-features

--- a/lib/vrl/compiler/Cargo.toml
+++ b/lib/vrl/compiler/Cargo.toml
@@ -34,6 +34,7 @@ parser = { package = "vrl-parser", path = "../parser" }
 lookup = { path = "../../lookup" }
 vector-common = { path = "../../vector-common", default-features = false, features = ["conversion", "serde"] }
 vector-config = { path = "../../vector-config" }
+vector-config-common = { path = "../../vector-config-common" }
 vector-config-macros = { path = "../../vector-config-macros" }
 value = { path = "../../value" }
 

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -18,7 +18,7 @@ const DEFAULT_LOAD_TIMEOUT: Duration = Duration::from_secs(5);
 #[serde(deny_unknown_fields, untagged)]
 pub enum AwsAuthentication {
     /// Authenticate using a fixed access key and secret pair.
-    Static {
+    AccessKey {
         /// The AWS access key ID.
         access_key_id: SensitiveString,
 
@@ -66,7 +66,7 @@ impl AwsAuthentication {
         service_region: Region,
     ) -> crate::Result<SharedCredentialsProvider> {
         match self {
-            Self::Static {
+            Self::AccessKey {
                 access_key_id,
                 secret_access_key,
             } => Ok(SharedCredentialsProvider::new(Credentials::from_keys(
@@ -97,7 +97,7 @@ impl AwsAuthentication {
 
     #[cfg(test)]
     pub fn test_auth() -> AwsAuthentication {
-        AwsAuthentication::Static {
+        AwsAuthentication::AccessKey {
             access_key_id: "dummy".to_string().into(),
             secret_access_key: "dummy".to_string().into(),
         }
@@ -220,7 +220,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(config.auth, AwsAuthentication::Static { .. }));
+        assert!(matches!(config.auth, AwsAuthentication::AccessKey { .. }));
     }
 
     #[test]

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -1,34 +1,18 @@
-use std::fmt;
+use std::{collections::BTreeSet, fmt};
 
+use indexmap::IndexMap;
 use serde::{de, ser};
 use vector_config::{
-    configurable_component,
-    schema::{generate_composite_schema, generate_number_schema, generate_string_schema},
+    schema::{
+        generate_const_string_schema, generate_enum_schema,
+        generate_internal_tagged_variant_schema, generate_one_of_schema, generate_struct_schema,
+        get_or_generate_schema,
+    },
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    validation::Validation,
-    Configurable, GenerateError,
+    Configurable, GenerateError, Metadata,
 };
 
-// NOTE: The resulting schema for `Compression` is not going to look right, because of how we do the customized "string
-// or map" stuff. We've done a bunch of work here to get us half-way towards generating a valid schema for it, including
-// add in the `CompressionLevel` type and doing a custom `Configurable` implementation for it... but the real meat of
-// the change would be doing so for `Compression` because of it being an enum and all the boilerplate involved there.
-//
-// It'd be nice to find a succinct way to allow the expression of these constraints, possibly through a declarative
-// macro that helps build the manual `Configurable` implementation such that, while still leaving the developer
-// responsible for generating a correct schema, it would be far closer to a human-readable description of the schema
-// i.e. "this schema can be X or Y, and if X, it can only be these values, or if Y, the value must fall within this
-// specific range" and so on, with methods for describing enum variants, etc.
-//
-// Another complication is that we can _almost_ sort of get there with the existing primitives but `serde` itself has no
-// way to express an enum that functions like what we're doing here i.e. the variant name is parsed from the value,
-// without needing to be a tag field, with the ability to fallback to a newtype variant, etc.
-//
-// Long story short, these custom (de)serialization strategies are hard to encode in a procedural way because they are
-// in fact not themselves declared procedurally.
-
 /// Compression configuration.
-#[configurable_component(no_ser, no_deser)]
 #[derive(Copy, Clone, Debug, Derivative, Eq, PartialEq)]
 #[derivative(Default)]
 pub enum Compression {
@@ -39,12 +23,12 @@ pub enum Compression {
     /// [Gzip][gzip] compression.
     ///
     /// [gzip]: https://en.wikipedia.org/wiki/Gzip
-    Gzip(#[configurable(derived)] CompressionLevel),
+    Gzip(CompressionLevel),
 
     /// [Zlib][zlib] compression.
     ///
     /// [zlib]: https://en.wikipedia.org/wiki/Zlib
-    Zlib(#[configurable(derived)] CompressionLevel),
+    Zlib(CompressionLevel),
 }
 
 impl Compression {
@@ -213,6 +197,67 @@ impl ser::Serialize for Compression {
     }
 }
 
+// TODO: Consider an approach for generating schema of "string or object" structure used by this type.
+impl Configurable for Compression {
+    fn referenceable_name() -> Option<&'static str> {
+        Some(std::any::type_name::<Self>())
+    }
+
+    fn description() -> Option<&'static str> {
+        Some("Compression configuration.")
+    }
+
+    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+        const ALGORITHM_NAME: &'static str = "algorithm";
+        const LEVEL_NAME: &'static str = "level";
+        const NONE_NAME: &'static str = "none";
+        const GZIP_NAME: &'static str = "gzip";
+        const ZLIB_NAME: &'static str = "zlib";
+
+        // First, we need to be able to handle all of the string-only variants.
+        let const_values = [NONE_NAME, GZIP_NAME, ZLIB_NAME]
+            .iter()
+            .map(|s| serde_json::Value::from(*s))
+            .collect();
+
+        // Now we need to handle when the user specifies the full object-based notation in order to
+        // specify the compression level, and so on.
+        let mut compression_level_metadata = Metadata::default();
+        compression_level_metadata.set_transparent();
+        let compression_level_schema =
+            get_or_generate_schema::<CompressionLevel>(gen, compression_level_metadata)?;
+
+        let mut gzip_properties = IndexMap::new();
+        gzip_properties.insert(
+            ALGORITHM_NAME.to_string(),
+            generate_const_string_schema(GZIP_NAME.to_string()),
+        );
+        gzip_properties.insert(LEVEL_NAME.to_string(), compression_level_schema.clone());
+
+        let mut zlib_properties = IndexMap::new();
+        zlib_properties.insert(
+            ALGORITHM_NAME.to_string(),
+            generate_const_string_schema(ZLIB_NAME.to_string()),
+        );
+        zlib_properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
+
+        let mut required = BTreeSet::new();
+        required.insert(ALGORITHM_NAME.to_string());
+
+        Ok(generate_one_of_schema(&[
+            // Handle the condensed string form.
+            generate_enum_schema(const_values),
+            // Handle the expanded object form.
+            generate_internal_tagged_variant_schema(
+                ALGORITHM_NAME.to_string(),
+                NONE_NAME.to_string(),
+            ),
+            generate_struct_schema(gzip_properties, required.clone(), None),
+            generate_struct_schema(zlib_properties, required, None),
+        ]))
+    }
+}
+
 /// Compression level.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CompressionLevel(flate2::Compression);
@@ -323,37 +368,25 @@ impl ser::Serialize for CompressionLevel {
     }
 }
 
+// TODO: Consider an approach for generating schema of "string or number" structure used by this type.
 impl Configurable for CompressionLevel {
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
-        let as_number = generate_number_schema::<u32>();
-        let as_string = generate_string_schema();
-
-        Ok(generate_composite_schema(&[as_number, as_string]))
+    fn referenceable_name() -> Option<&'static str> {
+        Some(std::any::type_name::<Self>())
     }
 
     fn description() -> Option<&'static str> {
         Some("Compression level.")
     }
 
-    fn metadata() -> vector_config::Metadata<Self> {
-        let mut metadata = vector_config::Metadata::default();
-        if let Some(description) = Self::description() {
-            metadata.set_description(description);
-        }
+    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+        let string_consts = ["none", "fast", "best", "default"]
+            .iter()
+            .map(|s| serde_json::Value::from(*s));
 
-        // Allows the user to specify any number from 0 to 9, or the constants "none", "fast", or "best".
-        //
-        // TODO: Technically, we can define `integer` or `number` for a schema's instance type, which would make the
-        // validation do the right thing, since as-is, while our implicit casting, everything in the schema ends up
-        // looking like it can be a floating-point number. We should add support for generating `integer` schemas, and
-        // then add validator support to do ranges specifically for integers vs numbers (floating-point).
-        metadata.add_validation(Validation::Range {
-            minimum: Some(0.0),
-            maximum: Some(9.0),
-        });
-        metadata.add_validation(Validation::Pattern(String::from("none|fast|best|default")));
+        let level_consts = (0u32..=9).map(|n| serde_json::Value::from(n));
 
-        metadata
+        let valid_values = string_consts.chain(level_consts).collect();
+        Ok(generate_enum_schema(valid_values))
     }
 }
 

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -1,6 +1,13 @@
 use serde::Serializer;
 use std::fmt;
-use vector_config::configurable_component;
+use vector_config::{
+    schema::{
+        apply_metadata, generate_const_string_schema, generate_number_schema,
+        generate_one_of_schema,
+    },
+    schemars::{gen::SchemaGenerator, schema::SchemaObject},
+    Configurable, GenerateError, Metadata,
+};
 
 use serde::{
     de::{self, Unexpected, Visitor},
@@ -8,7 +15,6 @@ use serde::{
 };
 
 /// Configuration for outbound request concurrency.
-#[configurable_component(no_ser, no_deser)]
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 pub enum Concurrency {
     /// A fixed concurrency of 1.
@@ -22,7 +28,7 @@ pub enum Concurrency {
     Adaptive,
 
     /// A fixed amount of concurrency will be allowed.
-    Fixed(#[configurable(transparent)] usize),
+    Fixed(usize),
 }
 
 impl Serialize for Concurrency {
@@ -113,6 +119,46 @@ impl<'de> Deserialize<'de> for Concurrency {
         }
 
         deserializer.deserialize_any(UsizeOrAdaptive)
+    }
+}
+
+// TODO: Consider an approach for generating schema of "string or number" structure used by this type.
+impl Configurable for Concurrency {
+    fn referenceable_name() -> Option<&'static str> {
+        Some(std::any::type_name::<Self>())
+    }
+
+    fn description() -> Option<&'static str> {
+        Some("Configuration for outbound request concurrency.")
+    }
+
+    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+        let mut none_schema = generate_const_string_schema("none".to_string());
+        let mut none_metadata = Metadata::<()>::with_title("A fixed concurrency of 1.");
+        none_metadata.set_description(
+            "In other words, only one request can be outstanding at any given time.",
+        );
+        apply_metadata(&mut none_schema, none_metadata);
+
+        let mut adaptive_schema = generate_const_string_schema("adaptive".to_string());
+        let mut adaptive_metadata = Metadata::<()>::with_title(
+            "Concurrency will be managed by Vector's [adaptive concurrency][arc] feature.",
+        );
+        adaptive_metadata
+            .set_description("[arc]: https://vector.dev/docs/about/under-the-hood/networking/arc/");
+        apply_metadata(&mut adaptive_schema, adaptive_metadata);
+
+        let mut fixed_schema = generate_number_schema::<usize>();
+        let mut fixed_metadata =
+            Metadata::<()>::with_description("A fixed amount of concurrency will be allowed.");
+        fixed_metadata.set_transparent();
+        apply_metadata(&mut fixed_schema, fixed_metadata);
+
+        Ok(generate_one_of_schema(&[
+            none_schema,
+            adaptive_schema,
+            fixed_schema,
+        ]))
     }
 }
 


### PR DESCRIPTION
## Context

This PR addresses two problems with the current configuration schema generation: types with invalid schemas, and a loss of information for enums and their variants.

First, we've fixed the schema for some common enums -- `Compression`, `Concurrency`, and `TimeZone` -- that had invalid schemas due to their use of specialized (de)serialization logic. As the types themselves did not have a shape that matched what we would allow deserializing from, this meant the schema did not accurately reflect what users can put in a configuration.

We've manually implemented `Configurable` for these types, with the hope that we can further enhance the procedural macros in the future to allow more control around describing the true shape of a type, or potentially move them over to using specialized `serde` (de)serialization helpers where we can do these hand-rolled implementations in a single place, and vet them accordingly.

Second, we've added a new piece of metadata for enum variants: the "logical" name. This is a new metadata attribute that gets added to the schema for every enum variant and specifies the ident of the variant itself.

In many cases, the title/description of an enum variant are more human-centric in terms of describing how the variant is used, but there's also a common need/desire for a friendly identifier that can be used to differentiate variants, without necessarily having to add hard-coded logic that has to know that we use const schemas to describe enum tagging fields, and so on.

With `logical_name`, consumers of the schema can now actually better detect when a schema represents a true enum, instead of situations dealing with multiple parsing strategies (i.e. `Compression` allowing a single string _or_ object).