### PR TITLE
fix(ci): Introduce trusted/untrusted regression workflow split

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -42,15 +42,6 @@ jobs:
       comparison-tag: ${{ steps.comparison.outputs.COMPARISON_TAG }}
       baseline: ${{ steps.baseline.outputs.BASELINE }}
       baseline-tag: ${{ steps.baseline.outputs.BASELINE_TAG }}
-
-      cpus: ${{ steps.system.outputs.CPUS }}
-      memory: ${{ steps.system.outputs.MEMORY }}
-
-      replicas: ${{ steps.experimental-meta.outputs.REPLICAS }}
-      warmup-seconds: ${{ steps.experimental-meta.outputs.WARMUP_SECONDS }}
-      total-samples: ${{ steps.experimental-meta.outputs.TOTAL_SAMPLES }}
-      p-value: ${{ steps.experimental-meta.outputs.P_VALUE }}
-      smp-version: ${{ steps.experimental-meta.outputs.SMP_CRATE_VERSION }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -61,27 +52,6 @@ jobs:
         id: pr-metadata
         run: |
           echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_OUTPUT
-
-      - name: Setup experimental metadata
-        id: experimental-meta
-        run: |
-          export WARMUP_SECONDS="45"
-          export REPLICAS="10"
-          export TOTAL_SAMPLES="600"
-          export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.5.0"
-
-          echo "warmup seconds: ${WARMUP_SECONDS}"
-          echo "replicas: ${REPLICAS}"
-          echo "total samples: ${TOTAL_SAMPLES}"
-          echo "regression p-value: ${P_VALUE}"
-          echo "smp crate version: ${SMP_CRATE_VERSION}"
-
-          echo "WARMUP_SECONDS=${WARMUP_SECONDS}" >> $GITHUB_OUTPUT
-          echo "REPLICAS=${REPLICAS}" >> $GITHUB_OUTPUT
-          echo "TOTAL_SAMPLES=${TOTAL_SAMPLES}" >> $GITHUB_OUTPUT
-          echo "P_VALUE=${P_VALUE}" >> $GITHUB_OUTPUT
-          echo "SMP_CRATE_VERSION=${SMP_CRATE_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Setup baseline variables
         id: baseline
@@ -109,35 +79,6 @@ jobs:
           echo "COMPARISON=${COMPARISON_SHA}" >> $GITHUB_OUTPUT
           echo "COMPARISON_TAG=${COMPARISON_TAG}" >> $GITHUB_OUTPUT
 
-      - name: Setup system details
-        id: system
-        run: |
-          export CPUS="8"
-          export MEMORY="30g"
-
-          echo "cpus total: ${CPUS}"
-          echo "memory total: ${MEMORY}"
-
-          echo "CPUS=${CPUS}" >> $GITHUB_OUTPUT
-          echo "MEMORY=${MEMORY}" >> $GITHUB_OUTPUT
-
-  confirm-valid-credentials:
-    name: Confirm AWS credentials are minimally valid
-    runs-on: ubuntu-22.04
-    needs:
-      - compute-metadata
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: Download SMP binary
-        run: |
-          aws s3 cp s3://smp-cli-releases/v${{ needs.compute-metadata.outputs.smp-version }}/x86_64-unknown-linux-gnu/smp ${{ runner.temp }}/bin/smp
-
   ##
   ## BUILD
   ##
@@ -146,7 +87,6 @@ jobs:
     name: Build baseline Vector container
     runs-on: [linux, soak-builder]
     needs:
-      - confirm-valid-credentials
       - compute-metadata
     steps:
       - uses: colpal/actions-clean@v1
@@ -162,22 +102,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2.2.1
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Docker Login to ECR
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ steps.login-ecr.outputs.registry }}
-
       - name: Build 'vector' target image
         uses: docker/build-push-action@v3
         with:
@@ -186,15 +110,20 @@ jobs:
           cache-to: type=gha,mode=max
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
+          outputs: type=docker,dest=/tmp/baseline-image.tar
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}
-          push: true
+            vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}
+
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: baseline-image
+          path: /tmp/baseline-image.tar
 
   build-comparison:
     name: Build comparison Vector container
     runs-on: [linux, soak-builder]
     needs:
-      - confirm-valid-credentials
       - compute-metadata
     steps:
       - uses: colpal/actions-clean@v1
