### PR TITLE
fix(config): Fix merging of configured timezones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9090,6 +9090,7 @@ dependencies = [
  "bitmask-enum",
  "bytes 1.2.1",
  "chrono",
+ "chrono-tz",
  "criterion",
  "crossbeam-utils",
  "db-key",

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -79,6 +79,7 @@ prost-build = "0.11.1"
 
 [dev-dependencies]
 base64 = "0.13.1"
+chrono-tz = { version = "0.7.0", default-features = false }
 criterion = { version = "0.4.0", features = ["html_reports"] }
 env-test-util = "1.0.1"
 quickcheck = "1.0.3"

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -235,7 +235,7 @@ impl EnrichmentTableConfig for FileConfig {
         &self,
         globals: &crate::config::GlobalOptions,
     ) -> crate::Result<Box<dyn Table + Send + Sync>> {
-        let (headers, data, modified) = self.load_file(globals.timezone)?;
+        let (headers, data, modified) = self.load_file(globals.timezone())?;
 
         Ok(Box::new(File::new(self.clone(), modified, data, headers)))
     }

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -72,7 +72,7 @@ impl GenerateConfig for LogstashConfig {
 impl SourceConfig for LogstashConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         let source = LogstashSource {
-            timestamp_converter: types::Conversion::Timestamp(cx.globals.timezone),
+            timestamp_converter: types::Conversion::Timestamp(cx.globals.timezone()),
         };
         let shutdown_secs = 30;
         let tls_config = self.tls.as_ref().map(|tls| tls.tls_config.clone());

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -55,7 +55,7 @@ impl TransformConfig for MetricToLogConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::function(MetricToLog::new(
             self.host_tag.clone(),
-            self.timezone.unwrap_or(context.globals.timezone),
+            self.timezone.unwrap_or_else(|| context.globals.timezone()),
         )))
     }
 


### PR DESCRIPTION
The `timezone` configuration was not an optional value. This means that in a
configuration that had multiple global sections (ie multi-file configuration),
all of those sections would have to have the same timezone setting. This works
_now_ because the default is the "local" time zone, which is what most users
want, but it makes setting the timezone in a single file impossible.

Fixes #15071 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
