### PR TITLE
Revert "enhancement(log_to_metric transform): Pre-parse all templates…

### DIFF
--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -629,7 +629,7 @@ mod tests {
             &["in"],
             LogToMetricConfig {
                 metrics: vec![MetricConfig::Gauge(GaugeConfig {
-                    field: "message".try_into().expect("Fixed template string"),
+                    field: "message".to_string(),
                     name: None,
                     namespace: None,
                     tags: None,

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -5,6 +5,7 @@ use vector_core::internal_event::InternalEvent;
 
 use crate::emit;
 use crate::internal_events::{ComponentEventsDropped, UNINTENTIONAL};
+use crate::template::TemplateParseError;
 use vector_common::internal_event::{error_stage, error_type};
 
 pub struct LogToMetricFieldNullError<'a> {
@@ -67,6 +68,37 @@ impl<'a> InternalEvent for LogToMetricParseFloatError<'a> {
         counter!(
             "processing_errors_total", 1,
             "error_type" => "parse_error",
+        );
+
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason })
+    }
+}
+
+pub struct LogToMetricTemplateParseError {
+    pub error: TemplateParseError,
+}
+
+impl InternalEvent for LogToMetricTemplateParseError {
+    fn emit(self) {
+        let reason = "Failed to parse template.";
+        error!(
+            message = reason,
+            error = ?self.error,
+            error_code = "failed_parsing_template",
+            error_type = error_type::TEMPLATE_FAILED,
+            stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total", 1,
+            "error_code" => "failed_parsing_template",
+            "error_type" => error_type::TEMPLATE_FAILED,
+            "stage" => error_stage::PROCESSING,
+        );
+        // deprecated
+        counter!(
+            "processing_errors_total", 1,
+            "error_type" => "template_error",
         );
 
         emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason })


### PR DESCRIPTION
… (#14902)"

This reverts commit 79387ae865ec11450bcf052ec02035cf1cc0b077.

DO NOT MERGE

This is just to see a before-and-after performance comparison of the recent `log_to_metric` change with the current soak tests. In this case, the "baseline" will be with the change made since it is already merged, and the comparison will be without the change.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
