### PR TITLE
fix(cli): fix another couple panics caused by the clap v4 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8930,6 +8930,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "clap 4.0.9",
  "futures 0.3.24",
  "graphql_client",
  "indoc",

--- a/lib/vector-api-client/Cargo.toml
+++ b/lib/vector-api-client/Cargo.toml
@@ -30,6 +30,7 @@ tokio-tungstenite = { version = "0.17.2", default-features = false, features = [
 
 # External libs
 chrono = { version = "0.4.6", default-features = false, features = ["serde"] }
+clap = { version = "4.0.9", default-features = false, features = ["derive"] }
 url = { version = "2.3.1", default-features = false }
 uuid = { version = "1", default-features = false, features = ["serde", "v4"] }
 indoc = { version = "1.0.7", default-features = false }

--- a/lib/vector-api-client/src/gql/tap.rs
+++ b/lib/vector-api-client/src/gql/tap.rs
@@ -19,7 +19,7 @@ pub struct OutputEventsByComponentIdPatternsSubscription;
 
 /// Tap encoding format type that is more convenient to use for public clients than the
 /// generated `output_events_by_component_id_patterns_subscription::EventEncodingType`.
-#[derive(Debug, Clone, Copy)]
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
 pub enum TapEncodingFormat {
     Json,
     Yaml,

--- a/src/list.rs
+++ b/src/list.rs
@@ -7,31 +7,15 @@ use vector_config::component::{SinkDescription, SourceDescription, TransformDesc
 #[command(rename_all = "kebab-case")]
 pub struct Opts {
     /// Format the list in an encoding scheme.
-    #[arg(long, default_value = "text", value_parser(["text", "json", "avro"]))]
+    #[arg(long, default_value = "text")]
     format: Format,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(clap::ValueEnum, Debug, Clone, PartialEq)]
 enum Format {
     Text,
     Json,
     Avro,
-}
-
-impl std::str::FromStr for Format {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "text" => Ok(Format::Text),
-            "json" => Ok(Format::Json),
-            "avro" => Ok(Format::Avro),
-            s => Err(format!(
-                "{} is not a valid option, expected `text` or `json`",
-                s
-            )),
-        }
-    }
 }
 
 #[derive(Serialize)]

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -21,7 +21,7 @@ pub struct Opts {
     limit: u32,
 
     /// Encoding format for events printed to screen
-    #[arg(default_value = "json", value_parser(["json", "yaml", "logfmt"]), short = 'f', long)]
+    #[arg(default_value = "json", short = 'f', long)]
     format: TapEncodingFormat,
 
     /// Components IDs to observe (comma-separated; accepts glob patterns)


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

No more usage of the problematic `value_parser`, the `buffer_perf` example isn't using derive and is happy - manually tested.

```shell
vector on  spencer/fix-more-clap-v4-changes is 📦 v0.25.0 via 🦀 v1.64.0
❯ rg 'value_parser'
lib/vector-buffers/examples/buffer_perf.rs
151:                    .value_parser(["disk-v1", "disk-v2", "in-memory"])

website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
165:- `key_value_parser`
370:##### `key_value_parser`
375:[transforms.key_value_parser]
376:type = "key_value_parser"
383:[transforms.key_value_parser]

website/content/en/highlights/2022-08-16-0-24-0-upgrade-guide.md
170:- `key_value_parser`

website/content/en/highlights/2021-02-16-0-12-upgrade-guide.md
107:* [`key_value_parser`][key_value_parser_transform]
161:[key_value_parser_transform]: /docs/reference/vrl/functions/#parse_key_value
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
