### PR TITLE
fix(docs): Hide the `log_namespace` option

### DIFF
--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -36,6 +36,7 @@ pub struct ConfigBuilder {
     pub api: api::Options,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     pub schema: schema::Options,
 

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -73,7 +73,7 @@ pub struct AmqpSourceConfig {
     #[serde(default = "default_offset_key")]
     pub(crate) offset_key: String,
 
-    /// The namespace to use. This overrides the global setting.
+    /// The namespace to use for logs. This overrides the global setting.
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     pub log_namespace: Option<bool>,

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -74,6 +74,7 @@ pub struct AmqpSourceConfig {
     pub(crate) offset_key: String,
 
     /// The namespace to use. This overrides the global setting.
+    #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     pub log_namespace: Option<bool>,
 

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -105,6 +105,7 @@ pub struct AwsS3Config {
     tls_options: Option<TlsConfig>,
 
     /// The namespace to use for logs. This overrides the global setting.
+    #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
 }

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -90,6 +90,7 @@ pub struct DatadogAgentConfig {
 
     /// The namespace to use for logs. This overrides the global settings
     #[serde(default)]
+    #[configurable(metadata(docs::hidden))]
     log_namespace: Option<bool>,
 
     #[configurable(derived)]

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -57,6 +57,7 @@ pub struct DemoLogsConfig {
 
     /// The namespace to use for logs. This overrides the global setting
     #[serde(default)]
+    #[configurable(metadata(docs::hidden))]
     pub log_namespace: Option<bool>,
 }
 

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -84,6 +84,7 @@ pub struct HttpClientConfig {
     pub auth: Option<Auth>,
 
     /// The namespace to use for logs. This overrides the global setting
+    #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     pub log_namespace: Option<bool>,
 }

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -217,11 +217,6 @@ base: components: sources: amqp: configuration: {
 			}
 		}
 	}
-	log_namespace: {
-		description: "The namespace to use. This overrides the global setting."
-		required:    false
-		type: bool: {}
-	}
 	offset_key: {
 		description: "The `AMQP` offset key."
 		required:    false

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -105,11 +105,6 @@ base: components: sources: aws_s3: configuration: {
 		required:    false
 		type: string: syntax: "literal"
 	}
-	log_namespace: {
-		description: "The namespace to use for logs. This overrides the global setting."
-		required:    false
-		type: bool: {}
-	}
 	multiline: {
 		description: """
 			Multiline aggregation configuration.

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -125,11 +125,6 @@ base: components: sources: datadog_agent: configuration: {
 			}
 		}
 	}
-	log_namespace: {
-		description: "The namespace to use for logs. This overrides the global settings"
-		required:    false
-		type: bool: {}
-	}
 	multiple_outputs: {
 		description: """
 			If this setting is set to `true` logs, metrics and traces will be sent to different outputs.

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -122,11 +122,6 @@ base: components: sources: demo_logs: configuration: {
 		required:      true
 		type: array: items: type: string: syntax: "literal"
 	}
-	log_namespace: {
-		description: "The namespace to use for logs. This overrides the global setting"
-		required:    false
-		type: bool: {}
-	}
 	sequence: {
 		description:   "If `true`, each output line starts with an increasing sequence number, beginning with 0."
 		relevant_when: "format = \"shuffle\""

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -145,11 +145,6 @@ base: components: sources: http_client: configuration: {
 			type: array: items: type: string: syntax: "literal"
 		}
 	}
-	log_namespace: {
-		description: "The namespace to use for logs. This overrides the global setting"
-		required:    false
-		type: bool: {}
-	}
 	method: {
 		description: "Specifies the action of the HTTP request."
 		required:    false


### PR DESCRIPTION
Hiding this field until we are ready to release it.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
