### PR TITLE
chore(aws_ec2_metadata transform): add log namespace support to `aws_ec2_metadata` transform

### DIFF
--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -36,7 +36,7 @@ impl BytesDeserializerConfig {
     /// The schema produced by the deserializer.
     pub fn schema_definition(&self, log_namespace: LogNamespace) -> schema::Definition {
         match log_namespace {
-            LogNamespace::Legacy => schema::Definition::empty_legacy_namespace().with_field(
+            LogNamespace::Legacy => schema::Definition::empty_legacy_namespace().with_event_field(
                 &parse_value_path(log_schema().message_key()).expect("valid message key"),
                 Kind::bytes(),
                 Some("message"),

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -44,9 +44,9 @@ impl GelfDeserializerConfig {
             Kind::object(Collection::empty()),
             [log_namespace],
         )
-        .with_field(&owned_value_path!(VERSION), Kind::bytes(), None)
-        .with_field(&owned_value_path!(HOST), Kind::bytes(), None)
-        .with_field(&owned_value_path!(SHORT_MESSAGE), Kind::bytes(), None)
+        .with_event_field(&owned_value_path!(VERSION), Kind::bytes(), None)
+        .with_event_field(&owned_value_path!(HOST), Kind::bytes(), None)
+        .with_event_field(&owned_value_path!(SHORT_MESSAGE), Kind::bytes(), None)
         .optional_field(&owned_value_path!(FULL_MESSAGE), Kind::bytes(), None)
         .optional_field(&owned_value_path!(TIMESTAMP), Kind::timestamp(), None)
         .optional_field(&owned_value_path!(LEVEL), Kind::integer(), None)

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -38,7 +38,7 @@ impl SyslogDeserializerConfig {
                 schema::Definition::empty_legacy_namespace()
                     // The `message` field is always defined. If parsing fails, the entire body becomes the
                     // message.
-                    .with_field(
+                    .with_event_field(
                         &parse_value_path(log_schema().message_key()).expect("valid message key"),
                         Kind::bytes(),
                         Some("message"),
@@ -73,7 +73,7 @@ impl SyslogDeserializerConfig {
                     Kind::object(Collection::empty()),
                     [log_namespace],
                 )
-                .with_field(
+                .with_event_field(
                     &owned_value_path!("message"),
                     Kind::bytes(),
                     Some("message"),

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -298,7 +298,7 @@ mod tests {
                 "invalid required meaning kind",
                 TestCase {
                     requirement: Requirement::empty().required_meaning("foo", Kind::boolean()),
-                    definition: Definition::empty_legacy_namespace().with_field(
+                    definition: Definition::empty_legacy_namespace().with_event_field(
                         &owned_value_path!("foo"),
                         Kind::integer(),
                         Some("foo"),
@@ -314,7 +314,7 @@ mod tests {
                 "invalid optional meaning kind",
                 TestCase {
                     requirement: Requirement::empty().optional_meaning("foo", Kind::boolean()),
-                    definition: Definition::empty_legacy_namespace().with_field(
+                    definition: Definition::empty_legacy_namespace().with_event_field(
                         &owned_value_path!("foo"),
                         Kind::integer(),
                         Some("foo"),
@@ -331,8 +331,8 @@ mod tests {
                 TestCase {
                     requirement: Requirement::empty().optional_meaning("foo", Kind::boolean()),
                     definition: Definition::empty_legacy_namespace()
-                        .with_field(&owned_value_path!("foo"), Kind::integer(), Some("foo"))
-                        .merge(Definition::empty_legacy_namespace().with_field(
+                        .with_event_field(&owned_value_path!("foo"), Kind::integer(), Some("foo"))
+                        .merge(Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("bar"),
                             Kind::boolean(),
                             Some("foo"),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -47,7 +47,7 @@ use crate::{
 };
 
 fn test_logs_schema_definition() -> schema::Definition {
-    schema::Definition::empty_legacy_namespace().with_field(
+    schema::Definition::empty_legacy_namespace().with_event_field(
         &owned_value_path!("a log field"),
         Kind::integer().or_bytes(),
         Some("log field"),
@@ -55,7 +55,7 @@ fn test_logs_schema_definition() -> schema::Definition {
 }
 
 fn test_metrics_schema_definition() -> schema::Definition {
-    schema::Definition::empty_legacy_namespace().with_field(
+    schema::Definition::empty_legacy_namespace().with_event_field(
         &owned_value_path!("a schema tag"),
         Kind::boolean().or_null(),
         Some("tag"),
@@ -1325,34 +1325,46 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty_legacy_namespace()
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("message"),
                                 Kind::bytes(),
                                 Some("message"),
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("status"),
                                 Kind::bytes(),
                                 Some("severity"),
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("timestamp"),
                                 Kind::timestamp(),
                                 Some("timestamp"),
                             )
-                            .with_field(&owned_value_path!("hostname"), Kind::bytes(), Some("host"))
-                            .with_field(
+                            .with_event_field(
+                                &owned_value_path!("hostname"),
+                                Kind::bytes(),
+                                Some("host"),
+                            )
+                            .with_event_field(
                                 &owned_value_path!("service"),
                                 Kind::bytes(),
                                 Some("service"),
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("ddsource"),
                                 Kind::bytes(),
                                 Some("source"),
                             )
-                            .with_field(&owned_value_path!("ddtags"), Kind::bytes(), Some("tags"))
-                            .with_field(&owned_value_path!("source_type"), Kind::bytes(), None),
+                            .with_event_field(
+                                &owned_value_path!("ddtags"),
+                                Kind::bytes(),
+                                Some("tags"),
+                            )
+                            .with_event_field(
+                                &owned_value_path!("source_type"),
+                                Kind::bytes(),
+                                None,
+                            ),
                     ),
                 )]),
             },
@@ -1366,34 +1378,46 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty_legacy_namespace()
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("message"),
                                 Kind::bytes(),
                                 Some("message"),
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("status"),
                                 Kind::bytes(),
                                 Some("severity"),
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("timestamp"),
                                 Kind::timestamp(),
                                 Some("timestamp"),
                             )
-                            .with_field(&owned_value_path!("hostname"), Kind::bytes(), Some("host"))
-                            .with_field(
+                            .with_event_field(
+                                &owned_value_path!("hostname"),
+                                Kind::bytes(),
+                                Some("host"),
+                            )
+                            .with_event_field(
                                 &owned_value_path!("service"),
                                 Kind::bytes(),
                                 Some("service"),
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("ddsource"),
                                 Kind::bytes(),
                                 Some("source"),
                             )
-                            .with_field(&owned_value_path!("ddtags"), Kind::bytes(), Some("tags"))
-                            .with_field(&owned_value_path!("source_type"), Kind::bytes(), None),
+                            .with_event_field(
+                                &owned_value_path!("ddtags"),
+                                Kind::bytes(),
+                                Some("tags"),
+                            )
+                            .with_event_field(
+                                &owned_value_path!("source_type"),
+                                Kind::bytes(),
+                                None,
+                            ),
                     ),
                 )]),
             },
@@ -1408,42 +1432,46 @@ fn test_config_outputs() {
                         Some(LOGS),
                         Some(
                             schema::Definition::empty_legacy_namespace()
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("message"),
                                     Kind::bytes(),
                                     Some("message"),
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("status"),
                                     Kind::bytes(),
                                     Some("severity"),
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("timestamp"),
                                     Kind::timestamp(),
                                     Some("timestamp"),
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("hostname"),
                                     Kind::bytes(),
                                     Some("host"),
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("service"),
                                     Kind::bytes(),
                                     Some("service"),
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("ddsource"),
                                     Kind::bytes(),
                                     Some("source"),
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("ddtags"),
                                     Kind::bytes(),
                                     Some("tags"),
                                 )
-                                .with_field(&owned_value_path!("source_type"), Kind::bytes(), None),
+                                .with_event_field(
+                                    &owned_value_path!("source_type"),
+                                    Kind::bytes(),
+                                    None,
+                                ),
                         ),
                     ),
                     (Some(METRICS), None),
@@ -1460,17 +1488,17 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty_legacy_namespace()
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("timestamp"),
                                 Kind::json().or_timestamp(),
                                 None,
                             )
-                            .with_field(&owned_value_path!("source_type"), Kind::json(), None)
-                            .with_field(&owned_value_path!("ddsource"), Kind::json(), None)
-                            .with_field(&owned_value_path!("ddtags"), Kind::json(), None)
-                            .with_field(&owned_value_path!("hostname"), Kind::json(), None)
-                            .with_field(&owned_value_path!("service"), Kind::json(), None)
-                            .with_field(&owned_value_path!("status"), Kind::json(), None)
+                            .with_event_field(&owned_value_path!("source_type"), Kind::json(), None)
+                            .with_event_field(&owned_value_path!("ddsource"), Kind::json(), None)
+                            .with_event_field(&owned_value_path!("ddtags"), Kind::json(), None)
+                            .with_event_field(&owned_value_path!("hostname"), Kind::json(), None)
+                            .with_event_field(&owned_value_path!("service"), Kind::json(), None)
+                            .with_event_field(&owned_value_path!("status"), Kind::json(), None)
                             .unknown_fields(Kind::json()),
                     ),
                 )]),
@@ -1486,17 +1514,29 @@ fn test_config_outputs() {
                         Some(LOGS),
                         Some(
                             schema::Definition::empty_legacy_namespace()
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("timestamp"),
                                     Kind::json().or_timestamp(),
                                     None,
                                 )
-                                .with_field(&owned_value_path!("source_type"), Kind::json(), None)
-                                .with_field(&owned_value_path!("ddsource"), Kind::json(), None)
-                                .with_field(&owned_value_path!("ddtags"), Kind::json(), None)
-                                .with_field(&owned_value_path!("hostname"), Kind::json(), None)
-                                .with_field(&owned_value_path!("service"), Kind::json(), None)
-                                .with_field(&owned_value_path!("status"), Kind::json(), None)
+                                .with_event_field(
+                                    &owned_value_path!("source_type"),
+                                    Kind::json(),
+                                    None,
+                                )
+                                .with_event_field(
+                                    &owned_value_path!("ddsource"),
+                                    Kind::json(),
+                                    None,
+                                )
+                                .with_event_field(&owned_value_path!("ddtags"), Kind::json(), None)
+                                .with_event_field(
+                                    &owned_value_path!("hostname"),
+                                    Kind::json(),
+                                    None,
+                                )
+                                .with_event_field(&owned_value_path!("service"), Kind::json(), None)
+                                .with_event_field(&owned_value_path!("status"), Kind::json(), None)
                                 .unknown_fields(Kind::json()),
                         ),
                     ),
@@ -1515,17 +1555,17 @@ fn test_config_outputs() {
                     None,
                     Some(
                         schema::Definition::empty_legacy_namespace()
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("message"),
                                 Kind::bytes(),
                                 Some("message"),
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("timestamp"),
                                 Kind::timestamp(),
                                 Some("timestamp"),
                             )
-                            .with_field(&owned_value_path!("hostname"), Kind::bytes(), None)
+                            .with_event_field(&owned_value_path!("hostname"), Kind::bytes(), None)
                             .optional_field(
                                 &owned_value_path!("severity"),
                                 Kind::bytes(),
@@ -1540,27 +1580,27 @@ fn test_config_outputs() {
                                 Kind::integer().or_bytes(),
                                 None,
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("source_type"),
                                 Kind::bytes().or_object(Collection::from_unknown(Kind::bytes())),
                                 None,
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("ddsource"),
                                 Kind::bytes().or_object(Collection::from_unknown(Kind::bytes())),
                                 None,
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("ddtags"),
                                 Kind::bytes().or_object(Collection::from_unknown(Kind::bytes())),
                                 None,
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("service"),
                                 Kind::bytes().or_object(Collection::from_unknown(Kind::bytes())),
                                 None,
                             )
-                            .with_field(
+                            .with_event_field(
                                 &owned_value_path!("status"),
                                 Kind::bytes().or_object(Collection::from_unknown(Kind::bytes())),
                                 None,
@@ -1583,17 +1623,21 @@ fn test_config_outputs() {
                         Some(LOGS),
                         Some(
                             schema::Definition::empty_legacy_namespace()
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("message"),
                                     Kind::bytes(),
                                     Some("message"),
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("timestamp"),
                                     Kind::timestamp(),
                                     Some("timestamp"),
                                 )
-                                .with_field(&owned_value_path!("hostname"), Kind::bytes(), None)
+                                .with_event_field(
+                                    &owned_value_path!("hostname"),
+                                    Kind::bytes(),
+                                    None,
+                                )
                                 .optional_field(
                                     &owned_value_path!("severity"),
                                     Kind::bytes(),
@@ -1612,31 +1656,31 @@ fn test_config_outputs() {
                                     Kind::integer().or_bytes(),
                                     None,
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("source_type"),
                                     Kind::bytes()
                                         .or_object(Collection::from_unknown(Kind::bytes())),
                                     None,
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("ddsource"),
                                     Kind::bytes()
                                         .or_object(Collection::from_unknown(Kind::bytes())),
                                     None,
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("ddtags"),
                                     Kind::bytes()
                                         .or_object(Collection::from_unknown(Kind::bytes())),
                                     None,
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("service"),
                                     Kind::bytes()
                                         .or_object(Collection::from_unknown(Kind::bytes())),
                                     None,
                                 )
-                                .with_field(
+                                .with_event_field(
                                     &owned_value_path!("status"),
                                     Kind::bytes()
                                         .or_object(Collection::from_unknown(Kind::bytes())),
@@ -1970,17 +2014,17 @@ fn test_output_schema_definition_json_legacy_namespace() {
     assert_eq!(
         definition,
         Definition::new_with_default_metadata(Kind::json(), [LogNamespace::Legacy])
-            .with_field(
+            .with_event_field(
                 &owned_value_path!("timestamp"),
                 Kind::json().or_timestamp(),
                 None
             )
-            .with_field(&owned_value_path!("ddsource"), Kind::json(), None)
-            .with_field(&owned_value_path!("ddtags"), Kind::json(), None)
-            .with_field(&owned_value_path!("hostname"), Kind::json(), None)
-            .with_field(&owned_value_path!("service"), Kind::json(), None)
-            .with_field(&owned_value_path!("source_type"), Kind::json(), None)
-            .with_field(&owned_value_path!("status"), Kind::json(), None)
+            .with_event_field(&owned_value_path!("ddsource"), Kind::json(), None)
+            .with_event_field(&owned_value_path!("ddtags"), Kind::json(), None)
+            .with_event_field(&owned_value_path!("hostname"), Kind::json(), None)
+            .with_event_field(&owned_value_path!("service"), Kind::json(), None)
+            .with_event_field(&owned_value_path!("source_type"), Kind::json(), None)
+            .with_event_field(&owned_value_path!("status"), Kind::json(), None)
     )
 }
 
@@ -2002,30 +2046,30 @@ fn test_output_schema_definition_bytes_legacy_namespace() {
             Kind::object(Collection::empty()),
             [LogNamespace::Legacy]
         )
-        .with_field(
+        .with_event_field(
             &owned_value_path!("ddsource"),
             Kind::bytes(),
             Some("source")
         )
-        .with_field(&owned_value_path!("ddtags"), Kind::bytes(), Some("tags"))
-        .with_field(&owned_value_path!("hostname"), Kind::bytes(), Some("host"))
-        .with_field(
+        .with_event_field(&owned_value_path!("ddtags"), Kind::bytes(), Some("tags"))
+        .with_event_field(&owned_value_path!("hostname"), Kind::bytes(), Some("host"))
+        .with_event_field(
             &owned_value_path!("message"),
             Kind::bytes(),
             Some("message")
         )
-        .with_field(
+        .with_event_field(
             &owned_value_path!("service"),
             Kind::bytes(),
             Some("service")
         )
-        .with_field(&owned_value_path!("source_type"), Kind::bytes(), None)
-        .with_field(
+        .with_event_field(&owned_value_path!("source_type"), Kind::bytes(), None)
+        .with_event_field(
             &owned_value_path!("status"),
             Kind::bytes(),
             Some("severity")
         )
-        .with_field(
+        .with_event_field(
             &owned_value_path!("timestamp"),
             Kind::timestamp(),
             Some("timestamp")

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -399,7 +399,7 @@ mod tests {
                     sources: IndexMap::from([(
                         "source-foo",
                         vec![Output::default(DataType::all()).with_schema_definition(
-                            Definition::empty_legacy_namespace().with_field(
+                            Definition::empty_legacy_namespace().with_event_field(
                                 &owned_value_path!("foo"),
                                 Kind::integer().or_bytes(),
                                 Some("foo bar"),
@@ -407,7 +407,7 @@ mod tests {
                         )],
                     )]),
                     transforms: IndexMap::default(),
-                    want: Definition::empty_legacy_namespace().with_field(
+                    want: Definition::empty_legacy_namespace().with_event_field(
                         &owned_value_path!("foo"),
                         Kind::integer().or_bytes(),
                         Some("foo bar"),
@@ -422,7 +422,7 @@ mod tests {
                         (
                             "source-foo",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
                                     Kind::integer().or_bytes(),
                                     Some("foo bar"),
@@ -432,7 +432,7 @@ mod tests {
                         (
                             "source-bar",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
                                     Kind::timestamp(),
                                     Some("baz qux"),
@@ -442,7 +442,7 @@ mod tests {
                     ]),
                     transforms: IndexMap::default(),
                     want: Definition::empty_legacy_namespace()
-                        .with_field(
+                        .with_event_field(
                             &owned_value_path!("foo"),
                             Kind::integer().or_bytes().or_timestamp(),
                             Some("foo bar"),
@@ -523,7 +523,7 @@ mod tests {
                     sources: IndexMap::from([(
                         "source-foo",
                         vec![Output::default(DataType::all()).with_schema_definition(
-                            Definition::empty_legacy_namespace().with_field(
+                            Definition::empty_legacy_namespace().with_event_field(
                                 &owned_value_path!("foo"),
                                 Kind::integer().or_bytes(),
                                 Some("foo bar"),
@@ -531,7 +531,7 @@ mod tests {
                         )],
                     )]),
                     transforms: IndexMap::default(),
-                    want: vec![Definition::empty_legacy_namespace().with_field(
+                    want: vec![Definition::empty_legacy_namespace().with_event_field(
                         &owned_value_path!("foo"),
                         Kind::integer().or_bytes(),
                         Some("foo bar"),
@@ -546,7 +546,7 @@ mod tests {
                         (
                             "source-foo",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
                                     Kind::integer().or_bytes(),
                                     Some("foo bar"),
@@ -556,7 +556,7 @@ mod tests {
                         (
                             "source-bar",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
                                     Kind::timestamp(),
                                     Some("baz qux"),
@@ -566,12 +566,12 @@ mod tests {
                     ]),
                     transforms: IndexMap::default(),
                     want: vec![
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("foo"),
                             Kind::integer().or_bytes(),
                             Some("foo bar"),
                         ),
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("foo"),
                             Kind::timestamp(),
                             Some("baz qux"),
@@ -587,7 +587,7 @@ mod tests {
                         (
                             "source-foo",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
                                     Kind::boolean(),
                                     Some("foo"),
@@ -597,7 +597,7 @@ mod tests {
                         (
                             "source-bar",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("bar"),
                                     Kind::integer(),
                                     Some("bar"),
@@ -610,7 +610,7 @@ mod tests {
                         (
                             vec![OutputId::from("source-foo")],
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("baz"),
                                     Kind::regex(),
                                     Some("baz"),
@@ -619,12 +619,12 @@ mod tests {
                         ),
                     )]),
                     want: vec![
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("bar"),
                             Kind::integer(),
                             Some("bar"),
                         ),
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("baz"),
                             Kind::regex(),
                             Some("baz"),
@@ -648,7 +648,7 @@ mod tests {
                         (
                             "Source 1",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("source-1"),
                                     Kind::boolean(),
                                     Some("source-1"),
@@ -658,7 +658,7 @@ mod tests {
                         (
                             "Source 2",
                             vec![Output::default(DataType::all()).with_schema_definition(
-                                Definition::empty_legacy_namespace().with_field(
+                                Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("source-2"),
                                     Kind::integer(),
                                     Some("source-2"),
@@ -672,7 +672,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 1")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty_legacy_namespace().with_field(
+                                    Definition::empty_legacy_namespace().with_event_field(
                                         &owned_value_path!("transform-1"),
                                         Kind::regex(),
                                         None,
@@ -685,7 +685,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 2")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty_legacy_namespace().with_field(
+                                    Definition::empty_legacy_namespace().with_event_field(
                                         &owned_value_path!("transform-2"),
                                         Kind::float().or_null(),
                                         Some("transform-2"),
@@ -698,7 +698,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 2")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty_legacy_namespace().with_field(
+                                    Definition::empty_legacy_namespace().with_event_field(
                                         &owned_value_path!("transform-3"),
                                         Kind::integer(),
                                         Some("transform-3"),
@@ -711,7 +711,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Source 2")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty_legacy_namespace().with_field(
+                                    Definition::empty_legacy_namespace().with_event_field(
                                         &owned_value_path!("transform-4"),
                                         Kind::timestamp().or_bytes(),
                                         Some("transform-4"),
@@ -724,7 +724,7 @@ mod tests {
                             (
                                 vec![OutputId::from("Transform 3"), OutputId::from("Transform 4")],
                                 vec![Output::default(DataType::all()).with_schema_definition(
-                                    Definition::empty_legacy_namespace().with_field(
+                                    Definition::empty_legacy_namespace().with_event_field(
                                         &owned_value_path!("transform-5"),
                                         Kind::boolean(),
                                         Some("transform-5"),
@@ -735,25 +735,25 @@ mod tests {
                     ]),
                     want: vec![
                         // Pipeline 1
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("transform-1"),
                             Kind::regex(),
                             None,
                         ),
                         // Pipeline 2
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("transform-2"),
                             Kind::float().or_null(),
                             Some("transform-2"),
                         ),
                         // Pipeline 3
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("transform-5"),
                             Kind::boolean(),
                             Some("transform-5"),
                         ),
                         // Pipeline 4
-                        Definition::empty_legacy_namespace().with_field(
+                        Definition::empty_legacy_namespace().with_event_field(
                             &owned_value_path!("transform-5"),
                             Kind::boolean(),
                             Some("transform-5"),

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -253,17 +253,18 @@ impl TransformConfig for RemapConfig {
             .log_namespaces()
             .contains(&LogNamespace::Legacy)
         {
-            dropped_definition = dropped_definition.merge(input_definition.clone().with_field(
-                &parse_value_path(log_schema().metadata_key()).expect("valid metadata key"),
-                Kind::object(BTreeMap::from([
-                    ("reason".into(), Kind::bytes()),
-                    ("message".into(), Kind::bytes()),
-                    ("component_id".into(), Kind::bytes()),
-                    ("component_type".into(), Kind::bytes()),
-                    ("component_kind".into(), Kind::bytes()),
-                ])),
-                Some("metadata"),
-            ));
+            dropped_definition =
+                dropped_definition.merge(input_definition.clone().with_event_field(
+                    &parse_value_path(log_schema().metadata_key()).expect("valid metadata key"),
+                    Kind::object(BTreeMap::from([
+                        ("reason".into(), Kind::bytes()),
+                        ("message".into(), Kind::bytes()),
+                        ("component_id".into(), Kind::bytes()),
+                        ("component_type".into(), Kind::bytes()),
+                        ("component_kind".into(), Kind::bytes()),
+                    ])),
+                    Some("metadata"),
+                ));
         }
 
         if input_definition
@@ -608,7 +609,7 @@ mod tests {
     use tokio_stream::wrappers::ReceiverStream;
 
     fn test_default_schema_definition() -> schema::Definition {
-        schema::Definition::empty_legacy_namespace().with_field(
+        schema::Definition::empty_legacy_namespace().with_event_field(
             &owned_value_path!("a default field"),
             Kind::integer().or_bytes(),
             Some("default"),
@@ -616,7 +617,7 @@ mod tests {
     }
 
     fn test_dropped_schema_definition() -> schema::Definition {
-        schema::Definition::empty_legacy_namespace().with_field(
+        schema::Definition::empty_legacy_namespace().with_event_field(
             &owned_value_path!("a dropped field"),
             Kind::boolean().or_null(),
             Some("dropped"),
@@ -1046,7 +1047,7 @@ mod tests {
                 Kind::any_object(),
                 [LogNamespace::Legacy],
             )
-            .with_field(&owned_value_path!("hello"), Kind::bytes(), None),
+            .with_event_field(&owned_value_path!("hello"), Kind::bytes(), None),
             ..Default::default()
         };
         let mut tform = Remap::new_ast(conf, &context).unwrap().0;
@@ -1289,8 +1290,8 @@ mod tests {
             Kind::any_object(),
             [LogNamespace::Legacy],
         )
-        .with_field(&owned_value_path!("foo"), Kind::any(), None)
-        .with_field(&owned_value_path!("tags"), Kind::any(), None);
+        .with_event_field(&owned_value_path!("foo"), Kind::any(), None)
+        .with_event_field(&owned_value_path!("tags"), Kind::any(), None);
 
         assert_eq!(
             conf.outputs(&schema::Definition::new_with_default_metadata(


### PR DESCRIPTION
ref: https://github.com/vectordotdev/vector/issues/15031

There were 2 main changes:
- The schema definition was updated with the enrichment data. (all optional)
- `Definition::with_field` was renamed to `Definition::with_event_field` to more closely match the naming of `Definition::with_metadata_field`. A new `Definition::with_field` was added that can set a field on either the event or metadata.