### PR TITLE
chore: Standardize on `cfg(windows)`

### DIFF
--- a/src/api/schema/metrics/host.rs
+++ b/src/api/schema/metrics/host.rs
@@ -110,7 +110,7 @@ impl SwapMetrics {
 
     /// Swapped in bytes total (not available on Windows)
     async fn swapped_in_bytes_total(&self) -> Option<f64> {
-        if cfg!(not(target_os = "windows")) {
+        if cfg!(not(windows)) {
             Some(filter_host_metric(&self.0, "memory_swapped_in_bytes_total"))
         } else {
             None
@@ -119,7 +119,7 @@ impl SwapMetrics {
 
     /// Swapped out bytes total (not available on Windows)
     async fn swapped_out_bytes_total(&self) -> Option<f64> {
-        if cfg!(not(target_os = "windows")) {
+        if cfg!(not(windows)) {
             Some(filter_host_metric(
                 &self.0,
                 "memory_swapped_out_bytes_total",
@@ -191,7 +191,7 @@ impl NetworkMetrics {
 
     /// Total transmission packets dropped (Linux/Windows only)
     async fn transmit_packets_drop_total(&self) -> Option<f64> {
-        if cfg!(any(target_os = "linux", target_os = "windows")) {
+        if cfg!(any(target_os = "linux", windows)) {
             Some(filter_host_metric(
                 &self.0,
                 "network_transmit_packets_drop_total",
@@ -203,7 +203,7 @@ impl NetworkMetrics {
 
     /// Total transmission packets (Linux/Windows only)
     async fn transmit_packets_total(&self) -> Option<f64> {
-        if cfg!(any(target_os = "linux", target_os = "windows")) {
+        if cfg!(any(target_os = "linux", windows)) {
             Some(filter_host_metric(
                 &self.0,
                 "network_transmit_packets_total",

--- a/src/sources/host_metrics/disk.rs
+++ b/src/sources/host_metrics/disk.rs
@@ -89,7 +89,7 @@ mod tests {
         let metrics = buffer.metrics;
 
         // The Windows test runner doesn't generate any disk metrics on the VM.
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         assert!(!metrics.is_empty());
         assert!(metrics.len() % 4 == 0);
         assert!(all_counters(&metrics));

--- a/src/sources/host_metrics/filesystem.rs
+++ b/src/sources/host_metrics/filesystem.rs
@@ -1,6 +1,6 @@
 use futures::StreamExt;
 use heim::units::information::byte;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 use heim::units::ratio::ratio;
 use vector_config::configurable_component;
 use vector_core::metric_tags;
@@ -106,7 +106,7 @@ impl HostMetrics {
                         usage.used().get::<byte>() as f64,
                         tags.clone(),
                     );
-                    #[cfg(not(target_os = "windows"))]
+                    #[cfg(not(windows))]
                     output.gauge(
                         "filesystem_used_ratio",
                         usage.ratio().get::<ratio>() as f64,
@@ -134,7 +134,7 @@ mod tests {
         FilesystemConfig,
     };
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn generates_filesystem_metrics() {
         let mut buffer = MetricsBuffer::new(None);
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(count_tag(&metrics, "mountpoint"), metrics.len());
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     #[tokio::test]
     async fn generates_filesystem_metrics() {
         let mut buffer = MetricsBuffer::new(None);

--- a/src/sources/host_metrics/memory.rs
+++ b/src/sources/host_metrics/memory.rs
@@ -2,7 +2,7 @@
 use heim::memory::os::linux::MemoryExt;
 #[cfg(target_os = "macos")]
 use heim::memory::os::macos::MemoryExt;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 use heim::memory::os::SwapExt;
 use heim::units::information::byte;
 use vector_core::event::MetricTags;
@@ -102,13 +102,13 @@ impl HostMetrics {
                     swap.used().get::<byte>() as f64,
                     MetricTags::default(),
                 );
-                #[cfg(not(target_os = "windows"))]
+                #[cfg(not(windows))]
                 output.counter(
                     "memory_swapped_in_bytes_total",
                     swap.sin().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,
                     MetricTags::default(),
                 );
-                #[cfg(not(target_os = "windows"))]
+                #[cfg(not(windows))]
                 output.counter(
                     "memory_swapped_out_bytes_total",
                     swap.sout().map(|swap| swap.get::<byte>()).unwrap_or(0) as f64,

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use glob::{Pattern, PatternError};
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 use heim::units::ratio::ratio;
 use heim::units::time::second;
 use tokio::time;
@@ -623,7 +623,7 @@ pub(self) mod tests {
     }
 
     // Windows does not produce load average metrics.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn generates_loadavg_metrics() {
         let mut buffer = MetricsBuffer::new(None);

--- a/src/sources/host_metrics/network.rs
+++ b/src/sources/host_metrics/network.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 #[cfg(target_os = "linux")]
 use heim::net::os::linux::IoCountersExt;
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 use heim::net::os::windows::IoCountersExt;
 use heim::units::information::byte;
 use vector_config::configurable_component;
@@ -69,13 +69,13 @@ impl HostMetrics {
                         counter.errors_sent() as f64,
                         MetricTags::from([(String::from("device"), interface.to_string())]),
                     );
-                    #[cfg(any(target_os = "linux", target_os = "windows"))]
+                    #[cfg(any(target_os = "linux", windows))]
                     output.counter(
                         "network_transmit_packets_drop_total",
                         counter.drop_sent() as f64,
                         MetricTags::from([(String::from("device"), interface.to_string())]),
                     );
-                    #[cfg(any(target_os = "linux", target_os = "windows"))]
+                    #[cfg(any(target_os = "linux", windows))]
                     output.counter(
                         "network_transmit_packets_total",
                         counter.packets_sent() as f64,
@@ -95,7 +95,7 @@ impl HostMetrics {
 
 // The Windows CI environment produces zero network metrics, causing
 // these tests to always fail.
-#[cfg(all(test, not(target_os = "windows")))]
+#[cfg(all(test, not(windows)))]
 mod tests {
     use super::{
         super::{


### PR DESCRIPTION
We have used both `cfg(windows)` and `cfg(target_os = "windows")` in a number of places. This picks the simpler form, which is equivalent to `cfg(target_family = "windows")` and related to `cfg(unix)` which we also use.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
