### PR TITLE
chore(core): Remove reference from `LegacyKey` usage to make it easier to use

### DIFF
--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -181,7 +181,7 @@ impl Definition {
     pub fn with_source_metadata(
         self,
         source_name: &str,
-        legacy_path: Option<LegacyKey<&OwnedValuePath>>,
+        legacy_path: Option<LegacyKey<OwnedValuePath>>,
         vector_path: &OwnedValuePath,
         kind: Kind,
         meaning: Option<&str>,
@@ -203,7 +203,7 @@ impl Definition {
     ) -> Self {
         self.with_namespaced_metadata(
             "vector",
-            legacy_path.map(LegacyKey::InsertIfEmpty),
+            legacy_path.cloned().map(LegacyKey::InsertIfEmpty),
             vector_path,
             kind,
             meaning,
@@ -215,7 +215,7 @@ impl Definition {
     fn with_namespaced_metadata(
         self,
         prefix: &str,
-        legacy_path: Option<LegacyKey<&OwnedValuePath>>,
+        legacy_path: Option<LegacyKey<OwnedValuePath>>,
         vector_path: &OwnedValuePath,
         kind: Kind,
         meaning: Option<&str>,
@@ -224,12 +224,12 @@ impl Definition {
             if self.log_namespaces.contains(&LogNamespace::Legacy) {
                 match legacy_path {
                     LegacyKey::InsertIfEmpty(legacy_path) => Some(self.clone().try_with_field(
-                        legacy_path,
+                        &legacy_path,
                         kind.clone(),
                         meaning,
                     )),
                     LegacyKey::Overwrite(legacy_path) => Some(self.clone().with_event_field(
-                        legacy_path,
+                        &legacy_path,
                         kind.clone(),
                         meaning,
                     )),

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -137,21 +137,21 @@ impl SourceConfig for AwsS3Config {
             .schema_definition(log_namespace)
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::Overwrite(&owned_value_path!("bucket"))),
+                Some(LegacyKey::Overwrite(owned_value_path!("bucket"))),
                 &owned_value_path!("bucket"),
                 Kind::bytes(),
                 None,
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::Overwrite(&owned_value_path!("object"))),
+                Some(LegacyKey::Overwrite(owned_value_path!("object"))),
                 &owned_value_path!("object"),
                 Kind::bytes(),
                 None,
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::Overwrite(&owned_value_path!("region"))),
+                Some(LegacyKey::Overwrite(owned_value_path!("region"))),
                 &owned_value_path!("region"),
                 Kind::bytes(),
                 None,

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -196,42 +196,42 @@ impl SourceConfig for DatadogAgentConfig {
             .schema_definition(global_log_namespace.merge(self.log_namespace))
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::InsertIfEmpty(&owned_value_path!("status"))),
+                Some(LegacyKey::InsertIfEmpty(owned_value_path!("status"))),
                 &owned_value_path!("status"),
                 Kind::bytes(),
                 Some("severity"),
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::InsertIfEmpty(&owned_value_path!("timestamp"))),
+                Some(LegacyKey::InsertIfEmpty(owned_value_path!("timestamp"))),
                 &owned_value_path!("timestamp"),
                 Kind::timestamp(),
                 Some("timestamp"),
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::InsertIfEmpty(&owned_value_path!("hostname"))),
+                Some(LegacyKey::InsertIfEmpty(owned_value_path!("hostname"))),
                 &owned_value_path!("hostname"),
                 Kind::bytes(),
                 Some("host"),
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::InsertIfEmpty(&owned_value_path!("service"))),
+                Some(LegacyKey::InsertIfEmpty(owned_value_path!("service"))),
                 &owned_value_path!("service"),
                 Kind::bytes(),
                 Some("service"),
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::InsertIfEmpty(&owned_value_path!("ddsource"))),
+                Some(LegacyKey::InsertIfEmpty(owned_value_path!("ddsource"))),
                 &owned_value_path!("ddsource"),
                 Kind::bytes(),
                 Some("source"),
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::InsertIfEmpty(&owned_value_path!("ddtags"))),
+                Some(LegacyKey::InsertIfEmpty(owned_value_path!("ddtags"))),
                 &owned_value_path!("ddtags"),
                 Kind::bytes(),
                 Some("tags"),


### PR DESCRIPTION
The type of the optional `legacy_key` in some helper functions was changed from `Option<LegacyKey<&OwnedValuePath>>` to `Option<LegacyKey<OwnedValuePath>>`. The reference made it hard to use in practice. The reference isn't really necessary. Since this code only runs at startup, an extra clone is easier.

Here is an example from the redis source to get a `legacy_key` value now:
(`self.redis_key` is `Option<String>`)
```rust
let redis_key_path = self
            .redis_key
            .as_ref()
            .map(|x| owned_value_path!(x))
            .map(LegacyKey::InsertIfEmpty);
```