### PR TITLE
chore(ci): Add timeouts to CI jobs that hung recently

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -90,6 +90,7 @@ jobs:
             env:
               SPLUNK_VERSION: 7.3.9
           - test: 'splunk'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - run: make ci-sweep

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -172,6 +172,7 @@ jobs:
     name: Build baseline 'soak-vector' container
     runs-on: [linux, soak-builder]
     needs: [compute-soak-meta]
+    timeout-minutes: 20
     steps:
       - uses: colpal/actions-clean@v1
 
@@ -217,6 +218,7 @@ jobs:
     name: Build comparison 'soak-vector' container
     runs-on: [linux, soak-builder]
     needs: [compute-soak-meta]
+    timeout-minutes: 20
     steps:
       - uses: colpal/actions-clean@v1
 


### PR DESCRIPTION
Discovered these ones hanging recently for the full 6 hours.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
