### PR TITLE
feat(http): add custom method support to http_scrape source

### DIFF
--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -25,8 +25,9 @@ use crate::{
     event::{Event, LogEvent},
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
-    sources::http::HttpMethod,
-    sources::util::{add_query_parameters, ErrorMessage, HttpSource, HttpSourceAuthConfig},
+    sources::util::{
+        add_query_parameters, http::HttpMethod, ErrorMessage, HttpSource, HttpSourceAuthConfig,
+    },
     tls::TlsEnableableConfig,
 };
 use lookup::event_path;

--- a/src/sources/http.rs
+++ b/src/sources/http.rs
@@ -23,36 +23,11 @@ use crate::{
     event::{Event, Value},
     serde::{bool_or_struct, default_decoding},
     sources::util::{
-        add_query_parameters, Encoding, ErrorMessage, HttpSource, HttpSourceAuthConfig,
+        add_query_parameters, http::HttpMethod, Encoding, ErrorMessage, HttpSource,
+        HttpSourceAuthConfig,
     },
     tls::TlsEnableableConfig,
 };
-
-/// HTTP method.
-#[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum HttpMethod {
-    /// HTTP HEAD method.
-    Head,
-
-    /// HTTP GET method.
-    Get,
-
-    /// HTTP POST method.
-    #[derivative(Default)]
-    Post,
-
-    /// HTTP Put method.
-    Put,
-
-    /// HTTP PATCH method.
-    Patch,
-
-    /// HTTP DELETE method.
-    Delete,
-}
 
 /// Configuration for the `http` source.
 #[configurable_component(source("http"))]
@@ -101,7 +76,7 @@ pub struct SimpleHttpConfig {
     path_key: String,
 
     /// Specifies the action of the HTTP request.
-    #[serde(default)]
+    #[serde(default = "default_http_method")]
     method: HttpMethod,
 
     #[configurable(derived)]
@@ -127,9 +102,9 @@ impl GenerateConfig for SimpleHttpConfig {
             query_parameters: Vec::new(),
             tls: None,
             auth: None,
-            path: "/".to_string(),
-            path_key: "path".to_string(),
-            method: HttpMethod::Post,
+            path: default_path(),
+            path_key: default_path_key(),
+            method: default_http_method(),
             strict_path: true,
             framing: None,
             decoding: Some(default_decoding()),
@@ -137,6 +112,10 @@ impl GenerateConfig for SimpleHttpConfig {
         })
         .unwrap()
     }
