### PR TITLE
docs(setup): Add pacman / Arch Linux

### DIFF
--- a/website/content/en/docs/administration/management.md
+++ b/website/content/en/docs/administration/management.md
@@ -40,9 +40,9 @@ killall -s SIGHUP vector
 
 ### Linux
 
-#### APT, dpkg, RPM, YUM
+#### APT, dpkg, RPM, YUM, pacman
 
-If you've installed Vector using [APT], [dpkg], [RPM], or [YUM], you can manage it using [systemctl].
+If you've installed Vector using [APT], [dpkg], [RPM], [YUM] or [pacman], you can manage it using [systemctl].
 
 {{< tabs default="Start" >}}
 {{< tab title="Start" >}}
@@ -237,6 +237,7 @@ Running Vector instances accept the IPC [signals](#signals) and produce the [exi
 [msi]: /docs/setup/installation/package-managers/msi
 [nix]: /docs/setup/installation/package-managers/nix
 [rpm]: /docs/setup/installation/package-managers/rpm
+[pacman]: /docs/setup/installation/package-managers/pacman
 [sources]: /docs/reference/configuration/sources
 [systemctl]: https://man7.org/linux/man-pages//man1/systemctl.1.html
 [watch_config]: /docs/reference/cli/#vector-watch-config

--- a/website/content/en/docs/setup/installation/operating-systems/archlinux.md
+++ b/website/content/en/docs/setup/installation/operating-systems/archlinux.md
@@ -1,0 +1,14 @@
+---
+title: Install Vector on Arch Linux
+short: Arch Linux
+supported_installers: ["pacman", "Vector installer", "Docker", "Helm"]
+weight: 2
+---
+
+[Arch Linux] is a lightweight and flexible Linux® distribution that tries to Keep It Simple. This page covers installing and managing Vector on the Arch Linux operating system.
+
+## Supported installers
+
+{{< supported-installers >}}
+
+[Arch Linux]: https://archlinux.org/

--- a/website/content/en/docs/setup/installation/operating-systems/centos.md
+++ b/website/content/en/docs/setup/installation/operating-systems/centos.md
@@ -2,7 +2,7 @@
 title: Install Vector on CentOS
 short: CentOS
 supported_installers: ["YUM", "RPM", "Docker", "Vector installer", "Helm"]
-weight: 2
+weight: 3
 ---
 
 [CentOS] is a Linux distribution that is functionally compatible with its upstream source, Red Hat Enterprise Linux. This page covers installing and managing Vector on the CentOS operating system.

--- a/website/content/en/docs/setup/installation/operating-systems/debian.md
+++ b/website/content/en/docs/setup/installation/operating-systems/debian.md
@@ -2,7 +2,7 @@
 title: Install Vector on Debian
 short: Debian
 supported_installers: ["APT", "dpkg", "Vector installer", "Docker"]
-weight: 3
+weight: 4
 ---
 
 [Debian], also known as Debian GNU/Linux, is a Linux distribution composed of free and open-source software, developed by the community-supported Debian Project. This page covers installing and managing Vector on the Debian operating system.

--- a/website/content/en/docs/setup/installation/operating-systems/macos.md
+++ b/website/content/en/docs/setup/installation/operating-systems/macos.md
@@ -1,5 +1,6 @@
 ---
 title: macOS
+weight: 5
 ---
 
 [macOS] is the primary operating system for Apple's Mac computers. It's a certified Unix system based on Apple's Darwin operating system. This page covers installing and managing Vector on the macOS operating system.

--- a/website/content/en/docs/setup/installation/operating-systems/nixos.md
+++ b/website/content/en/docs/setup/installation/operating-systems/nixos.md
@@ -2,7 +2,7 @@
 title: Install Vector on NixOS
 short: NixOS
 supported_installers: ["Nix", "Vector installer", "Docker"]
-weight: 4
+weight: 6
 ---
 
 [Debian], also known as Debian GNU/Linux, is a Linux distribution composed of free and open-source software, developed by the community-supported Debian Project. This page covers installing and managing Vector on the Debian operating system.

--- a/website/content/en/docs/setup/installation/operating-systems/raspbian.md
+++ b/website/content/en/docs/setup/installation/operating-systems/raspbian.md
@@ -2,7 +2,7 @@
 title: Install Vector on Raspbian
 short: Raspbian
 supported_installers: ["Vector installer", "Docker"]
-weight: 6
+weight: 7
 ---
 
 [Raspbian] is the operating system used on Raspberry Pis. It is a Debian-based operating system designed for compact single-board computers. This page covers installing and managing Vector on the Raspbian operating system.

--- a/website/content/en/docs/setup/installation/operating-systems/rhel.md
+++ b/website/content/en/docs/setup/installation/operating-systems/rhel.md
@@ -2,7 +2,7 @@
 title: Install Vector on RHEL
 short: RHEL
 supported_installers: ["YUM", "RPM", "Vector installer", "Docker", "Helm"]
-weight: 5
+weight: 8
 ---
 
 [Red Hat Enterprise Linux][rhel] is a Linux distribution developed by Red Hat for the commercial market. This page covers installing and managing Vector on the RHEL operating system.

--- a/website/content/en/docs/setup/installation/operating-systems/ubuntu.md
+++ b/website/content/en/docs/setup/installation/operating-systems/ubuntu.md
@@ -2,7 +2,7 @@
 title: Install Vector on Ubuntu
 short: Ubuntu
 supported_installers: ["APT", "dpkg", "Vector installer", "Docker", "Helm"]
-weight: 6
+weight: 9
 ---
 
 [Ubuntu] is a Linux distribution based on [Debian]. This page covers installing and managing Vector on the Ubuntu operating system.

--- a/website/content/en/docs/setup/installation/operating-systems/windows.md
+++ b/website/content/en/docs/setup/installation/operating-systems/windows.md
@@ -2,7 +2,7 @@
 title: Install Vector on Windows
 short: Windows
 supported_installers: ["MSI", "Vector installer", "Docker"]
-weight: 7
+weight: 10
 ---
 
 [Microsoft Windows][windows] is an operating system developed and sold by Microsoft. This page covers installing and managing Vector on the Windows operating system.

--- a/website/content/en/docs/setup/installation/package-managers/apt.md
+++ b/website/content/en/docs/setup/installation/package-managers/apt.md
@@ -51,7 +51,7 @@ sudo apt remove vector
 
 ## Management
 
-{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum" >}}
+{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum-pacman" >}}
 
 [apt]: https://en.wikipedia.org/wiki/APT_(software)
 [cloudsmith]: https://cloudsmith.io/~timber/repos/vector/packages

--- a/website/content/en/docs/setup/installation/package-managers/dpkg.md
+++ b/website/content/en/docs/setup/installation/package-managers/dpkg.md
@@ -38,6 +38,6 @@ dpkg -r vector-{{< version >}}-amd64
 
 ## Management
 
-{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum" >}}
+{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum-pacman" >}}
 
 [dpkg]: https://wiki.debian.org/dpkg

--- a/website/content/en/docs/setup/installation/package-managers/pacman.md
+++ b/website/content/en/docs/setup/installation/package-managers/pacman.md
@@ -1,0 +1,33 @@
+---
+title: Install Vector using pacman
+short: pacman
+weight: 7
+---
+
+[pacman] is a utility which manages software packages in Linux, primarily on [Arch Linux] and its derivates. This covers installing and managing Vector through the Arch Linux [community] package repository.
+
+## Installation
+
+```shell
+sudo pacman -Syu vector
+```
+
+## Other actions
+
+{{< tabs default="Uninstall Vector" >}}
+{{< tab title="Uninstall Vector" >}}
+
+```shell
+sudo pacman -Rs vector
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+## Management
+
+{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum-pacman" >}}
+
+[pacman]: https://archlinux.org/pacman/
+[Arch Linux]: https://archlinux.org/
+[community]: https://archlinux.org/packages/community/x86_64/vector/

--- a/website/content/en/docs/setup/installation/package-managers/pacman.md
+++ b/website/content/en/docs/setup/installation/package-managers/pacman.md
@@ -4,6 +4,10 @@ short: pacman
 weight: 7
 ---
 
+{{< info title="Community Maintained" >}}
+The Vector pacman package is supported and maintained by the open source community.
+{{< /info >}}
+
 [pacman] is a utility which manages software packages in Linux, primarily on [Arch Linux] and its derivates. This covers installing and managing Vector through the Arch Linux [community] package repository.
 
 ## Installation
@@ -31,3 +35,4 @@ sudo pacman -Rs vector
 [pacman]: https://archlinux.org/pacman/
 [Arch Linux]: https://archlinux.org/
 [community]: https://archlinux.org/packages/community/x86_64/vector/
+

--- a/website/content/en/docs/setup/installation/package-managers/rpm.md
+++ b/website/content/en/docs/setup/installation/package-managers/rpm.md
@@ -1,7 +1,7 @@
 ---
 title: Install Vector using RPM
 short: RPM
-weight: 7
+weight: 8
 ---
 
 RPM Package Manager is a free and open source package management system for installing and managing software on Fedora, CentOS, OpenSUSE, OpenMandriva, Red Hat Enterprise Linux, and related Linux-based systems. This covers installing and managing Vector through the RPM package repository.
@@ -32,6 +32,6 @@ sudo rpm -e vector
 
 ## Management
 
-{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum" >}}
+{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum-pacman" >}}
 
 [rpm]: https://rpm.org/

--- a/website/content/en/docs/setup/installation/package-managers/yum.md
+++ b/website/content/en/docs/setup/installation/package-managers/yum.md
@@ -1,7 +1,7 @@
 ---
 title: Install Vector using YUM
 short: YUM
-weight: 8
+weight: 9
 ---
 
 The [Yellowdog Updater, Modified][yum] (YUM) is a free and open-source command-line package-manager for Linux operating system using the RPM Package Manager.
@@ -44,7 +44,7 @@ sudo yum remove vector
 
 ## Management
 
-{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum" >}}
+{{< jump "/docs/administration/management" "apt-dpkg-rpm-yum-pacman" >}}
 
 [add_repo]: https://cloudsmith.io/~timber/repos/vector/setup/#formats-rpm
 [cloudsmith]: https://cloudsmith.io/~timber/repos/vector/packages/


### PR DESCRIPTION
With the next version (since 0.24.1 isn't building for me, but master is) Vector will be available in the Arch Linux community repository.

Current [PKGBUILD](https://man.archlinux.org/man/PKGBUILD.5) file in development: https://fb.hash.works/tIUPCi/

I wasn't sure about the weights, I figured you wanted stuff to be sorted alphabetically?