### PR TITLE
fix(amqp source, amqp sink): Flatten `connection` options

### DIFF
--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -27,6 +27,7 @@ pub struct AmqpSinkConfig {
     pub(crate) routing_key: Option<Template>,
 
     /// Connection options for the `amqp` sink.
+    #[serde(flatten)]
     pub(crate) connection: AmqpConfig,
 
     #[configurable(derived)]

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -59,6 +59,7 @@ pub struct AmqpSourceConfig {
     pub(crate) consumer: String,
 
     /// Connection options for `AMQP` source.
+    #[serde(flatten)]
     pub(crate) connection: AmqpConfig,
 
     /// The `AMQP` routing key.

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -27,105 +27,14 @@ base: components: sinks: amqp: configuration: {
 			type: bool: {}
 		}
 	}
-	connection: {
-		description: "Connection options for the `amqp` sink."
-		required:    true
-		type: object: options: {
-			connection_string: {
-				description: """
-					URI for the `AMQP` server.
+	connection_string: {
+		description: """
+			URI for the `AMQP` server.
 
-					Format: amqp://<user>:<password>@<host>:<port>/<vhost>?timeout=<seconds>
-					"""
-				required: true
-				type: string: syntax: "literal"
-			}
-			tls: {
-				description: "Standard TLS options."
-				required:    false
-				type: object: options: {
-					alpn_protocols: {
-						description: """
-																Sets the list of supported ALPN protocols.
-
-																Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
-																they are defined.
-																"""
-						required: false
-						type: array: items: type: string: syntax: "literal"
-					}
-					ca_file: {
-						description: """
-																Absolute path to an additional CA certificate file.
-
-																The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					crt_file: {
-						description: """
-																Absolute path to a certificate file used to identify this server.
-
-																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
-																an inline string in PEM format.
-
-																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					key_file: {
-						description: """
-																Absolute path to a private key file used to identify this server.
-
-																The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					key_pass: {
-						description: """
-																Passphrase used to unlock the encrypted key file.
-
-																This has no effect unless `key_file` is set.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					verify_certificate: {
-						description: """
-																Enables certificate verification.
-
-																If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
-																issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
-																certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
-																so on until reaching a root certificate.
-
-																Relevant for both incoming and outgoing connections.
-
-																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
-																"""
-						required: false
-						type: bool: {}
-					}
-					verify_hostname: {
-						description: """
-																Enables hostname verification.
-
-																If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
-																the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
-
-																Only relevant for outgoing connections.
-
-																Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
-																"""
-						required: false
-						type: bool: {}
-					}
-				}
-			}
-		}
+			Format: amqp://<user>:<password>@<host>:<port>/<vhost>?timeout=<seconds>
+			"""
+		required: true
+		type: string: syntax: "literal"
 	}
 	encoding: {
 		description: "Encoding configuration."
@@ -197,5 +106,90 @@ base: components: sinks: amqp: configuration: {
 		description: "Template used to generate a routing key which corresponds to a queue binding."
 		required:    false
 		type: string: syntax: "template"
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
+		}
 	}
 }

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -19,105 +19,14 @@ base: components: sources: amqp: configuration: {
 			type: bool: {}
 		}
 	}
-	connection: {
-		description: "Connection options for `AMQP` source."
-		required:    true
-		type: object: options: {
-			connection_string: {
-				description: """
-					URI for the `AMQP` server.
+	connection_string: {
+		description: """
+			URI for the `AMQP` server.
 
-					Format: amqp://<user>:<password>@<host>:<port>/<vhost>?timeout=<seconds>
-					"""
-				required: true
-				type: string: syntax: "literal"
-			}
-			tls: {
-				description: "Standard TLS options."
-				required:    false
-				type: object: options: {
-					alpn_protocols: {
-						description: """
-																Sets the list of supported ALPN protocols.
-
-																Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
-																they are defined.
-																"""
-						required: false
-						type: array: items: type: string: syntax: "literal"
-					}
-					ca_file: {
-						description: """
-																Absolute path to an additional CA certificate file.
-
-																The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					crt_file: {
-						description: """
-																Absolute path to a certificate file used to identify this server.
-
-																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
-																an inline string in PEM format.
-
-																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					key_file: {
-						description: """
-																Absolute path to a private key file used to identify this server.
-
-																The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					key_pass: {
-						description: """
-																Passphrase used to unlock the encrypted key file.
-
-																This has no effect unless `key_file` is set.
-																"""
-						required: false
-						type: string: syntax: "literal"
-					}
-					verify_certificate: {
-						description: """
-																Enables certificate verification.
-
-																If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
-																issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
-																certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
-																so on until reaching a root certificate.
-
-																Relevant for both incoming and outgoing connections.
-
-																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
-																"""
-						required: false
-						type: bool: {}
-					}
-					verify_hostname: {
-						description: """
-																Enables hostname verification.
-
-																If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
-																the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
-
-																Only relevant for outgoing connections.
-
-																Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
-																"""
-						required: false
-						type: bool: {}
-					}
-				}
-			}
-		}
+			Format: amqp://<user>:<password>@<host>:<port>/<vhost>?timeout=<seconds>
+			"""
+		required: true
+		type: string: syntax: "literal"
 	}
 	consumer: {
 		description: "The identifier for the consumer."
@@ -244,6 +153,91 @@ base: components: sources: amqp: configuration: {
 		type: string: {
 			default: "routing"
 			syntax:  "literal"
+		}
+	}
+	tls: {
+		description: "Standard TLS options."
+		required:    false
+		type: object: options: {
+			alpn_protocols: {
+				description: """
+					Sets the list of supported ALPN protocols.
+
+					Declare the supported ALPN protocols, which are used during negotiation with peer. Prioritized in the order
+					they are defined.
+					"""
+				required: false
+				type: array: items: type: string: syntax: "literal"
+			}
+			ca_file: {
+				description: """
+					Absolute path to an additional CA certificate file.
+
+					The certficate must be in the DER or PEM (X.509) format. Additionally, the certificate can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			crt_file: {
+				description: """
+					Absolute path to a certificate file used to identify this server.
+
+					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
+					an inline string in PEM format.
+
+					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_file: {
+				description: """
+					Absolute path to a private key file used to identify this server.
+
+					The key must be in DER or PEM (PKCS#8) format. Additionally, the key can be provided as an inline string in PEM format.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			key_pass: {
+				description: """
+					Passphrase used to unlock the encrypted key file.
+
+					This has no effect unless `key_file` is set.
+					"""
+				required: false
+				type: string: syntax: "literal"
+			}
+			verify_certificate: {
+				description: """
+					Enables certificate verification.
+
+					If enabled, certificates must be valid in terms of not being expired, as well as being issued by a trusted
+					issuer. This verification operates in a hierarchical manner, checking that not only the leaf certificate (the
+					certificate presented by the client/server) is valid, but also that the issuer of that certificate is valid, and
+					so on until reaching a root certificate.
+
+					Relevant for both incoming and outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
+					"""
+				required: false
+				type: bool: {}
+			}
+			verify_hostname: {
+				description: """
+					Enables hostname verification.
+
+					If enabled, the hostname used to connect to the remote host must be present in the TLS certificate presented by
+					the remote host, either as the Common Name or as an entry in the Subject Alternative Name extension.
+
+					Only relevant for outgoing connections.
+
+					Do NOT set this to `false` unless you understand the risks of not verifying the remote hostname.
+					"""
+				required: false
+				type: bool: {}
+			}
 		}
 	}
 }


### PR DESCRIPTION
`connection_string` and `tls` should be configurable on the top-level

This is technically a breaking change, but the docs currently document the flattened behavior so I think we can do this as a bug fix.

Closes: #15118.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
