### PR TITLE
[DO NOT MERGE] Intentionally break the build

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ needs.compute-soak-meta.outputs.baseline-sha }}
+          ref: ${{ needs.compute-metadata.outputs.baseline-sha }}
           path: baseline-vector
 
       - name: Set up Docker Buildx
@@ -132,7 +132,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ needs.compute-soak-meta.outputs.comparison-sha }}
+          ref: ${{ needs.compute-metadata.outputs.comparison-sha }}
           path: comparison-vector
 
       - name: Set up Docker Buildx

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -38,9 +38,9 @@ jobs:
     outputs:
       pr-number: ${{ steps.pr-metadata.outputs.PR_NUMBER }}
 
-      comparison: ${{ steps.comparison.outputs.COMPARISON }}
+      comparison-sha: ${{ steps.comparison.outputs.COMPARISON }}
       comparison-tag: ${{ steps.comparison.outputs.COMPARISON_TAG }}
-      baseline: ${{ steps.baseline.outputs.BASELINE }}
+      baseline-sha: ${{ steps.baseline.outputs.BASELINE }}
       baseline-tag: ${{ steps.baseline.outputs.BASELINE_TAG }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -98,6 +98,9 @@ jobs:
           ref: ${{ needs.compute-metadata.outputs.baseline-sha }}
           path: baseline-vector
 
+      - run: |
+          echo "BASELINE SHA: ${{ needs.compute-metadata.outputs.baseline-sha }}"
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2.2.1
@@ -129,6 +132,9 @@ jobs:
       - uses: colpal/actions-clean@v1
 
       - uses: actions/checkout@v3
+
+      - run: |
+          echo "COMPARISON SHA: ${{ needs.compute-metadata.outputs.comparison-sha }}"
 
       - uses: actions/checkout@v3
         with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,14 +171,3 @@ where
     #[cfg(not(tokio_unstable))]
     tokio::spawn(task)
 }
-
-pub fn num_threads() -> usize {
-    let count = match std::thread::available_parallelism() {
-        Ok(count) => count,
-        Err(error) => {
-            warn!(message = "Failed to determine available parallelism for thread count, defaulting to 1.", %error);
-            std::num::NonZeroUsize::new(1).unwrap()
-        }
-    };
-    usize::from(count)
-}


### PR DESCRIPTION
This PR is intended to help diagnose a curious build issue with the Regression Detector noted on #15230: it does not appear that the build of baseline and comparison are correctly demarcated. However considering that the logic of the soak and regression builds are similar we want to confirm that this is an observable behaviour independent of dependabot.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
