### PR TITLE
fix(stdin source): emit event on error

### DIFF
--- a/src/internal_events/file_descriptor.rs
+++ b/src/internal_events/file_descriptor.rs
@@ -1,0 +1,28 @@
+use metrics::counter;
+use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
+
+#[derive(Debug)]
+pub struct FileDescriptorReadError<E> {
+    pub error: E,
+}
+
+impl<E> InternalEvent for FileDescriptorReadError<E>
+where
+    E: std::fmt::Display,
+{
+    fn emit(self) {
+        error!(
+            message = "Error reading from file descriptor.",
+            error = %self.error,
+            error_type = error_type::CONNECTION_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true
+        );
+        counter!(
+            "component_errors_total", 1,
+            "error_type" => error_type::CONNECTION_FAILED,
+            "stage" => error_stage::RECEIVING,
+        );
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -41,6 +41,8 @@ mod encoding_transcode;
 mod eventstoredb_metrics;
 #[cfg(feature = "sources-exec")]
 mod exec;
+#[cfg(any(feature = "sources-file-descriptor", feature = "sources-stdin"))]
+mod file_descriptor;
 #[cfg(feature = "transforms-filter")]
 mod filter;
 #[cfg(feature = "sources-fluent")]
@@ -173,6 +175,8 @@ pub(crate) use self::exec::*;
     feature = "sinks-file",
 ))]
 pub(crate) use self::file::*;
+#[cfg(any(feature = "sources-file-descriptor", feature = "sources-stdin"))]
+pub(crate) use self::file_descriptor::*;
 #[cfg(feature = "transforms-filter")]
 pub(crate) use self::filter::*;
 #[cfg(feature = "sources-fluent")]

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -18,7 +18,7 @@ use vector_core::ByteSizeOf;
 use crate::{
     codecs::{Decoder, DecodingConfig},
     config::log_schema,
-    internal_events::{EventsReceived, StreamClosedError},
+    internal_events::{EventsReceived, FileDescriptorReadError, StreamClosedError},
     shutdown::ShutdownSignal,
     SourceSender,
 };
@@ -82,6 +82,7 @@ pub trait FileDescriptorConfig: NamedComponent {
 }
 
 type Sender = mpsc::Sender<std::result::Result<bytes::Bytes, std::io::Error>>;
+
 fn read_from_fd<R>(mut reader: R, mut sender: Sender)
 where
     R: Send + io::BufRead + 'static,
@@ -115,7 +116,12 @@ async fn process_stream(
     hostname: Option<String>,
 ) -> Result<(), ()> {
     let bytes_received = register!(BytesReceived::from(Protocol::NONE));
-    let stream = StreamReader::new(receiver);
+    let stream = receiver.inspect(|result| {
+        if let Err(error) = result {
+            emit!(FileDescriptorReadError { error: &error });
+        }
+    });
+    let stream = StreamReader::new(stream);
     let mut stream = FramedRead::new(stream, decoder).take_until(shutdown);
     let mut stream = stream! {
         while let Some(result) = stream.next().await {

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -94,9 +94,10 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
-    use crate::config::log_schema;
     use crate::{
-        shutdown::ShutdownSignal, test_util::components::assert_source_compliance, SourceSender,
+        config::log_schema, shutdown::ShutdownSignal,
+        test_util::components::assert_source_compliance, test_util::components::SOURCE_TAGS,
+        SourceSender,
     };
     use futures::StreamExt;
 
@@ -107,7 +108,7 @@ mod tests {
 
     #[tokio::test]
     async fn stdin_decodes_line() {
-        assert_source_compliance(&["protocol"], async {
+        assert_source_compliance(&SOURCE_TAGS, async {
             let (tx, rx) = SourceSender::new_test();
             let config = StdinConfig::default();
             let buf = Cursor::new("hello world\nhello world again");


### PR DESCRIPTION
Ref #14503 

This wraps the error path test in a `assert_source_error` call. The test failed so it also fixes it to emit an error when it occurs.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
