### PR TITLE
feat(vrl): Display VRL diagnostic messages in web UI

### DIFF
--- a/lib/vrl/web-playground/index.html
+++ b/lib/vrl/web-playground/index.html
@@ -141,7 +141,12 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
       let res = window.run_vrl(input);
 
       console.log(res);
-      window.outputEditor.setValue(JSON.stringify(res["result"], null, "\t"));
+      if (res.output) {
+        window.outputEditor.setValue(JSON.stringify(res["result"], null, "\t"));
+      } else if (res.msg) {
+        window.outputEditor.setValue(res["msg"]);
+      }
+      
 
     }
 

--- a/lib/vrl/web-playground/src/lib.rs
+++ b/lib/vrl/web-playground/src/lib.rs
@@ -37,10 +37,6 @@ impl VrlCompileResult {
     }
 }
 
-// TODO: return a diagnostic result if the user passed in vrl fails.
-// This will require us to create a struct that will mirror the json object the
-// function will receive upon executing failing code.
-
 #[derive(Deserialize, Serialize, Default)]
 pub struct VrlDiagnosticResult {
     pub list: Vec<String>,
@@ -64,6 +60,7 @@ impl VrlDiagnosticResult {
     }
 }
 
+// TODO: return diagnostic if fails upon compilation, currently being ignored
 fn compile(mut input: Input) -> Result<VrlCompileResult, VrlDiagnosticResult> {
     let event = &mut input.event;
     let functions = stdlib::all();

--- a/lib/vrl/web-playground/src/lib.rs
+++ b/lib/vrl/web-playground/src/lib.rs
@@ -2,16 +2,11 @@ use ::value::Value;
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use value::Secrets;
+use vrl::diagnostic::DiagnosticList;
 use vrl::state::TypeState;
 use vrl::{diagnostic::Formatter, prelude::BTreeMap, CompileConfig, Runtime};
 use vrl::{TargetValue, TimeZone};
 use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = console)]
-    fn log(s: &str);
-}
 
 #[derive(Serialize, Deserialize)]
 pub struct Input {
@@ -42,7 +37,34 @@ impl VrlCompileResult {
     }
 }
 
-fn compile(mut input: Input) -> Result<VrlCompileResult, String> {
+// TODO: return a diagnostic result if the user passed in vrl fails.
+// This will require us to create a struct that will mirror the json object the
+// function will receive upon executing failing code.
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct VrlDiagnosticResult {
+    pub list: Vec<String>,
+    pub msg: String,
+    pub msg_colorized: String,
+}
+
+impl VrlDiagnosticResult {
+    fn new(program: &str, diagnostic_list: DiagnosticList) -> Self {
+        Self {
+            list: diagnostic_list
+                .clone()
+                .into_iter()
+                .map(|diag| String::from(diag.message()))
+                .collect(),
+            msg: Formatter::new(program, diagnostic_list.clone()).to_string(),
+            msg_colorized: Formatter::new(program, diagnostic_list)
+                .colored()
+                .to_string(),
+        }
+    }
+}
+
+fn compile(mut input: Input) -> Result<VrlCompileResult, VrlDiagnosticResult> {
     let event = &mut input.event;
     let functions = stdlib::all();
     let state = TypeState::default();
@@ -50,6 +72,7 @@ fn compile(mut input: Input) -> Result<VrlCompileResult, String> {
     let config = CompileConfig::default();
     let timezone = TimeZone::default();
 
+    let mut diagnostics_res: VrlDiagnosticResult = VrlDiagnosticResult::default();
     let mut target_value = TargetValue {
         value: event.clone(),
         metadata: Value::Object(BTreeMap::new()),
@@ -59,16 +82,14 @@ fn compile(mut input: Input) -> Result<VrlCompileResult, String> {
     let program = match vrl::compile_with_state(&input.program, &functions, &state, config) {
         Ok(program) => program,
         Err(diagnostics) => {
-            let msg = Formatter::new(&input.program, diagnostics)
-                .colored()
-                .to_string();
-            return Err(msg);
+            diagnostics_res = VrlDiagnosticResult::new(&input.program, diagnostics);
+            return Err(diagnostics_res);
         }
     };
 
     match runtime.resolve(&mut target_value, &program.program, &timezone) {
         Ok(result) => Ok(VrlCompileResult::new(result, target_value.value)),
-        Err(err) => Err(err.to_string()),
+        Err(_err) => Err(diagnostics_res),
     }
 }
 
@@ -79,9 +100,6 @@ pub fn run_vrl(incoming: &JsValue) -> JsValue {
 
     match compile(input) {
         Ok(res) => JsValue::from_serde(&res).unwrap(),
-        Err(err) => {
-            log(&err);
-            JsValue::from_serde("invalid vrl").unwrap()
-        }
+        Err(err) => JsValue::from_serde(&err).unwrap(),
     }
 }


### PR DESCRIPTION
Closes https://github.com/vectordotdev/vector/issues/14659

Current iteration for printing out diagnostic messages while attempting to setup a more complex structure to eventually add severity, contains_warnings, etc as fields for future use. 

This will print out the diagnostic message in the existing output box but without using xterm.js as I found using the uncolorized field will satisfy the requirement and reduce complexity of introducing another library. 

If feedback is to add colorization then we can support that by adding the xterm.js console window. 

<img width="853" alt="image" src="https://user-images.githubusercontent.com/44036128/195943731-651e18ea-57a9-41fe-8a48-8aca2dd37149.png">
 
