### PR TITLE
Update kubernetes_logs.cue

### DIFF
--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -63,7 +63,7 @@ components: sources: kubernetes_logs: {
 						description: "Event field for Container id."
 						required:    false
 						type: string: {
-							default: "kubernetes.container_image"
+							default: "kubernetes.container_id"
 						}
 					}
 					container_image: {


### PR DESCRIPTION
Noticed while working on the log_namespace, confirmed it's correct on the cue generated from our schema.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
