### PR TITLE
fix(blackhole): add missing BytesSent metric

### DIFF
--- a/src/sinks/blackhole/sink.rs
+++ b/src/sinks/blackhole/sink.rs
@@ -13,7 +13,10 @@ use tokio::{
     sync::watch,
     time::{interval, sleep_until},
 };
-use vector_core::{internal_event::EventsSent, ByteSizeOf};
+use vector_core::{
+    internal_event::{BytesSent, EventsSent},
+    ByteSizeOf,
+};
 
 use crate::{
     event::{EventArray, EventContainer},
@@ -93,6 +96,11 @@ impl StreamSink<EventArray> for BlackholeSink {
                 count: events.len(),
                 byte_size: message_len,
                 output: None,
+            });
+
+            emit!(BytesSent {
+                byte_size: message_len,
+                protocol: "blackhole".to_string().into(),
             });
         }
 


### PR DESCRIPTION
Resolves https://github.com/vectordotdev/vector/issues/12964

Add missing BytesSent metric to Blackhole sink. The only possible strange is `protocol` value. Since blackhole does not use any dedicated protocol, I just introduced a specific placeholder since I see no strong need to introduce yet another `BytesSent` event without protocol or make `protocol` field `Option` in the existing `BytesSent` struct.

Tested:
- Local build
