### PR TITLE
chore(http_client source): Small cleanup on existing log namespace feature

### DIFF
--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -209,7 +209,7 @@ impl HttpClientContext {
                         log,
                         log_schema().source_type_key(),
                         "source_type",
-                        HttpClientConfig::NAME,
+                        Bytes::from(HttpClientConfig::NAME),
                     );
                     self.log_namespace.insert_vector_metadata(
                         log,
@@ -246,12 +246,7 @@ impl HttpClientBuilder for HttpClientContext {
 
 impl http_client::HttpClientContext for HttpClientContext {
     /// Decodes the HTTP response body into events per the decoder configured.
-    fn on_response(
-        &mut self,
-        _url: &http::Uri,
-        _header: &Parts,
-        body: &Bytes,
-    ) -> Option<Vec<Event>> {
+    fn on_response(&mut self, _url: &Uri, _header: &Parts, body: &Bytes) -> Option<Vec<Event>> {
         // get the body into a byte array
         let mut buf = BytesMut::new();
         let body = String::from_utf8_lossy(body);


### PR DESCRIPTION
Closes #14978

Standardizing on `Bytes::from` in the log namespacing feature, and removed extra qualification.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
