### PR TITLE
fix(remap transform, observability): `abort` is an intentional drop

### DIFF
--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -3,7 +3,7 @@ use metrics::counter;
 use vector_core::internal_event::InternalEvent;
 
 use vector_common::internal_event::{
-    error_stage, error_type, ComponentEventsDropped, UNINTENTIONAL,
+    error_stage, error_type, ComponentEventsDropped, INTENTIONAL, UNINTENTIONAL,
 };
 
 #[derive(Debug)]
@@ -54,7 +54,7 @@ impl InternalEvent for RemapMappingAbort {
         );
 
         if self.event_dropped {
-            emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+            emit!(ComponentEventsDropped::<INTENTIONAL> {
                 count: 1,
                 reason: "Event mapping aborted.",
             });


### PR DESCRIPTION
And so shouldn't log errors.

Closes: #15160

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
