### PR TITLE
chore(ci): Update Integration and Soak timeout

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -91,7 +91,7 @@ jobs:
             env:
               SPLUNK_VERSION: 7.3.9
           - test: 'splunk'
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - run: make ci-sweep

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -172,7 +172,7 @@ jobs:
     name: Build baseline 'soak-vector' container
     runs-on: [linux, soak-builder]
     needs: [compute-soak-meta]
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: colpal/actions-clean@v1
 
@@ -218,7 +218,7 @@ jobs:
     name: Build comparison 'soak-vector' container
     runs-on: [linux, soak-builder]
     needs: [compute-soak-meta]
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: colpal/actions-clean@v1
 


### PR DESCRIPTION
We're hitting 20 min timeouts multiple times a day. Trying a 30 min timeout.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
