### PR TITLE
chore(docs): synchronize machine-generated Cue documentation

### DIFF
--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -326,7 +326,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 	}
 	stream_name: {
 		description: """
-			The [stream name][stream_name] of the target Kinesis Logs stream.
+			The [stream name][stream_name] of the target Kinesis Firehose delivery stream.
 
 			[stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 			"""

--- a/website/cue/reference/components/sources/base/dnstap.cue
+++ b/website/cue/reference/components/sources/base/dnstap.cue
@@ -14,6 +14,11 @@ base: components: sources: dnstap: configuration: {
 		required: false
 		type: string: syntax: "literal"
 	}
+	log_namespace: {
+		description: "The namespace to use for logs. This overrides the global settings."
+		required:    false
+		type: bool: {}
+	}
 	max_frame_handling_tasks: {
 		description: "Maximum number of frames that can be processed concurrently."
 		required:    false

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -118,6 +118,11 @@ base: components: sources: socket: configuration: {
 			type: uint: {}
 		}
 	}
+	log_namespace: {
+		description: "The namespace to use for logs. This overrides the global setting."
+		required:    false
+		type: bool: {}
+	}
 	max_length: {
 		description: """
 			The maximum buffer size, in bytes, of incoming messages.


### PR DESCRIPTION
Some PRs got through with out-of-sync machine-generated Cue documentation files before the new CI check added in #15162 was merged in, which is now leading to `master` failing -- rightfully so -- as there is an out-of-sync issue.

This PR simply updates those files.