### PR TITLE
docs(kafka source, kafka sink): added docs for using kafka components with Azure Event Hubs

### DIFF
--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -87,7 +87,7 @@ components: _kafka: {
 		}
 		azure_event_hubs: {
 			title: "Azure Event Hubs"
-			body: """
+			body:  """
 				It is possible to use the `kafka` source and sink with [Azure Event Hubs](/(urls.azure_event_hubs))
 				for all tiers other than the [Basic tier](\(urls.azure_event_hubs_tiers)). More details
 				can be found [here](\(urls.azure_event_hubs_kafka)). To configure the source and

--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -89,10 +89,10 @@ components: _kafka: {
 			title: "Azure Event Hubs"
 			body: """
 				It is possible to use the `kafka` source and sink with Azure Event Hubs for all
-				tiers other than the Basic tier. More can be found [here](\(urls.azure_event_hubs_kafka)).
-				To configure the source and sink to connect to Azure Event Hubs set the following
-				options:
-				- `bootstrap_servers` - <namespace name>.servicebus.windows.net:9093 				
+				tiers other than the [Basic tier](\(urls.azure_event_hubs_tiers)). More details
+				can be found [here](\(urls.azure_event_hubs_kafka)). To configure the source and 
+				sink to connect to Azure Event Hubs set the following options:
+				- `bootstrap_servers` - `<namespace name>.servicebus.windows.net:9093`
 				- `group_id` - The consumer group. Note that if the default group (`$Default`) is used it must 
 				  be specified as `$$Default` to escape the `$` used for environment variables.				
 				- `topics` - The event hub name.

--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -90,11 +90,11 @@ components: _kafka: {
 			body: """
 				It is possible to use the `kafka` source and sink with [Azure Event Hubs](/(urls.azure_event_hubs))
 				for all tiers other than the [Basic tier](\(urls.azure_event_hubs_tiers)). More details
-				can be found [here](\(urls.azure_event_hubs_kafka)). To configure the source and 
+				can be found [here](\(urls.azure_event_hubs_kafka)). To configure the source and
 				sink to connect to Azure Event Hubs set the following options:
 				- `bootstrap_servers` - `<namespace name>.servicebus.windows.net:9093`
-				- `group_id` - The consumer group. Note that if the default group (`$Default`) is used it must 
-				  be specified as `$$Default` to escape the `$` used for environment variables.				
+				- `group_id` - The consumer group. Note that if the default group (`$Default`) is used it must
+				  be specified as `$$Default` to escape the `$` used for environment variables.
 				- `topics` - The event hub name.
 				- `sasl.enabled` - Set to `true`.
 				- `sasl.mechanism` - Set to `PLAIN`.

--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -88,7 +88,7 @@ components: _kafka: {
 		azure_event_hubs: {
 			title: "Azure Event Hubs"
 			body:  """
-				It is possible to use the `kafka` source and sink with [Azure Event Hubs](/(urls.azure_event_hubs))
+				It is possible to use the `kafka` source and sink with [Azure Event Hubs](\(urls.azure_event_hubs))
 				for all tiers other than the [Basic tier](\(urls.azure_event_hubs_tiers)). More details
 				can be found [here](\(urls.azure_event_hubs_kafka)). To configure the source and
 				sink to connect to Azure Event Hubs set the following options:

--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -88,8 +88,8 @@ components: _kafka: {
 		azure_event_hubs: {
 			title: "Azure Event Hubs"
 			body: """
-				It is possible to use the `kafka` source and sink with Azure Event Hubs for all
-				tiers other than the [Basic tier](\(urls.azure_event_hubs_tiers)). More details
+				It is possible to use the `kafka` source and sink with [Azure Event Hubs](/(urls.azure_event_hubs))
+				for all tiers other than the [Basic tier](\(urls.azure_event_hubs_tiers)). More details
 				can be found [here](\(urls.azure_event_hubs_kafka)). To configure the source and 
 				sink to connect to Azure Event Hubs set the following options:
 				- `bootstrap_servers` - `<namespace name>.servicebus.windows.net:9093`

--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -85,6 +85,26 @@ components: _kafka: {
 				this dependency is packaged with Vector, meaning you do not need to install it.
 				"""
 		}
+		azure_event_hubs: {
+			title: "Azure Event Hubs"
+			body: """
+				It is possible to use the `kafka` source and sink with Azure Event Hubs for all
+				tiers other than the Basic tier. More can be found [here](\(urls.azure_event_hubs_kafka)).
+				To configure the source and sink to connect to Azure Event Hubs set the following
+				options:
+				- `bootstrap_servers` - <namespace name>.servicebus.windows.net:9093 				
+				- `group_id` - The consumer group. Note that if the default group (`$Default`) is used it must 
+				  be specified as `$$Default` to escape the `$` used for environment variables.				
+				- `topics` - The event hub name.
+				- `sasl.enabled` - Set to `true`.
+				- `sasl.mechanism` - Set to `PLAIN`.
+				- `sasl.username` - Set to `$$ConnectionString` (note the double `$$`).
+				- `sasl.password` - Set to the connection string. See [here](\(urls.azure_event_hubs_connection_string)).
+				- `tls.enabled` - Set to `true`.
+				- `tls.ca_file` - The certificate authority file.
+				- `tls.verify_certificate` - Set to `true`.
+				"""
+		}
 	}
 
 	telemetry: metrics: {

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -3,6 +3,8 @@ package metadata
 urls: {
 	apex:                                       "https://apex.sh/logs/"
 	azure_blob_storage:                         "https://azure.microsoft.com/en-us/services/storage/blobs/"
+	azure_event_hubs_kafka:                     "https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-for-kafka-ecosystem-overview"
+	azure_event_hubs_connection_string:         "https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"
 	affine_type_system:                         "\(wikipedia)/wiki/Substructural_type_system#Affine_type_systems"
 	adaptive_request_concurrency_post:          "/blog/adaptive-request-concurrency/"
 	amazon_linux:                               "https://aws.amazon.com/amazon-linux-ami/"

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -3,6 +3,7 @@ package metadata
 urls: {
 	apex:                                       "https://apex.sh/logs/"
 	azure_blob_storage:                         "https://azure.microsoft.com/en-us/services/storage/blobs/"
+	azure_event_hubs:                           "https://learn.microsoft.com/en-us/azure/event-hubs/"
 	azure_event_hubs_kafka:                     "https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-for-kafka-ecosystem-overview"
 	azure_event_hubs_connection_string:         "https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"
 	azure_event_hubs_tiers:                     "https://learn.microsoft.com/en-us/azure/event-hubs/compare-tiers"

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -5,6 +5,7 @@ urls: {
 	azure_blob_storage:                         "https://azure.microsoft.com/en-us/services/storage/blobs/"
 	azure_event_hubs_kafka:                     "https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-for-kafka-ecosystem-overview"
 	azure_event_hubs_connection_string:         "https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"
+	azure_event_hubs_tiers:                     "https://learn.microsoft.com/en-us/azure/event-hubs/compare-tiers"
 	affine_type_system:                         "\(wikipedia)/wiki/Substructural_type_system#Affine_type_systems"
 	adaptive_request_concurrency_post:          "/blog/adaptive-request-concurrency/"
 	amazon_linux:                               "https://aws.amazon.com/amazon-linux-ami/"


### PR DESCRIPTION
Ref #4261

This adds documentation to the kafka source and sink to advise on how to use these components to connect to Azure event hubs.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

