### PR TITLE
Single Machine Performance Test PR, Do Not Merge

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       cpus: ${{ steps.system.outputs.CPUS }}
       memory: ${{ steps.system.outputs.MEMORY }}
+      vector-cpus: ${{ steps.system.outputs.VECTOR_CPUS }}
 
       comparison-sha: ${{ steps.metadata.outputs.COMPARISON_SHA }}
       comparison-tag: ${{ steps.metadata.outputs.COMPARISON_TAG }}
@@ -39,7 +40,7 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.5.0"
+          export SMP_CRATE_VERSION="0.5.1"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"
           echo "replicas: ${REPLICAS}"
@@ -56,14 +57,17 @@ jobs:
       - name: Setup system details
         id: system
         run: |
-          export CPUS="8"
+          export CPUS="7"
           export MEMORY="30g"
+          export VECTOR_CPUS="4"
 
           echo "cpus total: ${CPUS}"
           echo "memory total: ${MEMORY}"
+          echo "vector cpus: ${VECTOR_CPUS}"
 
           echo "CPUS=${CPUS}" >> $GITHUB_OUTPUT
           echo "MEMORY=${MEMORY}" >> $GITHUB_OUTPUT
+          echo "VECTOR_CPUS=${VECTOR_CPUS}" >> $GITHUB_OUTPUT
 
         # github.rest.actions.listWorkflowRunArtifacts only returns first 30
         # artifacts, and returns a { data, headers, status, url } object. The
@@ -322,6 +326,9 @@ jobs:
             --baseline-sha ${{ needs.compute-metadata.outputs.baseline-sha }} \
             --comparison-sha ${{ needs.compute-metadata.outputs.comparison-sha }} \
             --target-config-dir ${{ github.workspace }}/regression/ \
+            --target-cpu-allotment "${{ needs.compute-metadata.outputs.cpus }}" \
+            --target-memory-allotment "${{ needs.compute-metadata.outputs.memory }}" \
+            --target-environment-variables "VECTOR_THREADS=${{ needs.compute-metadata.outputs.vector-cpus }},VECTOR_REQUIRE_HEALTHY=true" \
             --target-name vector \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8885,6 +8885,7 @@ dependencies = [
  "crossbeam-utils",
  "derivative",
  "futures 0.3.25",
+ "indexmap",
  "metrics",
  "nom",
  "ordered-float 3.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8998,6 +8998,7 @@ dependencies = [
  "prost-types 0.11.1",
  "quanta",
  "quickcheck",
+ "quickcheck_macros",
  "rand 0.8.5",
  "rand_distr",
  "regex",

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -56,6 +56,7 @@ chrono = { version = "0.4", default-features = false, optional = true, features 
 crossbeam-utils = { version = "0.8.12", default-features = false }
 derivative = "2.1.3"
 futures = { version = "0.3.25", default-features = false, features = ["std"] }
+indexmap = { version = "~1.9.1", default-features = false }
 metrics = "0.20.1"
 nom = { version = "7", optional = true }
 ordered-float = { version = "3.3.0", default-features = false }

--- a/lib/vector-common/src/byte_size_of.rs
+++ b/lib/vector-common/src/byte_size_of.rs
@@ -189,3 +189,23 @@ impl ByteSizeOf for DateTime<Utc> {
         0
     }
 }
+
+impl<K, V> ByteSizeOf for indexmap::IndexMap<K, V>
+where
+    K: ByteSizeOf,
+    V: ByteSizeOf,
+{
+    fn allocated_bytes(&self) -> usize {
+        self.iter()
+            .fold(0, |acc, (k, v)| acc + k.size_of() + v.size_of())
+    }
+}
+
+impl<T> ByteSizeOf for indexmap::IndexSet<T>
+where
+    T: ByteSizeOf,
+{
+    fn allocated_bytes(&self) -> usize {
+        self.iter().map(ByteSizeOf::size_of).sum()
+    }
+}

--- a/lib/vector-config/src/external/indexmap.rs
+++ b/lib/vector-config/src/external/indexmap.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use crate::{
-    schema::{assert_string_schema_for_map, generate_map_schema},
+    schema::{assert_string_schema_for_map, generate_map_schema, generate_set_schema},
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
     str::ConfigurableString,
     Configurable, GenerateError,
@@ -23,5 +23,14 @@ where
         assert_string_schema_for_map::<K, Self>(gen)?;
 
         generate_map_schema::<V>(gen)
+    }
+}
+
+impl<V> Configurable for indexmap::IndexSet<V>
+where
+    V: Configurable + Serialize + std::hash::Hash + Eq,
+{
+    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+        generate_set_schema::<V>(gen)
     }
 }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -83,6 +83,7 @@ chrono-tz = { version = "0.8.0", default-features = false }
 criterion = { version = "0.4.0", features = ["html_reports"] }
 env-test-util = "1.0.1"
 quickcheck = "1.0.3"