@@ -210,22 +139,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2.2.1
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Docker Login to ECR
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ steps.login-ecr.outputs.registry }}
-
       - name: Build 'vector' target image
         uses: docker/build-push-action@v3
         with:
@@ -234,144 +147,35 @@ jobs:
           cache-to: type=gha,mode=max
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
+          outputs: type=docker,dest=/tmp/comparison-image.tar
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}
-          push: true
+            vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}
 
-  ##
-  ## SUBMIT
-  ##
-
-  submit-job:
-    name: Submit regression job
-    runs-on: ubuntu-22.04
-    needs:
-      - compute-metadata
-      - build-baseline
-      - build-comparison
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Download SMP binary
-        run: |
-          aws s3 cp s3://smp-cli-releases/v${{ needs.compute-metadata.outputs.smp-version }}/x86_64-unknown-linux-gnu/smp ${{ runner.temp }}/bin/smp
-
-      - name: Submit job
-        env:
-          RUST_LOG: debug
-        run: |
-          chmod +x ${{ runner.temp }}/bin/smp
-
-          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job submit \
-            --total-samples ${{ needs.compute-metadata.outputs.total-samples }} \
-            --warmup-seconds ${{ needs.compute-metadata.outputs.warmup-seconds }} \
-            --replicas ${{ needs.compute-metadata.outputs.replicas }} \
-            --baseline-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }} \
-            --comparison-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }} \
-            --baseline-sha ${{ needs.compute-metadata.outputs.baseline }} \
-            --comparison-sha ${{ needs.compute-metadata.outputs.comparison }} \
-            --target-config-dir ${{ github.workspace }}/regression/ \
-            --target-name vector \
-            --submission-metadata ${{ runner.temp }}/submission-metadata
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: vector-submission-metadata
-          path: ${{ runner.temp }}/submission-metadata
-
-      - name: Await job
-        timeout-minutes: 60
-        env:
-          RUST_LOG: info
-        run: |
-          chmod +x ${{ runner.temp }}/bin/smp
-
-          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job status \
-            --wait \
-            --wait-delay-seconds 60 \
-            --submission-metadata ${{ runner.temp }}/submission-metadata
-
-      - name: Handle cancellation if necessary
-        if: ${{ cancelled() }}
-        timeout-minutes: 60
-        env:
-          RUST_LOG: info
-        run: |
-          chmod +x ${{ runner.temp }}/bin/smp
-          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job cancel --submission-metadata ${{ runner.temp }}/submission-metadata
-
-  ##
-  ## ANALYZE
-  ##
-
-  ## NOTE intentionally left as an example. The SMP capture files are quite
-  ## large, 1.5Gb. In the future we won't sync capture files at all, doing
-  ## analysis in the background and shipping the analysis. That said, at this
-  ## stage, it's still useful to know that you can sync if you want.
-
-  download-analysis:
-    name: Download regression analysis & upload report
-    runs-on: ubuntu-22.04
-    needs:
-      - submit-job
-      - compute-metadata
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: Download SMP binary
-        run: |
-          aws s3 cp s3://smp-cli-releases/v${{ needs.compute-metadata.outputs.smp-version }}/x86_64-unknown-linux-gnu/smp ${{ runner.temp }}/bin/smp
-
-      - name: Download submission metadata
-        uses: actions/download-artifact@v3
-        with:
-          name: vector-submission-metadata
-          path: ${{ runner.temp }}/
-
-      - name: Sync regression report to local system
-        env:
-          RUST_LOG: info
-        run: |
-          chmod +x ${{ runner.temp }}/bin/smp
-
-          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job sync \
-            --submission-metadata ${{ runner.temp }}/submission-metadata \
-            --output-path "${{ runner.temp }}/outputs"
-
-      - name: Read regression report
-        id: read-analysis
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ${{ runner.temp }}/outputs/report.html
-
-      - name: Post report to PR
-        uses: peter-evans/create-or-update-comment@v2
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        with:
-          issue-number: ${{ github.event.number }}
-          edit-mode: append
-          body: ${{ steps.read-analysis.outputs.content }}
-
-      - name: Upload regression report to artifacts
+      - name: Upload image as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: capture-artifacts
-          path: ${{ runner.temp }}/outputs/*
+          name: comparison-image
+          path: /tmp/comparison-image.tar
+
+  transmit-metadata:
+    name: Transmit metadata to trusted workflow
+    runs-on: ubuntu-22.04
+    needs:
+      - compute-metadata
+    steps:
+      - name: Write out metadata
+        run: |
+          echo "COMPARISON_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}" > /tmp/meta
+          echo "COMPARISON_SHA=${{ needs.compute-metadata.outputs.comparison }}" >> /tmp/meta
+          echo "BASELINE_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}" >> /tmp/meta
+          echo "BASELINE_SHA=${{ needs.compute-metadata.outputs.baseline }}" >> /tmp/meta
+          echo "CHECKOUT_SHA=${{ github.sha }}" >> /tmp/meta
+          echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> /tmp/meta
+          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> /tmp/meta
+          echo "GITHUB_EVENT_NUMBER=${{ github.event.number }}" >> /tmp/meta
+
+      - name: Upload metadata
+        uses: actions/upload-artifact@v3
+        with:
+          name: meta
+          path: /tmp/meta

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -110,7 +110,7 @@ jobs:
           cache-to: type=gha,mode=max
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=docker,dest=/tmp/baseline-image.tar
+          outputs: type=docker,dest="${{ runner.temp }}/baseline-image.tar"
           tags: |
             vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}
 
@@ -118,7 +118,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: baseline-image
-          path: /tmp/baseline-image.tar
+          path: "${{ runner.temp }}/baseline-image.tar"
 
   build-comparison:
     name: Build comparison Vector container
@@ -147,7 +147,7 @@ jobs:
           cache-to: type=gha,mode=max
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=docker,dest=/tmp/comparison-image.tar
+          outputs: type=docker,dest="${{ runner.temp }}/comparison-image.tar"
           tags: |
             vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}
 
@@ -155,7 +155,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: comparison-image
-          path: /tmp/comparison-image.tar
+          path: "${{ runner.temp }}/comparison-image.tar"
 
   transmit-metadata:
     name: Transmit metadata to trusted workflow
@@ -165,17 +165,17 @@ jobs:
     steps:
       - name: Write out metadata
         run: |
-          echo "COMPARISON_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}" > /tmp/meta
-          echo "COMPARISON_SHA=${{ needs.compute-metadata.outputs.comparison }}" >> /tmp/meta
-          echo "BASELINE_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}" >> /tmp/meta
-          echo "BASELINE_SHA=${{ needs.compute-metadata.outputs.baseline }}" >> /tmp/meta
-          echo "CHECKOUT_SHA=${{ github.sha }}" >> /tmp/meta
-          echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> /tmp/meta
-          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> /tmp/meta
-          echo "GITHUB_EVENT_NUMBER=${{ github.event.number }}" >> /tmp/meta
+          echo "COMPARISON_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}" > ${{ runner.temp }}/meta
+          echo "COMPARISON_SHA=${{ needs.compute-metadata.outputs.comparison }}" >> ${{ runner.temp }}/meta
+          echo "BASELINE_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}" >> ${{ runner.temp }}/meta
+          echo "BASELINE_SHA=${{ needs.compute-metadata.outputs.baseline }}" >> ${{ runner.temp }}/meta
+          echo "CHECKOUT_SHA=${{ github.sha }}" >> ${{ runner.temp }}/meta
+          echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> ${{ runner.temp }}/meta
+          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> ${{ runner.temp }}/meta
+          echo "GITHUB_EVENT_NUMBER=${{ github.event.number }}" >> ${{ runner.temp }}/meta
 
       - name: Upload metadata
         uses: actions/upload-artifact@v3
         with:
           name: meta
-          path: /tmp/meta
+          path: "${{ runner.temp }}/meta"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -110,7 +110,7 @@ jobs:
           cache-to: type=gha,mode=max
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=docker,dest="${{ runner.temp }}/baseline-image.tar"
+          outputs: type=docker,dest=${{ runner.temp }}/baseline-image.tar
           tags: |
             vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}
 
@@ -147,7 +147,7 @@ jobs:
           cache-to: type=gha,mode=max
           file: regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          outputs: type=docker,dest="${{ runner.temp }}/comparison-image.tar"
+          outputs: type=docker,dest=${{ runner.temp }}/comparison-image.tar
           tags: |
             vector:${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}
 

--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -65,14 +65,19 @@ jobs:
           echo "CPUS=${CPUS}" >> $GITHUB_OUTPUT
           echo "MEMORY=${MEMORY}" >> $GITHUB_OUTPUT
 
+        # github.rest.actions.listWorkflowRunArtifacts only returns first 30
+        # artifacts, and returns a { data, headers, status, url } object. The
+        # "data" part of this object contains the artifact data we care about.
+        # The fields of this data object correspond to the fields in the
+        # "Example Response" JSON object in
+        # https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts.
+        # To return more than 30 responses, use the github.paginate API in
+        # https://octokit.github.io/rest.js/v19#custom-requests
+        # `github-script` aliases `octokit` to the `github` namespace.
       - name: 'Download metadata'
         uses: actions/github-script@v6.3.3
         with:
           script: |
-            # Please note, listWorkflowRunArtifacts only returns 30
-            # artifacts. The untrusted side of this workflow produces 3 but if
-            # that ever changes github.paginate will need to be used and this
-            # has its own wrapping container: it is not a drop-in solution.
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -130,14 +135,19 @@ jobs:
       - compute-metadata
       - confirm-valid-credentials
     steps:
+        # github.rest.actions.listWorkflowRunArtifacts only returns first 30
+        # artifacts, and returns a { data, headers, status, url } object. The
+        # "data" part of this object contains the artifact data we care about.
+        # The fields of this data object correspond to the fields in the
+        # "Example Response" JSON object in
+        # https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts.
+        # To return more than 30 responses, use the github.paginate API in
+        # https://octokit.github.io/rest.js/v19#custom-requests
+        # `github-script` aliases `octokit` to the `github` namespace.
       - name: 'Download baseline image'
         uses: actions/github-script@v6.3.3
         with:
           script: |
-            # Please note, listWorkflowRunArtifacts only returns 30
-            # artifacts. The untrusted side of this workflow produces 3 but if
-            # that ever changes github.paginate will need to be used and this
-            # has its own wrapping container: it is not a drop-in solution.
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -193,14 +203,19 @@ jobs:
       - compute-metadata
       - confirm-valid-credentials
     steps:
+        # github.rest.actions.listWorkflowRunArtifacts only returns first 30
+        # artifacts, and returns a { data, headers, status, url } object. The
+        # "data" part of this object contains the artifact data we care about.
+        # The fields of this data object correspond to the fields in the
+        # "Example Response" JSON object in
+        # https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts.
+        # To return more than 30 responses, use the github.paginate API in
+        # https://octokit.github.io/rest.js/v19#custom-requests
+        # `github-script` aliases `octokit` to the `github` namespace.
       - name: 'Download comparison image'
         uses: actions/github-script@v6.3.3
         with:
           script: |
-            # Please note, listWorkflowRunArtifacts only returns 30
-            # artifacts. The untrusted side of this workflow produces 3 but if
-            # that ever changes github.paginate will need to be used and this
-            # has its own wrapping container: it is not a drop-in solution.
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,

--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -66,10 +66,10 @@ jobs:
           echo "MEMORY=${MEMORY}" >> $GITHUB_OUTPUT
 
       - name: 'Download metadata'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -77,7 +77,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "meta"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.actions.rest.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -123,10 +123,10 @@ jobs:
       - confirm-valid-credentials
     steps:
       - name: 'Download baseline image'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -134,7 +134,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "baseline-image"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.actions.rest.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -178,10 +178,10 @@ jobs:
       - confirm-valid-credentials
     steps:
       - name: 'Download comparison image'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -189,7 +189,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "comparison-image"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.actions.rest.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,

--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -1,0 +1,500 @@
+name: Regression Detector (trusted)
+
+on:
+  workflow_run:
+    workflows: ["Regression Detector"]
+    types:
+      - completed
+
+jobs:
+  compute-metadata:
+    name: Compute metadata for regression experiments
+    runs-on: ubuntu-22.04
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      cpus: ${{ steps.system.outputs.CPUS }}
+      memory: ${{ steps.system.outputs.MEMORY }}
+
+      comparison-sha: ${{ steps.metadata.outputs.COMPARISON_SHA }}
+      comparison-tag: ${{ steps.metadata.outputs.COMPARISON_TAG }}
+      baseline-sha: ${{ steps.metadata.outputs.BASELINE_SHA }}
+      baseline-tag: ${{ steps.metadata.outputs.BASELINE_TAG }}
+      head-sha: ${{ steps.metadata.outputs.HEAD_SHA }}
+      checkout-sha: ${{ steps.metadata.outputs.CHECKOUT_SHA }}
+      github-event-number: ${{ steps.metadata.outputs.GITHUB_EVENT_NUMBER }}
+
+      replicas: ${{ steps.experimental-meta.outputs.REPLICAS }}
+      warmup-seconds: ${{ steps.experimental-meta.outputs.WARMUP_SECONDS }}
+      total-samples: ${{ steps.experimental-meta.outputs.TOTAL_SAMPLES }}
+      p-value: ${{ steps.experimental-meta.outputs.P_VALUE }}
+      smp-version: ${{ steps.experimental-meta.outputs.SMP_CRATE_VERSION }}
+
+    steps:
+      - name: Setup experimental metadata
+        id: experimental-meta
+        run: |
+          export WARMUP_SECONDS="45"
+          export REPLICAS="10"
+          export TOTAL_SAMPLES="600"
+          export P_VALUE="0.1"
+          export SMP_CRATE_VERSION="0.5.0"
+
+          echo "warmup seconds: ${WARMUP_SECONDS}"
+          echo "replicas: ${REPLICAS}"
+          echo "total samples: ${TOTAL_SAMPLES}"
+          echo "regression p-value: ${P_VALUE}"
+          echo "smp crate version: ${SMP_CRATE_VERSION}"
+
+          echo "WARMUP_SECONDS=${WARMUP_SECONDS}" >> $GITHUB_OUTPUT
+          echo "REPLICAS=${REPLICAS}" >> $GITHUB_OUTPUT
+          echo "TOTAL_SAMPLES=${TOTAL_SAMPLES}" >> $GITHUB_OUTPUT
+          echo "P_VALUE=${P_VALUE}" >> $GITHUB_OUTPUT
+          echo "SMP_CRATE_VERSION=${SMP_CRATE_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Setup system details
+        id: system
+        run: |
+          export CPUS="8"
+          export MEMORY="30g"
+
+          echo "cpus total: ${CPUS}"
+          echo "memory total: ${MEMORY}"
+
+          echo "CPUS=${CPUS}" >> $GITHUB_OUTPUT
+          echo "MEMORY=${MEMORY}" >> $GITHUB_OUTPUT
+
+      - name: 'Download metadata'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "meta"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/meta.zip', Buffer.from(download.data));
+
+      - run: unzip meta.zip
+
+      - name: Setup metadata
+        id: metadata
+        run: |
+          cat meta
+          cat meta >> $GITHUB_OUTPUT
+
+  confirm-valid-credentials:
+    name: Confirm AWS credentials are minimally valid
+    runs-on: ubuntu-22.04
+    needs:
+      - compute-metadata
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Download SMP binary
+        run: |
+          aws s3 cp s3://smp-cli-releases/v${{ needs.compute-metadata.outputs.smp-version }}/x86_64-unknown-linux-gnu/smp ${{ runner.temp }}/bin/smp
+
+  ##
+  ## SUBMIT
+  ##
+
+  upload-baseline-image-to-ecr:
+    name: Upload images to ECR
+    runs-on: ubuntu-22.04
+    needs:
+      - compute-metadata
+      - confirm-valid-credentials
+    steps:
+      - name: 'Download baseline image'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "baseline-image"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/baseline-image.zip', Buffer.from(download.data));
+
+      - run: unzip baseline-image.zip
+
+      - name: Load baseline image
+        run: |
+          docker load --input baseline-image.tar
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Tag & push baseline image
+        run: |
+          docker tag vector:${{ needs.compute-metadata.outputs.baseline-tag }} ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.baseline-tag }}
+          docker push ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.baseline-tag }}
+
+  upload-comparison-image-to-ecr:
+    name: Upload images to ECR
+    runs-on: ubuntu-22.04
+    needs:
+      - compute-metadata
+      - confirm-valid-credentials
+    steps:
+      - name: 'Download comparison image'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "comparison-image"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/comparison-image.zip', Buffer.from(download.data));
+
+      - run: unzip comparison-image.zip
+
+      - name: Load comparison image
+        run: |
+          docker load --input comparison-image.tar
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Tag & push comparison image
+        run: |
+          docker tag vector:${{ needs.compute-metadata.outputs.comparison-tag }} ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.comparison-tag }}
+          docker push ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.comparison-tag }}
+
+  submit-job:
+    name: Submit regression job
+    runs-on: ubuntu-22.04
+    needs:
+      - compute-metadata
+      - upload-baseline-image-to-ecr
+      - upload-comparison-image-to-ecr
+    steps:
+      - name: Check status, in-progress
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Submit Experiment",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "in_progress",
+               output: {
+                  title: "Submit Experiment",
+                  summary: "Submit experiments to Regression Detector cluster.",
+               },
+            });
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.compute-metadata.outputs.checkout-sha }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Download SMP binary
+        run: |
+          aws s3 cp s3://smp-cli-releases/v${{ needs.compute-metadata.outputs.smp-version }}/x86_64-unknown-linux-gnu/smp ${{ runner.temp }}/bin/smp
+
+      - name: Submit job
+        env:
+          RUST_LOG: debug
+        run: |
+          chmod +x ${{ runner.temp }}/bin/smp
+
+          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job submit \
+            --total-samples ${{ needs.compute-metadata.outputs.total-samples }} \
+            --warmup-seconds ${{ needs.compute-metadata.outputs.warmup-seconds }} \
+            --replicas ${{ needs.compute-metadata.outputs.replicas }} \
+            --baseline-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.baseline-tag }} \
+            --comparison-image ${{ steps.login-ecr.outputs.registry }}/${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }}-vector:${{ needs.compute-metadata.outputs.comparison-tag }} \
+            --baseline-sha ${{ needs.compute-metadata.outputs.baseline-sha }} \
+            --comparison-sha ${{ needs.compute-metadata.outputs.comparison-sha }} \
+            --target-config-dir ${{ github.workspace }}/regression/ \
+            --target-name vector \
+            --submission-metadata ${{ runner.temp }}/submission-metadata
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vector-submission-metadata
+          path: ${{ runner.temp }}/submission-metadata
+
+      - name: Await job
+        timeout-minutes: 60
+        env:
+          RUST_LOG: info
+        run: |
+          chmod +x ${{ runner.temp }}/bin/smp
+
+          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job status \
+            --wait \
+            --wait-delay-seconds 60 \
+            --submission-metadata ${{ runner.temp }}/submission-metadata
+
+      - name: Handle cancellation if necessary
+        if: ${{ cancelled() }}
+        timeout-minutes: 60
+        env:
+          RUST_LOG: info
+        run: |
+          chmod +x ${{ runner.temp }}/bin/smp
+          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job cancel \
+            --submission-metadata ${{ runner.temp }}/submission-metadata
+
+      - name: Check status, cancelled
+        if: ${{ cancelled() }}
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Submit Experiment",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "completed",
+               conclusion: "cancelled",
+               output: {
+                  title: "Submit Experiment",
+                  summary: "Submit experiments to Regression Detector cluster.",
+               },
+            });
+
+      - name: Check status, success
+        if: ${{ success() }}
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Submit Experiment",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "completed",
+               conclusion: "success",
+               output: {
+                  title: "Submit Experiment",
+                  summary: "Submit experiments to Regression Detector cluster.",
+               },
+            });
+
+      - name: Check status, failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Submit Experiment",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "completed",
+               conclusion: "failure",
+               output: {
+                  title: "Submit Experiment",
+                  summary: "Submit experiments to Regression Detector cluster.",
+               },
+            });
+
+  ##
+  ## ANALYZE
+  ##
+
+  download-analysis:
+    name: Download regression analysis & upload report
+    runs-on: ubuntu-22.04
+    needs:
+      - submit-job
+      - compute-metadata
+    steps:
+      - name: Check status, in-progress
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Analyze Experimental Results",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "in_progress",
+               output: {
+                  title: "Analyze Experiment",
+                  summary: "Analyze experimental results from Regression Detector.",
+               },
+            });
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.compute-metadata.outputs.checkout-sha }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_BOT_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Download SMP binary
+        run: |
+          aws s3 cp s3://smp-cli-releases/v${{ needs.compute-metadata.outputs.smp-version }}/x86_64-unknown-linux-gnu/smp ${{ runner.temp }}/bin/smp
+
+      - name: Download submission metadata
+        uses: actions/download-artifact@v3
+        with:
+          name: vector-submission-metadata
+          path: ${{ runner.temp }}/
+
+      - name: Sync regression report to local system
+        env:
+          RUST_LOG: info
+        run: |
+          chmod +x ${{ runner.temp }}/bin/smp
+
+          ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job sync \
+            --submission-metadata ${{ runner.temp }}/submission-metadata \
+            --output-path "${{ runner.temp }}/outputs"
+
+      - name: Read regression report
+        id: read-analysis
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ${{ runner.temp }}/outputs/report.html
+
+      - name: Post report to PR
+        uses: peter-evans/create-or-update-comment@v2
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        with:
+          issue-number: ${{ needs.compute-metadata.outputs.github-event-number }}
+          edit-mode: append
+          body: ${{ steps.read-analysis.outputs.content }}
+
+      - name: Upload regression report to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: capture-artifacts
+          path: ${{ runner.temp }}/outputs/*
+
+      - name: Check status, cancelled
+        if: ${{ cancelled() }}
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Analyze Experimental Results",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "completed",
+               conclusion: "cancelled",
+               output: {
+                  title: "Analyze Experiment",
+                  summary: "Analyze experimental results from Regression Detector.",
+               },
+            });
+
+      - name: Check status, success
+        if: ${{ success() }}
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Analyze Experimental Results",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "completed",
+               conclusion: "success",
+               output: {
+                  title: "Analyze Experiment",
+                  summary: "Analyze experimental results from Regression Detector.",
+               },
+            });
+
+      - name: Check status, failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.checks.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               name: "Analyze Experiment",
+               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
+               status: "completed",
+               conclusion: "failure",
+               output: {
+                  title: "Analyze Experimental Results",
+                  summary: "Analyze experimental results from Regression Detector.",
+               },
+            });

--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -69,14 +69,22 @@ jobs:
         uses: actions/github-script@v6.3.3
         with:
           script: |
+            # Please note, listWorkflowRunArtifacts only returns 30
+            # artifacts. The untrusted side of this workflow produces 3 but if
+            # that ever changes github.paginate will need to be used and this
+            # has its own wrapping container: it is not a drop-in solution.
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
             });
+
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "meta"
             })[0];
+
+            console.log("Downloading artifact %s", matchArtifact.id);
+
             var download = await github.actions.rest.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -126,14 +134,22 @@ jobs:
         uses: actions/github-script@v6.3.3
         with:
           script: |
+            # Please note, listWorkflowRunArtifacts only returns 30
+            # artifacts. The untrusted side of this workflow produces 3 but if
+            # that ever changes github.paginate will need to be used and this
+            # has its own wrapping container: it is not a drop-in solution.
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
             });
+
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "baseline-image"
             })[0];
+
+            console.log("Downloading artifact %s", matchArtifact.id);
+
             var download = await github.actions.rest.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -181,14 +197,22 @@ jobs:
         uses: actions/github-script@v6.3.3
         with:
           script: |
+            # Please note, listWorkflowRunArtifacts only returns 30
+            # artifacts. The untrusted side of this workflow produces 3 but if
+            # that ever changes github.paginate will need to be used and this
+            # has its own wrapping container: it is not a drop-in solution.
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
             });
+
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "comparison-image"
             })[0];
+
+            console.log("Downloading artifact %s", matchArtifact.id);
+
             var download = await github.actions.rest.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,


### PR DESCRIPTION
This commit splits the regression flow into an untrusted pull_request event triggered flow and a trusted workflow_run event triggered flow. This accomplishes the same basic goal as the existing workflow run excepting that we do not require the PR contributor to have access to project secrets, meaning that dependabot, open-source contributors et al will be able to participate in the regression detector.

This commit brings the regression detector up to feature parity with the soak tests. Because of the nature of the workflow_run this PR will not post regression detector results: the workflow_run must be present in `master` branch before it will kick on. I had originally intended to split this work into two PRs but decided against this as landing the `regression_trusted.yml` separately would temporarily double the load on the regression detector, which felt undesirable from a cost control perspective.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
