### PR TITLE
feat(logstash source): Add log namespace and schema def support

### DIFF
--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -61,7 +61,7 @@ pub struct LogstashConfig {
     /// The namespace to use for logs. This overrides the global setting.
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
-    pub log_namespace: Option<bool>,
+    log_namespace: Option<bool>,
 }
 
 impl LogstashConfig {

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -15,8 +15,10 @@ use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Decoder;
 use value::Kind;
 use vector_config::{configurable_component, NamedComponent};
-use vector_core::config::{LegacyKey, LogNamespace};
-use vector_core::schema::Definition;
+use vector_core::{
+    config::{LegacyKey, LogNamespace},
+    schema::Definition,
+};
 
 use super::util::net::{SocketListenAddr, TcpSource, TcpSourceAck, TcpSourceAcker};
 use crate::{
@@ -769,12 +771,12 @@ mod test {
                 .with_meaning(LookupBuf::root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
-                    &owned_value_path!(LogstashConfig::NAME, "timestamp"),
-                    Kind::timestamp().or_undefined(),
-                )
-                .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                )
+                .with_metadata_field(
+                    &owned_value_path!(LogstashConfig::NAME, "timestamp"),
+                    Kind::timestamp().or_undefined(),
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogstashConfig::NAME, "host"),


### PR DESCRIPTION
Adds log namespace and schema def support as described in https://github.com/vectordotdev/vector/pull/13720.

closes: https://github.com/vectordotdev/vector/issues/15026
epic: https://github.com/vectordotdev/vector/issues/13723
