### PR TITLE
fix(datadog_metrics sink): properly encode rate metrics

### DIFF
--- a/src/sinks/datadog/metrics/encoder.rs
+++ b/src/sinks/datadog/metrics/encoder.rs
@@ -425,20 +425,21 @@ fn generate_series_metrics(
 
     let results = match (metric.value(), metric.interval_ms()) {
         (MetricValue::Counter { value }, maybe_interval_ms) => {
-            let (value, interval) = match maybe_interval_ms {
-                None => (*value, None),
+            let (value, interval, metric_type) = match maybe_interval_ms {
+                None => (*value, None, DatadogMetricType::Count),
                 // When an interval is defined, it implies the value should be in a per-second form,
                 // so we need to get back to seconds from our milliseconds-based interval, and then
                 // divide our value by that amount as well.
                 Some(interval_ms) => (
                     (*value) * 1000.0 / (interval_ms.get() as f64),
                     Some(interval_ms.get() / 1000),
+                    DatadogMetricType::Rate,
                 ),
             };
 
             vec![DatadogSeriesMetric {
                 metric: name,
-                r#type: DatadogMetricType::Count,
+                r#type: metric_type,
                 interval,
                 points: vec![DatadogPoint(ts, value)],
                 tags,
@@ -656,6 +657,7 @@ mod tests {
     use std::{
         collections::BTreeMap,
         io::{self, copy},
+        num::NonZeroU32,
     };
 
     use bytes::{BufMut, Bytes, BytesMut};
@@ -666,20 +668,30 @@ mod tests {
         proptest, strategy::Strategy, string::string_regex,
     };
     use vector_core::{
+        config::log_schema,
         event::{Metric, MetricKind, MetricValue},
         metrics::AgentDDSketch,
     };
 
     use super::{
-        encode_tags, encode_timestamp, get_compressor, max_compression_overhead_len,
-        max_uncompressed_header_len, validate_payload_size_limits, write_payload_footer,
-        write_payload_header, DatadogMetricsEncoder,
+        encode_tags, encode_timestamp, generate_series_metrics, get_compressor,
+        max_compression_overhead_len, max_uncompressed_header_len, validate_payload_size_limits,
+        write_payload_footer, write_payload_header, DatadogMetricsEncoder, EncoderError,
     };
-    use crate::sinks::datadog::metrics::{config::DatadogMetricsEndpoint, encoder::EncoderError};
+    use crate::{
+        common::datadog::DatadogMetricType, sinks::datadog::metrics::config::DatadogMetricsEndpoint,
+    };
 
     fn get_simple_counter() -> Metric {
         let value = MetricValue::Counter { value: 3.14 };
         Metric::new("basic_counter", MetricKind::Incremental, value).with_timestamp(Some(ts()))
+    }
+
+    fn get_simple_rate_counter(value: f64, interval_ms: u32) -> Metric {
+        let value = MetricValue::Counter { value };
+        Metric::new("basic_counter", MetricKind::Incremental, value)
+            .with_timestamp(Some(ts()))
+            .with_interval_ms(NonZeroU32::new(interval_ms))
     }
 
     fn get_simple_sketch() -> Metric {
@@ -755,6 +767,33 @@ mod tests {
             sketch_result.err(),
             Some(EncoderError::InvalidMetric { .. })
         ));
+    }
+
+    #[test]
+    fn encode_counter_with_interval_as_rate() {
+        // When a counter explicitly has an interval, we need to encode it as a rate. This means
+        // diving the value by the interval (in seconds) and setting the metric type so that when it
+        // lands on the DD side, they can multiply the value by the interval (in seconds) and get
+        // back the correct total value for that time period.
+
+        let value = 423.1331;
+        let interval_ms = 10000;
+        let rate_counter = get_simple_rate_counter(value, interval_ms);
+        let expected_value = value / (interval_ms / 1000) as f64;
+        let expected_interval = interval_ms / 1000;
+
+        // Encode the metric and make sure we did the rate conversion correctly.
+        let result = generate_series_metrics(&rate_counter, &None, log_schema());
+        assert!(result.is_ok());
+
+        let metrics = result.unwrap();
+        assert_eq!(metrics.len(), 1);
+
+        let actual = &metrics[0];
+        assert_eq!(actual.r#type, DatadogMetricType::Rate);
+        assert_eq!(actual.interval, Some(expected_interval));
+        assert_eq!(actual.points.len(), 1);
+        assert_eq!(actual.points[0].1, expected_value);
     }
 
     #[test]

--- a/src/sinks/datadog/metrics/encoder.rs
+++ b/src/sinks/datadog/metrics/encoder.rs
@@ -772,8 +772,8 @@ mod tests {
     #[test]
     fn encode_counter_with_interval_as_rate() {
         // When a counter explicitly has an interval, we need to encode it as a rate. This means
-        // diving the value by the interval (in seconds) and setting the metric type so that when it
-        // lands on the DD side, they can multiply the value by the interval (in seconds) and get
+        // dividing the value by the interval (in seconds) and setting the metric type so that when
+        // it lands on the DD side, they can multiply the value by the interval (in seconds) and get
         // back the correct total value for that time period.
 
         let value = 423.1331;


### PR DESCRIPTION
This PR reintroduces the logic to differentiate rate metrics and count metrics in the `datadog_metrics` sink. This was a regression introduced in #13960.

We also now have a unit test making sure this is handled correctly, so hopefully no more regressions by yours truly, or anyone, as far as rate metrics go. 🤞🏻 😅 

Fixes #14740.