### PR TITLE
fix(tests): Check before installing cargo-deny

### DIFF
--- a/scripts/check-deny.sh
+++ b/scripts/check-deny.sh
@@ -10,5 +10,4 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -x
 
-cargo install --locked cargo-deny
 cargo deny --log-level error --all-features check all

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -14,6 +14,9 @@ fi
 if [[ "$(cargo-nextest --version)" != "cargo-nextest 0.9.25" ]] ; then
   rustup run stable cargo install cargo-nextest --version 0.9.25 --force --locked
 fi
+if ! cargo deny --version >& /dev/null ; then
+  rustup run stable cargo install --locked cargo-deny
+fi
 
 cd scripts
 bundle install

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -15,7 +15,7 @@ if [[ "$(cargo-nextest --version)" != "cargo-nextest 0.9.25" ]] ; then
   rustup run stable cargo install cargo-nextest --version 0.9.25 --force --locked
 fi
 if ! cargo deny --version >& /dev/null ; then
-  rustup run stable cargo install --locked cargo-deny
+  rustup run stable cargo install cargo-deny --force --locked
 fi
 
 cd scripts


### PR DESCRIPTION
This moves the installation of `cargy-deny` into the preparation script, and adds a conditional to check if it was previously installed before redoing that step.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
