### PR TITLE
docs(vrl): Clarify passing in example data via `vector vrl`

### DIFF
--- a/website/content/en/docs/reference/vrl/examples.md
+++ b/website/content/en/docs/reference/vrl/examples.md
@@ -10,9 +10,11 @@ facilities.
 
 ## Try Using the VRL subcommand
 
-You can run these examples using the `vector vrl` subcommand with `--input` (single-line JSON file
-representing the incoming event) and `--program` (VRL program) to pass in the example input and
-program as well as `--print-object` to show the modified object.
+You can run these examples using the `vector vrl` subcommand with `--input` (input is newline
+delemited JSON file representing a list of events).  and `--program` (VRL program) to pass in the
+example input and program as well as `--print-object` to show the modified object. The below
+examples show pretty-printed JSON for the input events, so collapse these to single lines when
+passing in via `--input`.
 
 For example: `vector vrl --input input.json --program program.vrl --print-object`. This closely
 matches how VRL will receive the input in a running Vector instance.

--- a/website/content/en/docs/reference/vrl/examples.md
+++ b/website/content/en/docs/reference/vrl/examples.md
@@ -8,9 +8,19 @@ Here you'll find a comprehensive list of all VRL program examples. These
 examples demonstrate the breadth of the language and its observability-focused
 facilities.
 
-## Try Using The REPL
+## Try Using the VRL subcommand
 
-You can run these examples using the **VRL REPL** (Read–eval–print loop).
+You can run these examples using the `vector vrl` subcommand with `--input` (single-line JSON file
+representing the incoming event) and `--program` (VRL program) to pass in the example input and
+program as well as `--print-object` to show the modified object.
+
+For example: `vector vrl --input input.json --program program.vrl --print-object`. This closely
+matches how VRL will receive the input in a running Vector instance.
+
+### VRL REPL
+
+Additionally, if `vector vrl` is run without any arguments, it will spawn a **REPL**
+(Read–eval–print loop).
 
 Assuming you have Vector installed, you can run `vector vrl` to start the REPL.
 From there, you can type `help` and press return to get further help.


### PR DESCRIPTION
Examples will most closely match real-world usage vs. copying into the REPL where the behavior can
diverge due to differences like known type information or lack of support for unicode escape
sequences.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
