### PR TITLE
enhancement(vrl): read grok aliases from file

### DIFF
--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -278,6 +278,31 @@ mod test {
             tdef: TypeDef::object(Collection::any()).fallible(),
         }
 
+        presence_of_alias_sources_argument {
+            args: func_args![
+                value: r##"2020-10-02T23:22:12.223222Z info 200 hello world"##,
+                patterns: Value::Array(vec![
+                    "%{common_prefix} %{_status} %{_message}".into(),
+                    "%{common_prefix} %{_message}".into(),
+                    ]),
+                aliases: value!({
+                    "common_prefix": "%{_timestamp} %{_loglevel}",
+                    "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+                    "_loglevel": "%{LOGLEVEL:level}",
+                    "_status": "%{POSINT:status}",
+                    "_message": "%{GREEDYDATA:message}"
+                }),
+                alias_sources: Value::Array(vec![]),
+            ],
+            want: Ok(Value::from(btreemap! {
+                "timestamp" => "2020-10-02T23:22:12.223222Z",
+                "level" => "info",
+                "status" => "200",
+                "message" => "hello world"
+            })),
+            tdef: TypeDef::object(Collection::any()).fallible(),
+        }
+
         multiple_patterns_and_aliases_second_pattern_matches {
             args: func_args![
                 value: r##"2020-10-02T23:22:12.223222Z info hello world"##,

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -166,9 +166,13 @@ impl Function for ParseGroks {
 
         for src in alias_sources {
             let path = Path::new(&src);
-            let file = File::open(&path).unwrap();
+            let file = File::open(&path).map_err(|_| {
+                vrl::function::Error::InvalidAliasSource { path: path.to_owned() }
+            })?;
             let reader = BufReader::new(file);
-            let mut src_aliases = serde_json::from_reader(reader).unwrap();
+            let mut src_aliases = serde_json::from_reader(reader).map_err(|_| {
+                vrl::function::Error::InvalidAliasSource { path: path.to_owned() }
+            })?;
 
             aliases.append(&mut src_aliases);
         }


### PR DESCRIPTION
This PR aims to address (in part) vectordotdev/vrl#89, allowing GROK aliases to be defined in one or more files. I am not sure 

- Files are assumed to contain JSON, with a single outer Object.
- Duplicate patterns are not handled
- Needs proper tests.
