### PR TITLE
chore(metrics): Rework tag value insert operation

### DIFF
--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -342,8 +342,8 @@ impl Metric {
     /// containing the previous value of the tag.
     ///
     /// *Note:* This will create the tags map if it is not present.
-    pub fn insert_tag(&mut self, name: String, value: String) -> Option<String> {
-        self.series.insert_tag(name, value)
+    pub fn replace_tag(&mut self, name: String, value: String) -> Option<String> {
+        self.series.replace_tag(name, value)
     }
 
     /// Zeroes out the data in this metric.

--- a/lib/vector-core/src/event/metric/series.rs
+++ b/lib/vector-core/src/event/metric/series.rs
@@ -41,8 +41,8 @@ impl MetricSeries {
     /// Sets or updates the string value of a tag.
     ///
     /// *Note:* This will create the tags map if it is not present.
-    pub fn insert_tag(&mut self, key: String, value: String) -> Option<String> {
-        (self.tags.get_or_insert_with(Default::default)).insert(key, value)
+    pub fn replace_tag(&mut self, key: String, value: String) -> Option<String> {
+        (self.tags.get_or_insert_with(Default::default)).replace(key, value)
     }
 
     /// Removes all the tags.

--- a/lib/vector-core/src/event/metric/series.rs
+++ b/lib/vector-core/src/event/metric/series.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use vector_common::byte_size_of::ByteSizeOf;
 use vector_config::configurable_component;
 
-use super::{write_list, write_word, MetricTags};
+use super::{write_list, write_word, MetricTags, TagValue};
 
 /// Metrics series.
 #[configurable_component]
@@ -41,7 +41,7 @@ impl MetricSeries {
     /// Sets or updates the string value of a tag.
     ///
     /// *Note:* This will create the tags map if it is not present.
-    pub fn replace_tag(&mut self, key: String, value: String) -> Option<String> {
+    pub fn replace_tag(&mut self, key: String, value: impl Into<TagValue>) -> Option<String> {
         (self.tags.get_or_insert_with(Default::default)).replace(key, value)
     }
 

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -18,6 +18,12 @@ pub enum TagValue {
     Value(#[configurable(transparent)] String),
 }
 
+impl From<String> for TagValue {
+    fn from(value: String) -> Self {
+        Self::Value(value)
+    }
+}
+
 impl From<Option<String>> for TagValue {
     fn from(value: Option<String>) -> Self {
         match value {
@@ -445,9 +451,9 @@ impl MetricTags {
         self.0.get(name).and_then(TagValueSet::as_single)
     }
 
-    pub fn replace(&mut self, name: String, value: String) -> Option<String> {
+    pub fn replace(&mut self, name: String, value: impl Into<TagValue>) -> Option<String> {
         self.0
-            .insert(name, TagValueSet::from([value]))
+            .insert(name, TagValueSet::from([value.into()]))
             .and_then(TagValueSet::into_single)
     }
 

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -445,7 +445,7 @@ impl MetricTags {
         self.0.get(name).and_then(TagValueSet::as_single)
     }
 
-    pub fn insert(&mut self, name: String, value: String) -> Option<String> {
+    pub fn replace(&mut self, name: String, value: String) -> Option<String> {
         self.0
             .insert(name, TagValueSet::from([value]))
             .and_then(TagValueSet::into_single)

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -451,6 +451,13 @@ impl MetricTags {
         self.0.get(name).and_then(TagValueSet::as_single)
     }
 
+    /// Add a value to a tag. This does not replace any existing tags unless the value is a
+    /// duplicate.
+    pub fn insert(&mut self, name: String, value: impl Into<TagValue>) {
+        self.0.entry(name).or_default().insert(value.into());
+    }
+
+    /// Replace all the values of a tag with a single value.
     pub fn replace(&mut self, name: String, value: impl Into<TagValue>) -> Option<String> {
         self.0
             .insert(name, TagValueSet::from([value.into()]))

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -477,7 +477,7 @@ impl Arbitrary for MetricSeries {
             for _ in 0..(usize::arbitrary(g) % MAX_MAP_SIZE) {
                 let key = String::from(Name::arbitrary(g));
                 let value = String::from(Name::arbitrary(g));
-                map.insert(key, value);
+                map.replace(key, value);
             }
             if map.is_empty() {
                 None

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -193,7 +193,7 @@ impl vrl_lib::Target for VrlTarget {
 
                                 metric.remove_tags();
                                 for (field, value) in &value {
-                                    metric.insert_tag(
+                                    metric.replace_tag(
                                         field.as_str().to_owned(),
                                         value
                                             .try_bytes_utf8_lossy()
@@ -204,7 +204,7 @@ impl vrl_lib::Target for VrlTarget {
                             }
                             ["tags", field] => {
                                 let value = value.clone().try_bytes().map_err(|e| e.to_string())?;
-                                metric.insert_tag(
+                                metric.replace_tag(
                                     (*field).to_owned(),
                                     String::from_utf8_lossy(&value).into_owned(),
                                 );

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -120,9 +120,9 @@ impl SinkConfig for InfluxDbLogsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let measurement = self.get_measurement()?;
         let mut tags: HashSet<String> = self.tags.clone().into_iter().collect();
-        tags.insert(log_schema().host_key().to_string());
-        tags.insert(log_schema().source_type_key().to_string());
-        tags.insert("metric_type".to_string());
+        tags.replace(log_schema().host_key().to_string());
+        tags.replace(log_schema().source_type_key().to_string());
+        tags.replace("metric_type".to_string());
 
         let tls_settings = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(tls_settings, cx.proxy())?;
@@ -204,7 +204,7 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
         let mut fields: HashMap<String, Field> = HashMap::new();
         log.convert_to_fields().for_each(|(key, value)| {
             if self.tags.contains(&key) {
-                tags.insert(key, value.to_string_lossy().into_owned());
+                tags.replace(key, value.to_string_lossy().into_owned());
             } else {
                 fields.insert(key, to_field(value));
             }

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -278,7 +278,7 @@ fn encode_events(
         let (metric_type, fields) = get_type_and_fields(event.value(), quantiles);
 
         let mut unwrapped_tags = tags.unwrap_or_default();
-        unwrapped_tags.insert("metric_type".to_owned(), metric_type.to_owned());
+        unwrapped_tags.replace("metric_type".to_owned(), metric_type.to_owned());
 
         if let Err(error_message) = influx_line_protocol(
             protocol_version,

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -334,9 +334,9 @@ impl TimeSeries {
         // label for the actual metric name. For convenience below, an
         // optional extra tag is added.
         let mut labels = tags.cloned().unwrap_or_default();
-        labels.insert(METRIC_NAME_LABEL.into(), [name, suffix].join(""));
+        labels.replace(METRIC_NAME_LABEL.into(), [name, suffix].join(""));
         if let Some((name, value)) = extra {
-            labels.insert(name.into(), value);
+            labels.replace(name.into(), value);
         }
 
         // Extract the labels into a vec and sort to produce a

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -266,14 +266,14 @@ fn encode_events(
 
         // Authentication in Sematext is by inserting the token as a tag.
         let mut tags = series.tags.unwrap_or_default();
-        tags.replace("token".into(), token.into());
+        tags.replace("token".into(), token.to_string());
         let (metric_type, fields) = match data.value {
             MetricValue::Counter { value } => ("counter", to_fields(label, value)),
             MetricValue::Gauge { value } => ("gauge", to_fields(label, value)),
             _ => unreachable!(), // handled by SematextMetricNormalize
         };
 
-        tags.replace("metric_type".into(), metric_type.into());
+        tags.replace("metric_type".into(), metric_type.to_string());
 
         if let Err(error) = influx_line_protocol(
             ProtocolVersion::V1,

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -266,14 +266,14 @@ fn encode_events(
 
         // Authentication in Sematext is by inserting the token as a tag.
         let mut tags = series.tags.unwrap_or_default();
-        tags.insert("token".into(), token.into());
+        tags.replace("token".into(), token.into());
         let (metric_type, fields) = match data.value {
             MetricValue::Counter { value } => ("counter", to_fields(label, value)),
             MetricValue::Gauge { value } => ("gauge", to_fields(label, value)),
             _ => unreachable!(), // handled by SematextMetricNormalize
         };
 
-        tags.insert("metric_type".into(), metric_type.into());
+        tags.replace("metric_type".into(), metric_type.into());
 
         if let Err(error) = influx_line_protocol(
             ProtocolVersion::V1,

--- a/src/sinks/util/buffer/metrics/split.rs
+++ b/src/sinks/util/buffer/metrics/split.rs
@@ -154,7 +154,7 @@ impl MetricSplit for AggregatedSummarySplitter {
                 for quantile in quantiles {
                     let mut quantile_series = series.clone();
                     quantile_series
-                        .insert_tag(String::from("quantile"), quantile.to_quantile_string());
+                        .replace_tag(String::from("quantile"), quantile.to_quantile_string());
                     let quantile_data = MetricData::from_parts(
                         time,
                         kind,

--- a/src/sources/apache_metrics/parser.rs
+++ b/src/sources/apache_metrics/parser.rs
@@ -209,7 +209,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("type".to_string(), "user".to_string());
+                    tags.replace("type".to_string(), "user".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -224,7 +224,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("type".to_string(), "system".to_string());
+                    tags.replace("type".to_string(), "system".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -239,7 +239,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("type".to_string(), "children_user".to_string());
+                    tags.replace("type".to_string(), "children_user".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -254,7 +254,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("type".to_string(), "children_system".to_string());
+                    tags.replace("type".to_string(), "children_system".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -282,7 +282,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("state".to_string(), "idle".to_string());
+                    tags.replace("state".to_string(), "idle".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -299,7 +299,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("state".to_string(), "busy".to_string());
+                    tags.replace("state".to_string(), "busy".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -315,7 +315,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("state".to_string(), "total".to_string());
+                    tags.replace("state".to_string(), "total".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -331,7 +331,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("state".to_string(), "writing".to_string());
+                    tags.replace("state".to_string(), "writing".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -347,7 +347,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("state".to_string(), "closing".to_string());
+                    tags.replace("state".to_string(), "closing".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -363,7 +363,7 @@ fn line_to_metrics<'a>(
                 .with_namespace(namespace.map(str::to_string))
                 .with_tags({
                     let mut tags = tags.cloned().unwrap_or_default();
-                    tags.insert("state".to_string(), "keepalive".to_string());
+                    tags.replace("state".to_string(), "keepalive".to_string());
                     Some(tags)
                 })
                 .with_timestamp(Some(now)),
@@ -415,7 +415,7 @@ fn score_to_metric(
     .with_namespace(namespace.map(str::to_string))
     .with_tags({
         let mut tags = tags.cloned().unwrap_or_default();
-        tags.insert("state".to_string(), state.to_string());
+        tags.replace("state".to_string(), state.to_string());
         Some(tags)
     })
     .with_timestamp(Some(now))

--- a/src/sources/aws_ecs_metrics/parser.rs
+++ b/src/sources/aws_ecs_metrics/parser.rs
@@ -154,8 +154,8 @@ fn gauge(
 
 fn blkio_tags(item: &BlockIoStat, tags: &MetricTags) -> MetricTags {
     let mut tags = tags.clone();
-    tags.insert("device".into(), format!("{}:{}", item.major, item.minor));
-    tags.insert("op".into(), item.op.to_lowercase());
+    tags.replace("device".into(), format!("{}:{}", item.major, item.minor));
+    tags.replace("op".into(), item.op.to_lowercase());
     tags
 }
 
@@ -344,7 +344,7 @@ fn cpu_metrics(
             metrics.extend((0..online_cpus).filter_map(|index| {
                 percpu_usage.get(index).map(|value| {
                     let mut tags = tags.clone();
-                    tags.insert("cpu".into(), index.to_string());
+                    tags.replace("cpu".into(), index.to_string());
 
                     counter(
                         "cpu",
@@ -478,7 +478,7 @@ fn network_metrics(
     tags: &MetricTags,
 ) -> Vec<Metric> {
     let mut tags = tags.clone();
-    tags.insert("device".into(), interface.into());
+    tags.replace("device".into(), interface.into());
 
     [
         ("receive_bytes_total", network.rx_bytes),
@@ -514,9 +514,9 @@ pub(super) fn parse(
 
     for (id, container) in parsed {
         let mut tags = MetricTags::default();
-        tags.insert("container_id".into(), id);
+        tags.replace("container_id".into(), id);
         if let Some(name) = container.name {
-            tags.insert("container_name".into(), name);
+            tags.replace("container_name".into(), name);
         }
 
         if let Some(blkio) = container.blkio_stats {

--- a/src/sources/aws_ecs_metrics/parser.rs
+++ b/src/sources/aws_ecs_metrics/parser.rs
@@ -478,7 +478,7 @@ fn network_metrics(
     tags: &MetricTags,
 ) -> Vec<Metric> {
     let mut tags = tags.clone();
-    tags.replace("device".into(), interface.into());
+    tags.replace("device".into(), interface.to_string());
 
     [
         ("receive_bytes_total", network.rx_bytes),

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -260,14 +260,14 @@ pub(crate) fn decode_ddseries_v2(
                 // As per https://github.com/DataDog/datadog-agent/blob/a62ac9fb13e1e5060b89e731b8355b2b20a07c5b/pkg/serializer/internal/metrics/iterable_series.go#L180-L189
                 // the hostname can be found in MetricSeries::resources and that is the only value stored there.
                 if r.r#type.eq("host") {
-                    tags.insert(log_schema().host_key().to_string(), r.name);
+                    tags.replace(log_schema().host_key().to_string(), r.name);
                 } else {
                     // But to avoid losing information if this situation changes, any other resource type/name will be saved in the tags map
-                    tags.insert(format!("resource.{}", r.r#type), r.name);
+                    tags.replace(format!("resource.{}", r.r#type), r.name);
                 }
             });
             (!serie.source_type_name.is_empty())
-                .then(|| tags.insert("source_type_name".into(), serie.source_type_name));
+                .then(|| tags.replace("source_type_name".into(), serie.source_type_name));
             // As per https://github.com/DataDog/datadog-agent/blob/a62ac9fb13e1e5060b89e731b8355b2b20a07c5b/pkg/serializer/internal/metrics/iterable_series.go#L224
             // serie.unit is omitted
             match metric_payload::MetricType::from_i32(serie.r#type) {
@@ -404,13 +404,13 @@ fn into_vector_metric(
 
     dd_metric
         .host
-        .and_then(|host| tags.insert(log_schema().host_key().to_owned(), host));
+        .and_then(|host| tags.replace(log_schema().host_key().to_owned(), host));
     dd_metric
         .source_type_name
-        .and_then(|source| tags.insert("source_type_name".into(), source));
+        .and_then(|source| tags.replace("source_type_name".into(), source));
     dd_metric
         .device
-        .and_then(|dev| tags.insert("device".into(), dev));
+        .and_then(|dev| tags.replace("device".into(), dev));
 
     let (namespace, name) = namespace_name_from_dd_metric(&dd_metric.metric);
 
@@ -503,7 +503,7 @@ pub(crate) fn decode_ddsketch(
         .flat_map(|sketch_series| {
             // sketch_series.distributions is also always empty from payload coming from dd agents
             let mut tags = into_metric_tags(sketch_series.tags);
-            tags.insert(
+            tags.replace(
                 log_schema().host_key().to_string(),
                 sketch_series.host.clone(),
             );

--- a/src/sources/eventstoredb_metrics/types.rs
+++ b/src/sources/eventstoredb_metrics/types.rs
@@ -19,7 +19,7 @@ impl Stats {
         let now = chrono::Utc::now();
         let namespace = namespace.unwrap_or_else(|| "eventstoredb".to_string());
 
-        tags.insert("id".to_string(), self.proc.id.to_string());
+        tags.replace("id".to_string(), self.proc.id.to_string());
 
         result.push(
             Metric::new(
@@ -100,7 +100,7 @@ impl Stats {
         );
 
         if let Some(drive) = self.sys.drive.as_ref() {
-            tags.insert("path".to_string(), drive.path.clone());
+            tags.replace("path".to_string(), drive.path.clone());
 
             result.push(
                 Metric::new(

--- a/src/sources/host_metrics/filesystem.rs
+++ b/src/sources/host_metrics/filesystem.rs
@@ -89,7 +89,7 @@ impl HostMetrics {
                         "mountpoint" => partition.mount_point().to_string_lossy()
                     };
                     if let Some(device) = partition.device() {
-                        tags.replace("device".into(), device.to_string_lossy().into());
+                        tags.replace("device".into(), device.to_string_lossy().to_string());
                     }
                     output.gauge(
                         "filesystem_free_bytes",

--- a/src/sources/host_metrics/filesystem.rs
+++ b/src/sources/host_metrics/filesystem.rs
@@ -89,7 +89,7 @@ impl HostMetrics {
                         "mountpoint" => partition.mount_point().to_string_lossy()
                     };
                     if let Some(device) = partition.device() {
-                        tags.insert("device".into(), device.to_string_lossy().into());
+                        tags.replace("device".into(), device.to_string_lossy().into());
                     }
                     output.gauge(
                         "filesystem_free_bytes",

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -318,9 +318,9 @@ impl MetricsBuffer {
     }
 
     fn tags(&self, mut tags: MetricTags) -> MetricTags {
-        tags.insert("collector".into(), self.name.into());
+        tags.replace("collector".into(), self.name.into());
         if let Some(host) = &self.host {
-            tags.insert("host".into(), host.clone());
+            tags.replace("host".into(), host.clone());
         }
         tags
     }

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -318,7 +318,7 @@ impl MetricsBuffer {
     }
 
     fn tags(&self, mut tags: MetricTags) -> MetricTags {
-        tags.replace("collector".into(), self.name.into());
+        tags.replace("collector".into(), self.name.to_string());
         if let Some(host) = &self.host {
             tags.replace("host".into(), host.clone());
         }

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -214,7 +214,7 @@ impl HttpClientContext {
                     );
                 }
                 Event::Metric(ref mut metric) => {
-                    metric.insert_tag(
+                    metric.replace_tag(
                         log_schema().source_type_key().to_string(),
                         HttpClientConfig::NAME.to_string(),
                     );

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -144,11 +144,11 @@ impl<'a> InternalMetrics<'a> {
 
                 if let Some(host_key) = &self.host_key {
                     if let Ok(hostname) = &hostname {
-                        metric.insert_tag(host_key.to_owned(), hostname.to_owned());
+                        metric.replace_tag(host_key.to_owned(), hostname.to_owned());
                     }
                 }
                 if let Some(pid_key) = &self.pid_key {
-                    metric.insert_tag(pid_key.to_owned(), pid.clone());
+                    metric.replace_tag(pid_key.to_owned(), pid.clone());
                 }
                 metric
             });

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -36,7 +36,7 @@ macro_rules! tags {
         {
             let mut tags = $tags.clone();
             $(
-                tags.insert($key.into(), $value.into());
+                tags.replace($key.into(), $value.into());
             )*
             tags
         }

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -36,7 +36,7 @@ macro_rules! tags {
         {
             let mut tags = $tags.clone();
             $(
-                tags.replace($key.into(), $value.into());
+                tags.replace($key.into(), $value.to_string());
             )*
             tags
         }

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -37,7 +37,7 @@ macro_rules! tags {
         {
             let mut tags = $tags.clone();
             $(
-                tags.replace($key.into(), $value.into());
+                tags.replace($key.into(), String::from($value));
             )*
             tags
         }

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -37,7 +37,7 @@ macro_rules! tags {
         {
             let mut tags = $tags.clone();
             $(
-                tags.insert($key.into(), $value.into());
+                tags.replace($key.into(), $value.into());
             )*
             tags
         }

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -229,12 +229,12 @@ impl HttpClientContext for PrometheusScrapeContext {
                     {
                         match (honor_label, metric.tag_value(tag)) {
                             (false, Some(old_instance)) => {
-                                metric.insert_tag(format!("exported_{}", tag), old_instance);
-                                metric.insert_tag(tag.clone(), instance.clone());
+                                metric.replace_tag(format!("exported_{}", tag), old_instance);
+                                metric.replace_tag(tag.clone(), instance.clone());
                             }
                             (true, Some(_)) => {}
                             (_, None) => {
-                                metric.insert_tag(tag.clone(), instance.clone());
+                                metric.replace_tag(tag.clone(), instance.clone());
                             }
                         }
                     }
@@ -246,12 +246,12 @@ impl HttpClientContext for PrometheusScrapeContext {
                     {
                         match (honor_label, metric.tag_value(tag)) {
                             (false, Some(old_endpoint)) => {
-                                metric.insert_tag(format!("exported_{}", tag), old_endpoint);
-                                metric.insert_tag(tag.clone(), endpoint.clone());
+                                metric.replace_tag(format!("exported_{}", tag), old_endpoint);
+                                metric.replace_tag(tag.clone(), endpoint.clone());
                             }
                             (true, Some(_)) => {}
                             (_, None) => {
-                                metric.insert_tag(tag.clone(), endpoint.clone());
+                                metric.replace_tag(tag.clone(), endpoint.clone());
                             }
                         }
                     }

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -279,7 +279,7 @@ impl Ec2MetadataTransform {
             }
             Event::Metric(ref mut metric) => {
                 state.iter().for_each(|(k, v)| {
-                    metric.insert_tag(k.metric_tag.clone(), String::from_utf8_lossy(v).to_string());
+                    metric.replace_tag(k.metric_tag.clone(), String::from_utf8_lossy(v).to_string());
                 });
             }
             Event::Trace(_) => panic!("Traces are not supported."),
@@ -864,7 +864,7 @@ mod integration_tests {
             let metric = make_metric();
             let mut expected_metric = metric.clone();
             for (k, v) in expected_metric_fields().iter() {
-                expected_metric.insert_tag(k.to_string(), v.to_string());
+                expected_metric.replace_tag(k.to_string(), v.to_string());
             }
 
             tx.send(metric.into()).await.unwrap();
@@ -930,8 +930,8 @@ mod integration_tests {
 
             let metric = make_metric();
             let mut expected_metric = metric.clone();
-            expected_metric.insert_tag(PUBLIC_IPV4_KEY.to_string(), "192.1.1.1".to_string());
-            expected_metric.insert_tag(REGION_KEY.to_string(), "us-east-1".to_string());
+            expected_metric.replace_tag(PUBLIC_IPV4_KEY.to_string(), "192.1.1.1".to_string());
+            expected_metric.replace_tag(REGION_KEY.to_string(), "us-east-1".to_string());
 
             tx.send(metric.into()).await.unwrap();
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -184,7 +184,7 @@ fn render_tags(
             for (name, template) in tags {
                 match render_template(template, event) {
                     Ok(tag) => {
-                        map.insert(name.to_string(), tag);
+                        map.replace(name.to_string(), tag);
                     }
                     Err(TransformError::TemplateRenderingError(error)) => {
                         emit!(crate::internal_events::TemplateRenderingError {

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -449,16 +449,16 @@ where
             },
             Event::Metric(ref mut metric) => {
                 let m = log_schema().metadata_key();
-                metric.insert_tag(format!("{}.dropped.reason", m), reason.into());
-                metric.insert_tag(
+                metric.replace_tag(format!("{}.dropped.reason", m), reason.into());
+                metric.replace_tag(
                     format!("{}.dropped.component_id", m),
                     self.component_key
                         .as_ref()
                         .map(ToString::to_string)
                         .unwrap_or_else(String::new),
                 );
-                metric.insert_tag(format!("{}.dropped.component_type", m), "remap".into());
-                metric.insert_tag(format!("{}.dropped.component_kind", m), "transform".into());
+                metric.replace_tag(format!("{}.dropped.component_type", m), "remap".into());
+                metric.replace_tag(format!("{}.dropped.component_kind", m), "transform".into());
             }
             Event::Trace(ref mut trace) => {
                 trace.insert(
@@ -991,7 +991,7 @@ mod tests {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 1.0 },
             );
-            metric.insert_tag("hello".into(), "world".into());
+            metric.replace_tag("hello".into(), "world".into());
             Event::Metric(metric)
         };
 
@@ -1001,7 +1001,7 @@ mod tests {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 1.0 },
             );
-            metric.insert_tag("hello".into(), "goodbye".into());
+            metric.replace_tag("hello".into(), "goodbye".into());
             Event::Metric(metric)
         };
 
@@ -1011,7 +1011,7 @@ mod tests {
                 MetricKind::Absolute,
                 MetricValue::Counter { value: 1.0 },
             );
-            metric.insert_tag("not_hello".into(), "oops".into());
+            metric.replace_tag("not_hello".into(), "oops".into());
             Event::Metric(metric)
         };
 


### PR DESCRIPTION
The existing tag value `insert` function actually does a `replace`. As we need to be able to insert values to multi-valued tags separate from replacing the whole tag set, this needs to be split up into separate operations, which is what this change does.

Epic: #14742 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
