### PR TITLE
fix(tag_cardinality_limit transform): Handle drop event edge case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,9 +3222,9 @@ checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
 ]
@@ -8814,6 +8814,7 @@ dependencies = [
  "grok",
  "h2",
  "hash_hasher",
+ "hashbrown",
  "headers",
  "heim",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,6 +253,7 @@ governor = { version = "0.5.0", default-features = false, features = ["dashmap",
 grok = { version = "2.0.0", default-features = false, optional = true }
 h2 = { version = "0.3.13", default-features = false, optional = true }
 hash_hasher = { version = "2.0.0", default-features = false }
+hashbrown = { version = "0.12.3", default-features = false, optional = true }
 headers = { version = "0.3.8", default-features = false }
 hostname = { version = "0.3.1", default-features = false }
 http = { version = "0.2.8", default-features = false }
@@ -586,7 +587,7 @@ transforms-reduce = []
 transforms-remap = []
 transforms-route = []
 transforms-sample = []
-transforms-tag_cardinality_limit = ["dep:bloom"]
+transforms-tag_cardinality_limit = ["dep:bloom", "dep:hashbrown"]
 transforms-throttle = ["dep:governor"]
 
 # Sinks

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -146,22 +146,17 @@ impl fmt::Debug for TagValueSetStorage {
 
 impl TagValueSet {
     fn new(value_limit: u32, mode: &Mode) -> Self {
-        match &mode {
-            Mode::Exact => Self {
-                storage: TagValueSetStorage::Set(HashSet::with_capacity(value_limit as usize)),
-                num_elements: 0,
-            },
+        let storage = match &mode {
+            Mode::Exact => TagValueSetStorage::Set(HashSet::with_capacity(value_limit as usize)),
             Mode::Probabilistic(config) => {
                 let num_bits = config.cache_size_per_key / 8; // Convert bytes to bits
                 let num_hashes = bloom::optimal_num_hashes(num_bits, value_limit);
-
-                Self {
-                    storage: TagValueSetStorage::Bloom(BloomFilter::with_size(
-                        num_bits, num_hashes,
-                    )),
-                    num_elements: 0,
-                }
+                TagValueSetStorage::Bloom(BloomFilter::with_size(num_bits, num_hashes))
             }
+        };
+        Self {
+            storage,
+            num_elements: 0,
         }
     }
 


### PR DESCRIPTION
With a limit of 2 and the action set to drop_event, given the following two
sequences of tags:

1. tag1=>val1,tag2=>val1
2. tag1=>val2,tag2=>val1
3. tag1=>val3,tag2=>val2
4. tag1=>val1,tag2=>val3

Sequence 2:

1. tag1=>val1,tag2=>val1
2. tag1=>val1,tag2=>val2
3. tag1=>val2,tag2=>val3
4. tag1=>val3,tag2=>val1

We should have identical behavior in both cases: event 3 should be rejected
because a tag went over the limit, but event 4 should be accepted because the
tags emitted by this transform are still within the limits.

The above behavior is not the current behavior. In the first scenario, only
events 3 would be rejected because tag2 would not be recorded, and in the latter
scenario, both events 3 and 4 would be rejected. This PR corrects the
inaccuracy.

This PR includes a few minor clean ups and an optimization using `hashbrown` (already used via the `indexmap` and `metrics`) to avoid triple-hashing keys.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
