### PR TITLE
fix(soak tests) Fix http pipelines soak tests

### DIFF
--- a/soaks/tests/http_pipelines_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole/vector.toml
@@ -20,7 +20,6 @@ decoding.codec = "bytes"
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_apache_log(.message, format: "common")
 if starts_with(strip_whitespace!(.message), "{") {
   custom, err = parse_json(.message)
   if (err == null) {

--- a/soaks/tests/http_pipelines_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole/vector.toml
@@ -20,7 +20,7 @@ decoding.codec = "bytes"
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_json(.message)
+., err = parse_apache_log(.message, format: "common")
 if starts_with(strip_whitespace!(.message), "{") {
   custom, err = parse_json(.message)
   if (err == null) {

--- a/soaks/tests/http_pipelines_blackhole_acks/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole_acks/vector.toml
@@ -21,7 +21,7 @@ acknowledgements = true
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_json(.message)
+., err = parse_apache_log(.message, format: "common")
 if starts_with(strip_whitespace!(.message), "{") {
   custom, err = parse_json(.message)
   if (err == null) {

--- a/soaks/tests/http_pipelines_blackhole_acks/vector.toml
+++ b/soaks/tests/http_pipelines_blackhole_acks/vector.toml
@@ -21,7 +21,6 @@ acknowledgements = true
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_apache_log(.message, format: "common")
 if starts_with(strip_whitespace!(.message), "{") {
   custom, err = parse_json(.message)
   if (err == null) {

--- a/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
@@ -20,8 +20,14 @@ decoding.codec = "bytes"
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_apache_log(.message, format: "common")
-.custom = {}
+if starts_with(strip_whitespace!(.message), "{") {
+  custom, err = parse_json(.message)
+  if (err == null) {
+    .custom, err = compact(custom, string: false)
+  }
+}
+.custom.message = .message
+.tags = []
 '''
 
 [transforms.processing]

--- a/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
@@ -20,14 +20,8 @@ decoding.codec = "bytes"
 type = "remap"
 inputs = ["logs"]
 source = '''
-if starts_with(strip_whitespace!(.message), "{") {
-  custom, err = parse_json(.message)
-  if (err == null) {
-    .custom, err = compact(custom, string: false)
-  }
-}
-.custom.message = .message
-.tags = []
+., err = parse_json(.message)
+.custom = {}
 '''
 
 [transforms.processing]

--- a/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
+++ b/soaks/tests/http_pipelines_no_grok_blackhole/vector.toml
@@ -20,7 +20,7 @@ decoding.codec = "bytes"
 type = "remap"
 inputs = ["logs"]
 source = '''
-., err = parse_json(.message)
+., err = parse_apache_log(.message, format: "common")
 .custom = {}
 '''
 


### PR DESCRIPTION
We currently set the event to null when the initial ```parse_json``` fails.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
