### PR TITLE
chore: Use `std::task::ready!` instead of `futures::ready!`

### DIFF
--- a/lib/vector-buffers/src/topology/channel/receiver.rs
+++ b/lib/vector-buffers/src/topology/channel/receiver.rs
@@ -1,11 +1,11 @@
 use std::{
     mem,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use async_recursion::async_recursion;
-use futures::{ready, Stream};
+use futures::Stream;
 use tokio::select;
 use tokio_util::sync::ReusableBoxFuture;
 use vector_common::internal_event::emit;

--- a/lib/vector-common/src/finalizer.rs
+++ b/lib/vector-common/src/finalizer.rs
@@ -161,7 +161,7 @@ pub struct FinalizerFuture<T> {
 impl<T> Future for FinalizerFuture<T> {
     type Output = (<BatchStatusReceiver as Future>::Output, T);
     fn poll(mut self: Pin<&mut Self>, ctx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let status = futures::ready!(self.receiver.poll_unpin(ctx));
+        let status = std::task::ready!(self.receiver.poll_unpin(ctx));
         // The use of this above in a `Futures{Ordered|Unordered|`
         // will only take this once before dropping the future.
         Poll::Ready((status, self.entry.take().unwrap_or_else(|| unreachable!())))

--- a/lib/vector-common/src/shutdown.rs
+++ b/lib/vector-common/src/shutdown.rs
@@ -5,10 +5,10 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
-use futures::{future, ready, FutureExt};
+use futures::{future, FutureExt};
 use stream_cancel::{Trigger, Tripwire};
 use tokio::time::{timeout_at, Instant};
 

--- a/lib/vector-core/src/stream/batcher/mod.rs
+++ b/lib/vector-core/src/stream/batcher/mod.rs
@@ -4,12 +4,11 @@ pub mod limiter;
 
 use std::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 pub use config::BatchConfig;
 use futures::{
-    ready,
     stream::{Fuse, Stream},
     Future, StreamExt,
 };

--- a/lib/vector-core/src/stream/concurrent_map.rs
+++ b/lib/vector-core/src/stream/concurrent_map.rs
@@ -3,11 +3,10 @@ use std::{
     num::NonZeroUsize,
     panic,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use futures_util::{
-    ready,
     stream::{Fuse, FuturesOrdered},
     Stream, StreamExt,
 };

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -199,11 +199,11 @@ mod tests {
         future::Future,
         pin::Pin,
         sync::{atomic::AtomicUsize, atomic::Ordering, Arc},
-        task::{Context, Poll},
+        task::{ready, Context, Poll},
         time::Duration,
     };
 
-    use futures_util::{ready, stream};
+    use futures_util::stream;
     use rand::{prelude::StdRng, SeedableRng};
     use rand_distr::{Distribution, Pareto};
     use tokio::{

--- a/lib/vector-core/src/stream/partitioned_batcher.rs
+++ b/lib/vector-core/src/stream/partitioned_batcher.rs
@@ -5,14 +5,11 @@ use std::{
     mem,
     num::NonZeroUsize,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
 
-use futures::{
-    ready,
-    stream::{Fuse, Stream, StreamExt},
-};
+use futures::stream::{Fuse, Stream, StreamExt};
 use pin_project::pin_project;
 use tokio_util::time::{delay_queue::Key, DelayQueue};
 use twox_hash::XxHash64;

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -267,7 +267,7 @@ impl MaybeTlsIncomingStream<TcpStream> {
         loop {
             return match &mut this.state {
                 StreamState::Accepted(stream) => poll_fn(Pin::new(stream), cx),
-                StreamState::Accepting(fut) => match futures::ready!(fut.as_mut().poll(cx)) {
+                StreamState::Accepting(fut) => match std::task::ready!(fut.as_mut().poll(cx)) {
                     Ok(stream) => {
                         this.state = StreamState::Accepted(MaybeTlsStream::Tls(stream));
                         continue;
@@ -316,7 +316,7 @@ impl AsyncWrite for MaybeTlsIncomingStream<TcpStream> {
                 }
                 poll_result => poll_result,
             },
-            StreamState::Accepting(fut) => match futures::ready!(fut.as_mut().poll(cx)) {
+            StreamState::Accepting(fut) => match std::task::ready!(fut.as_mut().poll(cx)) {
                 Ok(stream) => {
                     this.state = StreamState::Accepted(MaybeTlsStream::Tls(stream));
                     Poll::Pending

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -28,10 +28,10 @@
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
-use futures::{ready, stream::Peekable, Sink, SinkExt, Stream, StreamExt};
+use futures::{stream::Peekable, Sink, SinkExt, Stream, StreamExt};
 
 impl<T: ?Sized, Item> VecSinkExt<Item> for T where T: Sink<Item> {}
 

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -1,7 +1,7 @@
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use aws_sdk_cloudwatchlogs::error::{
@@ -15,7 +15,7 @@ use aws_sdk_cloudwatchlogs::output::{DescribeLogStreamsOutput, PutLogEventsOutpu
 use aws_sdk_cloudwatchlogs::types::SdkError;
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use aws_smithy_http::operation::{Operation, Request};
-use futures::{future::BoxFuture, ready, FutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use indexmap::IndexMap;
 use tokio::sync::oneshot;
 

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fmt,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use aws_sdk_cloudwatchlogs::error::{
@@ -11,7 +11,7 @@ use aws_sdk_cloudwatchlogs::model::InputLogEvent;
 use aws_sdk_cloudwatchlogs::types::SdkError;
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use chrono::Duration;
-use futures::{future::BoxFuture, ready, FutureExt};
+use futures::{future::BoxFuture, FutureExt};
 use futures_util::TryFutureExt;
 use indexmap::IndexMap;
 use tokio::sync::oneshot;

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -1,7 +1,7 @@
 use std::{
     num::NonZeroUsize,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
 };
 use bytes::BytesMut;
 use codecs::{encoding::SerializerConfig, TextSerializerConfig};
-use futures::{future::BoxFuture, ready, stream::FuturesUnordered, FutureExt, Sink, Stream};
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, Sink, Stream};
 use pulsar::authentication::oauth2::{OAuth2Authentication, OAuth2Params};
 use pulsar::error::AuthenticationError;
 use pulsar::{

--- a/src/sinks/splunk_hec/common/service.rs
+++ b/src/sinks/splunk_hec/common/service.rs
@@ -1,11 +1,11 @@
 use std::{
     fmt,
     sync::Arc,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use bytes::Bytes;
-use futures_util::{future::BoxFuture, ready};
+use futures_util::future::BoxFuture;
 use http::Request;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;

--- a/src/sinks/util/adaptive_concurrency/future.rs
+++ b/src/sinks/util/adaptive_concurrency/future.rs
@@ -4,11 +4,10 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Instant,
 };
 
-use futures::ready;
 use pin_project::pin_project;
 use tokio::sync::OwnedSemaphorePermit;
 

--- a/src/sinks/util/adaptive_concurrency/semaphore.rs
+++ b/src/sinks/util/adaptive_concurrency/semaphore.rs
@@ -7,13 +7,10 @@ use std::{
     mem::{drop, replace},
     pin::Pin,
     sync::{Arc, Mutex},
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
-use futures::{
-    future::{BoxFuture, FutureExt},
-    ready,
-};
+use futures::future::{BoxFuture, FutureExt};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// Wrapper for `tokio::sync::Semaphore` that allows for shrinking the

--- a/src/sinks/util/adaptive_concurrency/service.rs
+++ b/src/sinks/util/adaptive_concurrency/service.rs
@@ -3,10 +3,10 @@ use std::{
     future::Future,
     mem,
     sync::Arc,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
-use futures::{future::BoxFuture, ready};
+use futures::future::BoxFuture;
 use tokio::sync::OwnedSemaphorePermit;
 use tower::{load::Load, Service};
 

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -5,12 +5,12 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
 
 use bytes::{Buf, Bytes};
-use futures::{future::BoxFuture, ready, Sink};
+use futures::{future::BoxFuture, Sink};
 use http::StatusCode;
 use hyper::{body, Body};
 use indexmap::IndexMap;

--- a/src/sinks/util/normalizer.rs
+++ b/src/sinks/util/normalizer.rs
@@ -1,9 +1,9 @@
 use std::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
-use futures_util::{ready, stream::Fuse, Stream, StreamExt};
+use futures_util::{stream::Fuse, Stream, StreamExt};
 use pin_project::pin_project;
 use vector_core::event::Metric;
 

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -170,7 +170,7 @@ impl<L: RetryLogic> Future for RetryPolicyFuture<L> {
     type Output = FixedRetryPolicy<L>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        futures::ready!(self.delay.poll_unpin(cx));
+        std::task::ready!(self.delay.poll_unpin(cx));
         Poll::Ready(self.policy.clone())
     }
 }

--- a/src/sinks/util/service/health.rs
+++ b/src/sinks/util/service/health.rs
@@ -5,10 +5,10 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
-use futures::{ready, FutureExt};
+use futures::FutureExt;
 use futures_util::{future::BoxFuture, TryFuture};
 use pin_project::pin_project;
 use stream_cancel::{Trigger, Tripwire};

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -37,12 +37,10 @@ use std::{
     hash::Hash,
     marker::PhantomData,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
-use futures::{
-    future::BoxFuture, ready, stream::FuturesUnordered, FutureExt, Sink, Stream, TryFutureExt,
-};
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, Sink, Stream, TryFutureExt};
 use pin_project::pin_project;
 use tokio::{
     sync::oneshot,

--- a/src/sinks/util/socket_bytes_sink.rs
+++ b/src/sinks/util/socket_bytes_sink.rs
@@ -2,11 +2,11 @@ use std::{
     io::{Error as IoError, ErrorKind},
     marker::Unpin,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use bytes::Bytes;
-use futures::{ready, Sink};
+use futures::Sink;
 use pin_project::{pin_project, pinned_drop};
 use tokio::io::AsyncWrite;
 use tokio_util::codec::{BytesCodec, FramedWrite};

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -1,13 +1,13 @@
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
 
 use async_trait::async_trait;
 use bytes::BytesMut;
-use futures::{future::BoxFuture, ready, stream::BoxStream, FutureExt, StreamExt};
+use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
 use snafu::{ResultExt, Snafu};
 use tokio::{net::UdpSocket, sync::oneshot, time::sleep};
 use tokio_util::codec::Encoder;

--- a/src/sources/kubernetes_logs/lifecycle.rs
+++ b/src/sources/kubernetes_logs/lifecycle.rs
@@ -1,13 +1,13 @@
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use futures::{
     channel::oneshot,
     future::{select, BoxFuture, Either},
-    pin_mut, ready,
+    pin_mut,
     stream::FuturesOrdered,
     FutureExt, StreamExt,
 };

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -12,13 +12,11 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use flate2::read::MultiGzDecoder;
-use futures::{
-    ready, stream, task::noop_waker_ref, FutureExt, SinkExt, Stream, StreamExt, TryStreamExt,
-};
+use futures::{stream, task::noop_waker_ref, FutureExt, SinkExt, Stream, StreamExt, TryStreamExt};
 use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 use portpicker::pick_unused_port;
 use rand::{thread_rng, Rng};

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -1,11 +1,10 @@
 use std::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
 
 use futures::{Stream, StreamExt};
-use futures_util::ready;
 use metrics::gauge;
 use pin_project::pin_project;
 use tokio::time::interval;


### PR DESCRIPTION
Rust 1.64 [stabilized
`std::task::ready!`](https://doc.rust-lang.org/stable/std/task/macro.ready.html) which is an equivalent macro to `futures::ready!`, so prefer the `std` version.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
