### PR TITLE
fix(elasticsearch sink): don't assert a single endpoint for tests with multiple endpoints

### DIFF
--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -100,7 +100,11 @@ async fn create_template_index(common: &ElasticsearchCommon, name: &str) -> crat
         }))
         .send()
         .await?;
-    assert_eq!(response.status(), StatusCode::OK);
+
+    let status = response.status();
+    let text = response.text().await;
+    dbg!(&text);
+    assert_eq!(status, StatusCode::OK);
     Ok(())
 }
 
@@ -409,9 +413,10 @@ async fn run_insert_tests_with_config(
     break_events: bool,
     batch_status: BatchStatus,
 ) {
-    let common = ElasticsearchCommon::parse_single(config)
+    let common = ElasticsearchCommon::parse_many(config)
         .await
-        .expect("Config error");
+        .expect("Config error")
+        .remove(0);
     let index = match config.mode {
         // Data stream mode uses an index name generated from the event.
         ElasticsearchMode::DataStream => format!(

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -100,11 +100,7 @@ async fn create_template_index(common: &ElasticsearchCommon, name: &str) -> crat
         }))
         .send()
         .await?;
-
-    let status = response.status();
-    let text = response.text().await;
-    dbg!(&text);
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     Ok(())
 }
 


### PR DESCRIPTION
The ElasticSearch integration tests were failing because a recent merge allowed multiple endpoints to be specified. One of the tests was asserting that only a single endpoint was parsed from the config. This was now failing because some tests specified multiple endpoints.

I have removed the call to check for a single endpoint for these tests.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