+quickcheck_macros = "1"
 proptest = "1.0"
 similar-asserts = "1.4.2"
 tokio-test = "0.4.2"

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -5,7 +5,7 @@ use mlua::prelude::*;
 use super::util::{table_to_timestamp, timestamp_to_table};
 use crate::{
     event::{
-        metric::{self, MetricSketch, MetricTags},
+        metric::{self, MetricSketch, MetricTags, TagValueSet},
         Metric, MetricKind, MetricValue, StatisticKind,
     },
     metrics::AgentDDSketch,
@@ -61,6 +61,18 @@ impl<'a> FromLua<'a> for StatisticKind {
                 ),
             }),
         }
+    }
+}
+
+impl<'a> FromLua<'a> for TagValueSet {
+    fn from_lua(value: LuaValue<'a>, lua: &'a Lua) -> LuaResult<Self> {
+        Ok(Self::from([String::from_lua(value, lua)?]))
+    }
+}
+
+impl<'a> ToLua<'a> for TagValueSet {
+    fn to_lua(self, lua: &'a Lua) -> LuaResult<LuaValue> {
+        self.into_single().to_lua(lua)
     }
 }
 

--- a/lib/vector-core/src/event/metric/arbitrary.rs
+++ b/lib/vector-core/src/event/metric/arbitrary.rs
@@ -1,9 +1,11 @@
-use proptest::{collection::btree_set, prelude::*};
+use proptest::collection::{btree_set, hash_map, hash_set};
+use proptest::prelude::*;
 
 use crate::metrics::AgentDDSketch;
 
 use super::{
-    samples_to_buckets, Bucket, MetricSketch, MetricValue, Quantile, Sample, StatisticKind,
+    samples_to_buckets, Bucket, MetricSketch, MetricTags, MetricValue, Quantile, Sample,
+    StatisticKind, TagValueSet,
 };
 
 fn realistic_float() -> proptest::num::f64::Any {
@@ -123,6 +125,28 @@ impl Arbitrary for AgentDDSketch {
                 sketch.insert_many(&samples);
                 sketch
             })
+            .boxed()
+    }
+}
+
+impl Arbitrary for TagValueSet {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<TagValueSet>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        hash_set("[[:^cntrl:]]{0,16}", 1..16)
+            .prop_map(|values| values.into_iter().collect())
+            .boxed()
+    }
+}
+
+impl Arbitrary for MetricTags {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<MetricTags>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        hash_map("[[:word:]]{1,32}", "[[:^cntrl:]]{1,32}", 0..16)
+            .prop_map(|values| values.into_iter().collect())
             .boxed()
     }
 }

