### PR TITLE
chore(datadog_traces sink): Add a robust APM stats integration test

### DIFF
--- a/scripts/check-events
+++ b/scripts/check-events
@@ -376,7 +376,7 @@ Find.find('./src', './lib') do |path|
         # trailing period, respectively.
         has_message = !message_param.nil?
         message = if has_message then message_param["value"].gsub(/^"|"$/, '') else nil end
-        is_capitalized = !has_message || (message[0] == "{" || message.match(/^[[:upper:]]/))
+        is_capitalized = !has_message || (message[0] == "{" || !message.match(/^[a-zA-Z]/) || message.match(/^[[:upper:]]/))
         has_trailing_period = !has_message || (message[-1, 1] == "}" || message.match(/\.$/))
 
         match_reports = []

--- a/scripts/integration/docker-compose.datadog-traces.yml
+++ b/scripts/integration/docker-compose.datadog-traces.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  datadog-trace-agent-only:
+  datadog-trace-agent:
     image: docker.io/datadog/agent:7.39.1
     networks:
       - backend
@@ -12,8 +12,16 @@ services:
       - DD_HEALTH_PORT=8183
       - DD_CMD_PORT=5002
       - DD_USE_DOGSTATSD=false
-    volumes:
-      - ${PWD}/tests/data/datadog-traces/conf.yaml:/etc/datadog-agent/conf.d/test.d/conf.yaml
+      # This option supposedly allows stats payloads to send as soon as data comes in,
+      # but if it is enabled then no stats are received at all *shrug*
+        #- DD_APM_SYNC_FLUSHING=true
+      # Below disables sampling
+      - DD_APM_MAX_TPS=999999
+      - DD_APM_ERROR_TPS=999999
+      - DD_APM_MAX_MEMORY=0
+      - DD_APM_MAX_CPU_PERCENT=0
+    #volumes:
+      #- ${PWD}/tests/data/datadog-traces/conf.yaml:/etc/datadog-agent/conf.d/test.d/conf.yaml
   runner:
     build:
       context: ${PWD}
@@ -36,12 +44,13 @@ services:
       - "--lib"
       - "::datadog::traces::"
     environment:
-      - TRACE_AGENT_ONLY_URL=http://datadog-trace-agent-only:8126/v0.3/traces
+      - TEST_LOG=${TEST_LOG}
+      - TRACE_AGENT_URL=http://datadog-trace-agent:8126/v0.3/traces
       - TEST_DATADOG_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
-      - AGENT_TO_VECTOR_PORT=8081
-      - AGENT_ONLY_PORT=8082
+      - VECTOR_PORT=8081
+      - AGENT_PORT=8082
     depends_on:
-      - datadog-trace-agent-only
+      - datadog-trace-agent
     volumes:
       - ${PWD}:/code
       - target:/code/target

--- a/scripts/integration/docker-compose.datadog-traces.yml
+++ b/scripts/integration/docker-compose.datadog-traces.yml
@@ -1,20 +1,6 @@
 version: "3"
 
 services:
-  # TODO if not using DD agent source in vector, this service can be removed entirely
-  datadog-trace-agent-to-vector:
-    image: docker.io/datadog/agent:7.39.1
-    networks:
-      - backend
-    environment:
-      - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
-      - DD_APM_ENABLED=true
-      - DD_APM_DD_URL=http://runner:8081
-      - DD_HEALTH_PORT=8183
-      - DD_CMD_PORT=5002
-      - DD_USE_DOGSTATSD=false
-    volumes:
-      - ${PWD}/tests/data/datadog-traces/conf.yaml:/etc/datadog-agent/conf.d/test.d/conf.yaml
   datadog-trace-agent-only:
     image: docker.io/datadog/agent:7.39.1
     networks:
@@ -48,18 +34,14 @@ services:
       - "--features"
       - "datadog-traces-integration-tests"
       - "--lib"
-        # TODO revert when solid
-        #- "::datadog::traces::"
-      - "::datadog::traces::integration_tests::apm_stats_e2e_test_dd_agent_to_vector_correctness"
+      - "::datadog::traces::"
     environment:
       - TRACE_AGENT_ONLY_URL=http://datadog-trace-agent-only:8126/v0.3/traces
-      - TRACE_AGENT_VECTOR_URL=http://datadog-trace-agent-to-vector:8126/v0.3/traces
       - TEST_DATADOG_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
       - AGENT_TO_VECTOR_PORT=8081
       - AGENT_ONLY_PORT=8082
     depends_on:
       - datadog-trace-agent-only
-      - datadog-trace-agent-to-vector
     volumes:
       - ${PWD}:/code
       - target:/code/target

--- a/scripts/integration/docker-compose.datadog-traces.yml
+++ b/scripts/integration/docker-compose.datadog-traces.yml
@@ -1,6 +1,33 @@
 version: "3"
 
 services:
+  # TODO if not using DD agent source in vector, this service can be removed entirely
+  datadog-trace-agent-to-vector:
+    image: docker.io/datadog/agent:7.39.1
+    networks:
+      - backend
+    environment:
+      - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
+      - DD_APM_ENABLED=true
+      - DD_APM_DD_URL=http://runner:8081
+      - DD_HEALTH_PORT=8183
+      - DD_CMD_PORT=5002
+      - DD_USE_DOGSTATSD=false
+    volumes:
+      - ${PWD}/tests/data/datadog-traces/conf.yaml:/etc/datadog-agent/conf.d/test.d/conf.yaml
+  datadog-trace-agent-only:
+    image: docker.io/datadog/agent:7.39.1
+    networks:
+      - backend
+    environment:
+      - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
+      - DD_APM_ENABLED=true
+      - DD_APM_DD_URL=http://runner:8082
+      - DD_HEALTH_PORT=8183
+      - DD_CMD_PORT=5002
+      - DD_USE_DOGSTATSD=false
+    volumes:
+      - ${PWD}/tests/data/datadog-traces/conf.yaml:/etc/datadog-agent/conf.d/test.d/conf.yaml
   runner:
     build:
       context: ${PWD}
