### PR TITLE
fix(config): error message with threads=0

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -119,7 +119,10 @@ impl Application {
 
         if let Some(threads) = root_opts.threads {
             if threads < 1 {
-                error!("The `threads` argument must be greater or equal to 1.");
+                #[allow(clippy::print_stderr)]
+                {
+                    eprintln!("The `threads` argument must be greater or equal to 1.");
+                }
                 return Err(exitcode::CONFIG);
             } else {
                 WORKER_THREADS


### PR DESCRIPTION
Resolves https://github.com/vectordotdev/vector/issues/11944

Just a small fix: report an error to stderr instead of built-in logging based on tracing.

Tested locally - works fine.