### PR TITLE
chore(lua transform): Add deprecation notice for version 1 API

### DIFF
--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -37,7 +37,7 @@ pub struct LuaConfig {
 impl LuaConfig {
     pub fn build(&self) -> crate::Result<Transform> {
         warn!(
-            "The `lua` transform API version 1 is deprecated. Please convert your script to version 2."
+            "DEPRECATED The `lua` transform API version 1 is deprecated. Please convert your script to version 2."
         );
         Lua::new(self.source.clone(), self.search_dirs.clone()).map(Transform::event_task)
     }

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -36,6 +36,9 @@ pub struct LuaConfig {
 
 impl LuaConfig {
     pub fn build(&self) -> crate::Result<Transform> {
+        warn!(
+            "The `lua` transform API version 1 is deprecated. Please convert your script to version 2."
+        );
         Lua::new(self.source.clone(), self.search_dirs.clone()).map(Transform::event_task)
     }
 

--- a/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
@@ -21,6 +21,8 @@ Vector's 0.25.0 release includes **breaking changes**:
 and **deprecations**:
 
 1. [Deprecation of VRL metadata functions](#metadata-function-deprecation)
+1. [Deprecation of `endpoint` option in Elasticsearch sink](#elasticsearch-endpoint-deprecation)
+1. [Deprecation of the Lua version 1 API](#lua-v1-api-deprecation)
 
 We cover them below to help you upgrade quickly:
 
@@ -126,8 +128,14 @@ will be removed in the future.
 | delete | remove_metadata_field(.foo.bar)       | del(%foo.bar)      |
 
 
-#### Deprecation of `endpoint` option in Elasticsearch sink
+#### Deprecation of `endpoint` option in Elasticsearch sink {#elasticsearch-endpoint-deprecation}
 
 Vector `0.25.0` has introduced distribution of events to multiple endpoints for Elasticsearch sink.
 In order to enable this distribution, a new `endpoints` setting has been introduced which configures one or more destinations to which to distribute the events.
 The existing `endpoint` setting is now deprecated and will be removed in a future version.
+
+#### Deprecation of the Lua version 1 API {#lua-v1-api-deprecation}
+
+Vector `0.9.0` introduced the version 2 API for the `lua` transform.
+This API has long been considered fully mature, obviating the need to maintain the older API.
+The older version 1 API is now deprecated and will be removed in a future version.

--- a/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
@@ -138,4 +138,32 @@ The existing `endpoint` setting is now deprecated and will be removed in a futur
 
 Vector `0.9.0` introduced the version 2 API for the `lua` transform.
 This API has long been considered fully mature, obviating the need to maintain the older API.
+Additionally, the older API has no support for data types other than logs.
 The older version 1 API is now deprecated and will be removed in a future version.
+
+For example, the following partial configuration:
+
+```toml
+[transform.example]
+type = "lua"
+version = 1
+source = """
+  event["a"] = "some value"
+  event["b"] = nil
+"""
+```
+
+would need to be converted to the following:
+
+```toml
+[transform.example]
+type = "lua"
+version = 2
+hooks.process = """
+  function (event, emit)
+    event.log.a = "some value"
+    event.log.b = nil
+    emit(event)
+  end
+"""
+```

--- a/website/cue/reference/components/transforms/lua.cue
+++ b/website/cue/reference/components/transforms/lua.cue
@@ -182,7 +182,7 @@ components: transforms: lua: {
 			description: "Transform API version. Specifying this version ensures that Vector does not break backward compatibility."
 			required:    true
 			type: string: enum: {
-				"1": "Lua transform API version 1"
+				"1": "Lua transform API version 1. This version is deprecated and will be removed in a future version."
 				"2": "Lua transform API version 2"
 			}
 		}


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
