### PR TITLE
fix(vrl): Fix `target_insert` for metric tags

### DIFF
--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -300,6 +300,11 @@ impl Metric {
         self.series.remove_tag(key)
     }
 
+    /// Removes all the tags.
+    pub fn remove_tags(&mut self) {
+        self.series.remove_tags();
+    }
+
     /// Returns `true` if `name` tag is present, and matches the provided `value`
     pub fn tag_matches(&self, name: &str, value: &str) -> bool {
         self.tags()

--- a/lib/vector-core/src/event/metric/series.rs
+++ b/lib/vector-core/src/event/metric/series.rs
@@ -46,6 +46,11 @@ impl MetricSeries {
         (self.tags.get_or_insert_with(Default::default)).insert(key, value)
     }
 
+    /// Removes all the tags.
+    pub fn remove_tags(&mut self) {
+        self.tags = None;
+    }
+
     /// Removes the tag entry for the named key, if it exists, and returns the old value.
     ///
     /// *Note:* This will drop the tags map if the tag was the last entry in it.

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -190,6 +190,8 @@ impl vrl_lib::Target for VrlTarget {
                             ["tags"] => {
                                 let value =
                                     value.clone().try_object().map_err(|e| e.to_string())?;
+
+                                metric.remove_tags();
                                 for (field, value) in &value {
                                     metric.insert_tag(
                                         field.as_str().to_owned(),
@@ -1017,6 +1019,43 @@ mod test {
                     target.target_get(&path).map(Option::<&Value>::cloned)
                 );
             }
+        }
+    }
+
+    #[test]
+    fn metric_set_tags() {
+        let metric = Metric::new(
+            "name",
+            MetricKind::Absolute,
+            MetricValue::Counter { value: 1.23 },
+        )
+        .with_tags(Some({
+            let mut map = MetricTags::new();
+            map.insert("tig".to_string(), "tog".to_string());
+            map
+        }));
+
+        let info = ProgramInfo {
+            fallible: false,
+            abortable: false,
+            target_queries: vec![],
+            target_assignments: vec![],
+        };
+        let mut target = VrlTarget::new(Event::Metric(metric), &info);
+        let _ = target.target_insert(
+            &OwnedTargetPath::event(owned_value_path!("tags")),
+            Value::Object(BTreeMap::from([("a".into(), "b".into())])),
+        );
+
+        match target {
+            VrlTarget::Metric { metric, value: _ } => {
+                assert!(metric.tags().is_some());
+                assert_eq!(
+                    metric.tags().unwrap(),
+                    &BTreeMap::from([("a".into(), "b".into())])
+                );
+            }
+            _ => panic!("must be a metric"),
         }
     }
 

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -1042,7 +1042,7 @@ mod test {
             target_assignments: vec![],
         };
         let mut target = VrlTarget::new(Event::Metric(metric), &info);
-        let _ = target.target_insert(
+        let _result = target.target_insert(
             &OwnedTargetPath::event(owned_value_path!("tags")),
             Value::Object(BTreeMap::from([("a".into(), "b".into())])),
         );


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/14693

Previously assigning to `.tags` of a metric would only append tags. Now it overwrites instead.