### PR TITLE
chore(config, docs): import machine-generated Cue documentation for sources and sinks

### DIFF
--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -1,0 +1,203 @@
+package metadata
+
+base: components: sinks: configuration: {
+	buffer: {
+		description: """
+			Buffer configuration.
+
+			Buffers are compromised of stages(*) that form a buffer _topology_, with input items being
+			subject to configurable behavior when each stage reaches configured limits.  Buffers are
+			configured for sinks, where backpressure from the sink can be handled by the buffer.  This
+			allows absorbing temporary load, or potentially adding write-ahead-log behavior to a sink to
+			increase the durability of a given Vector pipeline.
+
+			While we use the term "buffer topology" here, a buffer topology is referred to by the more
+			common "buffer" or "buffers" shorthand.  This is related to buffers originally being a single
+			component, where you could only choose which buffer type to use.  As we expand buffer
+			functionality to allow chaining buffers together, you'll see "buffer topology" used in internal
+			documentation to correctly reflect the internal structure.
+			"""
+		required: false
+		type: object: options: {
+			max_events: {
+				description:   "The maximum number of events allowed in the buffer."
+				relevant_when: "type = \"memory\""
+				required:      false
+				type: uint: default: 500
+			}
+			max_size: {
+				description: """
+					The maximum size of the buffer on disk.
+
+					Must be at least ~256 megabytes (268435488 bytes).
+					"""
+				relevant_when: "type = \"disk_v1\" or type = \"disk\""
+				required:      true
+				type: uint: {}
+			}
+			type: {
+				required: false
+				type: string: {
+					default: "memory"
+					enum: {
+						disk: """
+														Events are buffered on disk. (version 2)
+
+														This is less performant, but more durable. Data that has been synchronized to disk will not
+														be lost if Vector is restarted forcefully or crashes.
+
+														Data is synchronized to disk every 500ms.
+														"""
+						disk_v1: """
+														Events are buffered on disk. (version 1)
+
+														This is less performant, but more durable. Data that has been synchronized to disk will not
+														be lost if Vector is restarted forcefully or crashes.
+														"""
+						memory: """
+														Events are buffered in memory.
+
+														This is more performant, but less durable. Data will be lost if Vector is restarted
+														forcefully or crashes.
+														"""
+					}
+				}
+			}
+			when_full: {
+				description: "Event handling behavior when a buffer is full."
+				required:    false
+				type: string: {
+					default: "block"
+					enum: {
+						block: """
+														Wait for free space in the buffer.
+
+														This applies backpressure up the topology, signalling that sources should slow down
+														the acceptance/consumption of events. This means that while no data is lost, data will pile
+														up at the edge.
+														"""
+						drop_newest: """
+														Drops the event instead of waiting for free space in buffer.
+
+														The event will be intentionally dropped. This mode is typically used when performance is the
+														highest priority, and it is preferable to temporarily lose events rather than cause a
+														slowdown in the acceptance/consumption of events.
+														"""
+						overflow: """
+														Overflows to the next stage in the buffer topology.
+
+														If the current buffer stage is full, attempt to send this event to the next buffer stage.
+														That stage may also be configured overflow, and so on, but ultimately the last stage in a
+														buffer topology must use one of the other handling behaviors. This means that next stage may
+														potentially be able to buffer the event, but it may also block or drop the event.
+
+														This mode can only be used when two or more buffer stages are configured.
+														"""
+					}
+				}
+			}
+		}
+	}
+	healthcheck: {
+		description: "Healthcheck configuration."
+		required:    false
+		type: object: options: {
+			enabled: {
+				description: "Whether or not to check the health of the sink when Vector starts up."
+				required:    false
+				type: bool: default: true
+			}
+			uri: {
+				description: """
+					The full URI to make HTTP healthcheck requests to.
+
+					This must be a valid URI, which requires at least the scheme and host. All other
+					components -- port, path, etc -- are allowed as well.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	inputs: {
+		description: """
+			A list of upstream [source][sources] or [transform][transforms] IDs.
+
+			Wildcards (`*`) are supported.
+
+			See [configuration][configuration] for more info.
+
+			[sources]: https://vector.dev/docs/reference/configuration/sources/
+			[transforms]: https://vector.dev/docs/reference/configuration/transforms/
+			[configuration]: https://vector.dev/docs/reference/configuration/
+			"""
+		required: true
+		type: array: items: type: string: {
+			examples: ["my-source-or-transform-id", "prefix-*"]
+			syntax: "literal"
+		}
+	}
+	proxy: {
+		description: """
+			Proxy configuration.
+
+			Vector can be configured to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
+			proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
+			as well as set specific hosts that should not be proxied.
+			"""
+		required: false
+		type: object: options: {
+			enabled: {
+				description: "Enables proxying support."
+				required:    false
+				type: bool: default: true
+			}
+			http: {
+				description: """
+					Proxy endpoint to use when proxying HTTP traffic.
+
+					Must be a valid URI string.
+					"""
+				required: false
+				type: string: {
+					examples: ["http://foo.bar:3128"]
+					syntax: "literal"
+				}
+			}
+			https: {
+				description: """
+					Proxy endpoint to use when proxying HTTPS traffic.
+
+					Must be a valid URI string.
+					"""
+				required: false
+				type: string: {
+					examples: ["http://foo.bar:3128"]
+					syntax: "literal"
+				}
+			}
+			no_proxy: {
+				description: """
+					A list of hosts to avoid proxying.
+
+					Multiple patterns are allowed:
+
+					| Pattern             | Example match                                                               |
+					| ------------------- | --------------------------------------------------------------------------- |
+					| Domain names        | `**example.com**` matches requests to `**example.com**`                     |
+					| Wildcard domains    | `**.example.com**` matches requests to `**example.com**` and its subdomains |
+					| IP addresses        | `**127.0.0.1**` matches requests to `**127.0.0.1**`                         |
+					| [CIDR][cidr] blocks | `**192.168.0.0/16**` matches requests to any IP addresses in this range     |
+					| Splat               | `__*__` matches all hosts                                                   |
+
+					[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
+					"""
+				required: false
+				type: array: {
+					default: []
+					items: type: string: syntax: "literal"
+				}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/base/sources.cue
+++ b/website/cue/reference/components/base/sources.cue
@@ -1,0 +1,65 @@
+package metadata
+
+base: components: sources: configuration: proxy: {
+	description: """
+		Proxy configuration.
+
+		Vector can be configured to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
+		proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
+		as well as set specific hosts that should not be proxied.
+		"""
+	required: false
+	type: object: options: {
+		enabled: {
+			description: "Enables proxying support."
+			required:    false
+			type: bool: default: true
+		}
+		http: {
+			description: """
+				Proxy endpoint to use when proxying HTTP traffic.
+
+				Must be a valid URI string.
+				"""
+			required: false
+			type: string: {
+				examples: ["http://foo.bar:3128"]
+				syntax: "literal"
+			}
+		}
+		https: {
+			description: """
+				Proxy endpoint to use when proxying HTTPS traffic.
+
+				Must be a valid URI string.
+				"""
+			required: false
+			type: string: {
+				examples: ["http://foo.bar:3128"]
+				syntax: "literal"
+			}
+		}
+		no_proxy: {
+			description: """
+				A list of hosts to avoid proxying.
+
+				Multiple patterns are allowed:
+
+				| Pattern             | Example match                                                               |
+				| ------------------- | --------------------------------------------------------------------------- |
+				| Domain names        | `**example.com**` matches requests to `**example.com**`                     |
+				| Wildcard domains    | `**.example.com**` matches requests to `**example.com**` and its subdomains |
+				| IP addresses        | `**127.0.0.1**` matches requests to `**127.0.0.1**`                         |
+				| [CIDR][cidr] blocks | `**192.168.0.0/16**` matches requests to any IP addresses in this range     |
+				| Splat               | `__*__` matches all hosts                                                   |
+
+				[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
+				"""
+			required: false
+			type: array: {
+				default: []
+				items: type: string: syntax: "literal"
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -1,0 +1,184 @@
+package metadata
+
+base: components: sinks: amqp: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	connection: {
+		description: "Connection options for the `amqp` sink."
+		required:    true
+		type: object: options: {
+			connection_string: {
+				description: """
+					URI for the `AMQP` server.
+
+					Format: amqp://<user>:<password>@<host>:<port>/<vhost>?timeout=<seconds>
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+			tls: {
+				description: "Standard TLS options."
+				required:    false
+				type: object: options: {
+					alpn_protocols: {
+						description: """
+																Sets the list of supported ALPN protocols.
+
+																Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+																they are defined.
+																"""
+						required: false
+						type: array: items: type: string: syntax: "literal"
+					}
+					ca_file: {
+						description: """
+																Absolute path to an additional CA certificate file.
+
+																The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					crt_file: {
+						description: """
+																Absolute path to a certificate file used to identify this server.
+
+																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+																an inline string in PEM format.
+
+																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_file: {
+						description: """
+																Absolute path to a private key file used to identify this server.
+
+																The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_pass: {
+						description: """
+																Passphrase used to unlock the encrypted key file.
+
+																This has no effect unless `key_file` is set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					verify_certificate: {
+						description: """
+																Enables certificate verification.
+
+																If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+																issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+																certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+																so on until reaching a root certificate.
+
+																Relevant for both incoming and outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+																"""
+						required: false
+						type: bool: {}
+					}
+					verify_hostname: {
+						description: """
+																Enables hostname verification.
+
+																If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+																the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+																Only relevant for outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+																"""
+						required: false
+						type: bool: {}
+					}
+				}
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	exchange: {
+		description: "The exchange to publish messages to."
+		required:    true
+		type: string: syntax: "template"
+	}
+	routing_key: {
+		description: "Template used to generate a routing key which corresponds to a queue binding."
+		required:    false
+		type: string: syntax: "template"
+	}
+}

--- a/website/cue/reference/components/sinks/base/apex.cue
+++ b/website/cue/reference/components/sinks/base/apex.cue
@@ -1,0 +1,179 @@
+package metadata
+
+base: components: sinks: apex: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_token: {
+		description: "The API token to use to authenticate with Apex."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	project_id: {
+		description: "The ID of the project to associate reported logs with."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	uri: {
+		description: """
+			The base URI of the Apex instance.
+
+			Vector will append `/add_events` to this.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -1,0 +1,448 @@
+package metadata
+
+base: components: sinks: aws_cloudwatch_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	assume_role: {
+		description: """
+			The ARN of an [IAM role][iam_role] to assume at startup.
+
+			[iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description: "The AWS access key ID."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description: "The ARN of the role to assume."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description: "Path to the credentials file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description: "Timeout for successfully loading any credentials, in seconds."
+				required:    false
+				type: uint: {}
+			}
+			profile: {
+				description: "The credentials profile to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description: "The AWS secret access key."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	create_missing_group: {
+		description: """
+			Dynamically create a [log group][log_group] if it does not already exist.
+
+			This will ignore `create_missing_stream` directly after creating the group and will create
+			the first stream.
+
+			[log_group]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+			"""
+		required: false
+		type: bool: {}
+	}
+	create_missing_stream: {
+		description: """
+			Dynamically create a [log stream][log_stream] if it does not already exist.
+
+			[log_stream]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+			"""
+		required: false
+		type: bool: {}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	group_name: {
+		description: """
+			The [group name][group_name] of the target CloudWatch Logs stream.
+
+			[group_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+			"""
+		required: true
+		type: string: syntax: "template"
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: "Outbound HTTP request settings."
+		required:    false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			headers: {
+				description: "Additional HTTP headers to add to every HTTP request."
+				required:    false
+				type: object: {
+					default: {}
+					options: "*": {
+						description: "Additional HTTP headers to add to every HTTP request."
+						required:    true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	stream_name: {
+		description: """
+			The [stream name][stream_name] of the target CloudWatch Logs stream.
+
+			Note that there can only be one writer to a log stream at a time. If you have multiple
+			instances of Vector writing to the same log group, you must include an identifier in the
+			stream name that is guaranteed to be unique per Vector instance.
+
+			For example, you might choose `host`.
+
+			[stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+			"""
+		required: true
+		type: string: syntax: "template"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -1,0 +1,344 @@
+package metadata
+
+base: components: sinks: aws_cloudwatch_metrics: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	assume_role: {
+		description: """
+			The ARN of an [IAM role][iam_role] to assume at startup.
+
+			[iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description: "The AWS access key ID."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description: "The ARN of the role to assume."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description: "Path to the credentials file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description: "Timeout for successfully loading any credentials, in seconds."
+				required:    false
+				type: uint: {}
+			}
+			profile: {
+				description: "The credentials profile to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description: "The AWS secret access key."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	default_namespace: {
+		description: """
+			The default namespace to use for metrics that do not have one.
+
+			Metrics with the same name can only be differentiated by their namespace, and not all
+			metrics have their own namespace.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -1,0 +1,395 @@
+package metadata
+
+base: components: sinks: aws_kinesis_firehose: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description: "The AWS access key ID."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description: "The ARN of the role to assume."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description: "Path to the credentials file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description: "Timeout for successfully loading any credentials, in seconds."
+				required:    false
+				type: uint: {}
+			}
+			profile: {
+				description: "The credentials profile to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description: "The AWS secret access key."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	stream_name: {
+		description: """
+			The [stream name][stream_name] of the target Kinesis Firehose delivery stream.
+
+			[stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -1,0 +1,404 @@
+package metadata
+
+base: components: sinks: aws_kinesis_streams: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description: "The AWS access key ID."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description: "The ARN of the role to assume."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description: "Path to the credentials file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description: "Timeout for successfully loading any credentials, in seconds."
+				required:    false
+				type: uint: {}
+			}
+			profile: {
+				description: "The credentials profile to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description: "The AWS secret access key."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	partition_key_field: {
+		description: """
+			The log field used as the Kinesis record’s partition key value.
+
+			If not specified, a unique partition key will be generated for each Kinesis record.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	stream_name: {
+		description: """
+			The [stream name][stream_name] of the target Kinesis Logs stream.
+
+			[stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -1,0 +1,676 @@
+package metadata
+
+base: components: sinks: aws_s3: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	acl: {
+		description: """
+			Canned ACL to apply to the created objects.
+
+			For more information, see [Canned ACL][canned_acl].
+
+			[canned_acl]: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+			"""
+		required: false
+		type: string: enum: {
+			"authenticated-read": """
+				Bucket/object can be read by authenticated users.
+
+				The bucket/object owner is granted the `FULL_CONTROL` permission, and anyone in the
+				`AuthenticatedUsers` grantee group is granted the `READ` permission.
+				"""
+			"aws-exec-read": """
+				Bucket/object are private, and readable by EC2.
+
+				The bucket/object owner is granted the `FULL_CONTROL` permission, and the AWS EC2 service is
+				granted the `READ` permission for the purpose of reading Amazon Machine Image (AMI) bundles
+				from the given bucket.
+				"""
+			"bucket-owner-full-control": """
+				Object is semi-private.
+
+				Both the object owner and bucket owner are granted the `FULL_CONTROL` permission.
+
+				Only relevant when specified for an object: this canned ACL is otherwise ignored when
+				specified for a bucket.
+				"""
+			"bucket-owner-read": """
+				Object is private, except to the bucket owner.
+
+				The object owner is granted the `FULL_CONTROL` permission, and the bucket owner is granted the `READ` permission.
+
+				Only relevant when specified for an object: this canned ACL is otherwise ignored when
+				specified for a bucket.
+				"""
+			"log-delivery-write": """
+				Bucket can have logs written.
+
+				The `LogDelivery` grantee group is granted `WRITE` and `READ_ACP` permissions.
+
+				Only relevant when specified for a bucket: this canned ACL is otherwise ignored when
+				specified for an object.
+				"""
+			private: """
+				Bucket/object are private.
+
+				The bucket/object owner is granted the `FULL_CONTROL` permission, and no one else has
+				access.
+
+				This is the default.
+				"""
+			"public-read": """
+				Bucket/object can be read publically.
+
+				The bucket/object owner is granted the `FULL_CONTROL` permission, and anyone in the
+				`AllUsers` grantee group is granted the `READ` permission.
+				"""
+			"public-read-write": """
+				Bucket/object can be read and written publically.
+
+				The bucket/object owner is granted the `FULL_CONTROL` permission, and anyone in the
+				`AllUsers` grantee group is granted the `READ` and `WRITE` permissions.
+
+				This is generally not recommended.
+				"""
+		}
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description: "The AWS access key ID."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description: "The ARN of the role to assume."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description: "Path to the credentials file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description: "Timeout for successfully loading any credentials, in seconds."
+				required:    false
+				type: uint: {}
+			}
+			profile: {
+				description: "The credentials profile to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description: "The AWS secret access key."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	bucket: {
+		description: """
+			The S3 bucket name.
+
+			This must not include a leading `s3://` or a trailing `/`.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "gzip"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	content_encoding: {
+		description: """
+			Specifies what content encoding has been applied to the object.
+
+			Directly comparable to the `Content-Encoding` HTTP header.
+
+			By default, the compression scheme used dictates this value.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	content_type: {
+		description: """
+			Specifies the MIME type of the object.
+
+			Directly comparable to the `Content-Type` HTTP header.
+
+			By default, `text/x-log` is used.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	filename_append_uuid: {
+		description: """
+			Whether or not to append a UUID v4 token to the end of the object key.
+
+			The UUID is appended to the timestamp portion of the object key, such that if the object key
+			being generated was `date=2022-07-18/1658176486`, setting this field to `true` would result
+			in an object key that looked like `date=2022-07-18/1658176486-30f6652c-71da-4f9f-800d-a1189c47c547`.
+
+			This ensures there are no name collisions, and can be useful in high-volume workloads where
+			object keys must be unique.
+			"""
+		required: false
+		type: bool: {}
+	}
+	filename_extension: {
+		description: "The filename extension to use in the object key."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	filename_time_format: {
+		description: """
+			The timestamp format for the time component of the object key.
+
+			By default, object keys are appended with a timestamp that reflects when the objects are
+			sent to S3, such that the resulting object key is functionally equivalent to joining the key
+			prefix with the formatted timestamp, such as `date=2022-07-18/1658176486`.
+
+			This would represent a `key_prefix` set to `date=%F/` and the timestamp of Mon Jul 18 2022
+			20:34:44 GMT+0000, with the `filename_time_format` being set to `%s`, which renders
+			timestamps in seconds since the Unix epoch.
+
+			Supports the common [`strftime`][chrono_strftime_specifiers] specifiers found in most
+			languages.
+
+			When set to an empty string, no timestamp will be appended to the key prefix.
+
+			[chrono_strftime_specifiers]: https://docs.rs/chrono/latest/chrono/format/strftime/index.html#specifiers
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	framing: {
+		description: "Framing configuration."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited encoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: delimiter: {
+					description: "The ASCII (7-bit) character that delimits byte sequences."
+					required:    true
+					type: uint: {}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Event data is not delimited at all."
+					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
+					length_delimited: """
+						Event data is prefixed with its length in bytes.
+
+						The prefix is a 32-bit unsigned integer, little endian.
+						"""
+					newline_delimited: "Event data is delimited by a newline (LF) character."
+				}
+			}
+		}
+	}
+	grant_full_control: {
+		description: """
+			Grants `READ`, `READ_ACP`, and `WRITE_ACP` permissions on the created objects to the named [grantee].
+
+			This allows the grantee to read the created objects and their metadata, as well as read and
+			modify the ACL on the created objects.
+
+			[grantee]: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#specifying-grantee
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	grant_read: {
+		description: """
+			Grants `READ` permissions on the created objects to the named [grantee].
+
+			This allows the grantee to read the created objects and their metadata.
+
+			[grantee]: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#specifying-grantee
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	grant_read_acp: {
+		description: """
+			Grants `READ_ACP` permissions on the created objects to the named [grantee].
+
+			This allows the grantee to read the ACL on the created objects.
+
+			[grantee]: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#specifying-grantee
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	grant_write_acp: {
+		description: """
+			Grants `WRITE_ACP` permissions on the created objects to the named [grantee].
+
+			This allows the grantee to modify the ACL on the created objects.
+
+			[grantee]: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#specifying-grantee
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	key_prefix: {
+		description: """
+			A prefix to apply to all object keys.
+
+			Prefixes are useful for partitioning objects, such as by creating an object key that
+			stores objects under a particular "directory". If using a prefix for this purpose, it must end
+			in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	server_side_encryption: {
+		description: "The Server-side Encryption algorithm used when storing these objects."
+		required:    false
+		type: string: enum: {
+			AES256: """
+				Each object is encrypted with AES-256 using a unique key.
+
+				This corresponds to the `SSE-S3` option.
+				"""
+			"aws:kms": """
+				Each object is encrypted with AES-256 using keys managed by AWS KMS.
+
+				Depending on whether or not a KMS key ID is specified, this will correspond either to the
+				`SSE-KMS` option (keys generated/managed by KMS) or the `SSE-C` option (keys generated by
+				the customer, managed by KMS).
+				"""
+		}
+	}
+	ssekms_key_id: {
+		description: """
+			Specifies the ID of the AWS Key Management Service (AWS KMS) symmetrical customer managed
+			customer master key (CMK) that will used for the created objects.
+
+			Only applies when `server_side_encryption` is configured to use KMS.
+
+			If not specified, Amazon S3 uses the AWS managed CMK in AWS to protect the data.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	storage_class: {
+		description: """
+			The storage class for the created objects.
+
+			See the [S3 Storage Classes][s3_storage_classes] for more details.
+
+			[s3_storage_classes]: https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html
+			"""
+		required: false
+		type: string: enum: {
+			DEEP_ARCHIVE:        "Glacier Deep Archive."
+			GLACIER:             "Glacier Flexible Retrieval."
+			INTELLIGENT_TIERING: "Intelligent Tiering."
+			ONEZONE_IA:          "Infrequently Accessed (single Availability zone)."
+			REDUCED_REDUNDANCY:  "Reduced Redundancy."
+			STANDARD: """
+				Standard Redundancy.
+
+				This is the default.
+				"""
+			STANDARD_IA: "Infrequently Accessed."
+		}
+	}
+	tags: {
+		description: "The tag-set for the object."
+		required:    false
+		type: object: options: "*": {
+			description: "Tags for a metric series."
+			required:    true
+			type: string: syntax: "literal"
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -1,0 +1,371 @@
+package metadata
+
+base: components: sinks: aws_sqs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	assume_role: {
+		description: """
+			The ARN of an [IAM role][iam_role] to assume at startup.
+
+			[iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description: "The AWS access key ID."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description: "The ARN of the role to assume."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description: "Path to the credentials file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description: "Timeout for successfully loading any credentials, in seconds."
+				required:    false
+				type: uint: {}
+			}
+			profile: {
+				description: "The credentials profile to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description: "The AWS secret access key."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	message_deduplication_id: {
+		description: """
+			The message deduplication ID value to allow AWS to identify duplicate messages.
+
+			This value is a template which should result in a unique string for each event. See the [AWS
+			documentation][deduplication_id_docs] for more about how AWS does message deduplication.
+
+			[deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	message_group_id: {
+		description: """
+			The tag that specifies that a message belongs to a specific message group.
+
+			Can be applied only to FIFO queues.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	queue_url: {
+		description: "The URL of the Amazon SQS queue to which messages are sent."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -1,0 +1,279 @@
+package metadata
+
+base: components: sinks: axiom: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	dataset: {
+		description: "The Axiom dataset to write to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	org_id: {
+		description: """
+			The Axiom organization ID.
+
+			Only required when using personal tokens.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: "Outbound HTTP request settings."
+		required:    false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			headers: {
+				description: "Additional HTTP headers to add to every HTTP request."
+				required:    false
+				type: object: {
+					default: {}
+					options: "*": {
+						description: "Additional HTTP headers to add to every HTTP request."
+						required:    true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	token: {
+		description: "The Axiom API token."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	url: {
+		description: """
+			URI of the Axiom endpoint to send data to.
+
+			Only required if not using Axiom Cloud.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -1,0 +1,357 @@
+package metadata
+
+base: components: sinks: azure_blob: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	blob_append_uuid: {
+		description: """
+			Whether or not to append a UUID v4 token to the end of the blob key.
+
+			The UUID is appended to the timestamp portion of the object key, such that if the blob key
+			being generated was `date=2022-07-18/1658176486`, setting this field to `true` would result
+			in an blob key that looked like
+			`date=2022-07-18/1658176486-30f6652c-71da-4f9f-800d-a1189c47c547`.
+
+			This ensures there are no name collisions, and can be useful in high-volume workloads where
+			blob keys must be unique.
+			"""
+		required: false
+		type: bool: {}
+	}
+	blob_prefix: {
+		description: """
+			A prefix to apply to all blob keys.
+
+			Prefixes are useful for partitioning objects, such as by creating an blob key that
+			stores blobs under a particular "directory". If using a prefix for this purpose, it must end
+			in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	blob_time_format: {
+		description: """
+			The timestamp format for the time component of the blob key.
+
+			By default, blob keys are appended with a timestamp that reflects when the blob are sent to
+			Azure Blob Storage, such that the resulting blob key is functionally equivalent to joining
+			the blob prefix with the formatted timestamp, such as `date=2022-07-18/1658176486`.
+
+			This would represent a `blob_prefix` set to `date=%F/` and the timestamp of Mon Jul 18 2022
+			20:34:44 GMT+0000, with the `filename_time_format` being set to `%s`, which renders
+			timestamps in seconds since the Unix epoch.
+
+			Supports the common [`strftime`][chrono_strftime_specifiers] specifiers found in most
+			languages.
+
+			When set to an empty string, no timestamp will be appended to the blob prefix.
+
+			[chrono_strftime_specifiers]: https://docs.rs/chrono/latest/chrono/format/strftime/index.html#specifiers
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "gzip"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	connection_string: {
+		description: """
+			The Azure Blob Storage Account connection string.
+
+			Authentication with access key is the only supported authentication method.
+
+			Either `storage_account`, or this field, must be specified.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	container_name: {
+		description: "The Azure Blob Storage Account container name."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Framing configuration."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited encoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: delimiter: {
+					description: "The ASCII (7-bit) character that delimits byte sequences."
+					required:    true
+					type: uint: {}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Event data is not delimited at all."
+					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
+					length_delimited: """
+						Event data is prefixed with its length in bytes.
+
+						The prefix is a 32-bit unsigned integer, little endian.
+						"""
+					newline_delimited: "Event data is delimited by a newline (LF) character."
+				}
+			}
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	storage_account: {
+		description: """
+			The Azure Blob Storage Account name.
+
+			Attempts to load credentials for the account in the following ways, in order:
+
+			- read from environment variables ([more information][env_cred_docs])
+			- looks for a [Managed Identity][managed_ident_docs]
+			- uses the `az` CLI tool to get an access token ([more information][az_cli_docs])
+
+			Either `connection_string`, or this field, must be specified.
+
+			[env_cred_docs]: https://docs.rs/azure_identity/latest/azure_identity/struct.EnvironmentCredential.html
+			[managed_ident_docs]: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+			[az_cli_docs]: https://docs.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az-account-get-access-token
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -1,0 +1,319 @@
+package metadata
+
+base: components: sinks: azure_monitor_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	azure_resource_id: {
+		description: """
+			The [Resource ID][resource_id] of the Azure resource the data should be associated with.
+
+			[resource_id]: https://docs.microsoft.com/en-us/azure/azure-monitor/platform/data-collector-api#request-headers
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	customer_id: {
+		description: """
+			The [unique identifier][uniq_id] for the Log Analytics workspace.
+
+			[uniq_id]: https://docs.microsoft.com/en-us/azure/azure-monitor/platform/data-collector-api#request-uri-parameters
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	host: {
+		description: """
+			[Alternative host][alt_host] for dedicated Azure regions.
+
+			[alt_host]: https://docs.azure.cn/en-us/articles/guidance/developerdifferences#check-endpoints-in-azure
+			"""
+		required: false
+		type: string: {
+			default: "ods.opinsights.azure.com"
+			syntax:  "literal"
+		}
+	}
+	log_type: {
+		description: """
+			The [record type][record_type] of the data that is being submitted.
+
+			Can only contain letters, numbers, and underscores (_), and may not exceed 100 characters.
+
+			[record_type]: https://docs.microsoft.com/en-us/azure/azure-monitor/platform/data-collector-api#request-headers
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	shared_key: {
+		description: """
+			The [primary or the secondary key][shared_key] for the Log Analytics workspace.
+
+			[shared_key]: https://docs.microsoft.com/en-us/azure/azure-monitor/platform/data-collector-api#authorization
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/blackhole.cue
+++ b/website/cue/reference/components/sinks/base/blackhole.cue
@@ -1,0 +1,31 @@
+package metadata
+
+base: components: sinks: blackhole: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	print_interval_secs: {
+		description: """
+			The number of seconds between reporting a summary of activity.
+
+			Set to `0` to disable reporting.
+			"""
+		required: false
+		type: uint: default: 1
+	}
+	rate: {
+		description: """
+			The number of events, per second, that the sink is allowed to consume.
+
+			By default, there is no limit.
+			"""
+		required: false
+		type: uint: {}
+	}
+}

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -1,0 +1,357 @@
+package metadata
+
+base: components: sinks: clickhouse: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: """
+			Configuration of the authentication strategy for HTTP requests.
+
+			HTTP authentication should almost always be used with HTTPS only, as the authentication credentials are passed as an
+			HTTP header without any additional encryption beyond what is provided by the transport itself.
+			"""
+		required: false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "gzip"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	database: {
+		description: "The database that contains the table that data will be inserted into."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint of the Clickhouse server."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	skip_unknown_fields: {
+		description: "Sets `input_format_skip_unknown_fields`, allowing Clickhouse to discard fields not present in the table schema."
+		required:    false
+		type: bool: default: false
+	}
+	table: {
+		description: "The table that data will be inserted into."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -1,0 +1,114 @@
+package metadata
+
+base: components: sinks: console: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Framing configuration."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited encoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: delimiter: {
+					description: "The ASCII (7-bit) character that delimits byte sequences."
+					required:    true
+					type: uint: {}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Event data is not delimited at all."
+					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
+					length_delimited: """
+						Event data is prefixed with its length in bytes.
+
+						The prefix is a 32-bit unsigned integer, little endian.
+						"""
+					newline_delimited: "Event data is delimited by a newline (LF) character."
+				}
+			}
+		}
+	}
+	target: {
+		description: "Output target."
+		required:    false
+		type: string: {
+			default: "stdout"
+			enum: {
+				stderr: "Standard error."
+				stdout: "Standard output."
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -1,0 +1,267 @@
+package metadata
+
+base: components: sinks: datadog_events: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	default_api_key: {
+		description: """
+			The default Datadog [API key][api_key] to send events with.
+
+			If an event has a Datadog [API key][api_key] set explicitly in its metadata, it will take
+			precedence over the default.
+
+			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The endpoint to send events to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: """
+			The Datadog region to send events to.
+
+			This option is deprecated, and the `site` field should be used instead.
+			"""
+		required: false
+		type: string: enum: {
+			eu: "EU region."
+			us: "US region."
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	site: {
+		description: """
+			The Datadog [site][dd_site] to send events to.
+
+			[dd_site]: https://docs.datadoghq.com/getting_started/site
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -1,0 +1,338 @@
+package metadata
+
+base: components: sinks: datadog_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: true
+					type: string: const: "zlib"
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	default_api_key: {
+		description: """
+			The default Datadog [API key][api_key] to send logs with.
+
+			If a log has a Datadog [API key][api_key] set explicitly in its metadata, it will take
+			precedence over the default.
+
+			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to send logs to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: """
+			The Datadog region to send logs to.
+
+			This option is deprecated, and the `site` field should be used instead.
+			"""
+		required: false
+		type: string: enum: {
+			eu: "EU region."
+			us: "US region."
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	site: {
+		description: """
+			The Datadog [site][dd_site] to send logs to.
+
+			[dd_site]: https://docs.datadoghq.com/getting_started/site
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -1,0 +1,303 @@
+package metadata
+
+base: components: sinks: datadog_metrics: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	default_api_key: {
+		description: """
+			The default Datadog [API key][api_key] to send metrics with.
+
+			If a metric has a Datadog [API key][api_key] set explicitly in its metadata, it will take
+			precedence over the default.
+
+			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	default_namespace: {
+		description: """
+			Sets the default namespace for any metrics sent.
+
+			This namespace is only used if a metric has no existing namespace. When a namespace is
+			present, it is used as a prefix to the metric name, and separated with a period (`.`).
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The endpoint to send metrics to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: """
+			The Datadog region to send metrics to.
+
+			This option is deprecated, and the `site` field should be used instead.
+			"""
+		required: false
+		type: string: enum: {
+			eu: "EU region."
+			us: "US region."
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	site: {
+		description: """
+			The Datadog [site][dd_site] to send metrics to.
+
+			[dd_site]: https://docs.datadoghq.com/getting_started/site
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -1,0 +1,302 @@
+package metadata
+
+base: components: sinks: datadog_traces: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: true
+					type: string: const: "zlib"
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	default_api_key: {
+		description: """
+			The default Datadog [API key][api_key] to send traces with.
+
+			If a trace has a Datadog [API key][api_key] set explicitly in its metadata, it will take
+			precedence over the default.
+
+			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The endpoint to send traces to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	site: {
+		description: """
+			The Datadog [site][dd_site] to send traces to.
+
+			[dd_site]: https://docs.datadoghq.com/getting_started/site
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -1,0 +1,594 @@
+package metadata
+
+base: components: sinks: elasticsearch: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: "Authentication strategies."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description:   "The AWS access key ID."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description:   "The ARN of the role to assume."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description:   "Path to the credentials file."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description:   "Timeout for successfully loading any credentials, in seconds."
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: uint: {}
+			}
+			password: {
+				description:   "Basic authentication password."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			profile: {
+				description:   "The credentials profile to use."
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description:   "The AWS secret access key."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					aws:   "Amazon OpenSearch Service-specific authentication."
+					basic: "HTTP Basic Authentication."
+				}
+			}
+			user: {
+				description:   "Basic authentication username."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	aws: {
+		description: "Configuration of the region/endpoint to use when interacting with an AWS service."
+		required:    false
+		type: object: options: {
+			endpoint: {
+				description: "The API endpoint of the service."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: "The AWS region to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	bulk: {
+		description: "Bulk mode configuration."
+		required:    false
+		type: object: options: {
+			action: {
+				description: "The bulk action to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			index: {
+				description: "The name of the index to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	data_stream: {
+		description: "Data stream mode configuration."
+		required:    false
+		type: object: options: {
+			auto_routing: {
+				description: """
+					Automatically routes events by deriving the data stream name using specific event fields.
+
+					The format of the data stream name is `<type>-<dataset>-<namespace>`, where each value comes
+					from the `data_stream` configuration field of the same name.
+
+					If enabled, the value of the `data_stream.type`, `data_stream.dataset`, and
+					`data_stream.namespace` event fields will be used if they are present. Otherwise, the values
+					set here in the configuration will be used.
+					"""
+				required: false
+				type: bool: default: true
+			}
+			dataset: {
+				description: "The data stream dataset used to construct the data stream at index time."
+				required:    false
+				type: string: {
+					default: "generic"
+					syntax:  "template"
+				}
+			}
+			namespace: {
+				description: "The data stream namespace used to construct the data stream at index time."
+				required:    false
+				type: string: {
+					default: "default"
+					syntax:  "template"
+				}
+			}
+			sync_fields: {
+				description: """
+					Automatically adds and syncs the `data_stream.*` event fields if they are missing from the event.
+
+					This ensures that fields match the name of the data stream that is receiving events.
+					"""
+				required: false
+				type: bool: default: true
+			}
+			type: {
+				description: "The data stream type used to construct the data stream at index time."
+				required:    false
+				type: string: {
+					default: "logs"
+					syntax:  "template"
+				}
+			}
+		}
+	}
+	distribution: {
+		description: "Options for determining health of an endpoint."
+		required:    false
+		type: object: options: {
+			retry_initial_backoff_secs: {
+				description: "Initial timeout, in seconds, between attempts to reactivate endpoints once they become unhealthy."
+				required:    false
+				type: uint: {}
+			}
+			retry_max_duration_secs: {
+				description: "Maximum timeout, in seconds, between attempts to reactivate endpoints once they become unhealthy."
+				required:    false
+				type: uint: {}
+			}
+		}
+	}
+	doc_type: {
+		description: """
+			The `doc_type` for your index data.
+
+			This is only relevant for Elasticsearch <= 6.X. If you are using >= 7.0 you do not need to
+			set this option since Elasticsearch has removed it.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: """
+			The Elasticsearch endpoint to send logs to.
+
+			This should be the full URL as shown in the example.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	endpoints: {
+		description: """
+			The Elasticsearch endpoints to send logs to.
+
+			Each endpoint should be the full URL as shown in the example.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	id_key: {
+		description: """
+			The name of the event key that should map to Elasticsearch’s [`_id` field][es_id].
+
+			By default, Vector does not set the `_id` field, which allows Elasticsearch to set this
+			automatically. You should think carefully about setting your own Elasticsearch IDs, since
+			this can [hinder performance][perf_doc].
+
+			[es_id]: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html
+			[perf_doc]: https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html#_use_auto_generated_ids
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	metrics: {
+		description: "Configuration for the `metric_to_log` transform."
+		required:    false
+		type: object: options: {
+			host_tag: {
+				description: """
+					Name of the tag in the metric to use for the source host.
+
+					If present, the value of the tag is set on the generated log event in the "host" field,
+					where the field key will use the [global `host_key` option][global_log_schema_host_key].
+
+					[global_log_schema_host_key]: https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key
+					"""
+				required: false
+				type: string: {
+					examples: ["host", "hostname"]
+					syntax: "literal"
+				}
+			}
+			timezone: {
+				description: """
+					The name of the timezone to apply to timestamp conversions that do not contain an explicit
+					time zone.
+
+					This overrides the [global `timezone`][global_timezone] option. The time zone name may be
+					any name in the [TZ database][tz_database], or `local` to indicate system local time.
+
+					[global_timezone]: https://vector.dev/docs/reference/configuration//global-options#timezone
+					[tz_database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+					"""
+				required: false
+				type: string: examples: ["local", "America/New_York", "EST5EDT"]
+			}
+		}
+	}
+	mode: {
+		description: "Indexing mode."
+		required:    false
+		type: string: {
+			default: "bulk"
+			enum: {
+				bulk: "Ingests documents in bulk, via the bulk API `index` action."
+				data_stream: """
+					Ingests documents in bulk, via the bulk API `create` action.
+
+					Elasticsearch Data Streams only support the `create` action.
+					"""
+			}
+		}
+	}
+	pipeline: {
+		description: "The name of the pipeline to apply."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	query: {
+		description: "Custom parameters to add to the query string of each request sent to Elasticsearch."
+		required:    false
+		type: object: options: "*": {
+			description: "Custom parameters to add to the query string of each request sent to Elasticsearch."
+			required:    true
+			type: string: syntax: "literal"
+		}
+	}
+	request: {
+		description: "Outbound HTTP request settings."
+		required:    false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			headers: {
+				description: "Additional HTTP headers to add to every HTTP request."
+				required:    false
+				type: object: {
+					default: {}
+					options: "*": {
+						description: "Additional HTTP headers to add to every HTTP request."
+						required:    true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	suppress_type_name: {
+		description: """
+			Whether or not to send the `type` field to Elasticsearch.
+
+			`type` field was deprecated in Elasticsearch 7.x and removed in Elasticsearch 8.x.
+
+			If enabled, the `doc_type` option will be ignored.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -1,0 +1,129 @@
+package metadata
+
+base: components: sinks: file: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	compression: {
+		description: "Compression algorithm."
+		required:    false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: "Gzip compression."
+				none: "No compression."
+				zstd: "Zstandard compression."
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Framing configuration."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited encoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: delimiter: {
+					description: "The ASCII (7-bit) character that delimits byte sequences."
+					required:    true
+					type: uint: {}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Event data is not delimited at all."
+					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
+					length_delimited: """
+						Event data is prefixed with its length in bytes.
+
+						The prefix is a 32-bit unsigned integer, little endian.
+						"""
+					newline_delimited: "Event data is delimited by a newline (LF) character."
+				}
+			}
+		}
+	}
+	idle_timeout_secs: {
+		description: """
+			The amount of time, in seconds, that a file can be idle and stay open.
+
+			After not receiving any events in this amount of time, the file will be flushed and closed.
+			"""
+		required: false
+		type: uint: {}
+	}
+	path: {
+		description: "File name to write events to."
+		required:    true
+		type: string: syntax: "template"
+	}
+}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -1,0 +1,370 @@
+package metadata
+
+base: components: sinks: gcp_chronicle_unstructured: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_key: {
+		description: """
+			An API key. ([documentation](https://cloud.google.com/docs/authentication/api-keys))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	credentials_path: {
+		description: """
+			Path to a service account credentials JSON file. ([documentation](https://cloud.google.com/docs/authentication/production#manually))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	customer_id: {
+		description: "The Unique identifier (UUID) corresponding to the Chronicle instance."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to send data to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	log_type: {
+		description: """
+			The type of log entries in a request.
+
+			This must be one of the [supported log types][unstructured_log_types_doc], otherwise
+			Chronicle will reject the entry with an error.
+
+			[unstructured_log_types_doc]: https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers
+			"""
+		required: true
+		type: string: syntax: "template"
+	}
+	region: {
+		description: "Google Chronicle regions."
+		required:    false
+		type: string: enum: {
+			asia: "APAC region."
+			eu:   "EU region."
+			us:   "US region."
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	skip_authentication: {
+		description: "Skip all authentication handling. For use with integration tests only."
+		required:    false
+		type: bool: default: false
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -1,0 +1,545 @@
+package metadata
+
+base: components: sinks: gcp_cloud_storage: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	acl: {
+		description: """
+			The Predefined ACL to apply to created objects.
+
+			For more information, see [Predefined ACLs][predefined_acls].
+
+			[predefined_acls]: https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
+			"""
+		required: false
+		type: string: enum: {
+			"authenticated-read": """
+				Bucket/object can be read by authenticated users.
+
+				The bucket/object owner is granted the `OWNER` permission, and anyone authenticated Google
+				account holder is granted the `READER` permission.
+				"""
+			"bucket-owner-full-control": """
+				Object is semi-private.
+
+				Both the object owner and bucket owner are granted the `OWNER` permission.
+
+				Only relevant when specified for an object: this predefined ACL is otherwise ignored when
+				specified for a bucket.
+				"""
+			"bucket-owner-read": """
+				Object is private, except to the bucket owner.
+
+				The object owner is granted the `OWNER` permission, and the bucket owner is granted the
+				`READER` permission.
+
+				Only relevant when specified for an object: this predefined ACL is otherwise ignored when
+				specified for a bucket.
+				"""
+			private: """
+				Bucket/object are private.
+
+				The bucket/object owner is granted the `OWNER` permission, and no one else has
+				access.
+				"""
+			"project-private": """
+				Bucket/object are private within the project.
+
+				Project owners and project editors are granted the `OWNER` permission, and anyone who is
+				part of the project team is granted the `READER` permission.
+
+				This is the default.
+				"""
+			"public-read": """
+				Bucket/object can be read publically.
+
+				The bucket/object owner is granted the `OWNER` permission, and all other users, whether
+				authenticated or anonymous, are granted the `READER` permission.
+				"""
+		}
+	}
+	api_key: {
+		description: """
+			An API key. ([documentation](https://cloud.google.com/docs/authentication/api-keys))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	bucket: {
+		description: "The GCS bucket name."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	credentials_path: {
+		description: """
+			Path to a service account credentials JSON file. ([documentation](https://cloud.google.com/docs/authentication/production#manually))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	filename_append_uuid: {
+		description: """
+			Whether or not to append a UUID v4 token to the end of the object key.
+
+			The UUID is appended to the timestamp portion of the object key, such that if the object key
+			being generated was `date=2022-07-18/1658176486`, setting this field to `true` would result
+			in an object key that looked like `date=2022-07-18/1658176486-30f6652c-71da-4f9f-800d-a1189c47c547`.
+
+			This ensures there are no name collisions, and can be useful in high-volume workloads where
+			object keys must be unique.
+			"""
+		required: false
+		type: bool: {}
+	}
+	filename_extension: {
+		description: "The filename extension to use in the object key."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	filename_time_format: {
+		description: """
+			The timestamp format for the time component of the object key.
+
+			By default, object keys are appended with a timestamp that reflects when the objects are
+			sent to S3, such that the resulting object key is functionally equivalent to joining the key
+			prefix with the formatted timestamp, such as `date=2022-07-18/1658176486`.
+
+			This would represent a `key_prefix` set to `date=%F/` and the timestamp of Mon Jul 18 2022
+			20:34:44 GMT+0000, with the `filename_time_format` being set to `%s`, which renders
+			timestamps in seconds since the Unix epoch.
+
+			Supports the common [`strftime`][chrono_strftime_specifiers] specifiers found in most
+			languages.
+
+			When set to an empty string, no timestamp will be appended to the key prefix.
+
+			[chrono_strftime_specifiers]: https://docs.rs/chrono/latest/chrono/format/strftime/index.html#specifiers
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	framing: {
+		description: "Framing configuration."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited encoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: delimiter: {
+					description: "The ASCII (7-bit) character that delimits byte sequences."
+					required:    true
+					type: uint: {}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Event data is not delimited at all."
+					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
+					length_delimited: """
+						Event data is prefixed with its length in bytes.
+
+						The prefix is a 32-bit unsigned integer, little endian.
+						"""
+					newline_delimited: "Event data is delimited by a newline (LF) character."
+				}
+			}
+		}
+	}
+	key_prefix: {
+		description: """
+			A prefix to apply to all object keys.
+
+			Prefixes are useful for partitioning objects, such as by creating an object key that
+			stores objects under a particular "directory". If using a prefix for this purpose, it must end
+			in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	metadata: {
+		description: """
+			The set of metadata `key:value` pairs for the created objects.
+
+			For more information, see [Custom metadata][custom_metadata].
+
+			[custom_metadata]: https://cloud.google.com/storage/docs/metadata#custom-metadata
+			"""
+		required: false
+		type: object: options: "*": {
+			description: """
+				The set of metadata `key:value` pairs for the created objects.
+
+				For more information, see [Custom metadata][custom_metadata].
+
+				[custom_metadata]: https://cloud.google.com/storage/docs/metadata#custom-metadata
+				"""
+			required: true
+			type: string: syntax: "literal"
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	skip_authentication: {
+		description: "Skip all authentication handling. For use with integration tests only."
+		required:    false
+		type: bool: default: false
+	}
+	storage_class: {
+		description: """
+			The storage class for created objects.
+
+			For more information, see [Storage classes][storage_classes].
+
+			[storage_classes]: https://cloud.google.com/storage/docs/storage-classes
+			"""
+		required: false
+		type: string: enum: {
+			ARCHIVE:  "Archive storage."
+			COLDLINE: "Coldline storage."
+			NEARLINE: "Nearline storage."
+			STANDARD: """
+				Standard storage.
+
+				This is the default.
+				"""
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -1,0 +1,354 @@
+package metadata
+
+base: components: sinks: gcp_pubsub: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_key: {
+		description: """
+			An API key. ([documentation](https://cloud.google.com/docs/authentication/api-keys))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	credentials_path: {
+		description: """
+			Path to a service account credentials JSON file. ([documentation](https://cloud.google.com/docs/authentication/production#manually))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to which to publish events."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	project: {
+		description: "The project name to which to publish events."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	skip_authentication: {
+		description: "Skip all authentication handling. For use with integration tests only."
+		required:    false
+		type: bool: default: false
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	topic: {
+		description: "The topic within the project to which to publish events."
+		required:    true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -1,0 +1,386 @@
+package metadata
+
+base: components: sinks: gcp_stackdriver_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_key: {
+		description: """
+			An API key. ([documentation](https://cloud.google.com/docs/authentication/api-keys))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	billing_account_id: {
+		description: "The billing account ID to which to publish logs."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	credentials_path: {
+		description: """
+			Path to a service account credentials JSON file. ([documentation](https://cloud.google.com/docs/authentication/production#manually))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	folder_id: {
+		description: """
+			The folder ID to which to publish logs.
+
+			See the [Google Cloud Platform folder documentation][folder_docs] for more details.
+
+			[folder_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-folders
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	log_id: {
+		description: """
+			The log ID to which to publish logs.
+
+			This is a name you create to identify this log stream.
+			"""
+		required: true
+		type: string: syntax: "template"
+	}
+	organization_id: {
+		description: """
+			The organization ID to which to publish logs.
+
+			This would be the identifier assigned to your organization on Google Cloud Platform.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	project_id: {
+		description: """
+			The project ID to which to publish logs.
+
+			See the [Google Cloud Platform project management documentation][project_docs] for more details.
+
+			[project_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	resource: {
+		description: "The monitored resource to associate the logs with."
+		required:    true
+		type: object: options: {
+			"*": {
+				description: "Type-specific labels."
+				required:    true
+				type: string: syntax: "template"
+			}
+			type: {
+				description: """
+					The monitored resource type.
+
+					For example, the type of a Compute Engine VM instance is `gce_instance`.
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	severity_key: {
+		description: """
+			The field of the log event from which to take the outgoing log’s `severity` field.
+
+			The named field is removed from the log event if present, and must be either an integer
+			between 0 and 800 or a string containing one of the [severity level names][sev_names] (case
+			is ignored) or a common prefix such as `err`.
+
+			If no severity key is specified, the severity of outgoing records is set to 0 (`DEFAULT`).
+
+			See the [GCP Stackdriver Logging LogSeverity description][logsev_docs] for more details on
+			the value of the `severity` field.
+
+			[sev_names]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+			[logsev_docs]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	skip_authentication: {
+		description: "Skip all authentication handling. For use with integration tests only."
+		required:    false
+		type: bool: default: false
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -1,0 +1,322 @@
+package metadata
+
+base: components: sinks: gcp_stackdriver_metrics: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_key: {
+		description: """
+			An API key. ([documentation](https://cloud.google.com/docs/authentication/api-keys))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	credentials_path: {
+		description: """
+			Path to a service account credentials JSON file. ([documentation](https://cloud.google.com/docs/authentication/production#manually))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	default_namespace: {
+		description: """
+			The default namespace to use for metrics that do not have one.
+
+			Metrics with the same name can only be differentiated by their namespace, and not all
+			metrics have their own namespace.
+			"""
+		required: false
+		type: string: {
+			default: "namespace"
+			syntax:  "literal"
+		}
+	}
+	project_id: {
+		description: """
+			The project ID to which to publish metrics.
+
+			See the [Google Cloud Platform project management documentation][project_docs] for more details.
+
+			[project_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	resource: {
+		description: "The monitored resource to associate the metrics with."
+		required:    true
+		type: object: options: {
+			"*": {
+				description: "Type-specific labels."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			type: {
+				description: """
+					The monitored resource type.
+
+					For example, the type of a Compute Engine VM instance is `gce_instance`.
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	skip_authentication: {
+		description: "Skip all authentication handling. For use with integration tests only."
+		required:    false
+		type: bool: default: false
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -1,0 +1,194 @@
+package metadata
+
+base: components: sinks: honeycomb: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_key: {
+		description: "The team key that will be used to authenticate against Honeycomb."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	dataset: {
+		description: "The dataset that Vector will send logs to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -1,0 +1,447 @@
+package metadata
+
+base: components: sinks: http: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: """
+			Configuration of the authentication strategy for HTTP requests.
+
+			HTTP authentication should almost always be used with HTTPS only, as the authentication credentials are passed as an
+			HTTP header without any additional encryption beyond what is provided by the transport itself.
+			"""
+		required: false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Framing configuration."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited encoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: delimiter: {
+					description: "The ASCII (7-bit) character that delimits byte sequences."
+					required:    true
+					type: uint: {}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Event data is not delimited at all."
+					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
+					length_delimited: """
+						Event data is prefixed with its length in bytes.
+
+						The prefix is a 32-bit unsigned integer, little endian.
+						"""
+					newline_delimited: "Event data is delimited by a newline (LF) character."
+				}
+			}
+		}
+	}
+	headers: {
+		description: "A list of custom headers to add to each request."
+		required:    false
+		type: object: options: "*": {
+			description: "A list of custom headers to add to each request."
+			required:    true
+			type: string: syntax: "literal"
+		}
+	}
+	method: {
+		description: "The HTTP method to use when making the request."
+		required:    false
+		type: string: enum: {
+			delete: "DELETE."
+			get: """
+				GET.
+
+				This is the default.
+				"""
+			head:    "HEAD."
+			options: "OPTIONS."
+			patch:   "PATCH."
+			post:    "POST."
+			put:     "PUT."
+			trace:   "TRACE."
+		}
+	}
+	request: {
+		description: "Outbound HTTP request settings."
+		required:    false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			headers: {
+				description: "Additional HTTP headers to add to every HTTP request."
+				required:    false
+				type: object: {
+					default: {}
+					options: "*": {
+						description: "Additional HTTP headers to add to every HTTP request."
+						required:    true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	uri: {
+		description: """
+			The full URI to make HTTP requests to.
+
+			This should include the protocol and host, but can also include the port, path, and any other valid part of a URI.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -1,0 +1,429 @@
+package metadata
+
+base: components: sinks: humio_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The base URL of the Humio instance."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	event_type: {
+		description: """
+			The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
+
+			If unset, Humio will default it to none.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to grab the hostname to send to Humio.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: {
+			default: "host"
+			syntax:  "literal"
+		}
+	}
+	index: {
+		description: """
+			Optional name of the repository to ingest into.
+
+			In public-facing APIs, this must (if present) be equal to the repository used to create the ingest token used for authentication.
+
+			In private cluster setups, Humio can be configured to allow these to be different.
+
+			For more information, see [Humio’s Format of Data][humio_data_format].
+
+			[humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	indexed_fields: {
+		description: """
+			Event fields to be added to Humio’s extra fields.
+
+			Can be used to tag events by specifying fields starting with `#`.
+
+			For more information, see [Humio’s Format of Data][humio_data_format].
+
+			[humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	source: {
+		description: """
+			The source of events sent to this sink.
+
+			Typically the filename the logs originated from. Maps to `@source` in Humio.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	timestamp_key: {
+		description: """
+			Overrides the name of the log field used to grab the timestamp to send to Humio.
+
+			By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+
+			[global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
+			"""
+		required: false
+		type: string: {
+			default: "timestamp"
+			syntax:  "literal"
+		}
+	}
+	timestamp_nanos_key: {
+		description: """
+			Overrides the name of the log field used to grab the nanosecond-enabled timestamp to send to Humio.
+
+			By default, `@timestamp.nanos` is used.
+			"""
+		required: false
+		type: string: {
+			default: "@timestamp.nanos"
+			syntax:  "literal"
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	token: {
+		description: "The Humio ingestion token."
+		required:    true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -1,0 +1,371 @@
+package metadata
+
+base: components: sinks: humio_metrics: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	endpoint: {
+		description: "The base URL of the Humio instance."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	event_type: {
+		description: """
+			The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
+
+			If unset, Humio will default it to none.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to grab the hostname to send to Humio.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: {
+			default: "host"
+			syntax:  "literal"
+		}
+	}
+	host_tag: {
+		description: """
+			Name of the tag in the metric to use for the source host.
+
+			If present, the value of the tag is set on the generated log event in the "host" field,
+			where the field key will use the [global `host_key` option][global_log_schema_host_key].
+
+			[global_log_schema_host_key]: https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key
+			"""
+		required: false
+		type: string: {
+			examples: ["host", "hostname"]
+			syntax: "literal"
+		}
+	}
+	index: {
+		description: """
+			Optional name of the repository to ingest into.
+
+			In public-facing APIs, this must (if present) be equal to the repository used to create the ingest token used for authentication.
+
+			In private cluster setups, Humio can be configured to allow these to be different.
+
+			For more information, see [Humio’s Format of Data][humio_data_format].
+
+			[humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	indexed_fields: {
+		description: """
+			Event fields to be added to Humio’s extra fields.
+
+			Can be used to tag events by specifying fields starting with `#`.
+
+			For more information, see [Humio’s Format of Data][humio_data_format].
+
+			[humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	source: {
+		description: """
+			The source of events sent to this sink.
+
+			Typically the filename the metrics originated from. Maps to `@source` in Humio.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	timezone: {
+		description: """
+			The name of the timezone to apply to timestamp conversions that do not contain an explicit
+			time zone.
+
+			This overrides the [global `timezone`][global_timezone] option. The time zone name may be
+			any name in the [TZ database][tz_database], or `local` to indicate system local time.
+
+			[global_timezone]: https://vector.dev/docs/reference/configuration//global-options#timezone
+			[tz_database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+			"""
+		required: false
+		type: string: examples: ["local", "America/New_York", "EST5EDT"]
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	token: {
+		description: "The Humio ingestion token."
+		required:    true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -1,0 +1,372 @@
+package metadata
+
+base: components: sinks: influxdb_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	bucket: {
+		description: """
+			The name of the bucket to write into.
+
+			Only relevant when using InfluxDB v2.x and above.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	consistency: {
+		description: """
+			The consistency level to use for writes.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	database: {
+		description: """
+			The name of the database to write into.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to send data to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	measurement: {
+		description: "The name of the InfluxDB measurement that will be written to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	namespace: {
+		description: """
+			The namespace of the measurement name to use.
+
+			When specified, the measurement name will be `<namespace>.vector`.
+
+			This field is deprecated, and `measurement` should be used instead.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	org: {
+		description: """
+			The name of the organization to write into.
+
+			Only relevant when using InfluxDB v2.x and above.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	password: {
+		description: """
+			The password to authenticate with.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	retention_policy_name: {
+		description: """
+			The target retention policy for writes.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	tags: {
+		description: "The list of names of log fields that should be added as tags to each measurement."
+		required:    false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	token: {
+		description: """
+			The [token][token_docs] to authenticate with.
+
+			Only relevant when using InfluxDB v2.x and above.
+
+			[token_docs]: https://v2.docs.influxdata.com/v2.0/security/tokens/
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	username: {
+		description: """
+			The username to authenticate with.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -1,0 +1,351 @@
+package metadata
+
+base: components: sinks: influxdb_metrics: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	bucket: {
+		description: """
+			The name of the bucket to write into.
+
+			Only relevant when using InfluxDB v2.x and above.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	consistency: {
+		description: """
+			The consistency level to use for writes.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	database: {
+		description: """
+			The name of the database to write into.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	default_namespace: {
+		description: """
+			Sets the default namespace for any metrics sent.
+
+			This namespace is only used if a metric has no existing namespace. When a namespace is
+			present, it is used as a prefix to the metric name, and separated with a period (`.`).
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The endpoint to send data to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	org: {
+		description: """
+			The name of the organization to write into.
+
+			Only relevant when using InfluxDB v2.x and above.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	password: {
+		description: """
+			The password to authenticate with.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	quantiles: {
+		description: "The list of quantiles to calculate when sending distribution metrics."
+		required:    false
+		type: array: {
+			default: [0.5, 0.75, 0.9, 0.95, 0.99]
+			items: type: number: {}
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	retention_policy_name: {
+		description: """
+			The target retention policy for writes.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	tags: {
+		description: "A map of additional tags, in the form of key/value pairs, to add to each measurement."
+		required:    false
+		type: object: options: "*": {
+			description: "A map of additional tags, in the form of key/value pairs, to add to each measurement."
+			required:    true
+			type: string: syntax: "literal"
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	token: {
+		description: """
+			The [token][token_docs] to authenticate with.
+
+			Only relevant when using InfluxDB v2.x and above.
+
+			[token_docs]: https://v2.docs.influxdata.com/v2.0/security/tokens/
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	username: {
+		description: """
+			The username to authenticate with.
+
+			Only relevant when using InfluxDB v0.x/v1.x.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -1,0 +1,310 @@
+package metadata
+
+base: components: sinks: kafka: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	bootstrap_servers: {
+		description: """
+			A comma-separated list of the initial Kafka brokers to connect to.
+
+			Each value must be in the form of `<host>` or `<host>:<port>`, and separated by a comma.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	compression: {
+		description: "Supported compression types for Kafka."
+		required:    false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip:   "Gzip."
+				lz4:    "LZ4."
+				none:   "No compression."
+				snappy: "Snappy."
+				zstd:   "Zstandard."
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	headers_key: {
+		description: """
+			The log field name to use for the Kafka headers.
+
+			If omitted, no headers will be written.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	key_field: {
+		description: """
+			The log field name or tags key to use for the topic key.
+
+			If the field does not exist in the log or in tags, a blank value will be used. If unspecified, the key is not sent.
+
+			Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	librdkafka_options: {
+		description: """
+			A map of advanced options to pass directly to the underlying `librdkafka` client.
+
+			For more information on configuration options, see [Configuration properties][config_props_docs].
+
+			[config_props_docs]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+			"""
+		required: false
+		type: object: options: "*": {
+			description: """
+				A map of advanced options to pass directly to the underlying `librdkafka` client.
+
+				For more information on configuration options, see [Configuration properties][config_props_docs].
+
+				[config_props_docs]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+				"""
+			required: true
+			type: string: syntax: "literal"
+		}
+	}
+	message_timeout_ms: {
+		description: "Local message timeout, in milliseconds."
+		required:    false
+		type: uint: default: 300000
+	}
+	sasl: {
+		description: "Configuration for SASL authentication when interacting with Kafka."
+		required:    false
+		type: object: options: {
+			enabled: {
+				description: """
+					Enables SASL authentication.
+
+					Only `PLAIN` and `SCRAM`-based mechanisms are supported when configuring SASL authentication via `sasl.*`. For
+					other mechanisms, `librdkafka_options.*` must be used directly to configure other `librdkafka`-specific values
+					i.e. `sasl.kerberos.*` and so on.
+
+					See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for details.
+
+					SASL authentication is not supported on Windows.
+					"""
+				required: false
+				type: bool: {}
+			}
+			mechanism: {
+				description: "The SASL mechanism to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			password: {
+				description: "The SASL password."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			username: {
+				description: "The SASL username."
+				required:    false
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	socket_timeout_ms: {
+		description: "Default timeout, in milliseconds, for network requests."
+		required:    false
+		type: uint: default: 60000
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	topic: {
+		description: "The Kafka topic name to write events to."
+		required:    true
+		type: string: syntax: "template"
+	}
+}

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -1,0 +1,224 @@
+package metadata
+
+base: components: sinks: logdna: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_key: {
+		description: "The Ingestion API key."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	default_app: {
+		description: "The default app that will be set for events that do not contain a `file` or `app` field."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	default_env: {
+		description: "The default environment that will be set for events that do not contain an `env` field."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to send logs to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	hostname: {
+		description: "The hostname that will be attached to each batch of events."
+		required:    true
+		type: string: syntax: "template"
+	}
+	ip: {
+		description: "The IP address that will be attached to each batch of events."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	mac: {
+		description: "The MAC address that will be attached to each batch of events."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tags: {
+		description: "The tags that will be attached to each batch of events."
+		required:    false
+		type: array: items: type: string: syntax: "template"
+	}
+}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -1,0 +1,472 @@
+package metadata
+
+base: components: sinks: loki: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: """
+			Configuration of the authentication strategy for HTTP requests.
+
+			HTTP authentication should almost always be used with HTTPS only, as the authentication credentials are passed as an
+			HTTP header without any additional encryption beyond what is provided by the transport itself.
+			"""
+		required: false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compose with basic compression and Loki-specific compression."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: true
+					type: string: const: "zlib"
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: {
+				default: "snappy"
+				enum: snappy: """
+					Snappy compression.
+
+					This implies sending push requests as Protocol Buffers.
+					"""
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: """
+			The base URL of the Loki instance.
+
+			Vector will append `/loki/api/v1/push` to this.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	labels: {
+		description: """
+			A set of labels that are attached to each batch of events.
+
+			Both keys and values are templateable, which enables you to attach dynamic labels to events.
+
+			Labels can be suffixed with a “*” to allow the expansion of objects into multiple labels,
+			see “How it works” for more information.
+
+			Note: If the set of labels has high cardinality, this can cause drastic performance issues
+			with Loki. To prevent this from happening, reduce the number of unique label keys and
+			values.
+			"""
+		required: false
+		type: object: options: "*": {
+			description: """
+				A set of labels that are attached to each batch of events.
+
+				Both keys and values are templateable, which enables you to attach dynamic labels to events.
+
+				Labels can be suffixed with a “*” to allow the expansion of objects into multiple labels,
+				see “How it works” for more information.
+
+				Note: If the set of labels has high cardinality, this can cause drastic performance issues
+				with Loki. To prevent this from happening, reduce the number of unique label keys and
+				values.
+				"""
+			required: true
+			type: string: syntax: "template"
+		}
+	}
+	out_of_order_action: {
+		description: """
+			Out-of-order event behavior.
+
+			Some sources may generate events with timestamps that aren’t in chronological order. While the
+			sink will sort events before sending them to Loki, there is the chance another event comes in
+			that is out-of-order with respective the latest events sent to Loki. Prior to Loki 2.4.0, this
+			was not supported and would result in an error during the push request.
+
+			If you're using Loki 2.4.0 or newer, `Accept` is the preferred action, which lets Loki handle
+			any necessary sorting/reordering. If you're using an earlier version, then you must use `Drop`
+			or `RewriteTimestamp` depending on which option makes the most sense for your use case.
+			"""
+		required: false
+		type: string: {
+			default: "drop"
+			enum: {
+				accept: """
+					Accept the event.
+
+					The event is not dropped and is sent without modification.
+
+					Requires Loki 2.4.0 or newer.
+					"""
+				drop:              "Drop the event."
+				rewrite_timestamp: "Rewrite the timestamp of the event to the timestamp of the latest event seen by the sink."
+			}
+		}
+	}
+	remove_label_fields: {
+		description: "Whether or not to delete fields from the event when they are used as labels."
+		required:    false
+		type: bool: default: false
+	}
+	remove_timestamp: {
+		description: """
+			Whether or not to remove the timestamp from the event payload.
+
+			The timestamp will still be sent as event metadata for Loki to use for indexing.
+			"""
+		required: false
+		type: bool: default: true
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tenant_id: {
+		description: """
+			The tenant ID to send.
+
+			By default, this is not required since a proxy should set this header.
+
+			When running Loki locally, a tenant ID is not required.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -1,0 +1,280 @@
+package metadata
+
+base: components: sinks: nats: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: "Configuration of the authentication strategy when interacting with NATS."
+		required:    false
+		type: object: options: {
+			credentials_file: {
+				description:   "Credentials file configuration."
+				relevant_when: "strategy = \"credentials_file\""
+				required:      true
+				type: object: options: path: {
+					description: "Path to credentials file."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			nkey: {
+				description:   "NKeys configuration."
+				relevant_when: "strategy = \"nkey\""
+				required:      true
+				type: object: options: {
+					nkey: {
+						description: """
+																User.
+
+																Conceptually, this is equivalent to a public key.
+																"""
+						required: true
+						type: string: syntax: "literal"
+					}
+					seed: {
+						description: """
+																Seed.
+
+																Conceptually, this is equivalent to a private key.
+																"""
+						required: true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					credentials_file: """
+						Credentials file authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt))
+						"""
+					nkey: """
+						NKey authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth))
+						"""
+					token: """
+						Token authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tokens))
+						"""
+					user_password: """
+						Username and password authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/username_password))
+						"""
+				}
+			}
+			token: {
+				description:   "Token configuration."
+				relevant_when: "strategy = \"token\""
+				required:      true
+				type: object: options: value: {
+					description: "Token."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			user_password: {
+				description:   "Username and password configuration."
+				relevant_when: "strategy = \"user_password\""
+				required:      true
+				type: object: options: {
+					password: {
+						description: "Password."
+						required:    true
+						type: string: syntax: "literal"
+					}
+					user: {
+						description: "Username."
+						required:    true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+		}
+	}
+	connection_name: {
+		description: "A name assigned to the NATS connection."
+		required:    false
+		type: string: {
+			default: "vector"
+			syntax:  "literal"
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	subject: {
+		description: "The NATS subject to publish messages to."
+		required:    true
+		type: string: syntax: "template"
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	url: {
+		description: """
+			The NATS URL to connect to.
+
+			The URL must take the form of `nats://server:port`.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -1,0 +1,235 @@
+package metadata
+
+base: components: sinks: new_relic: configuration: {
+	account_id: {
+		description: "The New Relic account ID."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api: {
+		description: "New Relic API endpoint."
+		required:    true
+		type: string: enum: {
+			events:  "Events API."
+			logs:    "Logs API."
+			metrics: "Metrics API."
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "gzip"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	license_key: {
+		description: "A valid New Relic license key."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "New Relic region."
+		required:    false
+		type: string: enum: {
+			eu: "EU region."
+			us: "US region."
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -1,0 +1,193 @@
+package metadata
+
+base: components: sinks: papertrail: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to send logs to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	keepalive: {
+		description: "TCP keepalive settings for socket-based components."
+		required:    false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	process: {
+		description: "The value to use as the `process` in Papertrail."
+		required:    false
+		type: string: syntax: "template"
+	}
+	send_buffer_bytes: {
+		description: "Configures the send buffer size using the `SO_SNDBUF` option on the socket."
+		required:    false
+		type: uint: {}
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_exporter.cue
@@ -1,0 +1,243 @@
+package metadata
+
+base: components: sinks: prometheus_exporter: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: """
+			The address to expose for scraping.
+
+			The metrics are exposed at the typical Prometheus exporter path, `/metrics`.
+			"""
+		required: false
+		type: string: {
+			default: "0.0.0.0:9598"
+			syntax:  "literal"
+		}
+	}
+	auth: {
+		description: """
+			Configuration of the authentication strategy for HTTP requests.
+
+			HTTP authentication should almost always be used with HTTPS only, as the authentication credentials are passed as an
+			HTTP header without any additional encryption beyond what is provided by the transport itself.
+			"""
+		required: false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	buckets: {
+		description: """
+			Default buckets to use for aggregating [distribution][dist_metric_docs] metrics into histograms.
+
+			[dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
+			"""
+		required: false
+		type: array: {
+			default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+			items: type: number: {}
+		}
+	}
+	default_namespace: {
+		description: """
+			The default namespace for any metrics sent.
+
+			This namespace is only used if a metric has no existing namespace. When a namespace is
+			present, it is used as a prefix to the metric name, and separated with an underscore (`_`).
+
+			It should follow the Prometheus [naming conventions][prom_naming_docs].
+
+			[prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	distributions_as_summaries: {
+		description: """
+			Whether or not to render [distributions][dist_metric_docs] as an [aggregated histogram][prom_agg_hist_docs] or  [aggregated summary][prom_agg_summ_docs].
+
+			While Vector supports distributions as a lossless way to represent a set of samples for a
+			metric, Prometheus clients (the application being scraped, which is this sink) must
+			aggregate locally into either an aggregated histogram or aggregated summary.
+
+			[dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
+			[prom_agg_hist_docs]: https://prometheus.io/docs/concepts/metric_types/#histogram
+			[prom_agg_summ_docs]: https://prometheus.io/docs/concepts/metric_types/#summary
+			"""
+		required: false
+		type: bool: default: false
+	}
+	flush_period_secs: {
+		description: """
+			The interval, in seconds, on which metrics are flushed.
+
+			On the flush interval, if a metric has not been seen since the last flush interval, it is
+			considered expired and is removed.
+
+			Be sure to configure this value higher than your client’s scrape interval.
+			"""
+		required: false
+		type: uint: {
+			default: 60
+			unit:    "seconds"
+		}
+	}
+	quantiles: {
+		description: """
+			Quantiles to use for aggregating [distribution][dist_metric_docs] metrics into a summary.
+
+			[dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
+			"""
+		required: false
+		type: array: {
+			default: [0.5, 0.75, 0.9, 0.95, 0.99]
+			items: type: number: {}
+		}
+	}
+	suppress_timestamp: {
+		description: """
+			Suppresses timestamps on the Prometheus output.
+
+			This can sometimes be useful when the source of metrics leads to their timestamps being too
+			far in the past for Prometheus to allow them, such as when aggregating metrics over long
+			time periods, or when replaying old metrics from a disk buffer.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -1,0 +1,387 @@
+package metadata
+
+base: components: sinks: prometheus_remote_write: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: "Authentication strategies."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description:   "The AWS access key ID."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description:   "The ARN of the role to assume."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description:   "Path to the credentials file."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description:   "Timeout for successfully loading any credentials, in seconds."
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: uint: {}
+			}
+			password: {
+				description:   "Basic authentication password."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			profile: {
+				description:   "The credentials profile to use."
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description:   "The AWS secret access key."
+				relevant_when: "strategy = \"aws\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					aws:   "Amazon Prometheus Service-specific authentication."
+					basic: "HTTP Basic Authentication."
+				}
+			}
+			user: {
+				description:   "Basic authentication username."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	aws: {
+		description: "Configuration of the region/endpoint to use when interacting with an AWS service."
+		required:    false
+		type: object: options: {
+			endpoint: {
+				description: "The API endpoint of the service."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: "The AWS region to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	buckets: {
+		description: """
+			Default buckets to use for aggregating [distribution][dist_metric_docs] metrics into histograms.
+
+			[dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
+			"""
+		required: false
+		type: array: {
+			default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+			items: type: number: {}
+		}
+	}
+	default_namespace: {
+		description: """
+			The default namespace for any metrics sent.
+
+			This namespace is only used if a metric has no existing namespace. When a namespace is
+			present, it is used as a prefix to the metric name, and separated with an underscore (`_`).
+
+			It should follow the Prometheus [naming conventions][prom_naming_docs].
+
+			[prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The endpoint to send data to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	quantiles: {
+		description: """
+			Quantiles to use for aggregating [distribution][dist_metric_docs] metrics into a summary.
+
+			[dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
+			"""
+		required: false
+		type: array: {
+			default: [0.5, 0.75, 0.9, 0.95, 0.99]
+			items: type: number: {}
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tenant_id: {
+		description: """
+			The tenant ID to send.
+
+			If set, a header named `X-Scope-OrgID` will be added to outgoing requests with the value of this setting.
+
+			This may be used by Cortex or other remote services to identify the tenant making the request.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -1,0 +1,145 @@
+package metadata
+
+base: components: sinks: pulsar: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: "Authentication configuration."
+		required:    false
+		type: object: options: {
+			name: {
+				description: """
+					Basic authentication name/username.
+
+					This can be used either for basic authentication (username/password) or JWT authentication.
+					When used for JWT, the value should be `token`.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			oauth2: {
+				description: "OAuth2-specific authenticatgion configuration."
+				required:    false
+				type: object: options: {
+					audience: {
+						description: "The OAuth2 audience."
+						required:    false
+						type: string: syntax: "literal"
+					}
+					credentials_url: {
+						description: """
+																The credentials URL.
+
+																A data URL is also supported.
+																"""
+						required: true
+						type: string: syntax: "literal"
+					}
+					issuer_url: {
+						description: "The issuer URL."
+						required:    true
+						type: string: syntax: "literal"
+					}
+					scope: {
+						description: "The OAuth2 scope."
+						required:    false
+						type: string: syntax: "literal"
+					}
+				}
+			}
+			token: {
+				description: """
+					Basic authentication password/token.
+
+					This can be used either for basic authentication (username/password) or JWT authentication.
+					When used for JWT, the value should be the signed JWT, in the compact representation.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to which the Pulsar client should connect to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	partition_key_field: {
+		description: "Log field to use as Pulsar message key"
+		required:    false
+		type: string: syntax: "literal"
+	}
+	topic: {
+		description: "The Pulsar topic name to write events to."
+		required:    true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -1,0 +1,279 @@
+package metadata
+
+base: components: sinks: redis: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	data_type: {
+		description: "Redis data type to store messages in."
+		required:    false
+		type: string: {
+			default: "list"
+			enum: {
+				channel: """
+					The Redis `channel` type.
+
+					Redis channels function in a pub/sub fashion, allowing many-to-many broadcasting and receiving.
+					"""
+				list: """
+					The Redis `list` type.
+
+					This resembles a deque, where messages can be popped and pushed from either end.
+
+					This is the default.
+					"""
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	key: {
+		description: "The Redis key to publish messages to."
+		required:    true
+		type: string: syntax: "template"
+	}
+	list_option: {
+		description: "List-specific options."
+		required:    false
+		type: object: options: method: {
+			description: "The method to use for pushing messages into a `list`."
+			required:    true
+			type: string: enum: {
+				lpush: """
+					Use the `lpush` method.
+
+					This pushes messages onto the head of the list.
+					"""
+				rpush: """
+					Use the `rpush` method.
+
+					This pushes messages onto the tail of the list.
+
+					This is the default.
+					"""
+			}
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	url: {
+		description: """
+			The Redis URL to connect to.
+
+			The URL _must_ take the form of `protocol://server:port/db` where the protocol can either be
+			`redis` or `rediss` for connections secured via TLS.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -1,0 +1,202 @@
+package metadata
+
+base: components: sinks: sematext_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	encoding: {
+		description: "Transformations to prepare an event for serialization."
+		required:    false
+		type: object: options: {
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint to send data to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "Sematext region."
+		required:    false
+		type: string: enum: {
+			eu: "EU region."
+			us: "US region."
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	token: {
+		description: "The token that will be used to write to Sematext."
+		required:    true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -1,0 +1,188 @@
+package metadata
+
+base: components: sinks: sematext_metrics: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	default_namespace: {
+		description: """
+			Sets the default namespace for any metrics sent.
+
+			This namespace is only used if a metric has no existing namespace. When a namespace is
+			present, it is used as a prefix to the metric name, and separated with a period (`.`).
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The endpoint to send data to."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "Sematext region."
+		required:    false
+		type: string: enum: {
+			eu: "EU region."
+			us: "US region."
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	token: {
+		description: "The token that will be used to write to Sematext."
+		required:    true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -1,0 +1,248 @@
+package metadata
+
+base: components: sinks: socket: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: """
+			The address to connect to.
+
+			The address _must_ include a port.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	framing: {
+		description:   "Framing configuration."
+		relevant_when: "mode = \"tcp\" or mode = \"unix\""
+		required:      false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited encoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: delimiter: {
+					description: "The ASCII (7-bit) character that delimits byte sequences."
+					required:    true
+					type: uint: {}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Event data is not delimited at all."
+					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
+					length_delimited: """
+						Event data is prefixed with its length in bytes.
+
+						The prefix is a 32-bit unsigned integer, little endian.
+						"""
+					newline_delimited: "Event data is delimited by a newline (LF) character."
+				}
+			}
+		}
+	}
+	keepalive: {
+		description:   "TCP keepalive settings for socket-based components."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	mode: {
+		required: true
+		type: string: enum: {
+			tcp:  "TCP."
+			udp:  "UDP."
+			unix: "Unix Domain Socket."
+		}
+	}
+	path: {
+		description: """
+			The Unix socket path.
+
+			This should be an absolute path.
+			"""
+		relevant_when: "mode = \"unix\""
+		required:      true
+		type: string: syntax: "literal"
+	}
+	send_buffer_bytes: {
+		description: """
+			The size, in bytes, of the socket's send buffer.
+
+			If set, the value of the setting is passed via the `SO_SNDBUF` option.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      false
+		type: uint: {}
+	}
+	tls: {
+		description:   "Configures the TLS options for incoming/outgoing connections."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -1,0 +1,470 @@
+package metadata
+
+base: components: sinks: splunk_hec_logs: configuration: {
+	acknowledgements: {
+		description: "Splunk HEC acknowledgement configuration."
+		required:    false
+		type: object: options: {
+			enabled: {
+				description: "Enables end-to-end acknowledgements."
+				required:    false
+				type: bool: {}
+			}
+			indexer_acknowledgements_enabled: {
+				description: """
+					Controls if the sink will integrate with [Splunk HEC indexer acknowledgements][splunk_indexer_ack_docs] for end-to-end acknowledgements.
+
+					[splunk_indexer_ack_docs]: https://docs.splunk.com/Documentation/Splunk/8.2.3/Data/AboutHECIDXAck
+					"""
+				required: false
+				type: bool: default: true
+			}
+			max_pending_acks: {
+				description: """
+					The maximum number of pending acknowledgements from events sent to the Splunk HEC collector.
+
+					Once reached, the sink will begin applying backpressure.
+					"""
+				required: false
+				type: uint: default: 1000000
+			}
+			query_interval: {
+				description: "The amount of time, in seconds, to wait in between queries to the Splunk HEC indexer acknowledgement endpoint."
+				required:    false
+				type: uint: default: 10
+			}
+			retry_limit: {
+				description: "The maximum number of times an acknowledgement ID will be queried for its status."
+				required:    false
+				type: uint: default: 30
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	default_token: {
+		description: """
+			Default Splunk HEC token.
+
+			If an event has a token set in its metadata, it will prevail over the one set here.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The base URL of the Splunk instance."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	endpoint_target: {
+		description: "Splunk HEC endpoint configuration."
+		required:    false
+		type: string: {
+			default: "event"
+			enum: {
+				event: """
+					Events are sent to the [event endpoint][event_endpoint_docs].
+
+					When the event endpoint is used, configured [event metadata][event_metadata_docs] is sent
+					directly with each event.
+
+					[event_endpoint_docs]: https://docs.splunk.com/Documentation/Splunk/8.0.0/RESTREF/RESTinput#services.2Fcollector.2Fevent
+					[event_metadata_docs]: https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
+					"""
+				raw: """
+					Events are sent to the [raw endpoint][raw_endpoint_docs].
+
+					When the raw endpoint is used, configured [event metadata][event_metadata_docs] is sent as
+					query parameters on the request, except for the `timestamp` field.
+
+					[raw_endpoint_docs]: https://docs.splunk.com/Documentation/Splunk/8.0.0/RESTREF/RESTinput#services.2Fcollector.2Fraw
+					[event_metadata_docs]: https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata
+					"""
+			}
+		}
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to grab the hostname to send to Splunk HEC.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: {
+			default: "host"
+			syntax:  "literal"
+		}
+	}
+	index: {
+		description: """
+			The name of the index where to send the events to.
+
+			If not specified, the default index is used.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	indexed_fields: {
+		description: """
+			Fields to be [added to Splunk index][splunk_field_index_docs].
+
+			[splunk_field_index_docs]: https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	source: {
+		description: """
+			The source of events sent to this sink.
+
+			This is typically the filename the logs originated from.
+
+			If unset, the Splunk collector will set it.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	sourcetype: {
+		description: """
+			The sourcetype of events sent to this sink.
+
+			If unset, Splunk will default to `httpevent`.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	timestamp_key: {
+		description: """
+			Overrides the name of the log field used to grab the timestamp to send to Splunk HEC.
+
+			By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+
+			[global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
+			"""
+		required: false
+		type: string: {
+			default: "timestamp"
+			syntax:  "literal"
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -1,0 +1,366 @@
+package metadata
+
+base: components: sinks: splunk_hec_metrics: configuration: {
+	acknowledgements: {
+		description: "Splunk HEC acknowledgement configuration."
+		required:    false
+		type: object: options: {
+			enabled: {
+				description: "Enables end-to-end acknowledgements."
+				required:    false
+				type: bool: {}
+			}
+			indexer_acknowledgements_enabled: {
+				description: """
+					Controls if the sink will integrate with [Splunk HEC indexer acknowledgements][splunk_indexer_ack_docs] for end-to-end acknowledgements.
+
+					[splunk_indexer_ack_docs]: https://docs.splunk.com/Documentation/Splunk/8.2.3/Data/AboutHECIDXAck
+					"""
+				required: false
+				type: bool: default: true
+			}
+			max_pending_acks: {
+				description: """
+					The maximum number of pending acknowledgements from events sent to the Splunk HEC collector.
+
+					Once reached, the sink will begin applying backpressure.
+					"""
+				required: false
+				type: uint: default: 1000000
+			}
+			query_interval: {
+				description: "The amount of time, in seconds, to wait in between queries to the Splunk HEC indexer acknowledgement endpoint."
+				required:    false
+				type: uint: default: 10
+			}
+			retry_limit: {
+				description: "The maximum number of times an acknowledgement ID will be queried for its status."
+				required:    false
+				type: uint: default: 30
+			}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: {
+			object: options: {
+				algorithm: {
+					required: false
+					type: string: {
+						const:   "zlib"
+						default: "none"
+					}
+				}
+				level: {
+					description: "Compression level."
+					required:    false
+					type: {
+						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						string: enum: ["none", "fast", "best", "default"]
+					}
+				}
+			}
+			string: enum: ["none", "gzip", "zlib"]
+		}
+	}
+	default_namespace: {
+		description: """
+			Sets the default namespace for any metrics sent.
+
+			This namespace is only used if a metric has no existing namespace. When a namespace is
+			present, it is used as a prefix to the metric name, and separated with a period (`.`).
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	default_token: {
+		description: """
+			Default Splunk HEC token.
+
+			If an event has a token set in its metadata, it will prevail over the one set here.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "The base URL of the Splunk instance."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to grab the hostname to send to Splunk HEC.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: {
+			default: "host"
+			syntax:  "literal"
+		}
+	}
+	index: {
+		description: """
+			The name of the index where to send the events to.
+
+			If not specified, the default index is used.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	source: {
+		description: """
+			The source of events sent to this sink.
+
+			This is typically the filename the logs originated from.
+
+			If unset, the Splunk collector will set it.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	sourcetype: {
+		description: """
+			The sourcetype of events sent to this sink.
+
+			If unset, Splunk will default to `httpevent`.
+			"""
+		required: false
+		type: string: syntax: "template"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/statsd.cue
+++ b/website/cue/reference/components/sinks/base/statsd.cue
@@ -1,0 +1,194 @@
+package metadata
+
+base: components: sinks: statsd: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: """
+			The address to connect to.
+
+			The address _must_ include a port.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      true
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description:   "Event batching behavior."
+		relevant_when: "mode = \"udp\""
+		required:      false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	default_namespace: {
+		description: """
+			Sets the default namespace for any metrics sent.
+
+			This namespace is only used if a metric has no existing namespace. When a namespace is
+			present, it is used as a prefix to the metric name, and separated with a period (`.`).
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	keepalive: {
+		description:   "TCP keepalive settings for socket-based components."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	mode: {
+		required: true
+		type: string: enum: {
+			tcp:  "TCP."
+			udp:  "UDP."
+			unix: "Unix Domain Socket."
+		}
+	}
+	path: {
+		description: """
+			The Unix socket path.
+
+			This should be an absolute path.
+			"""
+		relevant_when: "mode = \"unix\""
+		required:      true
+		type: string: syntax: "literal"
+	}
+	send_buffer_bytes: {
+		description: """
+			The size, in bytes, of the socket's send buffer.
+
+			If set, the value of the setting is passed via the `SO_SNDBUF` option.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      false
+		type: uint: {}
+	}
+	tls: {
+		description:   "Configures the TLS options for incoming/outgoing connections."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/base/unit_test.cue
+++ b/website/cue/reference/components/sinks/base/unit_test.cue
@@ -1,0 +1,14 @@
+package metadata
+
+base: components: sinks: unit_test: configuration: {
+	test_name: {
+		description: "Name of the test that this sink is being used for."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	transform_ids: {
+		description: "List of names of the transform/branch associated with this sink."
+		required:    true
+		type: array: items: type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sinks/base/unit_test_stream.cue
+++ b/website/cue/reference/components/sinks/base/unit_test_stream.cue
@@ -1,0 +1,3 @@
+package metadata
+
+base: components: sinks: unit_test_stream: configuration: {}

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -1,0 +1,280 @@
+package metadata
+
+base: components: sinks: vector: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: """
+			The downstream Vector address to connect to.
+
+			The address _must_ include a port.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that will be processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized / compressed.
+					"""
+				required: false
+				type: uint: {}
+			}
+			max_events: {
+				description: "The maximum size of a batch, in events, before it is flushed."
+				required:    false
+				type: uint: {}
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch, in seconds, before it is flushed."
+				required:    false
+				type: float: {}
+			}
+		}
+	}
+	compression: {
+		description: """
+			Whether or not to compress requests.
+
+			If set to `true`, requests will be compressed with [`gzip`][gzip_docs].
+
+			[gzip_docs]: https://en.wikipedia.org/wiki/Gzip
+			"""
+		required: false
+		type: bool: default: false
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: {
+					default: {
+						decrease_ratio:      0.9
+						ewma_alpha:          0.4
+						rtt_deviation_scale: 2.5
+					}
+					options: {
+						decrease_ratio: {
+							description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																Note that the new limit is rounded down after applying this ratio.
+																"""
+							required: false
+							type: float: default: 0.9
+						}
+						ewma_alpha: {
+							description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+							required: false
+							type: float: default: 0.4
+						}
+						rtt_deviation_scale: {
+							description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and we expect reasonable values to range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, we also compute a secondary “deviation” value that indicates how variable
+																those values are. We use that deviation when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+							required: false
+							type: float: default: 2.5
+						}
+					}
+				}
+			}
+			concurrency: {
+				description: "Configuration for outbound request concurrency."
+				required:    false
+				type: {
+					number: {}
+					string: {
+						const:   "adaptive"
+						default: "none"
+					}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window, in seconds, used for the `rate_limit_num` option."
+				required:    false
+				type: uint: default: 1
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: default: 9223372036854775807
+			}
+			retry_attempts: {
+				description: """
+					The maximum number of retries to make for failed requests.
+
+					The default, for all intents and purposes, represents an infinite number of retries.
+					"""
+				required: false
+				type: uint: default: 9223372036854775807
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the fibonacci sequence will be used to select future backoffs.
+					"""
+				required: false
+				type: uint: default: 1
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time, in seconds, to wait between retries."
+				required:    false
+				type: uint: default: 3600
+			}
+			timeout_secs: {
+				description: """
+					The maximum time a request can take before being aborted.
+
+					It is highly recommended that you do not lower this value below the service’s internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	version: {
+		description: "Version of the configuration."
+		required:    false
+		type: string: enum: "2": "Marker value for version two."
+	}
+}

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -1,0 +1,236 @@
+package metadata
+
+base: components: sinks: websocket: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: """
+			Configuration of the authentication strategy for HTTP requests.
+
+			HTTP authentication should almost always be used with HTTPS only, as the authentication credentials are passed as an
+			HTTP header without any additional encryption beyond what is provided by the transport itself.
+			"""
+		required: false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	encoding: {
+		description: "Encoding configuration."
+		required:    true
+		type: object: options: {
+			avro: {
+				description:   "Apache Avro serializer options."
+				relevant_when: "codec = \"avro\""
+				required:      true
+				type: object: options: schema: {
+					description: "The Avro schema."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			codec: {
+				required: true
+				type: string: enum: {
+					avro:        "Apache Avro serialization."
+					gelf:        "GELF serialization."
+					json:        "JSON serialization."
+					logfmt:      "Logfmt serialization."
+					native:      "Native Vector serialization based on Protocol Buffers."
+					native_json: "Native Vector serialization based on JSON."
+					raw_message: """
+						No serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+					text: """
+						Plaintext serialization.
+
+						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
+						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
+						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
+						event.
+						"""
+				}
+			}
+			except_fields: {
+				description: "List of fields that will be excluded from the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			only_fields: {
+				description: "List of fields that will be included in the encoded event."
+				required:    false
+				type: array: items: type: string: syntax: "literal"
+			}
+			timestamp_format: {
+				description: "Format used for timestamp fields."
+				required:    false
+				type: string: enum: {
+					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
+					unix:    "Represent the timestamp as a Unix timestamp."
+				}
+			}
+		}
+	}
+	ping_interval: {
+		description: "The interval, in seconds, between sending PINGs to the remote peer."
+		required:    false
+		type: uint: {}
+	}
+	ping_timeout: {
+		description: """
+			The timeout, in seconds, while waiting for a PONG response from the remote peer.
+
+			If a response is not received in this time, the connection is reestablished.
+			"""
+		required: false
+		type: uint: {}
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	uri: {
+		description: """
+			The WebSocket URI to connect to.
+
+			This should include the protocol and host, but can also include the port, path, and any other valid part of a URI.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -1,0 +1,240 @@
+package metadata
+
+base: components: sources: amqp: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	connection: {
+		description: "Connection options for `AMQP` source."
+		required:    true
+		type: object: options: {
+			connection_string: {
+				description: """
+					URI for the `AMQP` server.
+
+					Format: amqp://<user>:<password>@<host>:<port>/<vhost>?timeout=<seconds>
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+			tls: {
+				description: "Standard TLS options."
+				required:    false
+				type: object: options: {
+					alpn_protocols: {
+						description: """
+																Sets the list of supported ALPN protocols.
+
+																Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+																they are defined.
+																"""
+						required: false
+						type: array: items: type: string: syntax: "literal"
+					}
+					ca_file: {
+						description: """
+																Absolute path to an additional CA certificate file.
+
+																The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					crt_file: {
+						description: """
+																Absolute path to a certificate file used to identify this server.
+
+																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+																an inline string in PEM format.
+
+																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_file: {
+						description: """
+																Absolute path to a private key file used to identify this server.
+
+																The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_pass: {
+						description: """
+																Passphrase used to unlock the encrypted key file.
+
+																This has no effect unless `key_file` is set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					verify_certificate: {
+						description: """
+																Enables certificate verification.
+
+																If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+																issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+																certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+																so on until reaching a root certificate.
+
+																Relevant for both incoming and outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+																"""
+						required: false
+						type: bool: {}
+					}
+					verify_hostname: {
+						description: """
+																Enables hostname verification.
+
+																If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+																the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+																Only relevant for outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+																"""
+						required: false
+						type: bool: {}
+					}
+				}
+			}
+		}
+	}
+	consumer: {
+		description: "The identifier for the consumer."
+		required:    false
+		type: string: {
+			default: "vector"
+			syntax:  "literal"
+		}
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	exchange_key: {
+		description: "The `AMQP` exchange key."
+		required:    false
+		type: string: {
+			default: "exchange"
+			syntax:  "literal"
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	log_namespace: {
+		description: "The namespace to use. This overrides the global setting."
+		required:    false
+		type: bool: {}
+	}
+	offset_key: {
+		description: "The `AMQP` offset key."
+		required:    false
+		type: string: {
+			default: "offset"
+			syntax:  "literal"
+		}
+	}
+	queue: {
+		description: "The name of the queue to consume."
+		required:    false
+		type: string: {
+			default: "vector"
+			syntax:  "literal"
+		}
+	}
+	routing_key_field: {
+		description: "The `AMQP` routing key."
+		required:    false
+		type: string: {
+			default: "routing"
+			syntax:  "literal"
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/apache_metrics.cue
+++ b/website/cue/reference/components/sources/base/apache_metrics.cue
@@ -1,0 +1,26 @@
+package metadata
+
+base: components: sources: apache_metrics: configuration: {
+	endpoints: {
+		description: "The list of `mod_status` endpoints to scrape metrics from."
+		required:    true
+		type: array: items: type: string: syntax: "literal"
+	}
+	namespace: {
+		description: """
+			The namespace of the metric.
+
+			Disabled if empty.
+			"""
+		required: false
+		type: string: {
+			default: "apache"
+			syntax:  "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between scrapes, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+}

--- a/website/cue/reference/components/sources/base/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/base/aws_ecs_metrics.cue
@@ -1,0 +1,76 @@
+package metadata
+
+base: components: sources: aws_ecs_metrics: configuration: {
+	endpoint: {
+		description: """
+			Base URI of the task metadata endpoint.
+
+			If empty, the URI will be automatically discovered based on the latest version detected.
+
+			By default:
+			- The version 2 endpoint base URI is `169.254.170.2/v2/`.
+			- The version 3 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI`.
+			- The version 4 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI_V4`.
+			"""
+		required: false
+		type: string: {
+			default: "http://169.254.170.2/v2"
+			syntax:  "literal"
+		}
+	}
+	namespace: {
+		description: """
+			The namespace of the metric.
+
+			Disabled if empty.
+			"""
+		required: false
+		type: string: {
+			default: "awsecs"
+			syntax:  "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between scrapes, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+	version: {
+		description: """
+			The version of the task metadata endpoint to use.
+
+			If empty, the version is automatically discovered based on environment variables.
+
+			By default:
+			- Version 4 is used if the environment variable `ECS_CONTAINER_METADATA_URI_V4` is defined.
+			- Version 3 is used if the environment variable `ECS_CONTAINER_METADATA_URI_V4` is not defined, but the
+			  environment variable `ECS_CONTAINER_METADATA_URI` _is_ defined.
+			- Version 2 is used if neither of the environment variables `ECS_CONTAINER_METADATA_URI_V4` or
+			  `ECS_CONTAINER_METADATA_URI` are defined.
+			"""
+		required: false
+		type: string: {
+			default: "v2"
+			enum: {
+				v2: """
+					Version 2.
+
+					More information about version 2 of the task metadata endpoint can be found
+					(here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html].
+					"""
+				v3: """
+					Version 3.
+
+					More information about version 3 of the task metadata endpoint can be found
+					(here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html].
+					"""
+				v4: """
+					Version 4.
+
+					More information about version 4 of the task metadata endpoint can be found
+					(here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html].
+					"""
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -1,0 +1,233 @@
+package metadata
+
+base: components: sources: aws_kinesis_firehose: configuration: {
+	access_key: {
+		description: """
+			An optional access key to authenticate requests against.
+
+			AWS Kinesis Firehose can be configured to pass along a user-configurable access key with each request. If
+			configured, `access_key` should be set to the same value. Otherwise, all requests will be allowed.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: "The address to listen for connections on."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	record_compression: {
+		description: """
+			The compression scheme to use for decompressing records within the Firehose message.
+
+			Some services, like AWS CloudWatch Logs, will [compress the events with
+			gzip](\\(urls.aws_cloudwatch_logs_firehose)), before sending them AWS Kinesis Firehose. This option can be used
+			to automatically decompress them before forwarding them to the next component.
+
+			Note that this is different from [Content encoding option](\\(urls.aws_kinesis_firehose_http_protocol)) of the
+			Firehose HTTP endpoint destination. That option controls the content encoding of the entire HTTP request.
+			"""
+		required: false
+		type: string: enum: {
+			auto: """
+				Automatically attempt to determine the compression scheme.
+
+				Vector will try to determine the compression scheme of the object by looking at its file signature, also known
+				as [magic bytes](\\(urls.magic_bytes)).
+
+				Given that determining the encoding using magic bytes is not a perfect check, if the record fails to decompress
+				with the discovered format, the record will be forwarded as-is. Thus, if you know the records will always be
+				gzip encoded (for example if they are coming from AWS CloudWatch Logs) then you should prefer to set `gzip` here
+				to have Vector reject any records that are not-gziped.
+				"""
+			gzip: "GZIP."
+			none: "Uncompressed."
+		}
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -1,0 +1,413 @@
+package metadata
+
+base: components: sources: aws_s3: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: {
+			default: enabled: null
+			options: enabled: {
+				description: "Enables end-to-end acknowledgements."
+				required:    false
+				type: bool: {}
+			}
+		}
+	}
+	assume_role: {
+		description: """
+			The ARN of an [IAM role][iam_role] to assume at startup.
+
+			[iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: {
+			default: load_timeout_secs: null
+			options: {
+				access_key_id: {
+					description: "The AWS access key ID."
+					required:    true
+					type: string: syntax: "literal"
+				}
+				assume_role: {
+					description: "The ARN of the role to assume."
+					required:    true
+					type: string: syntax: "literal"
+				}
+				credentials_file: {
+					description: "Path to the credentials file."
+					required:    true
+					type: string: syntax: "literal"
+				}
+				load_timeout_secs: {
+					description: "Timeout for successfully loading any credentials, in seconds."
+					required:    false
+					type: uint: {}
+				}
+				profile: {
+					description: "The credentials profile to use."
+					required:    false
+					type: string: syntax: "literal"
+				}
+				region: {
+					description: """
+						The AWS region to send STS requests to.
+
+						If not set, this will default to the configured region
+						for the service itself.
+						"""
+					required: false
+					type: string: syntax: "literal"
+				}
+				secret_access_key: {
+					description: "The AWS secret access key."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+		}
+	}
+	compression: {
+		description: "The compression scheme used for decompressing objects retrieved from S3."
+		required:    false
+		type: string: {
+			default: "auto"
+			enum: {
+				auto: """
+					Automatically attempt to determine the compression scheme.
+
+					Vector will try to determine the compression scheme of the object from its: `Content-Encoding` and
+					`Content-Type` metadata, as well as the key suffix (e.g. `.gz`).
+
+					It will fallback to 'none' if the compression scheme cannot be determined.
+					"""
+				gzip: "GZIP."
+				none: "Uncompressed."
+				zstd: "ZSTD."
+			}
+		}
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	multiline: {
+		description: """
+			Multiline aggregation configuration.
+
+			If not specified, multiline aggregation is disabled.
+			"""
+		required: false
+		type: object: options: {
+			condition_pattern: {
+				description: """
+					Regular expression pattern that is used to determine whether or not more lines should be read.
+
+					This setting must be configured in conjunction with `mode`.
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+			mode: {
+				description: """
+					Aggregation mode.
+
+					This setting must be configured in conjunction with `condition_pattern`.
+					"""
+				required: true
+				type: string: enum: {
+					continue_past: """
+						All consecutive lines matching this pattern, plus one additional line, are included in the group.
+
+						This is useful in cases where a log message ends with a continuation marker, such as a backslash, indicating
+						that the following line is part of the same message.
+						"""
+					continue_through: """
+						All consecutive lines matching this pattern are included in the group.
+
+						The first line (the line that matched the start pattern) does not need to match the `ContinueThrough` pattern.
+
+						This is useful in cases such as a Java stack trace, where some indicator in the line (such as leading
+						whitespace) indicates that it is an extension of the proceeding line.
+						"""
+					halt_before: """
+						All consecutive lines not matching this pattern are included in the group.
+
+						This is useful where a log line contains a marker indicating that it begins a new message.
+						"""
+					halt_with: """
+						All consecutive lines, up to and including the first line matching this pattern, are included in the group.
+
+						This is useful where a log line ends with a termination marker, such as a semicolon.
+						"""
+				}
+			}
+			start_pattern: {
+				description: "Regular expression pattern that is used to match the start of a new message."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			timeout_ms: {
+				description: """
+					The maximum amount of time to wait for the next additional line, in milliseconds.
+
+					Once this timeout is reached, the buffered message is guaranteed to be flushed, even if incomplete.
+					"""
+				required: true
+				type: uint: {}
+			}
+		}
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	sqs: {
+		description: """
+			Configuration options for SQS.
+
+			Only relevant when `strategy = "sqs"`.
+			"""
+		required: false
+		type: object: options: {
+			client_concurrency: {
+				description: """
+					Number of concurrent tasks to create for polling the queue for messages.
+
+					Defaults to the number of available CPUs on the system.
+
+					Should not typically need to be changed, but it can sometimes be beneficial to raise this value when there is a
+					high rate of messages being pushed into the queue and the objects being fetched are small. In these cases,
+					Vector may not fully utilize system resources without fetching more messages per second, as the SQS message
+					consumption rate affects the S3 object retrieval rate.
+					"""
+				required: false
+				type: uint: default: 24
+			}
+			delete_message: {
+				description: """
+					Whether to delete the message once Vector processes it.
+
+					It can be useful to set this to `false` to debug or during initial Vector setup.
+					"""
+				required: false
+				type: bool: default: true
+			}
+			poll_secs: {
+				description: """
+					How long to wait while polling the queue for new messages, in seconds.
+
+					Generally should not be changed unless instructed to do so, as if messages are available, they will always be
+					consumed, regardless of the value of `poll_secs`.
+					"""
+				required: false
+				type: uint: default: 15
+			}
+			queue_url: {
+				description: "The URL of the SQS queue to poll for bucket notifications."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			tls_options: {
+				description: "Standard TLS options."
+				required:    false
+				type: object: options: {
+					alpn_protocols: {
+						description: """
+																Sets the list of supported ALPN protocols.
+
+																Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+																they are defined.
+																"""
+						required: false
+						type: array: items: type: string: syntax: "literal"
+					}
+					ca_file: {
+						description: """
+																Absolute path to an additional CA certificate file.
+
+																The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					crt_file: {
+						description: """
+																Absolute path to a certificate file used to identify this server.
+
+																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+																an inline string in PEM format.
+
+																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_file: {
+						description: """
+																Absolute path to a private key file used to identify this server.
+
+																The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_pass: {
+						description: """
+																Passphrase used to unlock the encrypted key file.
+
+																This has no effect unless `key_file` is set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					verify_certificate: {
+						description: """
+																Enables certificate verification.
+
+																If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+																issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+																certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+																so on until reaching a root certificate.
+
+																Relevant for both incoming and outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+																"""
+						required: false
+						type: bool: {}
+					}
+					verify_hostname: {
+						description: """
+																Enables hostname verification.
+
+																If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+																the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+																Only relevant for outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+																"""
+						required: false
+						type: bool: {}
+					}
+				}
+			}
+			visibility_timeout_secs: {
+				description: """
+					The visibility timeout to use for messages, in secords.
+
+					This controls how long a message is left unavailable after Vector receives it. If Vector receives a message, and
+					takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it will be made reavailable for another consumer.
+
+					This can happen if, for example, if Vector crashes between consuming a message and deleting it.
+					"""
+				required: false
+				type: uint: default: 300
+			}
+		}
+	}
+	strategy: {
+		description: "The strategy to use to consume objects from S3."
+		required:    false
+		type: string: {
+			default: "sqs"
+			enum: sqs: """
+				Consumes objects by processing bucket notification events sent to an [AWS SQS queue][aws_sqs].
+
+				[aws_sqs]: https://aws.amazon.com/sqs/
+				"""
+		}
+	}
+	tls_options: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -1,0 +1,286 @@
+package metadata
+
+base: components: sources: aws_sqs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auth: {
+		description: "Configuration of the authentication strategy for interacting with AWS services."
+		required:    false
+		type: object: options: {
+			access_key_id: {
+				description: "The AWS access key ID."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			assume_role: {
+				description: "The ARN of the role to assume."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			credentials_file: {
+				description: "Path to the credentials file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			load_timeout_secs: {
+				description: "Timeout for successfully loading any credentials, in seconds."
+				required:    false
+				type: uint: {}
+			}
+			profile: {
+				description: "The credentials profile to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			region: {
+				description: """
+					The AWS region to send STS requests to.
+
+					If not set, this will default to the configured region
+					for the service itself.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			secret_access_key: {
+				description: "The AWS secret access key."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	client_concurrency: {
+		description: """
+			Number of concurrent tasks to create for polling the queue for messages.
+
+			Defaults to the number of available CPUs on the system.
+
+			Should not typically need to be changed, but it can sometimes be beneficial to raise this value when there is a
+			high rate of messages being pushed into the queue and the messages being fetched are small. In these cases,
+			Vector may not fully utilize system resources without fetching more messages per second, as it spends more time
+			fetching the messages than processing them.
+			"""
+		required: false
+		type: uint: default: 24
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	delete_message: {
+		description: """
+			Whether to delete the message once Vector processes it.
+
+			It can be useful to set this to `false` to debug or during initial Vector setup.
+			"""
+		required: false
+		type: bool: default: true
+	}
+	endpoint: {
+		description: "The API endpoint of the service."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	poll_secs: {
+		description: """
+			How long to wait while polling the queue for new messages, in seconds.
+
+			Generally should not be changed unless instructed to do so, as if messages are available, they will always be
+			consumed, regardless of the value of `poll_secs`.
+			"""
+		required: false
+		type: uint: default: 15
+	}
+	queue_url: {
+		description: "The URL of the SQS queue to poll for messages."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	region: {
+		description: "The AWS region to use."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	visibility_timeout_secs: {
+		description: """
+			The visibility timeout to use for messages, in secords.
+
+			This controls how long a message is left unavailable after Vector receives it. If Vector receives a message, and
+			takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it will be made reavailable for another consumer.
+
+			This can happen if, for example, if Vector crashes between consuming a message and deleting it.
+			"""
+		required: false
+		type: uint: default: 300
+	}
+}

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -1,0 +1,237 @@
+package metadata
+
+base: components: sources: datadog_agent: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: """
+			The address to accept connections on.
+
+			The address _must_ include a port.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	disable_logs: {
+		description: "If this settings is set to `true`, logs won't be accepted by the component."
+		required:    false
+		type: bool: default: false
+	}
+	disable_metrics: {
+		description: "If this settings is set to `true`, metrics won't be accepted by the component."
+		required:    false
+		type: bool: default: false
+	}
+	disable_traces: {
+		description: "If this settings is set to `true`, traces won't be accepted by the component."
+		required:    false
+		type: bool: default: false
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	log_namespace: {
+		description: "The namespace to use for logs. This overrides the global settings"
+		required:    false
+		type: bool: {}
+	}
+	multiple_outputs: {
+		description: """
+			If this setting is set to `true` logs, metrics and traces will be sent to different outputs.
+
+			For a source component named `agent` the received logs, metrics, and traces can then be accessed by specifying
+			`agent.logs`, `agent.metrics`, and `agent.traces`, respectively, as the input to another component.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	store_api_key: {
+		description: """
+			When incoming events contain a Datadog API key, if this setting is set to `true` the key will kept in the event
+			metadata and will be used if the event is sent to a Datadog sink.
+			"""
+		required: false
+		type: bool: default: true
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -1,0 +1,136 @@
+package metadata
+
+base: components: sources: demo_logs: configuration: {
+	count: {
+		description: """
+			The total number of lines to output.
+
+			By default, the source continuously prints logs (infinitely).
+			"""
+		required: false
+		type: uint: default: 9223372036854775807
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: {
+			default: codec: "bytes"
+			options: codec: {
+				required: true
+				type: string: enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	format: {
+		required: false
+		type: string: {
+			default: "json"
+			enum: {
+				apache_common: "Randomly generated logs in [Apache common](\\(urls.apache_common)) format."
+				apache_error:  "Randomly generated logs in [Apache error](\\(urls.apache_error)) format."
+				bsd_syslog:    "Randomly generated logs in Syslog format ([RFC 3164](\\(urls.syslog_3164)))."
+				json:          "Randomly generated HTTP server logs in [JSON](\\(urls.json)) format."
+				shuffle:       "Lines are chosen at random from the list specified using `lines`."
+				syslog:        "Randomly generated logs in Syslog format ([RFC 5424](\\(urls.syslog_5424)))."
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: {
+			default: method: "bytes"
+			options: {
+				character_delimited: {
+					description:   "Options for the character delimited decoder."
+					relevant_when: "method = \"character_delimited\""
+					required:      true
+					type: object: options: {
+						delimiter: {
+							description: "The character that delimits byte sequences."
+							required:    true
+							type: uint: {}
+						}
+						max_length: {
+							description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+							required: false
+							type: uint: {}
+						}
+					}
+				}
+				method: {
+					required: true
+					type: string: enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+				newline_delimited: {
+					description:   "Options for the newline delimited decoder."
+					relevant_when: "method = \"newline_delimited\""
+					required:      false
+					type: object: options: max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+				octet_counting: {
+					description:   "Options for the octet counting decoder."
+					relevant_when: "method = \"octet_counting\""
+					required:      false
+					type: object: options: max_length: {
+						description: "The maximum length of the byte buffer."
+						required:    false
+						type: uint: {}
+					}
+				}
+			}
+		}
+	}
+	interval: {
+		description: """
+			The amount of time, in seconds, to pause between each batch of output lines.
+
+			The default is one batch per second. In order to remove the delay and output batches as quickly as possible, set
+			`interval` to `0.0`.
+			"""
+		required: false
+		type: float: default: 1.0
+	}
+	lines: {
+		description:   "The list of lines to output."
+		relevant_when: "format = \"shuffle\""
+		required:      true
+		type: array: items: type: string: syntax: "literal"
+	}
+	log_namespace: {
+		description: "The namespace to use for logs. This overrides the global setting"
+		required:    false
+		type: bool: {}
+	}
+	sequence: {
+		description:   "If `true`, each output line starts with an increasing sequence number, beginning with 0."
+		relevant_when: "format = \"shuffle\""
+		required:      false
+		type: bool: default: false
+	}
+}

--- a/website/cue/reference/components/sources/base/dnstap.cue
+++ b/website/cue/reference/components/sources/base/dnstap.cue
@@ -1,0 +1,80 @@
+package metadata
+
+base: components: sources: dnstap: configuration: {
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the source path to each event.
+
+			The value will be the socket path itself.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	max_frame_handling_tasks: {
+		description: "Maximum number of frames that can be processed concurrently."
+		required:    false
+		type: uint: {}
+	}
+	max_frame_length: {
+		description: "Maximum length, in bytes, that a frame can be."
+		required:    false
+		type: uint: default: 102400
+	}
+	multithreaded: {
+		description: "Whether or not to concurrently process DNSTAP frames."
+		required:    false
+		type: bool: {}
+	}
+	raw_data_only: {
+		description: """
+			Whether or not to skip parsing/decoding of DNSTAP frames.
+
+			If set to `true`, frames will not be parsed/decoded. The raw frame data will be set as a field on the event
+			(called `rawData`) and encoded as a base64 string.
+			"""
+		required: false
+		type: bool: {}
+	}
+	socket_file_mode: {
+		description: """
+			Unix file mode bits to be applied to the unix socket file as its designated file permissions.
+
+			Note that the file mode value can be specified in any numeric format supported by your configuration
+			language, but it is most intuitive to use an octal number.
+			"""
+		required: false
+		type: uint: {}
+	}
+	socket_path: {
+		description: """
+			Absolute path to the socket file to read DNSTAP data from.
+
+			The DNS server must be configured to send its DNSTAP data to this socket file. The socket file will be created,
+			if it doesn't already exist, when the source first starts.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	socket_receive_buffer_size: {
+		description: """
+			The size, in bytes, of the receive buffer used for the socket.
+
+			This should not typically needed to be changed.
+			"""
+		required: false
+		type: uint: {}
+	}
+	socket_send_buffer_size: {
+		description: """
+			The size, in bytes, of the send buffer used for the socket.
+
+			This should not typically needed to be changed.
+			"""
+		required: false
+		type: uint: {}
+	}
+}

--- a/website/cue/reference/components/sources/base/docker_logs.cue
+++ b/website/cue/reference/components/sources/base/docker_logs.cue
@@ -1,0 +1,200 @@
+package metadata
+
+base: components: sources: docker_logs: configuration: {
+	auto_partial_merge: {
+		description: "Enables automatic merging of partial events."
+		required:    false
+		type: bool: default: true
+	}
+	docker_host: {
+		description: """
+			Docker host to connect to.
+
+			Use an HTTPS URL to enable TLS encryption.
+
+			If absent, Vector will try to use `DOCKER_HOST` environment variable. If `DOCKER_HOST` is also absent, Vector will use default Docker local socket (`/var/run/docker.sock` on Unix platforms, `//./pipe/docker_engine` on Windows).
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	exclude_containers: {
+		description: """
+			A list of container IDs or names of containers to exclude from log collection.
+
+			Matching is prefix first, so specifying a value of `foo` would match any container named `foo` as well as any
+			container whose name started with `foo`. This applies equally whether matching container IDs or names.
+
+			By default, the source will collect logs for all containers. If `exclude_containers` is configured, any
+			container that matches a configured exclusion will be excluded even if it is also included via
+			`include_containers`, so care should be taken when utilizing prefix matches as they cannot be overridden by a
+			corresponding entry in `include_containers` e.g. excluding `foo` by attempting to include `foo-specific-id`.
+
+			This can be used in conjunction with `include_containers`.
+			"""
+		required: false
+		type: array: items: type: string: syntax: "literal"
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the current hostname to each event.
+
+			The value will be the current hostname for wherever Vector is running.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: {
+			default: "host"
+			syntax:  "literal"
+		}
+	}
+	include_containers: {
+		description: """
+			A list of container IDs or names of containers to include in log collection.
+
+			Matching is prefix first, so specifying a value of `foo` would match any container named `foo` as well as any
+			container whose name started with `foo`. This applies equally whether matching container IDs or names.
+
+			By default, the source will collect logs for all containers. If `include_containers` is configured, only
+			containers that match a configured inclusion and are also not excluded will be matched.
+
+			This can be used in conjunction with `include_containers`.
+			"""
+		required: false
+		type: array: items: type: string: syntax: "literal"
+	}
+	include_images: {
+		description: """
+			A list of image names to match against.
+
+			If not provided, all images will be included.
+			"""
+		required: false
+		type: array: items: type: string: syntax: "literal"
+	}
+	include_labels: {
+		description: """
+			A list of container object labels to match against when filtering running containers.
+
+			Labels should follow the syntax described in the [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/) documentation.
+			"""
+		required: false
+		type: array: items: type: string: syntax: "literal"
+	}
+	multiline: {
+		description: """
+			Multiline aggregation configuration.
+
+			If not specified, multiline aggregation is disabled.
+			"""
+		required: false
+		type: object: options: {
+			condition_pattern: {
+				description: """
+					Regular expression pattern that is used to determine whether or not more lines should be read.
+
+					This setting must be configured in conjunction with `mode`.
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+			mode: {
+				description: """
+					Aggregation mode.
+
+					This setting must be configured in conjunction with `condition_pattern`.
+					"""
+				required: true
+				type: string: enum: {
+					continue_past: """
+						All consecutive lines matching this pattern, plus one additional line, are included in the group.
+
+						This is useful in cases where a log message ends with a continuation marker, such as a backslash, indicating
+						that the following line is part of the same message.
+						"""
+					continue_through: """
+						All consecutive lines matching this pattern are included in the group.
+
+						The first line (the line that matched the start pattern) does not need to match the `ContinueThrough` pattern.
+
+						This is useful in cases such as a Java stack trace, where some indicator in the line (such as leading
+						whitespace) indicates that it is an extension of the proceeding line.
+						"""
+					halt_before: """
+						All consecutive lines not matching this pattern are included in the group.
+
+						This is useful where a log line contains a marker indicating that it begins a new message.
+						"""
+					halt_with: """
+						All consecutive lines, up to and including the first line matching this pattern, are included in the group.
+
+						This is useful where a log line ends with a termination marker, such as a semicolon.
+						"""
+				}
+			}
+			start_pattern: {
+				description: "Regular expression pattern that is used to match the start of a new message."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			timeout_ms: {
+				description: """
+					The maximum amount of time to wait for the next additional line, in milliseconds.
+
+					Once this timeout is reached, the buffered message is guaranteed to be flushed, even if incomplete.
+					"""
+				required: true
+				type: uint: {}
+			}
+		}
+	}
+	partial_event_marker_field: {
+		description: """
+			Overrides the name of the log field used to mark an event as partial.
+
+			If `auto_partial_merge` is disabled, partial events will be emitted with a log field, controlled by this
+			configuration value, is set, indicating that the event is not complete.
+
+			By default, `"_partial"` is used.
+			"""
+		required: false
+		type: string: {
+			default: "_partial"
+			syntax:  "literal"
+		}
+	}
+	retry_backoff_secs: {
+		description: "The amount of time, in seconds, to wait before retrying after an error."
+		required:    false
+		type: uint: default: 2
+	}
+	tls: {
+		description: """
+			Configuration of TLS when connecting to the Docker daemon.
+
+			Only relevant when connecting to Docker via an HTTPS URL.
+
+			If not configured, Vector will try to use environment variable `DOCKER_CERT_PATH` and then` DOCKER_CONFIG`. If both environment variables are absent, Vector will try to read certificates in `~/.docker/`.
+			"""
+		required: false
+		type: object: options: {
+			ca_file: {
+				description: "Path to the CA certificate file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: "Path to the TLS certificate file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: "Path to the TLS key file."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/eventstoredb_metrics.cue
+++ b/website/cue/reference/components/sources/base/eventstoredb_metrics.cue
@@ -1,0 +1,26 @@
+package metadata
+
+base: components: sources: eventstoredb_metrics: configuration: {
+	default_namespace: {
+		description: """
+			Overrides the default namespace for the metrics emitted by the source.
+
+			By default, `eventstoredb` is used.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	endpoint: {
+		description: "Endpoints to scrape stats from."
+		required:    false
+		type: string: {
+			default: "https://localhost:2113/stats"
+			syntax:  "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between scrapes, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+}

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -1,0 +1,152 @@
+package metadata
+
+base: components: sources: exec: configuration: {
+	command: {
+		description: "The command to be run, plus any arguments required."
+		required:    false
+		type: array: {
+			default: ["echo", "Hello World!"]
+			items: type: string: syntax: "literal"
+		}
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: {
+			default: codec: "bytes"
+			options: codec: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:       "Configures the `BytesDeserializer`."
+						gelf:        "Configures the `GelfDeserializer`."
+						json:        "Configures the `JsonDeserializer`."
+						native:      "Configures the `NativeDeserializer`."
+						native_json: "Configures the `NativeJsonDeserializer`."
+						syslog:      "Configures the `SyslogDeserializer`."
+					}
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Configures the `BytesDecoder`."
+					character_delimited: "Configures the `CharacterDelimitedDecoder`."
+					length_delimited:    "Configures the `LengthDelimitedDecoder`."
+					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+					octet_counting:      "Configures the `OctetCountingDecoder`."
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	include_stderr: {
+		description: "Whether or not the output from stderr should be included when generating events."
+		required:    false
+		type: bool: default: true
+	}
+	maximum_buffer_size_bytes: {
+		description: "The maximum buffer size allowed before a log event will be generated."
+		required:    false
+		type: uint: default: 1000000
+	}
+	mode: {
+		description: "Mode of operation for running the command."
+		required:    false
+		type: string: {
+			default: "scheduled"
+			enum: {
+				scheduled: "The command is run on a schedule."
+				streaming: "The command is run until it exits, potentially being restarted."
+			}
+		}
+	}
+	scheduled: {
+		description: "Configuration options for scheduled commands."
+		required:    false
+		type: object: {
+			default: exec_interval_secs: 60
+			options: exec_interval_secs: {
+				description: """
+					The interval, in seconds, between scheduled command runs.
+
+					If the command takes longer than `exec_interval_secs` to run, it will be killed.
+					"""
+				required: false
+				type: uint: default: 60
+			}
+		}
+	}
+	streaming: {
+		description: "Configuration options for streaming commands."
+		required:    false
+		type: object: options: {
+			respawn_interval_secs: {
+				description: "The amount of time, in seconds, that Vector will wait before rerunning a streaming command that exited."
+				required:    false
+				type: uint: default: 5
+			}
+			respawn_on_exit: {
+				description: "Whether or not the command should be rerun if the command exits."
+				required:    false
+				type: bool: default: true
+			}
+		}
+	}
+	working_directory: {
+		description: "The directory in which to run the command."
+		required:    false
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -1,0 +1,332 @@
+package metadata
+
+base: components: sources: file: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: {
+			default: enabled: null
+			options: enabled: {
+				description: "Enables end-to-end acknowledgements."
+				required:    false
+				type: bool: {}
+			}
+		}
+	}
+	data_dir: {
+		description: """
+			The directory used to persist file checkpoint positions.
+
+			By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	encoding: {
+		description: "Character set encoding."
+		required:    false
+		type: object: options: charset: {
+			description: """
+				Encoding of the source messages.
+
+				Takes one of the encoding [label strings](https://encoding.spec.whatwg.org/#concept-encoding-get) defined as
+				part of the [Encoding Standard](https://encoding.spec.whatwg.org/).
+
+				When set, the messages are transcoded from the specified encoding to UTF-8, which is the encoding that Vector
+				assumes internally for string-like data. You should enable this transcoding operation if you need your data to
+				be in UTF-8 for further processing. At the time of transcoding, any malformed sequences (that can’t be mapped to
+				UTF-8) will be replaced with the Unicode [REPLACEMENT
+				CHARACTER](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) and warnings will be
+				logged.
+				"""
+			required: true
+			type: string: syntax: "literal"
+		}
+	}
+	exclude: {
+		description: """
+			Array of file patterns to exclude. [Globbing](https://vector.dev/docs/reference/configuration/sources/file/#globbing) is supported.
+
+			Takes precedence over the `include` option.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	file_key: {
+		description: """
+			Overrides the name of the log field used to add the file path to each event.
+
+			The value will be the full path to the file where the event was read message.
+
+			By default, `file` is used.
+			"""
+		required: false
+		type: string: {
+			default: "file"
+			syntax:  "literal"
+		}
+	}
+	fingerprint: {
+		description: """
+			Configuration for how files should be identified.
+
+			This is important for `checkpointing` when file rotation is used.
+			"""
+		required: false
+		type: object: {
+			default: {
+				bytes:                null
+				ignored_header_bytes: 0
+				lines:                1
+				strategy:             "checksum"
+			}
+			options: {
+				bytes: {
+					description: """
+						Maximum number of bytes to use, from the lines that are read, for generating the checksum.
+
+						TODO: Should we properly expose this in the documentation? There could definitely be value in allowing more
+						bytes to be used for the checksum generation, but we should commit to exposing it rather than hiding it.
+						"""
+					relevant_when: "strategy = \"checksum\""
+					required:      false
+					type: uint: {}
+				}
+				ignored_header_bytes: {
+					description: """
+						The number of bytes to skip ahead (or ignore) when reading the data used for generating the checksum.
+
+						This can be helpful if all files share a common header that should be skipped.
+						"""
+					relevant_when: "strategy = \"checksum\""
+					required:      true
+					type: uint: {}
+				}
+				lines: {
+					description: """
+						The number of lines to read for generating the checksum.
+
+						If your files share a common header that is not always a fixed size,
+
+						If the file has less than this amount of lines, it won’t be read at all.
+						"""
+					relevant_when: "strategy = \"checksum\""
+					required:      false
+					type: uint: default: 1
+				}
+				strategy: {
+					required: true
+					type: string: enum: {
+						checksum:         "Read lines from the beginning of the file and compute a checksum over them."
+						device_and_inode: "Use the [device and inode](https://en.wikipedia.org/wiki/Inode) as the identifier."
+					}
+				}
+			}
+		}
+	}
+	glob_minimum_cooldown_ms: {
+		description: """
+			Delay between file discovery calls, in milliseconds.
+
+			This controls the interval at which Vector searches for files. Higher value result in greater chances of some short living files being missed between searches, but lower value increases the performance impact of file discovery.
+			"""
+		required: false
+		type: uint: default: 1000
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the current hostname to each event.
+
+			The value will be the current hostname for wherever Vector is running.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	ignore_checkpoints: {
+		description: """
+			Whether or not to ignore existing checkpoints when determining where to start reading a file.
+
+			Checkpoints are still written normally.
+			"""
+		required: false
+		type: bool: {}
+	}
+	ignore_not_found: {
+		description: """
+			Ignore missing files when fingerprinting.
+
+			This may be useful when used with source directories containing dangling symlinks.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	ignore_older_secs: {
+		description: "Ignore files with a data modification date older than the specified number of seconds."
+		required:    false
+		type: uint: {}
+	}
+	include: {
+		description: "Array of file patterns to include. [Globbing](https://vector.dev/docs/reference/configuration/sources/file/#globbing) is supported."
+		required:    false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	line_delimiter: {
+		description: "String sequence used to separate one file line from another."
+		required:    false
+		type: string: {
+			default: "\n"
+			syntax:  "literal"
+		}
+	}
+	max_line_bytes: {
+		description: """
+			The maximum number of bytes a line can contain before being discarded.
+
+			This protects against malformed lines or tailing incorrect files.
+			"""
+		required: false
+		type: uint: default: 102400
+	}
+	max_read_bytes: {
+		description: "An approximate limit on the amount of data read from a single file at a given time."
+		required:    false
+		type: uint: default: 2048
+	}
+	message_start_indicator: {
+		description: """
+			String value used to identify the start of a multi-line message.
+
+			DEPRECATED: This is a deprecated option -- replaced by `multiline` -- and should be removed.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	multi_line_timeout: {
+		description: """
+			How long to wait for more data when aggregating a multi-line message, in milliseconds.
+
+			DEPRECATED: This is a deprecated option -- replaced by `multiline` -- and should be removed.
+			"""
+		required: false
+		type: uint: default: 1000
+	}
+	multiline: {
+		description: """
+			Multiline aggregation configuration.
+
+			If not specified, multiline aggregation is disabled.
+			"""
+		required: false
+		type: object: options: {
+			condition_pattern: {
+				description: """
+					Regular expression pattern that is used to determine whether or not more lines should be read.
+
+					This setting must be configured in conjunction with `mode`.
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+			mode: {
+				description: """
+					Aggregation mode.
+
+					This setting must be configured in conjunction with `condition_pattern`.
+					"""
+				required: true
+				type: string: enum: {
+					continue_past: """
+						All consecutive lines matching this pattern, plus one additional line, are included in the group.
+
+						This is useful in cases where a log message ends with a continuation marker, such as a backslash, indicating
+						that the following line is part of the same message.
+						"""
+					continue_through: """
+						All consecutive lines matching this pattern are included in the group.
+
+						The first line (the line that matched the start pattern) does not need to match the `ContinueThrough` pattern.
+
+						This is useful in cases such as a Java stack trace, where some indicator in the line (such as leading
+						whitespace) indicates that it is an extension of the proceeding line.
+						"""
+					halt_before: """
+						All consecutive lines not matching this pattern are included in the group.
+
+						This is useful where a log line contains a marker indicating that it begins a new message.
+						"""
+					halt_with: """
+						All consecutive lines, up to and including the first line matching this pattern, are included in the group.
+
+						This is useful where a log line ends with a termination marker, such as a semicolon.
+						"""
+				}
+			}
+			start_pattern: {
+				description: "Regular expression pattern that is used to match the start of a new message."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			timeout_ms: {
+				description: """
+					The maximum amount of time to wait for the next additional line, in milliseconds.
+
+					Once this timeout is reached, the buffered message is guaranteed to be flushed, even if incomplete.
+					"""
+				required: true
+				type: uint: {}
+			}
+		}
+	}
+	offset_key: {
+		description: """
+			Enables adding the file offset to each event and sets the name of the log field used.
+
+			The value will be the byte offset of the start of the line within the file.
+
+			Off by default, the offset is only added to the event if this is set.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	oldest_first: {
+		description: "Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from younger files."
+		required:    false
+		type: bool: default: false
+	}
+	read_from: {
+		description: "File position to use when reading a new file."
+		required:    false
+		type: string: enum: {
+			beginning: "Read from the beginning of the file."
+			end:       "Start reading from the current end of the file."
+		}
+	}
+	remove_after_secs: {
+		description: """
+			Timeout from reaching `EOF` after which file will be removed from filesystem, unless new data is written in the meantime.
+
+			If not specified, files will not be removed.
+			"""
+		required: false
+		type: uint: {}
+	}
+	start_at_beginning: {
+		description: """
+			Whether or not to start reading from the beginning of a new file.
+
+			DEPRECATED: This is a deprecated option -- replaced by `ignore_checkpoints`/`read_from` -- and should be removed.
+			"""
+		required: false
+		type: bool: {}
+	}
+}

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -1,0 +1,108 @@
+package metadata
+
+base: components: sources: file_descriptor: configuration: {
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	fd: {
+		description: "The file descriptor number to read from."
+		required:    true
+		type: uint: {}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Configures the `BytesDecoder`."
+					character_delimited: "Configures the `CharacterDelimitedDecoder`."
+					length_delimited:    "Configures the `LengthDelimitedDecoder`."
+					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+					octet_counting:      "Configures the `OctetCountingDecoder`."
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the current hostname to each event.
+
+			The value will be the current hostname for wherever Vector is running.
+
+			By default, the [global `host_key` option](https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key) is used.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	max_length: {
+		description: """
+			The maximum buffer size, in bytes, of incoming messages.
+
+			Messages larger than this are truncated.
+			"""
+		required: false
+		type: uint: default: 102400
+	}
+}

--- a/website/cue/reference/components/sources/base/fluent.cue
+++ b/website/cue/reference/components/sources/base/fluent.cue
@@ -1,0 +1,144 @@
+package metadata
+
+base: components: sources: fluent: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: "The address to listen for connections on."
+		required:    true
+		type: {
+			number: {}
+			string: syntax: "literal"
+		}
+	}
+	connection_limit: {
+		description: "The maximum number of TCP connections that will be allowed at any given time."
+		required:    false
+		type: uint: {}
+	}
+	keepalive: {
+		description: "TCP keepalive settings for socket-based components."
+		required:    false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	receive_buffer_bytes: {
+		description: """
+			The size, in bytes, of the receive buffer used for each connection.
+
+			This should not typically needed to be changed.
+			"""
+		required: false
+		type: uint: {}
+	}
+	tls: {
+		description: "TlsEnableableConfig for `sources`, adding metadata from the client certificate"
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			client_metadata_key: {
+				description: "Event field for client certificate metadata."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -1,0 +1,283 @@
+package metadata
+
+base: components: sources: gcp_pubsub: configuration: {
+	ack_deadline_seconds: {
+		description: "Deprecated, old name of `ack_deadline_secs`."
+		required:    false
+		type: int: {}
+	}
+	ack_deadline_secs: {
+		description: """
+			The acknowledgement deadline, in seconds, to use for this stream.
+
+			Messages that are not acknowledged when this deadline expires may be retransmitted.
+			"""
+		required: false
+		type: int: {}
+	}
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	api_key: {
+		description: """
+			An API key. ([documentation](https://cloud.google.com/docs/authentication/api-keys))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	credentials_path: {
+		description: """
+			Path to a service account credentials JSON file. ([documentation](https://cloud.google.com/docs/authentication/production#manually))
+
+			Either an API key, or a path to a service account credentials JSON file can be specified.
+
+			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
+			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
+			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			credentials JSON file.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: "The endpoint from which to pull data."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	full_response_size: {
+		description: """
+			The number of messages in a response to mark a stream as
+			"busy". This is used to determine if more streams should be
+			started.
+			"""
+		required: false
+		type: uint: default: 100
+	}
+	keepalive_secs: {
+		description: """
+			The amount of time, in seconds, with no received activity
+			before sending a keepalive request. If this is set larger than
+			`60`, you may see periodic errors sent from the server.
+			"""
+		required: false
+		type: float: default: 60.0
+	}
+	max_concurrency: {
+		description: "The maximum number of concurrent stream connections to open at once."
+		required:    false
+		type: uint: default: 10
+	}
+	poll_time_seconds: {
+		description: """
+			How often to poll the currently active streams to see if they
+			are all busy and so open a new stream.
+			"""
+		required: false
+		type: float: default: 2.0
+	}
+	project: {
+		description: "The project name from which to pull logs."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	retry_delay_seconds: {
+		description: "Deprecated, old name of `retry_delay_secs`."
+		required:    false
+		type: float: {}
+	}
+	retry_delay_secs: {
+		description: "The amount of time, in seconds, to wait between retry attempts after an error."
+		required:    false
+		type: float: {}
+	}
+	skip_authentication: {
+		description: "Skip all authentication handling. For use with integration tests only."
+		required:    false
+		type: bool: default: false
+	}
+	subscription: {
+		description: "The subscription within the project which is configured to receive logs."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -1,0 +1,223 @@
+package metadata
+
+base: components: sources: heroku_logs: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: "The address to listen for connections on."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "HTTP Basic authentication configuration."
+		required:    false
+		type: object: options: {
+			password: {
+				description: "The password for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			username: {
+				description: "The username for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	query_parameters: {
+		description: """
+			A list of URL query parameters to include in the log event.
+
+			These will override any values included in the body with conflicting names.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/host_metrics.cue
+++ b/website/cue/reference/components/sources/base/host_metrics.cue
@@ -1,0 +1,214 @@
+package metadata
+
+base: components: sources: host_metrics: configuration: {
+	cgroups: {
+		description: """
+			Options for the “cgroups” (controller groups) metrics collector.
+
+			This collector is only available on Linux systems, and only supports either version 2 or hybrid cgroups.
+			"""
+		required: false
+		type: object: options: {
+			base: {
+				description: "The base cgroup name to provide metrics for."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			base_dir: {
+				description: "Base cgroup directory, for testing use only"
+				required:    false
+				type: string: syntax: "literal"
+			}
+			groups: {
+				description: "Lists of group name patterns to include or exclude."
+				required:    false
+				type: object: {
+					default: {
+						excludes: null
+						includes: null
+					}
+					options: {
+						excludes: {
+							description: "Any patterns which should be excluded."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+						includes: {
+							description: "Any patterns which should be included."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+					}
+				}
+			}
+			levels: {
+				description: """
+					The number of levels of the cgroups hierarchy for which to report metrics.
+
+					A value of `1` means just the root or named cgroup.
+					"""
+				required: false
+				type: uint: default: 100
+			}
+		}
+	}
+	collectors: {
+		description: """
+			The list of host metric collector services to use.
+
+			Defaults to all collectors.
+			"""
+		required: false
+		type: array: items: type: string: enum: {
+			cgroups:    "CGroups."
+			cpu:        "CPU."
+			disk:       "Disk."
+			filesystem: "Filesystem."
+			host:       "Host."
+			load:       "Load average."
+			memory:     "Memory."
+			network:    "Network."
+		}
+	}
+	disk: {
+		description: "Options for the “disk” metrics collector."
+		required:    false
+		type: object: options: devices: {
+			description: "Lists of device name patterns to include or exclude."
+			required:    false
+			type: object: {
+				default: {
+					excludes: null
+					includes: null
+				}
+				options: {
+					excludes: {
+						description: "Any patterns which should be excluded."
+						required:    false
+						type: array: items: type: string: syntax: "literal"
+					}
+					includes: {
+						description: "Any patterns which should be included."
+						required:    false
+						type: array: items: type: string: syntax: "literal"
+					}
+				}
+			}
+		}
+	}
+	filesystem: {
+		description: "Options for the “filesystem” metrics collector."
+		required:    false
+		type: object: options: {
+			devices: {
+				description: "Lists of device name patterns to include or exclude."
+				required:    false
+				type: object: {
+					default: {
+						excludes: null
+						includes: null
+					}
+					options: {
+						excludes: {
+							description: "Any patterns which should be excluded."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+						includes: {
+							description: "Any patterns which should be included."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+					}
+				}
+			}
+			filesystems: {
+				description: "Lists of filesystem name patterns to include or exclude."
+				required:    false
+				type: object: {
+					default: {
+						excludes: null
+						includes: null
+					}
+					options: {
+						excludes: {
+							description: "Any patterns which should be excluded."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+						includes: {
+							description: "Any patterns which should be included."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+					}
+				}
+			}
+			mountpoints: {
+				description: "Lists of mount point path patterns to include or exclude."
+				required:    false
+				type: object: {
+					default: {
+						excludes: null
+						includes: null
+					}
+					options: {
+						excludes: {
+							description: "Any patterns which should be excluded."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+						includes: {
+							description: "Any patterns which should be included."
+							required:    false
+							type: array: items: type: string: syntax: "literal"
+						}
+					}
+				}
+			}
+		}
+	}
+	namespace: {
+		description: """
+			Overrides the default namespace for the metrics emitted by the source.
+
+			By default, `host` is used.
+			"""
+		required: false
+		type: string: {
+			default: "host"
+			syntax:  "literal"
+		}
+	}
+	network: {
+		description: "Options for the “network” metrics collector."
+		required:    false
+		type: object: options: devices: {
+			description: "Lists of device name patterns to include or exclude."
+			required:    false
+			type: object: {
+				default: {
+					excludes: null
+					includes: null
+				}
+				options: {
+					excludes: {
+						description: "Any patterns which should be excluded."
+						required:    false
+						type: array: items: type: string: syntax: "literal"
+					}
+					includes: {
+						description: "Any patterns which should be included."
+						required:    false
+						type: array: items: type: string: syntax: "literal"
+					}
+				}
+			}
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between metric gathering, in seconds."
+		required:    false
+		type: float: default: 15.0
+	}
+}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -1,0 +1,287 @@
+package metadata
+
+base: components: sources: http: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: "The address to listen for connections on."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "HTTP Basic authentication configuration."
+		required:    false
+		type: object: options: {
+			password: {
+				description: "The password for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			username: {
+				description: "The username for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: true
+			type: string: enum: {
+				bytes:       "Configures the `BytesDeserializer`."
+				gelf:        "Configures the `GelfDeserializer`."
+				json:        "Configures the `JsonDeserializer`."
+				native:      "Configures the `NativeDeserializer`."
+				native_json: "Configures the `NativeJsonDeserializer`."
+				syslog:      "Configures the `SyslogDeserializer`."
+			}
+		}
+	}
+	encoding: {
+		description: """
+			The expected encoding of received data.
+
+			Note that for `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
+			"""
+		required: false
+		type: string: enum: {
+			binary: "Binary."
+			json:   "JSON."
+			ndjson: "Newline-delimited JSON."
+			text:   "Plaintext."
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Configures the `BytesDecoder`."
+					character_delimited: "Configures the `CharacterDelimitedDecoder`."
+					length_delimited:    "Configures the `LengthDelimitedDecoder`."
+					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+					octet_counting:      "Configures the `OctetCountingDecoder`."
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	headers: {
+		description: """
+			A list of HTTP headers to include in the log event.
+
+			These will override any values included in the JSON payload with conflicting names.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	method: {
+		description: "Specifies the action of the HTTP request."
+		required:    false
+		type: string: {
+			default: "POST"
+			enum: {
+				DELETE: "HTTP DELETE method."
+				GET:    "HTTP GET method."
+				HEAD:   "HTTP HEAD method."
+				PATCH:  "HTTP PATCH method."
+				POST:   "HTTP POST method."
+				PUT:    "HTTP Put method."
+			}
+		}
+	}
+	path: {
+		description: "The URL path on which log event POST requests shall be sent."
+		required:    false
+		type: string: {
+			default: "/"
+			syntax:  "literal"
+		}
+	}
+	path_key: {
+		description: "The event key in which the requested URL path used to send the request will be stored."
+		required:    false
+		type: string: {
+			default: "path"
+			syntax:  "literal"
+		}
+	}
+	query_parameters: {
+		description: """
+			A list of URL query parameters to include in the log event.
+
+			These will override any values included in the body with conflicting names.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	strict_path: {
+		description: """
+			Whether or not to treat the configured `path` as an absolute path.
+
+			If set to `true`, only requests using the exact URL path specified in `path` will be accepted. Otherwise,
+			requests sent to a URL path that starts with the value of `path` will be accepted.
+
+			With `strict_path` set to `false` and `path` set to `""`, the configured HTTP source will accept requests from
+			any URL path.
+			"""
+		required: false
+		type: bool: default: true
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -1,0 +1,277 @@
+package metadata
+
+base: components: sources: http_client: configuration: {
+	auth: {
+		description: "HTTP Authentication."
+		required:    false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	decoding: {
+		description: "Decoder to use on the HTTP responses."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	endpoint: {
+		description: """
+			Endpoint to collect events from. The full path must be specified.
+			Example: "http://127.0.0.1:9898/logs"
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	framing: {
+		description: "Framing to use in the decoding."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	headers: {
+		description: """
+			Headers to apply to the HTTP requests.
+			One or more values for the same header can be provided.
+			"""
+		required: false
+		type: object: options: "*": {
+			description: """
+				Headers to apply to the HTTP requests.
+				One or more values for the same header can be provided.
+				"""
+			required: true
+			type: array: items: type: string: syntax: "literal"
+		}
+	}
+	log_namespace: {
+		description: "The namespace to use for logs. This overrides the global setting"
+		required:    false
+		type: bool: {}
+	}
+	method: {
+		description: "Specifies the action of the HTTP request."
+		required:    false
+		type: string: {
+			default: "GET"
+			enum: {
+				DELETE: "HTTP DELETE method."
+				GET:    "HTTP GET method."
+				HEAD:   "HTTP HEAD method."
+				PATCH:  "HTTP PATCH method."
+				POST:   "HTTP POST method."
+				PUT:    "HTTP Put method."
+			}
+		}
+	}
+	query: {
+		description: """
+			Custom parameters for the HTTP request query string.
+
+			One or more values for the same parameter key can be provided. The parameters provided in this option are
+			appended to any parameters manually provided in the `endpoint` option.
+			"""
+		required: false
+		type: object: options: "*": {
+			description: """
+				Custom parameters for the HTTP request query string.
+
+				One or more values for the same parameter key can be provided. The parameters provided in this option are
+				appended to any parameters manually provided in the `endpoint` option.
+				"""
+			required: true
+			type: array: items: type: string: syntax: "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between calls, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+	tls: {
+		description: "TLS configuration."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -1,0 +1,287 @@
+package metadata
+
+base: components: sources: http_server: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: "The address to listen for connections on."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "HTTP Basic authentication configuration."
+		required:    false
+		type: object: options: {
+			password: {
+				description: "The password for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			username: {
+				description: "The username for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: true
+			type: string: enum: {
+				bytes:       "Configures the `BytesDeserializer`."
+				gelf:        "Configures the `GelfDeserializer`."
+				json:        "Configures the `JsonDeserializer`."
+				native:      "Configures the `NativeDeserializer`."
+				native_json: "Configures the `NativeJsonDeserializer`."
+				syslog:      "Configures the `SyslogDeserializer`."
+			}
+		}
+	}
+	encoding: {
+		description: """
+			The expected encoding of received data.
+
+			Note that for `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
+			"""
+		required: false
+		type: string: enum: {
+			binary: "Binary."
+			json:   "JSON."
+			ndjson: "Newline-delimited JSON."
+			text:   "Plaintext."
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Configures the `BytesDecoder`."
+					character_delimited: "Configures the `CharacterDelimitedDecoder`."
+					length_delimited:    "Configures the `LengthDelimitedDecoder`."
+					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+					octet_counting:      "Configures the `OctetCountingDecoder`."
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	headers: {
+		description: """
+			A list of HTTP headers to include in the log event.
+
+			These will override any values included in the JSON payload with conflicting names.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	method: {
+		description: "Specifies the action of the HTTP request."
+		required:    false
+		type: string: {
+			default: "POST"
+			enum: {
+				DELETE: "HTTP DELETE method."
+				GET:    "HTTP GET method."
+				HEAD:   "HTTP HEAD method."
+				PATCH:  "HTTP PATCH method."
+				POST:   "HTTP POST method."
+				PUT:    "HTTP Put method."
+			}
+		}
+	}
+	path: {
+		description: "The URL path on which log event POST requests shall be sent."
+		required:    false
+		type: string: {
+			default: "/"
+			syntax:  "literal"
+		}
+	}
+	path_key: {
+		description: "The event key in which the requested URL path used to send the request will be stored."
+		required:    false
+		type: string: {
+			default: "path"
+			syntax:  "literal"
+		}
+	}
+	query_parameters: {
+		description: """
+			A list of URL query parameters to include in the log event.
+
+			These will override any values included in the body with conflicting names.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	strict_path: {
+		description: """
+			Whether or not to treat the configured `path` as an absolute path.
+
+			If set to `true`, only requests using the exact URL path specified in `path` will be accepted. Otherwise,
+			requests sent to a URL path that starts with the value of `path` will be accepted.
+
+			With `strict_path` set to `false` and `path` set to `""`, the configured HTTP source will accept requests from
+			any URL path.
+			"""
+		required: false
+		type: bool: default: true
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/internal_logs.cue
+++ b/website/cue/reference/components/sources/base/internal_logs.cue
@@ -1,0 +1,28 @@
+package metadata
+
+base: components: sources: internal_logs: configuration: {
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the current hostname to each event.
+
+			The value will be the current hostname for wherever Vector is running.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	pid_key: {
+		description: """
+			Overrides the name of the log field used to add the current process ID to each event.
+
+			The value will be the current process ID for Vector itself.
+
+			By default, `"pid"` is used.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sources/base/internal_metrics.cue
+++ b/website/cue/reference/components/sources/base/internal_metrics.cue
@@ -1,0 +1,52 @@
+package metadata
+
+base: components: sources: internal_metrics: configuration: {
+	namespace: {
+		description: """
+			Overrides the default namespace for the metrics emitted by the source.
+
+			By default, `vector` is used.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	scrape_interval_secs: {
+		description: "The interval between metric gathering, in seconds."
+		required:    false
+		type: float: default: 2.0
+	}
+	tags: {
+		description: "Tag configuration for the `internal_metrics` source."
+		required:    false
+		type: object: {
+			default: {
+				host_key: null
+				pid_key:  null
+			}
+			options: {
+				host_key: {
+					description: """
+						Sets the name of the tag to use to add the current hostname to each metric.
+
+						The value will be the current hostname for wherever Vector is running.
+
+						By default, the [global `log_schema.host_key` option][global_host_key] is used.
+						"""
+					required: false
+					type: string: syntax: "literal"
+				}
+				pid_key: {
+					description: """
+						Sets the name of the tag to use to add the current process ID to each metric.
+
+						The value will be the current process ID for Vector itself.
+
+						By default, this is not set and the tag will not be automatically added.
+						"""
+					required: false
+					type: string: syntax: "literal"
+				}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/journald.cue
+++ b/website/cue/reference/components/sources/base/journald.cue
@@ -1,0 +1,143 @@
+package metadata
+
+base: components: sources: journald: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: {
+			default: enabled: null
+			options: enabled: {
+				description: "Enables end-to-end acknowledgements."
+				required:    false
+				type: bool: {}
+			}
+		}
+	}
+	batch_size: {
+		description: "The `systemd` journal is read in batches, and a checkpoint is set at the end of each batch. This option limits the size of the batch."
+		required:    false
+		type: uint: {}
+	}
+	current_boot_only: {
+		description: "Only include entries that occurred after the current boot of the system."
+		required:    false
+		type: bool: {}
+	}
+	data_dir: {
+		description: """
+			The directory used to persist file checkpoint positions.
+
+			By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	exclude_matches: {
+		description: """
+			A list of sets of field/value pairs that, if any are present in a journal entry, will cause the entry to be excluded from this source.
+
+			If `exclude_units` is specified, it will be merged into this list.
+			"""
+		required: false
+		type: object: {
+			default: {}
+			options: "*": {
+				description: """
+					A list of sets of field/value pairs that, if any are present in a journal entry, will cause the entry to be excluded from this source.
+
+					If `exclude_units` is specified, it will be merged into this list.
+					"""
+				required: true
+				type: array: items: type: string: syntax: "literal"
+			}
+		}
+	}
+	exclude_units: {
+		description: """
+			A list of unit names to exclude from monitoring.
+
+			Unit names lacking a "." will have ".service" appended to make them a valid service unit name.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	include_matches: {
+		description: """
+			A list of sets of field/value pairs to monitor.
+
+			If empty or not present, all journal fields are accepted. If `include_units` is specified, it will be merged into this list.
+			"""
+		required: false
+		type: object: {
+			default: {}
+			options: "*": {
+				description: """
+					A list of sets of field/value pairs to monitor.
+
+					If empty or not present, all journal fields are accepted. If `include_units` is specified, it will be merged into this list.
+					"""
+				required: true
+				type: array: items: type: string: syntax: "literal"
+			}
+		}
+	}
+	include_units: {
+		description: """
+			A list of unit names to monitor.
+
+			If empty or not present, all units are accepted. Unit names lacking a "." will have ".service" appended to make them a valid service unit name.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	journal_directory: {
+		description: """
+			The full path of the journal directory.
+
+			If not set, `journalctl` will use the default system journal paths.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	journalctl_path: {
+		description: """
+			The full path of the `journalctl` executable.
+
+			If not set, Vector will search the path for `journalctl`.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	remap_priority: {
+		description: """
+			Enables remapping the `PRIORITY` field from an integer to string value.
+
+			Has no effect unless the value of the field is already an integer.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	since_now: {
+		description: "Only include entries that appended to the journal after Vector starts reading it."
+		required:    false
+		type: bool: {}
+	}
+	units: {
+		description: """
+			The list of unit names to monitor.
+
+			If empty or not present, all units are accepted. Unit names lacking a "." will have ".service" appended to make them a valid service unit name.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -1,0 +1,371 @@
+package metadata
+
+base: components: sources: kafka: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	auto_offset_reset: {
+		description: """
+			If offsets for consumer group do not exist, set them using this strategy.
+
+			See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for the `auto.offset.reset` option for further clarification.
+			"""
+		required: false
+		type: string: {
+			default: "largest"
+			syntax:  "literal"
+		}
+	}
+	bootstrap_servers: {
+		description: """
+			A comma-separated list of Kafka bootstrap servers.
+
+			These are the servers in a Kafka cluster that a client should use to "bootstrap" its connection to the cluster,
+			allowing discovering all other hosts in the cluster.
+
+			Must be in the form of `host:port`, and comma-separated.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	commit_interval_ms: {
+		description: "The frequency that the consumer offsets are committed (written) to offset storage, in milliseconds."
+		required:    false
+		type: uint: default: 5000
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	fetch_wait_max_ms: {
+		description: "Maximum time the broker may wait to fill the response, in milliseconds."
+		required:    false
+		type: uint: default: 100
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	group_id: {
+		description: "The consumer group name to be used to consume events from Kafka."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	headers_key: {
+		description: """
+			Overrides the name of the log field used to add the headers to each event.
+
+			The value will be the headers of the Kafka message itself.
+
+			By default, `"headers"` is used.
+			"""
+		required: false
+		type: string: {
+			default: "headers"
+			syntax:  "literal"
+		}
+	}
+	key_field: {
+		description: """
+			Overrides the name of the log field used to add the message key to each event.
+
+			The value will be the message key of the Kafka message itself.
+
+			By default, `"message_key"` is used.
+			"""
+		required: false
+		type: string: {
+			default: "message_key"
+			syntax:  "literal"
+		}
+	}
+	librdkafka_options: {
+		description: """
+			Advanced options set directly on the underlying `librdkafka` client.
+
+			See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for details.
+			"""
+		required: false
+		type: object: options: "*": {
+			description: """
+				Advanced options set directly on the underlying `librdkafka` client.
+
+				See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for details.
+				"""
+			required: true
+			type: string: syntax: "literal"
+		}
+	}
+	offset_key: {
+		description: """
+			Overrides the name of the log field used to add the offset to each event.
+
+			The value will be the offset of the Kafka message itself.
+
+			By default, `"offset"` is used.
+			"""
+		required: false
+		type: string: {
+			default: "offset"
+			syntax:  "literal"
+		}
+	}
+	partition_key: {
+		description: """
+			Overrides the name of the log field used to add the partition to each event.
+
+			The value will be the partition from which the Kafka message was consumed from.
+
+			By default, `"partition"` is used.
+			"""
+		required: false
+		type: string: {
+			default: "partition"
+			syntax:  "literal"
+		}
+	}
+	sasl: {
+		description: "Configuration for SASL authentication when interacting with Kafka."
+		required:    false
+		type: object: options: {
+			enabled: {
+				description: """
+					Enables SASL authentication.
+
+					Only `PLAIN` and `SCRAM`-based mechanisms are supported when configuring SASL authentication via `sasl.*`. For
+					other mechanisms, `librdkafka_options.*` must be used directly to configure other `librdkafka`-specific values
+					i.e. `sasl.kerberos.*` and so on.
+
+					See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for details.
+
+					SASL authentication is not supported on Windows.
+					"""
+				required: false
+				type: bool: {}
+			}
+			mechanism: {
+				description: "The SASL mechanism to use."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			password: {
+				description: "The SASL password."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			username: {
+				description: "The SASL username."
+				required:    false
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	session_timeout_ms: {
+		description: "The Kafka session timeout, in milliseconds."
+		required:    false
+		type: uint: default: 10000
+	}
+	socket_timeout_ms: {
+		description: "Timeout for network requests, in milliseconds."
+		required:    false
+		type: uint: default: 60000
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	topic_key: {
+		description: """
+			Overrides the name of the log field used to add the topic to each event.
+
+			The value will be the topic from which the Kafka message was consumed from.
+
+			By default, `"topic"` is used.
+			"""
+		required: false
+		type: string: {
+			default: "topic"
+			syntax:  "literal"
+		}
+	}
+	topics: {
+		description: """
+			The Kafka topics names to read events from.
+
+			Regular expression syntax is supported if the topic begins with `^`.
+			"""
+		required: true
+		type: array: items: type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -1,0 +1,276 @@
+package metadata
+
+base: components: sources: kubernetes_logs: configuration: {
+	auto_partial_merge: {
+		description: "Whether or not to automatically merge partial events."
+		required:    false
+		type: bool: default: true
+	}
+	data_dir: {
+		description: """
+			The directory used to persist file checkpoint positions.
+
+			By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	delay_deletion_ms: {
+		description: """
+			How long to delay removing entries from our map when we receive a deletion
+			event from the watched stream.
+			"""
+		required: false
+		type: uint: default: 60000
+	}
+	exclude_paths_glob_patterns: {
+		description: "A list of glob patterns to exclude from reading the files."
+		required:    false
+		type: array: {
+			default: ["**/*.gz", "**/*.tmp"]
+			items: type: string: syntax: "literal"
+		}
+	}
+	extra_field_selector: {
+		description: "Specifies the field selector to filter `Pod`s with, to be used in addition to the built-in `Node` filter."
+		required:    false
+		type: string: {
+			default: ""
+			syntax:  "literal"
+		}
+	}
+	extra_label_selector: {
+		description: "Specifies the label selector to filter `Pod`s with, to be used in addition to the built-in `vector.dev/exclude` filter."
+		required:    false
+		type: string: {
+			default: ""
+			syntax:  "literal"
+		}
+	}
+	extra_namespace_label_selector: {
+		description: "Specifies the label selector to filter `Namespace`s with, to be used in  addition to the built-in `vector.dev/exclude` filter."
+		required:    false
+		type: string: {
+			default: ""
+			syntax:  "literal"
+		}
+	}
+	fingerprint_lines: {
+		description: "How many first lines in a file are used for fingerprinting."
+		required:    false
+		type: uint: default: 1
+	}
+	glob_minimum_cooldown_ms: {
+		description: """
+			This value specifies not exactly the globbing, but interval
+			between the polling the files to watch from the `paths_provider`.
+			This is quite efficient, yet might still create some load of the
+			file system; in addition, it is currently coupled with chechsum dumping
+			in the underlying file server, so setting it too low may introduce
+			a significant overhead.
+			"""
+		required: false
+		type: uint: default: 60000
+	}
+	ingestion_timestamp_field: {
+		description: """
+			A field to use to set the timestamp when Vector ingested the event.
+			This is useful to compute the latency between important event processing
+			stages, i.e. the time delta between log line was written and when it was
+			processed by the `kubernetes_logs` source.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	kube_config_file: {
+		description: """
+			Optional path to a kubeconfig file readable by Vector. If not set,
+			Vector will try to connect to Kubernetes using in-cluster configuration.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	max_line_bytes: {
+		description: """
+			The maximum number of bytes a line can contain before being discarded. This protects
+			against malformed lines or tailing incorrect files.
+			"""
+		required: false
+		type: uint: default: 32768
+	}
+	max_read_bytes: {
+		description: """
+			Max amount of bytes to read from a single file before switching over
+			to the next file.
+			This allows distributing the reads more or less evenly across
+			the files.
+			"""
+		required: false
+		type: uint: default: 2048
+	}
+	namespace_annotation_fields: {
+		description: "Configuration for how the events are annotated with Namespace metadata."
+		required:    false
+		type: object: {
+			default: namespace_labels: ".kubernetes.namespace_labels"
+			options: namespace_labels: {
+				description: "Event field for Namespace labels."
+				required:    false
+				type: string: {
+					default: ".kubernetes.namespace_labels"
+					syntax:  "literal"
+				}
+			}
+		}
+	}
+	node_annotation_fields: {
+		description: "Configuration for how the events are annotated with Node metadata."
+		required:    false
+		type: object: {
+			default: node_labels: ".kubernetes.node_labels"
+			options: node_labels: {
+				description: "Event field for Node labels."
+				required:    false
+				type: string: {
+					default: ".kubernetes.node_labels"
+					syntax:  "literal"
+				}
+			}
+		}
+	}
+	pod_annotation_fields: {
+		description: "Configuration for how the events are annotated with `Pod` metadata."
+		required:    false
+		type: object: {
+			default: {
+				container_id:    ".kubernetes.container_id"
+				container_image: ".kubernetes.container_image"
+				container_name:  ".kubernetes.container_name"
+				pod_annotations: ".kubernetes.pod_annotations"
+				pod_ip:          ".kubernetes.pod_ip"
+				pod_ips:         ".kubernetes.pod_ips"
+				pod_labels:      ".kubernetes.pod_labels"
+				pod_name:        ".kubernetes.pod_name"
+				pod_namespace:   ".kubernetes.pod_namespace"
+				pod_node_name:   ".kubernetes.pod_node_name"
+				pod_owner:       ".kubernetes.pod_owner"
+				pod_uid:         ".kubernetes.pod_uid"
+			}
+			options: {
+				container_id: {
+					description: "Event field for container ID."
+					required:    false
+					type: string: {
+						default: ".kubernetes.container_id"
+						syntax:  "literal"
+					}
+				}
+				container_image: {
+					description: "Event field for container image."
+					required:    false
+					type: string: {
+						default: ".kubernetes.container_image"
+						syntax:  "literal"
+					}
+				}
+				container_name: {
+					description: "Event field for container name."
+					required:    false
+					type: string: {
+						default: ".kubernetes.container_name"
+						syntax:  "literal"
+					}
+				}
+				pod_annotations: {
+					description: "Event field for Pod annotations."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_annotations"
+						syntax:  "literal"
+					}
+				}
+				pod_ip: {
+					description: "Event field for Pod IPv4 address."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_ip"
+						syntax:  "literal"
+					}
+				}
+				pod_ips: {
+					description: "Event field for Pod IPv4 and IPv6 addresses."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_ips"
+						syntax:  "literal"
+					}
+				}
+				pod_labels: {
+					description: "Event field for Pod labels."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_labels"
+						syntax:  "literal"
+					}
+				}
+				pod_name: {
+					description: "Event field for Pod name."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_name"
+						syntax:  "literal"
+					}
+				}
+				pod_namespace: {
+					description: "Event field for Pod namespace."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_namespace"
+						syntax:  "literal"
+					}
+				}
+				pod_node_name: {
+					description: "Event field for Pod node_name."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_node_name"
+						syntax:  "literal"
+					}
+				}
+				pod_owner: {
+					description: "Event field for Pod owner reference."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_owner"
+						syntax:  "literal"
+					}
+				}
+				pod_uid: {
+					description: "Event field for Pod uid."
+					required:    false
+					type: string: {
+						default: ".kubernetes.pod_uid"
+						syntax:  "literal"
+					}
+				}
+			}
+		}
+	}
+	self_node_name: {
+		description: """
+			The `name` of the Kubernetes `Node` that Vector runs at.
+
+			Configured to use an environment var by default, to be evaluated to a value provided by Kubernetes at `Pod` deploy time.
+			"""
+		required: false
+		type: string: {
+			default: "${VECTOR_SELF_NODE_NAME}"
+			syntax:  "literal"
+		}
+	}
+	timezone: {
+		description: "The default time zone for timestamps without an explicit zone."
+		required:    false
+		type: string: examples: ["local", "America/New_York", "EST5EDT"]
+	}
+}

--- a/website/cue/reference/components/sources/base/logstash.cue
+++ b/website/cue/reference/components/sources/base/logstash.cue
@@ -1,0 +1,144 @@
+package metadata
+
+base: components: sources: logstash: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: "The address to listen for connections on."
+		required:    true
+		type: {
+			number: {}
+			string: syntax: "literal"
+		}
+	}
+	connection_limit: {
+		description: "The maximum number of TCP connections that will be allowed at any given time."
+		required:    false
+		type: uint: {}
+	}
+	keepalive: {
+		description: "TCP keepalive settings for socket-based components."
+		required:    false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	receive_buffer_bytes: {
+		description: """
+			The size, in bytes, of the receive buffer used for each connection.
+
+			This should not typically needed to be changed.
+			"""
+		required: false
+		type: uint: {}
+	}
+	tls: {
+		description: "TlsEnableableConfig for `sources`, adding metadata from the client certificate"
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			client_metadata_key: {
+				description: "Event field for client certificate metadata."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/mongodb_metrics.cue
+++ b/website/cue/reference/components/sources/base/mongodb_metrics.cue
@@ -1,0 +1,32 @@
+package metadata
+
+base: components: sources: mongodb_metrics: configuration: {
+	endpoints: {
+		description: """
+			A list of MongoDB instances to scrape.
+
+			Each endpoint must be in the [Connection String URI Format](https://www.mongodb.com/docs/manual/reference/connection-string/).
+			"""
+		required: true
+		type: array: items: type: string: syntax: "literal"
+	}
+	namespace: {
+		description: """
+			Overrides the default namespace for the metrics emitted by the source.
+
+			If set to an empty string, no namespace is added to the metrics.
+
+			By default, `mongodb` is used.
+			"""
+		required: false
+		type: string: {
+			default: "mongodb"
+			syntax:  "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between scrapes, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -1,0 +1,294 @@
+package metadata
+
+base: components: sources: nats: configuration: {
+	auth: {
+		description: "Configuration of the authentication strategy when interacting with NATS."
+		required:    false
+		type: object: options: {
+			credentials_file: {
+				description:   "Credentials file configuration."
+				relevant_when: "strategy = \"credentials_file\""
+				required:      true
+				type: object: options: path: {
+					description: "Path to credentials file."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			nkey: {
+				description:   "NKeys configuration."
+				relevant_when: "strategy = \"nkey\""
+				required:      true
+				type: object: options: {
+					nkey: {
+						description: """
+																User.
+
+																Conceptually, this is equivalent to a public key.
+																"""
+						required: true
+						type: string: syntax: "literal"
+					}
+					seed: {
+						description: """
+																Seed.
+
+																Conceptually, this is equivalent to a private key.
+																"""
+						required: true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					credentials_file: """
+						Credentials file authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt))
+						"""
+					nkey: """
+						NKey authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth))
+						"""
+					token: """
+						Token authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tokens))
+						"""
+					user_password: """
+						Username and password authentication.
+						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/username_password))
+						"""
+				}
+			}
+			token: {
+				description:   "Token configuration."
+				relevant_when: "strategy = \"token\""
+				required:      true
+				type: object: options: value: {
+					description: "Token."
+					required:    true
+					type: string: syntax: "literal"
+				}
+			}
+			user_password: {
+				description:   "Username and password configuration."
+				relevant_when: "strategy = \"user_password\""
+				required:      true
+				type: object: options: {
+					password: {
+						description: "Password."
+						required:    true
+						type: string: syntax: "literal"
+					}
+					user: {
+						description: "Username."
+						required:    true
+						type: string: syntax: "literal"
+					}
+				}
+			}
+		}
+	}
+	connection_name: {
+		description: "A name assigned to the NATS connection."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	queue: {
+		description: "NATS Queue Group to join."
+		required:    false
+		type: string: syntax: "literal"
+	}
+	subject: {
+		description: "The NATS subject to publish messages to."
+		required:    true
+		type: string: syntax: "template"
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	url: {
+		description: """
+			The NATS URL to connect to.
+
+			The URL must take the form of `nats://server:port`.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sources/base/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/base/nginx_metrics.cue
@@ -1,0 +1,162 @@
+package metadata
+
+base: components: sources: nginx_metrics: configuration: {
+	auth: {
+		description: """
+			Configuration of the authentication strategy for HTTP requests.
+
+			HTTP authentication should almost always be used with HTTPS only, as the authentication credentials are passed as an
+			HTTP header without any additional encryption beyond what is provided by the transport itself.
+			"""
+		required: false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	endpoints: {
+		description: """
+			A list of NGINX instances to scrape.
+
+			Each endpoint must be a valid HTTP/HTTPS URI pointing to an NGINX instance that has the
+			`ngx_http_stub_status_module` module enabled.
+			"""
+		required: true
+		type: array: items: type: string: syntax: "literal"
+	}
+	namespace: {
+		description: """
+			Overrides the default namespace for the metrics emitted by the source.
+
+			If set to an empty string, no namespace is added to the metrics.
+
+			By default, `nginx` is used.
+			"""
+		required: false
+		type: string: {
+			default: "nginx"
+			syntax:  "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between scrapes, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -1,0 +1,233 @@
+package metadata
+
+base: components: sources: opentelemetry: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	grpc: {
+		description: "Configuration for the `opentelemetry` gRPC server."
+		required:    true
+		type: object: options: {
+			address: {
+				description: """
+					The address to listen for connections on.
+
+					It _must_ include a port.
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+			tls: {
+				description: "Configures the TLS options for incoming/outgoing connections."
+				required:    false
+				type: object: options: {
+					alpn_protocols: {
+						description: """
+																Sets the list of supported ALPN protocols.
+
+																Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+																they are defined.
+																"""
+						required: false
+						type: array: items: type: string: syntax: "literal"
+					}
+					ca_file: {
+						description: """
+																Absolute path to an additional CA certificate file.
+
+																The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					crt_file: {
+						description: """
+																Absolute path to a certificate file used to identify this server.
+
+																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+																an inline string in PEM format.
+
+																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					enabled: {
+						description: """
+																Whether or not to require TLS for incoming/outgoing connections.
+
+																When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+																more information.
+																"""
+						required: false
+						type: bool: {}
+					}
+					key_file: {
+						description: """
+																Absolute path to a private key file used to identify this server.
+
+																The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_pass: {
+						description: """
+																Passphrase used to unlock the encrypted key file.
+
+																This has no effect unless `key_file` is set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					verify_certificate: {
+						description: """
+																Enables certificate verification.
+
+																If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+																issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+																certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+																so on until reaching a root certificate.
+
+																Relevant for both incoming and outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+																"""
+						required: false
+						type: bool: {}
+					}
+					verify_hostname: {
+						description: """
+																Enables hostname verification.
+
+																If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+																the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+																Only relevant for outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+																"""
+						required: false
+						type: bool: {}
+					}
+				}
+			}
+		}
+	}
+	http: {
+		description: "Configuration for the `opentelemetry` HTTP server."
+		required:    true
+		type: object: options: {
+			address: {
+				description: """
+					The address to listen for connections on.
+
+					It _must_ include a port.
+					"""
+				required: true
+				type: string: syntax: "literal"
+			}
+			tls: {
+				description: "Configures the TLS options for incoming/outgoing connections."
+				required:    false
+				type: object: options: {
+					alpn_protocols: {
+						description: """
+																Sets the list of supported ALPN protocols.
+
+																Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+																they are defined.
+																"""
+						required: false
+						type: array: items: type: string: syntax: "literal"
+					}
+					ca_file: {
+						description: """
+																Absolute path to an additional CA certificate file.
+
+																The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					crt_file: {
+						description: """
+																Absolute path to a certificate file used to identify this server.
+
+																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+																an inline string in PEM format.
+
+																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					enabled: {
+						description: """
+																Whether or not to require TLS for incoming/outgoing connections.
+
+																When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+																more information.
+																"""
+						required: false
+						type: bool: {}
+					}
+					key_file: {
+						description: """
+																Absolute path to a private key file used to identify this server.
+
+																The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					key_pass: {
+						description: """
+																Passphrase used to unlock the encrypted key file.
+
+																This has no effect unless `key_file` is set.
+																"""
+						required: false
+						type: string: syntax: "literal"
+					}
+					verify_certificate: {
+						description: """
+																Enables certificate verification.
+
+																If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+																issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+																certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+																so on until reaching a root certificate.
+
+																Relevant for both incoming and outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+																"""
+						required: false
+						type: bool: {}
+					}
+					verify_hostname: {
+						description: """
+																Enables hostname verification.
+
+																If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+																the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+																Only relevant for outgoing connections.
+
+																Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+																"""
+						required: false
+						type: bool: {}
+					}
+				}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/base/postgresql_metrics.cue
@@ -1,0 +1,74 @@
+package metadata
+
+base: components: sources: postgresql_metrics: configuration: {
+	endpoints: {
+		description: """
+			A list of PostgreSQL instances to scrape.
+
+			Each endpoint must be in the [Connection URI
+			format](https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6).
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: syntax: "literal"
+		}
+	}
+	exclude_databases: {
+		description: """
+			A list of databases to match (by using [POSIX Regular
+			Expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP)) against
+			the `datname` column for which you don’t want to collect metrics from.
+
+			Specifying `""` will include metrics where `datname` is `NULL`.
+
+			This can be used in conjunction with `include_databases`.
+			"""
+		required: false
+		type: array: items: type: string: syntax: "literal"
+	}
+	include_databases: {
+		description: """
+			A list of databases to match (by using [POSIX Regular
+			Expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP)) against
+			the `datname` column for which you want to collect metrics from.
+
+			If not set, metrics are collected from all databases. Specifying `""` will include metrics where `datname` is
+			`NULL`.
+
+			This can be used in conjunction with `exclude_databases`.
+			"""
+		required: false
+		type: array: items: type: string: syntax: "literal"
+	}
+	namespace: {
+		description: """
+			Overrides the default namespace for the metrics emitted by the source.
+
+			By default, `postgresql` is used.
+			"""
+		required: false
+		type: string: {
+			default: "postgresql"
+			syntax:  "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between scrapes, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+	tls: {
+		description: "Configuration of TLS when connecting to PostgreSQL."
+		required:    false
+		type: object: options: ca_file: {
+			description: """
+				Absolute path to an additional CA certificate file.
+
+				The certficate must be in the DER or PEM (X.509) format.
+				"""
+			required: true
+			type: string: syntax: "literal"
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -1,0 +1,133 @@
+package metadata
+
+base: components: sources: prometheus_remote_write: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: """
+			The address to accept connections on.
+
+			The address _must_ include a port.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	auth: {
+		description: "HTTP Basic authentication configuration."
+		required:    false
+		type: object: options: {
+			password: {
+				description: "The password for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+			username: {
+				description: "The username for basic authentication."
+				required:    true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -1,0 +1,198 @@
+package metadata
+
+base: components: sources: prometheus_scrape: configuration: {
+	auth: {
+		description: """
+			Configuration of the authentication strategy for HTTP requests.
+
+			HTTP authentication should almost always be used with HTTPS only, as the authentication credentials are passed as an
+			HTTP header without any additional encryption beyond what is provided by the transport itself.
+			"""
+		required: false
+		type: object: options: {
+			password: {
+				description:   "The password to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			strategy: {
+				required: true
+				type: string: enum: {
+					basic: """
+						Basic authentication.
+
+						The username and password are concatenated and encoded via base64.
+						"""
+					bearer: """
+						Bearer authentication.
+
+						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						"""
+				}
+			}
+			token: {
+				description:   "The bearer token to send."
+				relevant_when: "strategy = \"bearer\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+			user: {
+				description:   "The username to send."
+				relevant_when: "strategy = \"basic\""
+				required:      true
+				type: string: syntax: "literal"
+			}
+		}
+	}
+	endpoint_tag: {
+		description: """
+			Overrides the name of the tag used to add the endpoint to each metric.
+
+			The tag value will be the endpoint of the scraped instance.
+
+			By default, `"endpoint"` is used.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	endpoints: {
+		description: "Endpoints to scrape metrics from."
+		required:    true
+		type: array: items: type: string: syntax: "literal"
+	}
+	honor_labels: {
+		description: """
+			Controls how tag conflicts are handled if the scraped source has tags that Vector would add.
+
+			If `true`, Vector will not add the new tag if the scraped metric has the tag already. If `false`, Vector will
+			rename the conflicting tag by prepending `exported_` to the name.
+
+			This matches Prometheus’ `honor_labels` configuration.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	instance_tag: {
+		description: """
+			Overrides the name of the tag used to add the instance to each metric.
+
+			The tag value will be the host/port of the scraped instance.
+
+			By default, `"instance"` is used.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	query: {
+		description: """
+			Custom parameters for the scrape request query string.
+
+			One or more values for the same parameter key can be provided. The parameters provided in this option are
+			appended to any parameters manually provided in the `endpoints` option. This option is especially useful when
+			scraping the `/federate` endpoint.
+			"""
+		required: false
+		type: object: options: "*": {
+			description: """
+				Custom parameters for the scrape request query string.
+
+				One or more values for the same parameter key can be provided. The parameters provided in this option are
+				appended to any parameters manually provided in the `endpoints` option. This option is especially useful when
+				scraping the `/federate` endpoint.
+				"""
+			required: true
+			type: array: items: type: string: syntax: "literal"
+		}
+	}
+	scrape_interval_secs: {
+		description: "The interval between scrapes, in seconds."
+		required:    false
+		type: uint: default: 15
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -1,0 +1,138 @@
+package metadata
+
+base: components: sources: redis: configuration: {
+	data_type: {
+		description: "The Redis data type (`list` or `channel`) to use."
+		required:    false
+		type: string: {
+			default: "list"
+			enum: {
+				channel: """
+					The `channel` data type.
+
+					This is based on Redis' Pub/Sub capabilities.
+					"""
+				list: "The `list` data type."
+			}
+		}
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:               "Configures the `BytesDecoder`."
+						character_delimited: "Configures the `CharacterDelimitedDecoder`."
+						length_delimited:    "Configures the `LengthDelimitedDecoder`."
+						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+						octet_counting:      "Configures the `OctetCountingDecoder`."
+					}
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	key: {
+		description: "The Redis key to read messages from."
+		required:    true
+		type: string: syntax: "literal"
+	}
+	list: {
+		description: "Options for the Redis `list` data type."
+		required:    false
+		type: object: options: method: {
+			description: "Method for getting events from the `list` data type."
+			required:    true
+			type: string: enum: {
+				lpop: "Pop messages from the head of the list."
+				rpop: "Pop messages from the tail of the list."
+			}
+		}
+	}
+	redis_key: {
+		description: """
+			Sets the name of the log field to use to add the key to each event.
+
+			The value will be the Redis key that the event was read from.
+
+			By default, this is not set and the field will not be automatically added.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	url: {
+		description: """
+			The Redis URL to connect to.
+
+			The URL must take the form of `protocol://server:port/db` where the `protocol` can either be `redis` or `rediss` for connections secured via TLS.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -1,0 +1,289 @@
+package metadata
+
+base: components: sources: socket: configuration: {
+	address: {
+		description:   "The address to listen for connections on."
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      true
+		type: {
+			number: {}
+			string: syntax: "literal"
+		}
+	}
+	connection_limit: {
+		description:   "The maximum number of TCP connections that will be allowed at any given time."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: {}
+	}
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: options: codec: {
+			required: false
+			type: string: {
+				default: "bytes"
+				enum: {
+					bytes:       "Configures the `BytesDeserializer`."
+					gelf:        "Configures the `GelfDeserializer`."
+					json:        "Configures the `JsonDeserializer`."
+					native:      "Configures the `NativeDeserializer`."
+					native_json: "Configures the `NativeJsonDeserializer`."
+					syslog:      "Configures the `SyslogDeserializer`."
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Configures the `BytesDecoder`."
+					character_delimited: "Configures the `CharacterDelimitedDecoder`."
+					length_delimited:    "Configures the `LengthDelimitedDecoder`."
+					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+					octet_counting:      "Configures the `OctetCountingDecoder`."
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the peer host to each event.
+
+			The value will be the peer host's address, including the port i.e. `1.2.3.4:9000`.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	keepalive: {
+		description:   "TCP keepalive settings for socket-based components."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	max_length: {
+		description: """
+			The maximum buffer size, in bytes, of incoming messages.
+
+			Messages larger than this are truncated.
+			"""
+		required: false
+		type: uint: {}
+	}
+	mode: {
+		required: true
+		type: string: enum: {
+			tcp:           "Listen on TCP."
+			udp:           "Listen on UDP."
+			unix_datagram: "Listen on UDS, in datagram mode. (Unix domain socket)"
+			unix_stream:   "Listen on UDS, in stream mode. (Unix domain socket)"
+		}
+	}
+	path: {
+		description: """
+			The Unix socket path.
+
+			This should be an absolute path.
+			"""
+		relevant_when: "mode = \"unix_datagram\" or mode = \"unix_stream\""
+		required:      true
+		type: string: syntax: "literal"
+	}
+	port_key: {
+		description: """
+			Overrides the name of the log field used to add the peer host's port to each event.
+
+			The value will be the peer host's port i.e. `9000`.
+
+			By default, `"port"` is used.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      false
+		type: string: syntax: "literal"
+	}
+	receive_buffer_bytes: {
+		description: """
+			The size, in bytes, of the receive buffer used for each connection.
+
+			This should not typically needed to be changed.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      false
+		type: uint: {}
+	}
+	shutdown_timeout_secs: {
+		description:   "The timeout, in seconds, before a connection is forcefully closed during shutdown."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: default: 30
+	}
+	socket_file_mode: {
+		description: """
+			Unix file mode bits to be applied to the unix socket file as its designated file permissions.
+
+			Note that the file mode value can be specified in any numeric format supported by your configuration
+			language, but it is most intuitive to use an octal number.
+			"""
+		relevant_when: "mode = \"unix_datagram\" or mode = \"unix_stream\""
+		required:      false
+		type: uint: {}
+	}
+	tls: {
+		description:   "TlsEnableableConfig for `sources`, adding metadata from the client certificate"
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			client_metadata_key: {
+				description: "Event field for client certificate metadata."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -1,0 +1,217 @@
+package metadata
+
+base: components: sources: splunk_hec: configuration: {
+	acknowledgements: {
+		description: "Acknowledgement configuration for the `splunk_hec` source."
+		required:    false
+		type: object: {
+			default: {
+				ack_idle_cleanup:             false
+				enabled:                      null
+				max_idle_time:                300
+				max_number_of_ack_channels:   1000000
+				max_pending_acks:             10000000
+				max_pending_acks_per_channel: 1000000
+			}
+			options: {
+				ack_idle_cleanup: {
+					description: """
+						Whether or not to remove channels after idling for `max_idle_time` seconds.
+
+						A channel is idling if it is not used for sending data or querying ack statuses.
+						"""
+					required: false
+					type: bool: default: false
+				}
+				enabled: {
+					description: "Enables end-to-end acknowledgements."
+					required:    false
+					type: bool: {}
+				}
+				max_idle_time: {
+					description: """
+						The amount of time, in seconds, a channel is allowed to idle before removal.
+
+						Channels can potentially idle for longer than this setting but clients should not rely on such behavior.
+
+						Minimum of `1`.
+						"""
+					required: false
+					type: uint: default: 300
+				}
+				max_number_of_ack_channels: {
+					description: """
+						The maximum number of Splunk HEC channels clients can use with this source.
+
+						Minimum of `1`.
+						"""
+					required: false
+					type: uint: default: 1000000
+				}
+				max_pending_acks: {
+					description: """
+						The maximum number of ack statuses pending query across all channels.
+
+						Equivalent to the `max_number_of_acked_requests_pending_query` Splunk HEC setting.
+
+						Minimum of `1`.
+						"""
+					required: false
+					type: uint: default: 10000000
+				}
+				max_pending_acks_per_channel: {
+					description: """
+						The maximum number of ack statuses pending query for a single channel.
+
+						Equivalent to the `max_number_of_acked_requests_pending_query_per_ack_channel` Splunk HEC setting.
+
+						Minimum of `1`.
+						"""
+					required: false
+					type: uint: default: 1000000
+				}
+			}
+		}
+	}
+	address: {
+		description: """
+			The address to listen for connections on.
+
+			The address _must_ include a port.
+			"""
+		required: false
+		type: string: {
+			default: "0.0.0.0:8088"
+			syntax:  "literal"
+		}
+	}
+	store_hec_token: {
+		description: """
+			Whether or not to forward the Splunk HEC authentication token with events.
+
+			If set to `true`, when incoming requests contain a Splunk HEC token, the token used will kept in the
+			event metadata and be preferentially used if the event is sent to a Splunk HEC sink.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	token: {
+		description: """
+			Optional authorization token.
+
+			If supplied, incoming requests must supply this token in the `Authorization` header, just as a client would if
+			it was communicating with the Splunk HEC endpoint directly.
+
+			If _not_ supplied, the `Authorization` header will be ignored and requests will not be authenticated.
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	valid_tokens: {
+		description: """
+			Optional list of valid authorization tokens.
+
+			If supplied, incoming requests must supply one of these tokens in the `Authorization` header, just as a client
+			would if it was communicating with the Splunk HEC endpoint directly.
+
+			If _not_ supplied, the `Authorization` header will be ignored and requests will not be authenticated.
+			"""
+		required: false
+		type: array: items: type: string: syntax: "literal"
+	}
+}

--- a/website/cue/reference/components/sources/base/statsd.cue
+++ b/website/cue/reference/components/sources/base/statsd.cue
@@ -1,0 +1,164 @@
+package metadata
+
+base: components: sources: statsd: configuration: {
+	address: {
+		description:   "The address to listen for connections on."
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      true
+		type: {
+			number: {}
+			string: syntax: "literal"
+		}
+	}
+	connection_limit: {
+		description:   "The maximum number of TCP connections that will be allowed at any given time."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: {}
+	}
+	keepalive: {
+		description:   "TCP keepalive settings for socket-based components."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	mode: {
+		required: true
+		type: string: enum: {
+			tcp:  "Listen on TCP."
+			udp:  "Listen on UDP."
+			unix: "Listen on UDS. (Unix domain socket)"
+		}
+	}
+	path: {
+		description: """
+			The Unix socket path.
+
+			This should be an absolute path.
+			"""
+		relevant_when: "mode = \"unix\""
+		required:      true
+		type: string: syntax: "literal"
+	}
+	receive_buffer_bytes: {
+		description: """
+			The size, in bytes, of the receive buffer used for each connection.
+
+			This should not typically needed to be changed.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      false
+		type: uint: {}
+	}
+	shutdown_timeout_secs: {
+		description:   "The timeout before a connection is forcefully closed during shutdown."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: default: 30
+	}
+	tls: {
+		description:   "TlsEnableableConfig for `sources`, adding metadata from the client certificate"
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			client_metadata_key: {
+				description: "Event field for client certificate metadata."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -1,0 +1,108 @@
+package metadata
+
+base: components: sources: stdin: configuration: {
+	decoding: {
+		description: "Configuration for building a `Deserializer`."
+		required:    false
+		type: object: {
+			default: codec: "bytes"
+			options: codec: {
+				required: false
+				type: string: {
+					default: "bytes"
+					enum: {
+						bytes:       "Configures the `BytesDeserializer`."
+						gelf:        "Configures the `GelfDeserializer`."
+						json:        "Configures the `JsonDeserializer`."
+						native:      "Configures the `NativeDeserializer`."
+						native_json: "Configures the `NativeJsonDeserializer`."
+						syslog:      "Configures the `SyslogDeserializer`."
+					}
+				}
+			}
+		}
+	}
+	framing: {
+		description: "Configuration for building a `Framer`."
+		required:    false
+		type: object: options: {
+			character_delimited: {
+				description:   "Options for the character delimited decoder."
+				relevant_when: "method = \"character_delimited\""
+				required:      true
+				type: object: options: {
+					delimiter: {
+						description: "The character that delimits byte sequences."
+						required:    true
+						type: uint: {}
+					}
+					max_length: {
+						description: """
+																The maximum length of the byte buffer.
+
+																This length does *not* include the trailing delimiter.
+																"""
+						required: false
+						type: uint: {}
+					}
+				}
+			}
+			method: {
+				required: true
+				type: string: enum: {
+					bytes:               "Configures the `BytesDecoder`."
+					character_delimited: "Configures the `CharacterDelimitedDecoder`."
+					length_delimited:    "Configures the `LengthDelimitedDecoder`."
+					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
+					octet_counting:      "Configures the `OctetCountingDecoder`."
+				}
+			}
+			newline_delimited: {
+				description:   "Options for the newline delimited decoder."
+				relevant_when: "method = \"newline_delimited\""
+				required:      false
+				type: object: options: max_length: {
+					description: """
+						The maximum length of the byte buffer.
+
+						This length does *not* include the trailing delimiter.
+						"""
+					required: false
+					type: uint: {}
+				}
+			}
+			octet_counting: {
+				description:   "Options for the octet counting decoder."
+				relevant_when: "method = \"octet_counting\""
+				required:      false
+				type: object: options: max_length: {
+					description: "The maximum length of the byte buffer."
+					required:    false
+					type: uint: {}
+				}
+			}
+		}
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the current hostname to each event.
+
+			The value will be the current hostname for wherever Vector is running.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	max_length: {
+		description: """
+			The maximum buffer size, in bytes, of incoming messages.
+
+			Messages larger than this are truncated.
+			"""
+		required: false
+		type: uint: default: 102400
+	}
+}

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -1,0 +1,192 @@
+package metadata
+
+base: components: sources: syslog: configuration: {
+	address: {
+		description:   "The address to listen for connections on."
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      true
+		type: {
+			number: {}
+			string: syntax: "literal"
+		}
+	}
+	connection_limit: {
+		description:   "The maximum number of TCP connections that will be allowed at any given time."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: {}
+	}
+	host_key: {
+		description: """
+			Overrides the name of the log field used to add the peer host to each event.
+
+			If using TCP or UDP, the value will be the peer host's address, including the port i.e. `1.2.3.4:9000`. If using
+			UDS, the value will be the socket path itself.
+
+			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
+			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+			"""
+		required: false
+		type: string: syntax: "literal"
+	}
+	keepalive: {
+		description:   "TCP keepalive settings for socket-based components."
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: time_secs: {
+			description: "The time to wait, in seconds, before starting to send TCP keepalive probes on an idle connection."
+			required:    false
+			type: uint: {}
+		}
+	}
+	max_length: {
+		description: """
+			The maximum buffer size of incoming messages, in bytes.
+
+			Messages larger than this are truncated.
+			"""
+		required: false
+		type: uint: default: 102400
+	}
+	mode: {
+		required: true
+		type: string: enum: {
+			tcp:  "Listen on TCP."
+			udp:  "Listen on UDP."
+			unix: "Listen on UDS. (Unix domain socket)"
+		}
+	}
+	path: {
+		description: """
+			The Unix socket path.
+
+			This should be an absolute path.
+			"""
+		relevant_when: "mode = \"unix\""
+		required:      true
+		type: string: syntax: "literal"
+	}
+	receive_buffer_bytes: {
+		description: """
+			The size, in bytes, of the receive buffer used for each connection.
+
+			This should not typically needed to be changed.
+			"""
+		relevant_when: "mode = \"tcp\" or mode = \"udp\""
+		required:      false
+		type: uint: {}
+	}
+	socket_file_mode: {
+		description: """
+			Unix file mode bits to be applied to the unix socket file as its designated file permissions.
+
+			Note that the file mode value can be specified in any numeric format supported by your configuration
+			language, but it is most intuitive to use an octal number.
+			"""
+		relevant_when: "mode = \"unix\""
+		required:      false
+		type: uint: {}
+	}
+	tls: {
+		description:   "TlsEnableableConfig for `sources`, adding metadata from the client certificate"
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			client_metadata_key: {
+				description: "Event field for client certificate metadata."
+				required:    false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+}

--- a/website/cue/reference/components/sources/base/unit_test.cue
+++ b/website/cue/reference/components/sources/base/unit_test.cue
@@ -1,0 +1,3 @@
+package metadata
+
+base: components: sources: unit_test: configuration: {}

--- a/website/cue/reference/components/sources/base/unit_test_stream.cue
+++ b/website/cue/reference/components/sources/base/unit_test_stream.cue
@@ -1,0 +1,3 @@
+package metadata
+
+base: components: sources: unit_test_stream: configuration: {}

--- a/website/cue/reference/components/sources/base/vector.cue
+++ b/website/cue/reference/components/sources/base/vector.cue
@@ -1,0 +1,122 @@
+package metadata
+
+base: components: sources: vector: configuration: {
+	acknowledgements: {
+		description: "Configuration of acknowledgement behavior."
+		required:    false
+		type: object: options: enabled: {
+			description: "Enables end-to-end acknowledgements."
+			required:    false
+			type: bool: {}
+		}
+	}
+	address: {
+		description: """
+			The address to listen for connections on.
+
+			It _must_ include a port.
+			"""
+		required: true
+		type: string: syntax: "literal"
+	}
+	tls: {
+		description: "Configures the TLS options for incoming/outgoing connections."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			enabled: {
+				description: """
+					Whether or not to require TLS for incoming/outgoing connections.
+
+					When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
+					more information.
+					"""
+				required: false
+				type: bool: {}
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
+	}
+	version: {
+		description: "Version of the configuration."
+		required:    false
+		type: string: enum: "2": "Marker value for version two."
+	}
+}


### PR DESCRIPTION
As a follow-up to #14929, this PR adds the remaining machine-generate base Cue documentation files to the repository, specifically the documentation for sources and sinks.

This merely adds the "base" files, but does not use them: that will happen in follow-up PRs. This is due to the fact that it will be easier to scope the aforementioned follow-up PRs without having to include the base files in the same set of changes to be reviewed.