### PR TITLE
chore(sinks): Emit `EventsSent` in driver in new-style sinks

### DIFF
--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -97,6 +97,8 @@ pub type Registered<T> = <T as RegisterInternalEvent>::Handle;
 
 pub struct ByteSize(pub usize);
 
+pub struct CountByteSize(pub usize, pub usize);
+
 pub struct Protocol(pub SharedString);
 
 impl Protocol {

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -5,7 +5,7 @@ use futures_util::future::poll_fn;
 use tokio::{pin, select};
 use tower::Service;
 use tracing::Instrument;
-use vector_common::internal_event::{service, BytesSent};
+use vector_common::internal_event::{service, BytesSent, CountByteSize};
 
 use super::FuturesUnorderedCount;
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
 
 pub trait DriverResponse {
     fn event_status(&self) -> EventStatus;
-    fn events_sent(&self) -> EventsSent;
+    fn events_sent(&self) -> CountByteSize;
 
     /// Return a tuple containing the number of bytes that were sent in the
     /// request that returned this response together with the protocol the
@@ -185,7 +185,12 @@ where
                             protocol: protocol.to_string().into(),
                         });
                     }
-                    emit(response.events_sent());
+                    let cbs = response.events_sent();
+                    emit(EventsSent {
+                        count: cbs.0,
+                        byte_size: cbs.1,
+                        output: None,
+                    });
                 }
             }
         };
@@ -215,7 +220,7 @@ mod tests {
     use vector_common::finalization::{
         BatchNotifier, EventFinalizer, EventFinalizers, EventStatus, Finalizable,
     };
-    use vector_common::internal_event::EventsSent;
+    use vector_common::internal_event::CountByteSize;
 
     use super::{Driver, DriverResponse};
 
@@ -249,12 +254,8 @@ mod tests {
             EventStatus::Delivered
         }
 
-        fn events_sent(&self) -> EventsSent {
-            EventsSent {
-                count: 1,
-                byte_size: 1,
-                output: None,
-            }
+        fn events_sent(&self) -> CountByteSize {
+            CountByteSize(1, 1)
         }
     }
 

--- a/src/sinks/amqp/service.rs
+++ b/src/sinks/amqp/service.rs
@@ -12,7 +12,7 @@ use std::{
 use tower::Service;
 use vector_common::{
     finalization::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::EventsSent,
+    internal_event::CountByteSize,
 };
 use vector_core::stream::DriverResponse;
 
@@ -57,12 +57,8 @@ impl DriverResponse for AmqpResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: 1,
-            byte_size: self.byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(1, self.byte_size)
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -22,7 +22,7 @@ use tower::{
     timeout::Timeout,
     Service, ServiceBuilder, ServiceExt,
 };
-use vector_core::{internal_event::EventsSent, stream::DriverResponse};
+use vector_core::{internal_event::CountByteSize, stream::DriverResponse};
 use vrl::prelude::fmt::Debug;
 
 use crate::{
@@ -117,12 +117,8 @@ impl DriverResponse for CloudwatchResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.events_count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.events_count, self.events_byte_size)
     }
 }
 

--- a/src/sinks/aws_kinesis_firehose/service.rs
+++ b/src/sinks/aws_kinesis_firehose/service.rs
@@ -6,7 +6,7 @@ use aws_sdk_firehose::{
 use futures::future::BoxFuture;
 use hyper::service::Service;
 use tracing::Instrument;
-use vector_core::{internal_event::EventsSent, stream::DriverResponse};
+use vector_core::{internal_event::CountByteSize, stream::DriverResponse};
 
 use super::request_builder::KinesisRequest;
 use crate::event::EventStatus;
@@ -28,12 +28,8 @@ impl DriverResponse for KinesisResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.count, self.events_byte_size)
     }
 }
 

--- a/src/sinks/aws_kinesis_streams/service.rs
+++ b/src/sinks/aws_kinesis_streams/service.rs
@@ -8,7 +8,7 @@ use aws_types::region::Region;
 use futures::future::BoxFuture;
 use tower::Service;
 use tracing::Instrument;
