### PR TITLE
chore(dev): Use nightly to fmt code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -3,7 +3,7 @@ newline_style = "unix"
 reorder_imports = true
 
 # Nightly only features
-# unstable_features = true
-# imports_granularity = "Crate"
-# group_imports = "StdExternalCrate"
-# indent_style = "Block"
+unstable_features = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+indent_style = "Block"

--- a/Makefile
+++ b/Makefile
@@ -643,7 +643,7 @@ clean: environment-clean ## Clean everything
 
 .PHONY: fmt
 fmt: ## Format code
-	${MAYBE_ENVIRONMENT_EXEC} cargo fmt
+	${MAYBE_ENVIRONMENT_EXEC} cargo +nightly fmt
 	${MAYBE_ENVIRONMENT_EXEC} ./scripts/check-style.sh --fix
 
 .PHONY: generate-kubernetes-manifests

--- a/benches/codecs/newline_bytes.rs
+++ b/benches/codecs/newline_bytes.rs
@@ -2,7 +2,9 @@ use std::{fmt, time::Duration};
 
 use bytes::BytesMut;
 use codecs::{
-    self, decoding::Deserializer, decoding::Framer, BytesDeserializer, NewlineDelimitedDecoder,
+    self,
+    decoding::{Deserializer, Framer},
+    BytesDeserializer, NewlineDelimitedDecoder,
 };
 use criterion::{
     criterion_group, measurement::WallTime, BatchSize, BenchmarkGroup, BenchmarkId, Criterion,

--- a/benches/template.rs
+++ b/benches/template.rs
@@ -2,7 +2,10 @@ use std::convert::TryFrom;
 
 use chrono::Utc;
 use criterion::{criterion_group, BatchSize, Criterion};
-use vector::{config::log_schema, event::Event, event::LogEvent};
+use vector::{
+    config::log_schema,
+    event::{Event, LogEvent},
+};
 
 fn bench_elasticsearch_index(c: &mut Criterion) {
     use vector::template::Template;

--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -1,12 +1,10 @@
 use bytes::Bytes;
-use lookup::lookup_v2::parse_value_path;
-use lookup::LookupBuf;
+use lookup::{lookup_v2::parse_value_path, LookupBuf};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use value::Kind;
-use vector_core::config::LogNamespace;
 use vector_core::{
-    config::{log_schema, DataType},
+    config::{log_schema, DataType, LogNamespace},
     event::{Event, LogEvent},
     schema,
 };

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -1,16 +1,14 @@
+use std::collections::HashMap;
+
 use bytes::Bytes;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use lookup::{event_path, owned_value_path};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
-use std::collections::HashMap;
-use value::kind::Collection;
-use value::Kind;
-use vector_core::config::LogNamespace;
+use value::{kind::Collection, Kind};
 use vector_core::{
-    config::{log_schema, DataType},
-    event::Event,
-    event::LogEvent,
+    config::{log_schema, DataType, LogNamespace},
+    event::{Event, LogEvent},
     schema,
 };
 
@@ -206,7 +204,6 @@ impl Deserializer for GelfDeserializer {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bytes::Bytes;
     use chrono::{DateTime, NaiveDateTime, Utc};
     use lookup::event_path;
@@ -215,6 +212,8 @@ mod tests {
     use smallvec::SmallVec;
     use value::Value;
     use vector_core::{config::log_schema, event::Event};
+
+    use super::*;
 
     fn deserialize_gelf_input(
         input: &serde_json::Value,

--- a/lib/codecs/src/decoding/format/mod.rs
+++ b/lib/codecs/src/decoding/format/mod.rs
@@ -11,6 +11,8 @@ mod native_json;
 #[cfg(feature = "syslog")]
 mod syslog;
 
+use std::fmt::Debug;
+
 use ::bytes::Bytes;
 use dyn_clone::DynClone;
 pub use gelf::{GelfDeserializer, GelfDeserializerConfig};
@@ -18,9 +20,7 @@ pub use json::{JsonDeserializer, JsonDeserializerConfig};
 pub use native::{NativeDeserializer, NativeDeserializerConfig};
 pub use native_json::{NativeJsonDeserializer, NativeJsonDeserializerConfig};
 use smallvec::SmallVec;
-use std::fmt::Debug;
-use vector_core::config::LogNamespace;
-use vector_core::event::Event;
+use vector_core::{config::LogNamespace, event::Event};
 
 pub use self::bytes::{BytesDeserializer, BytesDeserializerConfig};
 #[cfg(feature = "syslog")]

--- a/lib/codecs/src/decoding/format/native.rs
+++ b/lib/codecs/src/decoding/format/native.rs
@@ -3,9 +3,8 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use value::Kind;
-use vector_core::config::LogNamespace;
 use vector_core::{
-    config::DataType,
+    config::{DataType, LogNamespace},
     event::{proto, Event, EventArray, EventContainer},
     schema,
 };

--- a/lib/codecs/src/decoding/format/native_json.rs
+++ b/lib/codecs/src/decoding/format/native_json.rs
@@ -1,12 +1,14 @@
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
-use value::kind::Collection;
-use value::Kind;
-use vector_core::{config::DataType, event::Event, schema};
+use value::{kind::Collection, Kind};
+use vector_core::{
+    config::{DataType, LogNamespace},
+    event::Event,
+    schema,
+};
 
 use super::Deserializer;
-use vector_core::config::LogNamespace;
 
 /// Config used to build a `NativeJsonDeserializer`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -1,15 +1,14 @@
+use std::collections::BTreeMap;
+
 use bytes::Bytes;
 use chrono::{DateTime, Datelike, Utc};
-use lookup::lookup_v2::parse_value_path;
-use lookup::{event_path, owned_value_path};
+use lookup::{event_path, lookup_v2::parse_value_path, owned_value_path};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
-use std::collections::BTreeMap;
 use syslog_loose::{IncompleteDate, Message, ProcId, Protocol};
 use value::{kind::Collection, Kind};
-use vector_core::config::LogNamespace;
 use vector_core::{
-    config::{log_schema, DataType},
+    config::{log_schema, DataType, LogNamespace},
     event::{Event, LogEvent, Value},
     schema,
 };

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -5,6 +5,8 @@ mod error;
 pub mod format;
 pub mod framing;
 
+use std::fmt::Debug;
+
 use bytes::{Bytes, BytesMut};
 pub use error::StreamDecodingError;
 pub use format::{
@@ -22,7 +24,6 @@ pub use framing::{
     OctetCountingDecoderConfig, OctetCountingDecoderOptions,
 };
 use smallvec::SmallVec;
-use std::fmt::Debug;
 use vector_config::configurable_component;
 use vector_core::{
     config::{DataType, LogNamespace},

--- a/lib/codecs/src/encoding/format/avro.rs
+++ b/lib/codecs/src/encoding/format/avro.rs
@@ -1,9 +1,10 @@
-use crate::encoding::BuildError;
 use bytes::{BufMut, BytesMut};
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Encoder;
 use vector_config::configurable_component;
 use vector_core::{config::DataType, event::Event, schema};
+
+use crate::encoding::BuildError;
 
 /// Config used to build a `AvroSerializer`.
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/lib/codecs/src/encoding/format/gelf.rs
+++ b/lib/codecs/src/encoding/format/gelf.rs
@@ -1,4 +1,3 @@
-use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 use bytes::{BufMut, BytesMut};
 use lookup::event_path;
 use serde::{Deserialize, Serialize};
@@ -6,10 +5,11 @@ use snafu::Snafu;
 use tokio_util::codec::Encoder;
 use vector_core::{
     config::{log_schema, DataType},
-    event::Event,
-    event::LogEvent,
+    event::{Event, LogEvent},
     schema,
 };
+
+use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 
 /// On GELF encoding behavior:
 ///   Graylog has a relaxed parsing. They are much more lenient than the spec would
@@ -222,12 +222,12 @@ fn to_gelf_event(log: LogEvent) -> vector_common::Result<LogEvent> {
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::encoding::SerializerConfig;
-
-    use super::*;
     use value::Value;
     use vector_common::btreemap;
     use vector_core::event::{Event, EventMetadata};
+
+    use super::*;
+    use crate::encoding::SerializerConfig;
 
     fn do_serialize(
         expect_success: bool,

--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -71,8 +71,10 @@ mod tests {
     use bytes::BytesMut;
     use chrono::{TimeZone, Utc};
     use vector_common::btreemap;
-    use vector_core::event::{LogEvent, Metric, MetricKind, MetricValue, StatisticKind, Value};
-    use vector_core::metric_tags;
+    use vector_core::{
+        event::{LogEvent, Metric, MetricKind, MetricValue, StatisticKind, Value},
+        metric_tags,
+    };
 
     use super::*;
 

--- a/lib/codecs/src/encoding/format/logfmt.rs
+++ b/lib/codecs/src/encoding/format/logfmt.rs
@@ -57,10 +57,11 @@ impl Encoder<Event> for LogfmtSerializer {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bytes::BytesMut;
     use vector_common::btreemap;
     use vector_core::event::{LogEvent, Value};
+
+    use super::*;
 
     #[test]
     fn serialize_logfmt() {

--- a/lib/datadog/grok/src/filters/keyvalue.rs
+++ b/lib/datadog/grok/src/filters/keyvalue.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::fmt::Formatter;
+use std::{collections::BTreeMap, fmt::Formatter};
 
 use bytes::Bytes;
 use lookup::{Lookup, LookupBuf};

--- a/lib/datadog/grok/src/grok.rs
+++ b/lib/datadog/grok/src/grok.rs
@@ -8,8 +8,10 @@
 
 include!(concat!(env!("OUT_DIR"), "/patterns.rs"));
 
-use std::collections::{btree_map, BTreeMap};
-use std::sync::Arc;
+use std::{
+    collections::{btree_map, BTreeMap},
+    sync::Arc,
+};
 
 use onig::{Captures, Regex};
 use thiserror::Error;

--- a/lib/datadog/grok/src/parse_grok_rules.rs
+++ b/lib/datadog/grok/src/parse_grok_rules.rs
@@ -8,9 +8,9 @@ use once_cell::sync::Lazy;
 use tracing::error;
 use value::Value;
 
-use crate::grok::Grok;
 use crate::{
     ast::{self, Destination, GrokPattern},
+    grok::Grok,
     grok_filter::GrokFilter,
     matchers::{date, date::DateFilter},
     parse_grok_pattern::parse_grok_pattern,

--- a/lib/dnsmsg-parser/src/dns_message_parser.rs
+++ b/lib/dnsmsg-parser/src/dns_message_parser.rs
@@ -1,5 +1,4 @@
-use std::fmt::Write as _;
-use std::str::Utf8Error;
+use std::{fmt::Write as _, str::Utf8Error};
 
 use data_encoding::{BASE32HEX_NOPAD, BASE64, HEXUPPER};
 use thiserror::Error;

--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 use crate::{
     vrl_util::{self, add_index, evaluate_condition},

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeMap;
 
 use value::{kind::Collection, Kind, Value};
-use vrl::prelude::FunctionExpression;
-use vrl::state::TypeState;
 use vrl::{
     function::{ArgumentList, Compiled, Example, FunctionCompileContext, Parameter},
-    prelude::{expression, DiagnosticMessage, Resolved, Result, TypeDef, VrlValueConvert},
+    prelude::{
+        expression, DiagnosticMessage, FunctionExpression, Resolved, Result, TypeDef,
+        VrlValueConvert,
+    },
+    state::TypeState,
     value::kind,
     Context, Expression, Function,
 };

--- a/lib/loki-logproto/src/lib.rs
+++ b/lib/loki-logproto/src/lib.rs
@@ -9,9 +9,11 @@ pub mod logproto {
 }
 
 pub mod util {
-    use super::logproto;
-    use prost::Message;
     use std::collections::HashMap;
+
+    use prost::Message;
+
+    use super::logproto;
 
     const NANOS_RANGE: i64 = 1_000_000_000;
 
@@ -76,10 +78,12 @@ pub mod util {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use chrono::prelude::*;
+
     use super::util;
     use crate::util::{Batch, Entry};
-    use chrono::prelude::*;
-    use std::collections::HashMap;
 
     #[test]
     fn encode_labels() {

--- a/lib/lookup/src/lookup_v2/borrowed.rs
+++ b/lib/lookup/src/lookup_v2/borrowed.rs
@@ -1,7 +1,6 @@
+use std::{borrow::Cow, iter::Cloned, slice::Iter};
+
 use crate::lookup_v2::ValuePath;
-use std::borrow::Cow;
-use std::iter::Cloned;
-use std::slice::Iter;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BorrowedSegment<'a> {

--- a/lib/lookup/src/lookup_v2/compat.rs
+++ b/lib/lookup/src/lookup_v2/compat.rs
@@ -1,8 +1,9 @@
+use std::borrow::Cow;
+
 ///! Contains backwards compatibility with lookup "v1"
 ///! This is all temporary and will be deleted when migration to the V2 lookup code is complete.
 use crate::lookup_v2::{BorrowedSegment, OwnedSegment, OwnedValuePath, ValuePath};
 use crate::{FieldBuf, LookupBuf, SegmentBuf};
-use std::borrow::Cow;
 
 impl<'a> ValuePath<'a> for &'a LookupBuf {
     type Iter = LookupBufPathIter<'a>;
@@ -94,8 +95,7 @@ impl<'a> Iterator for LookupBufPathIter<'a> {
 
 #[cfg(test)]
 mod test {
-    use crate::lookup_v2::ValuePath;
-    use crate::LookupBuf;
+    use crate::{lookup_v2::ValuePath, LookupBuf};
 
     #[test]
     fn test() {

--- a/lib/lookup/src/lookup_v2/jit.rs
+++ b/lib/lookup/src/lookup_v2/jit.rs
@@ -7,8 +7,7 @@
 //! should pre-compile all paths. Once that happens it might make sense to re-write in something
 //! more readable.
 
-use std::borrow::Cow;
-use std::str::CharIndices;
+use std::{borrow::Cow, str::CharIndices};
 
 use crate::lookup_v2::{BorrowedSegment, ValuePath};
 

--- a/lib/lookup/src/lookup_v2/mod.rs
+++ b/lib/lookup/src/lookup_v2/mod.rs
@@ -5,14 +5,15 @@ mod jit;
 mod optional_path;
 mod owned;
 
-use self::jit::{JitValuePath, JitValuePathIter};
-use snafu::Snafu;
 use std::fmt::Debug;
 
 pub use borrowed::BorrowedSegment;
 pub use concat::PathConcat;
 pub use optional_path::OptionalTargetPath;
 pub use owned::{OwnedSegment, OwnedTargetPath, OwnedValuePath};
+use snafu::Snafu;
+
+use self::jit::{JitValuePath, JitValuePathIter};
 
 #[derive(Clone, Debug, Eq, PartialEq, Snafu)]
 pub enum PathParseError {
@@ -233,8 +234,7 @@ pub enum PathPrefix {
 
 #[cfg(test)]
 mod test {
-    use crate::lookup_v2::parse_target_path;
-    use crate::OwnedTargetPath;
+    use crate::{lookup_v2::parse_target_path, OwnedTargetPath};
 
     #[test]
     fn test_parse_target_path() {

--- a/lib/lookup/src/lookup_v2/optional_path.rs
+++ b/lib/lookup/src/lookup_v2/optional_path.rs
@@ -1,6 +1,6 @@
-use crate::lookup_v2::PathParseError;
-use crate::OwnedTargetPath;
 use vector_config::configurable_component;
+
+use crate::{lookup_v2::PathParseError, OwnedTargetPath};
 
 #[configurable_component]
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]

--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -1,9 +1,11 @@
-use crate::lookup_v2::{
-    parse_target_path, parse_value_path, BorrowedSegment, PathParseError, ValuePath,
-};
-use crate::PathPrefix;
 use std::fmt::{Debug, Display, Formatter};
+
 use vector_config::configurable_component;
+
+use crate::{
+    lookup_v2::{parse_target_path, parse_value_path, BorrowedSegment, PathParseError, ValuePath},
+    PathPrefix,
+};
 
 /// A lookup path.
 #[configurable_component]

--- a/lib/opentelemetry-proto/src/convert.rs
+++ b/lib/opentelemetry-proto/src/convert.rs
@@ -1,16 +1,18 @@
-use super::proto::{
-    common::v1::{any_value::Value as PBValue, KeyValue},
-    logs::v1::{LogRecord, ResourceLogs, SeverityNumber},
-    resource::v1::Resource,
-};
+use std::collections::BTreeMap;
+
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use ordered_float::NotNan;
-use std::collections::BTreeMap;
 use value::Value;
 use vector_core::{
     config::log_schema,
     event::{Event, LogEvent},
+};
+
+use super::proto::{
+    common::v1::{any_value::Value as PBValue, KeyValue},
+    logs::v1::{LogRecord, ResourceLogs, SeverityNumber},
+    resource::v1::Resource,
 };
 
 const RESOURCE_KEY: &str = "resources";

--- a/lib/value/src/kind.rs
+++ b/lib/value/src/kind.rs
@@ -9,11 +9,10 @@ mod debug;
 
 pub mod merge;
 
-pub use crud::*;
-
 use std::collections::BTreeMap;
 
 pub use collection::{Collection, Field, Index, Unknown};
+pub use crud::*;
 
 use crate::Value;
 

--- a/lib/value/src/kind/collection/field.rs
+++ b/lib/value/src/kind/collection/field.rs
@@ -1,5 +1,4 @@
-use crate::kind::collection::CollectionRemove;
-use crate::kind::Collection;
+use crate::kind::{collection::CollectionRemove, Collection};
 
 /// A `field` type that can be used in `Collection<Field>`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]

--- a/lib/value/src/kind/collection/index.rs
+++ b/lib/value/src/kind/collection/index.rs
@@ -1,5 +1,4 @@
-use crate::kind::collection::CollectionRemove;
-use crate::kind::Collection;
+use crate::kind::{collection::CollectionRemove, Collection};
 
 /// An `index` type that can be used in `Collection<Index>`
 #[derive(Debug, Clone, Default, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]

--- a/lib/value/src/kind/crud/get.rs
+++ b/lib/value/src/kind/crud/get.rs
@@ -1,8 +1,10 @@
 //! All types related to finding a [`Kind`] nested into another one.
 
-use crate::Kind;
-use lookup::lookup_v2::{BorrowedSegment, ValuePath};
 use std::borrow::Cow;
+
+use lookup::lookup_v2::{BorrowedSegment, ValuePath};
+
+use crate::Kind;
 
 impl Kind {
     /// Returns the type of a value that is retrieved from a certain path.
@@ -157,9 +159,12 @@ impl Kind {
 
 #[cfg(test)]
 mod tests {
-    use lookup::lookup_v2::{parse_value_path, OwnedValuePath};
-    use lookup::owned_value_path;
     use std::collections::BTreeMap;
+
+    use lookup::{
+        lookup_v2::{parse_value_path, OwnedValuePath},
+        owned_value_path,
+    };
 
     use super::*;
     use crate::kind::Collection;

--- a/lib/value/src/kind/crud/insert.rs
+++ b/lib/value/src/kind/crud/insert.rs
@@ -1,10 +1,11 @@
 //! All types related to inserting one [`Kind`] into another.
 
-use lookup::lookup_v2::{BorrowedSegment, ValuePath};
+use lookup::{
+    lookup_v2::{BorrowedSegment, ValuePath},
+    path,
+};
 
-use crate::kind::Collection;
-use crate::Kind;
-use lookup::path;
+use crate::{kind::Collection, Kind};
 
 impl Kind {
     /// Insert the `Kind` at the given `path` within `self`.
@@ -230,9 +231,12 @@ impl Kind {
 
 #[cfg(test)]
 mod tests {
-    use lookup::lookup_v2::{parse_value_path, OwnedValuePath};
-    use lookup::owned_value_path;
     use std::collections::BTreeMap;
+
+    use lookup::{
+        lookup_v2::{parse_value_path, OwnedValuePath},
+        owned_value_path,
+    };
 
     use super::*;
     use crate::kind::Collection;

--- a/lib/value/src/kind/crud/remove.rs
+++ b/lib/value/src/kind/crud/remove.rs
@@ -1,10 +1,14 @@
 //! All code related to removing from a [`Kind`].
 
-use crate::kind::collection::{CollectionRemove, EmptyState};
-use crate::kind::{Collection, Field};
-use crate::Kind;
-use lookup::lookup_v2::OwnedSegment;
-use lookup::OwnedValuePath;
+use lookup::{lookup_v2::OwnedSegment, OwnedValuePath};
+
+use crate::{
+    kind::{
+        collection::{CollectionRemove, EmptyState},
+        Collection, Field,
+    },
+    Kind,
+};
 
 impl Kind {
     /// Removes the `Kind` at the given `path` within `self`.
@@ -266,10 +270,11 @@ impl From<EmptyState> for CompactOptions {
 #[cfg(test)]
 #[allow(clippy::manual_assert)]
 mod test {
-    use super::*;
-    use lookup::lookup_v2::parse_value_path;
-    use lookup::owned_value_path;
     use std::collections::BTreeMap;
+
+    use lookup::{lookup_v2::parse_value_path, owned_value_path};
+
+    use super::*;
 
     #[test]
     #[allow(clippy::too_many_lines)]

--- a/lib/value/src/kind/debug.rs
+++ b/lib/value/src/kind/debug.rs
@@ -1,5 +1,6 @@
-use crate::{Kind, Value};
 use std::collections::BTreeMap;
+
+use crate::{Kind, Value};
 
 impl Kind {
     /// Returns a tree representation of `Kind`, in a more human readable format.

--- a/lib/value/src/kind/merge.rs
+++ b/lib/value/src/kind/merge.rs
@@ -1,9 +1,9 @@
 //! All types related to merging one [`Kind`] into another.
 
-use crate::kind::Field;
 use std::ops::BitOr;
 
 use super::{Collection, Kind};
+use crate::kind::Field;
 
 impl Kind {
     /// Merge `other` into `self`, using the provided `Strategy`.

--- a/lib/value/src/lib.rs
+++ b/lib/value/src/lib.rs
@@ -42,5 +42,7 @@ pub mod value;
 
 pub use kind::Kind;
 
-pub use self::secrets::Secrets;
-pub use self::value::{Value, ValueRegex};
+pub use self::{
+    secrets::Secrets,
+    value::{Value, ValueRegex},
+};

--- a/lib/value/src/secrets.rs
+++ b/lib/value/src/secrets.rs
@@ -1,8 +1,10 @@
 //! Contains the `Secrets` type.
 
-use std::collections::BTreeMap;
-use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
+use std::{
+    collections::BTreeMap,
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
 
 /// A container that holds secrets accessible from Vector / VRL.
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd)]

--- a/lib/value/src/value.rs
+++ b/lib/value/src/value.rs
@@ -26,12 +26,13 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-pub use crate::value::regex::ValueRegex;
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, SecondsFormat, Utc};
 pub use iter::IterItem;
 use lookup::lookup_v2::ValuePath;
 use ordered_float::NotNan;
+
+pub use crate::value::regex::ValueRegex;
 
 /// A boxed `std::error::Error`.
 pub type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -266,8 +267,7 @@ pub fn timestamp_to_string(timestamp: &DateTime<Utc>) -> String {
 
 #[cfg(test)]
 mod test {
-    use lookup::lookup_v2::BorrowedSegment;
-    use lookup::path;
+    use lookup::{lookup_v2::BorrowedSegment, path};
     use quickcheck::{QuickCheck, TestResult};
 
     use super::*;

--- a/lib/value/src/value/convert.rs
+++ b/lib/value/src/value/convert.rs
@@ -1,14 +1,11 @@
-use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use ordered_float::NotNan;
 use regex::Regex;
-use std::sync::Arc;
 
-use crate::value::regex::ValueRegex;
-use crate::{Kind, Value};
+use crate::{value::regex::ValueRegex, Kind, Value};
 
 impl Value {
     /// Returns self as `NotNan<f64>`, only if self is `Value::Float`.

--- a/lib/value/src/value/crud/get.rs
+++ b/lib/value/src/value/crud/get.rs
@@ -1,6 +1,9 @@
-use crate::value::crud::{get_matching_coalesce_key, ValueCollection};
-use crate::Value;
 use lookup::lookup_v2::BorrowedSegment;
+
+use crate::{
+    value::crud::{get_matching_coalesce_key, ValueCollection},
+    Value,
+};
 
 pub fn get<'a>(
     mut value: &Value,
@@ -38,8 +41,9 @@ pub fn get<'a>(
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_negative_index() {

--- a/lib/value/src/value/crud/get_mut.rs
+++ b/lib/value/src/value/crud/get_mut.rs
@@ -1,6 +1,9 @@
-use crate::value::crud::{get_matching_coalesce_key, ValueCollection};
-use crate::Value;
 use lookup::lookup_v2::BorrowedSegment;
+
+use crate::{
+    value::crud::{get_matching_coalesce_key, ValueCollection},
+    Value,
+};
 
 pub fn get_mut<'a>(
     mut value: &mut Value,
@@ -38,8 +41,9 @@ pub fn get_mut<'a>(
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_coalesce() {

--- a/lib/value/src/value/crud/insert.rs
+++ b/lib/value/src/value/crud/insert.rs
@@ -1,10 +1,11 @@
-use crate::value::crud::{
-    get_matching_coalesce_key, skip_remaining_coalesce_segments, ValueCollection,
-};
-use crate::Value;
+use std::{borrow::Borrow, collections::BTreeMap};
+
 use lookup::lookup_v2::BorrowedSegment;
-use std::borrow::Borrow;
-use std::collections::BTreeMap;
+
+use crate::{
+    value::crud::{get_matching_coalesce_key, skip_remaining_coalesce_segments, ValueCollection},
+    Value,
+};
 
 pub fn insert<'a, T: ValueCollection>(
     value: &mut T,
@@ -65,8 +66,9 @@ pub fn insert<'a, T: ValueCollection>(
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_insert_coalesce() {

--- a/lib/value/src/value/crud/mod.rs
+++ b/lib/value/src/value/crud/mod.rs
@@ -1,17 +1,18 @@
-use crate::Value;
+use std::{
+    borrow::{Borrow, Cow},
+    collections::BTreeMap,
+};
+
 use lookup::lookup_v2::BorrowedSegment;
-use std::borrow::{Borrow, Cow};
-use std::collections::BTreeMap;
+
+use crate::Value;
 
 mod get;
 mod get_mut;
 mod insert;
 mod remove;
 
-pub use self::get::get;
-pub use self::get_mut::get_mut;
-pub use self::insert::insert;
-pub use self::remove::remove;
+pub use self::{get::get, get_mut::get_mut, insert::insert, remove::remove};
 
 pub trait ValueCollection {
     type Key: Borrow<Self::BorrowedKey>;

--- a/lib/value/src/value/crud/remove.rs
+++ b/lib/value/src/value/crud/remove.rs
@@ -1,6 +1,9 @@
-use crate::value::crud::{get_matching_coalesce_key, ValueCollection};
-use crate::Value;
 use lookup::lookup_v2::BorrowedSegment;
+
+use crate::{
+    value::crud::{get_matching_coalesce_key, ValueCollection},
+    Value,
+};
 
 pub fn remove<'a, T: ValueCollection>(
     value: &mut T,
@@ -39,8 +42,9 @@ pub fn remove<'a, T: ValueCollection>(
 
 #[cfg(test)]
 mod test {
-    use crate::Value;
     use serde_json::json;
+
+    use crate::Value;
 
     #[test]
     fn remove_coalesce() {

--- a/lib/value/src/value/lua.rs
+++ b/lib/value/src/value/lua.rs
@@ -1,5 +1,4 @@
-use mlua::prelude::LuaResult;
-use mlua::{FromLua, Lua, ToLua, Value as LuaValue};
+use mlua::{prelude::LuaResult, FromLua, Lua, ToLua, Value as LuaValue};
 use ordered_float::NotNan;
 
 use crate::value::Value;

--- a/lib/value/src/value/regex.rs
+++ b/lib/value/src/value/regex.rs
@@ -1,11 +1,12 @@
-use bytes::Bytes;
-use regex::Regex;
-use std::cmp::Ordering;
-use std::sync::Arc;
 use std::{
+    cmp::Ordering,
     hash::{Hash, Hasher},
     ops::Deref,
+    sync::Arc,
 };
+
+use bytes::Bytes;
+use regex::Regex;
 
 /// Wraps a `Regex` and provides several trait implementations, such as `PartialOrd`
 #[derive(Debug, Clone)]

--- a/lib/value/src/value/serde.rs
+++ b/lib/value/src/value/serde.rs
@@ -2,9 +2,10 @@ use std::{borrow::Cow, collections::BTreeMap, fmt};
 
 use bytes::Bytes;
 use ordered_float::NotNan;
-use serde::de::Error as SerdeError;
-use serde::de::{MapAccess, SeqAccess, Visitor};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{
+    de::{Error as SerdeError, MapAccess, SeqAccess, Visitor},
+    Deserialize, Serialize, Serializer,
+};
 
 use crate::value::{timestamp_to_string, StdError, Value};
 
@@ -217,9 +218,7 @@ impl TryInto<serde_json::Value> for Value {
 
 #[cfg(test)]
 mod test {
-    use std::fs;
-    use std::io::Read;
-    use std::path::Path;
+    use std::{fs, io::Read, path::Path};
 
     use crate::value::Value;
 

--- a/lib/value/src/value/target.rs
+++ b/lib/value/src/value/target.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::iter::Peekable;
+use std::{collections::BTreeMap, iter::Peekable};
 
 use lookup::{FieldBuf, LookupBuf, SegmentBuf};
 

--- a/lib/vector-buffers/benches/common.rs
+++ b/lib/vector-buffers/benches/common.rs
@@ -13,8 +13,10 @@ use vector_buffers::{
     },
     BufferType, EventCount,
 };
-use vector_common::byte_size_of::ByteSizeOf;
-use vector_common::finalization::{AddBatchNotifier, BatchNotifier, EventFinalizers, Finalizable};
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalization::{AddBatchNotifier, BatchNotifier, EventFinalizers, Finalizable},
+};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Message<const N: usize> {

--- a/lib/vector-buffers/examples/buffer_perf.rs
+++ b/lib/vector-buffers/examples/buffer_perf.rs
@@ -23,9 +23,11 @@ use vector_buffers::{
     },
     BufferType, Bufferable, EventCount, WhenFull,
 };
-use vector_common::byte_size_of::ByteSizeOf;
-use vector_common::finalization::{
-    AddBatchNotifier, BatchNotifier, EventFinalizer, EventFinalizers, EventStatus, Finalizable,
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalization::{
+        AddBatchNotifier, BatchNotifier, EventFinalizer, EventFinalizers, EventStatus, Finalizable,
+    },
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -18,9 +18,8 @@ mod buffer_usage_data;
 pub mod config;
 pub use config::{BufferConfig, BufferType};
 use encoding::Encodable;
-use vector_config::configurable_component;
-
 pub(crate) use vector_common::Result;
+use vector_config::configurable_component;
 
 pub mod encoding;
 

--- a/lib/vector-buffers/src/test/messages.rs
+++ b/lib/vector-buffers/src/test/messages.rs
@@ -2,9 +2,9 @@ use std::{error, fmt, io, mem};
 
 use bytes::{Buf, BufMut};
 use quickcheck::{Arbitrary, Gen};
-use vector_common::byte_size_of::ByteSizeOf;
-use vector_common::finalization::{
-    AddBatchNotifier, BatchNotifier, EventFinalizer, EventFinalizers, Finalizable,
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalization::{AddBatchNotifier, BatchNotifier, EventFinalizer, EventFinalizers, Finalizable},
 };
 
 use crate::{encoding::FixedEncodable, EventCount};

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -258,8 +258,10 @@ mod tests {
 
     use super::TopologyBuilder;
     use crate::{
-        topology::builder::TopologyError,
-        topology::test_util::{assert_current_send_capacity, Sample},
+        topology::{
+            builder::TopologyError,
+            test_util::{assert_current_send_capacity, Sample},
+        },
         variants::MemoryBuffer,
         WhenFull,
     };

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -255,8 +255,8 @@ mod tests {
 
     use super::limited;
     use crate::{
-        test::MultiEventRecord, topology::channel::limited_queue::SendError,
-        topology::test_util::Sample,
+        test::MultiEventRecord,
+        topology::{channel::limited_queue::SendError, test_util::Sample},
     };
 
     #[tokio::test]

--- a/lib/vector-buffers/src/topology/test_util.rs
+++ b/lib/vector-buffers/src/topology/test_util.rs
@@ -1,8 +1,10 @@
 use std::{error, fmt, num::NonZeroUsize};
 
 use bytes::{Buf, BufMut};
-use vector_common::byte_size_of::ByteSizeOf;
-use vector_common::finalization::{AddBatchNotifier, BatchNotifier};
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalization::{AddBatchNotifier, BatchNotifier},
+};
 
 use super::builder::TopologyBuilder;
 use crate::{

--- a/lib/vector-buffers/src/variants/disk_v2/common.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/common.rs
@@ -436,11 +436,10 @@ where
 mod tests {
     use proptest::{prop_assert, proptest, test_runner::Config};
 
-    use crate::variants::disk_v2::common::MAX_ALIGNABLE_AMOUNT;
-
     use super::{
         align16, BuildError, DiskBufferConfigBuilder, MINIMUM_MAX_RECORD_SIZE, SERIALIZER_ALIGNMENT,
     };
+    use crate::variants::disk_v2::common::MAX_ALIGNABLE_AMOUNT;
 
     #[test]
     #[should_panic]

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -1,8 +1,10 @@
 use std::{
     fmt, io, mem,
     path::PathBuf,
-    sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
+        Arc,
+    },
     time::Instant,
 };
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/known_errors.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/known_errors.rs
@@ -10,8 +10,10 @@ use tokio::{
     io::{AsyncSeekExt, AsyncWriteExt},
 };
 use tracing::Instrument;
-use vector_common::byte_size_of::ByteSizeOf;
-use vector_common::finalization::{AddBatchNotifier, BatchNotifier};
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalization::{AddBatchNotifier, BatchNotifier},
+};
 
 use super::{create_buffer_v2_with_max_data_file_size, create_default_buffer_v2};
 use crate::{

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/action.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/action.rs
@@ -2,8 +2,7 @@ use proptest::{
     arbitrary::any,
     collection::{vec as arb_vec, SizeRange},
     prop_compose, prop_oneof,
-    strategy::Just,
-    strategy::Strategy,
+    strategy::{Just, Strategy},
 };
 
 use super::record::Record;

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/record.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/record.rs
@@ -1,9 +1,9 @@
 use std::{error, fmt, mem};
 
 use bytes::{Buf, BufMut};
-use vector_common::byte_size_of::ByteSizeOf;
-use vector_common::finalization::{
-    AddBatchNotifier, BatchNotifier, EventFinalizer, EventFinalizers,
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalization::{AddBatchNotifier, BatchNotifier, EventFinalizer, EventFinalizers},
 };
 
 use crate::{

--- a/lib/vector-common/src/estimated_json_encoded_size_of.rs
+++ b/lib/vector-common/src/estimated_json_encoded_size_of.rs
@@ -698,10 +698,11 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use super::*;
     use quickcheck::{Arbitrary, Gen, TestResult};
     use quickcheck_macros::quickcheck;
     use serde_json::json;
+
+    use super::*;
 
     #[derive(Serialize, Clone, Debug)]
     struct MyEvent {

--- a/lib/vector-common/src/event_test_util.rs
+++ b/lib/vector-common/src/event_test_util.rs
@@ -1,5 +1,4 @@
-use std::fmt::Write as _;
-use std::{cell::RefCell, collections::HashSet};
+use std::{cell::RefCell, collections::HashSet, fmt::Write as _};
 
 thread_local! {
     /// A buffer for recording internal events emitted by a single test.

--- a/lib/vector-common/src/finalizer.rs
+++ b/lib/vector-common/src/finalizer.rs
@@ -1,15 +1,27 @@
 #![allow(clippy::module_name_repetitions)]
 
-use std::marker::{PhantomData, Unpin};
-use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc, task::Context, task::Poll};
+use std::{
+    fmt::Debug,
+    future::Future,
+    marker::{PhantomData, Unpin},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
-use futures::stream::{BoxStream, FuturesOrdered, FuturesUnordered};
-use futures::{FutureExt, Stream, StreamExt};
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tokio::sync::Notify;
+use futures::{
+    stream::{BoxStream, FuturesOrdered, FuturesUnordered},
+    FutureExt, Stream, StreamExt,
+};
+use tokio::sync::{
+    mpsc::{self, UnboundedReceiver, UnboundedSender},
+    Notify,
+};
 
-use crate::finalization::{BatchStatus, BatchStatusReceiver};
-use crate::shutdown::ShutdownSignal;
+use crate::{
+    finalization::{BatchStatus, BatchStatusReceiver},
+    shutdown::ShutdownSignal,
+};
 
 /// The `OrderedFinalizer` framework produces a stream of acknowledged
 /// event batch identifiers from a source in a single background task

--- a/lib/vector-common/src/internal_event/component_events_dropped.rs
+++ b/lib/vector-common/src/internal_event/component_events_dropped.rs
@@ -1,5 +1,6 @@
-use super::{Count, InternalEvent, InternalEventHandle, RegisterInternalEvent};
 use metrics::{register_counter, Counter};
+
+use super::{Count, InternalEvent, InternalEventHandle, RegisterInternalEvent};
 
 pub const INTENTIONAL: bool = true;
 pub const UNINTENTIONAL: bool = false;

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -6,13 +6,12 @@ mod events_sent;
 mod prelude;
 pub mod service;
 
-pub use metrics::SharedString;
-
 pub use bytes_received::BytesReceived;
 pub use bytes_sent::BytesSent;
 pub use component_events_dropped::{ComponentEventsDropped, INTENTIONAL, UNINTENTIONAL};
 pub use events_received::EventsReceived;
 pub use events_sent::{EventsSent, DEFAULT_OUTPUT};
+pub use metrics::SharedString;
 pub use prelude::{error_stage, error_type};
 pub use service::{CallError, PollReadyError};
 

--- a/lib/vector-config-macros/src/component_name.rs
+++ b/lib/vector-config-macros/src/component_name.rs
@@ -1,6 +1,5 @@
 use darling::util::path_to_string;
 use proc_macro::TokenStream;
-
 use quote::quote;
 use syn::{parse_macro_input, spanned::Spanned, Attribute, DeriveInput, Error, LitStr};
 

--- a/lib/vector-config/src/component/mod.rs
+++ b/lib/vector-config/src/component/mod.rs
@@ -2,11 +2,13 @@ mod description;
 mod generate;
 mod marker;
 
-pub use self::description::{ComponentDescription, ExampleError};
-pub use self::generate::GenerateConfig;
-pub use self::marker::{
-    ComponentMarker, EnrichmentTableComponent, ProviderComponent, SecretsComponent, SinkComponent,
-    SourceComponent, TransformComponent,
+pub use self::{
+    description::{ComponentDescription, ExampleError},
+    generate::GenerateConfig,
+    marker::{
+        ComponentMarker, EnrichmentTableComponent, ProviderComponent, SecretsComponent,
+        SinkComponent, SourceComponent, TransformComponent,
+    },
 };
 
 // Create some type aliases for the component marker/description types, and collect (register,

--- a/lib/vector-config/src/lib.rs
+++ b/lib/vector-config/src/lib.rs
@@ -151,12 +151,11 @@ pub mod schema;
 pub mod ser;
 mod stdlib;
 mod str;
-pub use self::str::ConfigurableString;
-
 use vector_config_common::attributes::CustomAttribute;
-
 // Re-export of the `#[configurable_component]` and `#[derive(Configurable)]` proc macros.
 pub use vector_config_macros::*;
+
+pub use self::str::ConfigurableString;
 
 // Re-export of both `Format` and `Validation` from `vector_config_common`.
 //

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -4,8 +4,7 @@ use snafu::{ResultExt, Snafu};
 use vector_common::TimeZone;
 use vector_config::configurable_component;
 
-use super::super::default_data_dir;
-use super::{proxy::ProxyConfig, AcknowledgementsConfig, LogSchema};
+use super::{super::default_data_dir, proxy::ProxyConfig, AcknowledgementsConfig, LogSchema};
 use crate::serde::bool_or_struct;
 
 #[derive(Debug, Snafu)]

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -6,17 +6,15 @@ mod global_options;
 mod log_schema;
 pub mod proxy;
 
-use crate::event::LogEvent;
 pub use global_options::GlobalOptions;
 pub use log_schema::{init_log_schema, log_schema, LogSchema};
-use lookup::lookup_v2::ValuePath;
-use lookup::{path, PathPrefix};
+use lookup::{lookup_v2::ValuePath, path, PathPrefix};
 use serde::{Deserialize, Serialize};
 use value::Value;
 pub use vector_common::config::ComponentKey;
 use vector_config::configurable_component;
 
-use crate::schema;
+use crate::{event::LogEvent, schema};
 
 pub const MEMORY_BUFFER_DEFAULT_MAX_EVENTS: NonZeroUsize =
     vector_buffers::config::memory_buffer_default_max_events();

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -1,5 +1,3 @@
-use bytes::Bytes;
-use chrono::Utc;
 use std::{
     collections::{BTreeMap, HashMap},
     convert::{TryFrom, TryInto},
@@ -10,9 +8,10 @@ use std::{
     sync::Arc,
 };
 
+use bytes::Bytes;
+use chrono::Utc;
 use crossbeam_utils::atomic::AtomicCell;
-use lookup::lookup_v2::TargetPath;
-use lookup::PathPrefix;
+use lookup::{lookup_v2::TargetPath, path, PathPrefix};
 use serde::{Deserialize, Serialize, Serializer};
 use vector_common::{
     estimated_json_encoded_size_of::{EstimatedJsonEncodedSizeOf, JsonEncodedByteCountingValue},
@@ -24,10 +23,11 @@ use super::{
     metadata::EventMetadata,
     util, EventFinalizers, Finalizable, Value,
 };
-use crate::config::log_schema;
-use crate::config::LogNamespace;
-use crate::{event::MaybeAsLogMut, ByteSizeOf};
-use lookup::path;
+use crate::{
+    config::{log_schema, LogNamespace},
+    event::MaybeAsLogMut,
+    ByteSizeOf,
+};
 
 #[derive(Debug, Deserialize)]
 struct Inner {
@@ -598,10 +598,11 @@ impl tracing::field::Visit for LogEvent {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::test_util::open_fixture;
     use lookup::event_path;
     use vrl_lib::value;
+
+    use super::*;
+    use crate::test_util::open_fixture;
 
     // The following two tests assert that renaming a key has no effect if the
     // keys are equivalent, whether the key exists in the log or not.

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -1,15 +1,13 @@
 #![deny(missing_docs)]
 
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 use value::{Kind, Secrets, Value};
 use vector_common::EventDataEq;
 
 use super::{BatchNotifier, EventFinalizer, EventFinalizers, EventStatus};
-use crate::config::LogNamespace;
-use crate::{schema, ByteSizeOf};
+use crate::{config::LogNamespace, schema, ByteSizeOf};
 
 const DATADOG_API_KEY: &str = "datadog_api_key";
 const SPLUNK_HEC_TOKEN: &str = "splunk_hec_token";

--- a/lib/vector-core/src/event/metric/arbitrary.rs
+++ b/lib/vector-core/src/event/metric/arbitrary.rs
@@ -1,10 +1,9 @@
 use proptest::{collection::btree_set, prelude::*};
 
-use crate::metrics::AgentDDSketch;
-
 use super::{
     samples_to_buckets, Bucket, MetricSketch, MetricValue, Quantile, Sample, StatisticKind,
 };
+use crate::metrics::AgentDDSketch;
 
 fn realistic_float() -> proptest::num::f64::Any {
     proptest::num::f64::POSITIVE | proptest::num::f64::NEGATIVE | proptest::num::f64::ZERO

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -4,7 +4,6 @@ use std::{
     fmt::Debug,
 };
 
-use crate::ByteSizeOf;
 pub use ::value::Value;
 pub use array::{into_event_stream, EventArray, EventContainer, LogArray, MetricArray, TraceArray};
 pub use finalization::{
@@ -21,6 +20,8 @@ use vector_buffers::EventCount;
 use vector_common::{finalization, EventDataEq};
 #[cfg(feature = "vrl")]
 pub use vrl_target::{TargetEvents, VrlTarget};
+
+use crate::ByteSizeOf;
 
 pub mod array;
 pub mod discriminant;

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -10,10 +10,9 @@ use crate::{
 mod proto_event {
     include!(concat!(env!("OUT_DIR"), "/event.rs"));
 }
-pub use proto_event::*;
-
 pub use event_wrapper::Event;
 pub use metric::Value as MetricValue;
+pub use proto_event::*;
 
 use super::{array, metric::MetricSketch};
 

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -1,7 +1,6 @@
 use std::{collections::BTreeMap, convert::TryFrom, marker::PhantomData};
 
-use lookup::lookup_v2::OwnedSegment;
-use lookup::{OwnedTargetPath, OwnedValuePath, PathPrefix};
+use lookup::{lookup_v2::OwnedSegment, OwnedTargetPath, OwnedValuePath, PathPrefix};
 use snafu::Snafu;
 use vrl_lib::{prelude::VrlValueConvert, ProgramInfo, SecretTarget};
 
@@ -555,8 +554,7 @@ mod test {
     use vector_common::btreemap;
     use vrl_lib::Target;
 
-    use super::super::MetricValue;
-    use super::*;
+    use super::{super::MetricValue, *};
     use crate::metric_tags;
 
     #[test]

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -411,8 +411,7 @@ impl Sender {
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
-    use std::num::NonZeroUsize;
+    use std::{mem, num::NonZeroUsize};
 
     use futures::poll;
     use tokio::sync::mpsc::UnboundedSender;
@@ -427,9 +426,11 @@ mod tests {
     };
 
     use super::{ControlMessage, Fanout};
-    use crate::event::{Event, EventArray, LogEvent};
-    use crate::test_util::{collect_ready, collect_ready_events};
-    use crate::{config::ComponentKey, event::EventContainer};
+    use crate::{
+        config::ComponentKey,
+        event::{Event, EventArray, EventContainer, LogEvent},
+        test_util::{collect_ready, collect_ready_events},
+    };
 
     async fn build_sender_pair(
         capacity: usize,

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -49,10 +49,6 @@ mod vrl;
 use std::path::PathBuf;
 
 use float_eq::FloatEq;
-
-#[cfg(feature = "vrl")]
-pub use vrl::compile_vrl;
-
 pub use vector_buffers as buffers;
 #[cfg(any(test, feature = "test"))]
 pub use vector_common::event_test_util;
@@ -60,6 +56,8 @@ pub use vector_common::{
     byte_size_of::ByteSizeOf, estimated_json_encoded_size_of::EstimatedJsonEncodedSizeOf,
     internal_event,
 };
+#[cfg(feature = "vrl")]
+pub use vrl::compile_vrl;
 
 #[macro_use]
 extern crate tracing;

--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -14,7 +14,10 @@ use once_cell::sync::OnceCell;
 use snafu::Snafu;
 
 pub use self::ddsketch::{AgentDDSketch, BinMap, Config};
-use self::{label_filter::VectorLabelFilter, recorder::Registry, recorder::VectorRecorder};
+use self::{
+    label_filter::VectorLabelFilter,
+    recorder::{Registry, VectorRecorder},
+};
 use crate::event::{Metric, MetricValue};
 
 type Result<T> = std::result::Result<T, Error>;
@@ -247,7 +250,6 @@ macro_rules! update_counter {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::event::MetricKind;
 
     const IDLE_TIMEOUT: f64 = 0.5;

--- a/lib/vector-core/src/metrics/recency.rs
+++ b/lib/vector-core/src/metrics/recency.rs
@@ -47,10 +47,14 @@
 //! observed, to build a complete picture that allows deciding if a given metric has gone "idle" or
 //! not, and thus whether it should actually be deleted.
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use metrics::{Counter, CounterFn, Gauge, GaugeFn, HistogramFn};
 use metrics_util::{

--- a/lib/vector-core/src/metrics/recorder.rs
+++ b/lib/vector-core/src/metrics/recorder.rs
@@ -1,5 +1,7 @@
-use std::sync::{atomic::Ordering, Arc, RwLock};
-use std::time::Duration;
+use std::{
+    sync::{atomic::Ordering, Arc, RwLock},
+    time::Duration,
+};
 
 use chrono::Utc;
 use metrics::{Counter, Gauge, Histogram, Key, KeyName, Recorder, SharedString, Unit};
@@ -7,8 +9,10 @@ use metrics_util::{registry::Registry as MetricsRegistry, MetricKindMask};
 use once_cell::unsync::OnceCell;
 use quanta::Clock;
 
-use super::recency::{GenerationalStorage, Recency};
-use super::storage::VectorStorage;
+use super::{
+    recency::{GenerationalStorage, Recency},
+    storage::VectorStorage,
+};
 use crate::event::{Metric, MetricValue};
 
 thread_local!(static LOCAL_REGISTRY: OnceCell<Registry> = OnceCell::new());

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::config::{log_schema, LegacyKey, LogNamespace};
-use lookup::lookup_v2::parse_value_path;
-use lookup::{owned_value_path, LookupBuf, OwnedValuePath};
+use lookup::{lookup_v2::parse_value_path, owned_value_path, LookupBuf, OwnedValuePath};
 use value::{kind::Collection, Kind};
+
+use crate::config::{log_schema, LegacyKey, LogNamespace};
 
 /// The definition of a schema.
 ///
@@ -428,8 +428,9 @@ impl Definition {
 
 #[cfg(test)]
 mod tests {
-    use lookup::owned_value_path;
     use std::collections::{BTreeMap, HashMap};
+
+    use lookup::owned_value_path;
 
     use super::*;
 

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -225,8 +225,9 @@ impl std::error::Error for ValidationError {}
 
 #[cfg(test)]
 mod tests {
-    use lookup::owned_value_path;
     use std::collections::HashMap;
+
+    use lookup::owned_value_path;
 
     use super::*;
 

--- a/lib/vector-core/src/sink.rs
+++ b/lib/vector-core/src/sink.rs
@@ -1,7 +1,11 @@
 use std::{fmt, iter::IntoIterator, pin::Pin};
 
 use async_trait::async_trait;
-use futures::{stream, task::Context, task::Poll, Sink, SinkExt, Stream, StreamExt};
+use futures::{
+    stream,
+    task::{Context, Poll},
+    Sink, SinkExt, Stream, StreamExt,
+};
 
 use crate::event::{into_event_stream, Event, EventArray, EventContainer};
 

--- a/lib/vector-core/src/stream/driver.rs
+++ b/lib/vector-core/src/stream/driver.rs
@@ -4,8 +4,10 @@ use futures::{poll, FutureExt, Stream, StreamExt, TryFutureExt};
 use tokio::{pin, select};
 use tower::Service;
 use tracing::Instrument;
-use vector_common::internal_event::{BytesSent, CallError, CountByteSize, PollReadyError};
-use vector_common::request_metadata::{MetaDescriptive, RequestMetadata};
+use vector_common::{
+    internal_event::{BytesSent, CallError, CountByteSize, PollReadyError},
+    request_metadata::{MetaDescriptive, RequestMetadata},
+};
 
 use super::FuturesUnorderedCount;
 use crate::{
@@ -220,7 +222,10 @@ mod tests {
     use std::{
         future::Future,
         pin::Pin,
-        sync::{atomic::AtomicUsize, atomic::Ordering, Arc},
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
         task::{ready, Context, Poll},
         time::Duration,
     };
@@ -236,9 +241,9 @@ mod tests {
     use tower::Service;
     use vector_common::{
         finalization::{BatchNotifier, EventFinalizer, EventFinalizers, EventStatus, Finalizable},
-        request_metadata::RequestMetadata,
+        internal_event::CountByteSize,
+        request_metadata::{MetaDescriptive, RequestMetadata},
     };
-    use vector_common::{internal_event::CountByteSize, request_metadata::MetaDescriptive};
 
     use super::{Driver, DriverResponse};
 

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -8,13 +8,15 @@ use std::{
 };
 
 use futures::{future::BoxFuture, stream, FutureExt, Stream};
-use openssl::ssl::{Ssl, SslAcceptor, SslMethod};
-use openssl::x509::X509;
+use openssl::{
+    ssl::{Ssl, SslAcceptor, SslMethod},
+    x509::X509,
+};
 use snafu::ResultExt;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::{
     io::{self, AsyncRead, AsyncWrite, ReadBuf},
     net::{TcpListener, TcpStream},
+    sync::{OwnedSemaphorePermit, Semaphore},
 };
 use tokio_openssl::SslStream;
 use tonic::transport::{server::Connected, Certificate};

--- a/lib/vector-core/src/tls/mod.rs
+++ b/lib/vector-core/src/tls/mod.rs
@@ -1,13 +1,12 @@
 #![allow(clippy::missing_errors_doc)]
 
-use std::{fmt::Debug, net::SocketAddr, path::PathBuf, time::Duration};
+use std::{fmt::Debug, net::SocketAddr, num::TryFromIntError, path::PathBuf, time::Duration};
 
 use openssl::{
     error::ErrorStack,
     ssl::{ConnectConfiguration, SslConnector, SslConnectorBuilder, SslMethod},
 };
 use snafu::{ResultExt, Snafu};
-use std::num::TryFromIntError;
 use tokio::net::TcpStream;
 use tokio_openssl::SslStream;
 

--- a/lib/vector-core/src/vrl.rs
+++ b/lib/vector-core/src/vrl.rs
@@ -1,6 +1,7 @@
 use lookup::{owned_value_path, OwnedTargetPath};
-use vrl_lib::state::TypeState;
-use vrl_lib::{diagnostic::DiagnosticList, CompilationResult, CompileConfig, Function};
+use vrl_lib::{
+    diagnostic::DiagnosticList, state::TypeState, CompilationResult, CompileConfig, Function,
+};
 
 /// Compiles a VRL program
 /// Vector metadata is set to read-only to prevent it from being mutated

--- a/lib/vector-vrl-functions/src/get_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/get_metadata_field.rs
@@ -1,7 +1,7 @@
-use crate::{get_metadata_key, MetadataKey};
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
+
+use crate::{get_metadata_key, MetadataKey};
 
 fn get_metadata_field(
     ctx: &mut Context,

--- a/lib/vector-vrl-functions/src/get_secret.rs
+++ b/lib/vector-vrl-functions/src/get_secret.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn get_secret(ctx: &mut Context, key: Value) -> std::result::Result<Value, ExpressionError> {
     let key_bytes = key.as_bytes().expect("argument must be a string");

--- a/lib/vector-vrl-functions/src/remove_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/remove_metadata_field.rs
@@ -1,7 +1,7 @@
-use crate::{get_metadata_key, MetadataKey};
 use ::value::Value;
-use vrl::prelude::state::TypeState;
-use vrl::prelude::*;
+use vrl::prelude::{state::TypeState, *};
+
+use crate::{get_metadata_key, MetadataKey};
 
 fn remove_metadata_field(
     ctx: &mut Context,

--- a/lib/vector-vrl-functions/src/remove_secret.rs
+++ b/lib/vector-vrl-functions/src/remove_secret.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn remove_secret(ctx: &mut Context, key: Value) -> std::result::Result<Value, ExpressionError> {
     let key_bytes = key.as_bytes().expect("argument must be a string");

--- a/lib/vector-vrl-functions/src/set_metadata_field.rs
+++ b/lib/vector-vrl-functions/src/set_metadata_field.rs
@@ -1,7 +1,7 @@
-use crate::{get_metadata_key, MetadataKey};
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
+
+use crate::{get_metadata_key, MetadataKey};
 
 fn set_metadata_field(
     ctx: &mut Context,

--- a/lib/vector-vrl-functions/src/set_secret.rs
+++ b/lib/vector-vrl-functions/src/set_secret.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn set_secret(
     ctx: &mut Context,

--- a/lib/vector-vrl-functions/src/set_semantic_meaning.rs
+++ b/lib/vector-vrl-functions/src/set_semantic_meaning.rs
@@ -2,8 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use ::value::Value;
 use lookup::OwnedValuePath;
-use vrl::state::TypeState;
-use vrl::{diagnostic::Label, prelude::*};
+use vrl::{diagnostic::Label, prelude::*, state::TypeState};
 
 #[derive(Debug, Default, Clone)]
 pub struct MeaningList(pub BTreeMap<String, OwnedValuePath>);

--- a/lib/vrl/cli/src/cmd.rs
+++ b/lib/vrl/cli/src/cmd.rs
@@ -12,9 +12,10 @@ use clap::Parser;
 use lookup::{owned_value_path, OwnedTargetPath};
 use value::Secrets;
 use vector_common::TimeZone;
-use vrl::state::TypeState;
-use vrl::{diagnostic::Formatter, state, Program, Runtime, Target, VrlRuntime};
-use vrl::{CompilationResult, CompileConfig};
+use vrl::{
+    diagnostic::Formatter, state, state::TypeState, CompilationResult, CompileConfig, Program,
+    Runtime, Target, VrlRuntime,
+};
 
 #[cfg(feature = "repl")]
 use super::repl;

--- a/lib/vrl/cli/src/repl.rs
+++ b/lib/vrl/cli/src/repl.rs
@@ -18,9 +18,9 @@ use rustyline::{
 use value::Secrets;
 use vector_common::TimeZone;
 use vector_vrl_functions::vrl_functions;
-use vrl::state::TypeState;
 use vrl::{
-    diagnostic::Formatter, prelude::BTreeMap, state, CompileConfig, Runtime, Target, VrlRuntime,
+    diagnostic::Formatter, prelude::BTreeMap, state, state::TypeState, CompileConfig, Runtime,
+    Target, VrlRuntime,
 };
 
 // Create a list of all possible error values for potential docs lookup

--- a/lib/vrl/compiler/src/compile_config.rs
+++ b/lib/vrl/compiler/src/compile_config.rs
@@ -1,6 +1,7 @@
+use std::collections::BTreeSet;
+
 use anymap::AnyMap;
 use lookup::OwnedTargetPath;
-use std::collections::BTreeSet;
 
 pub struct CompileConfig {
     /// Custom context injected by the external environment

--- a/lib/vrl/compiler/src/compiler.rs
+++ b/lib/vrl/compiler/src/compiler.rs
@@ -1,19 +1,20 @@
 use core::Value;
+
 use diagnostic::{DiagnosticList, DiagnosticMessage, Note, Severity, Span};
 use lookup::{OwnedTargetPath, OwnedValuePath, PathPrefix};
 use parser::ast::{self, Node, QueryTarget};
 
-use crate::function::ArgumentList;
-use crate::state::TypeState;
-use crate::value::VrlValueConvert;
 use crate::{
     expression::{
         assignment, function_call, literal, predicate, query, Abort, Array, Assignment, Block,
         Container, Error, Expr, Expression, FunctionArgument, FunctionCall, Group, IfStatement,
         Literal, Noop, Not, Object, Op, Predicate, Query, Target, Unary, Variable,
     },
+    function::ArgumentList,
     parser::ast::RootExpr,
     program::ProgramInfo,
+    state::TypeState,
+    value::VrlValueConvert,
     CompileConfig, DeprecationWarning, Function, Program, TypeDef,
 };
 

--- a/lib/vrl/compiler/src/deprecation_warning.rs
+++ b/lib/vrl/compiler/src/deprecation_warning.rs
@@ -1,6 +1,8 @@
-use crate::Span;
-use diagnostic::{DiagnosticMessage, Label, Note, Severity};
 use std::fmt::{Display, Formatter};
+
+use diagnostic::{DiagnosticMessage, Label, Note, Severity};
+
+use crate::Span;
 
 #[derive(Debug)]
 pub struct DeprecationWarning {

--- a/lib/vrl/compiler/src/expression.rs
+++ b/lib/vrl/compiler/src/expression.rs
@@ -41,7 +41,6 @@ pub mod query;
 
 pub use core::{ExpressionError, Resolved};
 
-use crate::state::{TypeInfo, TypeState};
 #[cfg(feature = "expr-abort")]
 pub use abort::Abort;
 pub use array::Array;
@@ -72,6 +71,8 @@ pub use query::{Query, Target};
 #[cfg(feature = "expr-unary")]
 pub use unary::Unary;
 pub use variable::Variable;
+
+use crate::state::{TypeInfo, TypeState};
 
 pub trait Expression: Send + Sync + fmt::Debug + DynClone {
     /// Resolve an expression to a concrete [`Value`].

--- a/lib/vrl/compiler/src/expression/assignment.rs
+++ b/lib/vrl/compiler/src/expression/assignment.rs
@@ -1,8 +1,7 @@
 use std::{convert::TryFrom, fmt};
 
 use diagnostic::{DiagnosticMessage, Label, Note};
-use lookup::lookup_v2::OwnedTargetPath;
-use lookup::{LookupBuf, OwnedValuePath, PathPrefix, SegmentBuf};
+use lookup::{lookup_v2::OwnedTargetPath, LookupBuf, OwnedValuePath, PathPrefix, SegmentBuf};
 use value::{Kind, Value};
 
 use crate::{

--- a/lib/vrl/compiler/src/expression/block.rs
+++ b/lib/vrl/compiler/src/expression/block.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::state::{TypeInfo, TypeState};
 use crate::{
     expression::{Expr, Resolved},
+    state::{TypeInfo, TypeState},
     Context, Expression, TypeDef,
 };
 

--- a/lib/vrl/compiler/src/expression/function.rs
+++ b/lib/vrl/compiler/src/expression/function.rs
@@ -1,10 +1,13 @@
-use crate::state::{TypeInfo, TypeState};
-use crate::{Context, Expression, TypeDef};
 use core::Resolved;
+use std::{fmt, fmt::Debug};
+
 use dyn_clone::DynClone;
-use std::fmt;
-use std::fmt::Debug;
 use value::Value;
+
+use crate::{
+    state::{TypeInfo, TypeState},
+    Context, Expression, TypeDef,
+};
 
 /// A trait similar to `Expression`, but simplified specifically for functions.
 /// The main difference is this trait prevents mutation of variables both at runtime

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -1,8 +1,8 @@
-use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 use std::{fmt, sync::Arc};
 
+use diagnostic::{DiagnosticMessage, Label, Note, Urls};
+
 use super::Block;
-use crate::state::{TypeInfo, TypeState};
 use crate::{
     expression::{levenstein, ExpressionError, FunctionArgument},
     function::{
@@ -10,7 +10,7 @@ use crate::{
         ArgumentList, Example, FunctionClosure, FunctionCompileContext, Parameter,
     },
     parser::{Ident, Node},
-    state::LocalEnv,
+    state::{LocalEnv, TypeInfo, TypeState},
     type_def::Details,
     value::Kind,
     CompileConfig, Context, Expression, Function, Resolved, Span, TypeDef,

--- a/lib/vrl/compiler/src/expression/group.rs
+++ b/lib/vrl/compiler/src/expression/group.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::state::{TypeInfo, TypeState};
 use crate::{
     expression::{Expr, Resolved},
+    state::{TypeInfo, TypeState},
     Context, Expression,
 };
 

--- a/lib/vrl/compiler/src/expression/if_statement.rs
+++ b/lib/vrl/compiler/src/expression/if_statement.rs
@@ -2,9 +2,9 @@ use std::fmt;
 
 use value::Value;
 
-use crate::state::{TypeInfo, TypeState};
 use crate::{
     expression::{Block, Predicate, Resolved},
+    state::{TypeInfo, TypeState},
     value::VrlValueConvert,
     Context, Expression,
 };

--- a/lib/vrl/compiler/src/expression/noop.rs
+++ b/lib/vrl/compiler/src/expression/noop.rs
@@ -2,8 +2,11 @@ use std::fmt;
 
 use value::Value;
 
-use crate::state::{TypeInfo, TypeState};
-use crate::{expression::Resolved, Context, Expression, TypeDef};
+use crate::{
+    expression::Resolved,
+    state::{TypeInfo, TypeState},
+    Context, Expression, TypeDef,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Noop;

--- a/lib/vrl/compiler/src/expression/not.rs
+++ b/lib/vrl/compiler/src/expression/not.rs
@@ -2,10 +2,10 @@ use std::fmt;
 
 use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
-use crate::state::{TypeInfo, TypeState};
 use crate::{
     expression::{Expr, Resolved},
     parser::Node,
+    state::{TypeInfo, TypeState},
     value::{Kind, VrlValueConvert},
     Context, Expression, Span, TypeDef,
 };

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use diagnostic::{DiagnosticMessage, Label, Note, Span, Urls};
 use value::Value;
 
-use crate::state::{TypeInfo, TypeState};
 use crate::{
     expression::{self, Expr, Resolved},
     parser::{ast, Node},
+    state::{TypeInfo, TypeState},
     value::VrlValueArithmetic,
     Context, Expression, TypeDef,
 };

--- a/lib/vrl/compiler/src/expression/predicate.rs
+++ b/lib/vrl/compiler/src/expression/predicate.rs
@@ -2,9 +2,8 @@ use std::fmt;
 
 use diagnostic::{DiagnosticMessage, Label, Note, Urls};
 
-use crate::expression::Block;
 use crate::{
-    expression::{Expr, Resolved},
+    expression::{Block, Expr, Resolved},
     parser::Node,
     state::{TypeInfo, TypeState},
     value::Kind,

--- a/lib/vrl/compiler/src/expression/query.rs
+++ b/lib/vrl/compiler/src/expression/query.rs
@@ -1,14 +1,15 @@
+use std::fmt;
+
+use lookup::{OwnedTargetPath, OwnedValuePath, PathPrefix};
+use value::Value;
+
 use crate::{
     expression::{Container, Resolved, Variable},
     parser::ast::Ident,
-    state::ExternalEnv,
-    state::{TypeInfo, TypeState},
+    state::{ExternalEnv, TypeInfo, TypeState},
     type_def::Details,
     Context, Expression,
 };
-use lookup::{OwnedTargetPath, OwnedValuePath, PathPrefix};
-use std::fmt;
-use value::Value;
 
 #[derive(Clone, PartialEq)]
 pub struct Query {

--- a/lib/vrl/compiler/src/expression/variable.rs
+++ b/lib/vrl/compiler/src/expression/variable.rs
@@ -1,12 +1,12 @@
-use diagnostic::{DiagnosticMessage, Label};
 use std::fmt;
+
+use diagnostic::{DiagnosticMessage, Label};
 use value::Value;
 
-use crate::state::{TypeInfo, TypeState};
 use crate::{
     expression::{levenstein, Resolved},
     parser::ast::Ident,
-    state::LocalEnv,
+    state::{LocalEnv, TypeInfo, TypeState},
     Context, Expression, Span, TypeDef,
 };
 

--- a/lib/vrl/compiler/src/function.rs
+++ b/lib/vrl/compiler/src/function.rs
@@ -1,12 +1,13 @@
 pub mod closure;
 
-use diagnostic::{DiagnosticMessage, Label, Note};
-use lookup::OwnedTargetPath;
-use parser::ast::Ident;
 use std::{
     collections::{BTreeMap, HashMap},
     fmt,
 };
+
+use diagnostic::{DiagnosticMessage, Label, Note};
+use lookup::OwnedTargetPath;
+use parser::ast::Ident;
 use value::{kind::Collection, Value};
 
 use crate::{
@@ -433,8 +434,7 @@ fn required<T>(argument: Option<T>) -> T {
 #[cfg(any(test, feature = "test"))]
 mod test_impls {
     use super::*;
-    use crate::expression::FunctionArgument;
-    use crate::parser::Node;
+    use crate::{expression::FunctionArgument, parser::Node};
 
     impl From<HashMap<&'static str, Value>> for ArgumentList {
         fn from(map: HashMap<&'static str, Value>) -> Self {

--- a/lib/vrl/compiler/src/lib.rs
+++ b/lib/vrl/compiler/src/lib.rs
@@ -41,16 +41,15 @@ pub mod state;
 pub mod type_def;
 pub mod value;
 
-pub use self::compile_config::CompileConfig;
-pub use self::deprecation_warning::DeprecationWarning;
-pub use compiler::{CompilationResult, Compiler};
 pub use core::{
     value, ExpressionError, Resolved, SecretTarget, Target, TargetValue, TargetValueRef,
 };
+use std::{
+    fmt::{Debug, Display},
+    str::FromStr,
+};
 
-use std::fmt::Debug;
-use std::{fmt::Display, str::FromStr};
-
+pub use compiler::{CompilationResult, Compiler};
 pub use context::Context;
 use diagnostic::DiagnosticList;
 pub(crate) use diagnostic::Span;
@@ -61,6 +60,8 @@ pub use program::{Program, ProgramInfo};
 pub use state::{TypeInfo, TypeState};
 pub use type_def::TypeDef;
 use vector_config::configurable_component;
+
+pub use self::{compile_config::CompileConfig, deprecation_warning::DeprecationWarning};
 
 pub type Result<T = CompilationResult> = std::result::Result<T, DiagnosticList>;
 

--- a/lib/vrl/compiler/src/program.rs
+++ b/lib/vrl/compiler/src/program.rs
@@ -1,8 +1,8 @@
 use lookup::OwnedTargetPath;
 
-use crate::state::TypeState;
 use crate::{
     expression::{Block, Resolved},
+    state::TypeState,
     Context, Expression,
 };
 

--- a/lib/vrl/compiler/src/state.rs
+++ b/lib/vrl/compiler/src/state.rs
@@ -1,5 +1,6 @@
-use lookup::PathPrefix;
 use std::collections::{hash_map::Entry, HashMap};
+
+use lookup::PathPrefix;
 use value::{Kind, Value};
 
 use crate::{parser::ast::Ident, type_def::Details, value::Collection, TypeDef};

--- a/lib/vrl/core/src/target.rs
+++ b/lib/vrl/core/src/target.rs
@@ -1,7 +1,6 @@
 use std::convert::AsRef;
 
-use lookup::lookup_v2::OwnedTargetPath;
-use lookup::PathPrefix;
+use lookup::{lookup_v2::OwnedTargetPath, PathPrefix};
 use value::{Secrets, Value};
 
 /// Any target object you want to remap using VRL has to implement this trait.
@@ -214,8 +213,9 @@ impl SecretTarget for Secrets {
 
 #[cfg(any(test, feature = "test"))]
 mod value_target_impl {
-    use super::{SecretTarget, Target, Value};
     use lookup::{OwnedTargetPath, PathPrefix};
+
+    use super::{SecretTarget, Target, Value};
 
     impl Target for Value {
         fn target_insert(

--- a/lib/vrl/proptests/src/main.rs
+++ b/lib/vrl/proptests/src/main.rs
@@ -3,8 +3,7 @@
 #![allow(clippy::print_stderr)] // test framework
 #![allow(clippy::print_stdout)] // test framework
 use diagnostic::Span;
-use lookup::lookup_v2::OwnedSegment;
-use lookup::{FieldBuf, LookupBuf, OwnedValuePath, SegmentBuf};
+use lookup::{lookup_v2::OwnedSegment, FieldBuf, LookupBuf, OwnedValuePath, SegmentBuf};
 use ordered_float::NotNan;
 use parser::ast::{
     Assignment, AssignmentOp, AssignmentTarget, Block, Container, Expr, FunctionArgument,

--- a/lib/vrl/stdlib/src/append.rs
+++ b/lib/vrl/stdlib/src/append.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn append(value: Value, items: Value) -> Resolved {
     let mut value = value.try_array()?;

--- a/lib/vrl/stdlib/src/array.rs
+++ b/lib/vrl/stdlib/src/array.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn array(value: Value) -> Resolved {
     match value {

--- a/lib/vrl/stdlib/src/assert.rs
+++ b/lib/vrl/stdlib/src/assert.rs
@@ -1,6 +1,8 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::{diagnostic::Note, prelude::*};
+use vrl::{
+    diagnostic::Note,
+    prelude::{expression::FunctionExpression, *},
+};
 
 fn assert(condition: Value, message: Option<Value>, format: Option<String>) -> Resolved {
     match condition.try_boolean()? {

--- a/lib/vrl/stdlib/src/assert_eq.rs
+++ b/lib/vrl/stdlib/src/assert_eq.rs
@@ -1,6 +1,8 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::{diagnostic::Note, prelude::*};
+use vrl::{
+    diagnostic::Note,
+    prelude::{expression::FunctionExpression, *},
+};
 
 fn assert_eq(left: Value, right: Value, message: Option<Value>) -> Resolved {
     if left == right {

--- a/lib/vrl/stdlib/src/boolean.rs
+++ b/lib/vrl/stdlib/src/boolean.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn boolean(value: Value) -> Resolved {
     match value {

--- a/lib/vrl/stdlib/src/ceil.rs
+++ b/lib/vrl/stdlib/src/ceil.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 use crate::util::round_to_precision;
 

--- a/lib/vrl/stdlib/src/chunks.rs
+++ b/lib/vrl/stdlib/src/chunks.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn chunks(value: Value, chunk_size: Value) -> Resolved {
     let bytes = value.try_bytes()?;

--- a/lib/vrl/stdlib/src/compact.rs
+++ b/lib/vrl/stdlib/src/compact.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 use crate::util;
 

--- a/lib/vrl/stdlib/src/contains.rs
+++ b/lib/vrl/stdlib/src/contains.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn contains(value: Value, substring: Value, case_sensitive: bool) -> Resolved {
     let substring = {

--- a/lib/vrl/stdlib/src/decode_base64.rs
+++ b/lib/vrl/stdlib/src/decode_base64.rs
@@ -1,8 +1,7 @@
 use std::str::FromStr;
 
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 use crate::util::Base64Charset;
 

--- a/lib/vrl/stdlib/src/decode_mime_q.rs
+++ b/lib/vrl/stdlib/src/decode_mime_q.rs
@@ -10,8 +10,7 @@ use nom::{
     sequence::{delimited, pair, separated_pair},
     IResult,
 };
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 #[derive(Clone, Copy, Debug)]
 pub struct DecodeMimeQ;
@@ -191,8 +190,9 @@ impl<'a> EncodedWord<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use nom::error::VerboseError;
+
+    use super::*;
 
     #[test]
     fn internal() {

--- a/lib/vrl/stdlib/src/decode_percent.rs
+++ b/lib/vrl/stdlib/src/decode_percent.rs
@@ -1,7 +1,6 @@
 use ::value::Value;
 use percent_encoding::percent_decode;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn decode_percent(value: Value) -> Resolved {
     let value = value.try_bytes()?;

--- a/lib/vrl/stdlib/src/decrypt.rs
+++ b/lib/vrl/stdlib/src/decrypt.rs
@@ -7,8 +7,7 @@ use aes::cipher::{
 use cfb_mode::Decryptor as Cfb;
 use ctr::Ctr64LE;
 use ofb::Ofb;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 use crate::encrypt::{get_iv_bytes, get_key_bytes, is_valid_algorithm};
 

--- a/lib/vrl/stdlib/src/del.rs
+++ b/lib/vrl/stdlib/src/del.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeInfo;
+use vrl::{prelude::*, state::TypeInfo};
 
 #[inline]
 fn del(query: &expression::Query, compact: bool, ctx: &mut Context) -> Resolved {

--- a/lib/vrl/stdlib/src/downcase.rs
+++ b/lib/vrl/stdlib/src/downcase.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn downcase(value: Value) -> Resolved {
     Ok(value.try_bytes_utf8_lossy()?.to_lowercase().into())

--- a/lib/vrl/stdlib/src/encode_base64.rs
+++ b/lib/vrl/stdlib/src/encode_base64.rs
@@ -1,8 +1,7 @@
 use std::str::FromStr;
 
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 use crate::util::Base64Charset;
 

--- a/lib/vrl/stdlib/src/encode_json.rs
+++ b/lib/vrl/stdlib/src/encode_json.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn encode_json(value: Value) -> Resolved {
     // With `vrl::Value` it should not be possible to get `Err`.

--- a/lib/vrl/stdlib/src/encode_key_value.rs
+++ b/lib/vrl/stdlib/src/encode_key_value.rs
@@ -2,8 +2,7 @@ use std::result::Result;
 
 use ::value::Value;
 use vector_common::encode_key_value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 /// Also used by `encode_logfmt`.
 pub(crate) fn encode_key_value(

--- a/lib/vrl/stdlib/src/encode_logfmt.rs
+++ b/lib/vrl/stdlib/src/encode_logfmt.rs
@@ -1,5 +1,4 @@
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 use crate::encode_key_value::EncodeKeyValueFn;
 

--- a/lib/vrl/stdlib/src/encode_percent.rs
+++ b/lib/vrl/stdlib/src/encode_percent.rs
@@ -1,7 +1,6 @@
 use ::value::Value;
 use percent_encoding::{utf8_percent_encode, AsciiSet};
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn encode_percent(value: Value, ascii_set: &Bytes) -> Resolved {
     let string = value.try_bytes_utf8_lossy()?;

--- a/lib/vrl/stdlib/src/encrypt.rs
+++ b/lib/vrl/stdlib/src/encrypt.rs
@@ -7,8 +7,7 @@ use aes::cipher::{
 use cfb_mode::Encryptor as Cfb;
 use ctr::Ctr64LE;
 use ofb::Ofb;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 type Aes128Cbc = cbc::Encryptor<aes::Aes128>;
 type Aes192Cbc = cbc::Encryptor<aes::Aes192>;

--- a/lib/vrl/stdlib/src/ends_with.rs
+++ b/lib/vrl/stdlib/src/ends_with.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 fn ends_with(value: Value, substring: Value, case_sensitive: bool) -> Resolved {
     let substring = {

--- a/lib/vrl/stdlib/src/exists.rs
+++ b/lib/vrl/stdlib/src/exists.rs
@@ -1,5 +1,4 @@
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::*;
+use vrl::prelude::{expression::FunctionExpression, *};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Exists;

--- a/lib/vrl/stdlib/src/is_ipv4.rs
+++ b/lib/vrl/stdlib/src/is_ipv4.rs
@@ -1,8 +1,7 @@
 use std::net::Ipv4Addr;
 
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn is_ipv4(value: Value) -> Resolved {
     let value_str = value.try_bytes_utf8_lossy()?;

--- a/lib/vrl/stdlib/src/is_ipv6.rs
+++ b/lib/vrl/stdlib/src/is_ipv6.rs
@@ -1,8 +1,7 @@
 use std::net::Ipv6Addr;
 
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn is_ipv6(value: Value) -> Resolved {
     let value_str = value.try_bytes_utf8_lossy()?;

--- a/lib/vrl/stdlib/src/keys.rs
+++ b/lib/vrl/stdlib/src/keys.rs
@@ -1,12 +1,10 @@
 use ::value::Value;
-use vrl::function::ArgumentList;
-use vrl::function::Compiled;
-use vrl::function::Example;
-use vrl::function::FunctionCompileContext;
-use vrl::prelude::*;
-use vrl::state::TypeState;
-use vrl::Expression;
-use vrl::Function;
+use vrl::{
+    function::{ArgumentList, Compiled, Example, FunctionCompileContext},
+    prelude::*,
+    state::TypeState,
+    Expression, Function,
+};
 
 fn keys(value: Value) -> Resolved {
     let object = value.try_object()?;

--- a/lib/vrl/stdlib/src/parse_grok.rs
+++ b/lib/vrl/stdlib/src/parse_grok.rs
@@ -1,10 +1,10 @@
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use ::value::Value;
-use vrl::state::TypeState;
 use vrl::{
     diagnostic::{Label, Span},
     prelude::*,
+    state::TypeState,
 };
 
 fn parse_grok(value: Value, pattern: Arc<grok::Pattern>) -> Resolved {

--- a/lib/vrl/stdlib/src/parse_groks.rs
+++ b/lib/vrl/stdlib/src/parse_groks.rs
@@ -1,8 +1,9 @@
+use std::{collections::BTreeMap, fmt};
+
 use datadog_grok::{
     parse_grok,
     parse_grok_rules::{self, GrokRule},
 };
-use std::{collections::BTreeMap, fmt};
 use vrl::{
     diagnostic::{Label, Span},
     prelude::*,

--- a/lib/vrl/stdlib/src/type_def.rs
+++ b/lib/vrl/stdlib/src/type_def.rs
@@ -1,7 +1,8 @@
 use ::value::Value;
-use vrl::prelude::expression::FunctionExpression;
-use vrl::prelude::{TypeDef as VrlTypeDef, *};
-use vrl::state::TypeState;
+use vrl::{
+    prelude::{expression::FunctionExpression, TypeDef as VrlTypeDef, *},
+    state::TypeState,
+};
 
 fn type_def(type_def: &VrlTypeDef) -> Value {
     let mut tree = type_def.kind().canonicalize().debug_info();

--- a/lib/vrl/stdlib/src/upcase.rs
+++ b/lib/vrl/stdlib/src/upcase.rs
@@ -1,6 +1,5 @@
 use ::value::Value;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn upcase(value: Value) -> Resolved {
     Ok(value.try_bytes_utf8_lossy()?.to_uppercase().into())

--- a/lib/vrl/stdlib/src/uuid_v4.rs
+++ b/lib/vrl/stdlib/src/uuid_v4.rs
@@ -1,7 +1,6 @@
 use ::value::Value;
 use bytes::Bytes;
-use vrl::prelude::*;
-use vrl::state::TypeState;
+use vrl::{prelude::*, state::TypeState};
 
 fn uuid_v4() -> Value {
     let mut buf = [0; 36];

--- a/lib/vrl/stdlib/src/values.rs
+++ b/lib/vrl/stdlib/src/values.rs
@@ -1,12 +1,10 @@
 use ::value::Value;
-use vrl::function::ArgumentList;
-use vrl::function::Compiled;
-use vrl::function::Example;
-use vrl::function::FunctionCompileContext;
-use vrl::prelude::*;
-use vrl::state::TypeState;
-use vrl::Expression;
-use vrl::Function;
+use vrl::{
+    function::{ArgumentList, Compiled, Example, FunctionCompileContext},
+    prelude::*,
+    state::TypeState,
+    Expression, Function,
+};
 
 fn values(value: Value) -> Resolved {
     let object = value.try_object()?;

--- a/lib/vrl/tests/src/test.rs
+++ b/lib/vrl/tests/src/test.rs
@@ -1,8 +1,7 @@
 use std::{collections::BTreeMap, fs, path::Path};
 
 use ::value::Value;
-use lookup::lookup_v2::parse_value_path;
-use lookup::OwnedTargetPath;
+use lookup::{lookup_v2::parse_value_path, OwnedTargetPath};
 use vrl::function::Example;
 
 #[derive(Debug)]

--- a/lib/vrl/vrl/src/lib.rs
+++ b/lib/vrl/vrl/src/lib.rs
@@ -11,15 +11,15 @@ pub mod prelude;
 mod runtime;
 
 pub use compiler::{
-    function, state, value, CompilationResult, CompileConfig, Compiler, Context, Expression,
-    Function, Program, ProgramInfo, SecretTarget, Target, TargetValue, TargetValueRef, VrlRuntime,
+    expression::query, function, state, value, CompilationResult, CompileConfig, Compiler, Context,
+    Expression, Function, Program, ProgramInfo, SecretTarget, Target, TargetValue, TargetValueRef,
+    VrlRuntime,
 };
 pub use diagnostic;
 pub use runtime::{Runtime, RuntimeResult, Terminate};
 pub use vector_common::TimeZone;
 
 use crate::state::TypeState;
-pub use compiler::expression::query;
 
 /// Compile a given source into the final [`Program`].
 pub fn compile(source: &str, fns: &[Box<dyn Function>]) -> compiler::Result {

--- a/lib/vrl/web-playground/src/lib.rs
+++ b/lib/vrl/web-playground/src/lib.rs
@@ -2,10 +2,12 @@ use ::value::Value;
 use gloo_utils::format::JsValueSerdeExt;
 use serde::{Deserialize, Serialize};
 use value::Secrets;
-use vrl::diagnostic::DiagnosticList;
-use vrl::state::TypeState;
-use vrl::{diagnostic::Formatter, prelude::BTreeMap, CompileConfig, Runtime};
-use vrl::{TargetValue, TimeZone};
+use vrl::{
+    diagnostic::{DiagnosticList, Formatter},
+    prelude::BTreeMap,
+    state::TypeState,
+    CompileConfig, Runtime, TargetValue, TimeZone,
+};
 use wasm_bindgen::prelude::*;
 
 #[derive(Serialize, Deserialize)]

--- a/scripts/check-fmt.sh
+++ b/scripts/check-fmt.sh
@@ -10,4 +10,4 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -x
 
-cargo fmt -- --check
+cargo +nightly fmt -- --check

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -4,6 +4,7 @@ set -e -o verbose
 git config --global --add safe.directory /git/vectordotdev/vector
 
 rustup show # causes installation of version from rust-toolchain.toml
+rustup toolchain install nightly
 rustup default "$(rustup show active-toolchain | awk '{print $1;}')"
 if [[ "$(cargo-deb --version)" != "1.29.2" ]] ; then
   rustup run stable cargo install cargo-deb --version 1.29.2 --force --locked

--- a/src/api/schema/components/mod.rs
+++ b/src/api/schema/components/mod.rs
@@ -20,10 +20,10 @@ use crate::{
         filter::{self, filter_items},
         relay, sort,
     },
-    config::{ComponentKey, Config, TransformConfig},
+    config::{ComponentKey, Config, SourceConfig, TransformConfig},
     filter_check,
+    topology::schema::merged_definition,
 };
-use crate::{config::SourceConfig, topology::schema::merged_definition};
 
 #[derive(Debug, Clone, Interface)]
 #[graphql(

--- a/src/api/tap.rs
+++ b/src/api/tap.rs
@@ -422,15 +422,18 @@ mod tests {
     use tokio::sync::watch;
 
     use super::*;
-    use crate::api::schema::events::output::OutputEventsPayload;
-    use crate::api::schema::events::{create_events_stream, log, metric};
-    use crate::config::{Config, OutputId};
-    use crate::event::{LogEvent, Metric, MetricKind, MetricValue};
-    use crate::sinks::blackhole::BlackholeConfig;
-    use crate::sources::demo_logs::{DemoLogsConfig, OutputFormat};
-    use crate::test_util::{start_topology, trace_init};
-    use crate::transforms::log_to_metric::{LogToMetricConfig, MetricConfig, MetricTypeConfig};
-    use crate::transforms::remap::RemapConfig;
+    use crate::{
+        api::schema::events::{create_events_stream, log, metric, output::OutputEventsPayload},
+        config::{Config, OutputId},
+        event::{LogEvent, Metric, MetricKind, MetricValue},
+        sinks::blackhole::BlackholeConfig,
+        sources::demo_logs::{DemoLogsConfig, OutputFormat},
+        test_util::{start_topology, trace_init},
+        transforms::{
+            log_to_metric::{LogToMetricConfig, MetricConfig, MetricTypeConfig},
+            remap::RemapConfig,
+        },
+    };
 
     #[test]
     /// Patterns should accept globbing.

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1,18 +1,23 @@
-use futures::SinkExt;
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use tokio::sync::watch;
 
 use super::*;
-use crate::api::schema::events::notification::{EventNotification, EventNotificationType};
-use crate::api::schema::events::output::OutputEventsPayload;
-use crate::api::schema::events::{create_events_stream, log, metric};
-use crate::config::Config;
-use crate::event::{Metric, MetricKind, MetricValue};
-use crate::sinks::blackhole::BlackholeConfig;
-use crate::sources::demo_logs::{DemoLogsConfig, OutputFormat};
-use crate::test_util::start_topology;
-use crate::transforms::log_to_metric::{GaugeConfig, LogToMetricConfig, MetricConfig};
-use crate::transforms::remap::RemapConfig;
+use crate::{
+    api::schema::events::{
+        create_events_stream, log, metric,
+        notification::{EventNotification, EventNotificationType},
+        output::OutputEventsPayload,
+    },
+    config::Config,
+    event::{Metric, MetricKind, MetricValue},
+    sinks::blackhole::BlackholeConfig,
+    sources::demo_logs::{DemoLogsConfig, OutputFormat},
+    test_util::start_topology,
+    transforms::{
+        log_to_metric::{GaugeConfig, LogToMetricConfig, MetricConfig},
+        remap::RemapConfig,
+    },
+};
 
 #[test]
 /// Patterns should accept globbing.

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,12 +34,12 @@ use crate::{tap, top};
 
 pub static WORKER_THREADS: OnceNonZeroUsize = OnceNonZeroUsize::new();
 
+use tokio::sync::broadcast::error::RecvError;
+
 use crate::internal_events::{
     VectorConfigLoadError, VectorQuit, VectorRecoveryError, VectorReloadError, VectorReloaded,
     VectorStarted, VectorStopped,
 };
-
-use tokio::sync::broadcast::error::RecvError;
 
 pub struct ApplicationConfig {
     pub config_paths: Vec<config::ConfigPath>,

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -121,8 +121,9 @@ async fn default_credentials_provider(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde::{Deserialize, Serialize};
+
+    use super::*;
 
     #[derive(Serialize, Deserialize, Clone, Debug)]
     struct ComponentConfig {

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -1,39 +1,53 @@
 pub mod auth;
 pub mod region;
 
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::{Duration, SystemTime};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::{Duration, SystemTime},
+};
 
 pub use auth::AwsAuthentication;
 use aws_config::meta::region::ProvideRegion;
-use aws_sigv4::http_request::{SignableRequest, SigningSettings};
-use aws_sigv4::SigningParams;
+use aws_sigv4::{
+    http_request::{SignableRequest, SigningSettings},
+    SigningParams,
+};
 use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
-use aws_smithy_client::bounds::SmithyMiddleware;
-use aws_smithy_client::erase::{DynConnector, DynMiddleware};
-use aws_smithy_client::{Builder, SdkError};
-use aws_smithy_http::callback::BodyCallback;
-use aws_smithy_http::endpoint::Endpoint;
-use aws_smithy_http::event_stream::BoxError;
-use aws_smithy_http::operation::{Request, Response};
+use aws_smithy_client::{
+    bounds::SmithyMiddleware,
+    erase::{DynConnector, DynMiddleware},
+    Builder, SdkError,
+};
+use aws_smithy_http::{
+    callback::BodyCallback,
+    endpoint::Endpoint,
+    event_stream::BoxError,
+    operation::{Request, Response},
+};
 use aws_smithy_types::retry::RetryConfig;
-use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
-use aws_types::region::Region;
-use aws_types::SdkConfig;
+use aws_types::{
+    credentials::{ProvideCredentials, SharedCredentialsProvider},
+    region::Region,
+    SdkConfig,
+};
 use bytes::Bytes;
 use once_cell::sync::OnceCell;
 use regex::RegexSet;
 pub use region::RegionOrEndpoint;
 use tower::{Layer, Service, ServiceBuilder};
 
-use crate::config::ProxyConfig;
-use crate::http::{build_proxy_connector, build_tls_connector};
-use crate::internal_events::AwsBytesSent;
-use crate::tls::{MaybeTlsSettings, TlsConfig};
+use crate::{
+    config::ProxyConfig,
+    http::{build_proxy_connector, build_tls_connector},
+    internal_events::AwsBytesSent,
+    tls::{MaybeTlsSettings, TlsConfig},
+};
 
 static RETRIABLE_CODES: OnceCell<RegexSet> = OnceCell::new();
 

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -95,7 +95,6 @@ impl tokio_util::codec::Decoder for Decoder {
 
 #[cfg(test)]
 mod tests {
-    use super::Decoder;
     use bytes::Bytes;
     use codecs::{
         decoding::{Deserializer, Framer},
@@ -104,6 +103,8 @@ mod tests {
     use futures::{stream, StreamExt};
     use tokio_util::{codec::FramedRead, io::StreamReader};
     use value::Value;
+
+    use super::Decoder;
 
     #[tokio::test]
     async fn framed_read_recover_from_error() {

--- a/src/codecs/encoding/config.rs
+++ b/src/codecs/encoding/config.rs
@@ -1,9 +1,10 @@
-use crate::codecs::Transformer;
 use codecs::{
     encoding::{Framer, FramingConfig, Serializer, SerializerConfig},
     CharacterDelimitedEncoder, LengthDelimitedEncoder, NewlineDelimitedEncoder,
 };
 use vector_config::configurable_component;
+
+use crate::codecs::Transformer;
 
 /// Encoding configuration.
 #[configurable_component]

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -202,11 +202,12 @@ pub enum TimestampFormat {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use indoc::indoc;
     use vector_core::config::log_schema;
 
     use super::*;
-    use std::collections::BTreeMap;
 
     #[test]
     fn serialize() {

--- a/src/codecs/ready_frames.rs
+++ b/src/codecs/ready_frames.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 
 use futures::{
     task::{Context, Poll},
-    {Stream, StreamExt},
+    Stream, StreamExt,
 };
 
 const DEFAULT_CAPACITY: usize = 1024;

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -6,8 +6,7 @@ use datadog_filter::{
     regex::{wildcard_regex, word_regex},
     Filter, Matcher, Resolver, Run,
 };
-use datadog_search_syntax::parse;
-use datadog_search_syntax::{Comparison, ComparisonValue, Field};
+use datadog_search_syntax::{parse, Comparison, ComparisonValue, Field};
 use vector_config::configurable_component;
 use vector_core::event::{Event, LogEvent, Value};
 

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -4,11 +4,10 @@ use vector_config::configurable_component;
 use vector_core::compile_vrl;
 use vrl::{diagnostic::Formatter, CompilationResult, CompileConfig, Program, Runtime, VrlRuntime};
 
-use crate::event::TargetEvents;
 use crate::{
     conditions::{Condition, Conditional, ConditionalConfig},
     emit,
-    event::{Event, VrlTarget},
+    event::{Event, TargetEvents, VrlTarget},
     internal_events::VrlConditionExecutionError,
 };
 

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -8,11 +8,6 @@ use serde_json::Value;
 use vector_config::configurable_component;
 use vector_core::config::GlobalOptions;
 
-use crate::{
-    enrichment_tables::EnrichmentTables, providers::Providers, secrets::SecretBackends,
-    sinks::Sinks, sources::Sources, transforms::Transforms,
-};
-
 #[cfg(feature = "api")]
 use super::api;
 #[cfg(feature = "enterprise")]
@@ -20,6 +15,10 @@ use super::enterprise;
 use super::{
     compiler, schema, ComponentKey, Config, EnrichmentTableOuter, HealthcheckOptions, SinkOuter,
     SourceOuter, TestDefinition, TransformOuter,
+};
+use crate::{
+    enrichment_tables::EnrichmentTables, providers::Providers, secrets::SecretBackends,
+    sinks::Sinks, sources::Sources, transforms::Transforms,
 };
 
 /// A complete Vector configuration.
@@ -403,12 +402,11 @@ impl ConfigBuilder {
 mod tests {
     use indexmap::IndexMap;
 
+    use super::ConfigBuilderHash;
     use crate::config::{
         builder::{sort_json_value, to_sorted_json_string},
         enterprise, ConfigBuilder,
     };
-
-    use super::ConfigBuilderHash;
 
     #[test]
     /// If this test fails, it likely means an implementation detail has changed

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -4,8 +4,7 @@ use clap::Parser;
 use serde_json::Value;
 
 use super::{load_builder_from_paths, load_source_from_paths, process_paths, ConfigBuilder};
-use crate::cli::handle_config_errors;
-use crate::config;
+use crate::{cli::handle_config_errors, config};
 
 #[derive(Parser, Debug, Clone)]
 #[command(rename_all = "kebab-case")]
@@ -202,12 +201,11 @@ mod tests {
     use serde_json::json;
     use vector_config::component::{SinkDescription, SourceDescription, TransformDescription};
 
+    use super::merge_json;
     use crate::{
         config::{cmd::serialize_to_json, vars, ConfigBuilder},
         generate::{generate_example, TransformInputsStrategy},
     };
-
-    use super::merge_json;
 
     #[test]
     fn test_array_override() {

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -14,6 +14,7 @@ use tokio::{
     time::{sleep, Duration},
 };
 use url::{ParseError, Url};
+use vector_config::configurable_component;
 use vector_core::config::proxy::ProxyConfig;
 
 use super::{
@@ -35,7 +36,6 @@ use crate::{
     },
     transforms::{filter::FilterConfig, remap::RemapConfig},
 };
-use vector_config::configurable_component;
 
 static HOST_METRICS_KEY: &str = "_datadog_host_metrics";
 static TAG_METRICS_KEY: &str = "_datadog_tag_metrics";
@@ -818,8 +818,7 @@ mod test {
     use value::Kind;
     use vector_common::btreemap;
     use vector_core::config::proxy::ProxyConfig;
-    use vrl::prelude::Collection;
-    use vrl::CompileConfig;
+    use vrl::{prelude::Collection, CompileConfig};
     use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 
     use super::{

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -1,5 +1,6 @@
-use indexmap::{set::IndexSet, IndexMap};
 use std::collections::{HashMap, HashSet, VecDeque};
+
+use indexmap::{set::IndexSet, IndexMap};
 
 use super::{
     schema, ComponentKey, DataType, Output, OutputId, SinkConfig, SinkOuter, SourceConfig,

--- a/src/config/loading/config_builder.rs
+++ b/src/config/loading/config_builder.rs
@@ -3,8 +3,7 @@ use std::{collections::HashMap, io::Read};
 use indexmap::IndexMap;
 use toml::value::Table;
 
-use super::{deserialize_table, loader, prepare_input, secret};
-use super::{ComponentHint, Process};
+use super::{deserialize_table, loader, prepare_input, secret, ComponentHint, Process};
 use crate::config::{
     ComponentKey, ConfigBuilder, EnrichmentTableOuter, SinkOuter, SourceOuter, TestDefinition,
     TransformOuter,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -570,10 +570,10 @@ pub struct TestOutput<T = OutputId> {
 mod tests {
     use std::{collections::HashMap, path::PathBuf};
 
-    use crate::{config, topology};
     use indoc::indoc;
 
     use super::{builder::ConfigBuilder, format, load_from_str, ComponentKey, ConfigDiff, Format};
+    use crate::{config, topology};
 
     async fn load(config: &str, format: config::Format) -> Result<Vec<String>, Vec<String>> {
         match config::load_from_str(config, format) {
@@ -1431,10 +1431,11 @@ mod resource_tests {
     #[allow(clippy::print_stdout)]
     #[allow(clippy::print_stderr)]
     fn generate_component_config_schema() {
-        use crate::config::{SinkOuter, SourceOuter, TransformOuter};
         use indexmap::IndexMap;
         use vector_common::config::ComponentKey;
         use vector_config::configurable_component;
+
+        use crate::config::{SinkOuter, SourceOuter, TransformOuter};
 
         /// Top-level Vector configuration.
         #[configurable_component]

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -11,9 +11,8 @@ use vector_core::{
     transform::Transform,
 };
 
-use crate::transforms::Transforms;
-
 use super::{id::Inputs, ComponentKey};
+use crate::transforms::Transforms;
 
 /// Fully resolved transform component.
 #[configurable_component]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,14 +1,14 @@
-use crate::config::schema;
-use crate::topology::schema::merged_definition;
+use std::{collections::HashMap, path::PathBuf};
+
 use futures_util::{stream, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use heim::{disk::Partition, units::information::byte};
 use indexmap::IndexMap;
-use std::{collections::HashMap, path::PathBuf};
 use vector_core::internal_event::DEFAULT_OUTPUT;
 
 use super::{
     builder::ConfigBuilder, ComponentKey, Config, OutputId, Resource, SourceConfig, TransformConfig,
 };
+use crate::{config::schema, topology::schema::merged_definition};
 
 /// Check that provide + topology config aren't present in the same builder, which is an error.
 pub fn check_provider(config: &ConfigBuilder) -> Result<(), Vec<String>> {

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,5 +1,7 @@
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 pub use goauth::scopes::Scope;
 use goauth::{
@@ -16,7 +18,10 @@ use tokio::{sync::watch, time::Instant};
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 
-use crate::{config::ProxyConfig, http::HttpClient, http::HttpError};
+use crate::{
+    config::ProxyConfig,
+    http::{HttpClient, HttpError},
+};
 
 const SERVICE_ACCOUNT_TOKEN_URL: &str =
     "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,4 @@
-use std::fmt::Write as _;
-use std::path::PathBuf;
+use std::{fmt::Write as _, path::PathBuf};
 
 use clap::Parser;
 

--- a/src/internal_events/amqp.rs
+++ b/src/internal_events/amqp.rs
@@ -91,12 +91,13 @@ pub mod source {
 
 #[cfg(feature = "sinks-amqp")]
 pub mod sink {
-    use crate::emit;
     use metrics::counter;
     use vector_common::internal_event::{
         error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
     };
     use vector_core::internal_event::InternalEvent;
+
+    use crate::emit;
 
     #[derive(Debug)]
     pub struct AmqpDeliveryError<'a> {

--- a/src/internal_events/apache_metrics.rs
+++ b/src/internal_events/apache_metrics.rs
@@ -1,5 +1,4 @@
 use metrics::counter;
-
 use vector_common::internal_event::{error_stage, error_type};
 use vector_core::internal_event::InternalEvent;
 

--- a/src/internal_events/aws_ec2_metadata.rs
+++ b/src/internal_events/aws_ec2_metadata.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct AwsEc2MetadataRefreshSuccessful;

--- a/src/internal_events/aws_kinesis_streams.rs
+++ b/src/internal_events/aws_kinesis_streams.rs
@@ -1,9 +1,10 @@
-use crate::emit;
 use metrics::counter;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
 use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct AwsKinesisStreamNoPartitionKeyError<'a> {

--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -1,10 +1,9 @@
 use metrics::counter;
 #[cfg(feature = "sources-aws_s3")]
 pub use s3::*;
-use vector_core::internal_event::InternalEvent;
-
 #[cfg(any(feature = "sources-aws_s3", feature = "sources-aws_sqs"))]
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[cfg(feature = "sources-aws_s3")]
 mod s3 {

--- a/src/internal_events/batch.rs
+++ b/src/internal_events/batch.rs
@@ -1,10 +1,10 @@
-use crate::emit;
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct LargeEventDroppedError {

--- a/src/internal_events/codecs.rs
+++ b/src/internal_events/codecs.rs
@@ -1,10 +1,10 @@
-use crate::emit;
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct DecoderFramingError<E> {

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -1,13 +1,13 @@
 use std::time::Instant;
 
-use crate::emit;
 use metrics::{counter, histogram};
-pub use vector_core::internal_event::EventsReceived;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+pub use vector_core::internal_event::EventsReceived;
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct EndpointBytesReceived<'a> {

--- a/src/internal_events/conditions.rs
+++ b/src/internal_events/conditions.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug, Copy, Clone)]
 pub struct VrlConditionExecutionError<'a> {

--- a/src/internal_events/datadog_metrics.rs
+++ b/src/internal_events/datadog_metrics.rs
@@ -1,10 +1,10 @@
-use crate::emit;
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct DatadogMetricsEncodingError {

--- a/src/internal_events/datadog_traces.rs
+++ b/src/internal_events/datadog_traces.rs
@@ -1,10 +1,10 @@
-use crate::emit;
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct DatadogTracesEncodingError {

--- a/src/internal_events/dedupe.rs
+++ b/src/internal_events/dedupe.rs
@@ -1,6 +1,7 @@
-use crate::emit;
 use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct DedupeEventsDropped {

--- a/src/internal_events/dnstap.rs
+++ b/src/internal_events/dnstap.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub(crate) struct DnstapParseError<E> {

--- a/src/internal_events/eventstoredb_metrics.rs
+++ b/src/internal_events/eventstoredb_metrics.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct EventStoreDbMetricsHttpError {

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use crate::emit;
 use metrics::{counter, histogram};
 use tokio::time::error::Elapsed;
 use vector_common::internal_event::{
@@ -9,6 +8,7 @@ use vector_common::internal_event::{
 use vector_core::internal_event::InternalEvent;
 
 use super::prelude::io_error_code;
+use crate::emit;
 
 #[derive(Debug)]
 pub struct ExecEventsReceived<'a> {

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -1,12 +1,12 @@
-use metrics::{counter, gauge};
 use std::borrow::Cow;
-use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, UNINTENTIONAL};
 
-use crate::emit;
+use metrics::{counter, gauge};
+use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, UNINTENTIONAL};
 
 #[cfg(any(feature = "sources-file", feature = "sources-kubernetes_logs"))]
 pub use self::source::*;
-use vector_common::internal_event::{error_stage, error_type};
+use crate::emit;
 
 #[derive(Debug)]
 pub struct FileOpen {
@@ -83,10 +83,10 @@ mod source {
 
     use file_source::FileSourceInternalEvents;
     use metrics::counter;
+    use vector_common::internal_event::{error_stage, error_type};
 
     use super::{FileOpen, InternalEvent};
     use crate::emit;
-    use vector_common::internal_event::{error_stage, error_type};
 
     #[derive(Debug)]
     pub struct FileBytesReceived<'a> {

--- a/src/internal_events/filter.rs
+++ b/src/internal_events/filter.rs
@@ -1,9 +1,10 @@
-use crate::register;
 use metrics::{register_counter, Counter};
 use vector_common::internal_event::{
     ComponentEventsDropped, Count, InternalEventHandle, RegisterInternalEvent, Registered,
     INTENTIONAL,
 };
+
+use crate::register;
 
 #[derive(Debug)]
 pub struct FilterEventsDropped;

--- a/src/internal_events/fluent.rs
+++ b/src/internal_events/fluent.rs
@@ -1,8 +1,8 @@
 use metrics::counter;
+use vector_common::internal_event::{error_stage, error_type};
 use vector_core::internal_event::InternalEvent;
 
 use crate::sources::fluent::DecodeError;
-use vector_common::internal_event::{error_stage, error_type};
 
 #[derive(Debug)]
 pub struct FluentMessageReceived {

--- a/src/internal_events/gcp_pubsub.rs
+++ b/src/internal_events/gcp_pubsub.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 pub struct GcpPubsubConnectError {
     pub error: tonic::transport::Error,

--- a/src/internal_events/host_metrics.rs
+++ b/src/internal_events/host_metrics.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct HostMetricsScrapeError {

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
 use metrics::{counter, histogram};
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct HttpBytesReceived<'a> {

--- a/src/internal_events/http_client.rs
+++ b/src/internal_events/http_client.rs
@@ -6,9 +6,8 @@ use http::{
 };
 use hyper::{body::HttpBody, Error};
 use metrics::{counter, histogram};
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct AboutToSendHttpRequest<'a, T> {

--- a/src/internal_events/influxdb.rs
+++ b/src/internal_events/influxdb.rs
@@ -1,9 +1,10 @@
-use crate::emit;
 use metrics::counter;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
 use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct InfluxdbEncodingError {

--- a/src/internal_events/journald.rs
+++ b/src/internal_events/journald.rs
@@ -1,8 +1,7 @@
 use codecs::decoding::BoxedFramingError;
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct JournaldInvalidRecordError {

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -1,7 +1,6 @@
 use metrics::{counter, gauge};
-use vector_core::{internal_event::InternalEvent, update_counter};
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::{internal_event::InternalEvent, update_counter};
 
 #[derive(Debug)]
 pub struct KafkaBytesReceived<'a> {

--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -1,11 +1,10 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
-use crate::event::Event;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::{emit, event::Event};
 
 #[derive(Debug)]
 pub struct KubernetesLogsEventsReceived<'a> {

--- a/src/internal_events/log_to_metric.rs
+++ b/src/internal_events/log_to_metric.rs
@@ -1,12 +1,12 @@
 use std::num::ParseFloatError;
 
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 pub struct LogToMetricFieldNullError<'a> {
     pub field: &'a str,

--- a/src/internal_events/loki.rs
+++ b/src/internal_events/loki.rs
@@ -1,6 +1,7 @@
-use crate::emit;
 use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct LokiEventUnlabeled;

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -1,11 +1,10 @@
 use metrics::{counter, gauge};
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
-use crate::transforms::lua::v2::BuildError;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::{emit, transforms::lua::v2::BuildError};
 
 #[derive(Debug)]
 pub struct LuaGcTriggered {

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -1,11 +1,11 @@
 use metrics::counter;
 use serde_json::Error;
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct MetricToLogSerializeError {

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -154,7 +154,6 @@ pub(crate) use self::aws_kinesis_firehose::*;
 pub(crate) use self::aws_kinesis_streams::*;
 #[cfg(any(feature = "sources-aws_s3", feature = "sources-aws_sqs",))]
 pub(crate) use self::aws_sqs::*;
-pub(crate) use self::codecs::*;
 #[cfg(feature = "sinks-datadog_metrics")]
 pub(crate) use self::datadog_metrics::*;
 #[cfg(feature = "sinks-datadog_traces")]
@@ -212,7 +211,6 @@ pub(crate) use self::journald::*;
 pub(crate) use self::kafka::*;
 #[cfg(feature = "sources-kubernetes_logs")]
 pub(crate) use self::kubernetes_logs::*;
-pub(crate) use self::log_to_metric::*;
 #[cfg(feature = "sources-heroku_logs")]
 pub(crate) use self::logplex::*;
 #[cfg(feature = "sinks-loki")]
@@ -225,7 +223,6 @@ pub(crate) use self::metric_to_log::*;
 pub(crate) use self::nats::*;
 #[cfg(feature = "sources-nginx_metrics")]
 pub(crate) use self::nginx_metrics::*;
-pub(crate) use self::parser::*;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub(crate) use self::postgresql_metrics::*;
 #[cfg(any(feature = "sources-prometheus", feature = "sinks-prometheus"))]
@@ -268,8 +265,9 @@ pub(crate) use self::websocket::*;
 #[cfg(windows)]
 pub(crate) use self::windows::*;
 pub(crate) use self::{
-    adaptive_concurrency::*, batch::*, common::*, conditions::*, encoding_transcode::*,
-    heartbeat::*, open::*, process::*, socket::*, tcp::*, template::*, udp::*,
+    adaptive_concurrency::*, batch::*, codecs::*, common::*, conditions::*, encoding_transcode::*,
+    heartbeat::*, log_to_metric::*, open::*, parser::*, process::*, socket::*, tcp::*, template::*,
+    udp::*,
 };
 
 // this version won't be needed once all `InternalEvent`s implement `name()`

--- a/src/internal_events/mongodb_metrics.rs
+++ b/src/internal_events/mongodb_metrics.rs
@@ -1,8 +1,7 @@
 use metrics::counter;
 use mongodb::{bson, error::Error as MongoError};
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct MongoDbMetricsEventsReceived<'a> {

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -1,6 +1,5 @@
 use std::io::Error;
 
-use crate::emit;
 use metrics::counter;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
@@ -8,6 +7,7 @@ use vector_common::internal_event::{
 use vector_core::internal_event::InternalEvent;
 
 use super::prelude::io_error_code;
+use crate::emit;
 
 #[derive(Debug)]
 pub struct NatsEventSendError {

--- a/src/internal_events/nginx_metrics.rs
+++ b/src/internal_events/nginx_metrics.rs
@@ -1,8 +1,8 @@
 use metrics::counter;
+use vector_common::internal_event::{error_stage, error_type};
 use vector_core::internal_event::InternalEvent;
 
 use crate::sources::nginx_metrics::parser::ParseError;
-use vector_common::internal_event::{error_stage, error_type};
 
 #[derive(Debug)]
 pub struct NginxMetricsEventsReceived<'a> {

--- a/src/internal_events/parser.rs
+++ b/src/internal_events/parser.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 fn truncate_string_at(s: &str, maxlen: usize) -> Cow<str> {
     let ellipsis: &str = "[...]";

--- a/src/internal_events/postgresql_metrics.rs
+++ b/src/internal_events/postgresql_metrics.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct PostgresqlMetricsCollectError<'a> {

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -1,9 +1,8 @@
-use metrics::counter;
-use metrics::gauge;
+use metrics::{counter, gauge};
+use vector_common::internal_event::{error_stage, error_type};
 use vector_core::internal_event::InternalEvent;
 
 use crate::{built_info, config};
-use vector_common::internal_event::{error_stage, error_type};
 
 #[derive(Debug)]
 pub struct VectorStarted;

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -5,12 +5,12 @@ use hyper::StatusCode;
 use metrics::counter;
 #[cfg(feature = "sources-prometheus")]
 use prometheus_parser::ParserError;
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[cfg(feature = "sources-prometheus")]
 #[derive(Debug)]

--- a/src/internal_events/pulsar.rs
+++ b/src/internal_events/pulsar.rs
@@ -1,10 +1,10 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct PulsarSendingError {

--- a/src/internal_events/redis.rs
+++ b/src/internal_events/redis.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct RedisReceiveEventError {

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -1,10 +1,10 @@
-use crate::emit;
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct RemapMappingError {

--- a/src/internal_events/sample.rs
+++ b/src/internal_events/sample.rs
@@ -1,6 +1,7 @@
-use crate::emit;
 use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
+
+use crate::emit;
 
 #[derive(Debug)]
 pub struct SampleEventDiscarded;

--- a/src/internal_events/sematext_metrics.rs
+++ b/src/internal_events/sematext_metrics.rs
@@ -1,10 +1,10 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
-use crate::{emit, event::metric::Metric};
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
 };
+use vector_core::internal_event::InternalEvent;
+
+use crate::{emit, event::metric::Metric};
 
 #[derive(Debug)]
 pub struct SematextMetricsInvalidMetricError<'a> {

--- a/src/internal_events/splunk_hec.rs
+++ b/src/internal_events/splunk_hec.rs
@@ -9,15 +9,15 @@ pub use self::source::*;
 mod sink {
     use metrics::{counter, decrement_gauge, increment_gauge};
     use serde_json::Error;
+    use vector_common::internal_event::{
+        error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
+    };
     use vector_core::internal_event::InternalEvent;
 
     use crate::{
         emit,
         event::metric::{MetricKind, MetricValue},
         sinks::splunk_hec::common::acknowledgements::HecAckApiError,
-    };
-    use vector_common::internal_event::{
-        error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
     };
 
     #[derive(Debug)]
@@ -198,10 +198,10 @@ mod sink {
 #[cfg(feature = "sources-splunk_hec")]
 mod source {
     use metrics::counter;
+    use vector_common::internal_event::{error_stage, error_type};
     use vector_core::internal_event::InternalEvent;
 
     use crate::sources::splunk_hec::ApiError;
-    use vector_common::internal_event::{error_stage, error_type};
 
     #[derive(Debug)]
     pub struct SplunkHecRequestReceived<'a> {

--- a/src/internal_events/statsd_sink.rs
+++ b/src/internal_events/statsd_sink.rs
@@ -1,10 +1,12 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
-use crate::emit;
-use crate::event::metric::{MetricKind, MetricValue};
 use vector_common::internal_event::{
     error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
+};
+use vector_core::internal_event::InternalEvent;
+
+use crate::{
+    emit,
+    event::metric::{MetricKind, MetricValue},
 };
 
 #[derive(Debug)]

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -1,6 +1,7 @@
-use crate::emit;
 use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
+
+use crate::emit;
 
 pub struct TagCardinalityLimitRejectingEvent<'a> {
     pub tag_key: &'a str,

--- a/src/internal_events/template.rs
+++ b/src/internal_events/template.rs
@@ -1,8 +1,8 @@
-use crate::emit;
 use metrics::counter;
+use vector_common::internal_event::{error_stage, error_type};
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, UNINTENTIONAL};
 
-use vector_common::internal_event::{error_stage, error_type};
+use crate::emit;
 
 pub struct TemplateRenderingError<'a> {
     pub field: Option<&'a str>,

--- a/src/internal_events/throttle.rs
+++ b/src/internal_events/throttle.rs
@@ -1,6 +1,7 @@
-use crate::emit;
 use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
+
+use crate::emit;
 
 #[derive(Debug)]
 pub(crate) struct ThrottleEventDiscarded {

--- a/src/internal_events/websocket.rs
+++ b/src/internal_events/websocket.rs
@@ -1,10 +1,8 @@
-use std::error::Error;
-use std::fmt::Debug;
+use std::{error::Error, fmt::Debug};
 
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct WsConnectionEstablished;

--- a/src/internal_events/windows.rs
+++ b/src/internal_events/windows.rs
@@ -1,7 +1,6 @@
 use metrics::counter;
-use vector_core::internal_event::InternalEvent;
-
 use vector_common::internal_event::{error_stage, error_type};
+use vector_core::internal_event::InternalEvent;
 
 #[derive(Debug)]
 pub struct WindowsServiceStart<'a> {

--- a/src/internal_telemetry/allocations/allocator/mod.rs
+++ b/src/internal_telemetry/allocations/allocator/mod.rs
@@ -5,11 +5,12 @@ mod tracer;
 mod tracing;
 mod tracing_allocator;
 
-pub use self::token::AllocationGroupId;
-pub use self::token::AllocationGroupToken;
-pub use self::tracer::Tracer;
-pub use self::tracing::AllocationLayer;
-pub use self::tracing_allocator::GroupedTraceableAllocator;
+pub use self::{
+    token::{AllocationGroupId, AllocationGroupToken},
+    tracer::Tracer,
+    tracing::AllocationLayer,
+    tracing_allocator::GroupedTraceableAllocator,
+};
 
 /// Runs the given closure without tracing allocations or deallocations.
 ///

--- a/src/internal_telemetry/allocations/allocator/token.rs
+++ b/src/internal_telemetry/allocations/allocator/token.rs
@@ -6,8 +6,7 @@ use std::{
 
 use tracing::Span;
 
-use super::stack::GroupStack;
-use super::tracing::WithAllocationGroup;
+use super::{stack::GroupStack, tracing::WithAllocationGroup};
 
 thread_local! {
     /// The currently executing allocation token.

--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -103,8 +103,7 @@ mod tests {
         watcher,
     };
 
-    use super::custom_reflector;
-    use super::MetaCache;
+    use super::{custom_reflector, MetaCache};
 
     #[tokio::test]
     async fn applied_should_add_object() {

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -392,10 +392,11 @@ impl<C> Aggregate<C> {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use bytes::Bytes;
     use futures::SinkExt;
     use similar_asserts::assert_eq;
-    use std::fmt::Write as _;
 
     use super::*;
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use serde::Serialize;
-
 use vector_config::component::{SinkDescription, SourceDescription, TransformDescription};
 
 #[derive(Parser, Debug)]

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -7,14 +7,13 @@ use tokio::time;
 use url::Url;
 use vector_config::configurable_component;
 
+use super::BuildResult;
 use crate::{
     config::{self, provider::ProviderConfig, ProxyConfig},
     http::HttpClient,
     signal,
     tls::{TlsConfig, TlsSettings},
 };
-
-use super::BuildResult;
 
 /// Request settings.
 #[configurable_component]

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -1,4 +1,12 @@
 //! Configuration functionality for the `AMQP` sink.
+use std::sync::Arc;
+
+use codecs::TextSerializerConfig;
+use futures::FutureExt;
+use vector_config::configurable_component;
+use vector_core::config::AcknowledgementsConfig;
+
+use super::sink::AmqpSink;
 use crate::{
     amqp::AmqpConfig,
     codecs::EncodingConfig,
@@ -6,13 +14,6 @@ use crate::{
     sinks::{Healthcheck, VectorSink},
     template::Template,
 };
-use codecs::TextSerializerConfig;
-use futures::FutureExt;
-use std::sync::Arc;
-use vector_config::configurable_component;
-use vector_core::config::AcknowledgementsConfig;
-
-use super::sink::AmqpSink;
 
 /// Configuration for the `amqp` sink.
 ///

--- a/src/sinks/amqp/encoder.rs
+++ b/src/sinks/amqp/encoder.rs
@@ -1,11 +1,13 @@
 //! Encoding for the `AMQP` sink.
+use std::io;
+
+use bytes::BytesMut;
+use tokio_util::codec::Encoder as _;
+
 use crate::{
     event::Event,
     sinks::util::encoding::{write_all, Encoder},
 };
-use bytes::BytesMut;
-use std::io;
-use tokio_util::codec::Encoder as _;
 
 #[derive(Clone, Debug)]
 pub(super) struct AmqpEncoder {

--- a/src/sinks/amqp/integration_tests.rs
+++ b/src/sinks/amqp/integration_tests.rs
@@ -1,3 +1,8 @@
+use std::{sync::Arc, time::Duration};
+
+use futures::StreamExt;
+use vector_core::config::LogNamespace;
+
 use super::*;
 use crate::{
     config::{SinkConfig, SinkContext},
@@ -10,9 +15,6 @@ use crate::{
     },
     SourceSender,
 };
-use futures::StreamExt;
-use std::{sync::Arc, time::Duration};
-use vector_core::config::LogNamespace;
 
 pub fn make_config() -> AmqpSinkConfig {
     let mut config = AmqpSinkConfig {

--- a/src/sinks/amqp/request_builder.rs
+++ b/src/sinks/amqp/request_builder.rs
@@ -1,6 +1,15 @@
 //! Request builder for the `AMQP` sink.
 //! Responsible for taking the event (which includes rendered template values) and turning
 //! it into the raw bytes and other data needed to send the request to `AMQP`.
+use std::io;
+
+use bytes::Bytes;
+use vector_common::{
+    finalization::{EventFinalizers, Finalizable},
+    request_metadata::RequestMetadata,
+};
+
+use super::{encoder::AmqpEncoder, service::AmqpRequest, sink::AmqpEvent};
 use crate::{
     event::Event,
     sinks::util::{
@@ -8,14 +17,6 @@ use crate::{
         RequestBuilder,
     },
 };
-use bytes::Bytes;
-use std::io;
-use vector_common::{
-    finalization::{EventFinalizers, Finalizable},
-    request_metadata::RequestMetadata,
-};
-
-use super::{encoder::AmqpEncoder, service::AmqpRequest, sink::AmqpEvent};
 
 pub(super) struct AmqpMetadata {
     exchange: String,

--- a/src/sinks/amqp/service.rs
+++ b/src/sinks/amqp/service.rs
@@ -1,14 +1,14 @@
 //! The main tower service that takes the request created by the request builder
 //! and sends it to `AMQP`.
-use crate::internal_events::sink::{AmqpAcknowledgementError, AmqpDeliveryError};
-use bytes::Bytes;
-use futures::future::BoxFuture;
-use lapin::{options::BasicPublishOptions, BasicProperties};
-use snafu::Snafu;
 use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use lapin::{options::BasicPublishOptions, BasicProperties};
+use snafu::Snafu;
 use tower::Service;
 use vector_common::{
     finalization::{EventFinalizers, EventStatus, Finalizable},
@@ -16,6 +16,8 @@ use vector_common::{
     request_metadata::{MetaDescriptive, RequestMetadata},
 };
 use vector_core::stream::DriverResponse;
+
+use crate::internal_events::sink::{AmqpAcknowledgementError, AmqpDeliveryError};
 
 /// The request contains the data to send to `AMQP` together
 /// with the information need to route the message.

--- a/src/sinks/amqp/sink.rs
+++ b/src/sinks/amqp/sink.rs
@@ -1,15 +1,12 @@
 //! The sink for the `AMQP` sink that wires together the main stream that takes the
 //! event and sends it to `AMQP`.
-use crate::{
-    codecs::Transformer, event::Event, internal_events::TemplateRenderingError,
-    sinks::util::builder::SinkBuilderExt, template::Template,
-};
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures_util::stream::BoxStream;
 use lapin::options::ConfirmSelectOptions;
 use serde::Serialize;
-use std::sync::Arc;
 use tower::ServiceBuilder;
 use vector_buffers::EventCount;
 use vector_core::{sink::StreamSink, ByteSizeOf};
@@ -17,6 +14,10 @@ use vector_core::{sink::StreamSink, ByteSizeOf};
 use super::{
     config::AmqpSinkConfig, encoder::AmqpEncoder, request_builder::AmqpRequestBuilder,
     service::AmqpService, BuildError,
+};
+use crate::{
+    codecs::Transformer, event::Event, internal_events::TemplateRenderingError,
+    sinks::util::builder::SinkBuilderExt, template::Template,
 };
 
 /// Stores the event together with the rendered exchange and routing_key values.

--- a/src/sinks/apex/integration_tests.rs
+++ b/src/sinks/apex/integration_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "apex-integration-tests")]
 #![cfg(test)]
 
+use serde_json::json;
 use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};
 
 use super::ApexSinkConfig;
@@ -12,7 +13,6 @@ use crate::{
         generate_events_with_stream,
     },
 };
-use serde_json::json;
 
 fn mock_apex_address() -> String {
     std::env::var("MOCK_APEX_ADDRESS").unwrap_or_else(|_| "http://localhost:4567".into())

--- a/src/sinks/aws_cloudwatch_logs/healthcheck.rs
+++ b/src/sinks/aws_cloudwatch_logs/healthcheck.rs
@@ -1,6 +1,6 @@
-use aws_sdk_cloudwatchlogs::error::DescribeLogGroupsError;
-use aws_sdk_cloudwatchlogs::types::SdkError;
-use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
+use aws_sdk_cloudwatchlogs::{
+    error::DescribeLogGroupsError, types::SdkError, Client as CloudwatchLogsClient,
+};
 use snafu::Snafu;
 
 use crate::sinks::aws_cloudwatch_logs::config::CloudwatchLogsSinkConfig;

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -1,11 +1,9 @@
 #![cfg(feature = "aws-cloudwatch-logs-integration-tests")]
 #![cfg(test)]
 
-use std::convert::TryFrom;
-use std::str::FromStr;
+use std::{convert::TryFrom, str::FromStr};
 
-use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
-use aws_sdk_cloudwatchlogs::{Endpoint, Region};
+use aws_sdk_cloudwatchlogs::{Client as CloudwatchLogsClient, Endpoint, Region};
 use chrono::Duration;
 use codecs::TextSerializerConfig;
 use futures::{stream, StreamExt};
@@ -13,13 +11,11 @@ use http::Uri;
 use similar_asserts::assert_eq;
 
 use super::*;
-use crate::aws::create_client;
-use crate::aws::{AwsAuthentication, RegionOrEndpoint};
-use crate::sinks::aws_cloudwatch_logs::config::CloudwatchLogsClientBuilder;
 use crate::{
+    aws::{create_client, AwsAuthentication, RegionOrEndpoint},
     config::{log_schema, ProxyConfig, SinkConfig, SinkContext},
     event::{Event, LogEvent, Value},
-    sinks::util::BatchConfig,
+    sinks::{aws_cloudwatch_logs::config::CloudwatchLogsClientBuilder, util::BatchConfig},
     template::Template,
     test_util::{
         components::{run_and_assert_sink_compliance, AWS_SINK_TAGS},

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -4,16 +4,18 @@ use std::{
     task::{ready, Context, Poll},
 };
 
-use aws_sdk_cloudwatchlogs::error::{
-    CreateLogGroupError, CreateLogGroupErrorKind, CreateLogStreamError, CreateLogStreamErrorKind,
-    DescribeLogStreamsError, DescribeLogStreamsErrorKind, PutLogEventsError,
+use aws_sdk_cloudwatchlogs::{
+    error::{
+        CreateLogGroupError, CreateLogGroupErrorKind, CreateLogStreamError,
+        CreateLogStreamErrorKind, DescribeLogStreamsError, DescribeLogStreamsErrorKind,
+        PutLogEventsError,
+    },
+    model::InputLogEvent,
+    operation::PutLogEvents,
+    output::{DescribeLogStreamsOutput, PutLogEventsOutput},
+    types::SdkError,
+    Client as CloudwatchLogsClient,
 };
-use aws_sdk_cloudwatchlogs::operation::PutLogEvents;
-
-use aws_sdk_cloudwatchlogs::model::InputLogEvent;
-use aws_sdk_cloudwatchlogs::output::{DescribeLogStreamsOutput, PutLogEventsOutput};
-use aws_sdk_cloudwatchlogs::types::SdkError;
-use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use aws_smithy_http::operation::{Operation, Request};
 use futures::{future::BoxFuture, FutureExt};
 use indexmap::IndexMap;

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -1,12 +1,14 @@
 use std::marker::PhantomData;
 
-use aws_sdk_cloudwatchlogs::error::{
-    CreateLogStreamErrorKind, DescribeLogStreamsErrorKind, PutLogEventsErrorKind,
+use aws_sdk_cloudwatchlogs::{
+    error::{CreateLogStreamErrorKind, DescribeLogStreamsErrorKind, PutLogEventsErrorKind},
+    types::SdkError,
 };
-use aws_sdk_cloudwatchlogs::types::SdkError;
 
-use crate::aws::is_retriable_error;
-use crate::sinks::{aws_cloudwatch_logs::service::CloudwatchError, util::retries::RetryLogic};
+use crate::{
+    aws::is_retriable_error,
+    sinks::{aws_cloudwatch_logs::service::CloudwatchError, util::retries::RetryLogic},
+};
 
 #[derive(Debug)]
 pub struct CloudwatchRetryLogic<T> {
@@ -66,14 +68,16 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
 
 #[cfg(test)]
 mod test {
-    use aws_sdk_cloudwatchlogs::error::{PutLogEventsError, PutLogEventsErrorKind};
-    use aws_sdk_cloudwatchlogs::types::SdkError;
-    use aws_smithy_http::body::SdkBody;
-    use aws_smithy_http::operation::Response;
+    use aws_sdk_cloudwatchlogs::{
+        error::{PutLogEventsError, PutLogEventsErrorKind},
+        types::SdkError,
+    };
+    use aws_smithy_http::{body::SdkBody, operation::Response};
 
-    use crate::sinks::aws_cloudwatch_logs::retry::CloudwatchRetryLogic;
-    use crate::sinks::aws_cloudwatch_logs::service::CloudwatchError;
-    use crate::sinks::util::retries::RetryLogic;
+    use crate::sinks::{
+        aws_cloudwatch_logs::{retry::CloudwatchRetryLogic, service::CloudwatchError},
+        util::retries::RetryLogic,
+    };
 
     #[test]
     fn test_throttle_retry() {

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -4,12 +4,14 @@ use std::{
     task::{ready, Context, Poll},
 };
 
-use aws_sdk_cloudwatchlogs::error::{
-    CreateLogGroupError, CreateLogStreamError, DescribeLogStreamsError, PutLogEventsError,
+use aws_sdk_cloudwatchlogs::{
+    error::{
+        CreateLogGroupError, CreateLogStreamError, DescribeLogStreamsError, PutLogEventsError,
+    },
+    model::InputLogEvent,
+    types::SdkError,
+    Client as CloudwatchLogsClient,
 };
-use aws_sdk_cloudwatchlogs::model::InputLogEvent;
-use aws_sdk_cloudwatchlogs::types::SdkError;
-use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use chrono::Duration;
 use futures::{future::BoxFuture, FutureExt};
 use futures_util::TryFutureExt;

--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -1,6 +1,8 @@
 mod integration_tests;
 mod tests;
 
+use std::task::{Context, Poll};
+
 use aws_sdk_cloudwatch::{
     error::PutMetricDataError,
     model::{Dimension, MetricDatum},
@@ -10,7 +12,6 @@ use aws_sdk_cloudwatch::{
 use aws_smithy_types::DateTime as AwsDateTime;
 use futures::{stream, FutureExt, SinkExt};
 use futures_util::{future, future::BoxFuture};
-use std::task::{Context, Poll};
 use tower::Service;
 use vector_config::configurable_component;
 use vector_core::{sink::VectorSink, ByteSizeOf};

--- a/src/sinks/aws_kinesis_firehose/request_builder.rs
+++ b/src/sinks/aws_kinesis_firehose/request_builder.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use vector_common::request_metadata::{MetaDescriptive, RequestMetadata};
 use vector_core::ByteSizeOf;
 
+use super::sink::{KinesisKey, KinesisProcessedEvent};
 use crate::{
     codecs::{Encoder, Transformer},
     event::{Event, EventFinalizers, Finalizable},
@@ -13,8 +14,6 @@ use crate::{
         RequestBuilder,
     },
 };
-
-use super::sink::{KinesisKey, KinesisProcessedEvent};
 
 pub struct KinesisRequestBuilder {
     pub(super) compression: Compression,

--- a/src/sinks/aws_kinesis_streams/config.rs
+++ b/src/sinks/aws_kinesis_streams/config.rs
@@ -9,7 +9,8 @@ use tower::ServiceBuilder;
 use vector_config::configurable_component;
 
 use super::{
-    request_builder::KinesisRequestBuilder, service::KinesisResponse, service::KinesisService,
+    request_builder::KinesisRequestBuilder,
+    service::{KinesisResponse, KinesisService},
     sink::KinesisSink,
 };
 use crate::{

--- a/src/sinks/aws_kinesis_streams/service.rs
+++ b/src/sinks/aws_kinesis_streams/service.rs
@@ -1,9 +1,8 @@
 use std::task::{Context, Poll};
 
-use aws_sdk_kinesis::error::PutRecordsError;
-use aws_sdk_kinesis::output::PutRecordsOutput;
-use aws_sdk_kinesis::types::SdkError;
-use aws_sdk_kinesis::Client as KinesisClient;
+use aws_sdk_kinesis::{
+    error::PutRecordsError, output::PutRecordsOutput, types::SdkError, Client as KinesisClient,
+};
 use aws_types::region::Region;
 use futures::future::BoxFuture;
 use tower::Service;

--- a/src/sinks/aws_kinesis_streams/sink.rs
+++ b/src/sinks/aws_kinesis_streams/sink.rs
@@ -13,6 +13,7 @@ use vector_core::{
     stream::{BatcherSettings, DriverResponse},
 };
 
+use super::request_builder::KinesisRequest;
 use crate::{
     event::{Event, LogEvent},
     internal_events::{AwsKinesisStreamNoPartitionKeyError, SinkRequestBuildError},
@@ -21,8 +22,6 @@ use crate::{
         util::{processed_event::ProcessedEvent, SinkBuilderExt, StreamSink},
     },
 };
-
-use super::request_builder::KinesisRequest;
 
 pub type KinesisProcessedEvent = ProcessedEvent<LogEvent, KinesisKey>;
 

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -27,7 +27,6 @@ use vector_core::{
 };
 
 use super::S3SinkConfig;
-use crate::test_util::components::{run_and_assert_sink_error, COMPONENT_ERROR_TAGS};
 use crate::{
     aws::{create_client, AwsAuthentication, RegionOrEndpoint},
     common::s3::S3ClientBuilder,
@@ -37,7 +36,10 @@ use crate::{
         util::{BatchConfig, Compression, TowerRequestConfig},
     },
     test_util::{
-        components::{run_and_assert_sink_compliance, AWS_SINK_TAGS},
+        components::{
+            run_and_assert_sink_compliance, run_and_assert_sink_error, AWS_SINK_TAGS,
+            COMPONENT_ERROR_TAGS,
+        },
         random_lines_with_stream, random_string,
     },
 };

--- a/src/sinks/aws_sqs/integration_tests.rs
+++ b/src/sinks/aws_sqs/integration_tests.rs
@@ -1,7 +1,6 @@
 #![cfg(all(test, feature = "aws-sqs-integration-tests"))]
 
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
 use aws_sdk_sqs::{model::QueueAttributeName, Client as SqsClient, Endpoint, Region};
 use codecs::TextSerializerConfig;

--- a/src/sinks/aws_sqs/sink.rs
+++ b/src/sinks/aws_sqs/sink.rs
@@ -6,9 +6,9 @@ use futures_util::StreamExt;
 use vector_core::sink::StreamSink;
 
 use super::{config::SqsSinkConfig, request_builder::SqsRequestBuilder, service::SqsService};
-use crate::internal_events::SinkRequestBuildError;
 use crate::{
     event::Event,
+    internal_events::SinkRequestBuildError,
     sinks::util::{
         builder::SinkBuilderExt, ServiceBuilderExt, SinkBatchSettings, TowerRequestConfig,
     },

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -138,11 +138,12 @@ mod test {
 #[cfg(feature = "axiom-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
+    use std::env;
+
     use chrono::{DateTime, Duration, Utc};
     use futures::stream;
     use http::StatusCode;
     use serde::{Deserialize, Serialize};
-    use std::env;
     use tokio::time;
     use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};
 

--- a/src/sinks/azure_blob/test.rs
+++ b/src/sinks/azure_blob/test.rs
@@ -6,12 +6,15 @@ use codecs::{
 };
 use vector_core::partition::Partitioner;
 
-use super::config::AzureBlobSinkConfig;
-use super::request_builder::AzureBlobRequestOptions;
-use crate::codecs::EncodingConfigWithFraming;
-use crate::event::{Event, LogEvent};
-use crate::sinks::util::{request_builder::RequestBuilder, Compression};
-use crate::{codecs::Encoder, sinks::util::request_builder::EncodeResult};
+use super::{config::AzureBlobSinkConfig, request_builder::AzureBlobRequestOptions};
+use crate::{
+    codecs::{Encoder, EncodingConfigWithFraming},
+    event::{Event, LogEvent},
+    sinks::util::{
+        request_builder::{EncodeResult, RequestBuilder},
+        Compression,
+    },
+};
 
 fn default_config(encoding: EncodingConfigWithFraming) -> AzureBlobSinkConfig {
     AzureBlobSinkConfig {

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -1,5 +1,6 @@
 use vector_config::configurable_component;
 
+use super::http_sink::build_http_sink;
 use crate::{
     codecs::Transformer,
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
@@ -13,8 +14,6 @@ use crate::{
     },
     tls::TlsConfig,
 };
-
-use super::http_sink::build_http_sink;
 
 /// Configuration for the `clickhouse` sink.
 #[configurable_component(sink("clickhouse"))]

--- a/src/sinks/datadog/logs/integration_tests.rs
+++ b/src/sinks/datadog/logs/integration_tests.rs
@@ -3,8 +3,7 @@ use vector_core::event::{BatchNotifier, BatchStatus};
 
 use crate::{
     config::SinkConfig,
-    sinks::datadog::logs::DatadogLogsConfig,
-    sinks::util::test::load_sink,
+    sinks::{datadog::logs::DatadogLogsConfig, util::test::load_sink},
     test_util::{
         components::{run_and_assert_sink_compliance, SINK_TAGS},
         generate_lines_with_stream,

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -21,8 +21,10 @@ use vector_core::{
 
 use crate::{
     http::HttpClient,
-    sinks::datadog::DatadogApiError,
-    sinks::util::{retries::RetryLogic, Compression},
+    sinks::{
+        datadog::DatadogApiError,
+        util::{retries::RetryLogic, Compression},
+    },
 };
 
 #[derive(Debug, Default, Clone)]

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -13,14 +13,16 @@ use hyper::StatusCode;
 use indoc::indoc;
 use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};
 
+use super::service::LogApiRetry;
 use crate::{
     config::SinkConfig,
     http::HttpError,
     sinks::{
-        datadog::logs::DatadogLogsConfig,
-        datadog::DatadogApiError,
-        util::retries::RetryLogic,
-        util::test::{build_test_server_status, load_sink},
+        datadog::{logs::DatadogLogsConfig, DatadogApiError},
+        util::{
+            retries::RetryLogic,
+            test::{build_test_server_status, load_sink},
+        },
     },
     test_util::{
         components::{
@@ -31,8 +33,6 @@ use crate::{
     },
     tls::TlsError,
 };
-
-use super::service::LogApiRetry;
 
 // The sink must support v1 and v2 API endpoints which have different codes for
 // signaling status. This enum allows us to signal which API endpoint and what

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -11,7 +11,6 @@ use super::{
     service::{DatadogMetricsRetryLogic, DatadogMetricsService},
     sink::DatadogMetricsSink,
 };
-use crate::tls::{MaybeTlsSettings, TlsEnableableConfig};
 use crate::{
     common::datadog::get_base_domain,
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
@@ -24,6 +23,7 @@ use crate::{
         },
         Healthcheck, UriParseSnafu, VectorSink,
     },
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 // TODO: revisit our concurrency and batching defaults

--- a/src/sinks/datadog/metrics/request_builder.rs
+++ b/src/sinks/datadog/metrics/request_builder.rs
@@ -1,7 +1,8 @@
+use std::{num::NonZeroUsize, sync::Arc};
+
 use bytes::Bytes;
 use serde_json::error::Category;
 use snafu::Snafu;
-use std::{num::NonZeroUsize, sync::Arc};
 use vector_common::request_metadata::RequestMetadata;
 use vector_core::event::{EventFinalizers, Finalizable, Metric};
 

--- a/src/sinks/datadog/metrics/service.rs
+++ b/src/sinks/datadog/metrics/service.rs
@@ -1,5 +1,7 @@
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use bytes::{Buf, Bytes};
 use futures::future::BoxFuture;
@@ -19,8 +21,10 @@ use vector_core::{
 
 use crate::{
     http::{BuildRequestSnafu, CallRequestSnafu, HttpClient},
-    sinks::datadog::DatadogApiError,
-    sinks::util::retries::{RetryAction, RetryLogic},
+    sinks::{
+        datadog::DatadogApiError,
+        util::retries::{RetryAction, RetryLogic},
+    },
 };
 
 /// Retry logic specific to the Datadog metrics endpoints.

--- a/src/sinks/datadog/metrics/sink.rs
+++ b/src/sinks/datadog/metrics/sink.rs
@@ -23,8 +23,7 @@ use super::{
 use crate::{
     internal_events::DatadogMetricsEncodingError,
     sinks::util::{
-        buffer::metrics::sort::sort_for_compression,
-        buffer::metrics::{AggregatedSummarySplitter, MetricSplitter},
+        buffer::metrics::{sort::sort_for_compression, AggregatedSummarySplitter, MetricSplitter},
         SinkBuilderExt,
     },
 };

--- a/src/sinks/datadog/traces/integration_tests.rs
+++ b/src/sinks/datadog/traces/integration_tests.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, io::Read, net::SocketAddr, sync::Arc};
+
 use axum::{
     body::Body,
     extract::Extension,
@@ -11,9 +13,11 @@ use futures::stream;
 use indoc::indoc;
 use rmp_serde;
 use serde::Serialize;
-use std::{collections::HashMap, io::Read, net::SocketAddr, sync::Arc};
-use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::time::{sleep, Duration};
+use tokio::{
+    sync::mpsc::{self, Receiver, Sender},
+    time::{sleep, Duration},
+};
+use vector_core::event::{BatchNotifier, BatchStatus};
 
 use crate::{
     config::{ConfigBuilder, SinkConfig},
@@ -29,7 +33,6 @@ use crate::{
     },
     topology::RunningTopology,
 };
-use vector_core::event::{BatchNotifier, BatchStatus};
 
 /// The port on which the Agent will send traces to vector, and vector `datadog_agent` source will
 /// listen on

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use aws_types::credentials::SharedCredentialsProvider;
-use aws_types::region::Region;
+use aws_types::{credentials::SharedCredentialsProvider, region::Region};
 use bytes::Bytes;
 use http::{StatusCode, Uri};
 use snafu::ResultExt;

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use futures::{FutureExt, TryFutureExt};
+use lookup::event_path;
 use snafu::ResultExt;
 use vector_config::configurable_component;
 
@@ -33,7 +34,6 @@ use crate::{
     tls::TlsConfig,
     transforms::metric_to_log::MetricToLogConfig,
 };
-use lookup::event_path;
 
 /// The field name for the timestamp required by data stream mode
 pub const DATA_STREAM_TIMESTAMP_KEY: &str = "@timestamp";

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -3,8 +3,7 @@ use std::{fs::File, io::Read};
 use aws_smithy_http::body::SdkBody;
 use bytes::Bytes;
 use chrono::Utc;
-use futures::StreamExt;
-use futures::{future::ready, stream};
+use futures::{future::ready, stream, StreamExt};
 use http::{Request, StatusCode};
 use serde_json::{json, Value};
 use vector_core::{

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -24,8 +24,8 @@ use snafu::Snafu;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 
-use crate::aws::AwsAuthentication;
 use crate::{
+    aws::AwsAuthentication,
     event::{EventRef, LogEvent},
     internal_events::TemplateRenderingError,
     template::{Template, TemplateParseError},

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -4,8 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use aws_types::credentials::SharedCredentialsProvider;
-use aws_types::region::Region;
+use aws_types::{credentials::SharedCredentialsProvider, region::Region};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use http::{Response, Uri};
@@ -14,17 +13,18 @@ use tower::ServiceExt;
 use vector_common::request_metadata::{MetaDescriptive, RequestMetadata};
 use vector_core::{internal_event::CountByteSize, stream::DriverResponse, ByteSizeOf};
 
-use crate::sinks::elasticsearch::sign_request;
+use super::{ElasticsearchCommon, ElasticsearchConfig};
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
     http::{Auth, HttpClient},
-    sinks::util::{
-        http::{HttpBatchService, RequestConfig},
-        Compression, ElementCount,
+    sinks::{
+        elasticsearch::sign_request,
+        util::{
+            http::{HttpBatchService, RequestConfig},
+            Compression, ElementCount,
+        },
     },
 };
-
-use super::{ElasticsearchCommon, ElasticsearchConfig};
 
 #[derive(Clone)]
 pub struct ElasticsearchRequest {

--- a/src/sinks/elasticsearch/sink.rs
+++ b/src/sinks/elasticsearch/sink.rs
@@ -8,6 +8,7 @@ use vector_core::{
     ByteSizeOf,
 };
 
+use super::{ElasticsearchCommon, ElasticsearchConfig};
 use crate::{
     codecs::Transformer,
     event::{Event, LogEvent, Value},
@@ -21,8 +22,6 @@ use crate::{
     },
     transforms::metric_to_log::MetricToLog,
 };
-
-use super::{ElasticsearchCommon, ElasticsearchConfig};
 
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct PartitionKey {

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeMap, convert::TryFrom};
 
+use lookup::owned_value_path;
+
 use crate::{
     codecs::Transformer,
     event::{LogEvent, Metric, MetricKind, MetricValue, Value},
@@ -12,7 +14,6 @@ use crate::{
     },
     template::Template,
 };
-use lookup::owned_value_path;
 
 #[tokio::test]
 async fn sets_create_action_when_configured() {

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -1,6 +1,8 @@
 //! This sink sends data to Google Chronicles unstructured log entries endpoint.
 //! See https://cloud.google.com/chronicle/docs/reference/ingestion-api#unstructuredlogentries
 //! for more information.
+use std::io;
+
 use bytes::{Bytes, BytesMut};
 use futures_util::{future::BoxFuture, task::Poll};
 use goauth::scopes::Scope;
@@ -9,7 +11,6 @@ use hyper::Body;
 use indoc::indoc;
 use serde_json::json;
 use snafu::Snafu;
-use std::io;
 use tokio_util::codec::Encoder as _;
 use tower::{Service, ServiceBuilder};
 use vector_common::request_metadata::{MetaDescriptive, RequestMetadata};

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -5,15 +5,13 @@ use chrono::Utc;
 use codecs::encoding::Framer;
 use http::header::{HeaderName, HeaderValue};
 use indoc::indoc;
-use snafu::ResultExt;
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
 use tower::ServiceBuilder;
 use uuid::Uuid;
 use vector_common::request_metadata::RequestMetadata;
 use vector_config::configurable_component;
 use vector_core::event::{EventFinalizers, Finalizable};
 
-use crate::sinks::util::metadata::RequestMetadataBuilder;
 use crate::{
     codecs::{Encoder, EncodingConfigWithFraming, SinkType, Transformer},
     config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
@@ -30,9 +28,9 @@ use crate::{
             sink::GcsSink,
         },
         util::{
-            batch::BatchConfig, partitioner::KeyPartitioner, request_builder::EncodeResult,
-            BulkSizeBasedDefaultBatchSettings, Compression, RequestBuilder, ServiceBuilderExt,
-            TowerRequestConfig,
+            batch::BatchConfig, metadata::RequestMetadataBuilder, partitioner::KeyPartitioner,
+            request_builder::EncodeResult, BulkSizeBasedDefaultBatchSettings, Compression,
+            RequestBuilder, ServiceBuilderExt, TowerRequestConfig,
         },
         Healthcheck, VectorSink,
     },
@@ -381,18 +379,21 @@ fn make_header((name, value): (&String, &String)) -> crate::Result<(HeaderName, 
 
 #[cfg(test)]
 mod tests {
-    use codecs::encoding::FramingConfig;
-    use codecs::{JsonSerializerConfig, NewlineDelimitedEncoderConfig, TextSerializerConfig};
+    use codecs::{
+        encoding::FramingConfig, JsonSerializerConfig, NewlineDelimitedEncoderConfig,
+        TextSerializerConfig,
+    };
     use futures_util::{future::ready, stream};
     use vector_core::partition::Partitioner;
 
-    use crate::event::LogEvent;
-    use crate::test_util::{
-        components::{run_and_assert_sink_compliance, SINK_TAGS},
-        http::{always_200_response, spawn_blackhole_http_server},
-    };
-
     use super::*;
+    use crate::{
+        event::LogEvent,
+        test_util::{
+            components::{run_and_assert_sink_compliance, SINK_TAGS},
+            http::{always_200_response, spawn_blackhole_http_server},
+        },
+    };
 
     #[test]
     fn generate_config() {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -258,11 +258,15 @@ mod integration_tests {
     use vector_core::event::{BatchNotifier, BatchStatus};
 
     use super::*;
-    use crate::gcp;
-    use crate::test_util::components::{run_and_assert_sink_error, COMPONENT_ERROR_TAGS};
-    use crate::test_util::{
-        components::{run_and_assert_sink_compliance, HTTP_SINK_TAGS},
-        random_events_with_stream, random_string, trace_init,
+    use crate::{
+        gcp,
+        test_util::{
+            components::{
+                run_and_assert_sink_compliance, run_and_assert_sink_error, COMPONENT_ERROR_TAGS,
+                HTTP_SINK_TAGS,
+            },
+            random_events_with_stream, random_string, trace_init,
+        },
     };
 
     const PROJECT: &str = "testproject";

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -210,6 +210,7 @@ mod test {
     use futures::{future::ready, stream};
     use vector_core::event::{Event, LogEvent};
 
+    use super::HoneycombConfig;
     use crate::{
         config::{GenerateConfig, SinkConfig, SinkContext},
         test_util::{
@@ -217,8 +218,6 @@ mod test {
             http::{always_200_response, spawn_blackhole_http_server},
         },
     };
-
-    use super::HoneycombConfig;
 
     #[test]
     fn generate_config() {

--- a/src/sinks/loki/event.rs
+++ b/src/sinks/loki/event.rs
@@ -8,9 +8,8 @@ use vector_core::{
     ByteSizeOf, EstimatedJsonEncodedSizeOf,
 };
 
-use crate::sinks::util::encoding::{write_all, Encoder};
-
 use super::sink::LokiRecords;
+use crate::sinks::util::encoding::{write_all, Encoder};
 
 pub type Labels = Vec<(String, String)>;
 

--- a/src/sinks/loki/service.rs
+++ b/src/sinks/loki/service.rs
@@ -13,10 +13,12 @@ use vector_core::{
     stream::DriverResponse,
 };
 
-use crate::sinks::loki::config::{CompressionConfigAdapter, ExtendedCompression};
 use crate::{
     http::{get_http_scheme_from_uri, Auth, HttpClient},
-    sinks::util::{retries::RetryLogic, UriSerde},
+    sinks::{
+        loki::config::{CompressionConfigAdapter, ExtendedCompression},
+        util::{retries::RetryLogic, UriSerde},
+    },
 };
 
 #[derive(Clone)]

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -21,11 +21,6 @@ use super::{
     event::{LokiBatchEncoder, LokiEvent, LokiRecord, PartitionKey},
     service::{LokiRequest, LokiRetryLogic, LokiService},
 };
-use crate::sinks::loki::event::LokiBatchEncoding;
-use crate::sinks::{
-    loki::config::{CompressionConfigAdapter, ExtendedCompression},
-    util::metadata::RequestMetadataBuilder,
-};
 use crate::{
     codecs::{Encoder, Transformer},
     config::log_schema,
@@ -34,11 +29,18 @@ use crate::{
         LokiEventUnlabeled, LokiOutOfOrderEventDropped, LokiOutOfOrderEventRewritten,
         SinkRequestBuildError, TemplateRenderingError,
     },
-    sinks::util::{
-        builder::SinkBuilderExt,
-        request_builder::EncodeResult,
-        service::{ServiceBuilderExt, Svc},
-        Compression, RequestBuilder,
+    sinks::{
+        loki::{
+            config::{CompressionConfigAdapter, ExtendedCompression},
+            event::LokiBatchEncoding,
+        },
+        util::{
+            builder::SinkBuilderExt,
+            metadata::RequestMetadataBuilder,
+            request_builder::EncodeResult,
+            service::{ServiceBuilderExt, Svc},
+            Compression, RequestBuilder,
+        },
     },
     template::Template,
 };

--- a/src/sinks/nats.rs
+++ b/src/sinks/nats.rs
@@ -227,17 +227,20 @@ mod tests {
 #[cfg(feature = "nats-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
-    use codecs::TextSerializerConfig;
     use std::{thread, time::Duration};
 
+    use codecs::TextSerializerConfig;
+
     use super::*;
-    use crate::nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword};
-    use crate::sinks::VectorSink;
-    use crate::test_util::{
-        components::{run_and_assert_sink_compliance, SINK_TAGS},
-        random_lines_with_stream, random_string, trace_init,
+    use crate::{
+        nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword},
+        sinks::VectorSink,
+        test_util::{
+            components::{run_and_assert_sink_compliance, SINK_TAGS},
+            random_lines_with_stream, random_string, trace_init,
+        },
+        tls::TlsConfig,
     };
-    use crate::tls::TlsConfig;
 
     async fn publish_and_check(conf: NatsSinkConfig) -> Result<(), BuildError> {
         // Publish `N` messages to NATS.

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -183,12 +183,11 @@ mod tests {
     use tokio_util::codec::Encoder as _;
     use vector_core::event::{Event, LogEvent};
 
+    use super::*;
     use crate::test_util::{
         components::{run_and_assert_sink_compliance, SINK_TAGS},
         http::{always_200_response, spawn_blackhole_http_server},
     };
-
-    use super::*;
 
     #[test]
     fn generate_config() {

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-use std::task;
+use std::{sync::Arc, task};
 
-use aws_types::credentials::SharedCredentialsProvider;
-use aws_types::region::Region;
+use aws_types::{credentials::SharedCredentialsProvider, region::Region};
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, stream, FutureExt, SinkExt};
 use http::{Request, Uri};

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -4,21 +4,16 @@ use std::{
     task::{ready, Context, Poll},
 };
 
-use crate::{
-    codecs::{Encoder, EncodingConfig, Transformer},
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
-    event::{Event, EventFinalizers, EventStatus, Finalizable},
-    internal_events::PulsarSendingError,
-    sinks::util::metadata::RequestMetadataBuilder,
-};
 use bytes::BytesMut;
 use codecs::{encoding::SerializerConfig, TextSerializerConfig};
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, Sink, Stream};
-use pulsar::authentication::oauth2::{OAuth2Authentication, OAuth2Params};
-use pulsar::error::AuthenticationError;
 use pulsar::{
-    message::proto, producer::SendFuture, proto::CommandSendReceipt, Authentication,
-    Error as PulsarError, Producer, Pulsar, TokioExecutor,
+    authentication::oauth2::{OAuth2Authentication, OAuth2Params},
+    error::AuthenticationError,
+    message::proto,
+    producer::SendFuture,
+    proto::CommandSendReceipt,
+    Authentication, Error as PulsarError, Producer, Pulsar, TokioExecutor,
 };
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Encoder as _;
@@ -32,6 +27,14 @@ use vector_common::{
 };
 use vector_config::configurable_component;
 use vector_core::config::log_schema;
+
+use crate::{
+    codecs::{Encoder, EncodingConfig, Transformer},
+    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    event::{Event, EventFinalizers, EventStatus, Finalizable},
+    internal_events::PulsarSendingError,
+    sinks::util::metadata::RequestMetadataBuilder,
+};
 
 #[derive(Debug, Snafu)]
 enum BuildError {
@@ -415,10 +418,12 @@ mod integration_tests {
     use pulsar::SubType;
 
     use super::*;
-    use crate::sinks::VectorSink;
-    use crate::test_util::{
-        components::{assert_sink_compliance, SINK_TAGS},
-        random_lines_with_stream, random_string, trace_init,
+    use crate::{
+        sinks::VectorSink,
+        test_util::{
+            components::{assert_sink_compliance, SINK_TAGS},
+            random_lines_with_stream, random_string, trace_init,
+        },
     };
 
     fn pulsar_address() -> String {

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -17,8 +17,7 @@ use vector_core::{
     stream::DriverResponse,
 };
 
-use super::config::S3Options;
-use super::partitioner::S3PartitionKey;
+use super::{config::S3Options, partitioner::S3PartitionKey};
 
 #[derive(Debug, Clone)]
 pub struct S3Request {

--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -11,13 +11,12 @@ use vector_core::{
     stream::{BatcherSettings, DriverResponse},
 };
 
-use crate::internal_events::SinkRequestBuildError;
+use super::partitioner::{S3KeyPartitioner, S3PartitionKey};
 use crate::{
     event::Event,
+    internal_events::SinkRequestBuildError,
     sinks::util::{RequestBuilder, SinkBuilderExt},
 };
-
-use super::partitioner::{S3KeyPartitioner, S3PartitionKey};
 
 pub struct S3Sink<Svc, RB> {
     service: Svc,

--- a/src/sinks/sematext/mod.rs
+++ b/src/sinks/sematext/mod.rs
@@ -1,9 +1,9 @@
 pub mod logs;
 pub mod metrics;
 
-pub use self::{logs::SematextLogsConfig, metrics::SematextMetricsConfig};
-
 use vector_config::configurable_component;
+
+pub use self::{logs::SematextLogsConfig, metrics::SematextMetricsConfig};
 
 /// Sematext region.
 #[configurable_component]

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -303,9 +303,9 @@ mod test {
         };
         use tokio_stream::wrappers::IntervalStream;
 
-        use crate::event::EventArray;
-        use crate::tls::{
-            self, MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsEnableableConfig,
+        use crate::{
+            event::EventArray,
+            tls::{self, MaybeTlsIncomingStream, MaybeTlsSettings, TlsConfig, TlsEnableableConfig},
         };
 
         trace_init();

--- a/src/sinks/splunk_hec/common/response.rs
+++ b/src/sinks/splunk_hec/common/response.rs
@@ -1,5 +1,4 @@
-use vector_core::internal_event::CountByteSize;
-use vector_core::{event::EventStatus, stream::DriverResponse};
+use vector_core::{event::EventStatus, internal_event::CountByteSize, stream::DriverResponse};
 
 pub struct HecResponse {
     pub event_status: EventStatus,

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -2,6 +2,7 @@ use std::{fmt, num::NonZeroUsize, sync::Arc};
 
 use async_trait::async_trait;
 use futures_util::{stream::BoxStream, StreamExt};
+use lookup::event_path;
 use serde::Serialize;
 use tower::Service;
 use vector_buffers::EventCount;
@@ -16,9 +17,9 @@ use vector_core::{
 use super::request_builder::HecLogsRequestBuilder;
 use crate::{
     config::SinkContext,
-    internal_events::SplunkEventTimestampInvalidType,
-    internal_events::SplunkEventTimestampMissing,
-    internal_events::TemplateRenderingError,
+    internal_events::{
+        SplunkEventTimestampInvalidType, SplunkEventTimestampMissing, TemplateRenderingError,
+    },
     sinks::{
         splunk_hec::common::{
             render_template_string, request::HecRequest, EndpointTarget, INDEX_FIELD,
@@ -28,7 +29,6 @@ use crate::{
     },
     template::Template,
 };
-use lookup::event_path;
 
 pub struct HecLogsSink<S> {
     pub context: SinkContext,

--- a/src/sinks/splunk_hec/metrics/integration_tests.rs
+++ b/src/sinks/splunk_hec/metrics/integration_tests.rs
@@ -2,8 +2,10 @@ use std::convert::TryFrom;
 
 use futures::{future::ready, stream};
 use serde_json::Value as JsonValue;
-use vector_core::event::{BatchNotifier, BatchStatus, Event, MetricValue};
-use vector_core::metric_tags;
+use vector_core::{
+    event::{BatchNotifier, BatchStatus, Event, MetricValue},
+    metric_tags,
+};
 
 use super::config::HecMetricsSinkConfig;
 use crate::{

--- a/src/sinks/util/buffer/metrics/mod.rs
+++ b/src/sinks/util/buffer/metrics/mod.rs
@@ -127,8 +127,10 @@ pub fn compress_distribution(samples: &mut Vec<Sample>) -> Vec<Sample> {
 #[cfg(test)]
 pub(self) mod tests {
     use similar_asserts::assert_eq;
-    use vector_core::event::metric::{MetricKind, MetricKind::*, MetricValue, StatisticKind};
-    use vector_core::metric_tags;
+    use vector_core::{
+        event::metric::{MetricKind, MetricKind::*, MetricValue, StatisticKind},
+        metric_tags,
+    };
 
     use super::*;
     use crate::{

--- a/src/sinks/util/buffer/metrics/sort.rs
+++ b/src/sinks/util/buffer/metrics/sort.rs
@@ -9,11 +9,13 @@ pub fn sort_for_compression(metrics: &mut [Metric]) {
 
 #[cfg(test)]
 mod test {
+    use rand::{prelude::SliceRandom, thread_rng};
+    use vector_core::{
+        event::{Metric, MetricKind},
+        metric_tags,
+    };
+
     use crate::event::MetricValue;
-    use rand::prelude::SliceRandom;
-    use rand::thread_rng;
-    use vector_core::event::{Metric, MetricKind};
-    use vector_core::metric_tags;
 
     // This just ensures the sorting does not change. `sort_for_compression` relies on
     // the default `PartialOrd` on `MetricSeries`.

--- a/src/sinks/util/metadata.rs
+++ b/src/sinks/util/metadata.rs
@@ -1,9 +1,8 @@
 use std::num::NonZeroUsize;
 
 use vector_buffers::EventCount;
-use vector_core::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
-
 use vector_common::request_metadata::RequestMetadata;
+use vector_core::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
 
 use super::request_builder::EncodeResult;
 

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -1,5 +1,9 @@
-use serde::Serializer;
 use std::fmt;
+
+use serde::{
+    de::{self, Unexpected, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use vector_config::{
     schema::{
         apply_metadata, generate_const_string_schema, generate_number_schema,
@@ -9,11 +13,6 @@ use vector_config::{
     Configurable, GenerateError, Metadata,
 };
 use vector_config_common::attributes::CustomAttribute;
-
-use serde::{
-    de::{self, Unexpected, Visitor},
-    Deserialize, Deserializer, Serialize,
-};
 
 /// Configuration for outbound request concurrency.
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -572,7 +572,10 @@ impl<'a> Response for &'a str {}
 mod tests {
     use std::{
         convert::Infallible,
-        sync::{atomic::AtomicUsize, atomic::Ordering::Relaxed, Arc, Mutex},
+        sync::{
+            atomic::{AtomicUsize, Ordering::Relaxed},
+            Arc, Mutex,
+        },
     };
 
     use bytes::Bytes;

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -1,5 +1,4 @@
 use snafu::Snafu;
-
 use vector_config::configurable_component;
 
 mod config;
@@ -47,8 +46,7 @@ mod tests {
     use prost::Message;
     use vector_core::event::{BatchNotifier, BatchStatus};
 
-    use super::config::with_default_scheme;
-    use super::*;
+    use super::{config::with_default_scheme, *};
     use crate::{
         config::{SinkConfig as _, SinkContext},
         event::Event,

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -37,8 +37,10 @@ use crate::{
         ConnectionOpen, OpenGauge, WsConnectionError, WsConnectionEstablished,
         WsConnectionFailedError, WsConnectionShutdown,
     },
-    sinks::util::{retries::ExponentialBackoff, StreamSink},
-    sinks::websocket::config::WebSocketSinkConfig,
+    sinks::{
+        util::{retries::ExponentialBackoff, StreamSink},
+        websocket::config::WebSocketSinkConfig,
+    },
     tls::{MaybeTlsSettings, MaybeTlsStream, TlsError},
 };
 
@@ -378,8 +380,10 @@ mod tests {
     use tokio::time::timeout;
     use tokio_tungstenite::{
         accept_async, accept_hdr_async,
-        tungstenite::error::{Error as WsError, ProtocolError},
-        tungstenite::handshake::server::{Request, Response},
+        tungstenite::{
+            error::{Error as WsError, ProtocolError},
+            handshake::server::{Request, Response},
+        },
     };
 
     use super::*;

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -6,8 +6,7 @@ use tokio::time;
 use tokio_stream::wrappers::IntervalStream;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use crate::{
     config::{self, GenerateConfig, Output, SourceConfig, SourceContext},

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -8,9 +8,9 @@ use futures::StreamExt;
 use lookup::event_path;
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::FramedRead;
-use vector_common::finalization::AddBatchNotifier;
-use vector_common::internal_event::{
-    ByteSize, BytesReceived, InternalEventHandle as _, Registered,
+use vector_common::{
+    finalization::AddBatchNotifier,
+    internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Registered},
 };
 use vector_core::{event::BatchNotifier, ByteSizeOf};
 use warp::reject;

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -1,17 +1,19 @@
 use std::{future::ready, panic, sync::Arc};
 
-use aws_sdk_s3::error::GetObjectError;
-use aws_sdk_s3::Client as S3Client;
-use aws_sdk_sqs::error::{DeleteMessageBatchError, ReceiveMessageError};
-use aws_sdk_sqs::model::{DeleteMessageBatchRequestEntry, Message};
-use aws_sdk_sqs::output::DeleteMessageBatchOutput;
-use aws_sdk_sqs::Client as SqsClient;
+use aws_sdk_s3::{error::GetObjectError, Client as S3Client};
+use aws_sdk_sqs::{
+    error::{DeleteMessageBatchError, ReceiveMessageError},
+    model::{DeleteMessageBatchRequestEntry, Message},
+    output::DeleteMessageBatchOutput,
+    Client as SqsClient,
+};
 use aws_smithy_client::SdkError;
 use aws_types::region::Region;
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use codecs::{decoding::FramingError, BytesDeserializer, CharacterDelimitedDecoder};
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt};
+use lookup::path;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use snafu::{ResultExt, Snafu};
@@ -22,6 +24,10 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
 use vector_config::{configurable_component, NamedComponent};
+use vector_core::{
+    config::{LegacyKey, LogNamespace},
+    ByteSizeOf,
+};
 
 use crate::{
     config::{log_schema, SourceAcknowledgementsConfig, SourceContext},
@@ -38,9 +44,6 @@ use crate::{
     tls::TlsConfig,
     SourceSender,
 };
-use lookup::path;
-use vector_core::config::LegacyKey;
-use vector_core::{config::LogNamespace, ByteSizeOf};
 
 static SUPPORTED_S3_EVENT_VERSION: Lazy<semver::VersionReq> =
     Lazy::new(|| semver::VersionReq::parse("~2").unwrap());

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -2,15 +2,14 @@ use codecs::decoding::{DeserializerConfig, FramingConfig};
 use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
-use crate::aws::create_client;
-use crate::codecs::DecodingConfig;
-use crate::common::sqs::SqsClientBuilder;
-use crate::tls::TlsConfig;
 use crate::{
-    aws::{auth::AwsAuthentication, region::RegionOrEndpoint},
+    aws::{auth::AwsAuthentication, create_client, region::RegionOrEndpoint},
+    codecs::DecodingConfig,
+    common::sqs::SqsClientBuilder,
     config::{Output, SourceAcknowledgementsConfig, SourceConfig, SourceContext},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::aws_sqs::source::SqsSource,
+    tls::TlsConfig,
 };
 
 /// Configuration for the `aws_sqs` source.

--- a/src/sources/datadog_agent/logs.rs
+++ b/src/sources/datadog_agent/logs.rs
@@ -6,8 +6,7 @@ use codecs::StreamDecodingError;
 use http::StatusCode;
 use lookup::path;
 use tokio_util::codec::Decoder;
-use vector_core::config::LegacyKey;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LegacyKey, ByteSizeOf};
 use warp::{filters::BoxedFilter, path as warp_path, path::FullPath, reply::Response, Filter};
 
 use crate::{

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -32,8 +32,10 @@ use snafu::Snafu;
 use tracing::Span;
 use value::Kind;
 use vector_config::{configurable_component, NamedComponent};
-use vector_core::config::{LegacyKey, LogNamespace};
-use vector_core::event::{BatchNotifier, BatchStatus};
+use vector_core::{
+    config::{LegacyKey, LogNamespace},
+    event::{BatchNotifier, BatchStatus},
+};
 use warp::{filters::BoxedFilter, reject::Rejection, reply::Response, Filter, Reply};
 
 use crate::{

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -14,8 +14,7 @@ use codecs::{
 use futures::{Stream, StreamExt};
 use http::HeaderMap;
 use indoc::indoc;
-use lookup::owned_value_path;
-use lookup::LookupBuf;
+use lookup::{owned_value_path, LookupBuf};
 use ordered_float::NotNan;
 use prost::Message;
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
@@ -24,7 +23,6 @@ use value::Kind;
 use vector_core::config::LogNamespace;
 use vrl::prelude::Collection;
 
-use crate::schema::Definition;
 use crate::{
     common::datadog::{DatadogMetricType, DatadogPoint, DatadogSeriesMetric},
     config::{log_schema, SourceConfig, SourceContext},
@@ -34,6 +32,7 @@ use crate::{
         Event, EventStatus, Metric, Value,
     },
     schema,
+    schema::Definition,
     serde::{default_decoding, default_framing_message_based},
     sources::datadog_agent::{
         ddmetric_proto, ddtrace_proto, logs::decode_log_body, metrics::DatadogSeriesRequest,

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -1,3 +1,5 @@
+use std::task::Poll;
+
 use chrono::Utc;
 use codecs::{
     decoding::{DeserializerConfig, FramingConfig},
@@ -7,13 +9,11 @@ use fakedata::logs::*;
 use futures::StreamExt;
 use rand::seq::SliceRandom;
 use snafu::Snafu;
-use std::task::Poll;
 use tokio::time::{self, Duration};
 use tokio_util::codec::FramedRead;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use crate::{
     codecs::{Decoder, DecodingConfig},

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -259,8 +259,10 @@ impl FrameHandler for DnstapFrameHandler {
 mod integration_tests {
     #![allow(clippy::print_stdout)] // tests
 
-    use bollard::exec::{CreateExecOptions, StartExecOptions};
-    use bollard::Docker;
+    use bollard::{
+        exec::{CreateExecOptions, StartExecOptions},
+        Docker,
+    };
     use futures::StreamExt;
     use serde_json::json;
     use tokio::time;

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -30,8 +30,7 @@ use dnstap_proto::{
     message::Type as DnstapMessageType, Dnstap, Message as DnstapMessage, SocketFamily,
     SocketProtocol,
 };
-use lookup::lookup_v2::OwnedValuePath;
-use lookup::PathPrefix;
+use lookup::{lookup_v2::OwnedValuePath, PathPrefix};
 
 use super::{
     dns_message::{

--- a/src/sources/docker_logs.rs
+++ b/src/sources/docker_logs.rs
@@ -12,9 +12,7 @@ use bollard::{
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, FixedOffset, Local, ParseError, Utc};
 use futures::{Stream, StreamExt};
-use lookup::lookup_v2::ValuePath;
-use lookup::path;
-use lookup::PathPrefix;
+use lookup::{lookup_v2::ValuePath, path, PathPrefix};
 use once_cell::sync::Lazy;
 use tokio::sync::mpsc;
 use tracing_futures::Instrument;
@@ -22,8 +20,7 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use super::util::MultilineConfig;
 use crate::{

--- a/src/sources/eventstoredb_metrics/mod.rs
+++ b/src/sources/eventstoredb_metrics/mod.rs
@@ -6,8 +6,7 @@ use hyper::{Body, Request};
 use tokio_stream::wrappers::IntervalStream;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use self::types::Stats;
 use crate::{

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -11,6 +11,7 @@ use codecs::{
     StreamDecodingError,
 };
 use futures::StreamExt;
+use lookup::event_path;
 use smallvec::SmallVec;
 use snafu::Snafu;
 use tokio::{
@@ -23,7 +24,7 @@ use tokio_stream::wrappers::IntervalStream;
 use tokio_util::codec::FramedRead;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_config::{configurable_component, NamedComponent};
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use crate::{
     codecs::{Decoder, DecodingConfig},
@@ -37,8 +38,6 @@ use crate::{
     shutdown::ShutdownSignal,
     SourceSender,
 };
-use lookup::event_path;
-use vector_core::config::LogNamespace;
 
 pub mod sized_bytes_codec;
 

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -1,13 +1,11 @@
-use std::fs::File;
-use std::io;
-use std::os::unix::io::FromRawFd;
+use std::{fs::File, io, os::unix::io::FromRawFd};
 
-use super::FileDescriptorConfig;
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use indoc::indoc;
 use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
+use super::FileDescriptorConfig;
 use crate::{
     config::{GenerateConfig, Output, Resource, SourceConfig, SourceContext},
     serde::default_decoding,
@@ -90,6 +88,7 @@ impl SourceConfig for FileDescriptorSourceConfig {
 
 #[cfg(test)]
 mod tests {
+    use futures::StreamExt;
     use nix::unistd::{close, pipe, write};
 
     use super::*;
@@ -100,7 +99,6 @@ mod tests {
         },
         SourceSender,
     };
-    use futures::StreamExt;
 
     #[test]
     fn generate_config() {

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -11,9 +11,7 @@ use futures::{channel::mpsc, executor, SinkExt, StreamExt};
 use tokio_util::{codec::FramedRead, io::StreamReader};
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_config::NamedComponent;
-use vector_core::config::LogNamespace;
-use vector_core::event::Event;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, event::Event, ByteSizeOf};
 
 use crate::{
     codecs::{Decoder, DecodingConfig},

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -4,12 +4,11 @@ use codecs::decoding::{DeserializerConfig, FramingConfig};
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::LogNamespace;
 
+use super::FileDescriptorConfig;
 use crate::{
     config::{Output, Resource, SourceConfig, SourceContext},
     serde::default_decoding,
 };
-
-use super::FileDescriptorConfig;
 
 /// Configuration for the `stdin` source.
 #[configurable_component(source("stdin"))]
@@ -93,13 +92,15 @@ impl SourceConfig for StdinConfig {
 mod tests {
     use std::io::Cursor;
 
+    use futures::StreamExt;
+
     use super::*;
     use crate::{
-        config::log_schema, shutdown::ShutdownSignal,
-        test_util::components::assert_source_compliance, test_util::components::SOURCE_TAGS,
+        config::log_schema,
+        shutdown::ShutdownSignal,
+        test_util::components::{assert_source_compliance, SOURCE_TAGS},
         SourceSender,
     };
-    use futures::StreamExt;
 
     #[test]
     fn generate_config() {

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -1,5 +1,7 @@
-use std::io::{self, Read};
-use std::net::SocketAddr;
+use std::{
+    io::{self, Read},
+    net::SocketAddr,
+};
 
 use bytes::{Buf, Bytes, BytesMut};
 use codecs::StreamDecodingError;
@@ -465,11 +467,12 @@ impl From<FluentEvent> for LogEvent {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use bytes::BytesMut;
     use chrono::{DateTime, Utc};
     use rmp_serde::Serializer;
     use serde::Serialize;
-    use std::collections::BTreeMap;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         time::{error::Elapsed, timeout, Duration},

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -1,6 +1,12 @@
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::{
-    error::Error as _, future::Future, pin::Pin, sync::Arc, task::Context, task::Poll,
+    error::Error as _,
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
     time::Duration,
 };
 
@@ -18,10 +24,11 @@ use tonic::{
     transport::{Certificate, ClientTlsConfig, Endpoint, Identity},
     Code, Request, Status,
 };
-use vector_common::internal_event::{
-    ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalizer::UnorderedFinalizer,
+    internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered},
 };
-use vector_common::{byte_size_of::ByteSizeOf, finalizer::UnorderedFinalizer};
 use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
@@ -692,10 +699,19 @@ mod integration_tests {
     use vector_common::btreemap;
 
     use super::*;
-    use crate::config::{ComponentKey, ProxyConfig};
-    use crate::test_util::components::{assert_source_compliance, SOURCE_TAGS};
-    use crate::test_util::{self, components, random_string};
-    use crate::{event::EventStatus, gcp, http::HttpClient, shutdown, SourceSender};
+    use crate::{
+        config::{ComponentKey, ProxyConfig},
+        event::EventStatus,
+        gcp,
+        http::HttpClient,
+        shutdown,
+        test_util::{
+            self, components,
+            components::{assert_source_compliance, SOURCE_TAGS},
+            random_string,
+        },
+        SourceSender,
+    };
 
     const PROJECT: &str = "sourceproject";
     static PROJECT_URI: Lazy<String> =

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -11,9 +11,11 @@ use codecs::{
     decoding::{DeserializerConfig, FramingConfig},
     StreamDecodingError,
 };
+use lookup::event_path;
 use smallvec::SmallVec;
 use tokio_util::codec::Decoder as _;
 use vector_config::configurable_component;
+use vector_core::config::LogNamespace;
 use warp::http::{HeaderMap, StatusCode};
 
 use crate::{
@@ -30,8 +32,6 @@ use crate::{
     },
     tls::TlsEnableableConfig,
 };
-use lookup::event_path;
-use vector_core::config::LogNamespace;
 
 /// Configuration for `heroku_logs` source.
 #[configurable_component(source("heroku_logs"))]

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -1,4 +1,9 @@
-use std::{io, num::ParseIntError, path::Path, path::PathBuf, str::FromStr};
+use std::{
+    io,
+    num::ParseIntError,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use futures::future::BoxFuture;
 use snafu::{ResultExt, Snafu};
@@ -454,10 +459,12 @@ fn join_name(base_name: &Path, filename: impl AsRef<Path>) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-    use std::fs::{self, File};
-    use std::io::Write;
-    use std::path::{Path, PathBuf};
+    use std::{
+        collections::BTreeSet,
+        fs::{self, File},
+        io::Write,
+        path::{Path, PathBuf},
+    };
 
     use rand::{rngs::ThreadRng, Rng};
     use similar_asserts::assert_eq;

--- a/src/sources/host_metrics/cpu.rs
+++ b/src/sources/host_metrics/cpu.rs
@@ -1,4 +1,3 @@
-use crate::internal_events::{HostMetricsScrapeDetailError, HostMetricsScrapeError};
 use futures::StreamExt;
 #[cfg(target_os = "linux")]
 use heim::cpu::os::linux::CpuTimeExt;
@@ -6,6 +5,7 @@ use heim::units::time::second;
 use vector_core::{event::MetricTags, metric_tags};
 
 use super::{filter_result, HostMetrics};
+use crate::internal_events::{HostMetricsScrapeDetailError, HostMetricsScrapeError};
 
 const MODE: &str = "mode";
 const CPU_SECS_TOTAL: &str = "cpu_seconds_total";
@@ -78,8 +78,10 @@ impl HostMetrics {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{HostMetrics, HostMetricsConfig, MetricsBuffer};
-    use super::{CPU_SECS_TOTAL, LOGICAL_CPUS, MODE, PHYSICAL_CPUS};
+    use super::{
+        super::{HostMetrics, HostMetricsConfig, MetricsBuffer},
+        CPU_SECS_TOTAL, LOGICAL_CPUS, MODE, PHYSICAL_CPUS,
+    };
 
     #[tokio::test]
     async fn generates_cpu_metrics() {

--- a/src/sources/host_metrics/disk.rs
+++ b/src/sources/host_metrics/disk.rs
@@ -1,10 +1,10 @@
-use crate::internal_events::HostMetricsScrapeDetailError;
 use futures::StreamExt;
 use heim::units::information::byte;
 use vector_config::configurable_component;
 use vector_core::metric_tags;
 
 use super::{filter_result, FilterList, HostMetrics};
+use crate::internal_events::HostMetricsScrapeDetailError;
 
 /// Options for the “disk” metrics collector.
 #[configurable_component]

--- a/src/sources/host_metrics/filesystem.rs
+++ b/src/sources/host_metrics/filesystem.rs
@@ -5,9 +5,8 @@ use heim::units::ratio::ratio;
 use vector_config::configurable_component;
 use vector_core::metric_tags;
 
-use crate::internal_events::{HostMetricsScrapeDetailError, HostMetricsScrapeFilesystemError};
-
 use super::{filter_result, FilterList, HostMetrics};
+use crate::internal_events::{HostMetricsScrapeDetailError, HostMetricsScrapeFilesystemError};
 
 /// Options for the “filesystem” metrics collector.
 #[configurable_component]

--- a/src/sources/host_metrics/memory.rs
+++ b/src/sources/host_metrics/memory.rs
@@ -7,9 +7,8 @@ use heim::memory::os::SwapExt;
 use heim::units::information::byte;
 use vector_core::event::MetricTags;
 
-use crate::internal_events::HostMetricsScrapeDetailError;
-
 use super::HostMetrics;
+use crate::internal_events::HostMetricsScrapeDetailError;
 
 impl HostMetrics {
     pub async fn memory_metrics(&self, output: &mut super::MetricsBuffer) {

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -10,8 +10,7 @@ use tokio::time;
 use tokio_stream::wrappers::IntervalStream;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use crate::{
     config::{DataType, Output, SourceConfig, SourceContext},
@@ -481,10 +480,10 @@ impl From<PatternWrapper> for String {
 
 #[cfg(test)]
 pub(self) mod tests {
-    use crate::test_util::components::{run_and_assert_source_compliance, SOURCE_TAGS};
     use std::{collections::HashSet, future::Future, time::Duration};
 
     use super::*;
+    use crate::test_util::components::{run_and_assert_source_compliance, SOURCE_TAGS};
 
     #[test]
     fn filterlist_default_includes_everything() {

--- a/src/sources/host_metrics/network.rs
+++ b/src/sources/host_metrics/network.rs
@@ -7,9 +7,8 @@ use heim::units::information::byte;
 use vector_config::configurable_component;
 use vector_core::metric_tags;
 
-use crate::internal_events::HostMetricsScrapeDetailError;
-
 use super::{filter_result, FilterList, HostMetrics};
+use crate::internal_events::HostMetricsScrapeDetailError;
 
 /// Options for the “network” metrics collector.
 #[configurable_component]

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -3,19 +3,9 @@
 //! It leverages a static file server ("dufs"), which serves the files in tests/data/http-client
 
 use std::collections::HashMap;
-use tokio::time::{Duration, Instant};
 
-use crate::sources::util::http::HttpMethod;
-use crate::{
-    config::{ComponentKey, SourceConfig, SourceContext},
-    http::Auth,
-    serde::default_decoding,
-    serde::default_framing_message_based,
-    tls,
-    tls::TlsConfig,
-    SourceSender,
-};
 use codecs::decoding::DeserializerConfig;
+use tokio::time::{Duration, Instant};
 use vector_config::NamedComponent;
 use vector_core::config::log_schema;
 
@@ -23,8 +13,16 @@ use super::{
     tests::{run_compliance, INTERVAL_SECS},
     HttpClientConfig,
 };
-
-use crate::test_util::components::{run_and_assert_source_error, COMPONENT_ERROR_TAGS};
+use crate::{
+    config::{ComponentKey, SourceConfig, SourceContext},
+    http::Auth,
+    serde::{default_decoding, default_framing_message_based},
+    sources::util::http::HttpMethod,
+    test_util::components::{run_and_assert_source_error, COMPONENT_ERROR_TAGS},
+    tls,
+    tls::TlsConfig,
+    SourceSender,
+};
 
 fn dufs_address() -> String {
     std::env::var("DUFS_ADDRESS").unwrap_or_else(|_| "http://localhost:5000".into())

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -1,19 +1,21 @@
 use std::collections::HashMap;
-use tokio::time::Duration;
-use warp::{http::HeaderMap, Filter};
 
-use crate::sources::util::http::HttpMethod;
-use crate::{serde::default_decoding, serde::default_framing_message_based};
 use codecs::decoding::{
     CharacterDelimitedDecoderOptions, DeserializerConfig, FramingConfig,
     NewlineDelimitedDecoderOptions,
 };
+use tokio::time::Duration;
 use vector_core::event::Event;
+use warp::{http::HeaderMap, Filter};
 
 use super::HttpClientConfig;
-use crate::test_util::{
-    components::{run_and_assert_source_compliance, HTTP_PULL_SOURCE_TAGS},
-    next_addr, test_generate_config, wait_for_tcp,
+use crate::{
+    serde::{default_decoding, default_framing_message_based},
+    sources::util::http::HttpMethod,
+    test_util::{
+        components::{run_and_assert_source_compliance, HTTP_PULL_SOURCE_TAGS},
+        next_addr, test_generate_config, wait_for_tcp,
+    },
 };
 
 pub(crate) const INTERVAL_SECS: u64 = 1;

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -306,9 +306,7 @@ fn add_headers(events: &mut [Event], headers_config: &[String], headers: HeaderM
 
 #[cfg(test)]
 mod tests {
-    use lookup::event_path;
-    use std::str::FromStr;
-    use std::{collections::BTreeMap, io::Write, net::SocketAddr};
+    use std::{collections::BTreeMap, io::Write, net::SocketAddr, str::FromStr};
 
     use codecs::{
         decoding::{DeserializerConfig, FramingConfig},
@@ -320,13 +318,14 @@ mod tests {
     };
     use futures::Stream;
     use http::{HeaderMap, Method};
+    use lookup::event_path;
     use similar_asserts::assert_eq;
 
     use super::SimpleHttpConfig;
-    use crate::sources::http_server::HttpMethod;
     use crate::{
         config::{log_schema, SourceConfig, SourceContext},
         event::{Event, EventStatus, Value},
+        sources::http_server::HttpMethod,
         test_util::{
             components::{self, assert_source_compliance, HTTP_PUSH_SOURCE_TAGS},
             next_addr, spawn_collect_n, trace_init, wait_for_tcp,

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -2,8 +2,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use futures::{stream, StreamExt};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use crate::{
     config::{log_schema, DataType, Output, SourceConfig, SourceContext},

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -2,8 +2,7 @@ use futures::StreamExt;
 use tokio::time;
 use tokio_stream::wrappers::IntervalStream;
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use crate::{
     config::{log_schema, DataType, Output, SourceConfig, SourceContext},

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -28,10 +28,11 @@ use tokio::{
     time::sleep,
 };
 use tokio_util::codec::FramedRead;
-use vector_common::internal_event::{
-    ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalizer::OrderedFinalizer,
+    internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered},
 };
-use vector_common::{byte_size_of::ByteSizeOf, finalizer::OrderedFinalizer};
 use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
@@ -855,7 +856,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::ComponentKey, event::Event, event::EventStatus,
+        config::ComponentKey,
+        event::{Event, EventStatus},
         test_util::components::assert_source_compliance,
     };
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -20,11 +20,9 @@ use rdkafka::{
 };
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::FramedRead;
-
+use vector_common::{byte_size_of::ByteSizeOf, finalizer::OrderedFinalizer};
 use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
-
-use vector_common::{byte_size_of::ByteSizeOf, finalizer::OrderedFinalizer};
 
 use crate::{
     codecs::{Decoder, DecodingConfig},

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -24,8 +24,10 @@ use kube::{
     },
     Client, Config as ClientConfig,
 };
-use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
-use vector_common::TimeZone;
+use vector_common::{
+    internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol},
+    TimeZone,
+};
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::{transform::TaskTransform, ByteSizeOf};
 
@@ -59,14 +61,16 @@ mod pod_metadata_annotator;
 mod transform_utils;
 mod util;
 
-use self::namespace_metadata_annotator::NamespaceMetadataAnnotator;
-use self::node_metadata_annotator::NodeMetadataAnnotator;
-use self::parser::Parser;
-use self::pod_metadata_annotator::PodMetadataAnnotator;
 use futures::{future::FutureExt, stream::StreamExt};
 use k8s_paths_provider::K8sPathsProvider;
 use lifecycle::Lifecycle;
 use vector_core::config::LogNamespace;
+
+use self::{
+    namespace_metadata_annotator::NamespaceMetadataAnnotator,
+    node_metadata_annotator::NodeMetadataAnnotator, parser::Parser,
+    pod_metadata_annotator::PodMetadataAnnotator,
+};
 
 /// The key we use for `file` field.
 const FILE_KEY: &str = "file";

--- a/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
@@ -4,9 +4,7 @@
 
 use k8s_openapi::{api::core::v1::Namespace, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 use kube::runtime::reflector::{store::Store, ObjectRef};
-use lookup::lookup_v2::ValuePath;
-use lookup::OwnedTargetPath;
-use lookup::{owned_value_path, path};
+use lookup::{lookup_v2::ValuePath, owned_value_path, path, OwnedTargetPath};
 use vector_config::configurable_component;
 
 use crate::event::{Event, LogEvent};

--- a/src/sources/kubernetes_logs/node_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/node_metadata_annotator.rs
@@ -2,12 +2,12 @@
 
 #![deny(missing_docs)]
 
-use crate::event::{Event, LogEvent};
 use k8s_openapi::{api::core::v1::Node, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 use kube::runtime::reflector::{store::Store, ObjectRef};
-use lookup::lookup_v2::ValuePath;
-use lookup::{owned_value_path, path, OwnedTargetPath, PathPrefix};
+use lookup::{lookup_v2::ValuePath, owned_value_path, path, OwnedTargetPath, PathPrefix};
 use vector_config::configurable_component;
+
+use crate::event::{Event, LogEvent};
 
 /// Configuration for how the events are annotated with Node metadata.
 #[configurable_component]

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use lookup::event_path;
 use serde_json::Value as JsonValue;
 use snafu::{OptionExt, ResultExt, Snafu};
 
@@ -9,7 +10,6 @@ use crate::{
     internal_events::KubernetesLogsDockerFormatParseError,
     transforms::{FunctionTransform, OutputBuffer},
 };
-use lookup::event_path;
 
 pub const TIME: &str = "time";
 pub const LOG: &str = "log";

--- a/src/sources/kubernetes_logs/parser/mod.rs
+++ b/src/sources/kubernetes_logs/parser/mod.rs
@@ -76,7 +76,11 @@ impl FunctionTransform for Parser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{event::Event, event::LogEvent, test_util::trace_init, transforms::Transform};
+    use crate::{
+        event::{Event, LogEvent},
+        test_util::trace_init,
+        transforms::Transform,
+    };
 
     /// Picker has to work for all test cases for underlying parsers.
     fn cases() -> Vec<(String, Vec<Event>)> {

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -7,8 +7,10 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::ObjectMeta,
 };
 use kube::runtime::reflector::{store::Store, ObjectRef};
-use lookup::lookup_v2::{OptionalTargetPath, ValuePath};
-use lookup::{owned_value_path, path, OwnedTargetPath, PathPrefix};
+use lookup::{
+    lookup_v2::{OptionalTargetPath, ValuePath},
+    owned_value_path, path, OwnedTargetPath, PathPrefix,
+};
 use vector_config::configurable_component;
 
 use super::path_helpers::{parse_log_file_path, LogFileInfo};

--- a/src/sources/kubernetes_logs/transform_utils/optional.rs
+++ b/src/sources/kubernetes_logs/transform_utils/optional.rs
@@ -6,8 +6,7 @@ use std::pin::Pin;
 
 use futures::Stream;
 
-use crate::event::EventContainer;
-use crate::transforms::TaskTransform;
+use crate::{event::EventContainer, transforms::TaskTransform};
 
 /// Optional transform.
 /// Passes events through the specified transform is any, otherwise passes them,

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -1,8 +1,8 @@
-use std::net::SocketAddr;
 use std::{
     collections::{BTreeMap, VecDeque},
     convert::TryFrom,
     io::{self, Read},
+    net::SocketAddr,
 };
 
 use bytes::{Buf, Bytes, BytesMut};

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -218,13 +218,15 @@ mod integration_tests {
     #![allow(clippy::print_stdout)] //tests
 
     use super::*;
-    use crate::nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword};
-    use crate::test_util::{
-        collect_n,
-        components::{assert_source_compliance, SOURCE_TAGS},
-        random_string,
+    use crate::{
+        nats::{NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword},
+        test_util::{
+            collect_n,
+            components::{assert_source_compliance, SOURCE_TAGS},
+            random_string,
+        },
+        tls::TlsConfig,
     };
-    use crate::tls::TlsConfig;
 
     async fn publish_and_check(conf: NatsSourceConfig) -> Result<(), BuildError> {
         let subject = conf.subject.clone();

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -268,12 +268,13 @@ mod tests {
 
 #[cfg(all(test, feature = "nginx-integration-tests"))]
 mod integration_tests {
+    use tokio::time::Duration;
+
     use super::*;
     use crate::{
         config::ProxyConfig,
         test_util::components::{run_and_assert_source_compliance_advanced, HTTP_PULL_SOURCE_TAGS},
     };
-    use tokio::time::Duration;
 
     fn nginx_proxy_address() -> String {
         std::env::var("NGINX_PROXY_ADDRESS").unwrap_or_else(|_| "http://nginx-proxy:8000".into())

--- a/src/sources/opentelemetry/grpc.rs
+++ b/src/sources/opentelemetry/grpc.rs
@@ -1,18 +1,17 @@
+use futures::TryFutureExt;
+use opentelemetry_proto::proto::collector::logs::v1::{
+    logs_service_server::LogsService, ExportLogsServiceRequest, ExportLogsServiceResponse,
+};
+use tonic::{Request, Response, Status};
+use vector_core::{
+    event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event},
+    ByteSizeOf,
+};
+
 use crate::{
     internal_events::{EventsReceived, StreamClosedError},
     sources::opentelemetry::LOGS,
     SourceSender,
-};
-use futures::TryFutureExt;
-
-use tonic::{Request, Response, Status};
-
-use opentelemetry_proto::proto::collector::logs::v1::{
-    logs_service_server::LogsService, ExportLogsServiceRequest, ExportLogsServiceResponse,
-};
-use vector_core::{
-    event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event},
-    ByteSizeOf,
 };
 
 #[derive(Debug, Clone)]

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -18,6 +18,7 @@ use vector_core::{
 };
 use warp::{filters::BoxedFilter, reject::Rejection, reply::Response, Filter, Reply};
 
+use super::{reply::protobuf, status::Status};
 use crate::{
     event::Event,
     internal_events::{EventsReceived, StreamClosedError},
@@ -26,8 +27,6 @@ use crate::{
     tls::MaybeTlsSettings,
     SourceSender,
 };
-
-use super::{reply::protobuf, status::Status};
 
 #[derive(Clone, Copy, Debug, Snafu)]
 pub(crate) enum ApiError {

--- a/src/sources/opentelemetry/integration_tests.rs
+++ b/src/sources/opentelemetry/integration_tests.rs
@@ -4,6 +4,7 @@ use futures::Stream;
 use futures_util::StreamExt;
 use serde_json::json;
 
+use super::{GrpcConfig, HttpConfig, OpentelemetryConfig, LOGS};
 use crate::{
     config::{log_schema, SourceConfig, SourceContext},
     event::{into_event_stream, Event, EventStatus},
@@ -14,8 +15,6 @@ use crate::{
     },
     SourceSender,
 };
-
-use super::{GrpcConfig, HttpConfig, OpentelemetryConfig, LOGS};
 
 fn otel_health_url() -> String {
     std::env::var("OTEL_HEALTH_URL").unwrap_or_else(|_| "http://0.0.0.0:13133".to_owned())

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -11,12 +11,15 @@ mod status;
 use std::net::SocketAddr;
 
 use futures::{future::join, FutureExt, TryFutureExt};
-
 use opentelemetry_proto::proto::collector::logs::v1::logs_service_server::LogsServiceServer;
 use vector_common::internal_event::{BytesReceived, Protocol};
 use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
+use self::{
+    grpc::Service,
+    http::{build_warp_filter, run_http_server},
+};
 use crate::{
     config::{
         DataType, GenerateConfig, Output, Resource, SourceAcknowledgementsConfig, SourceConfig,
@@ -25,11 +28,6 @@ use crate::{
     serde::bool_or_struct,
     sources::{util::grpc::run_grpc_server, Source},
     tls::{MaybeTlsSettings, TlsEnableableConfig},
-};
-
-use self::{
-    grpc::Service,
-    http::{build_warp_filter, run_http_server},
 };
 
 pub const LOGS: &str = "logs";

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1,3 +1,16 @@
+use std::collections::BTreeMap;
+
+use chrono::{TimeZone, Utc};
+use futures::Stream;
+use futures_util::StreamExt;
+use opentelemetry_proto::proto::{
+    collector::logs::v1::{logs_service_client::LogsServiceClient, ExportLogsServiceRequest},
+    common::v1::{any_value, AnyValue, KeyValue},
+    logs::v1::{LogRecord, ResourceLogs, ScopeLogs},
+    resource::v1::Resource as OtelResource,
+};
+use tonic::Request;
+
 use crate::{
     config::{SourceConfig, SourceContext},
     event::{into_event_stream, Event, EventStatus, LogEvent, Value},
@@ -9,17 +22,6 @@ use crate::{
     },
     SourceSender,
 };
-use chrono::{TimeZone, Utc};
-use futures::Stream;
-use futures_util::StreamExt;
-use opentelemetry_proto::proto::{
-    collector::logs::v1::{logs_service_client::LogsServiceClient, ExportLogsServiceRequest},
-    common::v1::{any_value, AnyValue, KeyValue},
-    logs::v1::{LogRecord, ResourceLogs, ScopeLogs},
-    resource::v1::Resource as OtelResource,
-};
-use std::collections::BTreeMap;
-use tonic::Request;
 
 #[test]
 fn generate_config() {

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -19,8 +19,7 @@ use tokio_postgres::{
 };
 use tokio_stream::wrappers::IntervalStream;
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::{metric_tags, ByteSizeOf};
+use vector_core::{config::LogNamespace, metric_tags, ByteSizeOf};
 
 use crate::{
     config::{DataType, Output, SourceConfig, SourceContext},

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -3,22 +3,23 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use futures_util::FutureExt;
 use http::{response::Parts, Uri};
-
 use snafu::{ResultExt, Snafu};
 use vector_config::configurable_component;
 use vector_core::{config::LogNamespace, event::Event};
 
 use super::parser;
-use crate::sources::util::http::HttpMethod;
 use crate::{
     config::{self, GenerateConfig, Output, SourceConfig, SourceContext},
     http::Auth,
     internal_events::PrometheusParseError,
     sources::{
         self,
-        util::http_client::{
-            build_url, call, default_scrape_interval_secs, GenericHttpClientInputs,
-            HttpClientBuilder, HttpClientContext,
+        util::{
+            http::HttpMethod,
+            http_client::{
+                build_url, call, default_scrape_interval_secs, GenericHttpClientInputs,
+                HttpClientBuilder, HttpClientContext,
+            },
         },
     },
     tls::{TlsConfig, TlsSettings},

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -11,8 +11,7 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::ByteSizeOf;
+use vector_core::{config::LogNamespace, ByteSizeOf};
 
 use crate::{
     codecs::{Decoder, DecodingConfig},
@@ -267,10 +266,13 @@ mod integration_test {
     use redis::AsyncCommands;
 
     use super::*;
-    use crate::config::log_schema;
-    use crate::test_util::components::{run_and_assert_source_compliance_n, SOURCE_TAGS};
     use crate::{
-        test_util::{collect_n, random_string},
+        config::log_schema,
+        test_util::{
+            collect_n,
+            components::{run_and_assert_source_compliance_n, SOURCE_TAGS},
+            random_string,
+        },
         SourceSender,
     };
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -16,8 +16,7 @@ use snafu::Snafu;
 use tracing::Span;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::{event::BatchNotifier, ByteSizeOf};
+use vector_core::{config::LogNamespace, event::BatchNotifier, ByteSizeOf};
 use warp::{filters::BoxedFilter, path, reject::Rejection, reply::Response, Filter, Reply};
 
 use self::{
@@ -1002,8 +1001,7 @@ mod tests {
         config::{log_schema, SinkConfig, SinkContext, SourceConfig, SourceContext},
         event::{Event, LogEvent},
         sinks::{
-            splunk_hec::common::timestamp_key,
-            splunk_hec::logs::config::HecLogsSinkConfig,
+            splunk_hec::{common::timestamp_key, logs::config::HecLogsSinkConfig},
             util::{BatchConfig, Compression, TowerRequestConfig},
             Healthcheck, VectorSink,
         },

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -322,16 +322,20 @@ mod test {
     use vector_core::{config::ComponentKey, event::EventContainer};
 
     use super::*;
-    use crate::test_util::{
-        collect_limited,
-        components::{
-            assert_source_compliance, assert_source_error, COMPONENT_ERROR_TAGS,
-            SOCKET_HIGH_CARDINALITY_PUSH_SOURCE_TAGS,
+    use crate::{
+        series,
+        test_util::{
+            collect_limited,
+            components::{
+                assert_source_compliance, assert_source_error, COMPONENT_ERROR_TAGS,
+                SOCKET_HIGH_CARDINALITY_PUSH_SOURCE_TAGS,
+            },
+            metrics::{
+                assert_counter, assert_distribution, assert_gauge, assert_set, AbsoluteMetricState,
+            },
+            next_addr,
         },
-        metrics::{assert_counter, assert_distribution, assert_gauge, assert_set},
-        next_addr,
     };
-    use crate::{series, test_util::metrics::AbsoluteMetricState};
 
     #[test]
     fn generate_config() {

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -21,8 +21,7 @@ use crate::{
     codecs::Decoder,
     config::{log_schema, DataType, GenerateConfig, Output, Resource, SourceConfig, SourceContext},
     event::Event,
-    internal_events::StreamClosedError,
-    internal_events::{SocketBindError, SocketMode, SocketReceiveError},
+    internal_events::{SocketBindError, SocketMode, SocketReceiveError, StreamClosedError},
     shutdown::ShutdownSignal,
     sources::util::net::{try_bind_udp_socket, SocketListenAddr, TcpNullAcker, TcpSource},
     tcp::TcpKeepaliveConfig,
@@ -359,7 +358,6 @@ fn enrich_syslog_event(event: &mut Event, host_key: &str, default_host: Option<B
 
 #[cfg(test)]
 mod test {
-    use lookup::event_path;
     use std::{
         collections::{BTreeMap, HashMap},
         fmt,
@@ -368,6 +366,7 @@ mod test {
 
     use chrono::prelude::*;
     use codecs::decoding::format::Deserializer;
+    use lookup::event_path;
     use rand::{thread_rng, Rng};
     use serde::Deserialize;
     use tokio::time::{sleep, Duration, Instant};
@@ -858,12 +857,13 @@ mod test {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_unix_stream_syslog() {
-        use crate::test_util::components::SOCKET_HIGH_CARDINALITY_PUSH_SOURCE_TAGS;
-        use futures_util::{stream, SinkExt};
         use std::os::unix::net::UnixStream as StdUnixStream;
-        use tokio::io::AsyncWriteExt;
-        use tokio::net::UnixStream;
+
+        use futures_util::{stream, SinkExt};
+        use tokio::{io::AsyncWriteExt, net::UnixStream};
         use tokio_util::codec::{FramedWrite, LinesCodec};
+
+        use crate::test_util::components::SOCKET_HIGH_CARDINALITY_PUSH_SOURCE_TAGS;
 
         assert_source_compliance(&SOCKET_HIGH_CARDINALITY_PUSH_SOURCE_TAGS, async {
             let num_messages: usize = 1;

--- a/src/sources/util/grpc/decompression.rs
+++ b/src/sources/util/grpc/decompression.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp,
+    future::Future,
     io::Write,
     mem,
     pin::Pin,
@@ -14,7 +15,6 @@ use hyper::{
     body::{HttpBody, Sender},
     Body,
 };
-use std::future::Future;
 use tokio::{pin, select};
 use tonic::{body::BoxBody, metadata::AsciiMetadataValue, Status};
 use tower::{Layer, Service};

--- a/src/sources/util/grpc/mod.rs
+++ b/src/sources/util/grpc/mod.rs
@@ -1,17 +1,19 @@
-use crate::{
-    shutdown::{ShutdownSignal, ShutdownSignalToken},
-    tls::MaybeTlsSettings,
-};
+use std::{convert::Infallible, net::SocketAddr};
+
 use futures::FutureExt;
 use http::{Request, Response};
 use hyper::Body;
-use std::{convert::Infallible, net::SocketAddr};
 use tonic::{
     body::BoxBody,
     transport::server::{NamedService, Server},
 };
 use tower::Service;
 use tracing::{Instrument, Span};
+
+use crate::{
+    shutdown::{ShutdownSignal, ShutdownSignalToken},
+    tls::MaybeTlsSettings,
+};
 
 mod decompression;
 pub use self::decompression::{DecompressionAndMetrics, DecompressionAndMetricsLayer};

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -19,6 +19,11 @@ use warp::{
     Filter,
 };
 
+use super::{
+    auth::{HttpSourceAuth, HttpSourceAuthConfig},
+    encoding::decode,
+    error::ErrorMessage,
+};
 use crate::{
     config::SourceContext,
     internal_events::{
@@ -27,12 +32,6 @@ use crate::{
     sources::util::http::HttpMethod,
     tls::{MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
-};
-
-use super::{
-    auth::{HttpSourceAuth, HttpSourceAuthConfig},
-    encoding::decode,
-    error::ErrorMessage,
 };
 
 #[async_trait]

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -8,13 +8,19 @@
 //!   - Call call() supplying the generic inputs for calling and the source-specific
 //!     context.
 
+use std::{
+    collections::HashMap,
+    future::ready,
+    time::{Duration, Instant},
+};
+
 use bytes::Bytes;
 use futures_util::{stream, FutureExt, StreamExt, TryFutureExt};
 use http::{response::Parts, Uri};
 use hyper::{Body, Request};
-use std::time::{Duration, Instant};
-use std::{collections::HashMap, future::ready};
 use tokio_stream::wrappers::IntervalStream;
+use vector_common::shutdown::ShutdownSignal;
+use vector_core::{config::proxy::ProxyConfig, event::Event, ByteSizeOf};
 
 use crate::{
     http::{Auth, HttpClient},
@@ -26,8 +32,6 @@ use crate::{
     tls::TlsSettings,
     Error, SourceSender,
 };
-use vector_common::shutdown::ShutdownSignal;
-use vector_core::{config::proxy::ProxyConfig, event::Event, ByteSizeOf};
 
 /// Contains the inputs generic to any http client.
 pub(crate) struct GenericHttpClientInputs {

--- a/src/sources/util/message_decoding.rs
+++ b/src/sources/util/message_decoding.rs
@@ -6,7 +6,11 @@ use codecs::StreamDecodingError;
 use tokio_util::codec::Decoder as _;
 use vector_core::{internal_event::EventsReceived, ByteSizeOf};
 
-use crate::{codecs::Decoder, config::log_schema, event::BatchNotifier, event::Event};
+use crate::{
+    codecs::Decoder,
+    config::log_schema,
+    event::{BatchNotifier, Event},
+};
 
 pub fn decode_message<'a>(
     mut decoder: Decoder,

--- a/src/sources/util/net/mod.rs
+++ b/src/sources/util/net/mod.rs
@@ -8,12 +8,11 @@ use std::{fmt, net::SocketAddr};
 use serde::{de, Deserialize, Deserializer};
 use vector_config::configurable_component;
 
-use crate::config::{Protocol, Resource};
-
 #[cfg(feature = "sources-utils-net-tcp")]
 pub use self::tcp::{TcpNullAcker, TcpSource, TcpSourceAck, TcpSourceAcker};
 #[cfg(feature = "sources-utils-net-udp")]
 pub use self::udp::try_bind_udp_socket;
+use crate::config::{Protocol, Resource};
 
 /// A listening address that can be given directly or be managed via `systemd` socket activation.
 #[configurable_component]

--- a/src/sources/util/net/tcp/mod.rs
+++ b/src/sources/util/net/tcp/mod.rs
@@ -1,8 +1,6 @@
 mod request_limiter;
 
-use std::collections::BTreeMap;
-use std::net::SocketAddr;
-use std::{io, mem::drop, time::Duration};
+use std::{collections::BTreeMap, io, mem::drop, net::SocketAddr, time::Duration};
 
 use bytes::Bytes;
 use codecs::StreamDecodingError;

--- a/src/sources/util/net/tcp/request_limiter.rs
+++ b/src/sources/util/net/tcp/request_limiter.rs
@@ -1,5 +1,7 @@
-use std::cmp::Ordering;
-use std::sync::{Arc, Mutex};
+use std::{
+    cmp::Ordering,
+    sync::{Arc, Mutex},
+};
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -1,5 +1,4 @@
-use std::os::unix::fs::PermissionsExt;
-use std::{fs, fs::remove_file, path::Path};
+use std::{fs, fs::remove_file, os::unix::fs::PermissionsExt, path::Path};
 
 use crate::internal_events::UnixSocketFileDeleteError;
 

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -17,8 +17,7 @@ use crate::{
         UnixSocketFileDeleteError,
     },
     shutdown::ShutdownSignal,
-    sources::util::change_socket_permissions,
-    sources::Source,
+    sources::{util::change_socket_permissions, Source},
     SourceSender,
 };
 

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -24,8 +24,7 @@ use crate::{
         UnixSocketError, UnixSocketFileDeleteError,
     },
     shutdown::ShutdownSignal,
-    sources::util::change_socket_permissions,
-    sources::Source,
+    sources::{util::change_socket_permissions, Source},
     SourceSender,
 };
 

--- a/src/test_util/mock/mod.rs
+++ b/src/test_util/mock/mod.rs
@@ -5,8 +5,6 @@ use stream_cancel::Trigger;
 use tokio::sync::oneshot::Sender;
 use vector_core::event::EventArray;
 
-use crate::SourceSender;
-
 use self::{
     sinks::{
         BackpressureSinkConfig, BasicSinkConfig, ErrorSinkConfig, OneshotSinkConfig,
@@ -18,6 +16,7 @@ use self::{
     },
     transforms::BasicTransformConfig,
 };
+use crate::SourceSender;
 
 pub mod sinks;
 pub mod sources;

--- a/src/test_util/mock/sinks/backpressure.rs
+++ b/src/test_util/mock/sinks/backpressure.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use futures::stream::BoxStream;
-use futures::{FutureExt, StreamExt};
+use futures::{stream::BoxStream, FutureExt, StreamExt};
 use vector_config::configurable_component;
 
-use crate::config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext};
-use crate::event::Event;
-use crate::sinks::util::StreamSink;
-use crate::sinks::{Healthcheck, VectorSink};
+use crate::{
+    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
+    event::Event,
+    sinks::{util::StreamSink, Healthcheck, VectorSink},
+};
 
 #[derive(Debug)]
 struct BackpressureSink {

--- a/src/test_util/mock/sources/backpressure.rs
+++ b/src/test_util/mock/sources/backpressure.rs
@@ -7,11 +7,8 @@ use async_trait::async_trait;
 use futures_util::FutureExt;
 use vector_config::configurable_component;
 use vector_core::{
-    config::LogNamespace,
+    config::{DataType, LogNamespace, Output},
     event::{Event, LogEvent},
-};
-use vector_core::{
-    config::{DataType, Output},
     source::Source,
 };
 

--- a/src/test_util/mock/sources/basic.rs
+++ b/src/test_util/mock/sources/basic.rs
@@ -6,9 +6,8 @@ use std::sync::{
 use async_trait::async_trait;
 use vector_buffers::topology::channel::{limited, LimitedReceiver};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
 use vector_core::{
-    config::{DataType, Output},
+    config::{DataType, LogNamespace, Output},
     event::{EventArray, EventContainer},
     source::Source,
 };

--- a/src/test_util/mock/sources/error.rs
+++ b/src/test_util/mock/sources/error.rs
@@ -1,9 +1,8 @@
 use async_trait::async_trait;
 use futures_util::{future::err, FutureExt};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
 use vector_core::{
-    config::{DataType, Output},
+    config::{DataType, LogNamespace, Output},
     source::Source,
 };
 

--- a/src/test_util/mock/sources/panic.rs
+++ b/src/test_util/mock/sources/panic.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
 use vector_core::{
-    config::{DataType, Output},
+    config::{DataType, LogNamespace, Output},
     source::Source,
 };
 

--- a/src/test_util/mock/sources/tripwire.rs
+++ b/src/test_util/mock/sources/tripwire.rs
@@ -4,9 +4,8 @@ use async_trait::async_trait;
 use futures_util::{future, FutureExt};
 use stream_cancel::{Trigger, Tripwire};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
 use vector_core::{
-    config::{DataType, Output},
+    config::{DataType, LogNamespace, Output},
     source::Source,
 };
 

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -10,9 +10,8 @@ use vector_core::{
     transform::{FunctionTransform, OutputBuffer, TaskTransform, Transform},
 };
 
-use crate::config::{GenerateConfig, TransformConfig, TransformContext};
-
 use super::TransformType;
+use crate::config::{GenerateConfig, TransformConfig, TransformContext};
 
 /// Configuration for the `test_noop` transform.
 #[configurable_component(transform("test_noop"))]

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -28,13 +28,12 @@ pub(super) use running::RunningTopology;
 use tokio::sync::{mpsc, watch};
 use vector_buffers::topology::channel::{BufferReceiverStream, BufferSender};
 
+use self::task::{TaskError, TaskResult};
 use crate::{
     config::{ComponentKey, Config, ConfigDiff, Inputs, OutputId},
     event::EventArray,
     topology::{builder::Pieces, task::Task},
 };
-
-use self::task::{TaskError, TaskResult};
 
 type TaskHandle = tokio::task::JoinHandle<TaskResult>;
 

--- a/src/topology/ready_arrays.rs
+++ b/src/topology/ready_arrays.rs
@@ -2,7 +2,7 @@ use std::{cmp, num::NonZeroUsize, pin::Pin};
 
 use futures::{
     task::{Context, Poll},
-    {Stream, StreamExt},
+    Stream, StreamExt,
 };
 
 use crate::event::{EventArray, EventContainer};

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
+
 use value::Kind;
 
 pub(super) use crate::schema::Definition;
-
 use crate::{
     config::{
         ComponentKey, Config, Output, OutputId, SinkConfig, SinkOuter, SourceConfig,

--- a/src/topology/test/backpressure.rs
+++ b/src/topology/test/backpressure.rs
@@ -1,13 +1,21 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 use tokio::time::Duration;
 use vector_buffers::{BufferConfig, BufferType, WhenFull};
 use vector_core::config::MEMORY_BUFFER_DEFAULT_MAX_EVENTS;
 
-use crate::{config::Config, test_util, test_util::start_topology};
-use crate::{config::SinkOuter, test_util::mock::backpressure_source};
-use crate::{test_util::mock::backpressure_sink, topology::builder::SOURCE_SENDER_BUFFER_SIZE};
+use crate::{
+    config::{Config, SinkOuter},
+    test_util,
+    test_util::{
+        mock::{backpressure_sink, backpressure_source},
+        start_topology,
+    },
+    topology::builder::SOURCE_SENDER_BUFFER_SIZE,
+};
 
 // Based on how we pump events from `SourceSender` into `Fanout`, there's always one extra event we
 // may pull out of `SourceSender` but can't yet send into `Fanout`, so we account for that here.

--- a/src/topology/test/crash.rs
+++ b/src/topology/test/crash.rs
@@ -1,3 +1,7 @@
+use futures_util::StreamExt;
+use tokio::time::{sleep, Duration};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
 use crate::{
     config::Config,
     sinks::socket::SocketSinkConfig,
@@ -8,9 +12,6 @@ use crate::{
         CountReceiver,
     },
 };
-use futures_util::StreamExt;
-use tokio::time::{sleep, Duration};
-use tokio_stream::wrappers::UnboundedReceiverStream;
 
 /// Ensures that an unrelated source completing immediately with an error does not prematurely terminate the topology.
 #[tokio::test]

--- a/src/topology/test/end_to_end.rs
+++ b/src/topology/test/end_to_end.rs
@@ -1,9 +1,5 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use crate::{
-    config::{self, ConfigDiff, Format},
-    test_util, topology, Error,
-};
 use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server, StatusCode,
@@ -12,6 +8,11 @@ use tokio::{
     sync::{mpsc, oneshot, Mutex},
     task::JoinHandle,
     time::{timeout, Duration},
+};
+
+use crate::{
+    config::{self, ConfigDiff, Format},
+    test_util, topology, Error,
 };
 
 type Lock = Arc<Mutex<()>>;

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -7,6 +7,13 @@ use std::{
     },
 };
 
+use futures::{future, stream, StreamExt};
+use tokio::{
+    task::yield_now,
+    time::{sleep, Duration},
+};
+use vector_buffers::{BufferConfig, BufferType, WhenFull};
+
 use crate::{
     config::{Config, ConfigDiff, SinkOuter},
     event::{into_event_stream, Event, EventArray, EventContainer, LogEvent},
@@ -19,12 +26,6 @@ use crate::{
     },
     topology,
 };
-use futures::{future, stream, StreamExt};
-use tokio::{
-    task::yield_now,
-    time::{sleep, Duration},
-};
-use vector_buffers::{BufferConfig, BufferType, WhenFull};
 
 mod backpressure;
 mod compliance;

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -5,9 +5,10 @@ use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use http::{uri::PathAndQuery, Request, StatusCode, Uri};
 use hyper::{body::to_bytes as body_to_bytes, Body};
-use lookup::lookup_v2::{OptionalTargetPath, OwnedSegment};
-use lookup::owned_value_path;
-use lookup::OwnedTargetPath;
+use lookup::{
+    lookup_v2::{OptionalTargetPath, OwnedSegment},
+    owned_value_path, OwnedTargetPath,
+};
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_with::serde_as;
@@ -625,10 +626,14 @@ enum Ec2MetadataError {
 #[cfg(feature = "aws-ec2-metadata-integration-tests")]
 #[cfg(test)]
 mod integration_tests {
-    use lookup::lookup_v2::{OwnedSegment, OwnedValuePath};
-    use lookup::{event_path, PathPrefix};
+    use lookup::{
+        event_path,
+        lookup_v2::{OwnedSegment, OwnedValuePath},
+        PathPrefix,
+    };
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
+    use warp::Filter;
 
     use super::*;
     use crate::{
@@ -636,7 +641,6 @@ mod integration_tests {
         test_util::{components::assert_transform_compliance, next_addr},
         transforms::test::create_topology,
     };
-    use warp::Filter;
 
     fn ec2_metadata_address() -> String {
         std::env::var("EC2_METADATA_ADDRESS").unwrap_or_else(|_| "http://localhost:8111".into())

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -356,21 +356,22 @@ impl FunctionTransform for LogToMetric {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{offset::TimeZone, DateTime, Utc};
     use std::time::Duration;
+
+    use chrono::{offset::TimeZone, DateTime, Utc};
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
     use vector_core::metric_tags;
 
     use super::*;
-    use crate::test_util::components::assert_transform_compliance;
-    use crate::transforms::test::create_topology;
     use crate::{
         config::log_schema,
         event::{
             metric::{Metric, MetricKind, MetricValue, StatisticKind},
             Event, LogEvent,
         },
+        test_util::components::assert_transform_compliance,
+        transforms::test::create_topology,
     };
 
     #[test]

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -407,21 +407,22 @@ fn format_error(error: &mlua::Error) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::future::Future;
-    use std::sync::Arc;
-    use tokio::sync::mpsc;
-    use tokio::sync::mpsc::{Receiver, Sender};
+    use std::{future::Future, sync::Arc};
+
+    use tokio::sync::{
+        mpsc,
+        mpsc::{Receiver, Sender},
+    };
     use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
-    use crate::test_util::components::assert_transform_compliance;
-    use crate::transforms::test::create_topology;
     use crate::{
         event::{
             metric::{Metric, MetricKind, MetricValue},
             Event, LogEvent, Value,
         },
-        test_util::trace_init,
+        test_util::{components::assert_transform_compliance, trace_init},
+        transforms::test::create_topology,
     };
 
     fn from_config(config: &str) -> crate::Result<Box<Lua>> {

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -143,12 +143,14 @@ mod tests {
     use vector_core::metric_tags;
 
     use super::*;
-    use crate::event::{
-        metric::{MetricKind, MetricTags, MetricValue, StatisticKind},
-        Metric, Value,
+    use crate::{
+        event::{
+            metric::{MetricKind, MetricTags, MetricValue, StatisticKind},
+            Metric, Value,
+        },
+        test_util::components::assert_transform_compliance,
+        transforms::test::create_topology,
     };
-    use crate::test_util::components::assert_transform_compliance;
-    use crate::transforms::test::create_topology;
 
     #[test]
     fn generate_config() {

--- a/src/transforms/pipelines/mod.rs
+++ b/src/transforms/pipelines/mod.rs
@@ -104,8 +104,6 @@
 //! # any sink configuration
 //! ```
 mod config;
-pub use self::config::PipelineConfig;
-
 use std::{collections::HashSet, fmt::Debug};
 
 use config::EventTypeConfig;
@@ -116,9 +114,9 @@ use vector_core::{
     transform::Transform,
 };
 
+pub use self::config::PipelineConfig;
 use crate::{
-    conditions::AnyCondition,
-    conditions::ConditionConfig,
+    conditions::{AnyCondition, ConditionConfig},
     config::{
         GenerateConfig, InnerTopology, InnerTopologyTransform, Inputs, TransformConfig,
         TransformContext,
@@ -300,9 +298,11 @@ mod tests {
     use tokio_stream::wrappers::ReceiverStream;
 
     use super::{GenerateConfig, PipelinesConfig};
-    use crate::config::{ComponentKey, TransformOuter};
-    use crate::test_util::components::assert_transform_compliance;
-    use crate::transforms::test::create_topology;
+    use crate::{
+        config::{ComponentKey, TransformOuter},
+        test_util::components::assert_transform_compliance,
+        transforms::test::create_topology,
+    };
 
     #[test]
     fn generate_config() {

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -1,6 +1,5 @@
-use std::collections::BTreeMap;
 use std::{
-    collections::{hash_map, HashMap},
+    collections::{hash_map, BTreeMap, HashMap},
     pin::Pin,
     time::{Duration, Instant},
 };
@@ -22,8 +21,9 @@ use crate::{
 
 mod merge_strategy;
 
-use crate::event::Value;
 pub use merge_strategy::*;
+
+use crate::event::Value;
 
 /// Configuration for the `reduce` transform.
 #[serde_as]
@@ -364,9 +364,11 @@ mod test {
     use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
-    use crate::event::{LogEvent, Value};
-    use crate::test_util::components::assert_transform_compliance;
-    use crate::transforms::test::create_topology;
+    use crate::{
+        event::{LogEvent, Value},
+        test_util::components::assert_transform_compliance,
+        transforms::test::create_topology,
+    };
 
     #[test]
     fn generate_config() {

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -1,26 +1,24 @@
-use std::sync::Arc;
 use std::{
     collections::BTreeMap,
     fs::File,
     io::{self, Read},
     path::PathBuf,
+    sync::Arc,
 };
 
-use lookup::lookup_v2::{parse_value_path, ValuePath};
-use lookup::{metadata_path, owned_value_path, path, PathPrefix};
+use lookup::{
+    lookup_v2::{parse_value_path, ValuePath},
+    metadata_path, owned_value_path, path, PathPrefix,
+};
 use snafu::{ResultExt, Snafu};
 use value::Kind;
 use vector_common::TimeZone;
 use vector_config::configurable_component;
-use vector_core::compile_vrl;
-use vector_core::config::LogNamespace;
-use vector_core::schema::Definition;
-
+use vector_core::{compile_vrl, config::LogNamespace, schema::Definition};
 use vector_vrl_functions::set_semantic_meaning::MeaningList;
-use vrl::prelude::state::TypeState;
 use vrl::{
     diagnostic::{Formatter, Note},
-    prelude::{DiagnosticMessage, ExpressionError},
+    prelude::{state::TypeState, DiagnosticMessage, ExpressionError},
     CompileConfig, Program, Runtime, Terminate, VrlRuntime,
 };
 
@@ -587,6 +585,8 @@ mod tests {
     use std::collections::HashMap;
 
     use indoc::{formatdoc, indoc};
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
     use vector_common::btreemap;
     use vector_core::{event::EventMetadata, metric_tags};
 
@@ -601,11 +601,8 @@ mod tests {
         test_util::components::{
             assert_transform_compliance, init_test, COMPONENT_MULTIPLE_OUTPUTS_TESTS,
         },
-        transforms::test::create_topology,
-        transforms::OutputBuffer,
+        transforms::{test::create_topology, OutputBuffer},
     };
-    use tokio::sync::mpsc;
-    use tokio_stream::wrappers::ReceiverStream;
 
     fn test_default_schema_definition() -> schema::Definition {
         schema::Definition::empty_legacy_namespace().with_field(

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -135,6 +135,8 @@ impl FunctionTransform for Sample {
 #[cfg(test)]
 mod tests {
     use approx::assert_relative_eq;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
     use crate::{
@@ -144,8 +146,6 @@ mod tests {
         test_util::{components::assert_transform_compliance, random_lines},
         transforms::test::{create_topology, transform_one},
     };
-    use tokio::sync::mpsc;
-    use tokio_stream::wrappers::ReceiverStream;
 
     fn condition_contains(key: &str, needle: &str) -> Condition {
         let vrl_config = VrlConfig {

--- a/src/transforms/tag_cardinality_limit.rs
+++ b/src/transforms/tag_cardinality_limit.rs
@@ -299,6 +299,8 @@ impl TaskTransform<Event> for TagCardinalityLimit {
 
 #[cfg(test)]
 mod tests {
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
     use vector_core::metric_tags;
 
     use super::*;
@@ -310,8 +312,6 @@ mod tests {
             test::create_topology,
         },
     };
-    use tokio::sync::mpsc;
-    use tokio_stream::wrappers::ReceiverStream;
 
     #[test]
     fn generate_config() {

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -201,14 +201,14 @@ mod tests {
     use std::task::Poll;
 
     use futures::SinkExt;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
     use crate::{
         event::LogEvent, test_util::components::assert_transform_compliance,
         transforms::test::create_topology,
     };
-    use tokio::sync::mpsc;
-    use tokio_stream::wrappers::ReceiverStream;
 
     #[test]
     fn generate_config() {

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -3,8 +3,10 @@ use std::path::PathBuf;
 use clap::Parser;
 use colored::*;
 
-use crate::config::{self, UnitTestResult};
-use crate::signal;
+use crate::{
+    config::{self, UnitTestResult},
+    signal,
+};
 
 #[derive(Parser, Debug)]
 #[command(rename_all = "kebab-case")]

--- a/tests/enterprise.rs
+++ b/tests/enterprise.rs
@@ -3,7 +3,6 @@
 use std::{env, path::PathBuf, thread};
 
 use http::StatusCode;
-
 use vector::{
     app::Application,
     cli::{Color, LogFormat, Opts, RootOpts},


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

This uncomments the unstable formatting options we _sometimes_ used. Also updating our scripts and Makefile to call `cargo fmt` with the nightly toolchain. Running `cargo fmt` without nightly will return warnings but not fail.

Editors/IDE's should be configurable to allow for passing `+nightly` as well, for example:

# Code
```json
{
    "rust-analyzer.rustfmt.extraArgs": [
        "+nightly"
    ],
}
```

# Clion

<img width="664" alt="image" src="https://user-images.githubusercontent.com/11903873/199843064-68fd681a-85fa-40da-a79e-fe5dd1b3471c.png">

# Neovim
```lua
lspconfig.rust_analyzer.setup {
    settings = {
        ["rust-analyzer"] = {
            rustfmt = {
                extraArgs = { "+nightly", },
            },
        }
    }
}
```


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
