### PR TITLE
fix(vrl): fix closure block type calculation

### DIFF
--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -509,7 +509,6 @@ impl<'a> Builder<'a> {
 
             // Check the type definition of the resulting block.This needs to match
             // whatever is configured by the closure input type.
-            let block_type_def = block.type_info(state).result;
             let expected_kind = input.output.into_kind();
             if !expected_kind.is_superset(block_type_def.kind()) {
                 return Err(Error::ReturnTypeMismatch {

--- a/lib/vrl/tests/tests/issues/14796_closure_type_def.vrl
+++ b/lib/vrl/tests/tests/issues/14796_closure_type_def.vrl
@@ -1,0 +1,3 @@
+# Testing to make sure this compiles.
+# result: {}
+. = map_keys(., recursive: false) -> |key| { key }


### PR DESCRIPTION
closes https://github.com/vectordotdev/vector/issues/14796

Small fix for closures. The block type of a closure was being recalculated after the closure parameters were removed from the type. The correct type already exists, so that one is used instead.