### PR TITLE
enhancement(observability): Convert `EventsSent` to a registered event

### DIFF
--- a/lib/vector-common/src/internal_event/events_sent.rs
+++ b/lib/vector-common/src/internal_event/events_sent.rs
@@ -1,39 +1,100 @@
-use metrics::counter;
+use metrics::{register_counter, Counter};
 use tracing::trace;
 
-use crate::internal_event::InternalEvent;
+use super::{register, InternalEvent};
+use super::{CountByteSize, InternalEventHandle, Output, RegisterInternalEvent, SharedString};
 
-pub const DEFAULT_OUTPUT: &str = "_default";
+pub const DEFAULT_OUTPUT: &str = "_default"; //SharedString = SharedString::const_str("_default");
 
 #[derive(Debug)]
-pub struct EventsSent<'a> {
+pub struct EventsSent {
     pub count: usize,
     pub byte_size: usize,
-    pub output: Option<&'a str>,
+    pub output: Option<SharedString>,
 }
 
-impl<'a> InternalEvent for EventsSent<'a> {
+impl InternalEvent for EventsSent {
     fn emit(self) {
-        if let Some(output) = self.output {
-            trace!(message = "Events sent.", count = %self.count, byte_size = %self.byte_size, output = %output);
-        } else {
-            trace!(message = "Events sent.", count = %self.count, byte_size = %self.byte_size);
-        }
+        register(EventsSent::from(self.output.map(Output)))
+            .emit(CountByteSize(self.count, self.byte_size));
+    }
 
-        if self.count > 0 {
-            if let Some(output) = self.output {
-                counter!("component_sent_events_total", self.count as u64, "output" => output.to_owned());
-                counter!("events_out_total", self.count as u64, "output" => output.to_owned());
-                counter!("component_sent_event_bytes_total", self.byte_size as u64, "output" => output.to_owned());
-            } else {
-                counter!("component_sent_events_total", self.count as u64);
-                counter!("events_out_total", self.count as u64);
-                counter!("component_sent_event_bytes_total", self.byte_size as u64);
+    fn name(&self) -> Option<&'static str> {
+        Some("EventsSent")
+    }
+}
+
+impl From<Output> for EventsSent {
+    fn from(output: Output) -> Self {
+        Self {
+            count: 0,
+            byte_size: 0,
+            output: Some(output.0),
+        }
+    }
+}
+
+impl From<Option<Output>> for EventsSent {
+    fn from(output: Option<Output>) -> Self {
+        Self {
+            count: 0,
+            byte_size: 0,
+            output: output.map(|o| o.0),
+        }
+    }
+}
+
+impl RegisterInternalEvent for EventsSent {
+    type Handle = EventsSentHandle;
+
+    fn register(self) -> Self::Handle {
+        if let Some(output) = self.output {
+            EventsSentHandle {
+                events: register_counter!("component_sent_events_total", "output" => output.clone()),
+                events_out: register_counter!("events_out_total", "output" => output.clone()),
+                event_bytes: register_counter!("component_sent_event_bytes_total", "output" => output.clone()),
+                output: Some(output),
+            }
+        } else {
+            EventsSentHandle {
+                events: register_counter!("component_sent_events_total"),
+                events_out: register_counter!("events_out_total"),
+                event_bytes: register_counter!("component_sent_event_bytes_total"),
+                output: None,
             }
         }
     }
 
     fn name(&self) -> Option<&'static str> {
         Some("EventsSent")
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Clone)]
+pub struct EventsSentHandle {
+    events: Counter,
+    events_out: Counter,
+    event_bytes: Counter,
+    output: Option<SharedString>,
+}
+
+impl InternalEventHandle for EventsSentHandle {
+    type Data = CountByteSize;
+    fn emit(&self, data: Self::Data) {
+        let CountByteSize(count, byte_size) = data;
+
+        match &self.output {
+            Some(output) => {
+                trace!(message = "Events sent.", count = %count, byte_size = %byte_size, output = %output);
+            }
+            None => {
+                trace!(message = "Events sent.", count = %count, byte_size = %byte_size);
+            }
+        }
+
+        self.events.increment(count as u64);
+        self.events_out.increment(count as u64);
+        self.event_bytes.increment(byte_size as u64);
     }
 }

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -95,9 +95,15 @@ pub fn register<E: RegisterInternalEvent>(event: E) -> E::Handle {
 
 pub type Registered<T> = <T as RegisterInternalEvent>::Handle;
 
+// Wrapper types used to hold data emitted by registered events
+
 pub struct ByteSize(pub usize);
 
 pub struct CountByteSize(pub usize, pub usize);
+
+// Wrapper types used to hold inputs for registering an event
+
+pub struct Output(pub SharedString);
 
 pub struct Protocol(pub SharedString);
 

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -4,12 +4,14 @@ use futures::{poll, FutureExt, Stream, StreamExt, TryFutureExt};
 use tokio::{pin, select};
 use tower::Service;
 use tracing::Instrument;
-use vector_common::internal_event::{service, BytesSent, CountByteSize};
+use vector_common::internal_event::{
+    register, service, BytesSent, CountByteSize, EventsSent, InternalEventHandle as _, Registered,
+};
 
 use super::FuturesUnorderedCount;
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
-    internal_event::{emit, EventsSent},
+    internal_event::emit,
 };
 
 pub trait DriverResponse {
@@ -77,6 +79,8 @@ where
         let batched_input = input.ready_chunks(1024);
         pin!(batched_input);
 
+        let events_sent = register(EventsSent::from(None));
+
         loop {
             // Core behavior of the loop:
             // - always check to see if we have any response futures that have completed
@@ -141,10 +145,11 @@ where
                             request_id,
                         );
                         let finalizers = req.take_finalizers();
+                        let events_sent = events_sent.clone();
 
                         let fut = svc.call(req)
                             .err_into()
-                            .map(move |result| Self::handle_response(result, request_id, finalizers))
+                            .map(move |result| Self::handle_response(result, request_id, finalizers, &events_sent))
                             .instrument(info_span!("request", request_id).or_current());
 
                         in_flight.push(fut);
@@ -167,6 +172,7 @@ where
         result: Result<Svc::Response, Svc::Error>,
         request_id: usize,
         finalizers: EventFinalizers,
+        events_sent: &Registered<EventsSent>,
     ) {
         match result {
             Err(error) => {
@@ -184,12 +190,7 @@ where
                             protocol: protocol.to_string().into(),
                         });
                     }
-                    let cbs = response.events_sent();
-                    emit(EventsSent {
-                        count: cbs.0,
-                        byte_size: cbs.1,
-                        output: None,
-                    });
+                    events_sent.emit(response.events_sent());
                 }
             }
         };