+}
+
+const fn default_http_method() -> HttpMethod {
+    HttpMethod::Post
 }
 
 fn default_path() -> String {

--- a/src/sources/http_scrape/integration_tests.rs
+++ b/src/sources/http_scrape/integration_tests.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use tokio::time::{Duration, Instant};
 
+use crate::sources::http_scrape::scrape::HttpMethod;
 use crate::{
     config::{ComponentKey, SourceConfig, SourceContext},
     http::Auth,
@@ -57,6 +58,7 @@ async fn invalid_endpoint() {
         decoding: default_decoding(),
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,
@@ -74,6 +76,7 @@ async fn scraped_logs_bytes() {
         decoding: DeserializerConfig::Bytes,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,
@@ -97,6 +100,7 @@ async fn scraped_logs_json() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,
@@ -120,6 +124,7 @@ async fn scraped_metrics_native_json() {
         decoding: DeserializerConfig::NativeJson,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,
@@ -144,6 +149,7 @@ async fn scraped_trace_native_json() {
         decoding: DeserializerConfig::NativeJson,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,
@@ -167,6 +173,7 @@ async fn unauthorized_no_auth() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,
@@ -184,6 +191,7 @@ async fn unauthorized_wrong_auth() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: None,
         auth: Some(Auth::Basic {
             user: "white_rabbit".to_string(),
@@ -204,6 +212,7 @@ async fn authorized() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: None,
         auth: Some(Auth::Basic {
             user: "user".to_string(),
@@ -224,6 +233,7 @@ async fn tls_invalid_ca() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: Some(TlsConfig {
             ca_file: Some("tests/data/http-scrape/certs/invalid-ca-cert.pem".into()),
             ..Default::default()
@@ -244,6 +254,7 @@ async fn tls_valid() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: Some(TlsConfig {
             ca_file: Some(tls::TEST_PEM_CA_PATH.into()),
             ..Default::default()
@@ -265,6 +276,7 @@ async fn shutdown() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: None,
         auth: None,
         log_namespace: None,

--- a/src/sources/http_scrape/integration_tests.rs
+++ b/src/sources/http_scrape/integration_tests.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use tokio::time::{Duration, Instant};
 
-use crate::sources::http_scrape::scrape::HttpMethod;
+use crate::sources::util::http::HttpMethod;
 use crate::{
     config::{ComponentKey, SourceConfig, SourceContext},
     http::Auth,

--- a/src/sources/http_scrape/scrape.rs
+++ b/src/sources/http_scrape/scrape.rs
@@ -16,9 +16,12 @@ use crate::{
     serde::default_decoding,
     serde::default_framing_message_based,
     sources,
-    sources::util::http_scrape::{
-        build_url, default_scrape_interval_secs, http_scrape, GenericHttpScrapeInputs,
-        HttpScraperBuilder, HttpScraperContext,
+    sources::util::{
+        http::HttpMethod,
+        http_scrape::{
+            build_url, default_scrape_interval_secs, http_scrape, GenericHttpScrapeInputs,
+            HttpScraperBuilder, HttpScraperContext,
+        },
     },
     tls::{TlsConfig, TlsSettings},
     Result,
@@ -32,20 +35,6 @@ use vector_core::{
     config::{log_schema, LogNamespace, Output},
     event::Event,
 };
-
-/// HTTP method.
-#[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum HttpMethod {
-    /// HTTP GET method.
-    #[derivative(Default)]
-    Get,
-
-    /// HTTP POST method.
-    Post,
-}
 
 /// Configuration for the `http_scrape` source.
 #[configurable_component(source("http_scrape"))]
@@ -82,7 +71,7 @@ pub struct HttpScrapeConfig {
     pub headers: HashMap<String, Vec<String>>,
 
     /// Specifies the action of the HTTP request.
-    #[serde(default)]
+    #[serde(default = "default_http_method")]
     pub method: HttpMethod,
 
     /// TLS configuration.
@@ -98,6 +87,10 @@ pub struct HttpScrapeConfig {
     pub log_namespace: Option<bool>,
 }
 
+const fn default_http_method() -> HttpMethod {
+    HttpMethod::Get
+}
+
 impl Default for HttpScrapeConfig {
     fn default() -> Self {
         Self {
@@ -107,7 +100,7 @@ impl Default for HttpScrapeConfig {
             decoding: default_decoding(),
             framing: default_framing_message_based(),
             headers: HashMap::new(),
-            method: HttpMethod::Get,
+            method: default_http_method(),
             tls: None,
             auth: None,
             log_namespace: None,
@@ -155,7 +148,7 @@ impl SourceConfig for HttpScrapeConfig {
             shutdown: cx.shutdown,
         };
 
-        Ok(http_scrape(inputs, context, cx.out, Some(self.method)).boxed())
+        Ok(http_scrape(inputs, context, cx.out, self.method).boxed())
     }
 
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<Output> {

--- a/src/sources/http_scrape/scrape.rs
+++ b/src/sources/http_scrape/scrape.rs
@@ -33,6 +33,20 @@ use vector_core::{
     event::Event,
 };
 
+/// HTTP method.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Derivative)]
+#[derivative(Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    /// HTTP GET method.
+    #[derivative(Default)]
+    Get,
+
+    /// HTTP POST method.
+    Post,
+}
+
 /// Configuration for the `http_scrape` source.
 #[configurable_component(source("http_scrape"))]
 #[derive(Clone, Debug)]
@@ -67,6 +81,10 @@ pub struct HttpScrapeConfig {
     #[serde(default)]
     pub headers: HashMap<String, Vec<String>>,
 
+    /// Specifies the action of the HTTP request.
+    #[serde(default)]
+    pub method: HttpMethod,
+
     /// TLS configuration.
     #[configurable(derived)]
     pub tls: Option<TlsConfig>,
@@ -89,6 +107,7 @@ impl Default for HttpScrapeConfig {
             decoding: default_decoding(),
             framing: default_framing_message_based(),
             headers: HashMap::new(),
+            method: HttpMethod::Get,
             tls: None,
             auth: None,
             log_namespace: None,
@@ -136,7 +155,7 @@ impl SourceConfig for HttpScrapeConfig {
             shutdown: cx.shutdown,
         };
 
-        Ok(http_scrape(inputs, context, cx.out).boxed())
+        Ok(http_scrape(inputs, context, cx.out, Some(self.method)).boxed())
     }
 
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<Output> {

--- a/src/sources/http_scrape/tests.rs
+++ b/src/sources/http_scrape/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use tokio::time::Duration;
 use warp::{http::HeaderMap, Filter};
 
-use crate::sources::http_scrape::scrape::HttpMethod;
+use crate::sources::util::http::HttpMethod;
 use crate::{serde::default_decoding, serde::default_framing_message_based};
 use codecs::decoding::{
     CharacterDelimitedDecoderOptions, DeserializerConfig, FramingConfig,

--- a/src/sources/http_scrape/tests.rs
+++ b/src/sources/http_scrape/tests.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use tokio::time::Duration;
 use warp::{http::HeaderMap, Filter};
 
+use crate::sources::http_scrape::scrape::HttpMethod;
 use crate::{serde::default_decoding, serde::default_framing_message_based};
 use codecs::decoding::{
     CharacterDelimitedDecoderOptions, DeserializerConfig, FramingConfig,
@@ -52,6 +53,7 @@ async fn bytes_decoding() {
         decoding: default_decoding(),
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: None,
         auth: None,
         log_namespace: None,
@@ -81,6 +83,7 @@ async fn json_decoding_newline_delimited() {
             newline_delimited: NewlineDelimitedDecoderOptions::default(),
         },
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: None,
         auth: None,
         log_namespace: None,
@@ -113,6 +116,7 @@ async fn json_decoding_character_delimited() {
             },
         },
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: None,
         auth: None,
         log_namespace: None,
@@ -145,6 +149,7 @@ async fn request_query_applied() {
         decoding: DeserializerConfig::Json,
         framing: default_framing_message_based(),
         headers: HashMap::new(),
+        method: HttpMethod::Get,
         tls: None,
         auth: None,
         log_namespace: None,
@@ -209,6 +214,7 @@ async fn headers_applied() {
             "f00".to_string(),
             vec!["bazz".to_string(), "bizz".to_string()],
         )]),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,
@@ -236,6 +242,7 @@ async fn accept_header_override() {
         decoding: DeserializerConfig::Bytes,
         framing: default_framing_message_based(),
         headers: HashMap::from([("ACCEPT".to_string(), vec!["application/json".to_string()])]),
+        method: HttpMethod::Get,
         auth: None,
         tls: None,
         log_namespace: None,

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -15,8 +15,7 @@ use crate::{
     serde::bool_or_struct,
     sources::{
         self,
-        http::HttpMethod,
-        util::{decode, ErrorMessage, HttpSource, HttpSourceAuthConfig},
+        util::{decode, http::HttpMethod, ErrorMessage, HttpSource, HttpSourceAuthConfig},
     },
     tls::TlsEnableableConfig,
 };

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -132,7 +132,7 @@ impl SourceConfig for PrometheusScrapeConfig {
             shutdown: cx.shutdown,
         };
 
-        Ok(http_scrape(inputs, builder, cx.out).boxed())
+        Ok(http_scrape(inputs, builder, cx.out, None).boxed())
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<Output> {

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -9,6 +9,7 @@ use vector_config::configurable_component;
 use vector_core::{config::LogNamespace, event::Event};
 
 use super::parser;
+use crate::sources::util::http::HttpMethod;
 use crate::{
     config::{self, GenerateConfig, Output, SourceConfig, SourceContext},
     http::Auth,
@@ -132,7 +133,7 @@ impl SourceConfig for PrometheusScrapeConfig {
             shutdown: cx.shutdown,
         };
 
-        Ok(http_scrape(inputs, builder, cx.out, None).boxed())
+        Ok(http_scrape(inputs, builder, cx.out, HttpMethod::Get).boxed())
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<Output> {

--- a/src/sources/util/http/method.rs
+++ b/src/sources/util/http/method.rs
@@ -1,0 +1,25 @@
+use vector_config::configurable_component;
+
+/// HTTP method.
+#[configurable_component]
+#[derive(Clone, Copy, Debug)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    /// HTTP HEAD method.
+    Head,
+
+    /// HTTP GET method.
+    Get,
+
+    /// HTTP POST method.
+    Post,
+
+    /// HTTP Put method.
+    Put,
+
+    /// HTTP PATCH method.
+    Patch,
+
+    /// HTTP DELETE method.
+    Delete,
+}

--- a/src/sources/util/http/mod.rs
+++ b/src/sources/util/http/mod.rs
@@ -4,6 +4,7 @@ mod auth;
 mod encoding;
 #[cfg(feature = "sources-utils-http-error")]
 mod error;
+mod method;
 #[cfg(feature = "sources-utils-http-prelude")]
 mod prelude;
 #[cfg(any(
@@ -19,6 +20,7 @@ pub use auth::{HttpSourceAuth, HttpSourceAuthConfig};
 pub use encoding::decode;
 #[cfg(feature = "sources-utils-http-error")]
 pub use error::ErrorMessage;
+pub use method::HttpMethod;
 #[cfg(feature = "sources-utils-http-prelude")]
 pub use prelude::HttpSource;
 #[cfg(feature = "sources-utils-http-query")]

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -23,7 +23,7 @@ use crate::{
     internal_events::{
         HttpBadRequest, HttpBytesReceived, HttpEventsReceived, HttpInternalError, StreamClosedError,
     },
-    sources::http::HttpMethod,
+    sources::util::http::HttpMethod,
     tls::{MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
 };

--- a/src/sources/util/http_scrape.rs
+++ b/src/sources/util/http_scrape.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 use std::{collections::HashMap, future::ready};
 use tokio_stream::wrappers::IntervalStream;
 
+use crate::sources::http_scrape::scrape::HttpMethod;
 use crate::{
     http::{Auth, HttpClient},
     internal_events::{
@@ -105,6 +106,7 @@ pub(crate) async fn http_scrape<
     inputs: GenericHttpScrapeInputs,
     context_builder: B,
     mut out: SourceSender,
+    http_method: Option<HttpMethod>,
 ) -> Result<(), ()> {
     let mut stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(
         inputs.interval_secs,
@@ -122,7 +124,14 @@ pub(crate) async fn http_scrape<
         let context_builder = context_builder.clone();
         let mut context = context_builder.build(&url);
 
-        let mut builder = Request::get(&url);
+        let mut builder = if let Some(http_method) = http_method {
+            match http_method {
+                HttpMethod::Get => Request::get(&url),
+                HttpMethod::Post => Request::post(&url),
+            }
+        } else {
+            Request::get(&url)
+        };
 
         // add user specified headers
         for (header, values) in &inputs.headers {

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -12,7 +12,7 @@ pub mod grpc;
     feature = "sources-utils-http-prelude",
     feature = "sources-utils-http-query"
 ))]
-mod http;
+pub mod http;
 #[cfg(any(feature = "sources-http_scrape", feature = "sources-prometheus"))]
 pub mod http_scrape;
 #[cfg(any(feature = "sources-aws_sqs", feature = "sources-gcp_pubsub"))]

--- a/website/cue/reference/components/sources/http_scrape.cue
+++ b/website/cue/reference/components/sources/http_scrape.cue
@@ -72,6 +72,18 @@ components: sources: http_scrape: {
 				examples: [{"Your-Custom-Header": "it's-value"}]
 			}
 		}
+		method: {
+			common:      false
+			description: "Specifies the action of the HTTP request."
+			required:    false
+			type: string: {
+				default: "GET"
+				enum: {
+					"GET":    "HTTP GET method."
+					"POST":   "HTTP POST method."
+				}
+			}
+		}
 		query: {
 			common: false
 			description: """

--- a/website/cue/reference/components/sources/http_scrape.cue
+++ b/website/cue/reference/components/sources/http_scrape.cue
@@ -79,8 +79,12 @@ components: sources: http_scrape: {
 			type: string: {
 				default: "GET"
 				enum: {
+					"HEAD":   "HTTP HEAD method."
 					"GET":    "HTTP GET method."
+					"PUT":    "HTTP PUT method."
 					"POST":   "HTTP POST method."
+					"PATCH":  "HTTP PATCH method."
+					"DELETE": "HTTP DELETE method."
 				}
 			}
 		}


### PR DESCRIPTION
This PR partially resolves https://github.com/vectordotdev/vector/issues/14676

## Implementation details
### Supported HTTP methods
I have enabled only GET and POST methods like the most reasonable. Other methods could be enabled quite easily later if will be a need in it (just extend corresponding enum and update the documentation). This is the reason, why `HttpMethod` enum was copied from `http` source - they support different set of HTTP methods and I see no need to support in both sources equal set of HTTP methods.