### PR TITLE
chore(topology): Fix flaky `topology_disk_buffer_conflict` test

### DIFF
--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -21,7 +21,14 @@ use crate::{
 };
 
 fn internal_metrics_source() -> InternalMetricsConfig {
-    InternalMetricsConfig::default()
+    InternalMetricsConfig {
+        // TODO: A scrape interval left at the default of 1.0 seconds or less triggers some kind of
+        // race condition in the `topology_disk_buffer_conflict` test below, but it is unclear
+        // why. All these tests should work regardless of the scrape interval. This warrants further
+        // investigation.
+        scrape_interval_secs: 1.1,
+        ..Default::default()
+    }
 }
 
 fn prom_remote_write_source(addr: SocketAddr) -> PrometheusRemoteWriteConfig {


### PR DESCRIPTION
When the scrape interval on the `internal_metrics` source is left at the default of 1.0 seconds or less, some kind of race condition in the `topology_disk_buffer_conflict` test is triggered, but it is unclear why. All these tests should work regardless of the scrape interval. This warrants further investigation, but this at least shuts up the flaky test.

This was triggered by #15124

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
