### PR TITLE
chore(core): add schema definition test utility

### DIFF
--- a/lib/lookup/src/lookup_v2/owned.rs
+++ b/lib/lookup/src/lookup_v2/owned.rs
@@ -30,6 +30,10 @@ impl OwnedValuePath {
         self.segments.insert(0, OwnedSegment::field(field));
     }
 
+    pub fn push_front_segment(&mut self, segment: OwnedSegment) {
+        self.segments.insert(0, segment);
+    }
+
     pub fn with_field_appended(&self, field: &str) -> Self {
         let mut new_path = self.clone();
         new_path.push_field(field);
@@ -37,8 +41,12 @@ impl OwnedValuePath {
     }
 
     pub fn with_field_prefix(&self, field: &str) -> Self {
+        self.with_segment_prefix(OwnedSegment::field(field))
+    }
+
+    pub fn with_segment_prefix(&self, segment: OwnedSegment) -> Self {
         let mut new_path = self.clone();
-        new_path.push_front_field(field);
+        new_path.push_front_segment(segment);
         new_path
     }
 

--- a/lib/value/src/kind/collection.rs
+++ b/lib/value/src/kind/collection.rs
@@ -7,9 +7,15 @@ use std::collections::BTreeMap;
 
 pub use field::Field;
 pub use index::Index;
+use lookup::lookup_v2::OwnedSegment;
+use lookup::OwnedValuePath;
 pub use unknown::Unknown;
 
 use super::Kind;
+
+pub trait CollectionKey {
+    fn to_segment(&self) -> OwnedSegment;
+}
 
 /// The kinds of a collection (e.g. array or object).
 ///
@@ -172,46 +178,6 @@ impl<T: Ord + Clone> Collection<T> {
         self.unknown = self.unknown.to_kind().union(known_unknown).into();
     }
 
-    /// Check if `self` is a superset of `other`.
-    ///
-    /// Meaning, for all known fields in `other`, if the field also exists in `self`, then its type
-    /// needs to be a subset of `self`, otherwise its type needs to be a subset of self's
-    /// `unknown`.
-    ///
-    /// If `self` has known fields not defined in `other`, then `other`'s `unknown` must be
-    /// a superset of those fields defined in `self`.
-    ///
-    /// Additionally, other's `unknown` type needs to be a subset of `self`'s.
-    #[must_use]
-    pub fn is_superset(&self, other: &Self) -> bool {
-        // `self`'s `unknown` needs to be  a superset of `other`'s.
-        if !self.unknown.is_superset(&other.unknown) {
-            return false;
-        }
-
-        // All known fields in `other` need to either be a subset of a matching known field in
-        // `self`, or a subset of self's `unknown` type state.
-        if !other
-            .known
-            .iter()
-            .all(|(key, other_kind)| match self.known.get(key) {
-                Some(self_kind) => self_kind.is_superset(other_kind),
-                None => self.unknown_kind().is_superset(other_kind),
-            })
-        {
-            return false;
-        }
-
-        // All known fields in `self` not known in `other` need to be a superset of other's
-        // `unknown` type state.
-        self.known
-            .iter()
-            .all(|(key, self_kind)| match other.known.get(key) {
-                Some(_) => true,
-                None => self_kind.is_superset(&other.unknown_kind()),
-            })
-    }
-
     /// Merge the `other` collection into `self`.
     ///
     /// The following merge strategies are applied.
@@ -277,6 +243,59 @@ impl<T: Ord + Clone> Collection<T> {
             .reduce(|lhs, rhs| lhs.union(rhs))
             .unwrap_or_else(Kind::never)
             .union(self.unknown_kind().without_undefined())
+    }
+}
+
+impl<T: Ord + Clone + CollectionKey> Collection<T> {
+    /// Check if `self` is a superset of `other`.
+    ///
+    /// Meaning, for all known fields in `other`, if the field also exists in `self`, then its type
+    /// needs to be a subset of `self`, otherwise its type needs to be a subset of self's
+    /// `unknown`.
+    ///
+    /// If `self` has known fields not defined in `other`, then `other`'s `unknown` must be
+    /// a superset of those fields defined in `self`.
+    ///
+    /// Additionally, other's `unknown` type needs to be a subset of `self`'s.
+    ///
+    /// # Errors
+    /// If the type is not a superset, a path to one field that doesn't match is returned.
+    /// This is mostly useful for debugging.
+    pub fn is_superset(&self, other: &Self) -> Result<(), OwnedValuePath> {
+        // `self`'s `unknown` needs to be  a superset of `other`'s.
+
+        self.unknown
+            .is_superset(&other.unknown)
+            .map_err(|path| path.with_field_prefix("<unknown>"))?;
+
+        // All known fields in `other` need to either be a subset of a matching known field in
+        // `self`, or a subset of self's `unknown` type state.
+        for (key, other_kind) in &other.known {
+            match self.known.get(key) {
+                Some(self_kind) => {
+                    self_kind
+                        .is_superset(other_kind)
+                        .map_err(|path| path.with_segment_prefix(key.to_segment()))?;
+                }
+                None => {
+                    self.unknown_kind()
+                        .is_superset(other_kind)
+                        .map_err(|path| path.with_segment_prefix(key.to_segment()))?;
+                }
+            }
+        }
+
+        // All known fields in `self` not known in `other` need to be a superset of other's
+        // `unknown` type state.
+        for (key, self_kind) in &self.known {
+            if other.known.get(key).is_none() {
+                self_kind
+                    .is_superset(&other.unknown_kind())
+                    .map_err(|path| path.with_segment_prefix(key.to_segment()))?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -364,6 +383,12 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+
+    impl CollectionKey for &'static str {
+        fn to_segment(&self) -> OwnedSegment {
+            OwnedSegment::Field((*self).to_string())
+        }
+    }
 
     #[test]
     #[allow(clippy::too_many_lines)]
@@ -461,7 +486,7 @@ mod tests {
                 },
             ),
         ]) {
-            assert_eq!(this.is_superset(&other), want, "{}", title);
+            assert_eq!(this.is_superset(&other).is_ok(), want, "{}", title);
         }
     }
 

