### PR TITLE
fix(ci): fix issues in ci-metadata-script

### DIFF
--- a/scripts/ci-generate-publish-metadata.sh
+++ b/scripts/ci-generate-publish-metadata.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
 # ci-set-publish-metadata.sh
 #
 # SUMMARY
@@ -13,19 +15,19 @@ set -euo pipefail
 
 # Generate the Vector version, and build description.
 VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /^version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
-echo "name=vector_version::${VERSION}" >> "$GITHUB_OUTPUT"
+echo "vector_version::${VERSION}" >> "${GITHUB_OUTPUT}"
 
 GIT_SHA=$(git rev-parse --short HEAD)
 CURRENT_DATE=$(date +%Y-%m-%d)
-echo "name=vector_build_desc::${GIT_SHA} ${CURRENT_DATE}" >> "$GITHUB_OUTPUT"
+echo "vector_build_desc::${GIT_SHA} ${CURRENT_DATE}" >> "${GITHUB_OUTPUT}"
 
 # Figure out what our release channel is.
 CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
-echo "name=vector_release_channel::${CHANNEL}" >> "$GITHUB_OUTPUT"
+echo "vector_release_channel::${CHANNEL}" >> "${GITHUB_OUTPUT}"
 
 # Depending on the channel, this influences which Cloudsmith repository we publish to.
 if [[ "${CHANNEL}" == "nightly" ]]; then
-	echo "name=vector_cloudsmith_repo::vector-nightly" >> "$GITHUB_OUTPUT"
+	echo "vector_cloudsmith_repo::vector-nightly" >> "${GITHUB_OUTPUT}"
 else
-	echo "name=vector_cloudsmith_repo::vector" >> "$GITHUB_OUTPUT"
+	echo "vector_cloudsmith_repo::vector" >> "${GITHUB_OUTPUT}"
 fi

--- a/scripts/ci-generate-publish-metadata.sh
+++ b/scripts/ci-generate-publish-metadata.sh
@@ -15,19 +15,19 @@ GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
 
 # Generate the Vector version, and build description.
 VERSION="${VERSION:-"$(awk -F ' = ' '$1 ~ /^version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml)"}"
-echo "vector_version::${VERSION}" >> "${GITHUB_OUTPUT}"
+echo "vector_version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
 GIT_SHA=$(git rev-parse --short HEAD)
 CURRENT_DATE=$(date +%Y-%m-%d)
-echo "vector_build_desc::${GIT_SHA} ${CURRENT_DATE}" >> "${GITHUB_OUTPUT}"
+echo "vector_build_desc=${GIT_SHA} ${CURRENT_DATE}" >> "${GITHUB_OUTPUT}"
 
 # Figure out what our release channel is.
 CHANNEL="${CHANNEL:-"$(scripts/release-channel.sh)"}"
-echo "vector_release_channel::${CHANNEL}" >> "${GITHUB_OUTPUT}"
+echo "vector_release_channel=${CHANNEL}" >> "${GITHUB_OUTPUT}"
 
 # Depending on the channel, this influences which Cloudsmith repository we publish to.
 if [[ "${CHANNEL}" == "nightly" ]]; then
-	echo "vector_cloudsmith_repo::vector-nightly" >> "${GITHUB_OUTPUT}"
+	echo "vector_cloudsmith_repo=vector-nightly" >> "${GITHUB_OUTPUT}"
 else
-	echo "vector_cloudsmith_repo::vector" >> "${GITHUB_OUTPUT}"
+	echo "vector_cloudsmith_repo=vector" >> "${GITHUB_OUTPUT}"
 fi


### PR DESCRIPTION

Fixes some missing bit from this change:

https://github.com/vectordotdev/vector/commit/3b7916b82e28979a1121508f1926164fe03f60e9

which was done to address this:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


```
$ make ci-generate-publish-metadata         
vector_version::0.25.0
vector_build_desc::86bd9202a 2022-11-02
vector_release_channel::nightly
vector_cloudsmith_repo::vector-nightly
```

```
$ GITHUB_OUTPUT=/tmp/gh-output.out make ci-generate-publish-metadata 

$ cat /tmp/gh-output.out 
vector_version::0.25.0
vector_build_desc::86bd9202a 2022-11-02
vector_release_channel::nightly
vector_cloudsmith_repo::vector-nightly
```
