### PR TITLE
chore(docs): fix a broken link in the sink buffer docs + spelling error in upgrade notes

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -72,7 +72,7 @@ components: sinks: [Name=string]: {
 			description: """
 				Configures the sink specific buffer behavior.
 
-				More information about the individual buffer types, and buffer behavior, can be found in the [Buffering Model][\(urls.vector_buffering_model)] section.
+				More information about the individual buffer types, and buffer behavior, can be found in the [Buffering Model](\(urls.vector_buffering_model)) section.
 				"""
 			required:    false
 			type: object: {

--- a/website/cue/reference/releases/0.22.0.cue
+++ b/website/cue/reference/releases/0.22.0.cue
@@ -33,7 +33,7 @@ releases: "0.22.0": {
 		Be sure to check out the [upgrade guide](/highlights/2022-05-03-0-22-0-upgrade-guide) for breaking changes in
 		this release.
 
-		**Important**: as part of this release, we have promoted the new implemenation of disk buffers (`buffer.type
+		**Important**: as part of this release, we have promoted the new implementation of disk buffers (`buffer.type
 		= "disk_v2"`) to the default implementation (`buffer.type = "disk"`). Any existing disk buffers (`disk_v1`
 		or `disk`) will be automatically migrated. We have rigorously tested this migration, but recommend making
 		a back up of the disk buffers (in the configured `data_dir`, typically in `/var/lib/vector`) to roll back if


### PR DESCRIPTION
As stated in the title.

Specifically, #14617 made it look like this: https://deploy-preview-14617--vector-project.netlify.app/docs/reference/configuration/sinks/aws_s3/#buffer
This PR makes it look like this: https://deploy-preview-14664--vector-project.netlify.app/docs/reference/configuration/sinks/aws_s3/#buffer