--- a/lib/value/src/kind/collection/field.rs
+++ b/lib/value/src/kind/collection/field.rs
@@ -1,5 +1,6 @@
-use crate::kind::collection::CollectionRemove;
+use crate::kind::collection::{CollectionKey, CollectionRemove};
 use crate::kind::Collection;
+use lookup::lookup_v2::OwnedSegment;
 
 /// A `field` type that can be used in `Collection<Field>`
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
@@ -8,6 +9,12 @@ pub struct Field(lookup::FieldBuf);
 impl std::fmt::Display for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl CollectionKey for Field {
+    fn to_segment(&self) -> OwnedSegment {
+        OwnedSegment::Field(self.0.name.clone())
     }
 }
 

--- a/lib/value/src/kind/collection/index.rs
+++ b/lib/value/src/kind/collection/index.rs
@@ -1,5 +1,6 @@
-use crate::kind::collection::CollectionRemove;
+use crate::kind::collection::{CollectionKey, CollectionRemove};
 use crate::kind::Collection;
+use lookup::lookup_v2::OwnedSegment;
 
 /// An `index` type that can be used in `Collection<Index>`
 #[derive(Debug, Clone, Default, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
@@ -16,6 +17,12 @@ impl Index {
     #[must_use]
     pub const fn to_usize(self) -> usize {
         self.0
+    }
+}
+
+impl CollectionKey for Index {
+    fn to_segment(&self) -> OwnedSegment {
+        OwnedSegment::Index(self.0 as isize)
     }
 }
 

