### PR TITLE
docs(docker_logs source): Fix example log in docs

### DIFF
--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -312,11 +312,11 @@ components: sources: docker_logs: {
 					type: timestamp: {}
 				}
 				host: fields._local_host
-				"*": {
+				label: {
 					description: "Each container label is inserted with it's exact key/value pair."
 					required:    true
-					type: string: {
-						examples: ["Started GET / for 127.0.0.1 at 2012-03-10 14:28:14 +0100"]
+					type: object: {
+						examples: [{"mylabel": "myvalue"}]
 					}
 				}
 			}


### PR DESCRIPTION
While adding log namespace support I noticed this enrichment wasn't represented correctly in the documentation. The path was wrong, and the example was a copied from teh message example.

```rust
            // Labels.
            if !self.metadata.labels.is_empty() {
                for (key, value) in self.metadata.labels.iter() {
                    log_event.insert(
                        (PathPrefix::Event, path!("label").concat(path!(key))),
                        value.clone(),
                    );
                }
            }
```
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
