### PR TITLE
fix(gcp_pubsub source): change InsertIfEmpty to Overwrite

### DIFF
--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -318,14 +318,14 @@ impl SourceConfig for PubsubConfig {
             )
             .with_source_metadata(
                 PubsubConfig::NAME,
-                Some(LegacyKey::InsertIfEmpty(owned_value_path!("attributes"))),
+                Some(LegacyKey::Overwrite(owned_value_path!("attributes"))),
                 &owned_value_path!("attributes"),
                 Kind::object(Collection::empty().with_unknown(Kind::bytes())),
                 None,
             )
             .with_source_metadata(
                 PubsubConfig::NAME,
-                Some(LegacyKey::InsertIfEmpty(owned_value_path!("message_id"))),
+                Some(LegacyKey::Overwrite(owned_value_path!("message_id"))),
                 &owned_value_path!("message_id"),
                 Kind::bytes(),
                 None,
@@ -664,14 +664,14 @@ impl PubsubSource {
                 log_namespace.insert_source_metadata(
                     PubsubConfig::NAME,
                     log,
-                    Some(LegacyKey::InsertIfEmpty("message_id")),
+                    Some(LegacyKey::Overwrite("message_id")),
                     "message_id",
                     message.message_id.clone(),
                 );
                 log_namespace.insert_source_metadata(
                     PubsubConfig::NAME,
                     log,
-                    Some(LegacyKey::InsertIfEmpty("attributes")),
+                    Some(LegacyKey::Overwrite("attributes")),
                     "attributes",
                     attributes.clone(),
                 )


### PR DESCRIPTION
I missed [this comment](https://github.com/vectordotdev/vector/pull/15354/files#r1033803159) so this is rectifying it.

As far as I am aware, this won't change the functionality for the source, since that field should only be written to once, but it does mean we avoid the unnecessary check to see if it already exists.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