--- a/lib/value/src/kind/collection/unknown.rs
+++ b/lib/value/src/kind/collection/unknown.rs
@@ -118,7 +118,10 @@ impl Unknown {
             (Inner::Infinite(infinite), Inner::Exact(rhs)) => {
                 Kind::from(*infinite).is_superset(rhs)
             }
-            (Inner::Exact(lhs), Inner::Exact(rhs)) => lhs.is_superset(rhs),
+            (Inner::Exact(lhs), Inner::Exact(rhs)) => lhs
+                .clone()
+                .without_undefined()
+                .is_superset(&rhs.clone().without_undefined()),
             (Inner::Exact(lhs), Inner::Infinite(..)) => {
                 if lhs.is_any() {
                     Ok(())

--- a/lib/value/src/kind/collection/unknown.rs
+++ b/lib/value/src/kind/collection/unknown.rs
@@ -1,3 +1,4 @@
+use lookup::OwnedValuePath;
 use std::collections::BTreeMap;
 
 use super::Collection;
@@ -111,16 +112,27 @@ impl Unknown {
     ///
     /// Meaning, if `self` is `Any`, then it's always a superset of `other`, otherwise its
     /// accumulative types need to be a superset of `other`.
-    #[must_use]
-    pub(crate) fn is_superset(&self, other: &Self) -> bool {
+    pub(crate) fn is_superset(&self, other: &Self) -> Result<(), OwnedValuePath> {
         match (&self.0, &other.0) {
-            (Inner::Infinite(infinite), _) if infinite.is_any() => true,
+            (Inner::Infinite(infinite), _) if infinite.is_any() => Ok(()),
             (Inner::Infinite(infinite), Inner::Exact(rhs)) => {
                 Kind::from(*infinite).is_superset(rhs)
             }
             (Inner::Exact(lhs), Inner::Exact(rhs)) => lhs.is_superset(rhs),
-            (Inner::Exact(lhs), Inner::Infinite(..)) => lhs.is_any(),
-            (Inner::Infinite(lhs), Inner::Infinite(rhs)) => lhs.is_superset(rhs),
+            (Inner::Exact(lhs), Inner::Infinite(..)) => {
+                if lhs.is_any() {
+                    Ok(())
+                } else {
+                    Err(OwnedValuePath::root())
+                }
+            }
+            (Inner::Infinite(lhs), Inner::Infinite(rhs)) => {
+                if lhs.is_superset(rhs) {
+                    Ok(())
+                } else {
+                    Err(OwnedValuePath::root())
+                }
+            }
         }
     }
 
@@ -394,7 +406,7 @@ mod tests {
                 },
             ),
         ]) {
-            assert_eq!(this.is_superset(&other), want, "{}", title);
+            assert_eq!(this.is_superset(&other).is_ok(), want, "{}", title);
         }
     }
 }

--- a/lib/value/src/kind/comparison.rs
+++ b/lib/value/src/kind/comparison.rs
@@ -414,6 +414,60 @@ impl Kind {
     }
 }
 
