### PR TITLE
chore(core): RFC for enhanced metric tags storage

### DIFF
--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -2,7 +2,7 @@
 
 Vector's current metric model supports only a single value for each tag. Several sources, however,
 however, may send metrics that contain multiple values for a given tag name, or bare tags with no
-value. Vectors tag support should be enhanced to handle this data.
+value. Vector's tag support should be enhanced to handle this data.
 
 ## Context
 
@@ -91,9 +91,9 @@ duplicate values will also cause the duplicate to be dropped and a warning issue
 
 Examples:
 
-```vrl
-.tags.single_value = "value"
-.tags.bare_tag = null
+```coffee
+.tags.single_value = "value" # Same as ["value"], will produce a deprecation warning.
+.tags.bare_tag = null        # Same as [null],  will produce a deprecation warning.
 .tags.multi_valued_tag = ["value1", "value2"]
 .tags.complex_tag = ["value3", null]
 .tags.modified = push(.tags.modified, "value4")

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -42,7 +42,8 @@ Simply put, the tags representation will change from an alias into a newtype wra
 `indexmap` set to store the tag values. This newtype will hide the implementation details of the
 underlying storage from the callers. It will also add separate methods for inserting a new tag and
 replacing a tag set with a single value. The callers of the existing `insert` function will need to
-be audited to determine which use is intended at each call site.
+be audited to determine which use is intended at each call site. The tag values themselves are
+stored as optional strings, in which the `None` value represents a bare tag.
 
 ```rust
 type TagValue = Option<String>;

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -64,6 +64,7 @@ compatibility for existing uses while controlling the methods for uses that need
 values.
 
 The use of an `IndexSet` for the tag value provides us with two useful invariants:
+
 1. Only unique values for each tag will be stored, which prevents repeated values from showing up in
    the output.
 1. The values can be retrieved in the order they first appeared, which allows us to trivially
@@ -128,9 +129,9 @@ type MetricTags = MultiIndexTagMap;
 
 ## Outstanding Questions
 
-- VRL doesn't have any way of _adding_ a tag to a metric, only replacing or deleting, nor does it
-  really have support for creating bare tags. Does it need additional functions to match this
-  support?
+- VRL doesn't have any way of _adding_ a tag to a metric when a tag with the same name already
+  exists, only replacing or deleting, nor does it really have support for creating bare tags nor
+  retrieving all the values of a tag name. Does it need additional functions to match this support?
 
 ## Plan Of Attack
 

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -291,15 +291,20 @@ type MetricTags = MultiIndexTagMap;
 
 Incremental steps to execute this change. These will be converted to issues after the RFC is approved:
 
-- [ ] Convert the `MetricTags` alias to a newtype wrapper
-- [ ] Convert the `MetricTags` type to new storage as above
-- [ ] Audit all uses of `MetricTags::insert` to see which should do a replace
+- [X] Convert the `MetricTags` alias to a newtype wrapper
+- [ ] Convert the `MetricTags` type to new storage as above but expose as single tags
+- [ ] Introduce insert/replace distinction and audit all uses
 - [ ] Update the native protobuf encoding
 - [ ] Update the native JSON encoding
-- [ ] Update the `lua` transform to support multi-value tags
-- [ ] Update VRL to support multi-value tags
-- [ ] Add multi-value tag support to the `log_to_metric` transform
+- [ ] Update the `lua` transform to support multi-valued tags
+- [ ] Update VRL to support multi-valued tags
+- [ ] Update metric sources that could receive multi-valued tags
+- [ ] Update metric sinks to emit multi-valued tags
+- [ ] Add multi-valued tag support to the `log_to_metric` transform
 - [ ] Update the `tag_cardinality_limit` transform for multi-valued tags
+- [ ] Add deprecation warnings for single-valued tags behavior (Lua and VRL)
+- [ ] Change optional behavior to multi-valued tags (Lua and VRL)
+- [ ] Drop single-valued tags support (Lua and VRL)
 
 ## Future Improvements
 

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -28,12 +28,12 @@ that Vector's data model cannot currently represent. This is causing problems fo
 that want to add Vector to their observability pipelines but cannot do so because it would cause
 data loss. Those sources include:
 
-* `datadog_agent` natively stores tags as bare strings, with optional values separated from the name
+- `datadog_agent` natively stores tags as bare strings, with optional values separated from the name
   by a colon.
-* The Prometheus text encoding used by the `prometheus_scrape` source and `prometheus_exporter` sink
+- The Prometheus text encoding used by the `prometheus_scrape` source and `prometheus_exporter` sink
   can support both repeated tag names and bare tags (without a value).
-* The Prometheus `remote_write` encoding similarly supports repeated tag names.
-* OpenTelemetry attributes support keys having arrays of values, which corresponds to repeated tags.
+- The Prometheus `remote_write` encoding similarly supports repeated tag names.
+- OpenTelemetry attributes support keys having arrays of values, which corresponds to repeated tags.
 
 ## Proposal
 

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -118,15 +118,23 @@ stored as optional strings, in which the `None` value represents a bare tag.
 ```rust
 type TagValue = Option<String>;
 
