### PR TITLE
tech(throttle transform): Refactor inner select loop

### DIFF
--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -1,7 +1,7 @@
 use std::{num::NonZeroU32, pin::Pin, time::Duration};
 
 use async_stream::stream;
-use futures::{stream, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use governor::{clock, Quota, RateLimiter};
 use snafu::Snafu;
 use vector_config::configurable_component;
@@ -125,70 +125,69 @@ where
 
         let limiter = RateLimiter::dashmap_with_clock(self.quota, &self.clock);
 
-        Box::pin(
-            stream! {
-              loop {
-                let done = tokio::select! {
-                    biased;
+        Box::pin(stream! {
+          loop {
+            let done = tokio::select! {
+                biased;
 
-                    maybe_event = input_rx.next() => {
-                        match maybe_event {
-                            None => true,
-                            Some(event) => {
-                                let (throttle, event) = match self.exclude.as_ref() {
-                                    Some(condition) => {
-                                        let (result, event) = condition.check(event);
-                                        (!result, event)
-                                    },
-                                    _ => (true, event)
-                                };
-                                let output = if throttle {
-                                    let key = self.key_field.as_ref().and_then(|t| {
-                                        t.render_string(&event)
-                                            .map_err(|error| {
-                                                emit!(TemplateRenderingError {
-                                                    error,
-                                                    field: Some("key_field"),
-                                                    drop_event: false,
-                                                })
+                maybe_event = input_rx.next() => {
+                    match maybe_event {
+                        None => true,
+                        Some(event) => {
+                            let (throttle, event) = match self.exclude.as_ref() {
+                                Some(condition) => {
+                                    let (result, event) = condition.check(event);
+                                    (!result, event)
+                                },
+                                _ => (true, event)
+                            };
+                            let output = if throttle {
+                                let key = self.key_field.as_ref().and_then(|t| {
+                                    t.render_string(&event)
+                                        .map_err(|error| {
+                                            emit!(TemplateRenderingError {
+                                                error,
+                                                field: Some("key_field"),
+                                                drop_event: false,
                                             })
-                                            .ok()
-                                    });
+                                        })
+                                        .ok()
+                                });
 
-                                    match limiter.check_key(&key) {
-                                        Ok(()) => {
-                                            Some(event)
-                                        }
-                                        _ => {
-                                            if let Some(key) = key {
-                                                emit!(ThrottleEventDiscarded{key})
-                                            } else {
-                                                emit!(ThrottleEventDiscarded{key: "None".to_string()})
-                                            }
-                                            None
-                                        }
+                                match limiter.check_key(&key) {
+                                    Ok(()) => {
+                                        Some(event)
                                     }
-                                } else {
-                                    Some(event)
-                                };
-                                yield stream::iter(output.into_iter());
-                                false
+                                    _ => {
+                                        if let Some(key) = key {
+                                            emit!(ThrottleEventDiscarded{key})
+                                        } else {
+                                            emit!(ThrottleEventDiscarded{key: "None".to_string()})
+                                        }
+                                        None
+                                    }
+                                }
+                            } else {
+                                Some(event)
+                            };
+                            if let Some(event) = output {
+                                yield event;
                             }
+                            false
                         }
                     }
-                    _ = flush_keys.tick() => {
-                        limiter.retain_recent();
-                        false
-                    }
-                    _ = flush_stream.tick() => {
-                        false
-                    }
-                };
-                if done { break }
-              }
-            }
-            .flatten(),
-        )
+                }
+                _ = flush_keys.tick() => {
+                    limiter.retain_recent();
+                    false
+                }
+                _ = flush_stream.tick() => {
+                    false
+                }
+            };
+            if done { break }
+          }
+        })
     }
 }
 

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -121,8 +121,6 @@ where
     {
         let mut flush_keys = tokio::time::interval(self.flush_keys_interval * 2);
 
-        let mut flush_stream = tokio::time::interval(Duration::from_millis(1000));
-
         let limiter = RateLimiter::dashmap_with_clock(self.quota, &self.clock);
 
         Box::pin(stream! {
@@ -179,9 +177,6 @@ where
                 }
                 _ = flush_keys.tick() => {
                     limiter.retain_recent();
-                    false
-                }
-                _ = flush_stream.tick() => {
                     false
                 }
             };

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -128,7 +128,6 @@ where
         Box::pin(
             stream! {
               loop {
-                let mut output = Vec::new();
                 let done = tokio::select! {
                     biased;
 
@@ -136,6 +135,7 @@ where
                         match maybe_event {
                             None => true,
                             Some(event) => {
+                                let mut output = Vec::new();
                                 let (throttle, event) = match self.exclude.as_ref() {
                                         Some(condition) => {
                                             let (result, event) = condition.check(event);
@@ -171,6 +171,7 @@ where
                                     } else {
                                         output.push(event)
                                     }
+                                yield stream::iter(output.into_iter());
                                 false
                             }
                         }
@@ -183,7 +184,6 @@ where
                         false
                     }
                 };
-                yield stream::iter(output.into_iter());
                 if done { break }
               }
             }


### PR DESCRIPTION
Tiny refactor to the `throttle` transform to show that it doesn't actually need a task transform.

It might be useful to review this commit-by-commit to see if the logic of each step is correct.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
