### PR TITLE
enhancement(nats source): added subject key in event metadata

### DIFF
--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -375,6 +375,7 @@ mod integration_tests {
             tls: None,
             auth: None,
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -406,6 +407,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -437,6 +439,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -467,6 +470,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -497,6 +501,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -528,6 +533,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -559,6 +565,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -591,6 +598,7 @@ mod integration_tests {
             }),
             auth: None,
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -617,6 +625,7 @@ mod integration_tests {
             tls: None,
             auth: None,
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -651,6 +660,7 @@ mod integration_tests {
             }),
             auth: None,
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -683,6 +693,7 @@ mod integration_tests {
             }),
             auth: None,
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -719,6 +730,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;
@@ -755,6 +767,7 @@ mod integration_tests {
                 },
             }),
             log_namespace: None,
+            subject_key_field: "subject".to_string(),
         };
 
         let r = publish_and_check(conf).await;

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -9,7 +9,10 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, EventsReceived, InternalEventHandle as _, Protocol,
 };
 use vector_config::{configurable_component, NamedComponent};
-use vector_core::{config::{LogNamespace, LegacyKey}, EstimatedJsonEncodedSizeOf};
+use vector_core::{
+    config::{LegacyKey, LogNamespace},
+    EstimatedJsonEncodedSizeOf,
+};
 
 use crate::{
     codecs::{Decoder, DecodingConfig},
@@ -79,7 +82,6 @@ pub struct NatsSourceConfig {
     /// The `NATS` subject key.
     #[serde(default = "default_subject_key_field")]
     subject_key_field: String,
-
 }
 
 impl GenerateConfig for NatsSourceConfig {
@@ -121,7 +123,9 @@ impl SourceConfig for NatsSourceConfig {
             .with_standard_vector_source_metadata()
             .with_source_metadata(
                 NatsSourceConfig::NAME,
-                Some(LegacyKey::Overwrite(owned_value_path!(&self.subject_key_field))),
+                Some(LegacyKey::Overwrite(owned_value_path!(
+                    &self.subject_key_field
+                ))),
                 &owned_value_path!("subject"),
                 Kind::bytes(),
                 None,
@@ -196,9 +200,7 @@ async fn nats_source(
                             log_namespace.insert_source_metadata(
                                 NatsSourceConfig::NAME,
                                 log,
-                                Some(LegacyKey::InsertIfEmpty(
-                                    config.subject_key_field.as_str(),
-                                )),
+                                Some(LegacyKey::InsertIfEmpty(config.subject_key_field.as_str())),
                                 "subject",
                                 msg.subject.as_str(),
                             )

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -1,8 +1,10 @@
 use chrono::Utc;
 use codecs::decoding::{DeserializerConfig, FramingConfig, StreamDecodingError};
 use futures::{pin_mut, stream, Stream, StreamExt};
+use lookup::owned_value_path;
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::FramedRead;
+use value::Kind;
 use vector_common::internal_event::{
     ByteSize, BytesReceived, EventsReceived, InternalEventHandle as _, Protocol,
 };
@@ -116,7 +118,14 @@ impl SourceConfig for NatsSourceConfig {
         let schema_definition = self
             .decoding
             .schema_definition(log_namespace)
-            .with_standard_vector_source_metadata();
+            .with_standard_vector_source_metadata()
+            .with_source_metadata(
+                NatsSourceConfig::NAME,
+                Some(LegacyKey::Overwrite(owned_value_path!(&self.subject_key_field))),
+                &owned_value_path!("subject"),
+                Kind::bytes(),
+                None,
+            );
 
         vec![Output::default(self.decoding.output_type()).with_schema_definition(schema_definition)]
     }

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -259,6 +259,7 @@ mod tests {
     fn output_schema_definition_vector_namespace() {
         let config = NatsSourceConfig {
             log_namespace: Some(true),
+            subject_key_field: "subject".to_string(),
             ..Default::default()
         };
 
@@ -274,15 +275,18 @@ mod tests {
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
-                );
+                )
+                .with_metadata_field(&owned_value_path!("nats", "subject"), Kind::bytes());
 
         assert_eq!(definition, expected_definition);
     }
 
     #[test]
     fn output_schema_definition_legacy_namespace() {
-        let config = NatsSourceConfig::default();
-
+        let config = NatsSourceConfig {
+            subject_key_field: "subject".to_string(),
+            ..Default::default()
+        };
         let definition = config.outputs(LogNamespace::Legacy)[0]
             .clone()
             .log_schema_definition
@@ -298,7 +302,8 @@ mod tests {
             Some("message"),
         )
         .with_event_field(&owned_value_path!("timestamp"), Kind::timestamp(), None)
-        .with_event_field(&owned_value_path!("source_type"), Kind::bytes(), None);
+        .with_event_field(&owned_value_path!("source_type"), Kind::bytes(), None)
+        .with_event_field(&owned_value_path!("subject"), Kind::bytes(), None);
 
         assert_eq!(definition, expected_definition);
     }

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -187,6 +187,14 @@ base: components: sources: nats: configuration: {
 		required:    true
 		type: string: syntax: "template"
 	}
+	subject_key_field: {
+		description: "The `NATS` subject key."
+		required:    false
+		type: string: {
+			default: "subject"
+			syntax:  "literal"
+		}
+	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."
 		required:    false

--- a/website/cue/reference/components/sources/nats.cue
+++ b/website/cue/reference/components/sources/nats.cue
@@ -60,6 +60,13 @@ components: sources: nats: {
 					examples: ["nats"]
 				}
 			}
+			subject: {
+				description: "The NATS subject current message was retrieved from."
+				required:    true
+				type: string: {
+					examples: ["nats.subject"]
+				}
+			}
 		}
 	}
 

--- a/website/cue/reference/components/sources/nats.cue
+++ b/website/cue/reference/components/sources/nats.cue
@@ -61,7 +61,7 @@ components: sources: nats: {
 				}
 			}
 			subject: {
-				description: "The NATS subject current message was retrieved from."
+				description: "The subject from the NATS message."
 				required:    true
 				type: string: {
 					examples: ["nats.subject"]


### PR DESCRIPTION
Fixes: #14339


This MR adds information about subject for events extracted from NATS source
Example: 
```
{
  "message": "asd",
  "nats_subject": "test.123",
  "source_type": "nats",
  "timestamp": "2022-12-04T14:32:16.320259Z"
}
{
  "message": "asd",
  "nats_subject": "test.321",
  "source_type": "nats",
  "timestamp": "2022-12-04T14:32:22.696902Z"
}
```

Was retrieved by source with following configuration
```
sources:
  nats_source:
    type: nats
    url: nats://localhost:4222
    subject: "test.*"
    subject_key_field: "nats_subject"
    connection_name: noname
```

Key name is configured and default is just `subject`, but I'd be happy to change that if necessary. Also, I'd be happy to add any missing documentation/tests if i've missed something