-use vector_core::{internal_event::EventsSent, stream::DriverResponse};
+use vector_core::{internal_event::CountByteSize, stream::DriverResponse};
 
 use crate::{event::EventStatus, sinks::aws_kinesis_streams::request_builder::KinesisRequest};
 
@@ -29,12 +29,8 @@ impl DriverResponse for KinesisResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.count, self.events_byte_size)
     }
 }
 

--- a/src/sinks/aws_sqs/service.rs
+++ b/src/sinks/aws_sqs/service.rs
@@ -5,7 +5,7 @@ use futures::{future::BoxFuture, TryFutureExt};
 use tower::Service;
 use tracing::Instrument;
 use vector_core::{
-    event::EventStatus, internal_event::EventsSent, stream::DriverResponse, ByteSizeOf,
+    event::EventStatus, internal_event::CountByteSize, stream::DriverResponse, ByteSizeOf,
 };
 
 use super::request_builder::SendMessageEntry;
@@ -62,11 +62,7 @@ impl DriverResponse for SendMessageResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: 1,
-            byte_size: self.byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(1, self.byte_size)
     }
 }

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use futures::FutureExt;
 use http::StatusCode;
 use snafu::Snafu;
-use vector_core::{internal_event::EventsSent, stream::DriverResponse};
+use vector_core::{internal_event::CountByteSize, stream::DriverResponse};
 
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
@@ -67,12 +67,8 @@ impl DriverResponse for AzureBlobResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.count, self.events_byte_size)
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/datadog/events/service.rs
+++ b/src/sinks/datadog/events/service.rs
@@ -8,7 +8,7 @@ use futures::{
 use http::Request;
 use hyper::Body;
 use tower::{Service, ServiceExt};
-use vector_core::{internal_event::EventsSent, stream::DriverResponse};
+use vector_core::{internal_event::CountByteSize, stream::DriverResponse};
 
 use crate::{
     event::EventStatus,
@@ -30,12 +30,8 @@ impl DriverResponse for DatadogEventsResponse {
         self.event_status
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: 1,
-            byte_size: self.event_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(1, self.event_byte_size)
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -14,7 +14,7 @@ use tower::Service;
 use tracing::Instrument;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::EventsSent,
+    internal_event::CountByteSize,
     stream::DriverResponse,
 };
 
@@ -67,12 +67,8 @@ impl DriverResponse for LogApiResponse {
         self.event_status
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.count, self.events_byte_size)
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/datadog/metrics/service.rs
+++ b/src/sinks/datadog/metrics/service.rs
@@ -12,7 +12,7 @@ use snafu::ResultExt;
 use tower::Service;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::EventsSent,
+    internal_event::CountByteSize,
     stream::DriverResponse,
 };
 
@@ -132,12 +132,8 @@ impl DriverResponse for DatadogMetricsResponse {
         }
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.batch_size,
-            byte_size: self.byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.batch_size, self.byte_size)
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/datadog/traces/service.rs
+++ b/src/sinks/datadog/traces/service.rs
@@ -11,7 +11,7 @@ use snafu::ResultExt;
 use tower::Service;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::EventsSent,
+    internal_event::CountByteSize,
     stream::DriverResponse,
 };
 
@@ -100,12 +100,8 @@ impl DriverResponse for TraceApiResponse {
         }
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.batch_size,
-            byte_size: self.byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.batch_size, self.byte_size)
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -11,7 +11,7 @@ use futures::future::BoxFuture;
 use http::{Response, Uri};
 use hyper::{service::Service, Body, Request};
 use tower::ServiceExt;
-use vector_core::{internal_event::EventsSent, stream::DriverResponse, ByteSizeOf};
+use vector_core::{internal_event::CountByteSize, stream::DriverResponse, ByteSizeOf};
 
 use crate::sinks::elasticsearch::sign_request;
 use crate::{
@@ -129,12 +129,8 @@ impl DriverResponse for ElasticsearchResponse {
         self.event_status
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.batch_size,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.batch_size, self.events_byte_size)
     }
 }
 

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -8,7 +8,7 @@ use http::{
 };
 use hyper::Body;
 use tower::Service;
