### PR TITLE
feat(vrl): Polish web playground

### DIFF
--- a/lib/vrl/core/src/expression.rs
+++ b/lib/vrl/core/src/expression.rs
@@ -36,7 +36,7 @@ impl From<ExpressionError> for Diagnostic {
             code: error.code(),
             message: error.message(),
             labels: error.labels(),
-            notes: error.notes()
+            notes: error.notes(),
         }
     }
 }

--- a/lib/vrl/core/src/expression.rs
+++ b/lib/vrl/core/src/expression.rs
@@ -1,4 +1,4 @@
-use diagnostic::{DiagnosticMessage, Label, Note};
+use diagnostic::{Diagnostic, DiagnosticMessage, Label, Note, Severity};
 use value::Value;
 
 pub type Resolved = Result<Value, ExpressionError>;
@@ -26,6 +26,18 @@ impl std::fmt::Display for ExpressionError {
 impl std::error::Error for ExpressionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
+    }
+}
+
+impl From<ExpressionError> for Diagnostic {
+    fn from(error: ExpressionError) -> Self {
+        Self {
+            severity: Severity::Error,
+            code: error.code(),
+            message: error.message(),
+            labels: error.labels(),
+            notes: error.notes()
+        }
     }
 }
 

--- a/lib/vrl/diagnostic/src/diagnostic.rs
+++ b/lib/vrl/diagnostic/src/diagnostic.rs
@@ -6,11 +6,11 @@ use crate::{DiagnosticMessage, Label, Note, Severity, Span};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
-    severity: Severity,
-    code: usize,
-    message: String,
-    labels: Vec<Label>,
-    notes: Vec<Note>,
+    pub severity: Severity,
+    pub code: usize,
+    pub message: String,
+    pub labels: Vec<Label>,
+    pub notes: Vec<Note>,
 }
 
 impl Diagnostic {

--- a/lib/vrl/vrl/src/runtime.rs
+++ b/lib/vrl/vrl/src/runtime.rs
@@ -27,6 +27,15 @@ pub enum Terminate {
     Error(ExpressionError),
 }
 
+impl Terminate {
+    pub fn get_expression_error(self) -> ExpressionError {
+        match self {
+            Terminate::Abort(error) => error,
+            Terminate::Error(error) => error,
+        }
+    }
+}
+
 impl fmt::Display for Terminate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/lib/vrl/web-playground/public/index.css
+++ b/lib/vrl/web-playground/public/index.css
@@ -96,7 +96,6 @@ div#App {
     grid-template-rows: 12% 88%;
     grid-row: 2;
     height: 100%;
-    /* overflow: hidden; */
   }
 
   #output-section #output-cell #output-cell-title {
@@ -121,7 +120,6 @@ div#App {
     outline: 0;
     border: none;
     cursor: pointer;
-    /* font-weight: 600; */
     border-radius: 4px;
     font-size: 13px;
     height: 30px;
@@ -139,7 +137,6 @@ div#App {
     outline: 0;
     border: none;
     cursor: pointer;
-    /* font-weight: 600; */
     border-radius: 4px;
     font-size: 13px;
     height: 30px;
@@ -163,10 +160,7 @@ div#App {
         /* the app will have multiple rows
         stacking each section on top of each other */
         grid-template-rows: 20vh 25vh 10vh 50vh;
-        grid-template-columns: 100vw;
-
-        /* padding-left: 10%;
-        padding-right: 10%; */
+        grid-template-columns: 100%;
       }
 
       div#summary-section {
@@ -178,7 +172,7 @@ div#App {
         grid-gap: 2vw;
       }
 
-      div#summary-section p{
+      div#summary-section p {
         grid-row: 2;
         font-size: 2vh;
       }
@@ -240,8 +234,6 @@ div#App {
       /* event pane */
       #output-section #event-cell {
         display: grid;
-        /* this is double of input-cell-title row
-      because we are working with half the space */
         grid-template-rows: 20% 80%;
         grid-row: 1;
         height: 100%;
@@ -254,7 +246,6 @@ div#App {
 
       #output-section #event-cell #container-event {
         display: grid;
-        /* grid-row: 2; */
         height: 100%;
       }
 
@@ -264,7 +255,6 @@ div#App {
         grid-template-rows: 20% 80%;
         grid-row: 2;
         height: 100%;
-        /* overflow: hidden; */
       }
 
       #output-section #output-cell #output-cell-title {
@@ -289,7 +279,6 @@ div#App {
         outline: 0;
         border: none;
         cursor: pointer;
