### PR TITLE
chore(template website): Clean Up Privacy Links

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -165,6 +165,12 @@ parent = "about"
 weight = 2
 
 [[languages.en.menus.footer]]
+name = "Privacy"
+url = "https://www.datadoghq.com/privacy/"
+parent = "about"
+weight = 3
+
+[[languages.en.menus.footer]]
 name = "Components"
 url = "/components"
 identifier = "components"
@@ -250,24 +256,19 @@ weight = 3
 
 # Extra links under the "Meta" section in the docs
 [[languages.en.menus.meta]]
-name = "Privacy"
-url = "https://github.com/vectordotdev/vector/blob/master/PRIVACY.md"
-weight = 1
-
-[[languages.en.menus.meta]]
 name = "Security"
 url = "https://github.com/vectordotdev/vector/security/policy"
-weight = 2
+weight = 1
 
 [[languages.en.menus.meta]]
 name = "Releases"
 url = "https://github.com/vectordotdev/vector/blob/master/RELEASES.md"
-weight = 3
+weight = 2
 
 [[languages.en.menus.meta]]
 name = "Versioning"
 url = "https://github.com/vectordotdev/vector/blob/master/VERSIONING.md"
-weight = 4
+weight = 3
 
 # Buttons in "community" section on main page
 [[languages.en.menus.community]]
@@ -307,17 +308,6 @@ name = "RSS"
 params = { color = "rss-orange", icon = "rss" }
 url = "/blog/index.xml"
 weight = 4
-
-# Links in subfooter
-[[languages.en.menus.subfooter]]
-name = "Security policy"
-url = "https://github.com/vectordotdev/vector/blob/master/PRIVACY.md"
-weight = 1
-
-[[languages.en.menus.subfooter]]
-name = "Privacy policy"
-url = "https://github.com/vectordotdev/vector/blob/master/PRIVACY.md"
-weight = 2
 
 [security]
   enableInlineShortcodes = false


### PR DESCRIPTION
Clean up privacy links.
- Remove Privacy link from meta menu sidebar
- Add Privacy link in footer (to datadoghq.com/privacy)
- Remove unused `menus.subfooter` data

## Review
Looking at the docs site, see that "Privacy" is no longer in the Meta sidebar menu, but in the footer (Links to datadoghq.com)
https://deploy-preview-15194--vector-project.netlify.app/docs/