### PR TITLE
chore(core): Change `Value::to_string_lossy` to return `Cow`

### DIFF
--- a/lib/value/src/value/serde.rs
+++ b/lib/value/src/value/serde.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::fmt;
+use std::{borrow::Cow, collections::BTreeMap, fmt};
 
 use bytes::Bytes;
 use ordered_float::NotNan;
@@ -29,19 +28,22 @@ impl Value {
         }
     }
 
-    // TODO: return Cow 🐄
     /// Converts self into a `String` representation, using JSON for `Map`/`Array`.
-    pub fn to_string_lossy(&self) -> String {
+    pub fn to_string_lossy(&self) -> Cow<'_, str> {
         match self {
-            Self::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
-            Self::Regex(regex) => regex.as_str().to_string(),
-            Self::Timestamp(timestamp) => timestamp_to_string(timestamp),
-            Self::Integer(num) => num.to_string(),
-            Self::Float(num) => num.to_string(),
-            Self::Boolean(b) => b.to_string(),
-            Self::Object(map) => serde_json::to_string(map).expect("Cannot serialize map"),
-            Self::Array(arr) => serde_json::to_string(arr).expect("Cannot serialize array"),
-            Self::Null => "<null>".to_string(),
+            Self::Bytes(bytes) => String::from_utf8_lossy(bytes),
+            Self::Regex(regex) => regex.as_str().into(),
+            Self::Timestamp(timestamp) => timestamp_to_string(timestamp).into(),
+            Self::Integer(num) => num.to_string().into(),
+            Self::Float(num) => num.to_string().into(),
+            Self::Boolean(b) => b.to_string().into(),
+            Self::Object(map) => serde_json::to_string(map)
+                .expect("Cannot serialize map")
+                .into(),
+            Self::Array(arr) => serde_json::to_string(arr)
+                .expect("Cannot serialize array")
+                .into(),
+            Self::Null => "<null>".into(),
         }
     }
 }

