### PR TITLE
enhancement(log_to_metric transform): Pre-parse all templates

### DIFF
--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -629,7 +629,7 @@ mod tests {
             &["in"],
             LogToMetricConfig {
                 metrics: vec![MetricConfig::Gauge(GaugeConfig {
-                    field: "message".to_string(),
+                    field: "message".try_into().expect("Fixed template string"),
                     name: None,
                     namespace: None,
                     tags: None,

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -5,7 +5,6 @@ use vector_core::internal_event::InternalEvent;
 
 use crate::emit;
 use crate::internal_events::{ComponentEventsDropped, UNINTENTIONAL};
-use crate::template::TemplateParseError;
 use vector_common::internal_event::{error_stage, error_type};
 
 pub struct LogToMetricFieldNullError<'a> {
@@ -68,37 +67,6 @@ impl<'a> InternalEvent for LogToMetricParseFloatError<'a> {
         counter!(
             "processing_errors_total", 1,
             "error_type" => "parse_error",
-        );
-
-        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason })
-    }
-}
-
-pub struct LogToMetricTemplateParseError {
-    pub error: TemplateParseError,
-}
-
-impl InternalEvent for LogToMetricTemplateParseError {
-    fn emit(self) {
-        let reason = "Failed to parse template.";
-        error!(
-            message = reason,
-            error = ?self.error,
-            error_code = "failed_parsing_template",
-            error_type = error_type::TEMPLATE_FAILED,
-            stage = error_stage::PROCESSING,
-            internal_log_rate_limit = true,
-        );
-        counter!(
-            "component_errors_total", 1,
-            "error_code" => "failed_parsing_template",
-            "error_type" => error_type::TEMPLATE_FAILED,
-            "stage" => error_stage::PROCESSING,
-        );
-        // deprecated
-        counter!(
-            "processing_errors_total", 1,
-            "error_type" => "template_error",
         );
 
         emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason })


### PR DESCRIPTION
This moves parsing of the templates up into configuration handling instead of doing the parsing every time an event is handled. The template system doesn't actually store the parsed data (work in progress), but this removes some of the existing operations from the hot path, laying the ground for pre-parsed templates to show actual improvements.

Ref: #14898 #14864
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
