### PR TITLE
feat(vrl): Add MVP web UI to run VRL program without access to browser console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9345,6 +9345,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "vrl-web-playground"
+version = "0.1.0"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde-wasm-bindgen",
+ "value",
+ "vrl",
+ "vrl-stdlib",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vte"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9448,19 +9461,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm"
-version = "0.1.0"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde-wasm-bindgen",
- "value",
- "vrl",
- "vrl-stdlib",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"

--- a/lib/vrl/web-playground/Cargo.toml
+++ b/lib/vrl/web-playground/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasm"
+name = "vrl-web-playground"
 version = "0.1.0"
 edition = "2021"
 

--- a/lib/vrl/web-playground/index.html
+++ b/lib/vrl/web-playground/index.html
@@ -125,7 +125,7 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
   
   
   <script type="module">
-    import init, { run_vrl } from "./pkg/wasm.js";
+    import init, { run_vrl } from "./pkg/vrl_web_playground.js";
     init().then(() => {
       window.run_vrl = run_vrl;
       // console.log(run_vrl("."));

--- a/lib/vrl/web-playground/index.html
+++ b/lib/vrl/web-playground/index.html
@@ -41,6 +41,7 @@
   <p>Open up the developer console and try running run_vrl('upcase("hello world")')</p>
   
   <button onClick="handleRunCode()">run code</button>
+  <button onClick="handleShareCode()">share code</button>
   <div id="input-section">
     <div id="cell">
       <p class="cell-title">Program</p>
@@ -105,6 +106,20 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
         theme: 'vs-light',
         minimap: { enabled: false }
       });
+      const queryString = window.location.search;
+      if (queryString.length != 0) {
+        const urlParams = new URLSearchParams(queryString);
+        const stateParam = urlParams.get('state');
+
+        let urlState = JSON.parse(atob(stateParam));
+
+        window.programEditor.setValue(urlState["program"]);
+        window.eventEditor.setValue(JSON.stringify(urlState["event"], null, '\t'));
+
+        console.log("stateparams:", JSON.parse(atob(stateParam)));
+
+        console.log("run vrl stateparam:", run_vrl(JSON.parse(atob(stateParam))));
+      }
     });
   </script>
   
@@ -130,6 +145,18 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
 
     }
 
+  </script>
+  <script>
+    function handleShareCode() {
+      let state = {
+      program: window.programEditor.getValue(),
+      event: JSON.parse(window.eventEditor.getValue())
+      }
+
+      console.log(state);
+      console.log(btoa(JSON.stringify(state)));
+      window.history.pushState(state, "", `?state=${ btoa(JSON.stringify(state)) }`);
+    }
   </script>
 </body>
 

--- a/lib/vrl/web-playground/index.html
+++ b/lib/vrl/web-playground/index.html
@@ -1,19 +1,136 @@
 <!DOCTYPE html>
 <html lang="en-US">
