### PR TITLE
chore(core): allow protobuf building on >=3.12 for vector-core

### DIFF
--- a/lib/vector-core/build.rs
+++ b/lib/vector-core/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     println!("cargo:rerun-if-changed=proto/event.proto");
     prost_build::Config::new()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .btree_map(&["."])
         .bytes(&["raw_bytes"])
         .compile_protos(&["proto/event.proto"], &["proto", "../../proto"])


### PR DESCRIPTION
Follow-up to  #15367

, the same flag needs to be added to the `build.rs` for `vector-core`.

Manually tested using `make build-dev`