### PR TITLE
chore(throttle transform): add log namespace support to throttle transform

### DIFF
--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -53,8 +53,9 @@ impl TransformConfig for ThrottleConfig {
         Input::log()
     }
 
-    fn outputs(&self, _: &schema::Definition) -> Vec<Output> {
-        vec![Output::default(DataType::Log)]
+    fn outputs(&self, merged_definition: &schema::Definition) -> Vec<Output> {
+        // The event is not modified, so the definition is passed through as-is
+        vec![Output::default(DataType::Log).with_schema_definition(merged_definition.clone())]
     }
 }
 


### PR DESCRIPTION
ref: https://github.com/vectordotdev/vector/issues/15031

This one is very simple. The events are just passed through as-is, so the existing schema definition is used