### PR TITLE
docs(vector sink): Remove v1 related options

### DIFF
--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -29,12 +29,9 @@ components: sinks: vector: {
 			}
 			compression: enabled:       false
 			encoding: enabled:          false
-			send_buffer_bytes: enabled: true
-			keepalive: enabled:         true
 			request: {
 				enabled:       true
 				headers:       false
-				relevant_when: "version = \"2\""
 			}
 
 			tls: {
@@ -90,18 +87,6 @@ components: sinks: vector: {
 			common:      true
 			required:    false
 			type: bool: default: false
-		}
-		version: {
-			description: "Sink API version. Specifying this version ensures that Vector does not silently break backward compatibility."
-			common:      true
-			required:    false
-			warnings: ["Ensure you use the same version for both the sink and source."]
-			type: string: {
-				enum: {
-					"2": "Vector sink API version 2"
-				}
-				default: "2"
-			}
 		}
 	}
 


### PR DESCRIPTION
Cleaned up docs for the vector sink that are unused since the removal of v1

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
