### PR TITLE
docs: Make docs/contributing reference an actual link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-docs/CONTRIBUTING.md
+[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)


### PR DESCRIPTION
I've manually navigated this a few times so figured I'd make save a click for everyone