### PR TITLE
chore!(vrl): Call `parse_groks` in implementation of `parse_grok`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,16 +3181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "grok"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273797968160270573071022613fc4aa28b91fe68f3eef6c96a1b2a1947ddfbd"
-dependencies = [
- "glob",
- "onig",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.13"
 source = "git+https://github.com/hyperium/h2.git?rev=f6aa3be6719270cd7b4094ee1940751b5f4ec88e#f6aa3be6719270cd7b4094ee1940751b5f4ec88e"
@@ -8812,7 +8802,6 @@ dependencies = [
  "glob",
  "goauth",
  "governor",
- "grok",
  "h2",
  "hash_hasher",
  "headers",
@@ -9303,7 +9292,6 @@ dependencies = [
  "datadog-grok",
  "datadog-search-syntax",
  "dns-lookup",
- "grok",
  "hex",
  "hostname",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,6 @@ flate2 = { version = "1.0.24", default-features = false, features = ["default"] 
 futures-util = { version = "0.3.21", default-features = false }
 glob = { version = "0.3.0", default-features = false }
 governor = { version = "0.5.0", default-features = false, features = ["dashmap", "jitter", "std"], optional = true }
-grok = { version = "2.0.0", default-features = false, optional = true }
 h2 = { version = "0.3.13", default-features = false, optional = true }
 hash_hasher = { version = "2.0.0", default-features = false }
 headers = { version = "0.3.8", default-features = false }

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -22,7 +22,6 @@ chrono = { version = "0.4", optional = true }
 cidr-utils = { version = "0.5", optional = true }
 csv = { version = "1.1", optional = true }
 dns-lookup = { version = "1.0.8", optional = true }
-grok = { version = "2", optional = true }
 hex = { version = "0.4", optional = true }
 hostname = { version = "0.3", optional = true }
 indexmap = { version = "~1.9.1", default-features = false, optional = true}
@@ -296,8 +295,8 @@ parse_cef = ["parse_key_value"]
 parse_csv = ["dep:csv"]
 parse_duration = ["dep:rust_decimal", "dep:once_cell", "dep:regex"]
 parse_glog = ["dep:chrono", "dep:once_cell", "dep:regex"]
-parse_grok = ["dep:grok"]
-parse_groks = ["dep:grok", "dep:datadog-grok"]
+parse_grok = ["parse_groks"]
+parse_groks = ["dep:datadog-grok"]
 parse_int = []
 parse_json = ["dep:serde_json", "value/json"]
 parse_key_value = ["dep:nom"]

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -1,59 +1,6 @@
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use vrl::prelude::*;
 
-use ::value::Value;
-use vrl::state::TypeState;
-use vrl::{
-    diagnostic::{Label, Span},
-    prelude::*,
-};
-
-fn parse_grok(value: Value, pattern: Arc<grok::Pattern>) -> Resolved {
-    let bytes = value.try_bytes_utf8_lossy()?;
-    match pattern.match_against(&bytes) {
-        Some(matches) => {
-            let mut result = BTreeMap::new();
-
-            for (name, value) in matches.iter() {
-                result.insert(name.to_string(), Value::from(value));
-            }
-
-            Ok(Value::from(result))
-        }
-        None => Err("unable to parse input with grok pattern".into()),
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum Error {
-    InvalidGrokPattern(grok::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::InvalidGrokPattern(err) => err.fmt(f),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl DiagnosticMessage for Error {
-    fn code(&self) -> usize {
-        109
-    }
-
-    fn labels(&self) -> Vec<Label> {
-        match self {
-            Error::InvalidGrokPattern(err) => {
-                vec![Label::primary(
-                    format!("grok pattern error: {}", err),
-                    Span::default(),
-                )]
-            }
-        }
-    }
-}
+use crate::parse_groks::ParseGroks;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseGrok;
@@ -75,6 +22,11 @@ impl Function for ParseGrok {
                 kind: kind::BYTES,
                 required: true,
             },
+            Parameter {
+                keyword: "aliases",
+                kind: kind::OBJECT,
+                required: false,
+            },
         ]
     }
 
@@ -83,9 +35,8 @@ impl Function for ParseGrok {
             title: "parse grok pattern",
             source: indoc! {r#"
                 value = "2020-10-02T23:22:12.223222Z info Hello world"
-                pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
 
-                parse_grok!(value, pattern)
+                parse_grok!(value, "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}")
             "#},
             result: Ok(indoc! {r#"
                 {
@@ -103,48 +54,18 @@ impl Function for ParseGrok {
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
-        let value = arguments.required("value");
+        let value = arguments.required_expr("value");
+        let pattern = arguments.required_expr("pattern");
+        let patterns = vec![pattern];
+        let aliases = arguments.optional_object("aliases")?.unwrap_or_default();
 
-        let pattern = arguments
-            .required_literal("pattern")?
-            .to_value()
-            .try_bytes_utf8_lossy()
-            .expect("grok pattern not bytes")
-            .into_owned();
-
-        let mut grok = grok::Grok::with_default_patterns();
-        let pattern =
-            Arc::new(grok.compile(&pattern, true).map_err(|e| {
-                Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>
-            })?);
-
-        Ok(ParseGrokFn { value, pattern }.as_expr())
-    }
-}
-
-#[derive(Clone, Debug)]
-struct ParseGrokFn {
-    value: Box<dyn Expression>,
-
-    // Wrapping pattern in an Arc, as cloning the pattern could otherwise be expensive.
-    pattern: Arc<grok::Pattern>,
-}
-
-impl FunctionExpression for ParseGrokFn {
-    fn resolve(&self, ctx: &mut Context) -> Resolved {
-        let value = self.value.resolve(ctx)?;
-        let pattern = self.pattern.clone();
-
-        parse_grok(value, pattern)
-    }
-
-    fn type_def(&self, _: &TypeState) -> TypeDef {
-        TypeDef::object(Collection::any()).fallible()
+        ParseGroks::compile(value, patterns, aliases)
     }
 }
 
 #[cfg(test)]
 mod test {
+    use ::value::Value;
     use vector_common::btreemap;
 
     use super::*;
@@ -155,21 +76,21 @@ mod test {
         invalid_grok {
             args: func_args![ value: "foo",
                               pattern: "%{NOG}"],
-            want: Err("The given pattern definition name \"NOG\" could not be found in the definition map"),
+            want: Err("failed to parse grok expression '\\A%{NOG}\\z': The given pattern definition name \"NOG\" could not be found in the definition map"),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 
         error {
             args: func_args![ value: "an ungrokkable message",
                               pattern: "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"],
-            want: Err("unable to parse input with grok pattern"),
+            want: Err("unable to parse grok: value does not match any rule"),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 
         error2 {
             args: func_args![ value: "2020-10-02T23:22:12.223222Z an ungrokkable message",
                               pattern: "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"],
-            want: Err("unable to parse input with grok pattern"),
+            want: Err("unable to parse grok: value does not match any rule"),
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -5,7 +5,7 @@ use datadog_grok::{
 use std::{collections::BTreeMap, fmt};
 use vrl::{
     diagnostic::{Label, Span},
-    prelude::*,
+    prelude::{expression::Expr, *},
 };
 
 #[derive(Debug)]
@@ -42,6 +42,54 @@ impl DiagnosticMessage for Error {
 
 #[derive(Clone, Copy, Debug)]
 pub struct ParseGroks;
+
+impl ParseGroks {
+    pub(crate) fn compile(
+        value: Expr,
+        patterns: Vec<Expr>,
+        aliases: BTreeMap<String, Expr>,
+    ) -> Compiled {
+        let patterns = patterns
+            .into_iter()
+            .map(|expr| {
+                let pattern = expr
+                    .as_value()
+                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "patterns",
+                        expr,
+                    })?
+                    .try_bytes_utf8_lossy()
+                    .expect("grok pattern not bytes")
+                    .into_owned();
+                Ok(pattern)
+            })
+            .collect::<std::result::Result<Vec<String>, vrl::function::Error>>()?;
+
+        let aliases = aliases
+            .into_iter()
+            .map(|(key, expr)| {
+                let alias = expr
+                    .as_value()
+                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
+                        keyword: "aliases",
+                        expr,
+                    })
+                    .map(|e| {
+                        e.try_bytes_utf8_lossy()
+                            .expect("should be a string")
+                            .into_owned()
+                    })?;
+                Ok((key, alias))
+            })
+            .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>()?;
+
+        // we use a datadog library here because it is a superset of grok
+        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
+            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
+
+        Ok(ParseGroksFn { value, grok_rules }.as_expr())
+    }
+}
 
 impl Function for ParseGroks {
     fn identifier(&self) -> &'static str {
@@ -102,57 +150,18 @@ impl Function for ParseGroks {
         _ctx: &mut FunctionCompileContext,
         arguments: ArgumentList,
     ) -> Compiled {
-        let value = arguments.required("value");
+        let value = arguments.required_expr("value");
+        let patterns = arguments.required_array("patterns")?;
+        let aliases = arguments.optional_object("aliases")?.unwrap_or_default();
 
-        let patterns = arguments
-            .required_array("patterns")?
-            .into_iter()
-            .map(|expr| {
-                let pattern = expr
-                    .as_value()
-                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "patterns",
-                        expr,
-                    })?
-                    .try_bytes_utf8_lossy()
-                    .expect("grok pattern not bytes")
-                    .into_owned();
-                Ok(pattern)
-            })
-            .collect::<std::result::Result<Vec<String>, vrl::function::Error>>()?;
-
-        let aliases = arguments
-            .optional_object("aliases")?
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(key, expr)| {
-                let alias = expr
-                    .as_value()
-                    .ok_or(vrl::function::Error::ExpectedStaticExpression {
-                        keyword: "aliases",
-                        expr,
-                    })
-                    .map(|e| {
-                        e.try_bytes_utf8_lossy()
-                            .expect("should be a string")
-                            .into_owned()
-                    })?;
-                Ok((key, alias))
-            })
-            .collect::<std::result::Result<BTreeMap<String, String>, vrl::function::Error>>()?;
-
-        // we use a datadog library here because it is a superset of grok
-        let grok_rules = parse_grok_rules::parse_grok_rules(&patterns, aliases)
-            .map_err(|e| Box::new(Error::InvalidGrokPattern(e)) as Box<dyn DiagnosticMessage>)?;
-
-        Ok(ParseGroksFn { value, grok_rules }.as_expr())
+        Self::compile(value, patterns, aliases)
     }
 }
 
 #[derive(Clone, Debug)]
-struct ParseGroksFn {
-    value: Box<dyn Expression>,
-    grok_rules: Vec<GrokRule>,
+pub(crate) struct ParseGroksFn {
+    pub(crate) value: Expr,
+    pub(crate) grok_rules: Vec<GrokRule>,
 }
 
 impl FunctionExpression for ParseGroksFn {


### PR DESCRIPTION
This PR applies #13635 again after it has been reverted in #14109 since it contains breaking changes (namely, the match needs to be exhaustive).