### PR TITLE
fix(ci): Include PR number in the regression target tag

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -57,6 +57,11 @@ jobs:
           ref: ${{ github.base_ref }}
           path: baseline-vector
 
+      - name: Setup PR metadata
+        id: pr-metadata
+        run: |
+          echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_OUTPUT
+
       - name: Setup experimental metadata
         id: experimental-meta
         run: |
@@ -182,7 +187,7 @@ jobs:
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.baseline-tag }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}
           push: true
 
   build-comparison:
@@ -230,7 +235,7 @@ jobs:
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.comparison-tag }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}
           push: true
 
   ##
@@ -272,8 +277,8 @@ jobs:
             --total-samples ${{ needs.compute-metadata.outputs.total-samples }} \
             --warmup-seconds ${{ needs.compute-metadata.outputs.warmup-seconds }} \
             --replicas ${{ needs.compute-metadata.outputs.replicas }} \
-            --baseline-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.baseline-tag }} \
-            --comparison-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.comparison-tag }} \
+            --baseline-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }} \
+            --comparison-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }} \
             --baseline-sha ${{ needs.compute-metadata.outputs.baseline }} \
             --comparison-sha ${{ needs.compute-metadata.outputs.comparison }} \
             --target-config-dir ${{ github.workspace }}/regression/ \


### PR DESCRIPTION
It is possible that two PRs with working with the same baseline SHA can push the same tag up to ECR. Today this will silently pollute one PR experiment set. In the future this will cause an error that terminates the workflow. To correct this we include the unique PR number in the image tag.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
