### PR TITLE
chore(core): Add `OptionalValuePath`

### DIFF
--- a/lib/lookup/src/lookup_v2/mod.rs
+++ b/lib/lookup/src/lookup_v2/mod.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 
 pub use borrowed::BorrowedSegment;
 pub use concat::PathConcat;
-pub use optional_path::OptionalTargetPath;
+pub use optional_path::{OptionalTargetPath, OptionalValuePath};
 pub use owned::{OwnedSegment, OwnedTargetPath, OwnedValuePath};
 
 #[derive(Clone, Debug, Eq, PartialEq, Snafu)]

--- a/lib/lookup/src/lookup_v2/optional_path.rs
+++ b/lib/lookup/src/lookup_v2/optional_path.rs
@@ -1,5 +1,5 @@
 use crate::lookup_v2::PathParseError;
-use crate::OwnedTargetPath;
+use crate::{OwnedTargetPath, OwnedValuePath};
 use vector_config::configurable_component;
 
 #[configurable_component]
@@ -39,6 +39,47 @@ impl From<OptionalTargetPath> for String {
 
 impl From<OwnedTargetPath> for OptionalTargetPath {
     fn from(path: OwnedTargetPath) -> Self {
+        Self { path: Some(path) }
+    }
+}
+
+#[configurable_component]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]
+#[serde(try_from = "String", into = "String")]
+/// An optional path that will deserialize empty string to None
+pub struct OptionalValuePath {
+    pub path: Option<OwnedValuePath>,
+}
+
+impl OptionalValuePath {
+    pub fn none() -> Self {
+        Self { path: None }
+    }
+}
+
+impl TryFrom<String> for OptionalValuePath {
+    type Error = PathParseError;
+
+    fn try_from(src: String) -> Result<Self, Self::Error> {
+        if src.is_empty() {
+            Ok(Self { path: None })
+        } else {
+            OwnedValuePath::try_from(src).map(|path| Self { path: Some(path) })
+        }
+    }
+}
+
+impl From<OptionalValuePath> for String {
+    fn from(optional_path: OptionalValuePath) -> Self {
+        match optional_path.path {
+            Some(path) => String::from(path),
+            None => String::new(),
+        }
+    }
+}
+
+impl From<OwnedValuePath> for OptionalValuePath {
+    fn from(path: OwnedValuePath) -> Self {
         Self { path: Some(path) }
     }
 }


### PR DESCRIPTION
An `OptionalTargetPath` already existed, which allows setting a path to empty string to disable setting that field. This is the same thing, but for paths without a target.