### PR TITLE
chore(log_to_metric transform): Unify common config and render bits

### DIFF
--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -429,7 +429,7 @@ mod tests {
     use crate::sinks::blackhole::BlackholeConfig;
     use crate::sources::demo_logs::{DemoLogsConfig, OutputFormat};
     use crate::test_util::{start_topology, trace_init};
-    use crate::transforms::log_to_metric::{GaugeConfig, LogToMetricConfig, MetricConfig};
+    use crate::transforms::log_to_metric::{LogToMetricConfig, MetricConfig, MetricTypeConfig};
     use crate::transforms::remap::RemapConfig;
 
     #[test]
@@ -628,12 +628,13 @@ mod tests {
             "to_metric",
             &["in"],
             LogToMetricConfig {
-                metrics: vec![MetricConfig::Gauge(GaugeConfig {
+                metrics: vec![MetricConfig {
                     field: "message".try_into().expect("Fixed template string"),
                     name: None,
                     namespace: None,
                     tags: None,
-                })],
+                    metric: MetricTypeConfig::Gauge,
+                }],
             },
         );
         config.add_sink(

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -46,18 +46,18 @@ pub struct CounterConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct MetricConfig {
-    /// Name of the field in the event to generate the counter.
+    /// Name of the field in the event to generate the metric.
     field: Template,
 
     /// Overrides the name of the counter.
     ///
-    /// If not specified, `field` is used as the name of the counter.
+    /// If not specified, `field` is used as the name of the metric.
     name: Option<Template>,
 
-    /// Sets the namespace for the counter.
+    /// Sets the namespace for the metric.
     namespace: Option<Template>,
 
-    /// Tags to apply to the counter.
+    /// Tags to apply to the metric.
     tags: Option<IndexMap<String, Template>>,
 
     #[configurable(derived)]

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -35,11 +35,11 @@ pub struct LogToMetricConfig {
 pub struct CounterConfig {
     /// Increments the counter by the value in `field`, instead of only by `1`.
     #[serde(default = "default_increment_by_value")]
-    increment_by_value: bool,
+    pub increment_by_value: bool,
 
     #[configurable(derived)]
     #[serde(default = "default_kind")]
-    kind: MetricKind,
+    pub kind: MetricKind,
 }
 
 /// Specification of a metric derived from a log event.
@@ -47,22 +47,22 @@ pub struct CounterConfig {
 #[derive(Clone, Debug)]
 pub struct MetricConfig {
     /// Name of the field in the event to generate the metric.
-    field: Template,
+    pub field: Template,
 
     /// Overrides the name of the counter.
     ///
     /// If not specified, `field` is used as the name of the metric.
-    name: Option<Template>,
+    pub name: Option<Template>,
 
     /// Sets the namespace for the metric.
-    namespace: Option<Template>,
+    pub namespace: Option<Template>,
 
     /// Tags to apply to the metric.
-    tags: Option<IndexMap<String, Template>>,
+    pub tags: Option<IndexMap<String, Template>>,
 
     #[configurable(derived)]
     #[serde(flatten)]
-    metric: MetricTypeConfig,
+    pub metric: MetricTypeConfig,
 }
 
 /// Specification of the type of an individual metric, and any associated data.


### PR DESCRIPTION
While I was looking at `log_to_metric` for #14902, it seemed there was a lot of repetitive config and code in this transform. Rather than tack it on to the previous PR, I split it out to make it easier to review.

@tobz I'm assuming there should be something more intelligent said in the config commentary, but the rendered docs on this one are so far from the existing Cue that I have no idea what "better" looks like here.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
