### PR TITLE
feat(loki sink): Add `path` option to configure the URL path

### DIFF
--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -53,6 +53,10 @@ impl Default for CompressionConfigAdapter {
     }
 }
 
+fn default_loki_path() -> String {
+    "/loki/api/v1/push".to_string()
+}
+
 /// Configuration for the `loki` sink.
 #[configurable_component(sink("loki"))]
 #[derive(Clone, Debug)]
@@ -60,8 +64,14 @@ impl Default for CompressionConfigAdapter {
 pub struct LokiConfig {
     /// The base URL of the Loki instance.
     ///
-    /// Vector will append `/loki/api/v1/push` to this.
+    /// Vector will append the value of `path` to this.
     pub endpoint: UriSerde,
+
+    /// The path to use in the URL of the Loki instance.
+    ///
+    /// By default, `"/loki/api/v1/push"` is used.
+    #[serde(default = "default_loki_path")]
+    pub path: String,
 
     #[configurable(derived)]
     pub encoding: EncodingConfig,

--- a/src/sinks/loki/mod.rs
+++ b/src/sinks/loki/mod.rs
@@ -1,7 +1,7 @@
 //! Loki sink
 //!
 //! This sink provides downstream support for `Loki` via
-//! the `/loki/api/v1/push` endpoint.
+//! the (configurable) `/loki/api/v1/push` endpoint.
 //!
 //! <https://grafana.com/docs/loki/v2.6.x/api/>
 //!

--- a/src/sinks/loki/service.rs
+++ b/src/sinks/loki/service.rs
@@ -98,8 +98,13 @@ pub struct LokiService {
 }
 
 impl LokiService {
-    pub fn new(client: HttpClient, endpoint: UriSerde, auth: Option<Auth>) -> crate::Result<Self> {
-        let endpoint = endpoint.append_path("loki/api/v1/push")?.with_auth(auth);
+    pub fn new(
+        client: HttpClient,
+        endpoint: UriSerde,
+        path: String,
+        auth: Option<Auth>,
+    ) -> crate::Result<Self> {
+        let endpoint = endpoint.append_path(&path)?.with_auth(auth);
 
         Ok(Self { client, endpoint })
     }

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -385,7 +385,12 @@ impl LokiSink {
 
         let service = tower::ServiceBuilder::new()
             .settings(request_limits, LokiRetryLogic)
-            .service(LokiService::new(client, config.endpoint, config.auth)?);
+            .service(LokiService::new(
+                client,
+                config.endpoint,
+                config.path,
+                config.auth,
+            )?);
 
         let transformer = config.encoding.transformer();
         let serializer = config.encoding.build()?;

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -190,7 +190,7 @@ base: components: sinks: loki: configuration: {
 		description: """
 			The base URL of the Loki instance.
 
-			Vector will append `/loki/api/v1/push` to this.
+			Vector will append the value of `path` to this.
 			"""
 		required: true
 		type: string: syntax: "literal"
@@ -253,6 +253,18 @@ base: components: sinks: loki: configuration: {
 				drop:              "Drop the event."
 				rewrite_timestamp: "Rewrite the timestamp of the event to the timestamp of the latest event seen by the sink."
 			}
+		}
+	}
+	path: {
+		description: """
+			The path to use in the URL of the Loki instance.
+
+			By default, `"/loki/api/v1/push"` is used.
+			"""
+		required: false
+		type: string: {
+			default: "/loki/api/v1/push"
+			syntax:  "literal"
 		}
 	}
 	remove_label_fields: {

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -70,10 +70,18 @@ components: sinks: loki: {
 
 	configuration: {
 		endpoint: {
-			description: "The base URL of the Loki instance. Vector will append `/loki/api/v1/push` to this."
+			description: "The base URL of the Loki instance. Vector will append the value of `path` to this."
 			required:    true
 			type: string: {
 				examples: ["http://localhost:3100"]
+			}
+		}
+		path: {
+			description: "The path to use in the URL of the Loki instance."
+			required:    false
+			type: string: {
+				default: "/loki/api/v1/push"
+				examples: ["/loki/api/v1/push"]
 			}
 		}
 		auth: configuration._http_auth & {_args: {


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
