### PR TITLE
chore: Cleanup match used for legacy timestamp handling

### DIFF
--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -246,9 +246,10 @@ fn populate_event(
             log.insert(metadata_path!("vector", "ingest_timestamp"), Utc::now());
         }
         LogNamespace::Legacy => {
-            timestamp.unwrap_or_else(Utc::now);
-
-            log.try_insert((PathPrefix::Event, log_schema().timestamp_key()), timestamp);
+            log.try_insert(
+                (PathPrefix::Event, log_schema().timestamp_key()),
+                timestamp.unwrap_or_else(Utc::now),
+            );
         }
     };
 }

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -577,9 +577,10 @@ impl IngestorProcess {
                     log.insert(metadata_path!("vector", "ingest_timestamp"), Utc::now());
                 }
                 LogNamespace::Legacy => {
-                    timestamp.unwrap_or_else(Utc::now);
-
-                    log.try_insert((PathPrefix::Event, log_schema().timestamp_key()), timestamp);
+                    log.try_insert(
+                        (PathPrefix::Event, log_schema().timestamp_key()),
+                        timestamp.unwrap_or_else(Utc::now),
+                    );
                 }
             };
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
