### PR TITLE
fix(datadog_traces sink): Add more missing APM stats logic , temporarily replace Error with debug log

### DIFF
--- a/src/internal_events/datadog_traces.rs
+++ b/src/internal_events/datadog_traces.rs
@@ -40,26 +40,29 @@ impl InternalEvent for DatadogTracesEncodingError {
     }
 }
 
-#[derive(Debug)]
-pub struct DatadogTracesStatsError {
-    pub error_message: &'static str,
-    pub trace_id: Option<usize>,
-}
+// TODO enable when this GH issue is fixed:
+// https://github.com/vectordotdev/vector/issues/14859
 
-impl InternalEvent for DatadogTracesStatsError {
-    fn emit(self) {
-        error!(
-            message = "Trace stats calculation error.",
-            trace_id = ?self.trace_id,
-            error = %self.error_message,
-            error_type = error_type::PARSER_FAILED,
-            stage = error_stage::PROCESSING,
-            internal_log_rate_limit = true,
-        );
-        counter!(
-            "component_errors_total", 1,
-            "error_type" => error_type::PARSER_FAILED,
-            "stage" => error_stage::PROCESSING,
-        );
-    }
-}
+// #[derive(Debug)]
+// pub struct DatadogTracesStatsError {
+//     pub error_message: &'static str,
+//     pub trace_id: Option<usize>,
+// }
+//
+// impl InternalEvent for DatadogTracesStatsError {
+//     fn emit(self) {
+//         error!(
+//             message = "Trace stats calculation error.",
+//             trace_id = ?self.trace_id,
+//             error = %self.error_message,
+//             error_type = error_type::PARSER_FAILED,
+//             stage = error_stage::PROCESSING,
+//             internal_log_rate_limit = true,
+//         );
+//         counter!(
+//             "component_errors_total", 1,
+//             "error_type" => error_type::PARSER_FAILED,
+//             "stage" => error_stage::PROCESSING,
+//         );
+//     }
+// }

--- a/src/internal_events/datadog_traces.rs
+++ b/src/internal_events/datadog_traces.rs
@@ -39,30 +39,3 @@ impl InternalEvent for DatadogTracesEncodingError {
         }
     }
 }
-
-// TODO enable when this GH issue is fixed:
-// https://github.com/vectordotdev/vector/issues/14859
-
-// #[derive(Debug)]
-// pub struct DatadogTracesStatsError {
-//     pub error_message: &'static str,
-//     pub trace_id: Option<usize>,
-// }
-//
-// impl InternalEvent for DatadogTracesStatsError {
-//     fn emit(self) {
-//         error!(
-//             message = "Trace stats calculation error.",
-//             trace_id = ?self.trace_id,
-//             error = %self.error_message,
-//             error_type = error_type::PARSER_FAILED,
-//             stage = error_stage::PROCESSING,
-//             internal_log_rate_limit = true,
-//         );
-//         counter!(
-//             "component_errors_total", 1,
-//             "error_type" => error_type::PARSER_FAILED,
-//             "stage" => error_stage::PROCESSING,
-//         );
-//     }
-// }

