### PR TITLE
chore(socket source): Fix duplicate `internal_log_rate_limit` attribute

### DIFF
--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -115,7 +115,6 @@ impl<'a> InternalEvent for SocketReceiveError<'a> {
             error_code = "receiving_data",
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::RECEIVING,
-            internal_log_rate_limit = true,
             %mode,
             internal_log_rate_limit = true,
         );


### PR DESCRIPTION
This origined from a bad merge in #14511 I did on top of #14765.