### PR TITLE
fix(ci): Use commit statuses, not checks in Regression Detector workflow

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -277,20 +277,17 @@ jobs:
       - upload-comparison-image-to-ecr
     steps:
       - name: Check status, in-progress
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Submit Experiment",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "in_progress",
-               output: {
-                  title: "Submit Experiment",
-                  summary: "Submit experiments to Regression Detector cluster.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='pending' \
+            -f description='Experiments submitted to the Regression Detector cluster.' \
+            -f context='Regression Detector / submission' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - uses: actions/checkout@v3
         with:
@@ -360,58 +357,43 @@ jobs:
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - name: Check status, cancelled
-        if: ${{ cancelled() }}
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Submit Experiment",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "completed",
-               conclusion: "cancelled",
-               output: {
-                  title: "Submit Experiment",
-                  summary: "Submit experiments to Regression Detector cluster.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='failure' \
+            -f description='Experiments submitted to the Regression Detector cluster cancelled.' \
+            -f context='Regression Detector / submission' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Check status, success
-        if: ${{ success() }}
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Submit Experiment",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "completed",
-               conclusion: "success",
-               output: {
-                  title: "Submit Experiment",
-                  summary: "Submit experiments to Regression Detector cluster.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='success' \
+            -f description='Experiments submitted to the Regression Detector cluster successfully.' \
+            -f context='Regression Detector / submission' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Check status, failure
-        if: ${{ failure() }}
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Submit Experiment",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "completed",
-               conclusion: "failure",
-               output: {
-                  title: "Submit Experiment",
-                  summary: "Submit experiments to Regression Detector cluster.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='success' \
+            -f description='Experiments submitted to the Regression Detector cluster failed.' \
+            -f context='Regression Detector / submission' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   ##
   ## ANALYZE
@@ -425,20 +407,17 @@ jobs:
       - compute-metadata
     steps:
       - name: Check status, in-progress
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Analyze Experimental Results",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "in_progress",
-               output: {
-                  title: "Analyze Experiment",
-                  summary: "Analyze experimental results from Regression Detector.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='pending' \
+            -f description='Analyze experimental results from Regression Detector.' \
+            -f context='Regression Detector / analyze-experiment' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - uses: actions/checkout@v3
         with:
@@ -491,55 +470,40 @@ jobs:
           path: ${{ runner.temp }}/outputs/*
 
       - name: Check status, cancelled
-        if: ${{ cancelled() }}
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Analyze Experimental Results",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "completed",
-               conclusion: "cancelled",
-               output: {
-                  title: "Analyze Experiment",
-                  summary: "Analyze experimental results from Regression Detector.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='failure' \
+            -f description='Analyze experimental results from Regression Detector cancelled.' \
+            -f context='Regression Detector / analyze-experiment' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Check status, success
-        if: ${{ success() }}
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Analyze Experimental Results",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "completed",
-               conclusion: "success",
-               output: {
-                  title: "Analyze Experiment",
-                  summary: "Analyze experimental results from Regression Detector.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='success' \
+            -f description='Analyze experimental results from Regression Detector succeeded.' \
+            -f context='Regression Detector / analyze-experiment' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Check status, failure
-        if: ${{ failure() }}
-        uses: actions/github-script@v6.3.3
-        with:
-          script: |
-            github.rest.checks.create({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               name: "Analyze Experiment",
-               head_sha: "${{ needs.compute-metadata.outputs.head-sha }}",
-               status: "completed",
-               conclusion: "failure",
-               output: {
-                  title: "Analyze Experimental Results",
-                  summary: "Analyze experimental results from Regression Detector.",
-               },
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
+            -f state='success' \
+            -f description='Analyze experimental results from Regression Detector failed.' \
+            -f context='Regression Detector / analyze-experiment' \
+            -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
I find the Github API confusing, especially around Github Actions. Which pieces map to what parts of their UI, what works in concert implicitly and what do not is hard -- for me -- to understand. Fun fact, if you want to protect a branch you need a 'commit status' and that is separate from a 'check' although they are often both created at the same time, automatically? A "check run" is a single line-item in a "check suite" but is not a commit status and cannot gate a branch change, also a 'run' cannot be placed easily in a 'suite' per [this conversation](https://github.com/orgs/community/discussions/24616).

This commit adjusts the Regression Detector to use only commit statuses. We are now able to link to the triggered workflow and can also set branch protection based on the status. We are also able to avoid the use of github-script, relying instead on the more explicable `gh` cli tool.

Please note changes made in this PR will not be executed until this PR is merged to master branch.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
