### PR TITLE
enhancement(reduce transform): Add max_events option

### DIFF
--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -399,7 +399,7 @@ impl Reduce {
                     let mut state = ReduceState::new();
                     state.add_event(event, &self.merge_strategies);
                     state.flush().into()
-                },
+                }
             })
         } else {
             self.push_or_new_reduce_state(event, discriminant)

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -705,7 +705,8 @@ merge_strategies.id = "retain"
 merge_strategies.message = "array"
                 max_events = 3
             "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_transform_compliance(async move {
             let (tx, rx) = mpsc::channel(1);
@@ -729,15 +730,28 @@ merge_strategies.message = "array"
             let mut e_6 = LogEvent::from("test 6");
             e_6.insert("id", "1");
 
-            for event in vec![e_1.into(), e_2.into(), e_3.into(), e_4.into(), e_5.into(), e_6.into()] {
+            for event in vec![
+                e_1.into(),
+                e_2.into(),
+                e_3.into(),
+                e_4.into(),
+                e_5.into(),
+                e_6.into(),
+            ] {
                 tx.send(event).await.unwrap();
             }
 
             let output_1 = out.recv().await.unwrap().into_log();
-            assert_eq!(output_1["message"], vec!["test 1", "test 2", "test 3"].into());
+            assert_eq!(
+                output_1["message"],
+                vec!["test 1", "test 2", "test 3"].into()
+            );
 
             let output_2 = out.recv().await.unwrap().into_log();
-            assert_eq!(output_2["message"], vec!["test 4", "test 5", "test 6"].into());
+            assert_eq!(
+                output_2["message"],
+                vec!["test 4", "test 5", "test 6"].into()
+            );
 
             drop(tx);
             topology.stop().await;

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -330,11 +330,7 @@ impl Reduce {
             .map(|c| c.build(enrichment_tables))
             .transpose()?;
         let group_by = config.group_by.clone().into_iter().collect();
-        let max_events = if let Some(max) = config.max_events {
-            Some(max.into())
-        } else {
-            None
-        };
+        let max_events = config.max_events.map(|max| max.into());
 
         Ok(Reduce {
             expire_after: config.expire_after_ms,
@@ -715,7 +711,7 @@ max_events = 0
         );
 
         match reduce_config {
-            Ok(_conf) => assert!(false, "max_events=0 should be rejected."),
+            Ok(_conf) => unreachable!("max_events=0 should be rejected."),
             Err(err) => assert!(err.to_string().contains(
                 "invalid value: integer `0`, expected a nonzero usize for key `max_events`"
             )),

--- a/website/cue/reference/components/transforms/base/reduce.cue
+++ b/website/cue/reference/components/transforms/base/reduce.cue
@@ -22,14 +22,6 @@ base: components: transforms: reduce: configuration: {
 			unit:    "milliseconds"
 		}
 	}
-	max_events: {
-		common:      false
-		description: "The maximum number of events to group together."
-		required:    false
-		type: uint: {
-			default: null
-		}
-	}
 	flush_period_ms: {
 		description: "The interval to check for and flush any expired events, in milliseconds."
 		required:    false
@@ -54,6 +46,11 @@ base: components: transforms: reduce: configuration: {
 			default: []
 			items: type: string: examples: ["request_id", "user_id", "transaction_id"]
 		}
+	}
+	max_events: {
+		description: "The maximum number of events to group together."
+		required:    false
+		type: uint: {}
 	}
 	merge_strategies: {
 		description: """

--- a/website/cue/reference/components/transforms/base/reduce.cue
+++ b/website/cue/reference/components/transforms/base/reduce.cue
@@ -22,6 +22,14 @@ base: components: transforms: reduce: configuration: {
 			unit:    "milliseconds"
 		}
 	}
+	max_events: {
+		common:      false
+		description: "The maximum number of events to group together."
+		required:    false
+		type: uint: {
+			default: null
+		}
+	}
 	flush_period_ms: {
 		description: "The interval to check for and flush any expired events, in milliseconds."
 		required:    false


### PR DESCRIPTION
This adds a `max_events` configuration option for `reduce` transforms to put an upper bound on the number of events a single grouping will combine https://github.com/vectordotdev/vector/issues/3027