### PR TITLE
fix(observability): add internal_log_rate_limit to `error!` calls

### DIFF
--- a/src/internal_events/amqp.rs
+++ b/src/internal_events/amqp.rs
@@ -36,7 +36,7 @@ pub mod source {
                    error = ?self.error,
                    error_type = error_type::REQUEST_FAILED,
                    stage = error_stage::RECEIVING,
-                   internal_log_rate_secs = 10
+                   internal_log_rate_limit = true,
             );
             counter!(
                 "component_errors_total", 1,
@@ -57,7 +57,7 @@ pub mod source {
                    error = ?self.error,
                    error_type = error_type::ACKNOWLEDGMENT_FAILED,
                    stage = error_stage::RECEIVING,
-                   internal_log_rate_secs = 10
+                   internal_log_rate_limit = true,
             );
             counter!(
                 "component_errors_total", 1,
@@ -78,7 +78,7 @@ pub mod source {
                    error = ?self.error,
                    error_type = error_type::COMMAND_FAILED,
                    stage = error_stage::RECEIVING,
-                   internal_log_rate_secs = 10
+                   internal_log_rate_limit = true,
             );
             counter!(
                 "component_errors_total", 1,
@@ -112,7 +112,7 @@ pub mod sink {
                    error = ?self.error,
                    error_type = error_type::REQUEST_FAILED,
                    stage = error_stage::SENDING,
-                   internal_log_rate_secs = 10
+                   internal_log_rate_limit = true,
             );
             counter!(
                 "component_errors_total", 1,
@@ -139,7 +139,7 @@ pub mod sink {
                    error = ?self.error,
                    error_type = error_type::REQUEST_FAILED,
                    stage = error_stage::SENDING,
-                   internal_log_rate_secs = 10
+                   internal_log_rate_limit = true,
             );
             counter!(
                 "component_errors_total", 1,

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -45,6 +45,7 @@ impl InternalEvent for ApacheMetricsParseError<'_> {
             stage = error_stage::PROCESSING,
             error_type = error_type::PARSER_FAILED,
             endpoint = %self.endpoint,
+            internal_log_rate_limit = true,
         );
         debug!(
             message = %format!("Parse error:\n\n{}\n\n", self.error),
@@ -102,6 +103,7 @@ impl InternalEvent for ApacheMetricsHttpError<'_> {
             stage = error_stage::RECEIVING,
             error_type = error_type::REQUEST_FAILED,
             endpoint = %self.endpoint,
+            internal_log_rate_limit = true,
         );
         counter!("http_request_errors_total", 1);
         counter!(

--- a/src/internal_events/aws_cloudwatch_logs.rs
+++ b/src/internal_events/aws_cloudwatch_logs.rs
@@ -23,6 +23,7 @@ impl InternalEvent for AwsCloudwatchLogsMessageSizeError {
             error_code = "message_too_long",
             error_type = error_type::ENCODER_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/aws_ec2_metadata.rs
+++ b/src/internal_events/aws_ec2_metadata.rs
@@ -25,6 +25,7 @@ impl InternalEvent for AwsEc2MetadataRefreshError {
             error = %self.error,
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/codecs.rs
+++ b/src/internal_events/codecs.rs
@@ -20,6 +20,7 @@ impl<E: std::fmt::Display> InternalEvent for DecoderFramingError<E> {
             error = %self.error,
             error_type = error_type::PARSER_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -42,6 +43,7 @@ impl<'a> InternalEvent for DecoderDeserializeError<'a> {
             error = %self.error,
             error_type = error_type::PARSER_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -70,6 +70,7 @@ impl InternalEvent for StreamClosedError {
             error_code = STREAM_CLOSED,
             error_type = error_type::WRITER_FAILED,
             stage = error_stage::SENDING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -176,6 +176,7 @@ impl InternalEvent for DockerLogsLoggingDriverUnsupportedError<'_> {
             error_type = error_type::CONFIGURATION_FAILED,
             stage = error_stage::RECEIVING,
             container_id = ?self.container_id,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -202,6 +203,7 @@ impl InternalEvent for DockerLogsReceivedOutOfOrderError<'_> {
             stage = error_stage::RECEIVING,
             container_id = ?self.container_id,
             timestamp = ?self.timestamp_str,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/eventstoredb_metrics.rs
+++ b/src/internal_events/eventstoredb_metrics.rs
@@ -15,6 +15,7 @@ impl InternalEvent for EventStoreDbMetricsHttpError {
             error = ?self.error,
             stage = error_stage::RECEIVING,
             error_type = error_type::REQUEST_FAILED,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -38,6 +39,7 @@ impl InternalEvent for EventStoreDbStatsParsingError {
             error = ?self.error,
             stage = error_stage::PROCESSING,
             error_type = error_type::PARSER_FAILED,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -232,9 +232,9 @@ pub struct ExecChannelClosedError;
 
 impl InternalEvent for ExecChannelClosedError {
     fn emit(self) {
-        let reason = "Receive channel closed, unable to send.";
+        let exec_reason = "Receive channel closed, unable to send.";
         error!(
-            message = reason,
+            message = exec_reason,
             error_type = error_type::COMMAND_FAILED,
             stage = error_stage::RECEIVING,
             internal_log_rate_limit = true,
@@ -244,6 +244,6 @@ impl InternalEvent for ExecChannelClosedError {
             "error_type" => error_type::COMMAND_FAILED,
             "stage" => error_stage::RECEIVING,
         );
-        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason: exec_reason });
     }
 }

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -244,6 +244,9 @@ impl InternalEvent for ExecChannelClosedError {
             "error_type" => error_type::COMMAND_FAILED,
             "stage" => error_stage::RECEIVING,
         );
-        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason: exec_reason });
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+            count: 1,
+            reason: exec_reason
+        });
     }
 }

--- a/src/internal_events/gcp_pubsub.rs
+++ b/src/internal_events/gcp_pubsub.rs
@@ -15,6 +15,7 @@ impl InternalEvent for GcpPubsubConnectError {
             error_code = "failed_connecting",
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
 
         counter!(
@@ -38,6 +39,7 @@ impl InternalEvent for GcpPubsubStreamingPullError {
             error_code = "failed_streaming_pull",
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
 
         counter!(
@@ -61,6 +63,7 @@ impl InternalEvent for GcpPubsubReceiveError {
             error_code = "failed_fetching_events",
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
 
         counter!(

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -18,6 +18,7 @@ impl InternalEvent for JournaldInvalidRecordError {
             text = %self.text,
             stage = error_stage::PROCESSING,
             error_type = error_type::PARSER_FAILED,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -41,6 +42,7 @@ impl InternalEvent for JournaldStartJournalctlError {
             error = %self.error,
             stage = error_stage::RECEIVING,
             error_type = error_type::COMMAND_FAILED,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -62,6 +64,7 @@ impl InternalEvent for JournaldReadError {
             error = %self.error,
             stage = error_stage::PROCESSING,
             error_type = error_type::READER_FAILED,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total",
@@ -86,6 +89,7 @@ impl InternalEvent for JournaldCheckpointSetError {
             error = %self.error,
             stage = error_stage::PROCESSING,
             error_type = error_type::IO_FAILED,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -109,6 +113,7 @@ impl InternalEvent for JournaldCheckpointFileOpenError {
             error = %self.error,
             stage = error_stage::RECEIVING,
             error_type = error_type::IO_FAILED,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -72,6 +72,7 @@ impl InternalEvent for KafkaOffsetUpdateError {
             error_code = "kafka_offset_update",
             error_type = error_type::READER_FAILED,
             stage = error_stage::SENDING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -97,6 +98,7 @@ impl InternalEvent for KafkaReadError {
             error_code = "reading_message",
             error_type = error_type::READER_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -162,6 +164,7 @@ impl InternalEvent for KafkaHeaderExtractionError<'_> {
             error_type = error_type::PARSER_FAILED,
             stage = error_stage::RECEIVING,
             header_field = self.header_field,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -65,6 +65,7 @@ impl InternalEvent for KubernetesLogsEventAnnotationError<'_> {
             error_code = ANNOTATION_FAILED,
             error_type = error_type::READER_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/postgresql_metrics.rs
+++ b/src/internal_events/postgresql_metrics.rs
@@ -17,6 +17,7 @@ impl<'a> InternalEvent for PostgresqlMetricsCollectError<'a> {
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::RECEIVING,
             endpoint = %self.endpoint,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -83,6 +83,7 @@ impl InternalEvent for VectorReloadError {
             error_code = "reload",
             error_type = error_type::CONFIGURATION_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -105,6 +106,7 @@ impl InternalEvent for VectorConfigLoadError {
             error_code = "config_load",
             error_type = error_type::CONFIGURATION_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -127,6 +129,7 @@ impl InternalEvent for VectorRecoveryError {
             error_code = "recovery",
             error_type = error_type::CONFIGURATION_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -99,6 +99,7 @@ impl InternalEvent for PrometheusNormalizationError {
             message = reason,
             error_type = error_type::CONVERSION_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -94,9 +94,9 @@ pub struct PrometheusNormalizationError;
 
 impl InternalEvent for PrometheusNormalizationError {
     fn emit(self) {
-        let reason = "Prometheuse metric normalization failed.";
+        let normalization_reason = "Prometheuse metric normalization failed.";
         error!(
-            message = reason,
+            message = normalization_reason,
             error_type = error_type::CONVERSION_FAILED,
             stage = error_stage::PROCESSING,
             internal_log_rate_limit = true,
@@ -106,6 +106,9 @@ impl InternalEvent for PrometheusNormalizationError {
             "error_type" => error_type::CONVERSION_FAILED,
             "stage" => error_stage::PROCESSING,
         );
-        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+            count: 1,
+            reason: normalization_reason
+        });
     }
 }

--- a/src/internal_events/pulsar.rs
+++ b/src/internal_events/pulsar.rs
@@ -21,6 +21,7 @@ impl InternalEvent for PulsarSendingError {
             error = %self.error,
             error_type = error_type::REQUEST_FAILED,
             stage = error_stage::SENDING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -115,6 +115,7 @@ impl<'a> InternalEvent for SocketReceiveError<'a> {
             error_code = "receiving_data",
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
             %mode,
         );
         counter!(

--- a/src/internal_events/udp.rs
+++ b/src/internal_events/udp.rs
@@ -26,6 +26,7 @@ impl<E: std::error::Error> InternalEvent for UdpSocketConnectionError<E> {
             error_code = "connection",
             error_type = error_type::READER_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -50,6 +51,7 @@ impl InternalEvent for UdpSocketError {
             error = %self.error,
             error_type = error_type::READER_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/unix.rs
+++ b/src/internal_events/unix.rs
@@ -32,6 +32,7 @@ impl<E: std::error::Error> InternalEvent for UnixSocketConnectionError<'_, E> {
             error_code = "connection",
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -58,6 +59,7 @@ impl<E: std::fmt::Display> InternalEvent for UnixSocketError<'_, E> {
             path = ?self.path,
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -84,6 +86,7 @@ impl<'a> InternalEvent for UnixSocketFileDeleteError<'a> {
             error_code = "delete_socket_file",
             error_type = error_type::WRITER_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/websocket.rs
+++ b/src/internal_events/websocket.rs
@@ -33,6 +33,7 @@ impl InternalEvent for WsConnectionFailedError {
             error_code = "ws_connection_error",
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::SENDING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,
@@ -74,6 +75,7 @@ impl InternalEvent for WsConnectionError {
             error_code = "ws_connection_error",
             error_type = error_type::WRITER_FAILED,
             stage = error_stage::SENDING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,

--- a/src/internal_events/windows.rs
+++ b/src/internal_events/windows.rs
@@ -99,6 +99,7 @@ impl<'a> InternalEvent for WindowsServiceDoesNotExistError<'a> {
             error_code = "service_missing",
             error_type = error_type::CONDITION_FAILED,
             stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
         );
         counter!(
             "component_errors_total", 1,


### PR DESCRIPTION
This adds a `internal_log_rate_limit = true` to a bunch of `error!` calls in internal_metrics that were missing them.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