--- a/lib/vector-core/src/event/test/mod.rs
+++ b/lib/vector-core/src/event/test/mod.rs
@@ -21,13 +21,10 @@ fn event_iteration() {
     assert_eq!(
         all,
         vec![
+            ("Ke$ha".into(), "It's going down, I'm yelling timber".into()),
             (
-                String::from("Ke$ha"),
-                "It's going down, I'm yelling timber".to_string()
-            ),
-            (
-                String::from("Pitbull"),
-                "The bigger they are, the harder they fall".to_string()
+                "Pitbull".into(),
+                "The bigger they are, the harder they fall".into()
             ),
         ]
         .into_iter()

--- a/src/api/schema/events/log.rs
+++ b/src/api/schema/events/log.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use async_graphql::Object;
 use chrono::{DateTime, Utc};
 use vector_common::encode_logfmt;
@@ -19,7 +21,7 @@ impl Log {
         Self { output, event }
     }
 
-    pub fn get_message(&self) -> Option<String> {
+    pub fn get_message(&self) -> Option<Cow<'_, str>> {
         Some(self.event.get("message")?.to_string_lossy())
     }
 
@@ -48,7 +50,7 @@ impl Log {
 
     /// Log message
     async fn message(&self) -> Option<String> {
-        self.get_message()
+        self.get_message().map(Into::into)
     }
 
     /// Log timestamp

--- a/src/sinks/aws_kinesis_streams/sink.rs
+++ b/src/sinks/aws_kinesis_streams/sink.rs
@@ -1,4 +1,4 @@
-use std::{fmt, num::NonZeroUsize};
+use std::{borrow::Cow, fmt, num::NonZeroUsize};
 
 use async_trait::async_trait;
 use futures::{future, stream::BoxStream, StreamExt};
@@ -91,12 +91,12 @@ pub fn process_log(
             return None;
         }
     } else {
-        gen_partition_key()
+        Cow::Owned(gen_partition_key())
     };
     let partition_key = if partition_key.len() >= 256 {
         partition_key[..256].to_string()
     } else {
-        partition_key
+        partition_key.into_owned()
     };
 
     Some(KinesisProcessedEvent {

--- a/src/sinks/datadog/traces/request_builder.rs
+++ b/src/sinks/datadog/traces/request_builder.rs
@@ -249,7 +249,7 @@ impl DatadogTracesEncoder {
             .and_then(|m| m.as_object())
             .map(|m| {
                 m.iter()
-                    .map(|(k, v)| (k.clone(), v.to_string_lossy()))
+                    .map(|(k, v)| (k.clone(), v.to_string_lossy().into_owned()))
                     .collect::<BTreeMap<String, String>>()
             })
             .unwrap_or_default();
@@ -273,7 +273,7 @@ impl DatadogTracesEncoder {
                 .unwrap_or(1i32),
             origin: trace
                 .get("origin")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             dropped_trace: trace
                 .get("dropped")
@@ -286,37 +286,37 @@ impl DatadogTracesEncoder {
         dd_proto::TracerPayload {
             container_id: trace
                 .get("container_id")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             language_name: trace
                 .get("language_name")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             language_version: trace
                 .get("language_version")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             tracer_version: trace
                 .get("tracer_version")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             runtime_id: trace
                 .get("runtime_id")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             chunks: vec![chunk],
             tags,
             env: trace
                 .get("env")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             hostname: trace
                 .get("hostname")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             app_version: trace
                 .get("app_version")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
         }
     }
@@ -352,7 +352,7 @@ impl DatadogTracesEncoder {
             .and_then(|m| m.as_object())
             .map(|m| {
                 m.iter()
-                    .map(|(k, v)| (k.clone(), v.to_string_lossy()))
+                    .map(|(k, v)| (k.clone(), v.to_string_lossy().into_owned()))
                     .collect::<BTreeMap<String, String>>()
             })
             .unwrap_or_default();
@@ -386,19 +386,19 @@ impl DatadogTracesEncoder {
         dd_proto::Span {
             service: span
                 .get("service")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             name: span
                 .get("name")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             resource: span
                 .get("resource")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             r#type: span
                 .get("type")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             trace_id: trace_id as u64,
             span_id: span_id as u64,

--- a/src/sinks/datadog/traces/sink.rs
+++ b/src/sinks/datadog/traces/sink.rs
@@ -49,11 +49,19 @@ impl Partitioner for EventPartitioner {
             }
             Event::Trace(t) => PartitionKey {
                 api_key: item.metadata().datadog_api_key(),
-                env: t.get("env").map(|s| s.to_string_lossy()),
-                hostname: t.get(log_schema().host_key()).map(|s| s.to_string_lossy()),
-                agent_version: t.get("agent_version").map(|s| s.to_string_lossy()),
-                target_tps: t.get("target_tps").and_then(|tps| tps.as_integer()),
-                error_tps: t.get("error_tps").and_then(|tps| tps.as_integer()),
+                env: t.get("env").map(|s| s.to_string_lossy().into_owned()),
+                hostname: t
+                    .get(log_schema().host_key())
+                    .map(|s| s.to_string_lossy().into_owned()),
+                agent_version: t
+                    .get("agent_version")
+                    .map(|s| s.to_string_lossy().into_owned()),
+                target_tps: t
+                    .get("target_tps")
+                    .and_then(|tps| tps.as_integer().map(Into::into)),
+                error_tps: t
+                    .get("error_tps")
+                    .and_then(|tps| tps.as_integer().map(Into::into)),
             },
         }
     }

--- a/src/sinks/datadog/traces/stats.rs
+++ b/src/sinks/datadog/traces/stats.rs
@@ -41,19 +41,19 @@ impl AggregationKey {
             bucket_key: BucketAggregationKey {
                 service: span
                     .get("service")
-                    .map(|v| v.to_string_lossy())
+                    .map(|v| v.to_string_lossy().into_owned())
                     .unwrap_or_default(),
                 name: span
                     .get("name")
-                    .map(|v| v.to_string_lossy())
+                    .map(|v| v.to_string_lossy().into_owned())
                     .unwrap_or_default(),
                 resource: span
                     .get("resource")
-                    .map(|v| v.to_string_lossy())
+                    .map(|v| v.to_string_lossy().into_owned())
                     .unwrap_or_default(),
                 ty: span
                     .get("type")
-                    .map(|v| v.to_string_lossy())
+                    .map(|v| v.to_string_lossy().into_owned())
                     .unwrap_or_default(),
                 status_code: span
                     .get("meta")
@@ -83,7 +83,7 @@ impl PayloadAggregationKey {
                 .get("meta")
                 .and_then(|m| m.as_object())
                 .and_then(|m| m.get("env"))
-                .map(|s| s.to_string_lossy())
+                .map(|s| s.to_string_lossy().into_owned())
                 .unwrap_or(self.env),
             hostname: self.hostname,
             version: self.version,
@@ -311,11 +311,11 @@ impl Aggregator {
             hostname: partition_key.hostname.clone().unwrap_or_default(),
             version: trace
                 .get("app_version")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             container_id: trace
                 .get("container_id")
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
         };
         let synthetics = trace

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -359,15 +359,15 @@ impl DataStreamConfig {
             let data_stream = log.get("data_stream").and_then(|ds| ds.as_object());
             let dtype = data_stream
                 .and_then(|ds| ds.get("type"))
-                .map(|value| value.to_string_lossy())
+                .map(|value| value.to_string_lossy().into_owned())
                 .or_else(|| self.dtype(log))?;
             let dataset = data_stream
                 .and_then(|ds| ds.get("dataset"))
-                .map(|value| value.to_string_lossy())
+                .map(|value| value.to_string_lossy().into_owned())
                 .or_else(|| self.dataset(log))?;
             let namespace = data_stream
                 .and_then(|ds| ds.get("namespace"))
-                .map(|value| value.to_string_lossy())
+                .map(|value| value.to_string_lossy().into_owned())
                 .or_else(|| self.namespace(log))?;
             (dtype, dataset, namespace)
         };

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -204,7 +204,7 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
         let mut fields: HashMap<String, Field> = HashMap::new();
         log.convert_to_fields().for_each(|(key, value)| {
             if self.tags.contains(&key) {
-                tags.insert(key, value.to_string_lossy());
+                tags.insert(key, value.to_string_lossy().into_owned());
             } else {
                 fields.insert(key, to_field(value));
             }
@@ -293,7 +293,7 @@ fn to_field(value: &Value) -> Field {
         Value::Integer(num) => Field::Int(*num),
         Value::Float(num) => Field::Float(num.into_inner()),
         Value::Boolean(b) => Field::Bool(*b),
-        _ => Field::String(value.to_string_lossy()),
+        _ => Field::String(value.to_string_lossy().into_owned()),
     }
 }
 

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -176,7 +176,7 @@ impl EventEncoder {
                         for (k, v) in output {
                             vec.push((
                                 slugify_text(format!("{}{}", opening_prefix, k)),
-                                Value::from(v).to_string_lossy(),
+                                Value::from(v).to_string_lossy().into_owned(),
                             ))
                         }
                     }

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -132,7 +132,7 @@ impl tokio_util::codec::Encoder<Event> for PapertrailEncoder {
         let host = event
             .as_mut_log()
             .remove(log_schema().host_key())
-            .map(|host| host.to_string_lossy());
+            .map(|host| host.to_string_lossy().into_owned());
 
         let process = self
             .process

--- a/src/sinks/splunk_hec/logs/encoder.rs
+++ b/src/sinks/splunk_hec/logs/encoder.rs
@@ -94,7 +94,9 @@ impl Encoder<Vec<HecProcessedEvent>> for HecLogsEncoder {
 
                         let mut hec_data =
                             HecData::new(hec_event, metadata.fields, metadata.timestamp);
-                        hec_data.host = metadata.host.map(|host| host.to_string_lossy());
+                        hec_data.host = metadata
+                            .host
+                            .map(|host| host.to_string_lossy().into_owned());
                         hec_data.index = metadata.index;
                         hec_data.source = metadata.source;
                         hec_data.sourcetype = metadata.sourcetype;

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -169,7 +169,12 @@ mod tests {
             let mut events = Vec::with_capacity(req.events.len());
             for event in req.events {
                 let event: Event = event.into();
-                let string = event.as_log().get("message").unwrap().to_string_lossy();
+                let string = event
+                    .as_log()
+                    .get("message")
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned();
                 events.push(string)
             }
 
@@ -179,6 +184,7 @@ mod tests {
         .await
         .into_iter()
         .flatten()
+        .map(Into::into)
         .collect()
     }
 

--- a/src/sources/aws_sqs/integration_tests.rs
+++ b/src/sources/aws_sqs/integration_tests.rs
@@ -115,7 +115,7 @@ pub(crate) async fn test() {
                 .get(log_schema().message_key())
                 .unwrap()
                 .to_string_lossy();
-            if !expected_messages.remove(&message) {
+            if !expected_messages.remove(message.as_ref()) {
                 panic!("Received unexpected message: {:?}", message);
             }
         }

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -1772,6 +1772,7 @@ mod integration_tests {
                         .remove(crate::config::log_schema().message_key())
                         .unwrap()
                         .to_string_lossy()
+                        .into_owned()
                 })
                 .collect::<Vec<_>>();
             assert_eq!(actual_messages, expected_messages);

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1855,7 +1855,11 @@ mod tests {
         received
             .into_iter()
             .map(Event::into_log)
-            .map(|log| log[log_schema().message_key()].to_string_lossy())
+            .map(|log| {
+                log[log_schema().message_key()]
+                    .to_string_lossy()
+                    .into_owned()
+            })
             .collect()
     }
 

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -131,13 +131,17 @@ mod tests {
             let event = stream.next().await;
             assert_eq!(
                 Some("hello world".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()].to_string_lossy())
+                event.map(|event| event.as_log()[log_schema().message_key()]
+                    .to_string_lossy()
+                    .into_owned())
             );
 
             let event = stream.next().await;
             assert_eq!(
                 Some("hello world again".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()].to_string_lossy())
+                event.map(|event| event.as_log()[log_schema().message_key()]
+                    .to_string_lossy()
+                    .into_owned())
             );
 
             let event = stream.next().await;

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -124,13 +124,17 @@ mod tests {
             let event = stream.next().await;
             assert_eq!(
                 Some("hello world".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()].to_string_lossy())
+                event.map(|event| event.as_log()[log_schema().message_key()]
+                    .to_string_lossy()
+                    .into_owned())
             );
 
             let event = stream.next().await;
             assert_eq!(
                 Some("hello world again".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()].to_string_lossy())
+                event.map(|event| event.as_log()[log_schema().message_key()]
+                    .to_string_lossy()
+                    .into_owned())
             );
 
             let event = stream.next().await;

--- a/src/template.rs
+++ b/src/template.rs
@@ -191,12 +191,12 @@ fn render_fields(src: &str, event: EventRef<'_>) -> Result<String, TemplateRende
                 .expect("src should match regex");
             match event {
                 EventRef::Log(log) => log.get(key).map(|val| val.to_string_lossy()),
-                EventRef::Metric(metric) => render_metric_field(key, metric),
+                EventRef::Metric(metric) => render_metric_field(key, metric).map(Into::into),
                 EventRef::Trace(trace) => trace.get(&key).map(|val| val.to_string_lossy()),
             }
             .unwrap_or_else(|| {
                 missing_keys.push(key.to_owned());
-                String::new()
+                "".into()
             })
         })
         .into_owned();

--- a/src/test_util/mock/transforms/basic.rs
+++ b/src/test_util/mock/transforms/basic.rs
@@ -65,7 +65,8 @@ impl FunctionTransform for BasicTransform {
                 let mut v = log
                     .get(crate::config::log_schema().message_key())
                     .unwrap()
-                    .to_string_lossy();
+                    .to_string_lossy()
+                    .into_owned();
                 v.push_str(&self.suffix);
                 log.insert(crate::config::log_schema().message_key(), Value::from(v));
             }
@@ -107,7 +108,8 @@ impl FunctionTransform for BasicTransform {
                 let mut v = trace
                     .get(crate::config::log_schema().message_key())
                     .unwrap()
-                    .to_string_lossy();
+                    .to_string_lossy()
+                    .into_owned();
                 v.push_str(&self.suffix);
                 trace.insert(crate::config::log_schema().message_key(), Value::from(v));
             }

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -68,6 +68,7 @@ fn into_message(event: Event) -> String {
         .get(crate::config::log_schema().message_key())
         .unwrap()
         .to_string_lossy()
+        .into_owned()
 }
 
 fn into_message_stream(array: EventArray) -> impl futures::Stream<Item = String> {

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -416,7 +416,7 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
             .with_timestamp(timestamp))
         }
         MetricConfig::Set(set) => {
-            let value = value.to_string_lossy();
+            let value = value.to_string_lossy().into_owned();
 
             let name = set.name.as_ref().unwrap_or(&set.field);
             let name = render_template(name, event)?;

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -662,7 +662,12 @@ mod tests {
     }
 
     fn get_field_string(event: &Event, field: &str) -> String {
-        event.as_log().get(field).unwrap().to_string_lossy()
+        event
+            .as_log()
+            .get(field)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
     }
 
     #[test]


### PR DESCRIPTION
This allows for lossless bytes-to-utf8 conversions, as well as regex references and `Null`, to return without allocating a copy of the data.

This is mostly tech debt, found when working on pre-parsing template strings, but it could end up being a small performance lift.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
