### PR TITLE
fix(redis source): mark redis_key field as possibly undefined

### DIFF
--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -216,7 +216,7 @@ impl SourceConfig for RedisSourceConfig {
                 Self::NAME,
                 redis_key_path,
                 &owned_value_path!("key"),
-                Kind::bytes(),
+                Kind::bytes().or_undefined(),
                 None,
             )
             .with_standard_vector_source_metadata();


### PR DESCRIPTION
I just discovered the `or_undefined` setting recently, and this is a place where we should've used it. 