### PR TITLE
docs(aws_kinesis_firehose source) Updated how it works instructions

### DIFF
--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -226,7 +226,7 @@ components: sources: aws_kinesis_firehose: {
 					encoding.codec = "json"
 				   ```
 
-				2. Create a Kinesis Firewatch delivery stream in the region
+				2. Create a Kinesis Firehose delivery stream in the region
 				   where the CloudWatch Logs groups exist that you want to
 				   ingest.
 				3. Set the stream to forward to your Vector instance via its


### PR DESCRIPTION
chore(docs aws_kinesis_firehose source): Updated how it works instruction 2 which states <code>Create a Kinesis **Firewatch** delivery stream</code> to <code>Create a Kinesis **Firehose** delivery stream</code>