### PR TITLE
chore(deps): Bump prost, prost-build, and prost-types to 0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "ordered-float 3.4.0",
- "prost 0.11.0",
+ "prost 0.11.2",
  "regex",
  "serde",
  "serde_json",
@@ -1839,8 +1839,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
 dependencies = [
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prost 0.11.2",
+ "prost-types 0.11.2",
  "tonic",
  "tracing-core 0.1.30",
 ]
@@ -1857,7 +1857,7 @@ dependencies = [
  "futures 0.3.25",
  "hdrhistogram",
  "humantime",
- "prost-types 0.11.1",
+ "prost-types 0.11.2",
  "serde",
  "serde_json",
  "thread_local",
@@ -5180,8 +5180,8 @@ dependencies = [
  "chrono",
  "hex",
  "ordered-float 3.4.0",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost 0.11.2",
+ "prost-build 0.11.2",
  "tonic",
  "tonic-build",
  "value",
@@ -5745,9 +5745,9 @@ dependencies = [
  "indexmap",
  "nom",
  "num_enum",
- "prost 0.11.0",
- "prost-build 0.11.1",
- "prost-types 0.11.1",
+ "prost 0.11.2",
+ "prost-build 0.11.2",
+ "prost-types 0.11.2",
  "snafu",
  "value",
  "vector-common",
@@ -5797,9 +5797,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
 dependencies = [
  "bytes 1.2.1",
  "prost-derive 0.11.0",
@@ -5829,9 +5829,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
 dependencies = [
  "bytes 1.2.1",
  "heck 0.4.0",
@@ -5840,9 +5840,11 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prettyplease",
+ "prost 0.11.2",
+ "prost-types 0.11.2",
  "regex",
+ "syn",
  "tempfile",
  "which",
 ]
@@ -5885,12 +5887,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
 dependencies = [
  "bytes 1.2.1",
- "prost 0.11.0",
+ "prost 0.11.2",
 ]
 
 [[package]]
@@ -7929,7 +7931,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.0",
+ "prost 0.11.2",
  "prost-derive 0.11.0",
  "rustls-native-certs 0.6.2",
  "rustls-pemfile 1.0.0",
@@ -7952,7 +7954,7 @@ checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.11.1",
+ "prost-build 0.11.2",
  "quote",
  "syn",
 ]
@@ -8734,9 +8736,9 @@ dependencies = [
  "postgres-openssl",
  "prometheus-parser",
  "proptest",
- "prost 0.11.0",
- "prost-build 0.11.1",
- "prost-types 0.11.1",
+ "prost 0.11.2",
+ "prost-build 0.11.2",
+ "prost-types 0.11.2",
  "pulsar",
  "quickcheck",
  "rand 0.8.5",
@@ -8996,9 +8998,9 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "proptest",
- "prost 0.11.0",
- "prost-build 0.11.1",
- "prost-types 0.11.1",
+ "prost 0.11.2",
+ "prost-build 0.11.2",
+ "prost-types 0.11.2",
  "quanta",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,8 +194,8 @@ rmp-serde = { version = "1.1.1", default-features = false, optional = true }
 rmpv = { version = "1.0.0", default-features = false, features = ["with-serde"], optional = true }
 
 # Prost
-prost = { version = "0.11.0", default-features = false, features = ["std"] }
-prost-types = { version = "0.11.0", default-features = false, optional = true }
+prost = { version = "0.11.2", default-features = false, features = ["std"] }
+prost-types = { version = "0.11.2", default-features = false, optional = true }
 
 # GCP
 goauth = { version = "0.13.1", optional = true }
@@ -328,7 +328,7 @@ atty = { version = "0.2.14", default-features = false }
 nix = { version = "0.25.0", default-features = false, features = ["socket", "signal"] }
 
 [build-dependencies]
-prost-build = { version = "0.11.1", default-features = false, optional = true }
+prost-build = { version = "0.11.2", default-features = false, optional = true }
 tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"], optional = true }
 
 [dev-dependencies]

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -15,7 +15,7 @@ lookup = { path = "../lookup", default-features = false }
 memchr = { version = "2", default-features = false }
 once_cell = { version = "1.16", default-features = false }
 ordered-float = { version = "3.4.0", default-features = false }
-prost = { version = "0.11.0", default-features = false, features = ["std"] }
+prost = { version = "0.11.2", default-features = false, features = ["std"] }
 regex = { version = "1.7.0", default-features = false, features = ["std", "perf"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }

--- a/lib/opentelemetry-proto/Cargo.toml
+++ b/lib/opentelemetry-proto/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 publish = false
 
 [build-dependencies]
-prost-build = { version = "0.11.1", default-features = false}
+prost-build = { version = "0.11.2", default-features = false}
 tonic-build = { version = "0.8", default-features = false, features = ["prost", "transport"] }
 
 [dependencies]
 tonic = { version = "0.8", default-features = false, features = ["codegen", "gzip", "prost", "tls", "tls-roots", "transport"] }
 chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
-prost = { version = "0.11.0", default-features = false, features = ["std"] }
+prost = { version = "0.11.2", default-features = false, features = ["std"] }
 bytes = { version = "1.1.0", default-features = false, features = ["serde"] }
 vector-core = { path = "../vector-core", default-features = false }
 value = {path = "../value"}

--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -12,11 +12,11 @@ license = "MPL-2.0"
 indexmap = "~1.9.2"
 nom = "7.1.1"
 num_enum = "0.5.7"
-prost = "0.11.0"
-prost-types = "0.11.0"
+prost = "0.11.2"
+prost-types = "0.11.2"
 snafu = { version = "0.7" }
 vector-common = { path = "../vector-common", features = ["btreemap"] }
 value = { path = "../value", features = ["json"] }
 
 [build-dependencies]
-prost-build = "0.11.1"
+prost-build = "0.11.2"

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -35,8 +35,8 @@ ordered-float = { version = "3.4.0", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 pin-project = { version = "1.0.12", default-features = false }
 proptest = { version = "1.0", optional = true }
-prost-types = { version = "0.11.0", default-features = false }
-prost = { version = "0.11.0", default-features = false, features = ["std"] }
+prost-types = { version = "0.11.2", default-features = false }
+prost = { version = "0.11.2", default-features = false, features = ["std"] }
 quanta = { version = "0.10.1", default-features = false }
 regex = { version = "1.7.0", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive", "rc"] }
@@ -75,7 +75,7 @@ security-framework = "2.7.0"
 schannel = "0.1.20"
 
 [build-dependencies]
-prost-build = "0.11.1"
+prost-build = "0.11.2"
 
 [dev-dependencies]
 base64 = "0.13.1"


### PR DESCRIPTION
Closes #15229
Closes #15136 
Closes #15130 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
