### PR TITLE
enhancement(aws_s3 sink): Template support for ssekms_key_id

### DIFF
--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -69,6 +69,7 @@ pub struct S3Options {
     /// Only applies when `server_side_encryption` is configured to use KMS.
     ///
     /// If not specified, Amazon S3 uses the AWS managed CMK in AWS to protect the data.
+    #[configurable(metadata(templateable))]
     pub ssekms_key_id: Option<String>,
 
     /// The storage class for the created objects.

--- a/src/sinks/s3_common/mod.rs
+++ b/src/sinks/s3_common/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod config;
+pub(crate) mod partitioner;
 pub(crate) mod service;
 pub(crate) mod sink;

--- a/src/sinks/s3_common/partitioner.rs
+++ b/src/sinks/s3_common/partitioner.rs
@@ -1,0 +1,58 @@
+use vector_core::{event::Event, partition::Partitioner};
+
+use crate::{internal_events::TemplateRenderingError, template::Template};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct S3PartitionKey {
+    pub key_prefix: String,
+    pub ssekms_key_id: Option<String>,
+}
+
+/// Partitions items based on the generated key for the given event.
+pub struct S3KeyPartitioner(Template, Option<Template>);
+
+impl S3KeyPartitioner {
+    pub const fn new(
+        key_prefix_template: Template,
+        ssekms_key_id_template: Option<Template>,
+    ) -> Self {
+        Self(key_prefix_template, ssekms_key_id_template)
+    }
+}
+
+impl Partitioner for S3KeyPartitioner {
+    type Item = Event;
+    type Key = Option<S3PartitionKey>;
+
+    fn partition(&self, item: &Self::Item) -> Self::Key {
+        let key_prefix = self
+            .0
+            .render_string(item)
+            .map_err(|error| {
+                emit!(TemplateRenderingError {
+                    error,
+                    field: Some("key_prefix"),
+                    drop_event: true,
+                });
+            })
+            .ok()?;
+        let ssekms_key_id = self
+            .1
+            .as_ref()
+            .map(|ssekms_key_id| {
+                ssekms_key_id.render_string(item).map_err(|error| {
+                    emit!(TemplateRenderingError {
+                        error,
+                        field: Some("ssekms_key_id"),
+                        drop_event: true,
+                    });
+                })
+            })
+            .transpose()
+            .ok()?;
+        Some(S3PartitionKey {
+            key_prefix,
+            ssekms_key_id,
+        })
+    }
+}

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -17,6 +17,7 @@ use vector_core::{
 };
 
 use super::config::S3Options;
+use super::partitioner::S3PartitionKey;
 
 #[derive(Debug, Clone)]
 pub struct S3Request {
@@ -35,7 +36,8 @@ impl Finalizable for S3Request {
 
 #[derive(Clone, Debug)]
 pub struct S3Metadata {
-    pub partition_key: String,
+    pub partition_key: S3PartitionKey,
+    pub s3_key: String,
     pub count: usize,
     pub byte_size: usize,
     pub finalizers: EventFinalizers,
@@ -119,7 +121,7 @@ impl Service<S3Request> for S3Service {
                 .put_object()
                 .body(bytes_to_bytestream(request.body))
                 .bucket(request.bucket)
-                .key(request.metadata.partition_key)
+                .key(request.metadata.s3_key)
                 .set_content_encoding(content_encoding)
                 .set_content_type(content_type)
                 .set_acl(options.acl.map(Into::into))

--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -13,13 +13,15 @@ use vector_core::{
 use crate::internal_events::SinkRequestBuildError;
 use crate::{
     event::Event,
-    sinks::util::{partitioner::KeyPartitioner, RequestBuilder, SinkBuilderExt},
+    sinks::util::{RequestBuilder, SinkBuilderExt},
 };
+
+use super::partitioner::{S3KeyPartitioner, S3PartitionKey};
 
 pub struct S3Sink<Svc, RB> {
     service: Svc,
     request_builder: RB,
-    partitioner: KeyPartitioner,
+    partitioner: S3KeyPartitioner,
     batcher_settings: BatcherSettings,
 }
 
@@ -27,7 +29,7 @@ impl<Svc, RB> S3Sink<Svc, RB> {
     pub const fn new(
         service: Svc,
         request_builder: RB,
-        partitioner: KeyPartitioner,
+        partitioner: S3KeyPartitioner,
         batcher_settings: BatcherSettings,
     ) -> Self {
         Self {
@@ -45,7 +47,7 @@ where
     Svc::Future: Send + 'static,
     Svc::Response: DriverResponse + Send + 'static,
     Svc::Error: fmt::Debug + Into<crate::Error> + Send,
-    RB: RequestBuilder<(String, Vec<Event>)> + Send + Sync + 'static,
+    RB: RequestBuilder<(S3PartitionKey, Vec<Event>)> + Send + Sync + 'static,
     RB::Error: fmt::Display + Send,
     RB::Request: Finalizable + Send,
 {
@@ -82,7 +84,7 @@ where
     Svc::Future: Send + 'static,
     Svc::Response: DriverResponse + Send + 'static,
     Svc::Error: fmt::Debug + Into<crate::Error> + Send,
-    RB: RequestBuilder<(String, Vec<Event>)> + Send + Sync + 'static,
+    RB: RequestBuilder<(S3PartitionKey, Vec<Event>)> + Send + Sync + 'static,
     RB::Error: fmt::Display + Send,
     RB::Request: Finalizable + Send,
 {


### PR DESCRIPTION
Closes #12099

Adds a new composite key for partitioning that includes ssekme_key_id with templating as requested by https://github.com/vectordotdev/vector/issues/12099


