### PR TITLE
fix(amqp source): Fix `byte_size` in `EventsReceived` internal event in `amqp` source

### DIFF
--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -28,6 +28,7 @@ use vector_config::configurable_component;
 use vector_core::{
     config::{AcknowledgementsConfig, LogNamespace},
     event::Event,
+    ByteSizeOf,
 };
 
 #[derive(Debug, Snafu)]
@@ -269,7 +270,7 @@ async fn receive_event(
                     });
 
                     emit!(EventsReceived {
-                        byte_size: byte_size,
+                        byte_size: events.size_of(),
                         count: events.len(),
                     });
 


### PR DESCRIPTION
I did a quick audit on the usage of the `EventsReceived` internal event in our sources.

The `amqp` source reports the byte size of the incoming frame, rather than our calculation of the event byte size.