### PR TITLE
fix(syslog source): don't panic on invalid dates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7519,9 +7519,9 @@ dependencies = [
 
 [[package]]
 name = "syslog_loose"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4eae4d024d7912b5bea75e54319445d0ffe7f423bb4b68a46129cdcebecaef"
+checksum = "97fb75f176928530867b2a659e470f9c9ff71904695bab6556f7ad30f9039efd"
 dependencies = [
  "chrono",
  "nom",

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
 smallvec = { version = "1", default-features = false, features = ["union"] }
 snafu = { version = "0.7.1", default-features = false, features = ["futures"] }
-syslog_loose = { version = "0.17", default-features = false, optional = true }
+syslog_loose = { version = "0.18", default-features = false, optional = true }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 tracing = { version = "0.1", default-features = false }
 value = { path = "../value", default-features = false }

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -39,7 +39,7 @@ sha-1 = { version = "0.10", optional = true }
 sha-2 = { package = "sha2", version = "0.10", optional = true }
 sha-3 = { package = "sha3", version = "0.10", optional = true }
 strip-ansi-escapes = { version = "0.1", optional = true }
-syslog_loose = { version = "0.17", optional = true }
+syslog_loose = { version = "0.18", optional = true }
 tracing = { version = "0.1", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }


### PR DESCRIPTION
Closes #14651 

This updates the `syslog_loose` parser so it doesn't panic when parsing invalid dates (such as Feb 29 2022).

The PR in `syslog_loose` that fixes this can be seen [here](https://github.com/StephenWakely/syslog-loose/pull/19).

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

