### PR TITLE
chore: use in-memory size for JSON encoded size of metrics

### DIFF
--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -443,7 +443,9 @@ impl ByteSizeOf for Metric {
 
 impl EstimatedJsonEncodedSizeOf for Metric {
     fn estimated_json_encoded_size_of(&self) -> usize {
-        0 // The JSON encoded size of a metric is unspecified.
+        // TODO: For now we're using the in-memory representation of the metric, but we'll convert
+        // this to actually calculate the JSON encoded size in the near future.
+        self.size_of()
     }
 }
 


### PR DESCRIPTION
This was initially 0, as any JSON-encoded representation of metrics is not representative of the final shape of metrics as they are delivered by sinks (metrics are often compacted aggressively, as opposed to logs, which are free-form, and thus have to be (mostly) delivered "as-is").

But since this would confuse users by showing up as 0 bytes throughput in the topology for metrics, it is now reporting the in-memory size of metrics.

We might still do an actual JSON-encoded representation of metrics in the future, but this is "good enough" to solve the before-mentioned confusion.