--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -1,11 +1,13 @@
 use std::{collections::HashMap, pin::Pin};
 
 use futures::{Stream, StreamExt};
-use vector_common::internal_event::{emit, EventsSent, DEFAULT_OUTPUT};
+use vector_common::internal_event::{
+    self, register, CountByteSize, EventsSent, InternalEventHandle as _, Registered, DEFAULT_OUTPUT,
+};
 use vector_common::EventDataEq;
 
 use crate::{
-    config::Output,
+    config,
     event::{into_event_stream, Event, EventArray, EventContainer, EventRef},
     fanout::{self, Fanout},
     ByteSizeOf,
@@ -212,14 +214,21 @@ impl SyncTransform for Box<dyn FunctionTransform> {
     }
 }
 
+struct TransformOutput {
+    fanout: Fanout,
+    events_sent: Registered<EventsSent>,
+}
+
 pub struct TransformOutputs {
-    outputs_spec: Vec<Output>,
-    primary_output: Option<Fanout>,
-    named_outputs: HashMap<String, Fanout>,
+    outputs_spec: Vec<config::Output>,
+    primary_output: Option<TransformOutput>,
+    named_outputs: HashMap<String, TransformOutput>,
 }
 
 impl TransformOutputs {
-    pub fn new(outputs_in: Vec<Output>) -> (Self, HashMap<Option<String>, fanout::ControlChannel>) {
+    pub fn new(
+        outputs_in: Vec<config::Output>,
+    ) -> (Self, HashMap<Option<String>, fanout::ControlChannel>) {
         let outputs_spec = outputs_in.clone();
         let mut primary_output = None;
         let mut named_outputs = HashMap::new();
@@ -229,11 +238,24 @@ impl TransformOutputs {
             let (fanout, control) = Fanout::new();
             match output.port {
                 None => {
-                    primary_output = Some(fanout);
+                    primary_output = Some(TransformOutput {
+                        fanout,
+                        events_sent: register(EventsSent::from(internal_event::Output(
+                            DEFAULT_OUTPUT.into(),
+                        ))),
+                    });
                     controls.insert(None, control);
                 }
                 Some(name) => {
-                    named_outputs.insert(name.clone(), fanout);
+                    named_outputs.insert(
+                        name.clone(),
+                        TransformOutput {
+                            fanout,
+                            events_sent: register(EventsSent::from(internal_event::Output(
+                                name.clone().into(),
+                            ))),
+                        },
+                    );
                     controls.insert(Some(name.clone()), control);
                 }
             }
@@ -259,24 +281,16 @@ impl TransformOutputs {
             buf.primary_buffer
                 .as_mut()
                 .expect("mismatched outputs")
-                .send(primary)
+                .send(&mut primary.fanout)
                 .await;
-            emit(EventsSent {
-                count,
-                byte_size,
-                output: Some(DEFAULT_OUTPUT),
-            });
+            primary.events_sent.emit(CountByteSize(count, byte_size));
         }
         for (key, buf) in &mut buf.named_buffers {
             let count = buf.len();
             let byte_size = buf.size_of();
-            buf.send(self.named_outputs.get_mut(key).expect("unknown output"))
-                .await;
-            emit(EventsSent {
-                count,
-                byte_size,
-                output: Some(key.as_ref()),
-            });
+            let output = self.named_outputs.get_mut(key).expect("unknown output");
+            buf.send(&mut output.fanout).await;
+            output.events_sent.emit(CountByteSize(count, byte_size));
         }
     }
 }
@@ -288,7 +302,7 @@ pub struct TransformOutputsBuf {
 }
 
 impl TransformOutputsBuf {
-    pub fn new_with_capacity(outputs_in: Vec<Output>, capacity: usize) -> Self {
+    pub fn new_with_capacity(outputs_in: Vec<config::Output>, capacity: usize) -> Self {
         let mut primary_buffer = None;
         let mut named_buffers = HashMap::new();
 

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -10,7 +10,9 @@ use vector_core::event::{into_event_stream, EventStatus};
 use vector_core::{
     config::{log_schema, Output},
     event::{array, Event, EventArray, EventContainer, EventRef},
-    internal_event::{EventsSent, DEFAULT_OUTPUT},
+    internal_event::{
+        self, CountByteSize, EventsSent, InternalEventHandle as _, Registered, DEFAULT_OUTPUT,
+    },
     ByteSizeOf,
 };
 
@@ -223,6 +225,7 @@ struct Inner {
     inner: LimitedSender<EventArray>,
     output: String,
     lag_time: Option<Histogram>,
+    events_sent: Registered<EventsSent>,
 }
 
 impl fmt::Debug for Inner {
@@ -245,8 +248,9 @@ impl Inner {
         (
             Self {
                 inner: tx,
-                output,
+                output: output.clone(),
                 lag_time,
+                events_sent: register!(EventsSent::from(internal_event::Output(output.into()))),
             },
             rx,
         )
@@ -260,11 +264,7 @@ impl Inner {
         let byte_size = events.size_of();
         let count = events.len();
         self.inner.send(events).await.map_err(|_| ClosedError)?;
-        emit!(EventsSent {
-            count,
-            byte_size,
-            output: Some(self.output.as_ref()),
-        });
+        self.events_sent.emit(CountByteSize(count, byte_size));
         Ok(())
     }
 
@@ -306,21 +306,13 @@ impl Inner {
                     byte_size += this_size;
                 }
                 Err(error) => {
-                    emit!(EventsSent {
-                        count,
-                        byte_size,
-                        output: Some(self.output.as_ref()),
-                    });
+                    self.events_sent.emit(CountByteSize(count, byte_size));
                     return Err(error.into());
                 }
             }
         }
 
-        emit!(EventsSent {
-            count,
-            byte_size,
-            output: Some(self.output.as_ref()),
-        });
+        self.events_sent.emit(CountByteSize(count, byte_size));
 
         Ok(())
     }

--- a/src/test_util/mock/sinks/basic.rs
+++ b/src/test_util/mock/sinks/basic.rs
@@ -33,6 +33,7 @@ pub struct BasicSinkConfig {
 impl_generate_config_from_default!(BasicSinkConfig);
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 enum Mode {
     Normal(SourceSender),
     Dead,


### PR DESCRIPTION
Preliminary work, seeing if this moves the soak test needle on the file source, which emits once per line instead of per batch.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