+#[cfg(any(test, feature = "test"))]
+mod test_utils {
+
+    impl Kind {
+        pub fn is_superset_debug(&self, other: &Self) -> Result<(), Owned> {
+            if let (None, Some(_)) = (self.bytes, other.bytes) {
+                return false;
+            };
+
+            if let (None, Some(_)) = (self.integer, other.integer) {
+                return false;
+            };
+
+            if let (None, Some(_)) = (self.float, other.float) {
+                return false;
+            };
+
+            if let (None, Some(_)) = (self.boolean, other.boolean) {
+                return false;
+            };
+
+            if let (None, Some(_)) = (self.timestamp, other.timestamp) {
+                return false;
+            };
+
+            if let (None, Some(_)) = (self.regex, other.regex) {
+                return false;
+            };
+
+            if let (None, Some(_)) = (self.null, other.null) {
+                return false;
+            };
+
+            if let (None, Some(_)) = (self.undefined, other.undefined) {
+                return false;
+            };
+
+            match (self.array.as_ref(), other.array.as_ref()) {
+                (None, Some(_)) => return false,
+                (Some(lhs), Some(rhs)) if !lhs.is_superset(rhs) => return false,
+                _ => {}
+            };
+
+            match (self.object.as_ref(), other.object.as_ref()) {
+                (None, Some(_)) => return false,
+                (Some(lhs), Some(rhs)) if !lhs.is_superset(rhs) => return false,
+                _ => {}
+            };
+
+            true
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};

--- a/lib/value/src/kind/comparison.rs
+++ b/lib/value/src/kind/comparison.rs
@@ -1,4 +1,5 @@
 use super::Kind;
+use lookup::OwnedValuePath;
 
 impl Kind {
     /// Returns `true` if all type states are valid.
@@ -229,53 +230,58 @@ impl Kind {
     ///
     /// Collection types are recursively checked (meaning, known fields in `self` also need to be
     /// a superset of `other`.
-    #[must_use]
-    pub fn is_superset(&self, other: &Self) -> bool {
+    ///
+    /// # Errors
+    /// If the type is not a superset, a path to one field that doesn't match is returned.
+    /// This is mostly useful for debugging.
+    pub fn is_superset(&self, other: &Self) -> Result<(), OwnedValuePath> {
         if let (None, Some(_)) = (self.bytes, other.bytes) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         if let (None, Some(_)) = (self.integer, other.integer) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         if let (None, Some(_)) = (self.float, other.float) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         if let (None, Some(_)) = (self.boolean, other.boolean) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         if let (None, Some(_)) = (self.timestamp, other.timestamp) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         if let (None, Some(_)) = (self.regex, other.regex) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         if let (None, Some(_)) = (self.null, other.null) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         if let (None, Some(_)) = (self.undefined, other.undefined) {
-            return false;
+            return Err(OwnedValuePath::root());
         };
 
         match (self.array.as_ref(), other.array.as_ref()) {
-            (None, Some(_)) => return false,
-            (Some(lhs), Some(rhs)) if !lhs.is_superset(rhs) => return false,
+            (None, Some(_)) => return Err(OwnedValuePath::root()),
+            (Some(lhs), Some(rhs)) => {
+                lhs.is_superset(rhs)?;
+            }
             _ => {}
         };
 
         match (self.object.as_ref(), other.object.as_ref()) {
-            (None, Some(_)) => return false,
-            (Some(lhs), Some(rhs)) if !lhs.is_superset(rhs) => return false,
+            (None, Some(_)) => return Err(OwnedValuePath::root()),
+            (Some(lhs), Some(rhs)) => lhs.is_superset(rhs)?,
             _ => {}
         };
 
-        true
+        Ok(())
     }
 
     /// Check if `self` intersects `other`.
@@ -414,60 +420,6 @@ impl Kind {
     }
 }
 
-#[cfg(any(test, feature = "test"))]
-mod test_utils {
-
-    impl Kind {
-        pub fn is_superset_debug(&self, other: &Self) -> Result<(), Owned> {
-            if let (None, Some(_)) = (self.bytes, other.bytes) {
-                return false;
-            };
-
-            if let (None, Some(_)) = (self.integer, other.integer) {
-                return false;
-            };
-
-            if let (None, Some(_)) = (self.float, other.float) {
-                return false;
-            };
-
-            if let (None, Some(_)) = (self.boolean, other.boolean) {
-                return false;
-            };
-
-            if let (None, Some(_)) = (self.timestamp, other.timestamp) {
-                return false;
-            };
-
-            if let (None, Some(_)) = (self.regex, other.regex) {
-                return false;
-            };
-
-            if let (None, Some(_)) = (self.null, other.null) {
-                return false;
-            };
-
-            if let (None, Some(_)) = (self.undefined, other.undefined) {
-                return false;
-            };
-
-            match (self.array.as_ref(), other.array.as_ref()) {
-                (None, Some(_)) => return false,
-                (Some(lhs), Some(rhs)) if !lhs.is_superset(rhs) => return false,
-                _ => {}
-            };
-
-            match (self.object.as_ref(), other.object.as_ref()) {
-                (None, Some(_)) => return false,
-                (Some(lhs), Some(rhs)) if !lhs.is_superset(rhs) => return false,
-                _ => {}
-            };
-
-            true
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
@@ -580,7 +532,7 @@ mod tests {
                 },
             ),
         ]) {
-            assert_eq!(this.is_superset(&other), want, "{}", title);
+            assert_eq!(this.is_superset(&other).is_ok(), want, "{}", title);
         }
     }
 

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -180,12 +180,11 @@ impl LogEvent {
         &mut self.metadata
     }
 
+    /// This detects the log namespace used at runtime by checking for the existence
+    /// of the read-only "vector" metadata, which only exists (and is required to exist)
+    /// with the `Vector` log namespace.
     pub fn namespace(&self) -> LogNamespace {
-        // The (read-only) vector prefix on metadata is used to determine which namespace
-        // is being used. The user is prevented from modifying data here.
-        // This prefix should always exist for logs with the "Vector" namespace,
-        // and should never exist otherwise.
-        if self.metadata().value().contains(path!("vector")) {
+        if self.contains((PathPrefix::Metadata, path!("vector"))) {
             LogNamespace::Vector
         } else {
             LogNamespace::Legacy

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -43,6 +43,14 @@ fn default_metadata_value() -> Value {
 
 /// Secret access functions
 impl EventMetadata {
+    /// Creates `EventMetadata` with the given `Value`, and the rest of the fields with default values
+    pub fn default_with_value(value: Value) -> Self {
+        Self {
+            value,
+            ..Default::default()
+        }
+    }
+
     /// Returns a reference to the metadata value
     pub fn value(&self) -> &Value {
         &self.value

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -41,7 +41,6 @@ fn default_metadata_value() -> Value {
     Value::Object(BTreeMap::new())
 }
 
-/// Secret access functions
 impl EventMetadata {
     /// Creates `EventMetadata` with the given `Value`, and the rest of the fields with default values
     pub fn default_with_value(value: Value) -> Self {

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -470,8 +470,8 @@ mod test_utils {
                 if let Err(path) = self.event_kind.is_superset(&actual_kind) {
                     return Result::Err(format!("Event value doesn't match at path: {}\n\nEvent type at path = {:?}\n\nDefinition at path = {:?}",
                         path,
-                        actual_kind.get(&path).debug_info(),
-                        self.event_kind.get(&path).debug_info()
+                        actual_kind.at_path(&path).debug_info(),
+                        self.event_kind.at_path(&path).debug_info()
                     ));
                 }
 
@@ -482,8 +482,8 @@ mod test_utils {
                     return Result::Err(format!(
                         "Event METADATA value doesn't match at path: {}\n\nMetadata type at path = {:?}\n\nDefinition at path = {:?}",
                         path,
-                        actual_metadata_kind.get(&path).debug_info(),
-                        self.metadata_kind.get(&path).debug_info()
+                        actual_metadata_kind.at_path(&path).debug_info(),
+                        self.metadata_kind.at_path(&path).debug_info()
                     ));
                 }
                 if !self.log_namespaces.contains(&log.namespace()) {
@@ -573,11 +573,23 @@ mod tests {
                 event: Event::Log(LogEvent::from(BTreeMap::new())),
                 valid: false,
             },
+            TestCase {
+                title: "event mismatch - null vs undefined",
+                definition: Definition::new(
+                    Kind::object(Collection::empty()),
+                    Kind::any(),
+                    [LogNamespace::Legacy],
+                ),
+                event: Event::Log(LogEvent::from(BTreeMap::from([(
+                    "foo".into(),
+                    Value::Null,
+                )]))),
+                valid: false,
+            },
         ] {
             let result = definition.is_valid_for_event(&event);
             assert_eq!(result.is_ok(), valid, "{}", title);
         }
-        panic!();
     }
 
     #[test]

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -452,12 +452,59 @@ impl Definition {
     }
 }
 
+#[cfg(any(test, feature = "test"))]
+mod test_utils {
+    use super::*;
+    use crate::event::{Event, LogEvent};
+
+    impl Definition {
+        /// Asserts that the schema definition is _valid_ for the given event.
+        /// This will panic if the definition is not valid.
+
+        pub fn is_valid_for_event(&self, event: &Event) -> Result<(), String> {
+            if let Some(log) = event.as_log() {
+                let log: &LogEvent = log;
+                let actual_kind = Kind::from(log.value());
+                if !self.event_kind.is_superset(&actual_kind) {
+                    return Result::Err(format!("Event doesn't match"));
+                }
+                Ok(())
+            } else {
+                // schema definitions currently only apply to logs
+                Ok(())
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::event::{Event, LogEvent};
     use lookup::owned_value_path;
     use std::collections::{BTreeMap, HashMap};
 
     use super::*;
+
+    #[test]
+    fn test_definition_validity() {
+        struct TestCase {
+            title: &'static str,
+            definition: Definition,
+            event: Event,
+            valid: bool,
+        }
+
+        for TestCase {
+            title,
+            definition,
+            event,
+            valid,
+        } in [TestCase {
+            title: "",
+            definition: Default::default(),
+            event: Event::Log(LogEvent::from(value!())),
+        }] {}
+    }
 
     #[test]
     fn test_empty_legacy_field() {

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -458,8 +458,7 @@ mod test_utils {
     use crate::event::{Event, LogEvent};
 
     impl Definition {
-        /// Asserts that the schema definition is _valid_ for the given event.
-        /// This will panic if the definition is not valid.
+        /// Checks that the schema definition is _valid_ for the given event.
         ///
         /// # Errors
         /// If the definition is not valid, debug info will be returned.
@@ -502,6 +501,7 @@ mod test_utils {
             }
         }
 
+        /// Asserts that the schema definition is _valid_ for the given event.
         /// # Panics
         /// If the definition is not valid for the event.
         pub fn assert_valid_for_event(&self, event: &Event) {

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -469,7 +469,7 @@ mod test_utils {
 
                 let actual_kind = Kind::from(log.value());
                 if let Err(path) = self.event_kind.is_superset(&actual_kind) {
-                    return Result::Err(format!("Event value doesn't match at path: {:?}.\n\nEvent type at path = {:?}\n\nDefinition at path = {:?}",
+                    return Result::Err(format!("Event value doesn't match at path: {}\n\nEvent type at path = {:?}\n\nDefinition at path = {:?}",
                         path,
                         actual_kind.get(&path).debug_info(),
                         self.event_kind.get(&path).debug_info()
@@ -481,7 +481,7 @@ mod test_utils {
                     // return Result::Err(format!("Event metadata doesn't match definition.\n\nDefinition type=\n{:?}\n\nActual event metadata type=\n{:?}\n",
                     //                            self.metadata_kind.debug_info(), actual_metadata_kind.debug_info()));
                     return Result::Err(format!(
-                        "Event METADATA value doesn't match at path: {:?}.\n\nMetadata type at path = {:?}\n\nDefinition at path = {:?}",
+                        "Event METADATA value doesn't match at path: {}\n\nMetadata type at path = {:?}\n\nDefinition at path = {:?}",
                         path,
                         actual_metadata_kind.get(&path).debug_info(),
                         self.metadata_kind.get(&path).debug_info()
@@ -576,9 +576,6 @@ mod tests {
         ] {
             let result = definition.is_valid_for_event(&event);
             assert_eq!(result.is_ok(), valid, "{}", title);
-            if let Err(err) = result {
-                println!("{}", err);
-            }
         }
         panic!();
     }

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -100,7 +100,7 @@ impl Requirement {
                     // Get the kind at the path for the given semantic meaning.
                     let definition_kind = definition.event_kind().at_path(path);
 
-                    if !req_meaning.kind.is_superset(&definition_kind) {
+                    if req_meaning.kind.is_superset(&definition_kind).is_err() {
                         // The semantic meaning kind does not match the expected
                         // kind, so we can't use it in the sink.
                         errors.push(ValidationError::MeaningKind {

--- a/lib/vrl/compiler/src/expression/function_call.rs
+++ b/lib/vrl/compiler/src/expression/function_call.rs
@@ -138,7 +138,7 @@ impl<'a> Builder<'a> {
                     argument,
                     argument_span,
                 });
-            } else if !param_kind.is_superset(expr_kind) {
+            } else if param_kind.is_superset(expr_kind).is_err() {
                 arguments_with_unknown_type_validity.push((*parameter, node.clone()));
             }
 
@@ -244,7 +244,7 @@ impl<'a> Builder<'a> {
                             // Keep track of the type information, so that we
                             // can report these in a diagnostic error if no
                             // other input definition matches.
-                            if !input.kind.is_superset(type_def.kind()) {
+                            if input.kind.is_superset(type_def.kind()).is_err() {
                                 err_found_type_def = Some(type_def.kind().clone());
                                 continue;
                             }
@@ -510,7 +510,7 @@ impl<'a> Builder<'a> {
             // Check the type definition of the resulting block.This needs to match
             // whatever is configured by the closure input type.
             let expected_kind = input.output.into_kind();
-            if !expected_kind.is_superset(block_type_def.kind()) {
+            if expected_kind.is_superset(block_type_def.kind()).is_err() {
                 return Err(Error::ReturnTypeMismatch {
                     block_span,
                     found_kind: block_type_def.kind().clone(),

--- a/lib/vrl/compiler/src/expression/op.rs
+++ b/lib/vrl/compiler/src/expression/op.rs
@@ -147,7 +147,9 @@ impl Expression for Op {
             Or if lhs_def.is_null() => rhs_def,
 
             // not null || ...
-            Or if !(lhs_def.is_superset(&K::null()) || lhs_def.is_superset(&K::boolean())) => {
+            Or if !(lhs_def.is_superset(&K::null()).is_ok()
+                || lhs_def.is_superset(&K::boolean()).is_ok()) =>
+            {
                 lhs_def
             }
 

--- a/lib/vrl/compiler/src/type_def.rs
+++ b/lib/vrl/compiler/src/type_def.rs
@@ -330,7 +330,7 @@ impl TypeDef {
     /// within the provided kind.
     pub fn fallible_unless(mut self, kind: impl Into<Kind>) -> Self {
         let kind = kind.into();
-        if !kind.is_superset(&self.kind) {
+        if kind.is_superset(&self.kind).is_err() {
             self.fallible = true
         }
 


### PR DESCRIPTION
`schema::Definition::assert_valid_for_event` was added as an easy way to validate that a schema definition is valid for a specific event. This can easily be added to integration tests, or any test where you already have valid events, and the associated schema definition.

`assert_valid_for_event` will panic is the event doesn't match, and print out debug information.
`is_valid_for_event` is available if you don't want a panic. It will still give the debug info as a `String`.

Both of these functions are only available in tests. They are available in `vector-core` when running tests, or in any other crate by enabling the `test` feature of `vector-core` in `dev-dependencies` (which many crates do already).