-struct MetricTags(BTreeMap<String, indexmap::IndexSet<TagValue>>);
+struct TagValueSet(indexmap::IndexSet<TagValue>);
+
+struct MetricTags(BTreeMap<String, TagValueSet>);
 
 impl MetricTags {
-    // Insert returns the value unchanged if the exact (tag,value) pair already exists,
-    // otherwise it inserts a new value for the named tag.
+    /// Insert returns the value unchanged if the exact (tag,value) pair already exists,
+    /// otherwise it inserts a new value for the named tag.
     fn insert(&mut self, name: String, value: TagValue) -> Option<TagValue>;
 
-    // Replace returns all the existing values when overwriting a tag.
-    fn replace(&mut self, name: String, value: Option<TagValue>) -> Option<IndexSet<TagValue>>;
+    /// Replace returns all the existing values when overwriting a tag.
+    fn replace(&mut self, name: String, value: Option<TagValue>) -> Option<TagValueSet>;
+
+    /// Remove a single value of a tag.
+    fn remove(&mut self, name: &str, value: Option<&str>) -> Option<TagValue>;
+
+    /// Remove all values for a tag name.
+    fn remove_all(&mut self, name: &str) -> Option<TagValueSet>;
 }
 ```
 

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -96,6 +96,8 @@ Examples:
 .tags.bare_tag = null
 .tags.multi_valued_tag = ["value1", "value2"]
 .tags.complex_tag = ["value3", null]
+.tags.modified = push(.tags.modified, "value4")
+.tags.modified = filter(.tags.modified) -> |_, v| { v != "remove" }
 ```
 
 ##### Lua
