### PR TITLE
fix(tests): Fixes fails related to ```topology_disk_buffer_conflict```

### DIFF
--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -179,7 +179,7 @@ async fn topology_disk_buffer_conflict() {
 
     let sink_key = ComponentKey::from("out");
     old_config.sinks[&sink_key].buffer = BufferConfig::Single(BufferType::DiskV1 {
-        max_size: NonZeroU64::new(1024).unwrap(), 
+        max_size: NonZeroU64::new(1024).unwrap(),
         when_full: WhenFull::Block,
     });
 

--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -179,12 +179,13 @@ async fn topology_disk_buffer_conflict() {
 
     let sink_key = ComponentKey::from("out");
     old_config.sinks[&sink_key].buffer = BufferConfig::Single(BufferType::DiskV1 {
-        max_size: NonZeroU64::new(1024).unwrap(),
+        max_size: NonZeroU64::new(1024).unwrap(), 
         when_full: WhenFull::Block,
     });
 
     let mut new_config = old_config.clone();
-    new_config.sinks[&sink_key].inner = prom_exporter_sink(address_1, 1).into();
+    new_config.add_source("in", internal_metrics_source());
+    new_config.add_sink("out", &["in"], prom_exporter_sink(address_1, 1));
     new_config.sinks[&sink_key].buffer = BufferConfig::Single(BufferType::DiskV1 {
         max_size: NonZeroU64::new(1024).unwrap(),
         when_full: WhenFull::Block,

--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -179,15 +179,14 @@ async fn topology_disk_buffer_conflict() {
 
     let sink_key = ComponentKey::from("out");
     old_config.sinks[&sink_key].buffer = BufferConfig::Single(BufferType::DiskV1 {
-        max_size: NonZeroU64::new(1024).unwrap(),
+        max_size: NonZeroU64::new(268435488).unwrap(),
         when_full: WhenFull::Block,
     });
 
     let mut new_config = old_config.clone();
-    new_config.add_source("in", internal_metrics_source());
-    new_config.add_sink("out", &["in"], prom_exporter_sink(address_1, 1));
+    new_config.sinks[&sink_key].inner = prom_exporter_sink(address_1, 1).into();
     new_config.sinks[&sink_key].buffer = BufferConfig::Single(BufferType::DiskV1 {
-        max_size: NonZeroU64::new(1024).unwrap(),
+        max_size: NonZeroU64::new(268435488).unwrap(),
         when_full: WhenFull::Block,
     });
 


### PR DESCRIPTION
Changing the max size limit to 256 mb made the tests more stable. 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
