### PR TITLE
fix(ci): Correct Regression Detector variant checkout

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -38,9 +38,9 @@ jobs:
     outputs:
       pr-number: ${{ steps.pr-metadata.outputs.PR_NUMBER }}
 
-      comparison: ${{ steps.comparison.outputs.COMPARISON }}
+      comparison-sha: ${{ steps.comparison.outputs.COMPARISON }}
       comparison-tag: ${{ steps.comparison.outputs.COMPARISON_TAG }}
-      baseline: ${{ steps.baseline.outputs.BASELINE }}
+      baseline-sha: ${{ steps.baseline.outputs.BASELINE }}
       baseline-tag: ${{ steps.baseline.outputs.BASELINE_TAG }}
     steps:
       - uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ needs.compute-soak-meta.outputs.baseline-sha }}
+          ref: ${{ needs.compute-metadata.outputs.baseline-sha }}
           path: baseline-vector
 
       - name: Set up Docker Buildx
@@ -132,7 +132,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ needs.compute-soak-meta.outputs.comparison-sha }}
+          ref: ${{ needs.compute-metadata.outputs.comparison-sha }}
           path: comparison-vector
 
       - name: Set up Docker Buildx

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -166,9 +166,9 @@ jobs:
       - name: Write out metadata
         run: |
           echo "COMPARISON_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.comparison-tag }}" > ${{ runner.temp }}/meta
-          echo "COMPARISON_SHA=${{ needs.compute-metadata.outputs.comparison }}" >> ${{ runner.temp }}/meta
+          echo "COMPARISON_SHA=${{ needs.compute-metadata.outputs.comparison-sha }}" >> ${{ runner.temp }}/meta
           echo "BASELINE_TAG=${{ needs.compute-metadata.outputs.pr-number }}-${{ needs.compute-metadata.outputs.baseline-tag }}" >> ${{ runner.temp }}/meta
-          echo "BASELINE_SHA=${{ needs.compute-metadata.outputs.baseline }}" >> ${{ runner.temp }}/meta
+          echo "BASELINE_SHA=${{ needs.compute-metadata.outputs.baseline-sha }}" >> ${{ runner.temp }}/meta
           echo "CHECKOUT_SHA=${{ github.sha }}" >> ${{ runner.temp }}/meta
           echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> ${{ runner.temp }}/meta
           echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> ${{ runner.temp }}/meta


### PR DESCRIPTION
This PR is intended to correct the problem identified in #15230, namely that the Regression Detector is not correctly building baseline variant separately from comparison variant and is instead building two copies of the comparison. This is a consequence of Github Actions' willingness to treat a non-existent 'need' as an empty string and actions/checkout's willingness to treat an empty string as non-existent field.

Quite annoying to debug, relatively simple to fix. We have confirmed the efficacy of this fix in #15287 where we intentionally introduced a break into the comparison side. Note now that in that PR baseline builds as expected, comparison does not.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