-        /* font-weight: 600; */
         border-radius: 4px;
         font-size: 13px;
         height: 30px;
@@ -308,7 +297,6 @@ div#App {
         outline: 0;
         border: none;
         cursor: pointer;
-        /* font-weight: 600; */
         border-radius: 4px;
         font-size: 13px;
         height: 30px;

--- a/lib/vrl/web-playground/public/index.css
+++ b/lib/vrl/web-playground/public/index.css
@@ -1,3 +1,8 @@
+body {
+    margin-right: 2vw;
+    margin-left: 2vw;
+}
+
 div#App {
     display: grid;
     width: 100%;
@@ -309,5 +314,4 @@ div#App {
       .btn-secondary:hover {
         background-color: #dcdcdc;
       }
-
 }

--- a/lib/vrl/web-playground/public/index.css
+++ b/lib/vrl/web-playground/public/index.css
@@ -150,9 +150,9 @@ div#App {
   }
 
 /* Portrait and Landscape */
-@media only screen 
-  and (min-width: 200px) 
-  and (max-width: 1000px) { 
+@media only screen
+  and (min-width: 200px)
+  and (max-width: 1000px) {
     div#App {
         display: grid;
         width: 100%;

--- a/lib/vrl/web-playground/public/index.css
+++ b/lib/vrl/web-playground/public/index.css
@@ -1,0 +1,325 @@
+div#App {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    /* the app will have two columns, one for input
+  one for output, left and right */
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: 15vh 1vh 75vh;
+    grid-gap: 1rem;
+  }
+
+  div#summary-section {
+    display: grid;
+    grid-row: 1;
+    grid-template-rows: 35% 65%;
+    width: 100%;
+    font-size: 1vw;
+    grid-gap: 1vw;
+  }
+
+  div#summary-section p{
+    font-size: .9vw;
+  }
+
+  div#toolbar-section {
+    display: grid;
+    grid-row: 2;
+    grid-column: 1 / span 2;
+    grid-template-columns: repeat(8, 1fr);
+  }
+
+  #toolbar-section #run-code-btn {
+    grid-column: 1;
+  }
+
+  #toolbar-section #share-code-btn {
+    grid-column: 3;
+  }
+
+  /* input pane */
+  div#input-section {
+    display: grid;
+    grid-column: 1;
+    grid-row: 3;
+    overflow: hidden;
+  }
+
+  #input-section #cell {
+    display: grid;
+    grid-template-rows: 6% 94%;
+    overflow: hidden;
+  }
+
+  #input-section #cell #input-cell-title {
+    height: 100%;
+    grid-row: 1;
+  }
+
+  #input-section #cell #container-program {
+    display: grid;
+    height: 100%;
+  }
+
+  div#output-section {
+    display: grid;
+    grid-column: 2;
+    grid-row: 3;
+    grid-template-rows: 50% 50%;
+    overflow: hidden;
+  }
+
+  /* event pane */
+  #output-section #event-cell {
+    display: grid;
+    /* this is double of input-cell-title row
+  because we are working with half the space */
+    grid-template-rows: 12% 88%;
+    grid-row: 1;
+    height: 100%;
+  }
+
+  #output-section #event-cell #event-cell-title {
+    display: grid;
+    grid-row: 1;
+  }
+
+  #output-section #event-cell #container-event {
+    display: grid;
+    grid-row: 2;
+    height: 100%;
+  }
+
+  /* output pane */
+  #output-section #output-cell {
+    display: grid;
+    grid-template-rows: 12% 88%;
+    grid-row: 2;
+    height: 100%;
+    /* overflow: hidden; */
+  }
+
+  #output-section #output-cell #output-cell-title {
+    display: grid;
+    grid-row: 1;
+  }
+
+  #output-section #output-cell #container-output {
+    display: grid;
+    grid-row: 2;
+    height: 100%;
+  }
+
+  body {
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+      Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+      Segoe UI Symbol, Noto Color Emoji;
+  }
+
+  .btn-primary {
+    display: inline-block;
+    outline: 0;
+    border: none;
+    cursor: pointer;
+    /* font-weight: 600; */
+    border-radius: 4px;
+    font-size: 13px;
+    height: 30px;
+    background-color: #9147ff;
+    color: white;
+    padding: 0 20px;
+  }
+
+  .btn-primary:hover {
+    background-color: #772ce8;
+  }
+
+  .btn-secondary {
+    display: inline-block;
+    outline: 0;
+    border: none;
+    cursor: pointer;
+    /* font-weight: 600; */
+    border-radius: 4px;
+    font-size: 13px;
+    height: 30px;
+    background-color: #0000001a;
+    color: #000000;
+    padding: 0 20px;
+  }
+
+  .btn-secondary:hover {
+    background-color: #dcdcdc;
+  }
+
+/* Portrait and Landscape */
+@media only screen 
+  and (min-width: 200px) 
+  and (max-width: 1000px) { 
+    div#App {
+        display: grid;
+        width: 100%;
+        height: 100%;
+        /* the app will have multiple rows
+        stacking each section on top of each other */
+        grid-template-rows: 20vh 25vh 10vh 50vh;
+        grid-template-columns: 100vw;
+
+        /* padding-left: 10%;
+        padding-right: 10%; */
+      }
+
+      div#summary-section {
+        display: grid;
+        grid-row: 1;
+        grid-template-rows: 20% 80%;
+        width: 100%;
+        font-size: 1.5vh;
+        grid-gap: 2vw;
+      }
+
+      div#summary-section p{
+        grid-row: 2;
+        font-size: 2vh;
+      }
+
+      div#toolbar-section {
+        display: grid;
+        grid-row: 3;
+        grid-column: 1;
+        grid-template-columns: 100%;
+        grid-template-rows: repeat(2, 1fr);
+      }
+
+      #toolbar-section #run-code-btn {
+        display: grid;
+        grid-row: 1;
+        grid-column: 1;
+      }
+
+      #toolbar-section #share-code-btn {
+        display: grid;
+        grid-row: 2;
+        grid-column: 1;
+      }
+
+      /* input pane */
+      div#input-section {
+        display: grid;
+        grid-column: 1;
+        grid-row: 2;
+        overflow: hidden;
+      }
+
+      #input-section #cell {
+        display: grid;
+        grid-column: 1;
+        grid-template-rows: 23% 77%;
+        overflow: hidden;
+      }
+
+      #input-section #cell #input-cell-title {
+        height: 100%;
+        grid-column: 1;
+        grid-row: 1;
+      }
+
+      #input-section #cell #container-program {
+        display: grid;
+        height: 100%;
+      }
+
+      div#output-section {
+        display: grid;
+        grid-row: 4 / 5;
+        grid-column: 1;
+        grid-template-rows: 50% 50%;
+        overflow: hidden;
+      }
+
+      /* event pane */
+      #output-section #event-cell {
+        display: grid;
+        /* this is double of input-cell-title row
+      because we are working with half the space */
+        grid-template-rows: 20% 80%;
+        grid-row: 1;
+        height: 100%;
+      }
+
+      #output-section #event-cell #event-cell-title {
+        display: grid;
+        grid-row: 1;
+      }
+
+      #output-section #event-cell #container-event {
+        display: grid;
+        /* grid-row: 2; */
+        height: 100%;
+      }
+
+      /* output pane */
+      #output-section #output-cell {
+        display: grid;
+        grid-template-rows: 20% 80%;
+        grid-row: 2;
+        height: 100%;
+        /* overflow: hidden; */
+      }
+
+      #output-section #output-cell #output-cell-title {
+        display: grid;
+        grid-row: 1;
+      }
+
+      #output-section #output-cell #container-output {
+        display: grid;
+        grid-row: 2;
+        height: 100%;
+      }
+
+      body {
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+          Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+          Segoe UI Symbol, Noto Color Emoji;
+      }
+
+      .btn-primary {
+        display: inline-block;
+        outline: 0;
+        border: none;
+        cursor: pointer;
+        /* font-weight: 600; */
+        border-radius: 4px;
+        font-size: 13px;
+        height: 30px;
+        background-color: #9147ff;
+        color: white;
+        padding: 0 20px;
+        align-items: center;
+      }
+
+      .btn-primary:hover {
+        background-color: #772ce8;
+      }
+
+      .btn-secondary {
+        display: inline-block;
+        outline: 0;
+        border: none;
+        cursor: pointer;
+        /* font-weight: 600; */
+        border-radius: 4px;
+        font-size: 13px;
+        height: 30px;
+        background-color: #0000001a;
+        color: #000000;
+        padding: 0 20px;
+        align-items: center;
+      }
+
+      .btn-secondary:hover {
+        background-color: #dcdcdc;
+      }
+
+}

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -195,8 +195,7 @@ String: ${str}
               outputs.push(res["msg"]);
             }
           })
