### PR TITLE
fix(azure service)!: Retrieve .inner() from SensitiveString for Azure ConnectionString

### DIFF
--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -136,7 +136,9 @@ impl GenerateConfig for AzureBlobSinkConfig {
 impl SinkConfig for AzureBlobSinkConfig {
     async fn build(&self, _cx: SinkContext) -> Result<(VectorSink, Healthcheck)> {
         let client = azure_common::config::build_client(
-            self.connection_string.as_ref().map(|v| v.to_string()),
+            self.connection_string
+                .as_ref()
+                .map(|v| v.inner().to_string()),
             self.storage_account.as_ref().map(|v| v.to_string()),
             self.container_name.clone(),
         )?;


### PR DESCRIPTION
`azure_common::config::build_client` requires a String not a SensitiveString, in the conversion using to_string() we were accidentally converting to the sensitive value to `**REDACTED**`.

This fixes it by using the same method that seems to have been used in the PR that introduced this change: https://github.com/vectordotdev/vector/pull/14305 to call `.inner()` to retrieve the value from inside the struct and then converts that to a String.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Closes: #15214
Related:
- https://github.com/vectordotdev/vector/discussions/15170