@@ -8,23 +35,39 @@ services:
       args:
         - RUST_VERSION=${RUST_VERSION}
     working_dir: /code
+    hostname: runner
+    networks:
+      - backend
     command:
       - "cargo"
       - "nextest"
       - "run"
       - "--no-fail-fast"
+      - "--no-capture"
       - "--no-default-features"
       - "--features"
       - "datadog-traces-integration-tests"
       - "--lib"
-      - "::datadog::traces::"
+        # TODO revert when solid
+        #- "::datadog::traces::"
+      - "::datadog::traces::integration_tests::apm_stats_e2e_test_dd_agent_to_vector_correctness"
     environment:
+      - TRACE_AGENT_ONLY_URL=http://datadog-trace-agent-only:8126/v0.3/traces
+      - TRACE_AGENT_VECTOR_URL=http://datadog-trace-agent-to-vector:8126/v0.3/traces
       - TEST_DATADOG_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
+      - AGENT_TO_VECTOR_PORT=8081
+      - AGENT_ONLY_PORT=8082
+    depends_on:
+      - datadog-trace-agent-only
+      - datadog-trace-agent-to-vector
     volumes:
       - ${PWD}:/code
       - target:/code/target
       - cargogit:/usr/local/cargo/git
       - cargoregistry:/usr/local/cargo/registry
+
+networks:
+  backend: {}
 
 volumes:
   target: {}

--- a/src/sinks/datadog/traces/integration_tests.rs
+++ b/src/sinks/datadog/traces/integration_tests.rs
@@ -2,7 +2,7 @@ use axum::{
     body::Body,
     extract::Extension,
     http::{header::CONTENT_TYPE, Request},
-    routing::{get, post},
+    routing::post,
     Router,
 };
 use chrono::Utc;
@@ -33,48 +33,48 @@ use crate::{
 };
 use vector_core::event::{BatchNotifier, BatchStatus};
 
