### PR TITLE
chore(soak tests): Add templated tags to log2metric soaks

### DIFF
--- a/soaks/tests/syslog_log2metric_humio_metrics/vector.toml
+++ b/soaks/tests/syslog_log2metric_humio_metrics/vector.toml
@@ -21,9 +21,12 @@ mode = "tcp"
 type = "log_to_metric"
 inputs = ["syslog"]
 
-    [[transforms.log2metric.metrics]]
-    type = "gauge"
-    field = "procid"
+  [[transforms.log2metric.metrics]]
+  type = "gauge"
+  field = "procid"
+  tags.hostname = "{{ hostname }}"
+  tags.facility = "{{ facility }}"
+  tags.severity = "{{ severity }}"
 
 ##
 ## Sinks

--- a/soaks/tests/syslog_log2metric_splunk_hec_metrics/vector.toml
+++ b/soaks/tests/syslog_log2metric_splunk_hec_metrics/vector.toml
@@ -21,9 +21,12 @@ mode = "tcp"
 type = "log_to_metric"
 inputs = ["syslog"]
 
-    [[transforms.log2metric.metrics]]
-    type = "gauge"
-    field = "procid"
+  [[transforms.log2metric.metrics]]
+  type = "gauge"
+  field = "procid"
+  tags.hostname = "{{ hostname }}"
+  tags.facility = "{{ facility }}"
+  tags.severity = "{{ severity }}"
 
 ##
 ## Sinks

--- a/soaks/tests/syslog_regex_logs2metric_ddmetrics/vector.toml
+++ b/soaks/tests/syslog_regex_logs2metric_ddmetrics/vector.toml
@@ -29,6 +29,9 @@ inputs = ["remap"]
   [[transforms.log2metric.metrics]]
   type = "gauge"
   field = "procid"
+  tags.hostname = "{{ hostname }}"
+  tags.facility = "{{ facility }}"
+  tags.severity = "{{ severity }}"
 
 ##
 ## Sinks


### PR DESCRIPTION
The soak tests that use a `log_to_metric` transform have a trivial configuration that don't exercise many of the features of the transform. This change adds a set of tags to all of these transforms that use template substitution to generate dynamic tags, this increasing the complexity and exercising more code paths.

This will be used to check the impact of #14902 and #14908
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