--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "vrl")]
 use std::convert::TryFrom;
 use std::{
-    collections::btree_map,
     convert::AsRef,
     fmt::{self, Display, Formatter},
     num::NonZeroU32,
@@ -345,13 +344,6 @@ impl Metric {
     /// *Note:* This will create the tags map if it is not present.
     pub fn insert_tag(&mut self, name: String, value: String) -> Option<String> {
         self.series.insert_tag(name, value)
-    }
-
-    /// Gets the given tag's corresponding entry in this metric.
-    ///
-    /// *Note:* This will create the tags map if it is not present, even if nothing is later inserted.
-    pub fn tag_entry(&mut self, key: String) -> btree_map::Entry<String, String> {
-        self.series.tag_entry(key)
     }
 
     /// Zeroes out the data in this metric.

--- a/lib/vector-core/src/event/metric/series.rs
+++ b/lib/vector-core/src/event/metric/series.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use std::collections::btree_map;
 
 use vector_common::byte_size_of::ByteSizeOf;
 use vector_config::configurable_component;
@@ -65,13 +64,6 @@ impl MetricSeries {
                 result
             }
         }
-    }
-
-    /// Get the tag entry for the named key. *Note:* This will create
-    /// the tags map if it is not present, even if nothing is later
-    /// inserted.
-    pub fn tag_entry(&mut self, key: String) -> btree_map::Entry<String, String> {
-        self.tags.get_or_insert_with(Default::default).entry(key)
     }
 }
 

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -1,16 +1,156 @@
-use std::collections::{btree_map, BTreeMap};
+use std::cmp::Ordering;
+use std::collections::{btree_map, hash_map::DefaultHasher, BTreeMap};
+use std::hash::{Hash, Hasher};
 
-#[cfg(test)]
-use quickcheck::{Arbitrary, Gen};
+use indexmap::IndexSet;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vector_common::byte_size_of::ByteSizeOf;
-use vector_config::configurable_component;
+use vector_config::{configurable_component, Configurable};
 
 pub type TagValue = String;
 