-          // disable output validation for json
-          // since jsonl input won't ouput valid json
+          // disable output validation for json since jsonl input won't ouput valid json
           monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
             validate: false
           });

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -99,7 +99,7 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
 .timestamp = to_unix_timestamp(ts)`,
           language: "coffeescript",
           theme: "vs-light",
-          // minimap: { enabled: false },
+          minimap: { enabled: false },
           automaticLayout: true,
         });
 
@@ -109,14 +109,14 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
 }`,
           language: "json",
           theme: "vs-light",
-          // minimap: { enabled: false },
+          minimap: { enabled: false },
           automaticLayout: true,
         });
 
         window.outputEditor = monaco.editor.create(document.getElementById("container-output"), {
           language: "json",
           theme: "vs-light",
-          // minimap: { enabled: false },
+          minimap: { enabled: false },
           automaticLayout: true,
         });
         const queryString = window.location.search;
@@ -215,6 +215,11 @@ String: ${str}
         if (res.output) {
           window.outputEditor.setValue(JSON.stringify(res["result"], null, "\t"));
         } else if (res.msg) {
+          // disable output validation for json
+          // since vrl error msgs won't ouput json
+          monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+            validate: false
+          });
           window.outputEditor.setValue(res["msg"]);
         }
         return res;

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -88,7 +88,7 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
 
 
 .timestamp = to_unix_timestamp(ts)`,
-          language: "python",
+          language: "coffeescript",
           theme: "vs-light",
           // minimap: { enabled: false },
           automaticLayout: true,

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -34,9 +34,7 @@
 
       <div id="toolbar-section">
         <button id="run-code-btn" class="btn-primary" onClick="handleRunCode()">run code</button>
-        <button id="share-code-btn" class="btn-secondary" onClick="handleShareCode()">
-          share code
-        </button>
+        <button id="share-code-btn" class="btn-secondary" onClick="handleShareCode()">share code</button>
       </div>
 
       <div id="input-section">
@@ -116,16 +114,21 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
         const queryString = window.location.search;
         if (queryString.length != 0) {
           const urlParams = new URLSearchParams(queryString);
-          const stateParam = urlParams.get("state");
+          const stateParam = decodeURIComponent(urlParams.get("state"));
 
-          let urlState = JSON.parse(atob(stateParam));
+          try {
+            let urlState = JSON.parse(atob(stateParam));
 
-          window.programEditor.setValue(urlState["program"]);
-          window.eventEditor.setValue(JSON.stringify(urlState["event"], null, "\t"));
+            window.programEditor.setValue(urlState["program"]);
+            window.eventEditor.setValue(JSON.stringify(urlState["event"], null, "\t"));
 
-          console.log("[DEBUG::queryStringLogic] Current Params:", JSON.parse(atob(stateParam)));
-          let res = handleRunCode(JSON.parse(atob(stateParam)));
-          console.log("[DEBUG::queryStringLogic] Running VRL with current Params:", res);
+            console.log("[DEBUG::queryStringLogic] Current Params:", JSON.parse(atob(stateParam)));
+            let res = handleRunCode(JSON.parse(atob(stateParam)));
+            console.log("[DEBUG::queryStringLogic] Running VRL with current Params:", res);
+          } catch (e) {
+            window.outputEditor.setValue(`Error reading the shared URL\n${e}`);
+          }
+          
         }
       });
     </script>
@@ -138,11 +141,71 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
     </script>
 
     <script>
+      function tryJsonParse(str) {
+        try {
+          return JSON.parse(str);
+        } catch (e) {
+          monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+            validate: false
+          });
+          window.outputEditor.setValue(`Error attempting to parse the following string into valid JSON\n
+String: ${str}
+\nEnsure that the Event editor contains valid JSON
+\nCommon mistakes:\n
+  Trailing Commas\n  Last line is a newline or whitespace\n  Unbalanced curly braces`);
+        }
+      }
+
+      function isJsonL() {
+        if (window.eventEditor.getModel().getLineCount() > 1) {
+          let lines = window.eventEditor.getModel().getLinesContent();
+          // if the second line is a json object
+          // we assume the user has passed in valid json on each
+          // line
+          if (lines[1][0] == "{" && lines[1][lines[1].length - 1] == "}") {
+            return true;
+          }
+        }
+        return false;
+      }
       function handleRunCode(input) {
+        if (isJsonL()) {
+          let inputs = [];
+          let program = window.programEditor.getValue();
+          let lines = window.eventEditor.getModel().getLinesContent();
+          lines.forEach((line) => {
+            inputs.push({
+              program: program,
+              event: tryJsonParse(line)
+            })
+          });
+
+          let results = [];
+          inputs.forEach((input) => {
+            results.push(window.run_vrl(input));
+          })
+          
+          let outputs = [];
+          results.forEach((res) => {
+            if (res.output) {
+              outputs.push(JSON.stringify(res["result"], null, "\t"));
+            } else if (res.msg) {
+              outputs.push(res["msg"]);
+            }
+          })
+          // disable output validation for json
+          // since jsonl input won't ouput valid json
+          monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+            validate: false
+          });
+          window.outputEditor.setValue(outputs.join("\n"));
+          return results;
+        }
+
         if (input == null) {
           input = {
             program: window.programEditor.getValue(),
-            event: JSON.parse(window.eventEditor.getValue()),
+            event: tryJsonParse(window.eventEditor.getValue()),
           };
         }
 
@@ -168,8 +231,8 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
         console.log(
           "[DEBUG::handleShareCode()] Printing out base64 encoded state\n",
           btoa(JSON.stringify(state))
-        );
-        window.history.pushState(state, "", `?state=${btoa(JSON.stringify(state))}`);
+        ); 
+        window.history.pushState(state, "", `?state=${encodeURIComponent(btoa(JSON.stringify(state)))}`);
       }
     </script>
   </body>

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -5,6 +5,7 @@
     <!-- the below line lets monaco editor to appear nicely in mobile view -->
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     <title>VRL playground</title>
+    <link rel="icon" type="image/x-icon" href="https://vector.dev/favicon.ico">
     <link
       rel="stylesheet"
       data-name="vs/editor/editor.main"

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -1,77 +1,80 @@
 <!DOCTYPE html>
 <html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <!-- the below line lets monaco editor to appear nicely in mobile view -->
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <title>VRL playground</title>
+    <link
+      rel="stylesheet"
+      data-name="vs/editor/editor.main"
+      href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min/vs/editor/editor.main.min.css"
+    />
 
-<head>
-  <meta charset="utf-8" />
-  <title>VRL playground</title>
-  <link rel="stylesheet" data-name="vs/editor/editor.main"
-    href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.20.0/min/vs/editor/editor.main.min.css">
+    <link
+      rel="stylesheet"
+      href="index.css"
+    />
 
-  <style type="text/css">
-    div#input-section {
-      display: grid;
-      grid-template-columns: 50% 50%;
-      margin-bottom: 5rem;
-    }
-
-    div#container-program {
-      border-radius: 25px;
-      overflow: hidden;
-    }
-
-    div#container-event { 
-      border-radius: 25px;
-      overflow: hidden;
-    }
-
-    div#container-output {
-      border-radius: 25px;
-      overflow: hidden;
-    }
-
-    body {
-      font-family: ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-    }
-
-  </style>
+    <style type="text/css">
+      
+    </style>
   </head>
 
-<body>
-  <h1>[draft] VRL playground wasm</h1>
-  <p>Open up the developer console and try running</p>
-  <p>run_vrl({"program": ".", "event": {}})')</p>
-  
-  <button onClick="handleRunCode()">run code</button>
-  <button onClick="handleShareCode()">share code</button>
-  <div id="input-section">
-    <div id="cell">
-      <p class="cell-title">Program</p>
-      <div id="container-program" style="height:400px;border:1px solid black;width:800px"></div>
-    </div>
-    
-    <div id="cell">
-      <p class="cell-title">Event</p>
-      <div id="container-event" style="height:400px;border:1px solid black;width:800px"></div>
-    </div>
-    
-  </div>
-  
-  <div id="output-section">
-    <div id="cell">
-      <p class="cell-title">Output</p>
-      <div id="container-output" style="height:400px;border:1px solid black;width:800px"></div>
-    </div>
-    
-  </div>
+  <body>
+    <div id="App">
+      <div id="summary-section">
+        <h1>VRL Playground</h1>
+        <p>
+          We compiled the <a href="https://vrl.dev">Vector Remap Language</a> crate into a web
+          assembly binary so you could see how a VRL program changes an event. You can write a
+          program, change the input event, run the program, share it, and see the output.
+        </p>
+      </div>
 
-  
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs/loader.min.js"></script>
-  <script>
-    // require is provided by loader.min.js.
-    require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs' } });
-    require(["vs/editor/editor.main"], () => {
-      window.programEditor = monaco.editor.create(document.getElementById('container-program'), {
-        value: `# Parse as JSON or error if malformed
+      <div id="toolbar-section">
+        <button id="run-code-btn" class="btn-primary" onClick="handleRunCode()">run code</button>
+        <button id="share-code-btn" class="btn-secondary" onClick="handleShareCode()">
+          share code
+        </button>
+      </div>
+
+      <div id="input-section">
+        <div id="cell">
+          <div id="input-cell-title">
+            <p class="cell-title">Program</p>
+          </div>
+
+          <div id="container-program"></div>
+        </div>
+      </div>
+
+      <div id="output-section">
+        <div id="event-cell">
+          <div id="event-cell-title">
+            <p class="cell-title">Event</p>
+          </div>
+          <div id="container-event"></div>
+        </div>
+
+        <div id="output-cell">
+          <div id="output-cell-title">
+            <p class="cell-title">Output</p>
+          </div>
+          <div id="container-output"></div>
+        </div>
+      </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs/loader.min.js"></script>
+    <script>
+      // require is provided by loader.min.js.
+      require.config({
+        paths: { vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs" },
+      });
+      require(["vs/editor/editor.main"], () => {
+        window.programEditor = monaco.editor.create(document.getElementById("container-program"), {
+          value: `# Parse as JSON or error if malformed
 parsed, err = parse_syslog(.message)
 
 
@@ -88,83 +91,86 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
 
 
 .timestamp = to_unix_timestamp(ts)`,
-        language: 'python',
-        theme: 'vs-light',
-        minimap: { enabled: false }
-      });
+          language: "python",
+          theme: "vs-light",
+          // minimap: { enabled: false },
+          automaticLayout: true,
+        });
 
-      window.eventEditor = monaco.editor.create(document.getElementById('container-event'), {
-        value: `{
+        window.eventEditor = monaco.editor.create(document.getElementById("container-event"), {
+          value: `{
   "message": "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
 }`,
-        language: 'json',
-        theme: 'vs-light',
-        minimap: { enabled: false }
-      });
+          language: "json",
+          theme: "vs-light",
+          // minimap: { enabled: false },
+          automaticLayout: true,
+        });
 
-      window.outputEditor = monaco.editor.create(document.getElementById('container-output'), {
-        language: 'json',
-        theme: 'vs-light',
-        minimap: { enabled: false }
-      });
-      const queryString = window.location.search;
-      if (queryString.length != 0) {
-        const urlParams = new URLSearchParams(queryString);
-        const stateParam = urlParams.get('state');
+        window.outputEditor = monaco.editor.create(document.getElementById("container-output"), {
+          language: "json",
+          theme: "vs-light",
+          // minimap: { enabled: false },
+          automaticLayout: true,
+        });
+        const queryString = window.location.search;
+        if (queryString.length != 0) {
+          const urlParams = new URLSearchParams(queryString);
+          const stateParam = urlParams.get("state");
 
-        let urlState = JSON.parse(atob(stateParam));
+          let urlState = JSON.parse(atob(stateParam));
 
-        window.programEditor.setValue(urlState["program"]);
-        window.eventEditor.setValue(JSON.stringify(urlState["event"], null, '\t'));
+          window.programEditor.setValue(urlState["program"]);
+          window.eventEditor.setValue(JSON.stringify(urlState["event"], null, "\t"));
 
-        console.log("[DEBUG::queryStringLogic] Current Params:", JSON.parse(atob(stateParam)));
-        let res = handleRunCode(JSON.parse(atob(stateParam)));
-        console.log("[DEBUG::queryStringLogic] Running VRL with current Params:", res);
-      }
-    });
-  </script>
-
-  <script type="module">
-    import init, { run_vrl } from "./vrl_web_playground.js";
-    init().then(() => {
-      window.run_vrl = run_vrl;
-      // console.log(run_vrl({"program": ".", "event": {}}));
-    });
-  </script>
-
-  <script>
-    function handleRunCode(input) {
-      if (input == null) {
-        input = {
-          program: window.programEditor.getValue(),
-          event: JSON.parse(window.eventEditor.getValue())
+          console.log("[DEBUG::queryStringLogic] Current Params:", JSON.parse(atob(stateParam)));
+          let res = handleRunCode(JSON.parse(atob(stateParam)));
+          console.log("[DEBUG::queryStringLogic] Running VRL with current Params:", res);
         }
+      });
+    </script>
+
+    <script type="module">
+      import init, { run_vrl } from "./vrl_web_playground.js";
+      init().then(() => {
+        window.run_vrl = run_vrl;
+      });
+    </script>
+
+    <script>
+      function handleRunCode(input) {
+        if (input == null) {
+          input = {
+            program: window.programEditor.getValue(),
+            event: JSON.parse(window.eventEditor.getValue()),
+          };
+        }
+
+        let res = window.run_vrl(input);
+
+        console.log("[DEBUG::handleRunCode()] Printing out res: ", res);
+        if (res.output) {
+          window.outputEditor.setValue(JSON.stringify(res["result"], null, "\t"));
+        } else if (res.msg) {
+          window.outputEditor.setValue(res["msg"]);
+        }
+        return res;
       }
+    </script>
+    <script>
+      function handleShareCode() {
+        let state = {
+          program: window.programEditor.getValue(),
+          event: JSON.parse(window.eventEditor.getValue()),
+        };
 
-      let res = window.run_vrl(input);
-
-      console.log("[DEBUG::handleRunCode()] Printing out res: ", res);
-      if (res.output) {
-        window.outputEditor.setValue(JSON.stringify(res["result"], null, "\t"));
-      } else if (res.msg) {
-        window.outputEditor.setValue(res["msg"]);
+        console.log("[DEBUG::handleShareCode()] Printing out state", state);
+        console.log(
+          "[DEBUG::handleShareCode()] Printing out base64 encoded state\n",
+          btoa(JSON.stringify(state))
+        );
+        window.history.pushState(state, "", `?state=${btoa(JSON.stringify(state))}`);
       }
-      return res;
-    }
-
-  </script>
-  <script>
-    function handleShareCode() {
-      let state = {
-        program: window.programEditor.getValue(),
-        event: JSON.parse(window.eventEditor.getValue())
-      }
-
-      console.log("[DEBUG::handleShareCode()] Printing out state", state);
-      console.log("[DEBUG::handleShareCode()] Printing out base64 encoded state\n", btoa(JSON.stringify(state)));
-      window.history.pushState(state, "", `?state=${ btoa(JSON.stringify(state)) }`);
-    }
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -26,7 +26,7 @@
       <div id="summary-section">
         <h1>VRL Playground</h1>
         <p>
-          Vector Remap Language (VRL) is an expression-oriented language designed for transforming
+          <a href="https://vector.dev/docs/reference/vrl/functions/">Vector Remap Language (VRL)</a> is an expression-oriented language designed for transforming
           observability data. This playground lets you write a program, run it against an event or
           events, share it, and see how the events are transformed.
         </p>

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -17,7 +17,6 @@
     />
 
     <style type="text/css">
-      
     </style>
   </head>
 
@@ -128,7 +127,6 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
           } catch (e) {
             window.outputEditor.setValue(`Error reading the shared URL\n${e}`);
           }
-          
         }
       });
     </script>
@@ -184,7 +182,6 @@ String: ${str}
           inputs.forEach((input) => {
             results.push(window.run_vrl(input));
           })
-          
           let outputs = [];
           results.forEach((res) => {
             if (res.output) {
@@ -231,7 +228,7 @@ String: ${str}
         console.log(
           "[DEBUG::handleShareCode()] Printing out base64 encoded state\n",
           btoa(JSON.stringify(state))
-        ); 
+        );
         window.history.pushState(state, "", `?state=${encodeURIComponent(btoa(JSON.stringify(state)))}`);
       }
     </script>

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -25,9 +25,9 @@
       <div id="summary-section">
         <h1>VRL Playground</h1>
         <p>
-          We compiled the <a href="https://vrl.dev">Vector Remap Language</a> crate into a web
-          assembly binary so you could see how a VRL program changes an event. You can write a
-          program, change the input event, run the program, share it, and see the output.
+          Vector Remap Language (VRL) is an expression-oriented language designed for transforming
+          observability data. This playground lets you write a program, run it against an event or
+          events, share it, and see how the events are transformed.
         </p>
       </div>
 
@@ -64,6 +64,15 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs/loader.min.js"></script>
+
+    <!-- moving the below script above any calls to handleRunCode()
+    should help prevent "window.run_vrl is not a function" error -->
+    <script type="module">
+      import init, { run_vrl } from "./vrl_web_playground.js";
+      init().then(() => {
+        window.run_vrl = run_vrl;
+      });
+    </script>
     <script>
       // require is provided by loader.min.js.
       require.config({
@@ -128,13 +137,6 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
             window.outputEditor.setValue(`Error reading the shared URL\n${e}`);
           }
         }
-      });
-    </script>
-
-    <script type="module">
-      import init, { run_vrl } from "./vrl_web_playground.js";
-      init().then(() => {
-        window.run_vrl = run_vrl;
       });
     </script>
 

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -150,7 +150,8 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
 String: ${str}
 \nEnsure that the Event editor contains valid JSON
 \nCommon mistakes:\n
-  Trailing Commas\n  Last line is a newline or whitespace\n  Unbalanced curly braces`);
+  Trailing Commas\n  Last line is a newline or whitespace\n  Unbalanced curly braces
+  If using JSONL, ensure each line is valid JSON`);
         }
       }
 

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -80,23 +80,22 @@
       });
       require(["vs/editor/editor.main"], () => {
         window.programEditor = monaco.editor.create(document.getElementById("container-program"), {
-          value: `# Parse as JSON
-parsed, err = parse_syslog(.message)
+          value: `# Remove some fields
+del(.foo)
 
+# Add a timestamp
+.timestamp = now()
 
+# Parse HTTP status code into local variable
+http_status_code = parse_int!(.http_status)
+del(.http_status)
 
-# Set the event to the parsed JSON value
-. = parsed
-
-# Remove some fields
-del(.msgid)
-
-
-# Reformat the timestamp
-ts, err = parse_timestamp(.timestamp, format: "%s")
-
-
-.timestamp = to_unix_timestamp(ts)`,
+# Add status
+if http_status_code >= 200 && http_status_code <= 299 {
+    .status = "success"
+} else {
+    .status = "error"
+}`,
           language: "coffeescript",
           theme: "vs-light",
           minimap: { enabled: false },
@@ -105,7 +104,9 @@ ts, err = parse_timestamp(.timestamp, format: "%s")
 
         window.eventEditor = monaco.editor.create(document.getElementById("container-event"), {
           value: `{
-  "message": "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
+	"message": "Hello VRL",
+	"foo": "delete me",
+	"http_status": "200"
 }`,
           language: "json",
           theme: "vs-light",

--- a/lib/vrl/web-playground/public/index.html
+++ b/lib/vrl/web-playground/public/index.html
@@ -71,7 +71,7 @@
       });
       require(["vs/editor/editor.main"], () => {
         window.programEditor = monaco.editor.create(document.getElementById("container-program"), {
-          value: `# Parse as JSON or error if malformed
+          value: `# Parse as JSON
 parsed, err = parse_syslog(.message)
 
 

--- a/lib/vrl/web-playground/src/lib.rs
+++ b/lib/vrl/web-playground/src/lib.rs
@@ -92,7 +92,7 @@ fn compile(mut input: Input) -> Result<VrlCompileResult, VrlDiagnosticResult> {
 
     match runtime.resolve(&mut target_value, &program.program, &timezone) {
         Ok(result) => Ok(VrlCompileResult::new(result, target_value.value)),
-        Err(err) => return Err(VrlDiagnosticResult::new_runtime_error(&input.program, err)),
+        Err(err) => Err(VrlDiagnosticResult::new_runtime_error(&input.program, err)),
     }
 }
 

--- a/lib/vrl/web-playground/src/lib.rs
+++ b/lib/vrl/web-playground/src/lib.rs
@@ -70,7 +70,6 @@ impl VrlDiagnosticResult {
     }
 }
 
-// TODO: return diagnostic if fails upon compilation, currently being ignored
 fn compile(mut input: Input) -> Result<VrlCompileResult, VrlDiagnosticResult> {
     let event = &mut input.event;
     let functions = stdlib::all();


### PR DESCRIPTION
Closes https://github.com/vectordotdev/vector/issues/15176
Closes https://github.com/vectordotdev/vector/issues/15128
Closes https://github.com/vectordotdev/vector/issues/14713

- added JSONL support by using the monaco API
- added helpful error messages if JSON.parse() fails when reading input from event editor
- implemented styling recommendations from Jean's comments mentioned in issue linked above
- changed language highlighting to coffeescript
- changed layout when viewing from a mobile device
- fixed bug with `atob` and `btoa` failing when reading the base64 string from url params (we needed to use URIEncode and URIDecode)

<img width="1918" alt="image" src="https://user-images.githubusercontent.com/44036128/201767806-1cf0c96e-b70a-4334-b92c-6fcacea3c9f5.png">

Mobile device:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/44036128/201767940-9d1ce6eb-d2f5-4070-a072-9c46ce4ba925.png">

Edit:
Addressed comments below and also added formatted diagnostic messages from runtime errors or aborts.
<img width="1905" alt="image" src="https://user-images.githubusercontent.com/44036128/202028491-a51fc945-d729-4724-bfb5-38a33034c5ea.png">


We also handle runtime errors:
<img width="1905" alt="image" src="https://user-images.githubusercontent.com/44036128/202028602-5751dc39-b46e-4caa-881f-38b6b42dcc21.png">