@@ -150,6 +152,9 @@ impl MetricTags {
 
     /// Replace returns all the existing values when overwriting a tag.
     fn replace(&mut self, name: String, value: Option<TagValue>) -> Option<TagValueSet>;
+
+    /// Replace an entire tag set with the given value set, returning existing values.
+    fn replace_all(&mut self, name: String, values: TagValueSet) -> Option<TagValueSet>;
 
     /// Remove a single value of a tag.
     fn remove(&mut self, name: &str, value: Option<&str>) -> Option<TagValue>;

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -332,7 +332,7 @@ Incremental steps to execute this change. These will be converted to issues afte
 - [ ] Add multi-valued tag support to the `log_to_metric` transform
 - [ ] Update the `tag_cardinality_limit` transform for multi-valued tags
 - [ ] Add deprecation warnings for single-valued tags behavior (Lua and VRL)
-- [ ] Change optional behavior to multi-valued tags (Lua and VRL)
+- [ ] Change default behavior to multi-valued tags (Lua and VRL)
 - [ ] Drop single-valued tags support (Lua and VRL)
 
 ## Future Improvements
@@ -340,6 +340,11 @@ Incremental steps to execute this change. These will be converted to issues afte
 Most often, tags will only have a single value instead of an array. This suggests that an
 implementation that stores tag values as an enum switching between a simple `TagValue` and the above
 `IndexMap` would be more efficient for memory consumption and likely be more efficient for CPU time.
+
+Since tags will most often only have a single value, we may not want to change the default behavior
+of Lua and VRL to use multi-valued tags, as it represents a regression in user experience, and so
+also not remove the single value support. This will be determined after we start the deprecation
+process.
 
 We could also investigate reworking the storage based on `BTreeMap<String>`. This would allow us to
 avoid splitting tag strings in two pieces, reducing allocations and overhead, at the cost of

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -1,6 +1,6 @@
 # RFC 14742 - Support for Duplicate and Bare Tags on Metrics
 
-Vector's current metric model supports only a single value for each tag. The `datadog_agent` source,
+Vector's current metric model supports only a single value for each tag. Several sources, however,
 however, may send metrics that contain multiple values for a given tag name, or bare tags with no
 value. Vectors tag support should be enhanced to handle this data.
 
@@ -14,8 +14,8 @@ value. Vectors tag support should be enhanced to handle this data.
 
 ### In scope
 
-- Changes to the existing metric tag internal and external representation to support multiple values
-  and bare tags.
+- Changes to the existing metric tag internal and external representations to support multiple
+  values and bare tags.
 
 ### Out of scope
 
@@ -23,9 +23,17 @@ value. Vectors tag support should be enhanced to handle this data.
 
 ## Pain
 
-When ingesting data from a Datadog agent, the metric tags provided by that source may contain data
-that Vector's data model cannot represent. This is causing problems for prospective users that want
-to add Vector to their observability pipelines but cannot do so because it would cause data loss.
+When ingesting data from certain metric sources, the tags provided by that source may contain data
+that Vector's data model cannot currently represent. This is causing problems for prospective users
+that want to add Vector to their observability pipelines but cannot do so because it would cause
+data loss. Those sources include:
+
+* `datadog_agent` natively stores tags as bare strings, with optional values separated from the name
+  by a colon.
+* The Prometheus text encoding used by the `prometheus_scrape` source and `prometheus_exporter` sink
+  can support both repeated tag names and bare tags (without a value).
+* The Prometheus `remote_write` encoding similarly supports repeated tag names.
+* OpenTelemetry attributes support keys having arrays of values, which corresponds to repeated tags.
 
 ## Proposal
 

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -106,6 +106,27 @@ script is under complete control of the data between starting the script and emi
 cannot issue warnings about how assignments to the tags are made. Instead, the resulting tags data
 will be parsed using the same algorithm as the native JSON encoding above.
 
+#### `log_to_metric` Transform
+
+The `log_to_metric` transform is configured with a set of tags for the output metrics. Existing
+configurations with single value assignments will continue to work as they are currently
+written. Support will be added for assignments of arrays to produce multi-valued tags and null
+values to produce bare tags. As TOML does not support null values, the latter will be only be
+supported in YAML and JSON configuration.
+
+#### `tag_cardinality_limit` Transform
+
+The `tag_cardinality_limit` transform tracks all values of tags, dropping either individual tags or
+whole events when the cardinality exceeds a configured limit. There are three ways this will be
+supported in the presence of multi-valued tags, which will be selectable with configuration options:
+
+1. The individual values are tracked as before. Events are dropped when any one tag's cardinality
+   exceeds the limit, but only the tags that would exceed the limit are dropped.
+1. The individual values are tracked as before. Events are dropped when any one tag's cardinality
+   exceeds the limit, and all values of tags that would exceed the limit are dropped.
+1. Values of multi-valued tags are combined before tracking. Events are dropped as before and all
+   values of tags that would exceed the limit are dropped.
+
 ### Implementation
 
 Simply put, the tags representation will change from an alias into a newtype wrapper using an

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -282,6 +282,12 @@ Incremental steps to execute this change. These will be converted to issues afte
 - [ ] Convert the `MetricTags` alias to a newtype wrapper
 - [ ] Convert the `MetricTags` type to new storage as above
 - [ ] Audit all uses of `MetricTags::insert` to see which should do a replace
+- [ ] Update the native protobuf encoding
+- [ ] Update the native JSON encoding
+- [ ] Update the `lua` transform to support multi-value tags
+- [ ] Update VRL to support multi-value tags
+- [ ] Add multi-value tag support to the `log_to_metric` transform
+- [ ] Update the `tag_cardinality_limit` transform for multi-valued tags
 
 ## Future Improvements
 

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -1,0 +1,147 @@
+# RFC 14742 - Support for Duplicate and Bare Tags on Metrics
+
+Vector's current metric model supports only a single value for each tag. The `datadog_agent` source,
+however, may send metrics that contain multiple values for a given tag name, or bare tags with no
+value. Vectors tag support should be enhanced to handle this data.
+
+## Context
+
+- [Support duplicate tag and bare tags on metrics](https://github.com/vectordotdev/vector/issues/14742)
+- [DataDog Source -> Filter Transform -> DataDog Sink dropping kube_service tag](https://github.com/vectordotdev/vector/issues/14707)
+- [Invalid custom_tags metrics from sinks datadog_metric](https://github.com/vectordotdev/vector/issues/14239)
+
+## Scope
+
+### In scope
+
+- Changes to the existing metric tag internal and external representation to support multiple values
+  and bare tags.
+
+### Out of scope
+
+- Changes to any other aspect of metric or event representations.
+
+## Pain
+
+When ingesting data from a Datadog agent, the metric tags provided by that source may contain data
+that Vector's data model cannot represent. This is causing problems for prospective users that want
+to add Vector to their observability pipelines but cannot do so because it would cause data loss.
+
+## Proposal
+
+### User Experience
+
+This change should be effectively invisible to users of Vector, except for incoming data with
+multiple tags with the same name, which will now have all the tags reproduced when it reaches sinks.
+
+### Implementation
+
+Simply put, the tags representation will change from an alias into a newtype wrapper using an
+`indexmap` set to store the tag values:
+
+```rust
+struct MetricTags(BTreeMap<String, indexmap::IndexSet<Option<String>>>);
+```
+
+This newtype will hide the implementation details of the underlying storage from the callers. It
+will also add separate methods for inserting a new tag and replacing a tag set with a single
+value. The callers of the existing `insert` function will need to be audited to determine which use
+is intended at each call site.
+
+## Rationale
+
+Changing the `MetricTags` type from an alias to a newtype wrapper allows us to provide better
+compatibility for existing uses while controlling the methods for uses that need to access all the
+values.
+
+The use of an `IndexSet` for the tag value provides us with two useful invariants:
+1. Only unique values for each tag will be stored, which prevents repeated values from showing up in
+   the output.
+1. The values can be retrieved in the order they first appeared, which allows us to trivially
+   retrieve either the first or last stored value.
+
+- Why is this change worth it?
+- What is the impact of not doing this?
+- How does this position us for success in the future?
+
+## Drawbacks
+
+Metrics sinks that only support a single value per tag will need to be reworked accordingly for the
+new value type. Additionally, these sinks may change their behavior for sources that have been
+producing multiple tag values.
+
+## Prior Art
+
+The Datadog agent stores metric tags as a simple set of strings, equivalent to `HashSet<String>`. It
+does some clever hashing and deduplication internally to make this work efficiently. However, it
+doesn't do anything more interesting with the tags than adding and removing whole strings, which
+does not cover all our use cases.
+
+## Alternatives
+
+The Datadog agent represents the tags as a simple set of strings, ie `HashSet<String>` or
+`BTreeSet<String>`, where the key/value implications are just an interpretation detail for
+consumers. This is by far the simplest possible storage. However, Vector needs to be able to access
+tags by name for manipulation, making this representation more challenging. Through clever use of
+`BTreeSet::range` and a wrapper type for the tags, this could be made to work, but it is unclear if
+the benefits would be worth the additional complexity.
+
+When retaining `BTreeMap` as the top-level container, there are a number of options for the value
+that would support this feature but with different semantics:
+
+1. `Vec<String>` — Retains the ordering of tags as they appear, but allows for duplicate values and
+   cannot support both bare tags and multiple values simultaneously.
+1. `Vec<Option<String>>` — Same as above but supports bare tags and mutiple values simultaneously.
+1. `BTreeSet<Option<String>>` — Duplicate values are merged but are sorted, likely putting the bare
+   tag first for single-value uses.
+
+There are also at least two other container types that could possibly support this use case:
+
+[multimap](https://docs.rs/multimap/latest/multimap/) is a wrapper around a `HashMap` with a `Vec`
+in the value position. However, it does not sort the keys on retrieval, which changes the ordering
+guarantee that `BTreeMap` is currently providing.
+
+```rust
+type MetricTags = multimap::MultiMap<String, Option<String>>;
+```
+
+[multi_index_map](https://crates.io/crates/multi_index_map) supports both ordering of the tag names
+and multiple values. It is not clear, however, if there is any way to control for unique values for
+the same name without also preventing the same value appearing in different tags, nor how those
+values would be ordered.
+
+```rust
+#[derive(MultiIndexMap, Clone, Debug)]
+struct Tag {
+    #[multi_index(ordered_non_unique)]
+    name: String,
+    value: Option<String>,
+}
+
+type MetricTags = MultiIndexTagMap;
+```
+
+## Outstanding Questions
+
+- VRL doesn't have any way of _adding_ a tag to a metric, only replacing or deleting, nor does it
+  really have support for creating bare tags. Does it need additional functions to match this
+  support?
+
+## Plan Of Attack
+
+Incremental steps to execute this change. These will be converted to issues after the RFC is approved:
+
+- [ ] Convert the `MetricTags` alias to a newtype wrapper
+- [ ] Convert the `MetricTags` type to new storage as above
+- [ ] Audit all uses of `MetricTags::insert` to see which should do a replace
+
+## Future Improvements
+
+As referenced above, once the initial implementation is complete, we could rework the storage based
+on `BTreeMap<String>`. This would allow us to avoid splitting tag strings in two pieces, reducing
+allocations and overhead, at the cost of increased complexity when accessing a particular named tag.
+
+Metric tag sets are most often repeated a great number of times across different metrics. This
+suggests that a shared copy-on-write storage scheme where the individual metrics would contain just
+a handle to the shared value. This would improve Vector's memory efficience at least, and possibly
+run-time performance as well.

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -81,7 +81,7 @@ Both the Lua and VRL scripting languages will be given a new configuration optio
 `metric_tags_values` that controls how tag values are exposed to scripts. This may take two values,
 `"single"` or `"full"`. When set to the former, tag values will be exposed as single strings, the
 same as they are now. Tags with multiple values will show the last assigned value, and null values
-will be ignored. When set to the later, all tags will be exposed as arrays of either string or null
+will be ignored. When set to the latter, all tags will be exposed as arrays of either string or null
 values.  This control will initially default to the former setting, providing for backwards
 compatibility, but that default will later be deprecated and change to the latter. In both cases,
 assignment to a tag will overwrite all other values for the tag, and deleting a tag name or
@@ -127,6 +127,13 @@ supported in the presence of multi-valued tags, which will be selectable with co
    exceeds the limit, and all values of tags that would exceed the limit are dropped.
 1. Values of multi-valued tags are combined before tracking. Events are dropped as before and all
    values of tags that would exceed the limit are dropped.
+
+#### Sinks
+
+Vector has a number of sinks that can encode metrics. These will need to be audited to determine
+which sinks are limited to single-valued tags and which can accept the full multi-valued tags. The
+former will receive only the last value of any multi-valued tag, and will emit a new rate-limited
+warning when doing so. The latter will be upgraded to encode multi-valued tags appropriately.
 
 ### Implementation
 


### PR DESCRIPTION
Ref #14742 #14707

[Rendered preview](https://github.com/vectordotdev/vector/blob/bruceg/metric-tags-rfc/rfcs/2022-10-12-14742-flexible-metric-tags.md)
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
