### PR TITLE
fix(internal_metrics): change default scrape_interval to 1

### DIFF
--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -20,7 +20,7 @@ use crate::{
 #[serde(deny_unknown_fields, default)]
 pub struct InternalMetricsConfig {
     /// The interval between metric gathering, in seconds.
-    #[derivative(Default(value = "2.0"))]
+    #[derivative(Default(value = "1.0"))]
     pub scrape_interval_secs: f64,
 
     #[configurable(derived)]

--- a/website/cue/reference/components/sources/base/internal_metrics.cue
+++ b/website/cue/reference/components/sources/base/internal_metrics.cue
@@ -13,7 +13,7 @@ base: components: sources: internal_metrics: configuration: {
 	scrape_interval_secs: {
 		description: "The interval between metric gathering, in seconds."
 		required:    false
-		type: float: default: 2.0
+		type: float: default: 1.0
 	}
 	tags: {
 		description: "Tag configuration for the `internal_metrics` source."

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -50,7 +50,7 @@ components: sources: internal_metrics: {
 			common:      true
 			required:    false
 			type: float: {
-				default: 2.0
+				default: 1.0
 				unit:    "seconds"
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/vectordotdev/vector/issues/13143

Change default scrape_interval to 1 second.

Tested:
- Local build
