### PR TITLE
feat(loki): add Loki source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,6 +471,7 @@ sources-logs = [
   "sources-kafka",
   "sources-kubernetes_logs",
   "sources-logstash",
+  "sources-loki",
   "sources-nats",
   "sources-opentelemetry",
   "sources-file-descriptor",
@@ -521,6 +522,7 @@ sources-journald = []
 sources-kafka = ["dep:rdkafka"]
 sources-kubernetes_logs = ["dep:file-source", "kubernetes", "transforms-reduce"]
 sources-logstash = ["sources-utils-net-tcp", "tokio-util/net"]
+sources-loki = []
 sources-mongodb_metrics = ["dep:mongodb"]
 sources-nats = ["dep:nats", "dep:nkeys"]
 sources-nginx_metrics = ["dep:nom"]

--- a/src/sources/loki/config.rs
+++ b/src/sources/loki/config.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+
+use futures::future::FutureExt;
+use vector_config::configurable_component;
+use vector_core::config::{LogNamespace, Output};
+
+use super::{healthcheck::healthcheck, sink::LokiSink};
+use crate::{
+    codecs::EncodingConfig,
+    config::{DataType, GenerateConfig, Input, SourceContext},
+    http::{Auth, HttpClient, MaybeAuth},
+    template::Template,
+    tls::{TlsConfig, TlsSettings},
+};
+use crate::config::SourceConfig;
+
+fn default_loki_path() -> String {
+    "/loki/api/v1/tail".to_string()
+}
+
+/// Configuration for the `loki` sink.
+#[configurable_component(source("loki"))]
+#[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct LokiSourceConfig {
+    /// The base URL of the Loki instance.
+    ///
+    /// Vector will append the value of `path` to this.
+    pub endpoint: String,
+
+    /// The path to use in the URL of the Loki instance.
+    ///
+    /// By default, `"/loki/api/v1/tail"` is used.
+    #[serde(default = "default_loki_path")]
+    pub path: String,
+
+    /// A set of labels that are attached to each batch of events.
+    ///
+    /// Both keys and values are templateable, which enables you to attach dynamic labels to events.
+    ///
+    /// Labels can be suffixed with a “*” to allow the expansion of objects into multiple labels,
+    /// see “How it works” for more information.
+    ///
+    /// Note: If the set of labels has high cardinality, this can cause drastic performance issues
+    /// with Loki. To prevent this from happening, reduce the number of unique label keys and
+    /// values.
+    pub labels: HashMap<Template, Template>,
+
+    /// Whether or not to delete fields from the event when they are used as labels.
+    #[serde(default = "crate::serde::default_false")]
+    pub remove_label_fields: bool,
+
+    /// Whether or not to remove the timestamp from the event payload.
+    ///
+    /// The timestamp will still be sent as event metadata for Loki to use for indexing.
+    #[serde(default = "crate::serde::default_true")]
+    pub remove_timestamp: bool,
+
+    #[configurable(derived)]
+    pub auth: Option<Auth>,
+
+    #[configurable(derived)]
+    pub tls: Option<TlsConfig>,
+}
+
+impl GenerateConfig for LokiSourceConfig {
+    fn generate_config() -> toml::Value {
+        toml::from_str(
+            r#"endpoint = "ws://localhost:3100"
+            labels = {}"#,
+        )
+            .unwrap()
+    }
+}
+
+impl LokiSourceConfig {
+    pub(super) fn build_client(&self, cx: &SourceContext) -> crate::Result<HttpClient> {
+        let tls = TlsSettings::from_options(&self.tls)?;
+        let client = HttpClient::new(tls, &cx.proxy)?;
+        Ok(client)
+    }
+}
+
+#[async_trait::async_trait]
+impl SourceConfig for LokiSourceConfig {
+    async fn build(
+        &self,
+        cx: SourceContext,
+    ) -> crate::Result<vector_core::source::Source> {
+        if self.labels.is_empty() {
+            return Err("`labels` must include at least one label.".into());
+        }
+
+        for label in self.labels.keys() {
+            if !valid_label_name(label) {
+                return Err(format!("Invalid label name {:?}", label.get_ref()).into());
+            }
+        }
+
+        let client = self.build_client(&cx)?;
+
+        //let healthcheck = healthcheck(config, client).boxed();
+
+        Ok(Box::pin(super::source::loki_source(
+            &self,
+            client,
+            cx.shutdown,
+            cx.out,
+        )))
+    }
+
+    fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<Output> {
+        vec![Output::default(DataType::Log)]
+    }
+
+    fn can_acknowledge(&self) -> bool {
+        false
+    }
+}
+
+pub fn valid_label_name(label: &Template) -> bool {
+    label.is_dynamic() || {
+        // Loki follows prometheus on this https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+        // Although that isn't explicitly said anywhere besides what's in the code.
+        // The closest mention is in section about Parser Expression https://grafana.com/docs/loki/latest/logql/
+        //
+        // [a-zA-Z_][a-zA-Z0-9_]*
+        //
+        // '*' symbol at the end of the label name will be treated as a prefix for
+        // underlying object keys.
+        let mut label_trim = label.get_ref().trim();
+        if let Some(without_opening_end) = label_trim.strip_suffix('*') {
+            label_trim = without_opening_end
+        }
+
+        let mut label_chars = label_trim.chars();
+        if let Some(ch) = label_chars.next() {
+            (ch.is_ascii_alphabetic() || ch == '_')
+                && label_chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryInto;
+
+    use super::valid_label_name;
+
+    #[test]
+    fn valid_label_names() {
+        assert!(valid_label_name(&"name".try_into().unwrap()));
+        assert!(valid_label_name(&" name ".try_into().unwrap()));
+        assert!(valid_label_name(&"bee_bop".try_into().unwrap()));
+        assert!(valid_label_name(&"a09b".try_into().unwrap()));
+        assert!(valid_label_name(&"abc_*".try_into().unwrap()));
+        assert!(valid_label_name(&"_*".try_into().unwrap()));
+
+        assert!(!valid_label_name(&"0ab".try_into().unwrap()));
+        assert!(!valid_label_name(&"*".try_into().unwrap()));
+        assert!(!valid_label_name(&"".try_into().unwrap()));
+        assert!(!valid_label_name(&" ".try_into().unwrap()));
+
+        assert!(valid_label_name(&"{{field}}".try_into().unwrap()));
+    }
+}

--- a/src/sources/loki/healthcheck.rs
+++ b/src/sources/loki/healthcheck.rs
@@ -1,36 +1,36 @@
-use super::config::LokiSourceConfig;
-use crate::http::HttpClient;
-
-async fn fetch_status(
-    endpoint: &str,
-    config: &LokiConfig,
-    client: &HttpClient,
-) -> crate::Result<http::StatusCode> {
-    let endpoint = config.endpoint.append_path(endpoint)?;
-
-    let mut req = http::Request::get(endpoint.uri)
-        .body(hyper::Body::empty())
-        .expect("Building request never fails.");
-
-    if let Some(auth) = &config.auth {
-        auth.apply(&mut req);
-    }
-
-    Ok(client.send(req).await?.status())
-}
-
-pub async fn healthcheck(config: LokiSourceConfig, client: HttpClient) -> crate::Result<()> {
-    let status = match fetch_status("ready", &config, &client).await? {
-        // Issue https://github.com/vectordotdev/vector/issues/6463
-        http::StatusCode::NOT_FOUND => {
-            debug!("Endpoint `/ready` not found. Retrying healthcheck with top level query.");
-            fetch_status("", &config, &client).await?
-        }
-        status => status,
-    };
-
-    match status {
-        http::StatusCode::OK => Ok(()),
-        _ => Err(format!("A non-successful status returned: {}", status).into()),
-    }
-}
+// use super::config::LokiSourceConfig;
+// use crate::http::HttpClient;
+//
+// async fn fetch_status(
+//     endpoint: &str,
+//     config: &LokiSourceConfig,
+//     client: &HttpClient,
+// ) -> crate::Result<http::StatusCode> {
+//     let endpoint = config.endpoint.append_path(endpoint)?;
+//
+//     let mut req = http::Request::get(endpoint.uri)
+//         .body(hyper::Body::empty())
+//         .expect("Building request never fails.");
+//
+//     if let Some(auth) = &config.auth {
+//         auth.apply(&mut req);
+//     }
+//
+//     Ok(client.send(req).await?.status())
+// }
+//
+// pub async fn healthcheck(config: LokiSourceConfig, client: HttpClient) -> crate::Result<()> {
+//     let status = match fetch_status("ready", &config, &client).await? {
+//         // Issue https://github.com/vectordotdev/vector/issues/6463
+//         http::StatusCode::NOT_FOUND => {
+//             debug!("Endpoint `/ready` not found. Retrying healthcheck with top level query.");
+//             fetch_status("", &config, &client).await?
+//         }
+//         status => status,
+//     };
+//
+//     match status {
+//         http::StatusCode::OK => Ok(()),
+//         _ => Err(format!("A non-successful status returned: {}", status).into()),
+//     }
+// }

--- a/src/sources/loki/healthcheck.rs
+++ b/src/sources/loki/healthcheck.rs
@@ -1,0 +1,36 @@
+use super::config::LokiSourceConfig;
+use crate::http::HttpClient;
+
+async fn fetch_status(
+    endpoint: &str,
+    config: &LokiConfig,
+    client: &HttpClient,
+) -> crate::Result<http::StatusCode> {
+    let endpoint = config.endpoint.append_path(endpoint)?;
+
+    let mut req = http::Request::get(endpoint.uri)
+        .body(hyper::Body::empty())
+        .expect("Building request never fails.");
+
+    if let Some(auth) = &config.auth {
+        auth.apply(&mut req);
+    }
+
+    Ok(client.send(req).await?.status())
+}
+
+pub async fn healthcheck(config: LokiSourceConfig, client: HttpClient) -> crate::Result<()> {
+    let status = match fetch_status("ready", &config, &client).await? {
+        // Issue https://github.com/vectordotdev/vector/issues/6463
+        http::StatusCode::NOT_FOUND => {
+            debug!("Endpoint `/ready` not found. Retrying healthcheck with top level query.");
+            fetch_status("", &config, &client).await?
+        }
+        status => status,
+    };
+
+    match status {
+        http::StatusCode::OK => Ok(()),
+        _ => Err(format!("A non-successful status returned: {}", status).into()),
+    }
+}

--- a/src/sources/loki/mod.rs
+++ b/src/sources/loki/mod.rs
@@ -1,0 +1,3 @@
+mod config;
+mod healthcheck;
+mod source;

--- a/src/sources/loki/mod.rs
+++ b/src/sources/loki/mod.rs
@@ -1,3 +1,5 @@
 mod config;
 mod healthcheck;
 mod source;
+
+pub use config::LokiSourceConfig;

--- a/src/sources/loki/source.rs
+++ b/src/sources/loki/source.rs
@@ -1,0 +1,340 @@
+use std::{
+    fmt::Debug,
+    io,
+    net::SocketAddr,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use futures::{pin_mut, sink::SinkExt, stream::BoxStream, Sink, Stream, StreamExt};
+use snafu::{ResultExt, Snafu};
+use tokio::{net::TcpStream, time};
+use tokio_stream::StreamExt;
+use tokio_tungstenite::{
+    client_async_with_config,
+    tungstenite::{
+        client::{uri_mode, IntoClientRequest},
+        error::{Error as WsError, ProtocolError, UrlError},
+        handshake::client::Request as WsRequest,
+        protocol::{Message, WebSocketConfig},
+        stream::Mode as UriMode,
+    },
+    WebSocketStream as WsStream,
+};
+use tokio_util::codec::Encoder as _;
+use vector_common::shutdown::ShutdownSignal;
+use vector_core::{
+    internal_event::{ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol},
+    ByteSizeOf,
+};
+
+use crate::{codecs::{Encoder, Transformer}, dns, emit, event::{Event, EventStatus, Finalizable}, http::Auth, internal_events::{
+    ConnectionOpen, OpenGauge, WsConnectionError, WsConnectionEstablished,
+    WsConnectionFailedError, WsConnectionShutdown,
+}, SourceSender, tls::{MaybeTlsSettings, MaybeTlsStream, TlsError}};
+use crate::http::HttpClient;
+use crate::sources::loki::config::LokiSourceConfig;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum WebSocketError {
+    #[snafu(display("Creating WebSocket client failed: {}", source))]
+    CreateFailed { source: WsError },
+    #[snafu(display("Connect error: {}", source))]
+    ConnectError { source: TlsError },
+    #[snafu(display("Unable to resolve DNS: {}", source))]
+    DnsError { source: dns::DnsError },
+    #[snafu(display("No addresses returned."))]
+    NoAddresses,
+}
+
+#[derive(Clone)]
+pub struct WebSocketConnector {
+    uri: String,
+    host: String,
+    port: u16,
+    tls: MaybeTlsSettings,
+    auth: Option<Auth>,
+}
+
+impl WebSocketConnector {
+    pub fn new(
+        uri: String,
+        tls: MaybeTlsSettings,
+        auth: Option<Auth>,
+    ) -> Result<Self, WebSocketError> {
+        let request = (&uri).into_client_request().context(CreateFailedSnafu)?;
+        let (host, port) = Self::extract_host_and_port(&request).context(CreateFailedSnafu)?;
+
+        Ok(Self {
+            uri,
+            host,
+            port,
+            tls,
+            auth,
+        })
+    }
+
+    fn extract_host_and_port(request: &WsRequest) -> Result<(String, u16), WsError> {
+        let host = request
+            .uri()
+            .host()
+            .ok_or(WsError::Url(UrlError::NoHostName))?
+            .to_string();
+        let mode = uri_mode(request.uri())?;
+        let port = request.uri().port_u16().unwrap_or(match mode {
+            UriMode::Tls => 443,
+            UriMode::Plain => 80,
+        });
+
+        Ok((host, port))
+    }
+
+    const fn fresh_backoff() -> ExponentialBackoff {
+        ExponentialBackoff::from_millis(2)
+            .factor(250)
+            .max_delay(Duration::from_secs(60))
+    }
+
+    async fn tls_connect(&self) -> Result<MaybeTlsStream<TcpStream>, WebSocketError> {
+        let ip = dns::Resolver
+            .lookup_ip(self.host.clone())
+            .await
+            .context(DnsSnafu)?
+            .next()
+            .ok_or(WebSocketError::NoAddresses)?;
+
+        let addr = SocketAddr::new(ip, self.port);
+        self.tls
+            .connect(&self.host, &addr)
+            .await
+            .context(ConnectSnafu)
+    }
+
+    async fn connect(&self) -> Result<WsStream<MaybeTlsStream<TcpStream>>, WebSocketError> {
+        let mut request = (&self.uri)
+            .into_client_request()
+            .context(CreateFailedSnafu)?;
+
+        if let Some(auth) = &self.auth {
+            auth.apply(&mut request);
+        }
+
+        let maybe_tls = self.tls_connect().await?;
+
+        let ws_config = WebSocketConfig {
+            max_send_queue: None, // don't buffer messages
+            ..Default::default()
+        };
+
+        let (ws_stream, _response) = client_async_with_config(request, maybe_tls, Some(ws_config))
+            .await
+            .context(CreateFailedSnafu)?;
+
+        Ok(ws_stream)
+    }
+
+    async fn connect_backoff(&self) -> WsStream<MaybeTlsStream<TcpStream>> {
+        let mut backoff = Self::fresh_backoff();
+        loop {
+            match self.connect().await {
+                Ok(ws_stream) => {
+                    emit!(WsConnectionEstablished {});
+                    return ws_stream;
+                }
+                Err(error) => {
+                    emit!(WsConnectionFailedError {
+                        error: Box::new(error)
+                    });
+                    time::sleep(backoff.next().unwrap()).await;
+                }
+            }
+        }
+    }
+
+    pub async fn healthcheck(&self) -> crate::Result<()> {
+        self.connect().await.map(|_| ()).map_err(Into::into)
+    }
+}
+
+struct PingInterval {
+    interval: Option<time::Interval>,
+}
+
+impl PingInterval {
+    fn new(period: Option<u64>) -> Self {
+        Self {
+            interval: period.map(|period| time::interval(Duration::from_secs(period))),
+        }
+    }
+
+    fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<time::Instant> {
+        match self.interval.as_mut() {
+            Some(interval) => interval.poll_tick(cx),
+            None => Poll::Pending,
+        }
+    }
+
+    async fn tick(&mut self) -> time::Instant {
+        std::future::poll_fn(|cx| self.poll_tick(cx)).await
+    }
+}
+
+pub struct LokiSource {
+    connector: WebSocketConnector,
+    ping_interval: Option<u64>,
+    ping_timeout: Option<u64>,
+}
+
+impl LokiSource {
+    pub fn new(config: &LokiSourceConfig, connector: WebSocketConnector) -> crate::Result<Self> {
+        Ok(Self {
+            connector,
+            ping_interval: config.ping_interval.filter(|v| *v > 0),
+            ping_timeout: config.ping_timeout.filter(|v| *v > 0),
+        })
+    }
+
+    async fn create_sink_and_stream(
+        &self,
+    ) -> (
+        impl Sink<Message, Error = WsError>,
+        impl Stream<Item = Result<Message, WsError>>,
+    ) {
+        let ws_stream = self.connector.connect_backoff().await;
+        ws_stream.split()
+    }
+
+    fn check_received_pong_time(&self, last_pong: Instant) -> Result<(), WsError> {
+        if let Some(ping_timeout) = self.ping_timeout {
+            if last_pong.elapsed() > Duration::from_secs(ping_timeout) {
+                return Err(WsError::Io(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "Pong not received in time",
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_events<I, WS, O>(
+        &mut self,
+        input: &mut I,
+        ws_stream: &mut WS,
+        ws_sink: &mut O,
+    ) -> Result<(), ()>
+        where
+            I: Stream<Item = Event> + Unpin,
+            WS: Stream<Item = Result<Message, WsError>> + Unpin,
+            O: Sink<Message, Error = WsError> + Unpin,
+    {
+        const PING: &[u8] = b"PING";
+
+        let mut ping_interval = PingInterval::new(self.ping_interval);
+
+        if let Err(error) = ws_sink.send(Message::Ping(PING.to_vec())).await {
+            emit!(WsConnectionError { error });
+            return Err(());
+        }
+        let mut last_pong = Instant::now();
+
+        let bytes_sent = register!(BytesSent::from(Protocol("websocket".into())));
+
+        loop {
+            let result = tokio::select! {
+                _ = ping_interval.tick() => {
+                    match self.check_received_pong_time(last_pong) {
+                        Ok(()) => ws_sink.send(Message::Ping(PING.to_vec())).await.map(|_| ()),
+                        Err(e) => Err(e)
+                    }
+                },
+
+                Some(msg) = ws_stream.next() => {
+                    // Pongs are sent automatically by tungstenite during reading from the stream.
+                    match msg {
+                        Ok(Message::Pong(_)) => {
+                            last_pong = Instant::now();
+                            Ok(())
+                        },
+                        Ok(_) => Ok(()),
+                        Err(e) => Err(e)
+                    }
+                },
+
+                event = input.next() => {
+                    let mut event = if let Some(event) = event {
+                        event
+                    } else {
+                        break;
+                    };
+
+                    let finalizers = event.take_finalizers();
+
+                    self.transformer.transform(&mut event);
+
+                    let event_byte_size = event.size_of();
+
+                    let mut bytes = BytesMut::new();
+                    let res = match self.encoder.encode(event, &mut bytes) {
+                        Ok(()) => {
+                            finalizers.update_status(EventStatus::Delivered);
+
+                            let message = Message::text(String::from_utf8_lossy(&bytes));
+                            let message_len = message.len();
+
+                            ws_sink.send(message).await.map(|_| {
+                                emit!(EventsSent {
+                                    count: 1,
+                                    byte_size: event_byte_size,
+                                    output: None
+                                });
+                                bytes_sent.emit(ByteSize(message_len));
+                            })
+                        },
+                        Err(_) => {
+                            // Error is handled by `Encoder`.
+                            finalizers.update_status(EventStatus::Errored);
+                            Ok(())
+                        }
+                    };
+
+                    res
+                },
+                else => break,
+            };
+
+            if let Err(error) = result {
+                if is_closed(&error) {
+                    emit!(WsConnectionShutdown);
+                } else {
+                    emit!(WsConnectionError { error });
+                }
+                return Err(());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn build_connector(config: &LokiSourceConfig) -> Result<WebSocketConnector, WebSocketError> {
+    let tls = MaybeTlsSettings::from_config(&config.tls, false).context(ConnectSnafu)?;
+    WebSocketConnector::new(config.uri.clone(), tls, config.auth.clone())
+}
+
+pub async fn loki_source(
+    config: &LokiSourceConfig,
+    http_client: HttpClient,
+    shutdown: ShutdownSignal,
+    mut out: SourceSender,
+) -> Result<(), ()> {
+    let connector = build_connector(config)?;
+
+    let ws_stream = connector.connect_backoff().await;
+    //ws_stream.split()
+    ws_stream
+    Ok(())
+}

--- a/src/sources/loki/source.rs
+++ b/src/sources/loki/source.rs
@@ -6,12 +6,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use async_trait::async_trait;
-use bytes::BytesMut;
-use futures::{pin_mut, sink::SinkExt, stream::BoxStream, Sink, Stream, StreamExt};
+use futures::{sink::SinkExt, Sink, Stream, StreamExt};
 use snafu::{ResultExt, Snafu};
 use tokio::{net::TcpStream, time};
-use tokio_stream::StreamExt;
 use tokio_tungstenite::{
     client_async_with_config,
     tungstenite::{
@@ -23,19 +20,22 @@ use tokio_tungstenite::{
     },
     WebSocketStream as WsStream,
 };
-use tokio_util::codec::Encoder as _;
 use vector_common::shutdown::ShutdownSignal;
-use vector_core::{
-    internal_event::{ByteSize, BytesSent, EventsSent, InternalEventHandle as _, Protocol},
-    ByteSizeOf,
-};
+use vector_core::event::{Event, LogEvent};
+use vector_core::internal_event::{BytesSent, Protocol};
 
-use crate::{codecs::{Encoder, Transformer}, dns, emit, event::{Event, EventStatus, Finalizable}, http::Auth, internal_events::{
-    ConnectionOpen, OpenGauge, WsConnectionError, WsConnectionEstablished,
-    WsConnectionFailedError, WsConnectionShutdown,
-}, SourceSender, tls::{MaybeTlsSettings, MaybeTlsStream, TlsError}};
-use crate::http::HttpClient;
+use crate::internal_events::StreamClosedError;
+use crate::sinks::util::retries::ExponentialBackoff;
 use crate::sources::loki::config::LokiSourceConfig;
+use crate::{
+    dns, emit,
+    http::Auth,
+    internal_events::{
+        WsConnectionError, WsConnectionEstablished, WsConnectionFailedError, WsConnectionShutdown,
+    },
+    tls::{MaybeTlsSettings, MaybeTlsStream, TlsError},
+    SourceSender,
+};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -154,9 +154,9 @@ impl WebSocketConnector {
         }
     }
 
-    pub async fn healthcheck(&self) -> crate::Result<()> {
-        self.connect().await.map(|_| ()).map_err(Into::into)
-    }
+    // pub async fn healthcheck(&self) -> crate::Result<()> {
+    //     self.connect().await.map(|_| ()).map_err(Into::into)
+    // }
 }
 
 struct PingInterval {
@@ -182,159 +182,122 @@ impl PingInterval {
     }
 }
 
-pub struct LokiSource {
-    connector: WebSocketConnector,
-    ping_interval: Option<u64>,
-    ping_timeout: Option<u64>,
-}
-
-impl LokiSource {
-    pub fn new(config: &LokiSourceConfig, connector: WebSocketConnector) -> crate::Result<Self> {
-        Ok(Self {
-            connector,
-            ping_interval: config.ping_interval.filter(|v| *v > 0),
-            ping_timeout: config.ping_timeout.filter(|v| *v > 0),
-        })
-    }
-
-    async fn create_sink_and_stream(
-        &self,
-    ) -> (
-        impl Sink<Message, Error = WsError>,
-        impl Stream<Item = Result<Message, WsError>>,
-    ) {
-        let ws_stream = self.connector.connect_backoff().await;
-        ws_stream.split()
-    }
-
-    fn check_received_pong_time(&self, last_pong: Instant) -> Result<(), WsError> {
-        if let Some(ping_timeout) = self.ping_timeout {
-            if last_pong.elapsed() > Duration::from_secs(ping_timeout) {
-                return Err(WsError::Io(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "Pong not received in time",
-                )));
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn handle_events<I, WS, O>(
-        &mut self,
-        input: &mut I,
-        ws_stream: &mut WS,
-        ws_sink: &mut O,
-    ) -> Result<(), ()>
-        where
-            I: Stream<Item = Event> + Unpin,
-            WS: Stream<Item = Result<Message, WsError>> + Unpin,
-            O: Sink<Message, Error = WsError> + Unpin,
-    {
-        const PING: &[u8] = b"PING";
-
-        let mut ping_interval = PingInterval::new(self.ping_interval);
-
-        if let Err(error) = ws_sink.send(Message::Ping(PING.to_vec())).await {
-            emit!(WsConnectionError { error });
-            return Err(());
-        }
-        let mut last_pong = Instant::now();
-
-        let bytes_sent = register!(BytesSent::from(Protocol("websocket".into())));
-
-        loop {
-            let result = tokio::select! {
-                _ = ping_interval.tick() => {
-                    match self.check_received_pong_time(last_pong) {
-                        Ok(()) => ws_sink.send(Message::Ping(PING.to_vec())).await.map(|_| ()),
-                        Err(e) => Err(e)
-                    }
-                },
-
-                Some(msg) = ws_stream.next() => {
-                    // Pongs are sent automatically by tungstenite during reading from the stream.
-                    match msg {
-                        Ok(Message::Pong(_)) => {
-                            last_pong = Instant::now();
-                            Ok(())
-                        },
-                        Ok(_) => Ok(()),
-                        Err(e) => Err(e)
-                    }
-                },
-
-                event = input.next() => {
-                    let mut event = if let Some(event) = event {
-                        event
-                    } else {
-                        break;
-                    };
-
-                    let finalizers = event.take_finalizers();
-
-                    self.transformer.transform(&mut event);
-
-                    let event_byte_size = event.size_of();
-
-                    let mut bytes = BytesMut::new();
-                    let res = match self.encoder.encode(event, &mut bytes) {
-                        Ok(()) => {
-                            finalizers.update_status(EventStatus::Delivered);
-
-                            let message = Message::text(String::from_utf8_lossy(&bytes));
-                            let message_len = message.len();
-
-                            ws_sink.send(message).await.map(|_| {
-                                emit!(EventsSent {
-                                    count: 1,
-                                    byte_size: event_byte_size,
-                                    output: None
-                                });
-                                bytes_sent.emit(ByteSize(message_len));
-                            })
-                        },
-                        Err(_) => {
-                            // Error is handled by `Encoder`.
-                            finalizers.update_status(EventStatus::Errored);
-                            Ok(())
-                        }
-                    };
-
-                    res
-                },
-                else => break,
-            };
-
-            if let Err(error) = result {
-                if is_closed(&error) {
-                    emit!(WsConnectionShutdown);
-                } else {
-                    emit!(WsConnectionError { error });
-                }
-                return Err(());
-            }
-        }
-
-        Ok(())
-    }
+const fn is_closed(error: &WsError) -> bool {
+    matches!(
+        error,
+        WsError::ConnectionClosed
+            | WsError::AlreadyClosed
+            | WsError::Protocol(ProtocolError::ResetWithoutClosingHandshake)
+    )
 }
 
 fn build_connector(config: &LokiSourceConfig) -> Result<WebSocketConnector, WebSocketError> {
     let tls = MaybeTlsSettings::from_config(&config.tls, false).context(ConnectSnafu)?;
-    WebSocketConnector::new(config.uri.clone(), tls, config.auth.clone())
+    WebSocketConnector::new(config.endpoint.clone(), tls, config.auth.clone())
+}
+
+fn check_received_pong_time(last_pong: Instant) -> Result<(), WsError> {
+    // TODO: make configurable
+    //if let Some(ping_timeout) = self.ping_timeout {
+    if last_pong.elapsed() > Duration::from_secs(60) {
+        return Err(WsError::Io(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "Pong not received in time",
+        )));
+    }
+    //}
+
+    Ok(())
+}
+
+async fn handle_events<WS, O>(
+    ws_stream: &mut WS,
+    ws_sink: &mut O,
+    mut shutdown: ShutdownSignal,
+    mut out: SourceSender,
+) -> Result<(), ()>
+where
+    WS: Stream<Item = Result<Message, WsError>> + Unpin,
+    O: Sink<Message, Error = WsError> + Unpin,
+{
+    const PING: &[u8] = b"PING";
+
+    //TODO: make ping interval configurable
+    let mut ping_interval = PingInterval::new(Some(10u64));
+
+    if let Err(error) = ws_sink.send(Message::Ping(PING.to_vec())).await {
+        emit!(WsConnectionError { error });
+        return Err(());
+    }
+    let mut last_pong = Instant::now();
+
+    let _bytes_sent = register!(BytesSent::from(Protocol("websocket".into())));
+
+    loop {
+        let result = tokio::select! {
+            _ = &mut shutdown => break,
+            _ = ping_interval.tick() => {
+                match check_received_pong_time(last_pong) {
+                    Ok(()) => ws_sink.send(Message::Ping(PING.to_vec())).await.map(|_| ()),
+                    Err(e) => Err(e)
+                }
+            },
+
+            Some(msg) = ws_stream.next() => {
+                // Pongs are sent automatically by tungstenite during reading from the stream.
+                match msg {
+                    Ok(Message::Pong(_)) => {
+                        last_pong = Instant::now();
+                        Ok(())
+                    },
+                    Ok(Message::Text(text)) => {
+                        //TODO: rewrite it
+                        //println!("start message");
+                        //println!("{}", text);
+                        //println!("end message");
+                        let count = 1;
+                        out.send_event(Event::Log(LogEvent::from_str_legacy(text))).await.map_err(|error| {
+                            emit!(StreamClosedError { error, count });
+                        })?;
+                        Ok(())
+                    },
+                    Ok(_) => Ok(()),
+                    Err(e) => Err(e)
+                }
+            },
+        else => break,
+        };
+
+        if let Err(error) = result {
+            if is_closed(&error) {
+                emit!(WsConnectionShutdown);
+            } else {
+                emit!(WsConnectionError { error });
+            }
+            return Err(());
+        }
+    }
+
+    Ok(())
 }
 
 pub async fn loki_source(
-    config: &LokiSourceConfig,
-    http_client: HttpClient,
+    config: LokiSourceConfig,
     shutdown: ShutdownSignal,
-    mut out: SourceSender,
+    out: SourceSender,
 ) -> Result<(), ()> {
-    let connector = build_connector(config)?;
+    //TODO: rewrite to proper error handling
+    let connector = build_connector(&config).expect("Cannot build WS connector");
 
     let ws_stream = connector.connect_backoff().await;
-    //ws_stream.split()
-    ws_stream
+    let (mut ws_sink, mut ws_stream) = ws_stream.split();
+
+    if handle_events(&mut ws_stream, &mut ws_sink, shutdown, out)
+        .await
+        .is_ok()
+    {
+        let _ = ws_sink.close().await;
+    }
+
     Ok(())
 }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -56,6 +56,8 @@ pub mod kafka;
 pub mod kubernetes_logs;
 #[cfg(all(feature = "sources-logstash"))]
 pub mod logstash;
+#[cfg(all(feature = "sources-loki"))]
+pub mod loki;
 #[cfg(feature = "sources-mongodb_metrics")]
 pub mod mongodb_metrics;
 #[cfg(all(feature = "sources-nats"))]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -218,6 +218,10 @@ pub enum Sources {
     #[cfg(all(feature = "sources-logstash"))]
     Logstash(#[configurable(derived)] logstash::LogstashConfig),
 
+    /// Loki.
+    #[cfg(all(feature = "sources-loki"))]
+    Loki(#[configurable(derived)] loki::LokiSourceConfig),
+
     /// MongoDB Metrics.
     #[cfg(feature = "sources-mongodb_metrics")]
     MongodbMetrics(#[configurable(derived)] mongodb_metrics::MongoDbMetricsConfig),
@@ -363,6 +367,8 @@ impl NamedComponent for Sources {
             Self::KubernetesLogs(config) => config.get_component_name(),
             #[cfg(all(feature = "sources-logstash"))]
             Self::Logstash(config) => config.get_component_name(),
+            #[cfg(all(feature = "sources-loki"))]
+            Self::Loki(config) => config.get_component_name(),
             #[cfg(feature = "sources-mongodb_metrics")]
             Self::MongodbMetrics(config) => config.get_component_name(),
             #[cfg(all(feature = "sources-nats"))]


### PR DESCRIPTION
Resolves https://github.com/vectordotdev/vector/issues/6873

In this PR I have implemented the initial Loki source. Right now it's just a basic Websocket connection with some Loki specific. Later, proper logs handling, tests, documentation and much more stuff will be added to this PR.

Current state - WIP.

Right now it successfully consumes logs from Loki and sends it to the Vector pipeline (so I can see logs via the console sink).