### PR TITLE
docs(observability): Fix documented name of `source_lag_time_seconds`

### DIFF
--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -369,6 +369,6 @@ components: sources: [Name=string]: {
 		events_out_total:                 components.sources.internal_metrics.output.metrics.events_out_total
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		lag_time_seconds:                 components.sources.internal_metrics.output.metrics.lag_time_seconds
+		source_lag_time_seconds:          components.sources.internal_metrics.output.metrics.source_lag_time_seconds
 	}
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -851,12 +851,6 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		lag_time_seconds: {
-			description:       "The difference between the timestamp recorded in each event and the time when it was ingested, expressed as fractional seconds."
-			type:              "histogram"
-			default_namespace: "vector"
-			tags:              _component_tags
-		}
 		logging_driver_errors_total: {
 			description: """
 				The total number of logging driver errors encountered caused by not using either
@@ -981,6 +975,12 @@ components: sources: internal_metrics: {
 		send_errors_total: {
 			description:       "The total number of errors sending messages."
 			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		source_lag_time_seconds: {
+			description:       "The difference between the timestamp recorded in each event and the time when it was ingested, expressed as fractional seconds."
+			type:              "histogram"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}


### PR DESCRIPTION
The docs call this metric `lag_time_seconds` but that differs from the actual implementation.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
