### PR TITLE
chore(docs): various improvements to the generated configuration schema

### DIFF
--- a/lib/vector-config-macros/src/configurable.rs
+++ b/lib/vector-config-macros/src/configurable.rs
@@ -388,12 +388,92 @@ fn generate_field_metadata(meta_ident: &Ident, field: &Field<'_>) -> proc_macro2
     let field_ty = field.ty();
     let field_schema_ty = get_field_schema_ty(field);
 
+    // Our rules around how we generate this metadata are slightly complex, but here it goes:
+    //
+    // - All `Configurable` types define their own metadata, which at a minimum is their
+    //   description. It can optionally include things like validation rules, and custom attributes,
+    //   of which we use to better document types for downstream consumption. An example would be
+    //   specifying the integer type (signed vs unsigned vs floating point) as JSON Schema does not
+    //   differentiate between the three.
+    // - Building on that, there are types like `bool` or `u64` (scalars, essentially) where having
+    //   a description for the `Configurable` implementation on `bool` or `u64` makes no sense,
+    //   because the type name is self-describing. These types set the "transparent" flag in their
+    //   metadata to indicate that they intentionally have no description and that it's fine to not
+    //   emit a description in the schema for this type.
+    // - Scalars are also not "referenceable" which means their schema is used inline, not pointed
+    //   to by a schema reference.
+    // - All other types, whether they have a derive-based or hand-written implementation of
+    //   `Configurable` should have a referencable name.
+    // - When using a referenceable type for a named field (struct or enum variant), it can be
+    //   annotated with a derive helper attribute called `derived`, which informs the codegen that
+    //   the title/description for that field should come from the field type's schema itself.
+    //
+    // Now that we've laid out the rules and invariants, let's talk about this code below.
+    //
+    // For non-referenceable types, their schema -- and thus their metadata -- will be used inline
+    // as the schema for the field, so we want to simply _merge_ our field's metadata into the field
+    // type's metadata.
+    //
+    // For referenceable types, their schema will be referred to by an identifier, and the
+    // definition attached to that identifier will carry the field type's metadata. Any metadata
+    // specified on the field itself should live solely on the field's schema (which can exist
+    // alongside the schema reference) and vise versa.
+    //
+    // Conflating factors: transparent fields, derived fields, and flattened fields.
+    //
+    // For transparent fields -- where we're _explicitly_ opting out of requiring a
+    // title/description -- there's nothing to do except set the transparent flag on the field
+    // metadata, so that the schema generation code doesn't panic and yell at us about a missing
+    // description.
+    //
+    // For derived fields -- where we're _explictly_ stating that our title/description should come
+    // from the field type itself -- we don't necessarily need to have a title/description on the
+    // field's schema, because it can come from the referenced schema as part of schema processing.
+    // What we do need to do, however, is make sure the schema generation code, similar to
+    // `transparent`, doesn't yell at us that our field is missing a title/description. Thus, we
+    // also set the transparent flag on the field metadata.
+    //
+    // For flattened fields -- where we're taking a schema for a struct, etc, and replacing a single
+    // field with all of the fields in the struct itself -- we're in a similar situation as we are
+    // with derived fields. The struct we're flattening will by definition have to have a
+    // description present, but because we generate the schema on a per-field basis, and then
+    // flatten (merge) the schemas at the end of the schema generation step, we also hit the same
+    // logic/checks that yell at us if no description is present... unless the transparent flag is
+    // set, so we also set the transparent flag on the field metadata.
+    //
+    // We now come to the required logic:
+    //
+    // - if the field's type is referenceable, we start with an empty `Metadata` object, otherwise we
+    //   start with the output from `<T as Configurable>::metadata()`
+    // - if this field is transparent, we set the transparent flag
+    // - if this field is derived or flattened, we don't set the transparent flag, as when we
+    //   generate the schema for the field type, we'll check _then_ to see if the field type's
+    //   schema has a description defined... if it doesn't, and the field schema doesn't have a
+    //   description defined, _then_ we'll panic
     let spanned_metadata = quote_spanned! {field.span()=>
-        <#field_schema_ty as ::vector_config::Configurable>::metadata()
+        if <#field_schema_ty as ::vector_config::Configurable>::referenceable_name().is_none() {
+            <#field_schema_ty as ::vector_config::Configurable>::metadata()
+        } else {
+            ::vector_config::Metadata::default()
+        }
     };
 
     let maybe_title = get_metadata_title(meta_ident, field.title());
     let maybe_description = get_metadata_description(meta_ident, field.description());
