### PR TITLE
fix(tests): Work around race condition initializing test metrics

### DIFF
--- a/benches/metrics_snapshot.rs
+++ b/benches/metrics_snapshot.rs
@@ -18,7 +18,7 @@ fn benchmark(c: &mut Criterion) {
 }
 
 fn prepare_metrics(cardinality: usize) -> &'static vector::metrics::Controller {
-    let _ = vector::metrics::init_test();
+    vector::metrics::init_test();
     let controller = vector::metrics::Controller::get().unwrap();
     controller.reset();
 

--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -107,13 +107,18 @@ pub fn init_global() -> Result<()> {
     init(VectorRecorder::new_global())
 }
 
-/// Initialize the thread-local metrics sub-system
-///
-/// # Errors
-///
-/// This function will error if it is called multiple times.
-pub fn init_test() -> Result<()> {
-    init(VectorRecorder::new_test())
+/// Initialize the thread-local metrics sub-system. This function will loop until a recorder is
+/// actually set.
+pub fn init_test() {
+    if init(VectorRecorder::new_test()).is_err() {
+        // The only error case returned by `init` is `AlreadyInitialized`. A race condition is
+        // possible here: if metrics are being initialized by two (or more) test threads
+        // simultaneously, the ones that fail to set return immediately, possibly allowing
+        // subsequent code to execute before the static recorder value is actually set within the
+        // `metrics` crate. To prevent subsequent code from running with an unset recorder, loop
+        // here until a recorder is available.
+        while metrics::try_recorder().is_none() {}
+    }
 }
 
 impl Controller {
@@ -248,20 +253,14 @@ mod tests {
     const IDLE_TIMEOUT: f64 = 0.5;
 
     fn init_metrics() -> &'static Controller {
-        if let Err(error) = init_test() {
-            assert!(
-                error == Error::AlreadyInitialized,
-                "Failed to initialize metrics recorder: {:?}",
-                error
-            );
-        }
+        init_test();
         Controller::get().expect("Could not get global metrics controller")
     }
 
     #[test]
     fn cardinality_matches() {
         for cardinality in [0, 1, 10, 100, 1000, 10000] {
-            let _ = init_test();
+            init_test();
             let controller = Controller::get().unwrap();
             controller.reset();
 
@@ -288,6 +287,20 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn handles_registered_metrics() {
+        let controller = init_metrics();
+
+        let counter = metrics::register_counter!("test7");
+        assert_eq!(controller.capture_metrics().len(), 3);
+        counter.increment(1);
+        assert_eq!(controller.capture_metrics().len(), 3);
+        let gauge = metrics::register_gauge!("test8");
+        assert_eq!(controller.capture_metrics().len(), 4);
+        gauge.set(1.0);
+        assert_eq!(controller.capture_metrics().len(), 4);
     }
 
     #[test]

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -403,7 +403,7 @@ mod tests {
     }
 
     async fn emit_and_test(make_event: impl FnOnce(DateTime<Utc>) -> Event) {
-        let _ = metrics::init_test();
+        metrics::init_test();
         let (mut sender, _stream) = SourceSender::new_test();
         let millis = thread_rng().gen_range(10..10000);
         let timestamp = Utc::now() - Duration::milliseconds(millis);

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -130,12 +130,7 @@ pub fn trace_init() {
     trace::init(color, false, &levels, 10);
 
     // Initialize metrics as well
-    if let Err(error) = vector_core::metrics::init_test() {
-        // Handle multiple initializations.
-        if error != vector_core::metrics::Error::AlreadyInitialized {
-            panic!("Failed to initialize metrics recorder: {:?}", error);
-        }
-    }
+    vector_core::metrics::init_test();
 }
 
 pub async fn send_lines(

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -77,7 +77,7 @@ mod tests {
     // Initialize the metrics system.
     fn init_metrics() -> oneshot::Sender<()> {
         vector::trace::init(true, true, "info");
-        let _ = vector::metrics::init_test();
+        vector::metrics::init_test();
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
         tokio::spawn(async move {

--- a/tests/enterprise.rs
+++ b/tests/enterprise.rs
@@ -60,7 +60,7 @@ fn get_root_opts(config_path: PathBuf) -> RootOpts {
 /// without prior approval.
 #[tokio::test]
 async fn vector_continues_on_reporting_error() {
-    let _ = vector::metrics::init_test();
+    vector::metrics::init_test();
 
     let server = build_test_server_error_and_recover(StatusCode::NOT_IMPLEMENTED).await;
     let endpoint = server.uri();
@@ -99,7 +99,7 @@ async fn vector_continues_on_reporting_error() {
 
 #[tokio::test]
 async fn vector_does_not_start_with_enterprise_misconfigured() {
-    let _ = vector::metrics::init_test();
+    vector::metrics::init_test();
 
     let server = build_test_server_error_and_recover(StatusCode::NOT_IMPLEMENTED).await;
     let endpoint = server.uri();


### PR DESCRIPTION
A race condition is possible when initializing the test metrics recorder. If metrics are being initialized by two (or more) test threads simultaneously, the ones that fail to set return immediately, possibly allowing subsequent code to execute before the static recorder value is actually set within the `metrics` crate. To prevent subsequent code from running with an unset recorder, loop until a recorder is available.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
