### PR TITLE
fix(vrl): allow tabs to be used as delimiter in parse_key_value

### DIFF
--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -11,7 +11,7 @@ use nom::{
     character::complete::{char, satisfy, space0},
     combinator::{eof, map, opt, peek, recognize, rest, verify},
     error::{ContextError, ParseError, VerboseError},
-    multi::{many1, many_m_n, separated_list1, many0},
+    multi::{many0, many1, many_m_n, separated_list1},
     sequence::{delimited, preceded, terminated, tuple},
     IResult,
 };

--- a/lib/vrl/stdlib/src/parse_key_value.rs
+++ b/lib/vrl/stdlib/src/parse_key_value.rs
@@ -11,7 +11,7 @@ use nom::{
     character::complete::{char, satisfy, space0},
     combinator::{eof, map, opt, peek, recognize, rest, verify},
     error::{ContextError, ParseError, VerboseError},
-    multi::{many1, many_m_n, separated_list1},
+    multi::{many1, many_m_n, separated_list1, many0},
     sequence::{delimited, preceded, terminated, tuple},
     IResult,
 };
@@ -309,7 +309,7 @@ fn parse_field_delimiter<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         if field_delimiter == " " {
             map(many1(tag(field_delimiter)), |_| " ")(input)
         } else {
-            preceded(space0, tag(field_delimiter))(input)
+            preceded(many0(tag(" ")), tag(field_delimiter))(input)
         }
     }
 }
@@ -608,6 +608,12 @@ mod test {
             ]),
             parse("foo:bar ,   foobar   ", ":", ",", Whitespace::Strict, true)
         );
+    }
+
+    #[test]
+    fn test_parse_tab_delimiter() {
+        let res = parse_field_delimiter::<VerboseError<&str>>("\t")(" \tzonk");
+        assert_eq!(("zonk", "\t"), res.unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Closes #14630 

This fixes an issue where a tab could not be used as a delimiter in `parse_key_value`. 

The issue was caused because it was looking for the delimiter with:

```rust
        preceded(space0, tag(field_delimiter))(input)     
```

`space0` consumes tab characters as well as spaces, so the `tag(field_delimiter)` was not finding the tab.

This PR changes `space0` to `many0(tag(" "))` which searches exclusively for spaces and not tabs.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

