### PR TITLE
chore(docs): miscellaneous fixes to generate config schema and derived docs output

### DIFF
--- a/lib/vector-config/src/num.rs
+++ b/lib/vector-config/src/num.rs
@@ -7,10 +7,12 @@ use std::{
 };
 
 use num_traits::{Bounded, One, ToPrimitive, Zero};
+use schemars::schema::InstanceType;
 use serde_json::Number;
 use vector_config_common::num::{NUMERIC_ENFORCED_LOWER_BOUND, NUMERIC_ENFORCED_UPPER_BOUND};
 
 /// The class of a numeric type.
+#[derive(Clone, Copy)]
 pub enum NumberClass {
     /// A signed integer.
     Signed,
@@ -20,6 +22,19 @@ pub enum NumberClass {
 
     /// A floating-point number.
     FloatingPoint,
+}
+
+impl NumberClass {
+    /// Gets the equivalent instance type of this number class.
+    ///
+    /// The "instance type" is the JSON Schema term for value type i.e. string, number, integer,
+    /// array, and so on.
+    pub fn as_instance_type(self) -> InstanceType {
+        match self {
+            Self::Signed | Self::Unsigned => InstanceType::Integer,
+            Self::FloatingPoint => InstanceType::Number,
+        }
+    }
 }
 
 impl fmt::Display for NumberClass {

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -151,13 +151,16 @@ pub fn generate_number_schema<N>() -> SchemaObject
 where
     N: Configurable + ConfigurableNumber,
 {
+    // TODO: Once `schemars` has proper integer support, we should allow specifying min/max bounds
+    // in a way that's relevant to the number class. As is, we're always forcing bounds to fit into
+    // `f64` regardless of whether or not we're using `u64` vs `f64` vs `i16`, and so on.
     let minimum = N::get_enforced_min_bound();
     let maximum = N::get_enforced_max_bound();
 
     // We always set the minimum/maximum bound to the mechanical limits. Any additional constraining as part of field
     // validators will overwrite these limits.
     let mut schema = SchemaObject {
-        instance_type: Some(InstanceType::Number.into()),
+        instance_type: Some(N::class().as_instance_type().into()),
         number: Some(Box::new(NumberValidation {
             minimum: Some(minimum),
             maximum: Some(maximum),

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -471,7 +471,7 @@ end
 # For any overlapping fields in the given schema and the referenced schema, the fields from the
 # given schema will win.
 def expand_schema_references(root_schema, unexpanded_schema)
-  # Break any cycles during expansion, to same as we do during resolution.
+  # Break any cycles during expansion, the same as we do during resolution.
   if get_schema_metadata(unexpanded_schema, 'docs::cycle_entrypoint')
     return unexpanded_schema
   end

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -649,7 +649,7 @@ end
 
 # Fully resolves a schema definition, if it exists.
 #
-# This looks up a schema definition by the given `name` within `root_schema` and resolves i
+# This looks up a schema definition by the given `name` within `root_schema` and resolves it.
 # If no schema definition exists for the given name, `nil` is returned. Otherwise, the schema
 # definition is preprocessed (collapsing schema references, etc), and then resolved. Both the
 # "source" schema (preprocessed value) and the resolved schema are returned.

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -124,8 +124,8 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -124,7 +124,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -124,8 +124,8 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -124,7 +124,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -115,8 +115,8 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -115,7 +115,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -115,8 +115,8 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -115,7 +115,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}
@@ -326,7 +326,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 	}
 	stream_name: {
 		description: """
-			The [stream name][stream_name] of the target Kinesis Logs stream.
+			The [stream name][stream_name] of the target Kinesis Firehose delivery stream.
 
 			[stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 			"""

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -195,8 +195,8 @@ base: components: sinks: aws_s3: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}
@@ -600,7 +600,7 @@ base: components: sinks: aws_s3: configuration: {
 		description: "The tag-set for the object."
 		required:    false
 		type: object: options: "*": {
-			description: "Tags for a metric series."
+			description: "The tag-set for the object."
 			required:    true
 			type: object: options: {
 				Set: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -195,7 +195,7 @@ base: components: sinks: aws_s3: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -43,8 +43,8 @@ base: components: sinks: axiom: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -43,7 +43,7 @@ base: components: sinks: axiom: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -117,8 +117,8 @@ base: components: sinks: azure_blob: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -117,7 +117,7 @@ base: components: sinks: azure_blob: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -113,8 +113,8 @@ base: components: sinks: clickhouse: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -113,7 +113,7 @@ base: components: sinks: clickhouse: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -66,8 +66,8 @@ base: components: sinks: datadog_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -66,7 +66,7 @@ base: components: sinks: datadog_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -66,8 +66,8 @@ base: components: sinks: datadog_traces: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -66,7 +66,7 @@ base: components: sinks: datadog_traces: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -186,8 +186,8 @@ base: components: sinks: elasticsearch: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -186,7 +186,7 @@ base: components: sinks: elasticsearch: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -143,8 +143,8 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -143,7 +143,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -113,8 +113,8 @@ base: components: sinks: http: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -113,7 +113,7 @@ base: components: sinks: http: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -69,8 +69,8 @@ base: components: sinks: humio_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -69,7 +69,7 @@ base: components: sinks: humio_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -69,8 +69,8 @@ base: components: sinks: humio_metrics: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -69,7 +69,7 @@ base: components: sinks: humio_metrics: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -110,8 +110,8 @@ base: components: sinks: loki: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -110,7 +110,7 @@ base: components: sinks: loki: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -83,8 +83,8 @@ base: components: sinks: new_relic: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -83,7 +83,7 @@ base: components: sinks: new_relic: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -93,8 +93,8 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -93,7 +93,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -93,8 +93,8 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
+						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -93,7 +93,7 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 					description: "Compression level."
 					required:    false
 					type: {
-						number: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+						integer: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 						string: enum: ["none", "fast", "best", "default"]
 					}
 				}

--- a/website/cue/reference/components/sources/base/dnstap.cue
+++ b/website/cue/reference/components/sources/base/dnstap.cue
@@ -14,6 +14,11 @@ base: components: sources: dnstap: configuration: {
 		required: false
 		type: string: syntax: "literal"
 	}
+	log_namespace: {
+		description: "The namespace to use for logs. This overrides the global settings."
+		required:    false
+		type: bool: {}
+	}
 	max_frame_handling_tasks: {
 		description: "Maximum number of frames that can be processed concurrently."
 		required:    false


### PR DESCRIPTION
This PR fixes two small glitches:
- adding (un)signed integer fields to the configuration schema as `number` (which implies floating-point number) instead of `integer`
- generating the incorrect numeric type for numeric values that are part of any "enum" values in a schema

The first thing is simple: JSON Schema supports two numeric type, `integer` and `number`, which represent whole integers (`u32`, `i64`, etc etc) and floating-point numbers, respectively. We were emitting `number` in all cases, even though we had access to the necessary data to properly select either `integer` or `number`. We fixed that with a mere few changed lines.

The second thing, and the thing that represents like 95% of this PR, is fixing the numeric type used to describe numeric values in an "enum" schema.

Essentially, in the `CompressionLevel` type, we allow some fixed strings (good, best, fast, etc) and a fixed set of levels: 0-9, inclusive. When generated as part of the configuration schema, we simply emit those values in a single JSON array. When machine generating documentation from the configuration schema, we would emit something that looks like:

```
type:
  string: enum: ["good", "fast", "best"],
  integer: enum :[0, 1, 3, ..., 9],
```

Normally in the configuration schema, for fields with numeric types, we add a metadata annotation that describes the actual numeric type -- `uint`, `int`, or `float` -- to provide clarity where JSON's own types cannot. Instead of `integer` or `number`, we actually use one of those three, more precise values.

In the case of enum values, though, we can't do that because it wouldn't be clear what that annotation applies to amongst all the different enum values. So, the meat of this PR: we now use a simple heuristic when grouping enum values by their type in order to promote `integer`/`number` to something more specific if we can.

The logic is simple and is centered around seeing if all the values would fit in an `int` or a `uint` or a `float` -- which represent `i64`, `u64`, and `f64`, respectively -- and basically just picks the type that is most constrained, with a preference for `uint`, because most of our numeric fields actually are unsigned. It's not perfect, and it's a simple heuristic, but it works and is at least more descriptive than what was being generated before.

Since, as you might surmise, such logic would only take tens of lines, not hundreds, you're wondering: what the hell is the rest of the diff, then? Simply put: all the related changes to thread the "source" schema -- the unfettered configuration schema -- through the necessary places so that we can try and look up the numeric type metadata annotation where possible for maximum precision, rather than always falling back to the heuristic.

It's cursed code, yes, and I'm going to eventually throw it all away and rewrite this in Rust... but until then, you can take solace in the isolated diff of the machine-generated output itself, and that I will never foist the maintenance of this thing, in its Ruby form, upon any of you.