### PR TITLE
fix(ci): Remove dependabot restriction from comment step

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -472,7 +472,6 @@ jobs:
 
       - name: Post report to PR
         uses: peter-evans/create-or-update-comment@v2
-        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           issue-number: ${{ needs.compute-metadata.outputs.github-event-number }}
           edit-mode: append


### PR DESCRIPTION
Dependabot-originated PRs should be able to post comments with the new trusted/untrusted workflow split.

Previously: #15142
cc: @blt