### PR TITLE
docs: Update AWS documentation

### DIFF
--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -108,14 +108,6 @@ components: _aws: {
 			}
 		}
 
-		AWS_CREDENTIAL_EXPIRATION: {
-			description: "Expiration time in RFC 3339 format. If unset, credentials won't expire."
-			type: string: {
-				default: null
-				examples: ["1996-12-19T16:39:57-08:00"]
-			}
-		}
-
 		AWS_DEFAULT_REGION: {
 			description:   "The default [AWS region](\(urls.aws_regions))."
 			relevant_when: "endpoint = null"
@@ -177,11 +169,6 @@ components: _aws: {
 				4. The [IAM instance profile](\(urls.iam_instance_profile)) (only works if running on an EC2 instance
 				   with an instance profile/role). Requires IMDSv2 to be enabled. For EKS, you may need to increase the
 				   metadata token response hop limit to 2.
-
-				Note that use of
-				[`credentials_process`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html)
-				in AWS credentials files is not supported as the underlying AWS SDK currently [lacks
-				support](https://github.com/awslabs/aws-sdk-rust/issues/261).
 
 				If no credentials are found, Vector's health check fails and an error is [logged](\(urls.vector_monitoring)).
 				If your AWS credentials expire, Vector will automatically search for up-to-date


### PR DESCRIPTION
* Remove `AWS_CREDENTIAL_EXPIRATION` reference which seems to be a leftover from Rusoto migration.
* Remove warning about credentials process now that it's [implemented](https://github.com/awslabs/smithy-rs/pull/1356) in the SDK. Confirmed in `0.24.1`
  ```
  2022-10-01T07:43:17.176046Z DEBUG send_operation{operation="HeadBucket" service="s3"}:provide_credentials{provider=default_chain}:load_credentials{provider=Profile}:load_credentials_file: aws_config::profile::parser::source: config file loaded path=~/.aws/credentials size=175
  2022-10-01T07:43:17.176214Z  INFO send_operation{operation="HeadBucket" service="s3"}:provide_credentials{provider=default_chain}:load_credentials{provider=Profile}: aws_config::profile::credentials: constructed abstract provider from config file chain=ProfileChain { base: CredentialProcess("xxxxx ** arguments redacted **"), chain: [] }
  2022-10-01T07:43:17.176240Z  INFO send_operation{operation="HeadBucket" service="s3"}:provide_credentials{provider=default_chain}:load_credentials{provider=Profile}: aws_config::profile::credentials::exec: first credentials will be loaded from CredentialProcess("xxxxx ** arguments redacted **") base=CredentialProcess("xxxxx ** arguments redacted **")
  2022-10-01T07:43:17.176332Z DEBUG send_operation{operation="HeadBucket" service="s3"}:provide_credentials{provider=default_chain}:load_credentials{provider=Profile}:load_base_credentials: aws_config::credential_process: loading credentials from external process command=xxxxx ** arguments redacted **
  2022-10-01T07:43:17.564104Z  INFO send_operation{operation="HeadBucket" service="s3"}:provide_credentials{provider=default_chain}:load_credentials{provider=Profile}: aws_config::profile::credentials: loaded base credentials creds=Credentials { provider_name: "CredentialProcess", access_key_id: "xxxxxxxx", secret_access_key: "** redacted **", expires_after: "2022-10-01T15:07:43Z" }
  ```
