### PR TITLE
docs(enriching): document enrichment table `type` field

### DIFF
--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -110,6 +110,13 @@ configuration: {
 				"""
 			required:    false
 			type: object: options: {
+				type: string: {
+					default: null
+					enum: {
+						"file":  "Enrich data from a CSV file."
+						"geoip": "Enrich data from a [MaxMind](\(urls.maxmind)) database."
+					}
+				}
 				file: {
 					required:    true
 					description: "Configuration options for the file that provides the enrichment table."

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -110,11 +110,16 @@ configuration: {
 				"""
 			required:    false
 			type: object: options: {
-				type: string: {
-					default: null
-					enum: {
-						"file":  "Enrich data from a CSV file."
-						"geoip": "Enrich data from a [MaxMind](\(urls.maxmind)) database."
+				type: {
+					description: """
+						Determines the type of enrichment data that is to be loaded.
+						"""
+					required: true
+					type: string: {
+						enum: {
+							"file":  "Enrich data from a CSV file."
+							"geoip": "Enrich data from a [MaxMind](\(urls.maxmind)) database."
+						}
 					}
 				}
 				file: {


### PR DESCRIPTION
Closes #14378 

This adds documentation for the `type` field in enrichment tables.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>