-fn agent_to_vector_port() -> u16 {
+// The port for an http server to receive data from vector
+fn vector_port() -> u16 {
     std::env::var("AGENT_TO_VECTOR_PORT")
         .unwrap_or_else(|_| "8081".to_string())
         .parse::<u16>()
         .unwrap()
 }
 
-fn agent_only_port() -> u16 {
+// The port for an http server to receive data from the agent
+fn agent_port() -> u16 {
     std::env::var("AGENT_ONLY_PORT")
         .unwrap_or_else(|_| "8082".to_string())
         .parse::<u16>()
         .unwrap()
 }
 
+// The agent url to post traces to.
 fn trace_agent_only_url() -> String {
     std::env::var("TRACE_AGENT_ONLY_URL")
         .unwrap_or_else(|_| "http://127.0.0.1:8126/v0.3/traces".to_owned())
 }
 
-//fn trace_agent_vector_url() -> String {
-//    std::env::var("TRACE_AGENT_VECTOR_URL")
-//        .unwrap_or_else(|_| "http://127.0.0.1:8126/v0.3/traces".to_owned())
-//}
-
 // Shared state for the HTTP server
 struct AppState {
+    name: String,
     tx: Sender<StatsPayload>,
 }
 
 // build the app with a route and run our app with hyper
-async fn run_server(port: u16, tx: Sender<StatsPayload>) {
-    let state = Arc::new(AppState { tx });
+async fn run_server(name: String, port: u16, tx: Sender<StatsPayload>) {
+    let state = Arc::new(AppState {
+        name: name.clone(),
+        tx,
+    });
     let app = Router::new()
-        .route("/", get(root))
         .route("/api/v0.2/traces", post(process_traces))
         .route("/api/v0.2/stats", post(process_stats))
         .layer(Extension(state));
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    //println!("{:?}", addr);
 
-    println!("listening on {}", addr);
+    println!("HTTP server for `{}` listening on {}", name, addr);
 
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
@@ -82,33 +82,34 @@ async fn run_server(port: u16, tx: Sender<StatsPayload>) {
         .unwrap();
 }
 
-// basic handler that responds with a static string
-async fn root(Extension(_state): Extension<Arc<AppState>>) -> &'static str {
-    ""
-}
-
-/// TODO
+// At a later time (perhaps if we make this a full e2e test), we could parse the trace payloads
+// from vector and the agent and compare. As it stands, we have unit tests validating the trace
+// structure for the sink so not much value in doing that yet.
 async fn process_traces(Extension(_state): Extension<Arc<AppState>>, request: Request<Body>) {
     let content_type_header = request.headers().get(CONTENT_TYPE);
     let content_type = content_type_header.and_then(|value| value.to_str().ok());
 
     if let Some(content_type) = content_type {
         if content_type.starts_with("application/x-protobuf") {
-            println!("got trace payload!");
+            debug!("got trace payload!");
         }
     }
 }
 
-/// TODO
+// process a POST request from the stats endpoint.
+// De-compresses and De-serializes the payload, then forwards it on the Sender channel.
 async fn process_stats(Extension(state): Extension<Arc<AppState>>, mut request: Request<Body>) {
-    println!("process_stats request: {:?}", request);
+    debug!(
+        "`{}` server process_stats request: {:?}",
+        state.name, request
+    );
 
     let content_type_header = request.headers().get(CONTENT_TYPE);
     let content_type = content_type_header.and_then(|value| value.to_str().ok());
 
     if let Some(content_type) = content_type {
         if content_type.starts_with("application/msgpack") {
-            println!("got stats payload!");
+            debug!("`{}` server got stats payload!", state.name);
 
             let body = request.body_mut();
             let compressed_body_bytes = hyper::body::to_bytes(body)
@@ -122,7 +123,11 @@ async fn process_stats(Extension(state): Extension<Arc<AppState>>, mut request: 
 
             let payload: StatsPayload = rmp_serde::from_slice(&decompressed_body_bytes).unwrap();
 
-            println!("deserialized stats payload: {:?}", payload);
+            println!(
+                "`{}` server received and deserialized stats payload.",
+                state.name
+            );
+            debug!("{:?}", payload);
 
             state.tx.send(payload).await.unwrap();
         }
@@ -169,34 +174,62 @@ fn build_traces_payload(start: i64, duration: i64, span_id: i64) -> Vec<Vec<Span
     vec![vec![span]]
 }
 
-async fn feed_traces(urls: &Vec<String>, start: i64, duration: i64, span_id: i64) -> bool {
-    let traces_payload = build_traces_payload(start, duration, span_id);
-    let client = reqwest::Client::new();
+// Sends traces into the Agent container.
+// Send two separate requests with thin the same bucket time window to invoke the aggregation logic in the Agent.
+async fn send_agent_traces(start: i64, duration: i64, span_id: i64) {
+    async fn send_trace(urls: &Vec<String>, start: i64, duration: i64, span_id: i64) -> bool {
+        let traces_payload = build_traces_payload(start, duration, span_id);
+        let client = reqwest::Client::new();
 
-    for url in urls {
-        let res = client
-            .post(url)
-            .header(CONTENT_TYPE, "application/json")
-            .json(&traces_payload)
-            .send()
-            .await
-            .unwrap();
+        for url in urls {
+            let res = client
+                .post(url)
+                .header(CONTENT_TYPE, "application/json")
+                .json(&traces_payload)
+                .send()
+                .await
+                .unwrap();
 
-        if res.status() != hyper::StatusCode::OK {
-            println!("error feeding traces to {}, res: {:?}", url, res);
-            return false;
+            if res.status() != hyper::StatusCode::OK {
+                println!("error sending traces to {}, res: {:?}", url, res);
+                return false;
+            }
         }
+        println!("sent a trace to the Agent.");
+        true
     }
-    true
+
+    // If at a later time we create a more "complete" end to end test which will send data through
+    // the full vector topology [agent -> datadog_agent_source -> datadog_traces_sink] , then we
+    // can just add the url for the traces endpoint of that container here.
+    let urls = vec![trace_agent_only_url()];
+
+    // send first set of trace data
+    if !send_trace(&urls, start, duration, span_id + 1).await {
+        panic!("can't perform checks if traces aren't accepted by agent.");
+    }
+
+    sleep(Duration::from_secs(1)).await;
+
+    // send second set of trace data
+    if !send_trace(&urls, start + 1, duration, span_id + 1).await {
+        panic!("can't perform checks if traces aren't accepted by agent.");
+    }
 }
 
-async fn run_sink(start: i64, duration: i64, span_id: i64) {
+// The sink is run with a max batch size of one, and a stream containing two trace events.
+// The two trace events are intentionally configured within the same time bucket window.
+// This creates a scenario where the stats payload that is output by the sink after processing the
+// *second* batch of events (the second event) >should< contain the aggregated statistics of both
+// of the trace events. i.e , the hit count for that bucket should be equal to "2" , not "1".
+async fn run_sink_and_send_traces(start: i64, duration: i64, span_id: i64) {
     assert_sink_compliance(&SINK_TAGS, async {
         let config = indoc! {r#"
                 default_api_key = "atoken"
                 compression = "gzip"
                 site = "datadoghq.com"
                 endpoint = "http://0.0.0.0:8081"
+                batch.max_events = 1
             "#};
 
         let api_key = std::env::var("TEST_DATADOG_API_KEY")
@@ -210,51 +243,53 @@ async fn run_sink(start: i64, duration: i64, span_id: i64) {
         let (batch, receiver) = BatchNotifier::new_with_receiver();
 
         {
-            let trace = vec![Event::Trace(
-                simple_trace_event_detailed(
-                    "a_resource".to_string(),
-                    Some(start),
-                    Some(duration),
-                    Some(span_id),
-                )
-                .with_batch_notifier(&batch),
-            )];
+            let traces = vec![
+                Event::Trace(
+                    simple_trace_event_detailed(
+                        "a_resource".to_string(),
+                        Some(start),
+                        Some(duration),
+                        Some(span_id),
+                        Some(0),
+                    )
+                    .with_batch_notifier(&batch),
+                ),
+                Event::Trace(
+                    simple_trace_event_detailed(
+                        "a_resource".to_string(),
+                        Some(start + 1),
+                        Some(duration),
+                        Some(span_id + 1),
+                        Some(0),
+                    )
+                    .with_batch_notifier(&batch),
+                ),
+            ];
 
-            let stream = map_event_batch_stream(stream::iter(trace), Some(batch));
+            let stream = map_event_batch_stream(stream::iter(traces), Some(batch));
 
+            println!("sent traces to vector.");
             sink.run(stream).await.unwrap();
         }
-
-        // TODO how to send events in separate batches
-
-        //sleep(Duration::from_secs(1)).await;
-
-        //{
-        //    let trace = vec![Event::Trace(
-        //        simple_trace_event_detailed(
-        //            "a_resource".to_string(),
-        //            Some(start + 1),
-        //            Some(duration),
-        //            Some(span_id + 1),
-        //        )
-        //        .with_batch_notifier(&batch),
-        //    )];
-
-        //    let stream = map_event_batch_stream(stream::iter(trace), Some(batch));
-
-        //    sink.run(stream).await.unwrap();
-        //}
 
         assert_eq!(receiver.await, BatchStatus::Delivered);
     })
     .await;
 }
 
+// Receives the stats payloads from the Receiver channels from both of the server instances.
+// If either of the servers does not respond with a stats payload, the test will fail.
+// The lastest received stats payload is the only one considered. This is the same logic that the
+// Datadog UI follows.
+// Wait for up to 25 seconds for the stats payload to arrive. The Agent can take some time to send
+// the stats out.
+// TODO: Looking into if there is a way to configure the agent bucket interval to force the
+// flushing to occur faster (reducing the timeout we use and overall runtime of the test)
 async fn receive_the_stats(
     rx_agent_only: &mut Receiver<StatsPayload>,
     rx_agent_vector: &mut Receiver<StatsPayload>,
 ) -> (StatsPayload, StatsPayload) {
-    let timeout = sleep(Duration::from_secs(30));
+    let timeout = sleep(Duration::from_secs(25));
     tokio::pin!(timeout);
 
     let mut stats_agent_vector = None;
@@ -287,6 +322,8 @@ async fn receive_the_stats(
     (stats_agent_only.unwrap(), stats_agent_vector.unwrap())
 }
 
+// Compares the stats payload (specifically the bucket for the time window we sent events on)
+// between the Vector and Agent for consistency.
 fn validate_stats(agent_stats: &StatsPayload, vector_stats: &StatsPayload) {
     let agent_bucket = agent_stats.stats.first().unwrap().stats.first().unwrap();
 
@@ -332,44 +369,31 @@ async fn apm_stats_e2e_test_dd_agent_to_vector_correctness() {
 
     // spawn the servers
     {
-        // [agent -> vector -> the server]
+        // [vector -> the server]
         tokio::spawn(async move {
-            run_server(agent_to_vector_port(), tx_agent_vector).await;
+            run_server("vector".to_string(), vector_port(), tx_agent_vector).await;
         });
 
         // [agent -> the server]
         tokio::spawn(async move {
-            run_server(agent_only_port(), tx_agent_only).await;
+            run_server("agent".to_string(), agent_port(), tx_agent_only).await;
         });
     }
 
     // allow the agent to start up
-    sleep(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(5)).await;
 
     let start = Utc::now().timestamp_nanos();
     let duration = 20;
     let span_id = 3;
 
-    // start the sink
-    run_sink(start, duration, span_id).await;
+    // starts the sink and sends the traces through it
+    // panics if the batch status was not Delivered.
+    run_sink_and_send_traces(start, duration, span_id).await;
 
-    // feed in the traces
-    {
-        //let urls = vec![trace_agent_only_url(), trace_agent_vector_url()];
-        let urls = vec![trace_agent_only_url()];
-
-        // feed first set of trace data
-        if !feed_traces(&urls, start, duration, span_id + 1).await {
-            panic!("can't perform checks if traces aren't accepted");
-        }
-
-        sleep(Duration::from_secs(1)).await;
-
-        // feed second set of trace data
-        if !feed_traces(&urls, start + 1, duration, span_id + 1).await {
-            panic!("can't perform checks if traces aren't accepted");
-        }
-    }
+    // sends the traces through the agent
+    // panics if the HTTP post fails
+    send_agent_traces(start, duration, span_id).await;
 
     // receive the stats on the channel receivers from the servers
     let (stats_agent, stats_vector) =

--- a/src/sinks/datadog/traces/integration_tests.rs
+++ b/src/sinks/datadog/traces/integration_tests.rs
@@ -35,7 +35,7 @@ use vector_core::event::{BatchNotifier, BatchStatus};
 
 // The port for an http server to receive data from vector
 fn vector_port() -> u16 {
-    std::env::var("AGENT_TO_VECTOR_PORT")
+    std::env::var("VECTOR_PORT")
         .unwrap_or_else(|_| "8081".to_string())
         .parse::<u16>()
         .unwrap()
@@ -43,7 +43,7 @@ fn vector_port() -> u16 {
 
 // The port for an http server to receive data from the agent
 fn agent_port() -> u16 {
-    std::env::var("AGENT_ONLY_PORT")
+    std::env::var("AGENT_PORT")
         .unwrap_or_else(|_| "8082".to_string())
         .parse::<u16>()
         .unwrap()
@@ -51,7 +51,7 @@ fn agent_port() -> u16 {
 
 // The agent url to post traces to.
 fn trace_agent_only_url() -> String {
-    std::env::var("TRACE_AGENT_ONLY_URL")
+    std::env::var("TRACE_AGENT_URL")
         .unwrap_or_else(|_| "http://127.0.0.1:8126/v0.3/traces".to_owned())
 }
 
@@ -290,7 +290,7 @@ async fn receive_the_stats(
     rx_agent_only: &mut Receiver<StatsPayload>,
     rx_agent_vector: &mut Receiver<StatsPayload>,
 ) -> (StatsPayload, StatsPayload) {
-    let timeout = sleep(Duration::from_secs(25));
+    let timeout = sleep(Duration::from_secs(30));
     tokio::pin!(timeout);
 
     let mut stats_agent_vector = None;
@@ -379,7 +379,7 @@ async fn apm_stats_e2e_test_dd_agent_to_vector_correctness() {
     }
 
     // allow the agent to start up
-    sleep(Duration::from_secs(5)).await;
+    sleep(Duration::from_secs(8)).await;
 
     let start = Utc::now().timestamp_nanos();
     let duration = 20;

--- a/src/sinks/datadog/traces/integration_tests.rs
+++ b/src/sinks/datadog/traces/integration_tests.rs
@@ -1,27 +1,391 @@
+use axum::{
+    body::Body,
+    extract::Extension,
+    http::{header::CONTENT_TYPE, Request},
+    routing::{get, post},
+    Router,
+};
+use chrono::Utc;
+use flate2::read::GzDecoder;
 use futures::stream;
 use indoc::indoc;
-use vector_core::event::{BatchNotifier, BatchStatus};
+use rmp_serde;
+use serde::Serialize;
+use std::{collections::HashMap, io::Read, net::SocketAddr, sync::Arc};
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::time::{sleep, Duration};
 
 use crate::{
     config::SinkConfig,
     event::Event,
     sinks::{
-        datadog::traces::{tests::simple_trace_event, DatadogTracesConfig},
+        datadog::traces::{
+            stats::StatsPayload,
+            tests::{simple_trace_event, simple_trace_event_detailed},
+            DatadogTracesConfig,
+        },
         util::test::load_sink,
     },
     test_util::{
         components::{assert_sink_compliance, SINK_TAGS},
-        map_event_batch_stream,
+        map_event_batch_stream, trace_init,
     },
 };
+use vector_core::event::{BatchNotifier, BatchStatus};
+
+fn agent_to_vector_port() -> u16 {
+    std::env::var("AGENT_TO_VECTOR_PORT")
+        .unwrap_or_else(|_| "8081".to_string())
+        .parse::<u16>()
+        .unwrap()
+}
+
+fn agent_only_port() -> u16 {
+    std::env::var("AGENT_ONLY_PORT")
+        .unwrap_or_else(|_| "8082".to_string())
+        .parse::<u16>()
+        .unwrap()
+}
+
+fn trace_agent_only_url() -> String {
+    std::env::var("TRACE_AGENT_ONLY_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8126/v0.3/traces".to_owned())
+}
+
+//fn trace_agent_vector_url() -> String {
+//    std::env::var("TRACE_AGENT_VECTOR_URL")
+//        .unwrap_or_else(|_| "http://127.0.0.1:8126/v0.3/traces".to_owned())
+//}
+
+// Shared state for the HTTP server
+struct AppState {
+    tx: Sender<StatsPayload>,
+}
+
+// build the app with a route and run our app with hyper
+async fn run_server(port: u16, tx: Sender<StatsPayload>) {
+    let state = Arc::new(AppState { tx });
+    let app = Router::new()
+        .route("/", get(root))
+        .route("/api/v0.2/traces", post(process_traces))
+        .route("/api/v0.2/stats", post(process_stats))
+        .layer(Extension(state));
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    //println!("{:?}", addr);
+
+    println!("listening on {}", addr);
+
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+// basic handler that responds with a static string
+async fn root(Extension(_state): Extension<Arc<AppState>>) -> &'static str {
+    ""
+}
+
+/// TODO
+async fn process_traces(Extension(_state): Extension<Arc<AppState>>, request: Request<Body>) {
+    let content_type_header = request.headers().get(CONTENT_TYPE);
+    let content_type = content_type_header.and_then(|value| value.to_str().ok());
+
+    if let Some(content_type) = content_type {
+        if content_type.starts_with("application/x-protobuf") {
+            println!("got trace payload!");
+        }
+    }
+}
+
+/// TODO
+async fn process_stats(Extension(state): Extension<Arc<AppState>>, mut request: Request<Body>) {
+    println!("process_stats request: {:?}", request);
+
+    let content_type_header = request.headers().get(CONTENT_TYPE);
+    let content_type = content_type_header.and_then(|value| value.to_str().ok());
+
+    if let Some(content_type) = content_type {
+        if content_type.starts_with("application/msgpack") {
+            println!("got stats payload!");
+
+            let body = request.body_mut();
+            let compressed_body_bytes = hyper::body::to_bytes(body)
+                .await
+                .expect("could not decode body into bytes");
+
+            let mut gz = GzDecoder::new(compressed_body_bytes.as_ref());
+            let mut decompressed_body_bytes = vec![];
+            gz.read_to_end(&mut decompressed_body_bytes)
+                .expect("unable to decompress gzip stats payload");
+
+            let payload: StatsPayload = rmp_serde::from_slice(&decompressed_body_bytes).unwrap();
+
+            println!("deserialized stats payload: {:?}", payload);
+
+            state.tx.send(payload).await.unwrap();
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Span {
+    duration: i64,
+    error: i32,
+    meta: HashMap<String, String>,
+    metrics: HashMap<String, f64>,
+    name: String,
+    parent_id: u64,
+    resource: String,
+    service: String,
+    span_id: i64,
+    start: i64,
+    trace_id: u64,
+    r#type: String,
+}
+
+fn build_traces_payload(start: i64, duration: i64, span_id: i64) -> Vec<Vec<Span>> {
+    let parent_id = 1;
+    let trace_id = 2;
+    let resource = "a_resource";
+    let service = "a_service";
+
+    let span = Span {
+        duration,
+        error: 0,
+        meta: HashMap::from([("this_is".to_string(), "so_meta".to_string())]),
+        metrics: HashMap::from([("_top_level".to_string(), 1.0)]),
+        name: "a_name".to_string(),
+        parent_id,
+        resource: resource.to_string(),
+        service: service.to_string(),
+        span_id,
+        start,
+        trace_id,
+        r#type: "a_type".to_string(),
+    };
+
+    vec![vec![span]]
+}
+
+async fn feed_traces(urls: &Vec<String>, start: i64, duration: i64, span_id: i64) -> bool {
+    let traces_payload = build_traces_payload(start, duration, span_id);
+    let client = reqwest::Client::new();
+
+    for url in urls {
+        let res = client
+            .post(url)
+            .header(CONTENT_TYPE, "application/json")
+            .json(&traces_payload)
+            .send()
+            .await
+            .unwrap();
+
+        if res.status() != hyper::StatusCode::OK {
+            println!("error feeding traces to {}, res: {:?}", url, res);
+            return false;
+        }
+    }
+    true
+}
+
+async fn run_sink(start: i64, duration: i64, span_id: i64) {
+    assert_sink_compliance(&SINK_TAGS, async {
+        let config = indoc! {r#"
+                default_api_key = "atoken"
+                compression = "gzip"
+                site = "datadoghq.com"
+                endpoint = "http://0.0.0.0:8081"
+            "#};
+
+        let api_key = std::env::var("TEST_DATADOG_API_KEY")
+            .expect("couldn't find the Datatog api key in environment variables");
+        assert!(!api_key.is_empty(), "TEST_DATADOG_API_KEY required");
+
+        let config = config.replace("atoken", &api_key);
+        let (config, cx) = load_sink::<DatadogTracesConfig>(config.as_str()).unwrap();
+
+        let (sink, _) = config.build(cx).await.unwrap();
+        let (batch, receiver) = BatchNotifier::new_with_receiver();
+
+        {
+            let trace = vec![Event::Trace(
+                simple_trace_event_detailed(
+                    "a_resource".to_string(),
+                    Some(start),
+                    Some(duration),
+                    Some(span_id),
+                )
+                .with_batch_notifier(&batch),
+            )];
+
+            let stream = map_event_batch_stream(stream::iter(trace), Some(batch));
+
+            sink.run(stream).await.unwrap();
+        }
+
+        // TODO how to send events in separate batches
+
+        //sleep(Duration::from_secs(1)).await;
+
+        //{
+        //    let trace = vec![Event::Trace(
+        //        simple_trace_event_detailed(
+        //            "a_resource".to_string(),
+        //            Some(start + 1),
+        //            Some(duration),
+        //            Some(span_id + 1),
+        //        )
+        //        .with_batch_notifier(&batch),
+        //    )];
+
+        //    let stream = map_event_batch_stream(stream::iter(trace), Some(batch));
+
+        //    sink.run(stream).await.unwrap();
+        //}
+
+        assert_eq!(receiver.await, BatchStatus::Delivered);
+    })
+    .await;
+}
+
+async fn receive_the_stats(
+    rx_agent_only: &mut Receiver<StatsPayload>,
+    rx_agent_vector: &mut Receiver<StatsPayload>,
+) -> (StatsPayload, StatsPayload) {
+    let timeout = sleep(Duration::from_secs(30));
+    tokio::pin!(timeout);
+
+    let mut stats_agent_vector = None;
+    let mut stats_agent_only = None;
+
+    loop {
+        tokio::select! {
+            d1 = rx_agent_vector.recv() => {
+                stats_agent_vector = d1;
+                if stats_agent_only.is_some() && stats_agent_vector.is_some() {
+                    break;
+                }
+            },
+            d2 = rx_agent_only.recv() => {
+                stats_agent_only = d2;
+                if stats_agent_only.is_some() && stats_agent_vector.is_some() {
+                    break;
+                }
+            },
+            _ = &mut timeout => break,
+        }
+    }
+
+    assert!(
+        stats_agent_vector.is_some(),
+        "received no stats from vector"
+    );
+    assert!(stats_agent_only.is_some(), "received no stats from agent");
+
+    (stats_agent_only.unwrap(), stats_agent_vector.unwrap())
+}
+
+fn validate_stats(agent_stats: &StatsPayload, vector_stats: &StatsPayload) {
+    let agent_bucket = agent_stats.stats.first().unwrap().stats.first().unwrap();
+
+    let vector_bucket = vector_stats.stats.first().unwrap().stats.first().unwrap();
+    assert!(
+        agent_bucket.start == vector_bucket.start,
+        "bucket start times do not match"
+    );
+    assert!(
+        agent_bucket.duration == vector_bucket.duration,
+        "bucket durations do not match"
+    );
+
+    let agent_s = agent_bucket.stats.first().unwrap();
+    let vector_s = vector_bucket.stats.first().unwrap();
+
+    println!();
+    println!("agent_stats : {:?}", agent_s);
+    println!();
+    println!("vector_stats : {:?}", vector_s);
+    println!();
+
+    assert!(agent_s.service == vector_s.service);
+    assert!(agent_s.name == vector_s.name);
+    assert!(agent_s.resource == vector_s.resource);
+    assert!(agent_s.http_status_code == vector_s.http_status_code);
+    assert!(agent_s.r#type == vector_s.r#type);
+    assert!(agent_s.db_type == vector_s.db_type);
+    assert!(agent_s.hits == vector_s.hits);
+    assert!(agent_s.errors == vector_s.errors);
+    assert!(agent_s.duration == vector_s.duration);
+    assert!(agent_s.synthetics == vector_s.synthetics);
+    assert!(agent_s.top_level_hits == vector_s.top_level_hits);
+}
+
+#[tokio::test]
+async fn apm_stats_e2e_test_dd_agent_to_vector_correctness() {
+    trace_init();
+
+    // channels for the servers to send us back data on
+    let (tx_agent_vector, mut rx_agent_vector) = mpsc::channel(32);
+    let (tx_agent_only, mut rx_agent_only) = mpsc::channel(32);
+
+    // spawn the servers
+    {
+        // [agent -> vector -> the server]
+        tokio::spawn(async move {
+            run_server(agent_to_vector_port(), tx_agent_vector).await;
+        });
+
+        // [agent -> the server]
+        tokio::spawn(async move {
+            run_server(agent_only_port(), tx_agent_only).await;
+        });
+    }
+
+    // allow the agent to start up
+    sleep(Duration::from_secs(10)).await;
+
+    let start = Utc::now().timestamp_nanos();
+    let duration = 20;
+    let span_id = 3;
+
+    // start the sink
+    run_sink(start, duration, span_id).await;
+
+    // feed in the traces
+    {
+        //let urls = vec![trace_agent_only_url(), trace_agent_vector_url()];
+        let urls = vec![trace_agent_only_url()];
+
+        // feed first set of trace data
+        if !feed_traces(&urls, start, duration, span_id + 1).await {
+            panic!("can't perform checks if traces aren't accepted");
+        }
+
+        sleep(Duration::from_secs(1)).await;
+
+        // feed second set of trace data
+        if !feed_traces(&urls, start + 1, duration, span_id + 1).await {
+            panic!("can't perform checks if traces aren't accepted");
+        }
+    }
+
+    // receive the stats on the channel receivers from the servers
+    let (stats_agent, stats_vector) =
+        receive_the_stats(&mut rx_agent_only, &mut rx_agent_vector).await;
+
+    // compare the stats from agent and vector for consistency
+    validate_stats(&stats_agent, &stats_vector);
+}
 
 #[tokio::test]
 async fn to_real_traces_endpoint() {
     assert_sink_compliance(&SINK_TAGS, async {
         let config = indoc! {r#"
-        default_api_key = "atoken"
-        compression = "none"
-    "#};
+            default_api_key = "atoken"
+            compression = "none"
+        "#};
         let api_key = std::env::var("TEST_DATADOG_API_KEY")
             .expect("couldn't find the Datatog api key in environment variables");
         assert!(!api_key.is_empty(), "TEST_DATADOG_API_KEY required");

--- a/src/sinks/datadog/traces/tests.rs
+++ b/src/sinks/datadog/traces/tests.rs
@@ -59,6 +59,7 @@ fn simple_span(
     start: i64,
     duration: i64,
     span_id: i64,
+    error: i64,
 ) -> BTreeMap<String, Value> {
     BTreeMap::<String, Value>::from([
         ("service".to_string(), Value::from("a_service")),
@@ -70,7 +71,7 @@ fn simple_span(
         ("parent_id".to_string(), Value::Integer(789)),
         ("start".to_string(), Value::from(Utc.timestamp_nanos(start))),
         ("duration".to_string(), Value::Integer(duration)),
-        ("error".to_string(), Value::Integer(404)),
+        ("error".to_string(), Value::Integer(error)),
         (
             "meta".to_string(),
             Value::Object(BTreeMap::<String, Value>::from([
@@ -99,10 +100,12 @@ pub fn simple_trace_event_detailed(
     start: Option<i64>,
     duration: Option<i64>,
     span_id: Option<i64>,
+    error: Option<i64>,
 ) -> TraceEvent {
     let duration = duration.unwrap_or(1_000_000);
     let start = start.unwrap_or(1_431_648_000_000_001i64);
     let span_id = span_id.unwrap_or(456);
+    let error = error.unwrap_or(404);
 
     let mut t = TraceEvent::default();
     t.insert("language", "a_language");
@@ -115,14 +118,14 @@ pub fn simple_trace_event_detailed(
     t.insert(
         "spans",
         Value::Array(vec![Value::from(simple_span(
-            resource, start, duration, span_id,
+            resource, start, duration, span_id, error,
         ))]),
     );
     t
 }
 
 pub fn simple_trace_event(resource: String) -> TraceEvent {
-    simple_trace_event_detailed(resource, None, None, None)
+    simple_trace_event_detailed(resource, None, None, None, None)
 }
 
 fn validate_simple_span(span: dd_proto::Span, resource: String) {

--- a/tests/data/datadog-traces/conf.yaml
+++ b/tests/data/datadog-traces/conf.yaml
@@ -1,7 +1,0 @@
-
-# "disables" sampling
-apm_config:
-  max_traces_per_second: 999999
-  errors_per_second: 9999999
-  max_memory: 0
-  max_cpu_percent: 0

--- a/tests/data/datadog-traces/conf.yaml
+++ b/tests/data/datadog-traces/conf.yaml
@@ -1,0 +1,7 @@
+
+# "disables" sampling
+apm_config:
+  max_traces_per_second: 999999
+  errors_per_second: 9999999
+  max_memory: 0
+  max_cpu_percent: 0


### PR DESCRIPTION
This is a follow-up PR to https://github.com/vectordotdev/vector/pull/14694 .

This test validates the Aggregation behavior that was missing in the APM stats logic.

Ideally we would have the verification go from [agent -> Vector{agent_source -> traces_sink} -> server] 
, but currently we don't have framework for that.

As a first start, this test just uses the agent in a container to get stats from, and feeds traces into the vector sink that mimics the same behavior as was found to be the bug with the Aggregation- that is, multiple batches of events are processed, with the same bucket start window, and the stats payload should contain the stats for the aggregate of them.

Currently the test takes about 25 seconds to complete.

I've spent the last couple of hours talking with guys from the Agent teams trying to get config options to reduce that.
Still in discussions, so if that manifests into something tangible. I may post another commit to this PR to reduce the overall runtime, hopefully.

### A/B test data:

BEFORE merging in the APM stats PR fix, the hit counts were off because vector is not aggregating.


```
running 1 test
HTTP server for `vector` listening on 0.0.0.0:8081
HTTP server for `agent` listening on 0.0.0.0:8082
sent traces to vector.
`vector` server received and deserialized stats payload.
`vector` server received and deserialized stats payload.
sent a trace to the Agent.
sent a trace to the Agent.
`agent` server received and deserialized stats payload.

agent_stats : ClientGroupedStats { service: "a_service", name: "a_name", resource: "a_resource", http_status_code: 0, type: "a_type", db_type: "", hits: 2, errors: 0, duration: 40, ok_summary: [10, 9, 9, 253, 74, 129, 90, 191, 82, 240, 63, 18, 13, 18, 8, 0, 0, 0, 0, 0, 0, 0, 64, 24, 170, 2, 26, 0], error_summary: [10, 9, 9, 253, 74, 129, 90, 191, 82, 240, 63, 18, 0, 26, 0], synthetics: false, top_level_hits: 2 }

vector_stats : ClientGroupedStats { service: "a_service", name: "a_name", resource: "a_resource", http_status_code: 0, type: "a_type", db_type: "", hits: 1, errors: 0, duration: 20, ok_summary: [10, 18, 9, 0, 0, 0, 0, 0, 64, 240, 63, 17, 0, 0, 0, 0, 0, 232, 148, 64, 18, 14, 10, 12, 8, 246, 23, 17, 0, 0, 0, 0, 0, 0, 240, 63, 26, 0], error_summary: [10, 18, 9, 0, 0, 0, 0, 0, 64, 240, 63, 17, 0, 0, 0, 0, 0, 232, 148, 64, 18, 0, 26, 0], synthetics: false, top_level_hits: 1 }

thread 'sinks::datadog::traces::integration_tests::apm_stats_e2e_test_dd_agent_to_vector_correctness' panicked at 'assertion failed: agent_s.hits == vector_s.hits', src/sinks/datadog/traces/integration_tests.rs:358:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test sinks::datadog::traces::integration_tests::apm_stats_e2e_test_dd_agent_to_vector_correctness ... FAILED

failures:

failures:
    sinks::datadog::traces::integration_tests::apm_stats_e2e_test_dd_agent_to_vector_correctness

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 260 filtered out; finished in 21.28s
```

AFTER merging in the APM stats PR fix:

```
running 1 test
2022-10-06T20:30:06.472797Z  INFO vector::sinks::datadog::traces::integration_tests: HTTP server for `vector` listening on 0.0.0.0:8081
2022-10-06T20:30:06.473097Z  INFO vector::sinks::datadog::traces::integration_tests: HTTP server for `agent` listening on 0.0.0.0:8082
2022-10-06T20:30:14.483440Z  INFO vector::sinks::datadog::traces::integration_tests: Sent traces to vector.
2022-10-06T20:30:14.488497Z  INFO vector::sinks::datadog::traces::integration_tests: `vector` server received and deserialized stats payload.
2022-10-06T20:30:14.490858Z  INFO vector::sinks::datadog::traces::integration_tests: `vector` server received and deserialized stats payload.
2022-10-06T20:30:14.498672Z  INFO vector::sinks::datadog::traces::integration_tests: Sent a trace to the Agent.
2022-10-06T20:30:15.505444Z  INFO vector::sinks::datadog::traces::integration_tests: Sent a trace to the Agent.
2022-10-06T20:30:30.462832Z  INFO vector::sinks::datadog::traces::integration_tests: `agent` server received and deserialized stats payload.
2022-10-06T20:30:30.463314Z  INFO vector::sinks::datadog::traces::integration_tests: 
agent_stats : ClientGroupedStats { service: "a_service", name: "a_name", resource: "a_resource", http_status_code: 0, type: "a_type", db_type: "", hits: 2, errors: 0, duration: 40, ok_summary: [10, 9, 9, 253, 74, 129, 90, 191, 82, 240, 63, 18, 13, 18, 8, 0, 0, 0, 0, 0, 0, 0, 64, 24, 170, 2, 26, 0], error_summary: [10, 9, 9, 253, 74, 129, 90, 191, 82, 240, 63, 18, 0, 26, 0], synthetics: false, top_level_hits: 2 }
2022-10-06T20:30:30.463441Z  INFO vector::sinks::datadog::traces::integration_tests: 
vector_stats : ClientGroupedStats { service: "a_service", name: "a_name", resource: "a_resource", http_status_code: 0, type: "a_type", db_type: "", hits: 2, errors: 0, duration: 40, ok_summary: [10, 18, 9, 0, 0, 0, 0, 0, 64, 240, 63, 17, 0, 0, 0, 0, 0, 232, 148, 64, 18, 14, 10, 12, 8, 246, 23, 17, 0, 0, 0, 0, 0, 0, 0, 64, 26, 0], error_summary: [10, 18, 9, 0, 0, 0, 0, 0, 64, 240, 63, 17, 0, 0, 0, 0, 0, 232, 148, 64, 18, 0, 26, 0], synthetics: false, top_level_hits: 2 }
test sinks::datadog::traces::integration_tests::apm_stats_e2e_test_dd_agent_to_vector_correctness ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 260 filtered out; finished in 23.99s
```