-  <head>
-    <meta charset="utf-8" />
-    <title>VRL playground</title>
-  </head>
-  <body>
-    <h1>[draft] VRL playground wasm</h1>
-    <p>Open up the developer console and try running run_vrl({program: 'keys({"name": "jonathan"})', event: {}
-    })')</p>
-    <script type="module">
-      import init, { run_vrl } from "./pkg/wasm.js";
-      init().then(() => {
-        window.run_vrl = run_vrl;
-      });
-    </script>
 
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <title>VRL playground</title>
+  <link rel="stylesheet" data-name="vs/editor/editor.main"
+    href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min/vs/editor/editor.main.min.css">
+
+  <style type="text/css">
+    div#input-section {
+      display: grid;
+      grid-template-columns: 50% 50%;
+      margin-bottom: 5rem;
+    }
+
+    div#container-program {
+      border-radius: 25px;
+      overflow: hidden;
+    }
+
+    div#container-event { 
+      border-radius: 25px;
+      overflow: hidden;
+    }
+
+    div#container-output {
+      border-radius: 25px;
+      overflow: hidden;
+    }
+
+    body {
+      font-family: ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
+    }
+
+  </style>
+  </head>
+
+<body>
+  <h1>[draft] VRL playground wasm</h1>
+  <p>Open up the developer console and try running run_vrl('upcase("hello world")')</p>
+  
+  <button onClick="handleRunCode()">run code</button>
+  <div id="input-section">
+    <div id="cell">
+      <p class="cell-title">Program</p>
+      <div id="container-program" style="height:400px;border:1px solid black;width:800px"></div>
+    </div>
+    
+    <div id="cell">
+      <p class="cell-title">Event</p>
+      <div id="container-event" style="height:400px;border:1px solid black;width:800px"></div>
+    </div>
+    
+  </div>
+  
+  <div id="output-section">
+    <div id="cell">
+      <p class="cell-title">Output</p>
+      <div id="container-output" style="height:400px;border:1px solid black;width:800px"></div>
+    </div>
+    
+  </div>
+
+  
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs/loader.min.js"></script>
+  <script>
+    // require is provided by loader.min.js.
+    require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs' } });
+    require(["vs/editor/editor.main"], () => {
+      window.programEditor = monaco.editor.create(document.getElementById('container-program'), {
+        value: `# Parse as JSON or error if malformed
+parsed, err = parse_syslog(.message)
+
+
+
+# Set the event to the parsed JSON value
+. = parsed
+
+# Remove some fields
+del(.msgid)
+
+
+# Reformat the timestamp
+ts, err = parse_timestamp(.timestamp, format: "%s")
+
+
+.timestamp = to_unix_timestamp(ts)`,
+        language: 'python',
+        theme: 'vs-light',
+        minimap: { enabled: false }
+      });
+
+      window.eventEditor = monaco.editor.create(document.getElementById('container-event'), {
+        value: `{
+  "message": "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
+}`,
+        language: 'json',
+        theme: 'vs-light',
+        minimap: { enabled: false }
+      });
+
+      window.outputEditor = monaco.editor.create(document.getElementById('container-output'), {
+        language: 'json',
+        theme: 'vs-light',
+        minimap: { enabled: false }
+      });
+    });
+  </script>
+  
+  
+  <script type="module">
+    import init, { run_vrl } from "./pkg/wasm.js";
+    init().then(() => {
+      window.run_vrl = run_vrl;
+      // console.log(run_vrl("."));
+    });
+  </script>
+
+  <script>
+    function handleRunCode() {
+      const input = {
+        program: window.programEditor.getValue(),
+        event: JSON.parse(window.eventEditor.getValue())
+      }
+      let res = window.run_vrl(input);
+
+      console.log(res);
+      window.outputEditor.setValue(JSON.stringify(res["result"], null, "\t"));
+
+    }
+
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
Closes https://github.com/vectordotdev/vector/issues/14657
Closes https://github.com/vectordotdev/vector/issues/14712

Added three monaco editors one for the program, the event, and the output.
Added a button to get the content of the program and event to pass to `run_vrl()` parse the output and print it in the output monaco editor.

<img width="1859" alt="image" src="https://user-images.githubusercontent.com/44036128/193961352-f7f3f8dd-f0c9-4575-b228-f6964fd10266.png">

The above image showcases the current state of the three editors and how they can be used to run vrl code.

Recently pushed out a commit that adds the state of the web playground to the URL encoded into base64.
Example:

A state of
```javascript
{
    "program": ".message2 = \"something here\"",
    "event": {
        "message": "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
    }
}
```
Generates the URL
http://[::]:8000/?state=eyJwcm9ncmFtIjoiLm1lc3NhZ2UyID0gXCJzb21ldGhpbmcgaGVyZVwiIiwiZXZlbnQiOnsibWVzc2FnZSI6IjwxMDI+MSAyMDIwLTEyLTIyVDE1OjIyOjMxLjExMVogdmVjdG9yLXVzZXIuYml6IHN1IDI2NjYgSUQzODkgLSBTb21ldGhpbmcgd2VudCB3cm9uZyJ9fQ==

Which when we host the application in port 8000 we can see the program and event fields populated with the state object above. 