+/// Tag values for a metric series.
+#[derive(Clone, Configurable, Debug, Default, Eq, PartialEq)]
+pub struct TagValueSet(#[configurable(transparent)] IndexSet<TagValue>);
+
+impl TagValueSet {
+    pub fn into_single(self) -> Option<TagValue> {
+        self.0.into_iter().last()
+    }
+
+    pub fn as_single(&self) -> Option<&str> {
+        self.0.iter().last().map(String::as_ref)
+    }
+
+    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
+        self.into_iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn contains(&self, value: &str) -> bool {
+        self.0.contains(value)
+    }
+
+    pub fn retain(&mut self, mut f: impl FnMut(&str) -> bool) {
+        self.0.retain(|value| f(value.as_str()));
+    }
+
+    pub fn insert(&mut self, value: TagValue) -> bool {
+        // If the value was previously present, we want to move it to become the last element. The
+        // only way to do this is to remove any existing value.
+        self.0.remove(&value);
+        self.0.insert(value)
+    }
+}
+
+// The impl for `Hash` here follows the guarantees for the derived `PartialEq`, The resulting hash
+// will always be the same if the contents compare equal, so we can ignore the clippy lint.
+#[allow(clippy::derive_hash_xor_eq)]
+impl Hash for TagValueSet {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        // Hash each contained value individually and then combine the hash values using
+        // exclusive-or. This results in the same value no matter what order the storage order.
+        let combined = self
+            .0
+            .iter()
+            .map(|tag| {
+                let mut hasher = DefaultHasher::default();
+                tag.hash(&mut hasher);
+                hasher.finish()
+            })
+            .reduce(|a, b| a ^ b);
+        combined.hash(hasher);
+    }
+}
+
+impl Ord for TagValueSet {
+    fn cmp(&self, _: &Self) -> Ordering {
+        todo!() // Luke is removing Ord from Event, which will make this unnecessary
+    }
+}
+
+impl PartialOrd for TagValueSet {
+    fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
+        todo!() // Luke is removing PartialOrd from Event, which will make this unnecessary
+    }
+}
+
+impl<const N: usize> From<[TagValue; N]> for TagValueSet {
+    fn from(values: [TagValue; N]) -> Self {
+        // See logic in `TagValueSet::insert` to why we can't just use `Self(values.into())`
+        let mut result = Self::default();
+        for value in values {
+            result.insert(value);
+        }
+        result
+    }
+}
+
+impl From<Vec<TagValue>> for TagValueSet {
+    fn from(values: Vec<TagValue>) -> Self {
+        let mut result = Self::default();
+        for value in values {
+            result.insert(value);
+        }
+        result
+    }
+}
+
+impl IntoIterator for TagValueSet {
+    type IntoIter = <IndexSet<TagValue> as IntoIterator>::IntoIter;
+    type Item = TagValue;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a TagValueSet {
+    type IntoIter = <&'a IndexSet<TagValue> as IntoIterator>::IntoIter;
+    type Item = &'a String;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl ByteSizeOf for TagValueSet {
+    fn allocated_bytes(&self) -> usize {
+        self.0.allocated_bytes()
+    }
+}
+
+impl<'de> Deserialize<'de> for TagValueSet {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        // Deserialize from a single string only
+        let s = String::deserialize(de)?;
+        Ok(Self::from([s]))
+    }
+}
+
+impl Serialize for TagValueSet {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        // Always serialize the tags as a single value
+        match self.as_single() {
+            Some(s) => ser.serialize_str(s),
+            None => ser.serialize_none(),
+        }
+    }
+}
+
 /// Tags for a metric series.
 #[configurable_component]
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct MetricTags(#[configurable(transparent)] pub(in crate::event) BTreeMap<String, TagValue>);
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct MetricTags(
+    #[configurable(transparent)] pub(in crate::event) BTreeMap<String, TagValueSet>,
+);
 
 impl MetricTags {
     pub fn is_empty(&self) -> bool {
@@ -21,8 +161,10 @@ impl MetricTags {
         (!self.is_empty()).then_some(self)
     }
 
-    pub fn iter(&self) -> btree_map::Iter<'_, String, TagValue> {
-        self.0.iter()
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.0
+            .iter()
+            .flat_map(|(name, tags)| tags.iter().map(|tag| (name.as_ref(), tag.as_ref())))
     }
 
     pub fn contains_key(&self, name: &str) -> bool {
@@ -30,79 +172,142 @@ impl MetricTags {
     }
 
     pub fn get(&self, name: &str) -> Option<&str> {
-        self.0.get(name).map(String::as_str)
-    }
-
-    pub fn entry(&mut self, name: String) -> btree_map::Entry<String, TagValue> {
-        self.0.entry(name)
+        self.0.get(name).and_then(TagValueSet::as_single)
     }
 
     pub fn insert(&mut self, name: String, value: TagValue) -> Option<TagValue> {
-        self.0.insert(name, value)
+        self.0
+            .insert(name, TagValueSet::from([value]))
+            .and_then(TagValueSet::into_single)
     }
 
     pub fn remove(&mut self, name: &str) -> Option<TagValue> {
-        self.0.remove(name)
+        self.0.remove(name).and_then(TagValueSet::into_single)
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &str> {
         self.0.keys().map(String::as_str)
     }
 
-    pub fn extend(&mut self, tags: impl Iterator<Item = (String, TagValue)>) {
-        self.0.extend(tags);
+    pub fn extend(&mut self, tags: impl IntoIterator<Item = (String, TagValue)>) {
+        for (key, value) in tags {
+            self.0.entry(key).or_default().insert(value);
+        }
     }
 
     pub fn retain(&mut self, mut f: impl FnMut(&str, &str) -> bool) {
-        self.0.retain(|k, v| f(k, v));
-    }
-}
-
-impl From<BTreeMap<String, TagValue>> for MetricTags {
-    fn from(tags: BTreeMap<String, TagValue>) -> Self {
-        Self(tags)
+        self.0.retain(|key, tags| {
+            tags.retain(|tag| f(key, tag));
+            !tags.is_empty()
+        });
     }
 }
 
 impl IntoIterator for MetricTags {
     type Item = (String, TagValue);
-
-    type IntoIter = btree_map::IntoIter<String, TagValue>;
+    type IntoIter = IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        IntoIter {
+            base: self.0.into_iter(),
+            current: None,
+        }
+    }
+}
+
+pub struct IntoIter {
+    base: btree_map::IntoIter<String, TagValueSet>,
+    current: Option<(String, <TagValueSet as IntoIterator>::IntoIter)>,
+}
+
+impl Iterator for IntoIter {
+    type Item = (String, TagValue);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match &mut self.current {
+                Some((key, tag_set)) => {
+                    if let Some(value) = tag_set.next() {
+                        break Some((key.clone(), value));
+                    }
+                    self.current = None;
+                }
+                None => {
+                    self.current = self
+                        .base
+                        .next()
+                        .map(|(key, value)| (key, value.into_iter()));
+                    if self.current.is_none() {
+                        break None;
+                    }
+                }
+            }
+        }
     }
 }
 
 impl<'a> IntoIterator for &'a MetricTags {
     type Item = (&'a str, &'a str);
-
     type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        Iter(self.0.iter())
+        Iter {
+            base: self.0.iter(),
+            current: None,
+        }
     }
 }
 
