### PR TITLE
fix(aws_s3 source): Correct serde tagging on event enum

### DIFF
--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -603,9 +603,10 @@ impl IngestorProcess {
 
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-enable-disable-notification-intro.html
 #[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
 enum Event {
-    TestEvent(S3TestEvent),
     Event(S3Event),
+    TestEvent(S3TestEvent),
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
A change was made to the aws_s3 source to add support for test events, which are sent when notification configuration is changed. However, the new enum representing both event types was left to the default representation, which is "externally tagged" which does not actually match the encoding of the events. This PR corrects that deserialization policy to "untagged", as the incoming events are not tagged.

Ref #14572 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