--- a/src/sinks/datadog/traces/stats.rs
+++ b/src/sinks/datadog/traces/stats.rs
@@ -438,7 +438,7 @@ impl Aggregator {
         // input to the sink.
         // If this becomes problematic for users, we will have to spin up a separate thread that
         // flushes on a specific time interval.
-        // In theory this approach should work, and would just manifest as overall more stats payloads
+        // In theory the existing approach should work, and would just manifest as overall more stats payloads
         // being output by Vector, but the payloads themselves should be correct.
         // https://github.com/DataDog/datadog-agent/blob/cfa750c7412faa98e87a015f8ee670e5828bbe7f/pkg/trace/stats/concentrator.go#L83-L108
 
@@ -590,33 +590,24 @@ fn extract_weight_from_root_span(spans: &[&BTreeMap<String, Value>]) -> f64 {
 
     // There should be only one value remaining, the weight from the root span
     if parent_id_to_child_weight.len() != 1 {
-        // TODO remove the debug print and uncomment the Error emit when this GH issue is
-        // fixed: https://github.com/vectordotdev/vector/issues/14859
+        // TODO remove the debug print and emit the Error event as outlined in
+        // https://github.com/vectordotdev/vector/issues/14859
         debug!(
             "Didn't reliably find the root span for weight calculation of trace_id {:?}.",
             trace_id
         );
-        //     trace_id,
-        // emit!(DatadogTracesStatsError {
-        //     error_message: "Didn't reliably find the root span for weight calculation.",
-        //     trace_id,
-        // });
     }
 
     *parent_id_to_child_weight
         .values()
         .next()
         .unwrap_or_else(|| {
-            // TODO remove the debug print and uncomment the Error emit when this GH issue is
-            // fixed: https://github.com/vectordotdev/vector/issues/14859
+            // TODO remove the debug print and emit the Error event as outlined in
+            // https://github.com/vectordotdev/vector/issues/14859
             debug!(
                 "Root span was not found. Defaulting to weight of 1.0 for trace_id {:?}.",
                 trace_id
             );
-            // emit!(DatadogTracesStatsError {
-            //     error_message: "Root span was not found. Defaulting to weight of 1.0.",
-            //     trace_id,
-            // });
             &1.0
         })
 }

--- a/src/sinks/datadog/traces/stats.rs
+++ b/src/sinks/datadog/traces/stats.rs
@@ -8,7 +8,6 @@ use serde_bytes;
 use super::{ddsketch_full, sink::PartitionKey};
 use crate::{
     event::{TraceEvent, Value},
-    internal_events::DatadogTracesStatsError,
     metrics::AgentDDSketch,
 };
 
@@ -435,6 +434,14 @@ impl Aggregator {
         // Based on https://github.com/DataDog/datadog-agent/blob/cfa750c7412faa98e87a015f8ee670e5828bbe7f/pkg/trace/stats/concentrator.go#L38-L41
         // , and https://github.com/DataDog/datadog-agent/blob/cfa750c7412faa98e87a015f8ee670e5828bbe7f/pkg/trace/stats/concentrator.go#L195-L207
 
+        // NOTE: The Agent flushes on a specific time interval. We are currently flushing per batch
+        // input to the sink.
+        // If this becomes problematic for users, we will have to spin up a separate thread that
+        // flushes on a specific time interval.
+        // In theory this approach should work, and would just manifest as overall more stats payloads
+        // being output by Vector, but the payloads themselves should be correct.
+        // https://github.com/DataDog/datadog-agent/blob/cfa750c7412faa98e87a015f8ee670e5828bbe7f/pkg/trace/stats/concentrator.go#L83-L108
+
         let now = Utc::now().timestamp_nanos() as u64;
         let flush_cutoff_time = now - (BUCKET_DURATION_NANOSECONDS * BUCKET_WINDOW_LEN);
 
@@ -450,8 +457,13 @@ impl Aggregator {
 
         // update the oldest_timestamp allowed, to prevent having stats for an already flushed
         // bucket
-        self.oldest_timestamp =
+        let new_oldest_ts =
             align_timestamp(now) - ((BUCKET_WINDOW_LEN - 1) * BUCKET_DURATION_NANOSECONDS);
+
+        if new_oldest_ts > self.oldest_timestamp {
+            debug!("Updated oldest_timestamp to {}.", new_oldest_ts);
+            self.oldest_timestamp = new_oldest_ts;
+        }
     }
 }
 
@@ -510,10 +522,13 @@ fn is_partial_snapshot(span: &BTreeMap<String, Value>) -> bool {
     }
 }
 
-/// This extracts the relative weights from the top level span (i.e. the span that does not have
-/// a parent). The weight calculation is borrowed from
+/// This extracts the relative weights from the top level span (i.e. the span that does not have a parent).
 fn extract_weight_from_root_span(spans: &[&BTreeMap<String, Value>]) -> f64 {
     // Based on https://github.com/DataDog/datadog-agent/blob/cfa750c7412faa98e87a015f8ee670e5828bbe7f/pkg/trace/stats/weight.go#L17-L26.
+
+    // TODO this logic likely has a bug(s) that need to be root caused. The root span is not reliably found and defaults to "1.0"
+    // regularly for users even when sampling is disabled in the Agent.
+    // GH issue to track that: https://github.com/vectordotdev/vector/issues/14859
 
     if spans.is_empty() {
         return 1.0;
@@ -575,20 +590,33 @@ fn extract_weight_from_root_span(spans: &[&BTreeMap<String, Value>]) -> f64 {
 
     // There should be only one value remaining, the weight from the root span
     if parent_id_to_child_weight.len() != 1 {
-        emit!(DatadogTracesStatsError {
-            error_message: "Didn't reliably find the root span for weight calculation.",
-            trace_id,
-        });
+        // TODO remove the debug print and uncomment the Error emit when this GH issue is
+        // fixed: https://github.com/vectordotdev/vector/issues/14859
+        debug!(
+            "Didn't reliably find the root span for weight calculation of trace_id {:?}.",
+            trace_id
+        );
+        //     trace_id,
+        // emit!(DatadogTracesStatsError {
+        //     error_message: "Didn't reliably find the root span for weight calculation.",
+        //     trace_id,
+        // });
     }
 
     *parent_id_to_child_weight
         .values()
         .next()
         .unwrap_or_else(|| {
-            emit!(DatadogTracesStatsError {
-                error_message: "Root span was not found. Defaulting to weight of 1.0.",
-                trace_id,
-            });
+            // TODO remove the debug print and uncomment the Error emit when this GH issue is
+            // fixed: https://github.com/vectordotdev/vector/issues/14859
+            debug!(
+                "Root span was not found. Defaulting to weight of 1.0 for trace_id {:?}.",
+                trace_id
+            );
+            // emit!(DatadogTracesStatsError {
+            //     error_message: "Root span was not found. Defaulting to weight of 1.0.",
+            //     trace_id,
+            // });
             &1.0
         })
 }


### PR DESCRIPTION
Adds this missing logic:

https://github.com/DataDog/datadog-agent/blob/cfa750c7412faa98e87a015f8ee670e5828bbe7f/pkg/trace/stats/concentrator.go#L211-L214


Also reverted the Error emission based on user feedback- that Error is being fired all the time, and so reverted it back to debug log and created an issue to track that.

The issue is here: https://github.com/vectordotdev/vector/issues/14859

, and in it I've included the logic for the `Error` internal event so it doesn't have to be re-created.