-use vector_core::{internal_event::EventsSent, stream::DriverResponse};
+use vector_core::{internal_event::CountByteSize, stream::DriverResponse};
 
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
@@ -79,12 +79,11 @@ impl DriverResponse for GcsResponse {
         }
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.metadata.event_count(),
-            byte_size: self.metadata.events_byte_size(),
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(
+            self.metadata.event_count(),
+            self.metadata.events_byte_size(),
+        )
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -11,7 +11,7 @@ use rdkafka::{
 use tower::Service;
 use vector_core::{
     internal_event::{
-        ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol, Registered,
+        ByteSize, BytesSent, CountByteSize, InternalEventHandle as _, Protocol, Registered,
     },
     stream::DriverResponse,
 };
@@ -44,12 +44,8 @@ impl DriverResponse for KafkaResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: 1,
-            byte_size: self.event_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(1, self.event_byte_size)
     }
 }
 

--- a/src/sinks/loki/service.rs
+++ b/src/sinks/loki/service.rs
@@ -8,7 +8,7 @@ use tower::Service;
 use tracing::Instrument;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::EventsSent,
+    internal_event::CountByteSize,
     stream::DriverResponse,
 };
 
@@ -56,12 +56,11 @@ impl DriverResponse for LokiResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.metadata.event_count(),
-            byte_size: self.metadata.events_byte_size(),
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(
+            self.metadata.event_count(),
+            self.metadata.events_byte_size(),
+        )
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/new_relic/service.rs
+++ b/src/sinks/new_relic/service.rs
@@ -15,7 +15,7 @@ use tower::Service;
 use tracing::Instrument;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::EventsSent,
+    internal_event::CountByteSize,
     stream::DriverResponse,
 };
 
@@ -52,12 +52,11 @@ impl DriverResponse for NewRelicApiResponse {
         self.event_status
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.metadata.event_count(),
-            byte_size: self.metadata.events_byte_size(),
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(
+            self.metadata.event_count(),
+            self.metadata.events_byte_size(),
+        )
     }
 
     fn bytes_sent(&self) -> Option<(usize, &str)> {

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -12,7 +12,7 @@ use tower::Service;
 use tracing::Instrument;
 use vector_core::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::EventsSent,
+    internal_event::CountByteSize,
     stream::DriverResponse,
 };
 
@@ -52,12 +52,8 @@ impl DriverResponse for S3Response {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.count, self.events_byte_size)
     }
 }
 

--- a/src/sinks/splunk_hec/common/response.rs
+++ b/src/sinks/splunk_hec/common/response.rs
@@ -1,4 +1,5 @@
-use vector_core::{event::EventStatus, internal_event::EventsSent, stream::DriverResponse};
+use vector_core::internal_event::CountByteSize;
+use vector_core::{event::EventStatus, stream::DriverResponse};
 
 pub struct HecResponse {
     pub event_status: EventStatus,
@@ -17,11 +18,7 @@ impl DriverResponse for HecResponse {
         self.event_status
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.events_count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.events_count, self.events_byte_size)
     }
 }

--- a/src/sinks/vector/service.rs
+++ b/src/sinks/vector/service.rs
@@ -9,7 +9,7 @@ use prost::Message;
 use proto_event::EventWrapper;
 use tonic::{body::BoxBody, IntoRequest};
 use vector_core::{
-    event::proto as proto_event, internal_event::EventsSent, stream::DriverResponse,
+    event::proto as proto_event, internal_event::CountByteSize, stream::DriverResponse,
 };
 
 use super::VectorSinkError;
@@ -38,12 +38,8 @@ impl DriverResponse for VectorResponse {
         EventStatus::Delivered
     }
 
-    fn events_sent(&self) -> EventsSent {
-        EventsSent {
-            count: self.events_count,
-            byte_size: self.events_byte_size,
-            output: None,
-        }
+    fn events_sent(&self) -> CountByteSize {
+        CountByteSize(self.events_count, self.events_byte_size)
     }
 }
 


### PR DESCRIPTION
This is a small refactoring of sinks to move the creation of the `EventsSent` emitted by the new-style sink driver from the individual sinks into the driver itself. This will assist with setting up the registered `EventsSent` type.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
