### PR TITLE
docs: Re-add concurrency diagram

### DIFF
--- a/website/content/en/docs/about/under-the-hood/architecture/concurrency-model.md
+++ b/website/content/en/docs/about/under-the-hood/architecture/concurrency-model.md
@@ -4,6 +4,8 @@ weight: 2
 tags: ["concurrency", "pipeline", "state"]
 ---
 
+{{< svg "img/concurrency-model.svg" >}}
+
 Vector implements a concurrency model that scales naturally with incoming data volume as shown above. Each Vector
 [source][sources] is responsible for defining the unit of concurrency and implementing it accordingly. This allows for
 a natural concurrency model that adapts to however Vector is being used, avoiding the need for tedious concurrency


### PR DESCRIPTION
Noticed by https://github.com/vectordotdev/vector/commit/c69081153841e1bfcee3a59a02f867036616e26e#r85543345

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
