### PR TITLE
chore: Use `std::future::poll_fn` instead of `futures::future::poll_fn`

### DIFF
--- a/lib/vector-common/src/shutdown.rs
+++ b/lib/vector-common/src/shutdown.rs
@@ -15,7 +15,7 @@ use tokio::time::{timeout_at, Instant};
 use crate::{config::ComponentKey, trigger::DisabledTrigger};
 
 pub async fn tripwire_handler(closed: bool) {
-    futures::future::poll_fn(|_| {
+    std::future::poll_fn(|_| {
         if closed {
             Poll::Ready(())
         } else {

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -1,7 +1,6 @@
-use std::{collections::VecDeque, fmt, task::Poll};
+use std::{collections::VecDeque, fmt, future::poll_fn, task::Poll};
 
 use futures::{poll, FutureExt, Stream, StreamExt, TryFutureExt};
-use futures_util::future::poll_fn;
 use tokio::{pin, select};
 use tower::Service;
 use tracing::Instrument;

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -368,7 +368,7 @@ mod test {
 
                     let mut stream: MaybeTlsIncomingStream<TcpStream> = connection.unwrap();
 
-                    future::poll_fn(move |cx| loop {
+                    std::future::poll_fn(move |cx| loop {
                         if let Some(fut) = close_rx.as_mut() {
                             if let Poll::Ready(()) = fut.poll_unpin(cx) {
                                 stream

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -295,7 +295,7 @@ mod test {
             task::Poll,
         };
 
-        use futures::{channel::mpsc, future, FutureExt, SinkExt, StreamExt};
+        use futures::{channel::mpsc, FutureExt, SinkExt, StreamExt};
         use tokio::{
             io::{AsyncRead, AsyncWriteExt, ReadBuf},
             net::TcpStream,

--- a/src/sinks/splunk_hec/common/service.rs
+++ b/src/sinks/splunk_hec/common/service.rs
@@ -261,6 +261,7 @@ impl HttpRequestBuilder {
 mod tests {
     use std::{
         collections::HashMap,
+        future::poll_fn,
         num::{NonZeroU64, NonZeroU8},
         sync::{
             atomic::{AtomicU64, Ordering},
@@ -270,7 +271,7 @@ mod tests {
     };
 
     use bytes::Bytes;
-    use futures_util::{future::poll_fn, poll, stream::FuturesUnordered, StreamExt};
+    use futures_util::{poll, stream::FuturesUnordered, StreamExt};
     use tower::{util::BoxService, Service, ServiceExt};
     use vector_core::{
         config::proxy::ProxyConfig,

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -8,13 +8,7 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::BytesMut;
-use futures::{
-    future::{self},
-    pin_mut,
-    sink::SinkExt,
-    stream::BoxStream,
-    Sink, Stream, StreamExt,
-};
+use futures::{future, pin_mut, sink::SinkExt, stream::BoxStream, Sink, Stream, StreamExt};
 use snafu::{ResultExt, Snafu};
 use tokio::{net::TcpStream, time};
 use tokio_tungstenite::{
@@ -189,7 +183,7 @@ impl PingInterval {
     }
 
     async fn tick(&mut self) -> time::Instant {
-        future::poll_fn(|cx| self.poll_tick(cx)).await
+        std::future::poll_fn(|cx| self.poll_tick(cx)).await
     }
 }
 

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -8,7 +8,7 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::BytesMut;
-use futures::{future, pin_mut, sink::SinkExt, stream::BoxStream, Sink, Stream, StreamExt};
+use futures::{pin_mut, sink::SinkExt, stream::BoxStream, Sink, Stream, StreamExt};
 use snafu::{ResultExt, Snafu};
 use tokio::{net::TcpStream, time};
 use tokio_tungstenite::{


### PR DESCRIPTION
Rust 1.64 [stabilized
`std::future::poll_fn`](https://doc.rust-lang.org/stable/std/future/fn.poll_fn.html), so prefer the `std` version.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
