### PR TITLE
fix(vector source,opentelemetry source): emit errors on grpc errors

### DIFF
--- a/src/internal_events/grpc.rs
+++ b/src/internal_events/grpc.rs
@@ -14,7 +14,7 @@ impl InternalEvent for GrpcInvalidCompressionScheme<'_> {
             error = ?self.status.message(),
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::RECEIVING,
-            internal_log_rate_secs = true
+            internal_log_rate_limit = true
         );
         counter!(
             "component_errors_total", 1,
@@ -39,7 +39,7 @@ where
             error = %self.error,
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::RECEIVING,
-            internal_log_rate_secs = true
+            internal_log_rate_limit = true
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/grpc.rs
+++ b/src/internal_events/grpc.rs
@@ -9,11 +9,12 @@ pub struct GrpcInvalidCompressionScheme<'a> {
 
 impl InternalEvent for GrpcInvalidCompressionScheme<'_> {
     fn emit(self) {
-        error!(message = "Invalid compression scheme.",
-               error = ?self.status.message(),
-               error_type = error_type::REQUEST_FAILED,
-               stage = error_stage::RECEIVING,
-               internal_log_rate_secs = 10
+        error!(
+            message = "Invalid compression scheme.",
+            error = ?self.status.message(),
+            error_type = error_type::REQUEST_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_secs = true
         );
         counter!(
             "component_errors_total", 1,
@@ -33,11 +34,12 @@ where
     E: std::fmt::Display,
 {
     fn emit(self) {
-        error!(message = "Grpc error.",
-               error = %self.error,
-               error_type = error_type::REQUEST_FAILED,
-               stage = error_stage::RECEIVING,
-               internal_log_rate_secs = 10
+        error!(
+            message = "Grpc error.",
+            error = %self.error,
+            error_type = error_type::REQUEST_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_secs = true
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/grpc.rs
+++ b/src/internal_events/grpc.rs
@@ -3,11 +3,11 @@ use vector_common::internal_event::{error_stage, error_type};
 use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
-pub struct GrpcInvalidCompressionScheme<'a> {
+pub struct GrpcInvalidCompressionSchemeError<'a> {
     pub status: &'a tonic::Status,
 }
 
-impl InternalEvent for GrpcInvalidCompressionScheme<'_> {
+impl InternalEvent for GrpcInvalidCompressionSchemeError<'_> {
     fn emit(self) {
         error!(
             message = "Invalid compression scheme.",

--- a/src/internal_events/grpc.rs
+++ b/src/internal_events/grpc.rs
@@ -1,0 +1,48 @@
+use metrics::counter;
+use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
+
+#[derive(Debug)]
+pub struct GrpcInvalidCompressionScheme<'a> {
+    pub status: &'a tonic::Status,
+}
+
+impl InternalEvent for GrpcInvalidCompressionScheme<'_> {
+    fn emit(self) {
+        error!(message = "Invalid compression scheme.",
+               error = ?self.status.message(),
+               error_type = error_type::REQUEST_FAILED,
+               stage = error_stage::RECEIVING,
+               internal_log_rate_secs = 10
+        );
+        counter!(
+            "component_errors_total", 1,
+            "error_type" => error_type::REQUEST_FAILED,
+            "stage" => error_stage::RECEIVING,
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct GrpcError<E> {
+    pub error: E,
+}
+
+impl<E> InternalEvent for GrpcError<E>
+where
+    E: std::fmt::Display,
+{
+    fn emit(self) {
+        error!(message = "Grpc error.",
+               error = %self.error,
+               error_type = error_type::REQUEST_FAILED,
+               stage = error_stage::RECEIVING,
+               internal_log_rate_secs = 10
+        );
+        counter!(
+            "component_errors_total", 1,
+            "error_type" => error_type::REQUEST_FAILED,
+            "stage" => error_stage::RECEIVING,
+        );
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -49,6 +49,8 @@ mod fluent;
 mod gcp_pubsub;
 #[cfg(feature = "transforms-geoip")]
 mod geoip;
+#[cfg(any(feature = "sources-vector", feature = "sources-opentelemetry"))]
+mod grpc;
 mod heartbeat;
 #[cfg(feature = "sources-host_metrics")]
 mod host_metrics;
@@ -181,6 +183,8 @@ pub(crate) use self::fluent::*;
 pub(crate) use self::gcp_pubsub::*;
 #[cfg(feature = "transforms-geoip")]
 pub(crate) use self::geoip::*;
+#[cfg(any(feature = "sources-vector", feature = "sources-opentelemetry"))]
+pub(crate) use self::grpc::*;
 #[cfg(feature = "sources-host_metrics")]
 pub(crate) use self::host_metrics::*;
 #[cfg(any(

--- a/src/sources/util/grpc/decompression.rs
+++ b/src/sources/util/grpc/decompression.rs
@@ -284,10 +284,14 @@ where
         Ok(res) if res.status().is_success() => {
             bytes_received.emit(ByteSize(body_bytes_received));
         }
+        Ok(res) => {
+            emit!(GrpcError {
+                error: format!("Received {}", res.status())
+            });
+        }
         Err(error) => {
             emit!(GrpcError { error: &error });
         }
-        _ => {}
     };
 
     result

--- a/src/sources/util/grpc/decompression.rs
+++ b/src/sources/util/grpc/decompression.rs
@@ -22,6 +22,8 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
 
+use crate::internal_events::{GrpcError, GrpcInvalidCompressionScheme};
+
 // Every gRPC message has a five byte header:
 // - a compressed flag (u8, 0/1 for compressed/decompressed)
 // - a length prefix, indicating the number of remaining bytes to read (u32)
@@ -247,6 +249,7 @@ async fn drive_request<F, E>(
 ) -> Result<Response<BoxBody>, E>
 where
     F: Future<Output = Result<Response<BoxBody>, E>>,
+    E: std::fmt::Display,
 {
     let body_decompression = drive_body_decompression(source, destination);
 
@@ -275,15 +278,17 @@ where
         }
     };
 
-    // If the response indicates success, then emit the necessary metrics.
-    let should_emit = match &result {
-        Ok(res) => res.status().is_success(),
-        Err(_) => false,
+    // If the response indicates success, then emit the necessary metrics
+    // otherwise emit the error.
+    match &result {
+        Ok(res) if res.status().is_success() => {
+            bytes_received.emit(ByteSize(body_bytes_received));
+        }
+        Err(error) => {
+            emit!(GrpcError { error: &error });
+        }
+        _ => {}
     };
-
-    if should_emit {
-        bytes_received.emit(ByteSize(body_bytes_received));
-    }
 
     result
 }
@@ -298,6 +303,7 @@ impl<S> Service<Request<Body>> for DecompressionAndMetrics<S>
 where
     S: Service<Request<Body>, Response = Response<BoxBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
+    S::Error: std::fmt::Display,
 {
     type Response = Response<BoxBody>;
     type Error = S::Error;
@@ -310,7 +316,10 @@ where
     fn call(&mut self, req: Request<Body>) -> Self::Future {
         match CompressionScheme::from_encoding_header(&req) {
             // There was a header for the encoding, but it was either invalid data or a scheme we don't support.
-            Err(status) => Box::pin(async move { Ok(status.to_http()) }),
+            Err(status) => {
+                emit!(GrpcInvalidCompressionScheme { status: &status });
+                Box::pin(async move { Ok(status.to_http()) })
+            }
 
             // The request either isn't using compression, or it has indicated compression may be used and we know we
             // can support decompression based on the indicated compression scheme... so wrap the body to decompress, if

--- a/src/sources/util/grpc/decompression.rs
+++ b/src/sources/util/grpc/decompression.rs
@@ -22,7 +22,7 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
 
-use crate::internal_events::{GrpcError, GrpcInvalidCompressionScheme};
+use crate::internal_events::{GrpcError, GrpcInvalidCompressionSchemeError};
 
 // Every gRPC message has a five byte header:
 // - a compressed flag (u8, 0/1 for compressed/decompressed)
@@ -321,7 +321,7 @@ where
         match CompressionScheme::from_encoding_header(&req) {
             // There was a header for the encoding, but it was either invalid data or a scheme we don't support.
             Err(status) => {
-                emit!(GrpcInvalidCompressionScheme { status: &status });
+                emit!(GrpcInvalidCompressionSchemeError { status: &status });
                 Box::pin(async move { Ok(status.to_http()) })
             }
 


### PR DESCRIPTION
Ref #14501 

This emits errors when an error occurs in the grpc server used by the Vector and OpenTelemetry sources.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
