### PR TITLE
fix(aws_s3 source): fix s3:TestEvent serialization

### DIFF
--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -669,7 +669,7 @@ enum Event {
 #[serde(rename_all = "PascalCase")]
 pub struct S3TestEvent {
     pub service: String,
-    pub event_name: S3EventName,
+    pub event: S3EventName,
     pub bucket: String,
 }
 
@@ -863,4 +863,24 @@ fn test_key_deserialize() {
         },
         value
     );
+}
+
+#[test]
+fn test_s3_testevent() {
+    let value: S3TestEvent = serde_json::from_str(
+        r#"{
+        "Service":"Amazon S3",
+        "Event":"s3:TestEvent",
+        "Time":"2014-10-13T15:57:02.089Z",
+        "Bucket":"bucketname",
+        "RequestId":"5582815E1AEA5ADF",
+        "HostId":"8cLeGAmw098X5cv4Zkwcmo8vvZa3eH3eKxsPzbB9wrR+YstdA6Knx4Ip8EXAMPLE"
+     }"#,
+    )
+    .unwrap();
+
+    assert_eq!(value.service, "Amazon S3".to_string());
+    assert_eq!(value.bucket, "bucketname".to_string());
+    assert_eq!(value.event.kind, "s3".to_string());
+    assert_eq!(value.event.name, "TestEvent".to_string());
 }


### PR DESCRIPTION
Vector logs an error like this when attempting to handle S3 test events via SQS:
`Could not parse SQS message with id 9447ae6e-d699-4944-940f-d4017230993b as S3 notification: data did not match any variant of untagged enum Event`

The Amazon S3 test event messages is structured like so (https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html) :
```
{  
   "Service":"Amazon S3",
   "Event":"s3:TestEvent",
   "Time":"2014-10-13T15:57:02.089Z",
   "Bucket":"bucketname",
   "RequestId":"5582815E1AEA5ADF",
   "HostId":"8cLeGAmw098X5cv4Zkwcmo8vvZa3eH3eKxsPzbB9wrR+YstdA6Knx4Ip8EXAMPLE"
}
```

This changes the S3 TestEvent struct to match the above by renaming the "event_name" member to "event". I'm not sure if my test case is correct or if I should be testing a specific function / putting it somewhere else... 🤞 