### PR TITLE
fix(elasticsearch sink): Revert add `api_version` option

### DIFF
--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -9,7 +9,7 @@ use crate::{
         SinkContext,
     },
     sinks::{
-        elasticsearch::{ElasticsearchApiVersion, ElasticsearchAuth, ElasticsearchConfig},
+        elasticsearch::{ElasticsearchAuth, ElasticsearchConfig},
         util::{http::RequestConfig, Compression},
         Healthcheck, VectorSink,
     },
@@ -100,7 +100,6 @@ impl SinkConfig for AxiomConfig {
             query: Some(query),
             tls: self.tls.clone(),
             request,
-            api_version: ElasticsearchApiVersion::V6,
             ..Default::default()
         };
 

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -171,27 +171,6 @@ impl ElasticsearchCommonMode {
     }
 }
 
-/// Configuration for api version.
-#[configurable_component]
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum ElasticsearchApiVersion {
-    /// Auto-detect the api version. Will fail if endpoint isn't reachable.
-    Auto,
-    /// Use the Elasticsearch 6.x API.
-    V6,
-    /// Use the Elasticsearch 7.x API.
-    V7,
-    /// Use the Elasticsearch 8.x API.
-    V8,
-}
-
-impl Default for ElasticsearchApiVersion {
-    fn default() -> Self {
-        Self::Auto
-    }
-}
-
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum ParseError {

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -5,8 +5,8 @@ use crate::{
     event::{LogEvent, Metric, MetricKind, MetricValue, Value},
     sinks::{
         elasticsearch::{
-            sink::process_log, BulkAction, BulkConfig, DataStreamConfig, ElasticsearchApiVersion,
-            ElasticsearchCommon, ElasticsearchConfig, ElasticsearchMode,
+            sink::process_log, BulkAction, BulkConfig, DataStreamConfig, ElasticsearchCommon,
+            ElasticsearchConfig, ElasticsearchMode,
         },
         util::encoding::Encoder,
     },
@@ -26,7 +26,6 @@ async fn sets_create_action_when_configured() {
             index: Some(String::from("vector")),
         }),
         endpoints: vec![String::from("https://example.com")],
-        api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
@@ -75,7 +74,6 @@ async fn encode_datastream_mode() {
         }),
         endpoints: vec![String::from("https://example.com")],
         mode: ElasticsearchMode::DataStream,
-        api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
@@ -122,7 +120,6 @@ async fn encode_datastream_mode_no_routing() {
             namespace: Template::try_from("something").unwrap(),
             ..Default::default()
         }),
-        api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
@@ -158,7 +155,6 @@ async fn handle_metrics() {
             index: Some(String::from("vector")),
         }),
         endpoints: vec![String::from("https://example.com")],
-        api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
@@ -200,7 +196,6 @@ async fn decode_bulk_action_error() {
             index: Some(String::from("vector")),
         }),
         endpoints: vec![String::from("https://example.com")],
-        api_version: ElasticsearchApiVersion::V7,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
@@ -220,7 +215,6 @@ async fn decode_bulk_action() {
             index: Some(String::from("vector")),
         }),
         endpoints: vec![String::from("https://example.com")],
-        api_version: ElasticsearchApiVersion::V7,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
@@ -248,7 +242,6 @@ async fn encode_datastream_mode_no_sync() {
             sync_fields: false,
             ..Default::default()
         }),
-        api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
     };
 
@@ -292,7 +285,6 @@ async fn allows_using_except_fields() {
         )
         .unwrap(),
         endpoints: vec![String::from("https://example.com")],
-        api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
@@ -327,7 +319,6 @@ async fn allows_using_only_fields() {
         }),
         encoding: Transformer::new(Some(vec![owned_value_path!("foo")]), None, None).unwrap(),
         endpoints: vec![String::from("https://example.com")],
-        api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
     };
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -10,7 +10,7 @@ use crate::{
     config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     event::EventArray,
     sinks::{
-        elasticsearch::{BulkConfig, ElasticsearchApiVersion, ElasticsearchConfig},
+        elasticsearch::{BulkConfig, ElasticsearchConfig},
         util::{
             http::RequestConfig, BatchConfig, Compression, RealtimeSizeBasedDefaultBatchSettings,
             StreamSink, TowerRequestConfig,
@@ -98,7 +98,6 @@ impl SinkConfig for SematextLogsConfig {
                 ..Default::default()
             },
             encoding: self.encoding.clone(),
-            api_version: ElasticsearchApiVersion::V6,
             ..Default::default()
         }
         .build(cx)

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -74,19 +74,6 @@ components: sinks: elasticsearch: {
 	}
 
 	configuration: {
-		api_version: {
-			common:      false
-			description: "The API version of Elasticsearch."
-			required:    false
-			type: string: {
-				default: "auto"
-				enum: {
-					auto: "Auto-detect the api version. Will fail if version endpoint (`/_cluster/state/version`) isn't reachable."
-					v7:   "Use the Elasticsearch 7.x API."
-					v8:   "Use the Elasticsearch 8.x API."
-				}
-			}
-		}
 		auth: {
 			common:      false
 			description: "Options for the authentication strategy."
@@ -358,7 +345,6 @@ components: sinks: elasticsearch: {
 
 				If enabled the `doc_type` option will be ignored.
 				"""
-			warnings: ["This option has been deprecated, the `api_version` option should be used instead."]
 			required: false
 			type: bool: default: false
 		}


### PR DESCRIPTION
Reverts vectordotdev/vector#14918

This is causing soak tests to fail because lading doesn't respond correctly to the version endpoint. This fact also highlights that the PR being reverted could be considered a "breaking change" so, before we re-introduce it, we should decide to either preserve compatibility (default to `v7`) or make the breaking change and add an upgrade note to the next release so that users know to expect it.

cc/ @ktff 