### PR TITLE
chore(core): add `LogNamespace` getter functions

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -307,6 +307,25 @@ impl LogNamespace {
         }
     }
 
+    /// Vector: This is added to "event metadata", nested under the source name.
+    ///
+    /// Legacy: This is stored on the event root, only if a field with that name doesn't already exist.
+    pub fn get_source_metadata<'a, 'b>(
+        &self,
+        source_name: &'a str,
+        log: &'b mut LogEvent,
+        legacy_key: impl ValuePath<'a>,
+        metadata_key: impl ValuePath<'a>,
+    ) -> Option<&'b Value> {
+        match self {
+            LogNamespace::Vector => log
+                .metadata()
+                .value()
+                .get(path!(source_name).concat(metadata_key)),
+            LogNamespace::Legacy => log.get((PathPrefix::Event, legacy_key)),
+        }
+    }
+
     /// Vector: This is added to the "event metadata", nested under the name "vector". This data
     /// will be marked as read-only in VRL.
     ///
@@ -325,6 +344,24 @@ impl LogNamespace {
                     .insert(path!("vector").concat(metadata_key), value);
             }
             LogNamespace::Legacy => log.try_insert((PathPrefix::Event, legacy_key), value),
+        }
+    }
+
+    /// Vector: This is retrieved from the "event metadata", nested under the name "vector".
+    ///
+    /// Legacy: This is retrieved from the event.
+    pub fn get_vector_metadata<'a, 'b>(
+        &self,
+        log: &'b mut LogEvent,
+        legacy_key: impl ValuePath<'a>,
+        metadata_key: impl ValuePath<'a>,
+    ) -> Option<&'b Value> {
+        match self {
+            LogNamespace::Vector => log
+                .metadata()
+                .value()
+                .get(path!("vector").concat(metadata_key)),
+            LogNamespace::Legacy => log.get((PathPrefix::Event, legacy_key)),
         }
     }
 

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -307,9 +307,9 @@ impl LogNamespace {
         }
     }
 
-    /// Vector: This is added to "event metadata", nested under the source name.
+    /// Vector: This is retrieved from the "event metadata", nested under the source name.
     ///
-    /// Legacy: This is stored on the event root, only if a field with that name doesn't already exist.
+    /// Legacy: This is retrieved from the event.
     pub fn get_source_metadata<'a, 'b>(
         &self,
         source_name: &'a str,


### PR DESCRIPTION
This adds `get_source_metadata` and `get_vector_metadata` functions on `LogNamespace` to make it easier to fetch information where the location depends on the log namespace.