-pub struct Iter<'a>(btree_map::Iter<'a, String, TagValue>);
+pub struct Iter<'a> {
+    base: btree_map::Iter<'a, String, TagValueSet>,
+    current: Option<(&'a str, <&'a TagValueSet as IntoIterator>::IntoIter)>,
+}
 
 impl<'a> Iterator for Iter<'a> {
     type Item = (&'a str, &'a str);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(k, v)| (k.as_str(), v.as_str()))
+        loop {
+            match &mut self.current {
+                Some((key, tag_set)) => {
+                    if let Some(value) = tag_set.next() {
+                        break Some((key, value));
+                    }
+                    self.current = None;
+                }
+                None => {
+                    self.current = self
+                        .base
+                        .next()
+                        .map(|(key, value)| (key.as_str(), value.iter()));
+                    if self.current.is_none() {
+                        break None;
+                    }
+                }
+            }
+        }
     }
 }
 
-impl FromIterator<(String, TagValue)> for MetricTags {
-    fn from_iter<T: IntoIterator<Item = (String, TagValue)>>(iter: T) -> Self {
-        Self(BTreeMap::from_iter(iter))
+impl From<BTreeMap<String, TagValue>> for MetricTags {
+    fn from(tags: BTreeMap<String, TagValue>) -> Self {
+        tags.into_iter().collect()
     }
 }
 
 impl<const N: usize> From<[(String, TagValue); N]> for MetricTags {
     fn from(tags: [(String, TagValue); N]) -> Self {
-        Self(BTreeMap::from(tags))
+        tags.into_iter().collect()
+    }
+}
+
+impl FromIterator<(String, TagValue)> for MetricTags {
+    fn from_iter<T: IntoIterator<Item = (String, TagValue)>>(tags: T) -> Self {
+        let mut result = Self::default();
+        for (key, value) in tags {
+            result.0.entry(key).or_default().insert(value);
+        }
+        result
     }
 }
 
@@ -113,12 +318,94 @@ impl ByteSizeOf for MetricTags {
 }
 
 #[cfg(test)]
-impl Arbitrary for MetricTags {
-    fn arbitrary(g: &mut Gen) -> Self {
-        Self(BTreeMap::arbitrary(g))
+mod test_support {
+    use std::collections::HashSet;
+
+    use quickcheck::{Arbitrary, Gen};
+
+    use super::*;
+
+    impl Arbitrary for TagValueSet {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Self(HashSet::<TagValue>::arbitrary(g).into_iter().collect())
+        }
     }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        Box::new(self.0.shrink().map(Self))
+    impl Arbitrary for MetricTags {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Self(BTreeMap::arbitrary(g))
+        }
+
+        fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+            Box::new(self.0.shrink().map(Self))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quickcheck_macros::quickcheck;
+
+    use super::*;
+
+    #[quickcheck]
+    fn eq_implies_hash_matches(values1: TagValueSet, values2: TagValueSet) -> bool {
+        fn hash<T: Hash>(values: &T) -> u64 {
+            let mut hasher = DefaultHasher::default();
+            values.hash(&mut hasher);
+            hasher.finish()
+        }
+        values1 != values2 || hash(&values1) == hash(&values2)
+    }
+
+    #[quickcheck]
+    fn tag_value_set_checks(values: Vec<TagValue>, addition: TagValue) -> bool {
+        let mut set = TagValueSet::from(values.clone());
+        assert_eq!(set.is_empty(), values.is_empty());
+        // All input values are contained in the set.
+        assert!(values.iter().all(|v| set.contains(v.as_str())));
+        // All set values were in the input.
+        assert!(set.iter().all(|v| values.contains(v)));
+        // Critical: the "single value" of the set is the last value added.
+        assert_eq!(set.as_single(), values.last().map(String::as_str));
+
+        let start_len = set.len();
+
+        // Is the input value set unique?
+        if values
+            .iter()
+            .enumerate()
+            .any(|(i, v1)| values[i + 1..].iter().any(|v2| v1 == v2))
+        {
+            // Input values are not unique, so the resulting set will be shorter.
+            assert!(start_len < values.len());
+        } else {
+            // All input values were unique, so the resulting set will have all of them.
+            assert_eq!(start_len, values.len());
+
+            if !values.is_empty() {
+                // Check that re-adding the last value doesn't change the set.
+                set.insert(values.last().unwrap().clone());
+                assert_eq!(set.len(), start_len);
+                assert_eq!(set.as_single(), values.last().map(String::as_str));
+
+                // But re-adding the first value makes it the last.
+                set.insert(values.first().unwrap().clone());
+                assert_eq!(set.len(), start_len);
+                assert_eq!(set.as_single(), values.first().map(String::as_str));
+            }
+        }
+
+        let new_addition = !values.iter().any(|v| v == &addition);
+        assert_eq!(new_addition, !set.contains(&addition));
+        set.insert(addition.clone());
+        assert!(set.contains(&addition));
+
+        // If the addition wasn't in the start set, it will increase the length.
+        assert_eq!(set.len(), start_len + if new_addition { 1 } else { 0 });
+        // The "single" value will match the addition.
+        assert_eq!(set.as_single(), Some(addition.as_str()));
+
+        true
     }
 }

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -7,17 +7,21 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vector_common::byte_size_of::ByteSizeOf;
 use vector_config::{configurable_component, Configurable};
 
-pub type TagValue = String;
+type TagValue = String;
 
 /// Tag values for a metric series.
 #[derive(Clone, Configurable, Debug, Default, Eq, PartialEq)]
 pub struct TagValueSet(#[configurable(transparent)] IndexSet<TagValue>);
 
 impl TagValueSet {
-    pub fn into_single(self) -> Option<TagValue> {
+    /// Convert this set into a single value, mimicking the behavior of this set being just a plain
+    /// single string while still storing all of the values.
+    pub fn into_single(self) -> Option<String> {
         self.0.into_iter().last()
     }
 
+    /// Get the "single" value of this set, mimicking the behavior of this set being just a plain
+    /// single string while still storing all of the values.
     pub fn as_single(&self) -> Option<&str> {
         self.0.iter().last().map(String::as_ref)
     }

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -5,10 +5,12 @@ use quickcheck::{Arbitrary, Gen};
 use vector_common::byte_size_of::ByteSizeOf;
 use vector_config::configurable_component;
 
+pub type TagValue = String;
+
 /// Tags for a metric series.
 #[configurable_component]
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct MetricTags(#[configurable(transparent)] pub(in crate::event) BTreeMap<String, String>);
+pub struct MetricTags(#[configurable(transparent)] pub(in crate::event) BTreeMap<String, TagValue>);
 
 impl MetricTags {
     pub fn is_empty(&self) -> bool {
@@ -19,7 +21,7 @@ impl MetricTags {
         (!self.is_empty()).then_some(self)
     }
 
-    pub fn iter(&self) -> btree_map::Iter<'_, String, String> {
+    pub fn iter(&self) -> btree_map::Iter<'_, String, TagValue> {
         self.0.iter()
     }
 
@@ -31,15 +33,15 @@ impl MetricTags {
         self.0.get(name).map(String::as_str)
     }
 
-    pub fn entry(&mut self, name: String) -> btree_map::Entry<String, String> {
+    pub fn entry(&mut self, name: String) -> btree_map::Entry<String, TagValue> {
         self.0.entry(name)
     }
 
-    pub fn insert(&mut self, name: String, value: String) -> Option<String> {
+    pub fn insert(&mut self, name: String, value: TagValue) -> Option<TagValue> {
         self.0.insert(name, value)
     }
 
-    pub fn remove(&mut self, name: &str) -> Option<String> {
+    pub fn remove(&mut self, name: &str) -> Option<TagValue> {
         self.0.remove(name)
     }
 
@@ -47,7 +49,7 @@ impl MetricTags {
         self.0.keys().map(String::as_str)
     }
 
-    pub fn extend(&mut self, tags: impl Iterator<Item = (String, String)>) {
+    pub fn extend(&mut self, tags: impl Iterator<Item = (String, TagValue)>) {
         self.0.extend(tags);
     }
 
@@ -56,16 +58,16 @@ impl MetricTags {
     }
 }
 
-impl From<BTreeMap<String, String>> for MetricTags {
-    fn from(tags: BTreeMap<String, String>) -> Self {
+impl From<BTreeMap<String, TagValue>> for MetricTags {
+    fn from(tags: BTreeMap<String, TagValue>) -> Self {
         Self(tags)
     }
 }
 
 impl IntoIterator for MetricTags {
-    type Item = (String, String);
+    type Item = (String, TagValue);
 
-    type IntoIter = btree_map::IntoIter<String, String>;
+    type IntoIter = btree_map::IntoIter<String, TagValue>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -82,7 +84,7 @@ impl<'a> IntoIterator for &'a MetricTags {
     }
 }
 
-pub struct Iter<'a>(btree_map::Iter<'a, String, String>);
+pub struct Iter<'a>(btree_map::Iter<'a, String, TagValue>);
 
 impl<'a> Iterator for Iter<'a> {
     type Item = (&'a str, &'a str);
@@ -92,14 +94,14 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-impl FromIterator<(String, String)> for MetricTags {
-    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
+impl FromIterator<(String, TagValue)> for MetricTags {
+    fn from_iter<T: IntoIterator<Item = (String, TagValue)>>(iter: T) -> Self {
         Self(BTreeMap::from_iter(iter))
     }
 }
 
-impl<const N: usize> From<[(String, String); N]> for MetricTags {
-    fn from(tags: [(String, String); N]) -> Self {
+impl<const N: usize> From<[(String, TagValue); N]> for MetricTags {
+    fn from(tags: [(String, TagValue); N]) -> Self {
         Self(BTreeMap::from(tags))
     }
 }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -222,7 +222,7 @@ impl From<Metric> for event::Metric {
 
         Self::new_with_metadata(name, kind, value, metadata)
             .with_namespace(namespace)
-            .with_tags(tags.map(MetricTags))
+            .with_tags(tags.map(MetricTags::from_iter))
             .with_timestamp(timestamp)
             .with_interval_ms(std::num::NonZeroU32::new(metric.interval_ms))
     }
@@ -393,7 +393,11 @@ impl From<event::Metric> for WithMetadata<Metric> {
             name,
             namespace,
             timestamp,
-            tags: tags.0,
+            tags: tags
+                .0
+                .into_iter()
+                .filter_map(|(name, values)| values.into_single().map(|value| (name, value)))
+                .collect(),
             kind,
             interval_ms,
             value: Some(metric),

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -254,14 +254,7 @@ pub(crate) fn decode_ddseries_v2(
         .into_iter()
         .flat_map(|serie| {
             let (namespace, name) = namespace_name_from_dd_metric(&serie.metric);
-            let mut tags: MetricTags = serie
-                .tags
-                .iter()
-                .map(|tag| {
-                    let kv = tag.split_once(':').unwrap_or((tag, ""));
-                    (kv.0.trim().into(), kv.1.trim().into())
-                })
-                .collect();
+            let mut tags = into_metric_tags(serie.tags);
 
             serie.resources.into_iter().for_each(|r| {
                 // As per https://github.com/DataDog/datadog-agent/blob/a62ac9fb13e1e5060b89e731b8355b2b20a07c5b/pkg/serializer/internal/metrics/iterable_series.go#L180-L189
@@ -393,20 +386,21 @@ fn decode_datadog_series_v1(
     Ok(decoded_metrics)
 }
 
+fn into_metric_tags(tags: Vec<String>) -> MetricTags {
+    tags.iter()
+        .map(|tag| {
+            let kv = tag.split_once(':').unwrap_or((tag, ""));
+            (kv.0.trim().to_string(), kv.1.trim().to_string())
+        })
+        .collect()
+}
+
 fn into_vector_metric(
     dd_metric: DatadogSeriesMetric,
     api_key: Option<Arc<str>>,
     schema_definition: &Arc<schema::Definition>,
 ) -> Vec<Event> {
-    let mut tags: MetricTags = dd_metric
-        .tags
-        .unwrap_or_default()
-        .iter()
-        .map(|tag| {
-            let kv = tag.split_once(':').unwrap_or((tag, ""));
-            (kv.0.trim().into(), kv.1.trim().into())
-        })
-        .collect();
+    let mut tags = into_metric_tags(dd_metric.tags.unwrap_or_default());
 
     dd_metric
         .host
@@ -508,15 +502,7 @@ pub(crate) fn decode_ddsketch(
         .into_iter()
         .flat_map(|sketch_series| {
             // sketch_series.distributions is also always empty from payload coming from dd agents
-            let mut tags: MetricTags = sketch_series
-                .tags
-                .iter()
-                .map(|tag| {
-                    let kv = tag.split_once(':').unwrap_or((tag, ""));
-                    (kv.0.trim().into(), kv.1.trim().into())
-                })
-                .collect();
-
+            let mut tags = into_metric_tags(sketch_series.tags);
             tags.insert(
                 log_schema().host_key().to_string(),
                 sketch_series.host.clone(),

--- a/src/test_util/metrics.rs
+++ b/src/test_util/metrics.rs
@@ -155,7 +155,9 @@ macro_rules! series {
 				name: $name.into(),
 				namespace: None,
 			},
-			tags: Some(vector_core::metric_tags!( $( $tk => $tv, )* )),
+			tags: Some(vector_core::event::MetricTags::from_iter(
+				[$(($tk.to_string(), $tv.to_string())),*]
+			)),
 		}
 	};
 }

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{btree_map::Entry, BTreeMap},
+    collections::{hash_map::Entry, HashMap},
     pin::Pin,
     time::Duration,
 };
@@ -54,14 +54,14 @@ type MetricEntry = (metric::MetricData, EventMetadata);
 #[derive(Debug)]
 pub struct Aggregate {
     interval: Duration,
-    map: BTreeMap<metric::MetricSeries, MetricEntry>,
+    map: HashMap<metric::MetricSeries, MetricEntry>,
 }
 
 impl Aggregate {
     pub fn new(config: &AggregateConfig) -> crate::Result<Self> {
         Ok(Self {
             interval: Duration::from_millis(config.interval_ms),
-            map: BTreeMap::new(),
+            map: Default::default(),
         })
     }
 


### PR DESCRIPTION
The commits in this branch are largely pulled from #14984. Until [1fb9102](https://github.com/vectordotdev/vector/pull/14984/commits/1fb91020a6a2917c82ef56d58591acd8f23c59a3) the Soak Tests and Regression Detector reported distinct results. In #15159 we removed one difference between these two approaches: the lading version. This now leaves the following differences:

* the Soak Tests and Regression Detector use a different machine instance type when running replicates and
* the math between the two has changed very slightly. 

This PR is meant to give us, Single Machine Performance, clean data and should not be merged. 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
