### PR TITLE
docs: Remove extra deprecation warning

### DIFF
--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -40,8 +40,6 @@ configuration: {
 		expire_metrics: {
 			common: false
 			description: """
-				Deprecated, please use `expire_metric_secs` instead.
-
 				If set, Vector will configure the internal metrics system to automatically
 				remove all metrics that have not been updated in the given time.
 				This value must be positive.


### PR DESCRIPTION
I _swear_ this wasn't rendering when I made the PR adding this line but...
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
