### PR TITLE
chore(docs): Avoid indexing branch deploys

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -52,7 +52,7 @@ preview-build:
 	--buildFuture \
 	--environment "preview" \
 	--minify
-	cp ./custom-headers/_preview ./dist/_headers
+	cp ./custom-headers/_preview ./public/_headers
 
 ci-preview-build: setup structured-data preview-build run-link-checker algolia
 

--- a/website/Makefile
+++ b/website/Makefile
@@ -52,6 +52,7 @@ preview-build:
 	--buildFuture \
 	--environment "preview" \
 	--minify
+	cp ./custom-headers/_preview ./dist/_headers
 
 ci-preview-build: setup structured-data preview-build run-link-checker algolia
 

--- a/website/custom-headers/_preview
+++ b/website/custom-headers/_preview
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
This adds a `X-Robots-Tag: noindex` header for deploy previews and branch deploys.

We currently use branch deploys for versioned docs deploys (e.g. https://v0-24.vector.dev/).
I realized while working on this that it uses the same settings for these branch deploys (staging
Algolia index and "preview" environment for the Hugo build). I started down the path to making the
branch deploys more "production like" but this turned into a rabbit hole I thought best to leave for
now and just solve the immediate need of avoiding these sites being indexed.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
