### PR TITLE
fix(ci): Correct github.actions.rest to github.rest.actions

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -90,7 +90,7 @@ jobs:
 
             console.log("Downloading artifact %s", matchArtifact.id);
 
-            var download = await github.actions.rest.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -160,7 +160,7 @@ jobs:
 
             console.log("Downloading artifact %s", matchArtifact.id);
 
-            var download = await github.actions.rest.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -228,7 +228,7 @@ jobs:
 
             console.log("Downloading artifact %s", matchArtifact.id);
 
-            var download = await github.actions.rest.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,


### PR DESCRIPTION
In #15142 we introduced the split between the trusted and untrusted regresison detector workflow. Unfortunately the trusted side can only be tested once it's merged into master branch and we had a bug. The github-scripts that download artifacts referenced `github.actions.rest` when it should have read `github.rest.actions`.

Please note that because of the nature of workflow_run triggered workflows this change will not be reflected in the PR's workflow runs.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
