### PR TITLE
add insert_standard_vector_source_metadata function to streamline usage

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -11,12 +11,11 @@ pub mod proxy;
 use crate::event::LogEvent;
 pub use global_options::GlobalOptions;
 pub use log_schema::{init_log_schema, log_schema, LogSchema};
-use lookup::lookup_v2::ValuePath;
-use lookup::{path, PathPrefix};
+use lookup::{lookup_v2::ValuePath, path, PathPrefix};
 use serde::{Deserialize, Serialize};
 use value::Value;
 pub use vector_common::config::ComponentKey;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 
 use crate::schema;
 
@@ -333,15 +332,16 @@ impl LogNamespace {
     ///
     /// Legacy: The values of `source_type_key`, and `timestamp_key` are stored as keys on the event root,
     /// only if a field with that name doesn't already exist.
-    pub fn insert_standard_vector_source_metadata<S>(&self, log: &mut LogEvent, source: &S)
-    where
-        S: NamedComponent,
-    {
+    pub fn insert_standard_vector_source_metadata(
+        &self,
+        log: &mut LogEvent,
+        source_name: &'static str,
+    ) {
         self.insert_vector_metadata(
             log,
             path!(log_schema().source_type_key()),
             path!("source_type"),
-            Bytes::from_static(source.get_component_name().as_bytes()),
+            Bytes::from_static(source_name.as_bytes()),
         );
         self.insert_vector_metadata(
             log,

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -285,7 +285,6 @@ pub struct ApiKeyQueryParams {
 pub(crate) struct DatadogAgentSource {
     pub(crate) api_key_extractor: ApiKeyExtractor,
     pub(crate) log_schema_host_key: &'static str,
-    pub(crate) log_schema_timestamp_key: &'static str,
     pub(crate) log_schema_source_type_key: &'static str,
     pub(crate) log_namespace: LogNamespace,
     pub(crate) decoder: Decoder,
@@ -338,7 +337,6 @@ impl DatadogAgentSource {
             },
             log_schema_host_key: log_schema().host_key(),
             log_schema_source_type_key: log_schema().source_type_key(),
-            log_schema_timestamp_key: log_schema().timestamp_key(),
             decoder,
             protocol,
             logs_schema_definition: Arc::new(logs_schema_definition),

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use codecs::{
     decoding::{DeserializerConfig, FramingConfig},
     StreamDecodingError,
@@ -11,13 +10,13 @@ use std::task::Poll;
 use tokio::time::{self, Duration};
 use tokio_util::codec::FramedRead;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
-use vector_config::configurable_component;
+use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::LogNamespace;
 use vector_core::ByteSizeOf;
 
 use crate::{
     codecs::{Decoder, DecodingConfig},
-    config::{log_schema, Output, SourceConfig, SourceContext},
+    config::{Output, SourceConfig, SourceContext},
     internal_events::{DemoLogsEventProcessed, EventsReceived, StreamClosedError},
     serde::{default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
@@ -209,22 +208,12 @@ async fn demo_logs_source(
                         count,
                         byte_size: events.size_of()
                     });
-                    let now = Utc::now();
 
                     let events = events.into_iter().map(|mut event| {
                         let log = event.as_mut_log();
-                        log_namespace.insert_vector_metadata(
-                            log,
-                            log_schema().source_type_key(),
-                            "source_type",
-                            "demo_logs",
-                        );
-                        log_namespace.insert_vector_metadata(
-                            log,
-                            log_schema().timestamp_key(),
-                            "ingest_timestamp",
-                            now,
-                        );
+
+                        log_namespace
+                            .insert_standard_vector_source_metadata(log, DemoLogsConfig::NAME);
 
                         event
                     });

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -2,7 +2,6 @@
 //! Calls an endpoint at an interval, decoding the HTTP responses into events.
 
 use bytes::{Bytes, BytesMut};
-use chrono::Utc;
 use futures_util::FutureExt;
 use http::{response::Parts, Uri};
 use snafu::ResultExt;
@@ -205,18 +204,8 @@ impl HttpClientContext {
         for event in events {
             match event {
                 Event::Log(ref mut log) => {
-                    self.log_namespace.insert_vector_metadata(
-                        log,
-                        log_schema().source_type_key(),
-                        "source_type",
-                        Bytes::from(HttpClientConfig::NAME),
-                    );
-                    self.log_namespace.insert_vector_metadata(
-                        log,
-                        log_schema().timestamp_key(),
-                        "ingest_timestamp",
-                        Utc::now(),
-                    );
+                    self.log_namespace
+                        .insert_standard_vector_source_metadata(log, HttpClientConfig::NAME);
                 }
                 Event::Metric(ref mut metric) => {
                     metric.insert_tag(


### PR DESCRIPTION
- chore: Add helper to add all standard vector source metadata
- +update fn and replace usage of single key functions, outstanding questions about correctness

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