+    let maybe_clear_title_description = field
+        .title()
+        .or_else(|| field.description())
+        .is_some()
+        .then(|| {
+            quote! {
+                // Fields with a title/description of their own cannot merge with the title/description
+                // of the field type itself, as this will generally lead to confusing output, so we
+                // explicitly clear the title/description first if we're about to set our own
+                // title/description.
+                #meta_ident.clear_title();
+                #meta_ident.clear_description();
+            }
+        });
     let maybe_default_value = if field_ty != field_schema_ty {
         get_metadata_default_value_delegated(meta_ident, field_schema_ty, field.default_value())
     } else {
@@ -406,6 +486,7 @@ fn generate_field_metadata(meta_ident: &Ident, field: &Field<'_>) -> proc_macro2
 
     quote! {
         let mut #meta_ident = #spanned_metadata;
+        #maybe_clear_title_description
         #maybe_title
         #maybe_description
         #maybe_default_value

--- a/lib/vector-config/src/configurable.rs
+++ b/lib/vector-config/src/configurable.rs
@@ -24,7 +24,9 @@ where
     ///
     /// For standard types, this will be `None`. Commonly, custom types would implement this
     /// directly, while fields using standard types would provide a field-specific description that
-    /// would be used instead of the default descrption.
+    /// would be used instead of the default description.
+    // TODO: We should probably just remove this, because it's not always required and we don't use
+    // it directly when asserting if types have a description specified, we look in the metadata.
     fn description() -> Option<&'static str> {
         None
     }

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -22,15 +22,22 @@ use crate::{
 /// patterns, etc), as well as actual arbitrary key/value data.
 pub fn apply_metadata<T>(schema: &mut SchemaObject, metadata: Metadata<T>)
 where
-    T: Serialize,
+    T: Configurable + Serialize,
 {
     // Set the title/description of this schema.
     //
     // By default, we want to populate `description` because most things don't need a title: their property name or type
     // name is the title... which is why we enforce description being present at the very least.
+    //
+    // Additionally, we panic if a description is missing _unless_ one of these two conditions is
+    // met:
+    // - the field is marked transparent
+    // - `T` is referenceable and _does_ have a description
+    let has_referenceable_description =
+        T::referenceable_name().is_some() && T::metadata().description().is_some();
     let schema_title = metadata.title().map(|s| s.to_string());
     let schema_description = metadata.description().map(|s| s.to_string());
-    if schema_description.is_none() && !metadata.transparent() {
+    if schema_description.is_none() && !metadata.transparent() && !has_referenceable_description {
         panic!("no description provided for `{}`; all `Configurable` types must define a description or be provided one when used within another `Configurable` type", std::any::type_name::<T>());
     }
 
@@ -47,15 +54,44 @@ where
         ..Default::default()
     };
 
-    // Set any custom attributes as extensions on the schema.
+    // Set any custom attributes as extensions on the schema. If an attribute is declared multiple
+    // times, we turn the value into an array and merge them together. We _do_ not that, however, if
+    // the original value is a flag, or the value being added to an existing key is a flag, as
+    // having a flag declared multiple times, or mixing a flag with a KV pair, doesn't make sense.
     let mut custom_map = Map::new();
     for attribute in metadata.custom_attributes() {
         match attribute {
             CustomAttribute::Flag(key) => {
-                custom_map.insert(key.to_string(), Value::Bool(true));
+                match custom_map.insert(key.to_string(), Value::Bool(true)) {
+                    // Overriding a flag is fine, because flags are only ever "enabled", so there's
+                    // no harm to enabling it... again. Likewise, if there was no existing value,
+                    // it's fine.
+                    Some(Value::Bool(_)) | None => {},
+                    // Any other value being present means we're clashing with a different metadata
+                    // attribute, which is not good, so we have to bail out.
+                    _ => panic!("Tried to set metadata flag '{}' but already existed in schema metadata for `{}`.", key, std::any::type_name::<T>()),
+                }
             }
             CustomAttribute::KeyValue { key, value } => {
-                custom_map.insert(key.to_string(), Value::String(value.to_string()));
+                custom_map.entry(key.to_string())
+                    .and_modify(|existing_value| match existing_value {
+                        // When we have an existing KV pair, convert it to a multi-value KV pair.
+                        Value::String(_) => {
+                            let existing_str = std::mem::replace(existing_value, Value::Null);
+                            *existing_value = Value::Array(vec![existing_str, Value::String(value.to_string())]);
+                        },
+                        // This is already a multi-value KV pair, so just append the value.
+                        Value::Array(items) => {
+                            items.push(Value::String(value.to_string()));
+                        },
+                        // We have an unexpected value for this existing key, which is unallowed.
+                        Value::Bool(_) => {
+                            panic!("Tried to set metadata key/value pair '{}' but already existed in schema metadata for `{}` as a flag.", key, std::any::type_name::<T>());
+                        },
+                        // The existing value had an entirely unexpected value type... uh oh!
+                        _ => panic!("Tried to set metadata key/value pair '{}' but already existed in schema metadata for `{}` as unexpected value type.", key, std::any::type_name::<T>()),
+                    })
+                    .or_insert(Value::String(value.to_string()));
             }
         }
     }

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -77,9 +77,6 @@ impl Configurable for String {
 impl Configurable for char {
     fn metadata() -> Metadata<Self> {
         let mut metadata = Metadata::default();
-        if let Some(description) = Self::description() {
-            metadata.set_description(description);
-        }
         metadata.add_validation(Validation::Length {
             minimum: Some(1),
             maximum: Some(1),
@@ -99,10 +96,6 @@ macro_rules! impl_configuable_numeric {
 			impl Configurable for $ty {
                 fn metadata() -> Metadata<Self> {
                     let mut metadata = Metadata::default();
-                    if let Some(description) = Self::description() {
-                        metadata.set_description(description);
-                    }
-
                     let numeric_type = <Self as ConfigurableNumber>::class();
                     metadata.add_custom_attribute(CustomAttribute::kv("numeric_type", numeric_type));
 

--- a/lib/vector-config/tests/smoke.rs
+++ b/lib/vector-config/tests/smoke.rs
@@ -221,7 +221,6 @@ pub struct SimpleSinkConfig {
     encoding: Encoding,
 
     /// The filepath to write the events to.
-    #[configurable(metadata(templateable))]
     output_path: Template,
 
     /// The tags to apply to each event.

--- a/scripts/generate-components-docs.rb
+++ b/scripts/generate-components-docs.rb
@@ -12,13 +12,29 @@ end
 
 @logger = Logging.logger['default']
 @logger.add_appenders(Logging.appenders.stdout(
-                        'stdout',
-                        layout: Logging.layouts.pattern(
-                          pattern: '[%d] %l %m\n',
-                          color_scheme: 'default'
-                        )
-                      ))
+  'stdout',
+  layout: Logging.layouts.pattern(
+    pattern: '[%d] %l %m\n',
+    color_scheme: 'default'
+  )
+))
 @logger.level = ENV['LOG_LEVEL'] || 'info'
+
+# Cross-platform friendly method of finding if command exists on the current path.
+#
+# If the command is found, the full path to it is returned. Otherwise, `nil` is returned.
+def find_command_on_path(command)
+  exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+    exts.each do |ext|
+      maybe_command_path = File.join(path, "#{command}#{ext}")
+      return maybe_command_path if File.executable?(maybe_command_path) && !File.directory?(maybe_command_path)
+    end
+  end
+  nil
+end
+
+@cue_binary_path = find_command_on_path('cue')
 
 # Helpers for caching resolved schemas and detecting schema resolution cycles.
 @resolved_schema_cache = {}
@@ -75,10 +91,10 @@ end
 def sort_hash_nested(input)
   input.keys.sort.each_with_object({}) do |key, acc|
     acc[key] = if input[key].is_a?(Hash)
-                 sort_hash_nested(input[key])
-               else
-                 input[key]
-               end
+      sort_hash_nested(input[key])
+    else
+      input[key]
+    end
   end
 end
 
@@ -265,7 +281,7 @@ def resolve_schema_by_name(root_schema, schema_name)
   resolved = resolve_schema(root_schema, schema)
   remove_from_schema_resolution_stack(schema_name)
   @resolved_schema_cache[schema_name] = resolved
-  resolved
+  deep_copy(resolved)
 end
 
 # Fully resolves the schema.
@@ -312,15 +328,18 @@ def resolve_schema(root_schema, schema)
   # Otherwise, we simply resolve the schema as it exists.
   referenced_schema_name = get_schema_ref(schema)
   resolved = if !referenced_schema_name.nil?
-               resolve_schema_by_name(root_schema, referenced_schema_name)
-             else
-               resolve_bare_schema(root_schema, schema)
-             end
+    resolve_schema_by_name(root_schema, referenced_schema_name)
+  else
+    resolve_bare_schema(root_schema, schema)
+  end
 
   # Apply any necessary defaults, descriptions, etc, to the resolved schema. This must happen here
   # because there could be callsite-specific overrides to defaults, descriptions, etc, for a given
   # schema definition that have to be layered.
   apply_schema_default_value!(schema, resolved)
+  apply_schema_metadata!(schema, resolved)
+
+  @logger.debug "About to resolve original schema: #{schema}"
 
   description = get_rendered_description_from_schema(schema)
   resolved['description'] = description unless description.empty?
@@ -332,104 +351,112 @@ end
 # A bare schema is one that has no references to another schema, etc.
 def resolve_bare_schema(root_schema, schema)
   resolved = case get_schema_type(schema)
-             when 'all-of'
-               @logger.debug 'Resolving composite schema.'
+    when 'all-of'
+      @logger.debug 'Resolving composite schema.'
 
-               # Composite schemas are indeed the sum of all of their parts, so resolve each subschema and
-               # merge their resolved state together.
-               reduced = schema['allOf'].filter_map { |subschema| resolve_schema(root_schema, subschema) }
-                                        .reduce { |acc, item| nested_merge(acc, item) }
-               reduced['type']
-             when 'one-of'
-               @logger.debug 'Resolving enum schema.'
+      # Composite schemas are indeed the sum of all of their parts, so resolve each subschema and
+      # merge their resolved state together.
+      reduced = schema['allOf'].filter_map { |subschema| resolve_schema(root_schema, subschema) }
+                              .reduce { |acc, item| nested_merge(acc, item) }
+      reduced['type']
+    when 'one-of'
+      @logger.debug 'Resolving enum schema.'
 
-               # We completely defer resolution of enum schemas to `resolve_enum_schema` because there's a
-               # lot of tricks and matching we need to do to suss out patterns that can be represented in more
-               # condensed resolved forms.
-               wrapped = resolve_enum_schema(root_schema, schema)
+      # We completely defer resolution of enum schemas to `resolve_enum_schema` because there's a
+      # lot of tricks and matching we need to do to suss out patterns that can be represented in more
+      # condensed resolved forms.
+      wrapped = resolve_enum_schema(root_schema, schema)
 
-               # `resolve_enum_schema` always hands back the resolved schema under the key `_resolved`, so
-               # that we can add extra details about the resolved schema (anything that will help us render
-               # it better in the docs output) on the side. That's why we have to unwrap the resolved schema
-               # like this.
+      # `resolve_enum_schema` always hands back the resolved schema under the key `_resolved`, so
+      # that we can add extra details about the resolved schema (anything that will help us render
+      # it better in the docs output) on the side. That's why we have to unwrap the resolved schema
+      # like this.
 
-               # TODO: Do something with the extra detail (`annotations`).
+      # TODO: Do something with the extra detail (`annotations`).
 
-               wrapped.dig('_resolved', 'type')
-             when 'array'
-               @logger.debug 'Resolving array schema.'
+      wrapped.dig('_resolved', 'type')
+    when 'array'
+      @logger.debug 'Resolving array schema.'
 
-               { 'array' => { 'items' => resolve_schema(root_schema, schema['items']) } }
-             when 'object'
-               @logger.debug 'Resolving object schema.'
+      { 'array' => { 'items' => resolve_schema(root_schema, schema['items']) } }
+    when 'object'
+      @logger.debug 'Resolving object schema.'
 
-               # TODO: Not all objects have an actual set of properties, such as anything using
-               # `additionalProperties` to allow for arbitrary key/values to be set, which is why we're
-               # handling the case of nothing in `properties`... but we probably want to be able to better
-               # handle expressing this in the output.. or maybe it doesn't matter, dunno!
-               properties = schema['properties'] || {}
+      # TODO: Not all objects have an actual set of properties, such as anything using
+      # `additionalProperties` to allow for arbitrary key/values to be set, which is why we're
+      # handling the case of nothing in `properties`... but we probably want to be able to better
+      # handle expressing this in the output.. or maybe it doesn't matter, dunno!
+      properties = schema['properties'] || {}
 
-               options = properties.filter_map do |property_name, property_schema|
-                 @logger.debug "Resolving object property '#{property_name}'..."
-                 resolved_property = resolve_schema(root_schema, property_schema)
-                 if !resolved_property.nil?
-                   apply_object_property_fields!(schema, property_schema, property_name, resolved_property)
+      options = properties.filter_map do |property_name, property_schema|
+        @logger.debug "Resolving object property '#{property_name}'..."
+        resolved_property = resolve_schema(root_schema, property_schema)
+        if !resolved_property.nil?
+          apply_object_property_fields!(schema, property_schema, property_name, resolved_property)
 
-                   @logger.debug "Resolved object property '#{property_name}'."
+          @logger.debug "Resolved object property '#{property_name}'."
 
-                   [property_name, resolved_property]
-                 else
-                   @logger.debug "Resolution failed for '#{property_name}'."
+          [property_name, resolved_property]
+        else
+          @logger.debug "Resolution failed for '#{property_name}'."
 
-                   nil
-                 end
-               end
+          nil
+        end
+      end
 
-               { 'object' => { 'options' => options.to_h } }
-             when 'string'
-               @logger.debug 'Resolving string schema.'
+      # If the object schema has `additionalProperties` set, we add an additional field
+      # (`*`) which uses the specified schema for that field.
+      additional_properties = schema['additionalProperties']
+      if !additional_properties.nil?
+        resolved_additional_properties = resolve_schema(root_schema, additional_properties)
+        options.push(['*', resolved_additional_properties])
+      end
 
-               string_def = {}
-               string_def['default'] = schema['default'] unless schema['default'].nil?
+      { 'object' => { 'options' => options.to_h } }
+    when 'string'
+      @logger.debug 'Resolving string schema.'
 
-               { 'string' => string_def }
-             when 'number'
-               @logger.debug 'Resolving number schema.'
+      string_def = { 'syntax' => 'literal' }
+      string_def['default'] = schema['default'] unless schema['default'].nil?
 
-               numeric_type = get_schema_metadata(schema, 'numeric_type') || 'number'
-               number_def = {}
-               number_def['default'] = schema['default'] unless schema['default'].nil?
+      { 'string' => string_def }
+    when 'number'
+      @logger.debug 'Resolving number schema.'
 
-               { numeric_type => number_def }
-             when 'boolean'
-               @logger.debug 'Resolving boolean schema.'
+      numeric_type = get_schema_metadata(schema, 'numeric_type') || 'number'
+      number_def = {}
+      number_def['default'] = schema['default'] unless schema['default'].nil?
 
-               bool_def = {}
-               bool_def['default'] = schema['default'] unless schema['default'].nil?
+      { numeric_type => number_def }
+    when 'boolean'
+      @logger.debug 'Resolving boolean schema.'
 
-               { 'bool' => bool_def }
-             when 'const'
-               @logger.debug 'Resolving const schema.'
+      bool_def = {}
+      bool_def['default'] = schema['default'] unless schema['default'].nil?
 
-               # For `const` schemas, just figure out the type of the constant value so we can generate the
-               # resolved output.
-               const_value = schema['const']
-               const_type = docs_type_str(const_value)
-               { const_type => { 'const' => const_value } }
-             when 'enum'
-               @logger.debug 'Resolving enum const schema.'
+      { 'bool' => bool_def }
+    when 'const'
+      @logger.debug 'Resolving const schema.'
 
-               # Similarly to `const` schemas, `enum` schemas are merely multiple possible constant values. Given
-               # that JSON Schema does allow for the constant values to differ in type, we group them all by
-               # type to get the resolved output.
-               enum_values = schema['enum']
-               grouped = enum_values.group_by { |value| docs_type_str(value) }
-               grouped.transform_values! { |values| { 'enum' => values } }
-               grouped
-             else
-               @logger.error "Failed to resolve the schema. Schema: #{schema}"
-               exit
-             end
+      # For `const` schemas, just figure out the type of the constant value so we can generate the
+      # resolved output.
+      const_value = schema['const']
+      const_type = docs_type_str(const_value)
+      { const_type => { 'const' => const_value } }
+    when 'enum'
+      @logger.debug 'Resolving enum const schema.'
+
+      # Similarly to `const` schemas, `enum` schemas are merely multiple possible constant values. Given
+      # that JSON Schema does allow for the constant values to differ in type, we group them all by
+      # type to get the resolved output.
+      enum_values = schema['enum']
+      grouped = enum_values.group_by { |value| docs_type_str(value) }
+      grouped.transform_values! { |values| { 'enum' => values } }
+      grouped
+    else
+      @logger.error "Failed to resolve the schema. Schema: #{schema}"
+      exit
+    end
 
   { 'type' => resolved }
 end
@@ -522,9 +549,7 @@ def resolve_enum_schema(root_schema, schema)
       unique_tag_values = {}
 
       resolved_subschemas.each do |resolved_subschema|
-        # Unwrap the resolved subschema since we only want to interact with the definition, not the
-        # wrapper boilerplate.
-        resolved_subschema = resolved_subschema.dig('type', 'object', 'options')
+        resolved_subschema_properties = resolved_subschema.dig('type', 'object', 'options')
 
         # Extract the tag property and figure out any necessary intersections, etc.
         #
@@ -532,7 +557,13 @@ def resolve_enum_schema(root_schema, schema)
         # only ever use `const` for describing enum variants and what not, so this is my middle-ground
         # approach to also allow for other constant-y types, but not objects/arrays which would
         # just... not make sense.
-        tag_subschema = resolved_subschema.delete(enum_tag_field)
+        #
+        # We also steal the title and/or description from the variant subschema and apply it to the
+        # tag's subschema, as we don't curry the title/description for a variant itself to the
+        # respective tag field used to indicate which variant is specified.
+        tag_subschema = resolved_subschema_properties.delete(enum_tag_field)
+        tag_subschema['title'] = resolved_subschema['title'] if !resolved_subschema['title'].nil?
+        tag_subschema['description'] = resolved_subschema['description'] if !resolved_subschema['description'].nil?
         tag_value = nil
 
         %w[string number boolean].each do |allowed_type|
@@ -542,6 +573,8 @@ def resolve_enum_schema(root_schema, schema)
             break
           end
         end
+
+        @logger.debug "Tag value of #{tag_value}, with original resolved schema: #{resolved_subschema}"
 
         if tag_value.nil?
           @logger.error 'All enum subschemas representing an internally-tagged enum must have the tag field use a const value.'
@@ -558,29 +591,29 @@ def resolve_enum_schema(root_schema, schema)
 
         # Now merge all of the properties from the given subschema, so long as the overlapping
         # properties have the same schema.
-        resolved_subschema.each do |property_name, property_schema|
+        resolved_subschema_properties.each do |property_name, property_schema|
           existing_property = unique_resolved_properties[property_name]
           resolved_property = if !existing_property.nil?
-                                # The property is already being tracked, so just do a check to make sure the property from our
-                                # current subschema matches the existing property, schema-wise, before we update it.
-                                reduced_existing_property = get_reduced_schema(existing_property)
-                                reduced_new_property = get_reduced_schema(property_schema)
+            # The property is already being tracked, so just do a check to make sure the property from our
+            # current subschema matches the existing property, schema-wise, before we update it.
+            reduced_existing_property = get_reduced_schema(existing_property)
+            reduced_new_property = get_reduced_schema(property_schema)
 
-                                if reduced_existing_property != reduced_new_property
-                                  @logger.error "Had overlapping property '#{property_name}' from resolved enum subschema, but schemas differed: \
-                                  Existing property schema (reduced): #{reduced_existing_property} \
-                                  New property schema (reduced): #{reduced_new_property}"
-                                  exit
-                                end
+            if reduced_existing_property != reduced_new_property
+              @logger.error "Had overlapping property '#{property_name}' from resolved enum subschema, but schemas differed: \
+              Existing property schema (reduced): #{reduced_existing_property} \
+              New property schema (reduced): #{reduced_new_property}"
+              exit
+            end
 
-                                # The schemas match, so just update the list of "relevant when" values.
-                                existing_property['relevant_when'].push(tag_value)
-                                existing_property
-                              else
-                                # First time seeing this particular property.
-                                property_schema['relevant_when'] = [tag_value]
-                                property_schema
-                              end
+            # The schemas match, so just update the list of "relevant when" values.
+            existing_property['relevant_when'].push(tag_value)
+            existing_property
+          else
+            # First time seeing this particular property.
+            property_schema['relevant_when'] = [tag_value]
+            property_schema
+          end
 
           unique_resolved_properties[property_name] = resolved_property
         end
@@ -615,16 +648,19 @@ def resolve_enum_schema(root_schema, schema)
       # Now we build our property for the tag field itself, and add that in before returning all of
       # the unique resolved properties.
       unique_resolved_properties[enum_tag_field] = {
+        'required' => true,
         'type' => {
           'string' => {
             'enum' => unique_tag_values.transform_values do |tag_schema|
-                        get_rendered_description_from_schema(tag_schema)
-                      end
+              @logger.debug "Tag schema: #{tag_schema}"
+              get_rendered_description_from_schema(tag_schema)
+            end
           }
         }
       }
 
       @logger.debug "Resolved as 'internally-tagged with named fields' enum schema."
+      @logger.debug "Resolved properties for ITNF enum schema: #{unique_resolved_properties}"
 
       return { '_resolved' => { 'type' => { 'object' => { 'options' => unique_resolved_properties } } } }
     end
@@ -675,6 +711,10 @@ def resolve_enum_schema(root_schema, schema)
 end
 
 def apply_schema_default_value!(source_schema, resolved_schema)
+  @logger.debug "Apply defaults to schema."
+  @logger.debug "Source schema: #{source_schema}"
+  @logger.debug "Resolved schema: #{resolved_schema}"
+
   default_value = source_schema['default']
   unless default_value.nil?
     # Make sure that the resolved schema actually has a type definition that matches the type of the
@@ -733,12 +773,35 @@ def apply_schema_default_value!(source_schema, resolved_schema)
       end
     else
       # We're dealing with a normal scalar or whatever, so just apply the default directly.
+      @logger.debug "Resolved schema type field: #{resolved_schema_type_field}"
+      @logger.debug "Default value on fallback path: #{default_value}"
       resolved_schema_type_field['default'] = default_value
     end
   end
 end
 
+def apply_schema_metadata!(source_schema, resolved_schema)
+  # Handle marking string schemas as templateable, which shows a special blurb in the rendered
+  # documentation HTML that explains what this means and links to the template syntax, etc.
+  is_templateable = get_schema_metadata(source_schema, 'templateable') == true
+  string_type_def = resolved_schema.dig('type', 'string')
+  if !string_type_def.nil? && is_templateable
+    string_type_def['syntax'] = 'template'
+  end
+
+  # Handle the niche case where we have an object schema without any of its own fields -- aka a map
+  # of optional key/value pairs i.e. tags -- and it allows templateable values.
+end
+
 def get_rendered_description_from_schema(schema)
+  # If the schema is marked as `no_description`, we're being told -- for whatever reason -- that the
+  # existing title/description should not be rendered in the output. This is primarily to avoid
+  # spitting out developer-oriented documentation into the user-facing documentation, when we're
+  # providing the necessary description in another way.
+  if !get_schema_metadata(schema, 'no_description').nil?
+    return ''
+  end
+
   # Grab both the raw description and raw title, and if the title is empty, just use the
   # description, otherwise concatenate the title and description with newlines so that there's a
   # whitespace break between the title and description.
@@ -791,11 +854,11 @@ def render_and_import_schema(root_schema, schema_name, friendly_name, config_map
   # Try importing it as Cue.
   @logger.info "[*] Importing #{friendly_name} schema as Cue file..."
   cue_output_file = "website/cue/reference/components/#{cue_relative_path}"
-  unless system('cue', 'import', '-f', '-o', cue_output_file, '-p', 'metadata', json_output_file)
+  unless system(@cue_binary_path, 'import', '-f', '-o', cue_output_file, '-p', 'metadata', json_output_file)
     @logger.error "[!]   Failed to import #{friendly_name} schema as valid Cue."
     exit
   end
-  @logger.info "[✓]   Imported #{friendly_name} schema as Cue."
+  @logger.info "[✓]   Imported #{friendly_name} schema to '#{cue_output_file}'."
 end
 
 def render_and_import_base_component_schema(root_schema, schema_name, component_type)
@@ -820,6 +883,12 @@ end
 
 if ARGV.empty?
   puts 'usage: extract-component-schema.rb <configuration schema path>'
+  exit
+end
+
+# Ensure that Cue is present since we need it to import our intermediate JSON representation.
+if @cue_binary_path.nil?
+  puts 'Failed to find \'cue\' binary on the current path. Install \'cue\' (or make it available on the current path) and try again.'
   exit
 end
 

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -21,11 +21,9 @@ use super::sink::AmqpSink;
 #[derive(Clone, Debug)]
 pub struct AmqpSinkConfig {
     /// The exchange to publish messages to.
-    #[configurable(metadata(templateable))]
     pub(crate) exchange: Template,
 
     /// Template used to generate a routing key which corresponds to a queue binding.
-    #[configurable(metadata(templateable))]
     pub(crate) routing_key: Option<Template>,
 
     /// Connection options for the `amqp` sink.

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -200,17 +200,14 @@ impl BulkConfig {
 #[serde(rename_all = "snake_case")]
 pub struct DataStreamConfig {
     /// The data stream type used to construct the data stream at index time.
-    #[configurable(metadata(templateable))]
     #[serde(rename = "type", default = "DataStreamConfig::default_type")]
     pub dtype: Template,
 
     /// The data stream dataset used to construct the data stream at index time.
-    #[configurable(metadata(templateable))]
     #[serde(default = "DataStreamConfig::default_dataset")]
     pub dataset: Template,
 
     /// The data stream namespace used to construct the data stream at index time.
-    #[configurable(metadata(templateable))]
     #[serde(default = "DataStreamConfig::default_namespace")]
     pub namespace: Template,
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -40,7 +40,6 @@ use bytes_path::BytesPath;
 #[serde(deny_unknown_fields)]
 pub struct FileSinkConfig {
     /// File name to write events to.
-    #[configurable(metadata(templateable))]
     pub path: Template,
 
     /// The amount of time, in seconds, that a file can be idle and stay open.

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -130,7 +130,6 @@ pub struct ChronicleUnstructuredConfig {
     /// Chronicle will reject the entry with an error.
     ///
     /// [unstructured_log_types_doc]: https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers
-    #[configurable(metadata(templateable))]
     pub log_type: Template,
 
     #[configurable(derived)]

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -47,7 +47,6 @@ pub struct StackdriverConfig {
     /// The log ID to which to publish logs.
     ///
     /// This is a name you create to identify this log stream.
-    #[configurable(metadata(templateable))]
     pub log_id: Template,
 
     /// The monitored resource to associate the logs with.

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -38,7 +38,6 @@ pub struct HumioLogsConfig {
     /// The source of events sent to this sink.
     ///
     /// Typically the filename the logs originated from. Maps to `@source` in Humio.
-    #[configurable(metadata(templateable))]
     pub(super) source: Option<Template>,
 
     #[configurable(derived)]
@@ -47,7 +46,6 @@ pub struct HumioLogsConfig {
     /// The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
     ///
     /// If unset, Humio will default it to none.
-    #[configurable(metadata(templateable))]
     pub(super) event_type: Option<Template>,
 
     /// Overrides the name of the log field used to grab the hostname to send to Humio.
@@ -77,7 +75,6 @@ pub struct HumioLogsConfig {
     /// For more information, see [Humio’s Format of Data][humio_data_format].
     ///
     /// [humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
-    #[configurable(metadata(templateable))]
     #[serde(default)]
     pub(super) index: Option<Template>,
 

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -49,13 +49,11 @@ pub struct HumioMetricsConfig {
     /// The source of events sent to this sink.
     ///
     /// Typically the filename the metrics originated from. Maps to `@source` in Humio.
-    #[configurable(metadata(templateable))]
     source: Option<Template>,
 
     /// The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
     ///
     /// If unset, Humio will default it to none.
-    #[configurable(metadata(templateable))]
     event_type: Option<Template>,
 
     /// Overrides the name of the log field used to grab the hostname to send to Humio.
@@ -85,7 +83,6 @@ pub struct HumioMetricsConfig {
     /// For more information, see [Humio’s Format of Data][humio_data_format].
     ///
     /// [humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
-    #[configurable(metadata(templateable))]
     #[serde(default)]
     index: Option<Template>,
 

--- a/src/sinks/logdna.rs
+++ b/src/sinks/logdna.rs
@@ -37,7 +37,6 @@ pub struct LogdnaConfig {
     endpoint: Option<UriSerde>,
 
     /// The hostname that will be attached to each batch of events.
-    #[configurable(metadata(templateable))]
     hostname: Template,
 
     /// The MAC address that will be attached to each batch of events.
@@ -47,7 +46,6 @@ pub struct LogdnaConfig {
     ip: Option<String>,
 
     /// The tags that will be attached to each batch of events.
-    #[configurable(metadata(templateable))]
     tags: Option<Vec<Template>>,
 
     #[configurable(derived)]

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -83,7 +83,8 @@ pub struct LokiConfig {
     /// Note: If the set of labels has high cardinality, this can cause drastic performance issues
     /// with Loki. To prevent this from happening, reduce the number of unique label keys and
     /// values.
-    #[configurable(metadata(templateable))]
+    // TESTMARK: Make sure this has the `templateable` metadata flag even being used through
+    // `HashMap<Template, Template>`.
     pub labels: HashMap<Template, Template>,
 
     /// Whether or not to delete fields from the event when they are used as labels.

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -37,7 +37,6 @@ pub struct PapertrailConfig {
     send_buffer_bytes: Option<usize>,
 
     /// The value to use as the `process` in Papertrail.
-    #[configurable(metadata(templateable))]
     process: Option<Template>,
 
     #[configurable(derived)]

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -94,7 +94,6 @@ pub struct RemoteWriteConfig {
     /// If set, a header named `X-Scope-OrgID` will be added to outgoing requests with the value of this setting.
     ///
     /// This may be used by Cortex or other remote services to identify the tenant making the request.
-    #[configurable(metadata(templateable))]
     #[serde(default)]
     pub tenant_id: Option<Template>,
 

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -131,7 +131,6 @@ pub struct RedisSinkConfig {
     url: String,
 
     /// The Redis key to publish messages to.
-    #[configurable(metadata(templateable))]
     #[configurable(validation(length(min = 1)))]
     key: Template,
 

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -59,13 +59,11 @@ pub struct HecLogsSinkConfig {
     /// The name of the index where to send the events to.
     ///
     /// If not specified, the default index is used.
-    #[configurable(metadata(templateable))]
     pub index: Option<Template>,
 
     /// The sourcetype of events sent to this sink.
     ///
     /// If unset, Splunk will default to `httpevent`.
-    #[configurable(metadata(templateable))]
     pub sourcetype: Option<Template>,
 
     /// The source of events sent to this sink.
@@ -73,7 +71,6 @@ pub struct HecLogsSinkConfig {
     /// This is typically the filename the logs originated from.
     ///
     /// If unset, the Splunk collector will set it.
-    #[configurable(metadata(templateable))]
     pub source: Option<Template>,
 
     #[configurable(derived)]

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -57,13 +57,11 @@ pub struct HecMetricsSinkConfig {
     /// The name of the index where to send the events to.
     ///
     /// If not specified, the default index is used.
-    #[configurable(metadata(templateable))]
     pub index: Option<Template>,
 
     /// The sourcetype of events sent to this sink.
     ///
     /// If unset, Splunk will default to `httpevent`.
-    #[configurable(metadata(templateable))]
     pub sourcetype: Option<Template>,
 
     /// The source of events sent to this sink.
@@ -71,7 +69,6 @@ pub struct HecMetricsSinkConfig {
     /// This is typically the filename the logs originated from.
     ///
     /// If unset, the Splunk collector will set it.
-    #[configurable(metadata(templateable))]
     pub source: Option<Template>,
 
     #[configurable(derived)]

--- a/src/template.rs
+++ b/src/template.rs
@@ -42,6 +42,8 @@ pub enum TemplateRenderingError {
 /// field of the event being processed would serve as the value when rendering the template into a string.
 #[configurable_component]
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+#[configurable(metadata(templateable))]
+#[configurable(metadata(no_description))]
 #[serde(try_from = "String", into = "String")]
 pub struct Template {
     src: String,


### PR DESCRIPTION
This PR contains a number of incremental improvements necessary to eventually work on #14815, where we'll begin to actually incorporate the generated output from the configuration schema into our Cue-based documentation.

Changes in no particular order:

- tweaks to the way we generate schema metadata for fields, to both properly incorporate metadata defined on the type of the field itself with metadata defined specifically at the field, as well as make sure we don't unintentionally pollute certain aspects of the metadata (such as including a derived description when a higher-priority description is present, etc)
- added the ability to define multiple values for a metadata key/value attribute, in preparation of being able to specify example values for fields
- removed unused code in many manual `Configurable` implementations (such as trying to include the value of `Configurable::description` in the type's schema metadata when they verifiably didn't/shouldn't have their own description to begin with)
- removed many instances of `#[configurable(metadata(templateable))]` as it's now correctly derived/merged from the usage of `Template` itself
- improved `generate-components-docs.rb` to:
  - look for `cue` on the command path in a cross-platform way, and to emit an error when the script runs to let the user know they're missing it/need to install it
  - fixed some weird formatting/indentation that `rubocop` added to try and make it more palatable to read/review
  - added proper support for open-ended map fields (i.e. a `tags: HashMap<String, String>` field) to generate the same output as we already use to signify that pattern in our Cue docs
  - fixed the title/description generation for enum tags (i.e. the description next to each possible value for a given field that is used as the tag field for an enum)
  - properly mark enum tag fields as `required`
  - properly mark string fields as having the `template` syntax if they have the `templateable` metadata attribute