### PR TITLE
Revert "chore(deps): bump serde_json from 1.0.87 to 1.0.88 (#15301)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6930,9 +6930,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.88"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "indexmap",
  "itoa 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ tower = { version = "0.4.13", default-features = false, features = ["buffer", "l
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }
 serde-toml-merge = { version = "0.3.0", default-features = false }
 serde_bytes = { version = "0.11.7", default-features = false, features = ["std"], optional = true }
-serde_json = { version = "1.0.88", default-features = false, features = ["raw_value"] }
+serde_json = { version = "1.0.87", default-features = false, features = ["raw_value"] }
 serde_with = { version = "2.1.0", default-features = false, features = ["macros", "std"], optional = true }
 serde_yaml = { version = "0.9.14", default-features = false }
 

--- a/lib/datadog/grok/Cargo.toml
+++ b/lib/datadog/grok/Cargo.toml
@@ -16,7 +16,7 @@ onig = { version = "6.4", default-features = false }
 ordered-float = { version = "3", default-features = false }
 peeking_take_while = { version = "1.0.0", default-features = false }
 regex = { version = "1.7", default-features = false, features = ["perf"] }
-serde_json = { version = "1.0.88", default-features = false }
+serde_json = { version = "1.0.87", default-features = false }
 thiserror = { version = "1", default-features = false }
 tracing = { version = "0.1.34", default-features = false }
 

--- a/lib/lookup/Cargo.toml
+++ b/lib/lookup/Cargo.toml
@@ -18,7 +18,7 @@ vector-config-macros = { path = "../vector-config-macros" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports", "async_tokio"] }
-serde_json = { version = "1.0.88", features = ["raw_value"] }
+serde_json = { version = "1.0.87", features = ["raw_value"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 quickcheck = { version = "1.0.3" }
 

--- a/lib/value/Cargo.toml
+++ b/lib/value/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { version = "0.1.34", default-features = false, features = ["attribute
 async-graphql = { version = "4.0.16", default-features = false, optional = true }
 mlua = { version = "0.8.6", default-features = false, features = ["lua54", "send", "vendored"], optional = true}
 serde = { version = "1.0.147", default-features = false, features = ["derive", "rc"], optional = true }
-serde_json = { version = "1.0.88", optional = true }
+serde_json = { version = "1.0.87", optional = true }
 toml = { version = "0.5.9", default-features = false, optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 
@@ -37,6 +37,6 @@ indoc = { version = "1.0.7", default-features = false }
 quickcheck = "1.0.3"
 lookup = { path = "../lookup", default-features = false, features = ["arbitrary"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive", "rc"]}
-serde_json = { version = "1.0.88"}
+serde_json = { version = "1.0.87"}
 toml = { version = "0.5.9", default-features = false }
 mlua = { version = "0.8.6", default-features = false, features = ["lua54", "send", "vendored"]}

--- a/lib/vector-api-client/Cargo.toml
+++ b/lib/vector-api-client/Cargo.toml
@@ -10,7 +10,7 @@ license = "MPL-2.0"
 
 # Serde
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.88", default-features = false, features = ["raw_value"] }
+serde_json = { version = "1.0.87", default-features = false, features = ["raw_value"] }
 
 # Error handling
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -62,7 +62,7 @@ nom = { version = "7", optional = true }
 ordered-float = { version = "3.4.0", default-features = false }
 pin-project = { version = "1.0.12", default-features = false }
 ryu = { version = "1", default-features = false }
-serde_json = { version = "1.0.88", default-features = false, features = ["std", "raw_value"] }
+serde_json = { version = "1.0.87", default-features = false, features = ["std", "raw_value"] }
 serde = { version = "1.0.147", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false }
 snafu = { version = "0.7", optional = true }

--- a/lib/vector-config/Cargo.toml
+++ b/lib/vector-config/Cargo.toml
@@ -15,7 +15,7 @@ no-proxy = { version  = "0.3.1", default-features = false, features = ["serializ
 num-traits = { version = "0.2.15", default-features = false }
 schemars = { version = "0.8.11", default-features = true, features = ["preserve_order"] }
 serde = { version = "1.0", default-features = false }
-serde_json = { version = "1.0.88", default-features = false }
+serde_json = { version = "1.0.87", default-features = false }
 serde_with = { version = "2.1.0", default-features = false, features = ["std"] }
 snafu = { version = "0.7.3", default-features = false }
 toml = { version = "0.5.9", default-features = false }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -40,7 +40,7 @@ prost = { version = "0.11.0", default-features = false, features = ["std"] }
 quanta = { version = "0.10.1", default-features = false }
 regex = { version = "1.7.0", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive", "rc"] }
-serde_json = { version = "1.0.88", default-features = false }
+serde_json = { version = "1.0.87", default-features = false }
 serde_with = { version = "2.1.0", default-features = false, features = ["std", "macros"] }
 snafu = { version = "0.7.3", default-features = false }
 socket2 = { version = "0.4.7", default-features = false }


### PR DESCRIPTION
This reverts commit f37e22c6759e06690db13a04b6be942eb498de66.

I noticed a performance regression in the original for this just after hitting "Squash and Merge" so I'm running this to see if the regression is repeatable or not.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
