### PR TITLE
fix(datadog_archives sink): align object prefixes with DD rehydration

### DIFF
--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -760,7 +760,7 @@ fn generate_object_key(key_prefix: Option<String>, partition_key: String) -> Str
     let filename = Uuid::new_v4().to_string();
 
     format!(
-        "{}/{}{}.{}",
+        "{}/{}/archive_{}.{}",
         key_prefix.unwrap_or_default(),
         partition_key,
         filename,

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -103,6 +103,7 @@ use crate::config::{
     unit_test::{UnitTestSinkConfig, UnitTestStreamSinkConfig},
     AcknowledgementsConfig, Resource, SinkConfig, SinkContext,
 };
+use crate::sinks::datadog_archives::DatadogArchivesSinkConfig;
 
 pub type Healthcheck = BoxFuture<'static, crate::Result<()>>;
 
@@ -189,6 +190,10 @@ pub enum Sinks {
     /// Console.
     #[cfg(feature = "sinks-console")]
     Console(#[configurable(derived)] console::ConsoleSinkConfig),
+
+    /// Datadog Archives.
+    #[cfg(feature = "sinks-datadog_archives")]
+    DatadogArchives(#[configurable(derived)] DatadogArchivesSinkConfig),
 
     /// Datadog Events.
     #[cfg(feature = "sinks-datadog_events")]
@@ -398,6 +403,8 @@ impl NamedComponent for Sinks {
             Self::Clickhouse(config) => config.get_component_name(),
             #[cfg(feature = "sinks-console")]
             Self::Console(config) => config.get_component_name(),
+            #[cfg(feature = "sinks-datadog_archives")]
+            Self::DatadogArchives(config) => config.get_component_name(),
             #[cfg(feature = "sinks-datadog_events")]
             Self::DatadogEvents(config) => config.get_component_name(),
             #[cfg(feature = "sinks-datadog_logs")]


### PR DESCRIPTION
DD rehydration feature expects objects to be prefixed with `archive_`. 
This PR aligns object prefixes and also re-adds `datadog_archives` sink to the list of available sinks.