### PR TITLE
fix(kafka): support PEM encoded certificates

### DIFF
--- a/lib/vector-core/src/tls/mod.rs
+++ b/lib/vector-core/src/tls/mod.rs
@@ -22,8 +22,8 @@ pub use incoming::{CertificateMetadata, MaybeTlsIncomingStream, MaybeTlsListener
 pub use maybe_tls::MaybeTls;
 pub use settings::{
     MaybeTlsSettings, TlsConfig, TlsEnableableConfig, TlsSettings, TlsSourceConfig,
-    TEST_PEM_CA_PATH, TEST_PEM_CLIENT_CRT_PATH, TEST_PEM_CLIENT_KEY_PATH, TEST_PEM_CRT_PATH,
-    TEST_PEM_INTERMEDIATE_CA_PATH, TEST_PEM_KEY_PATH,
+    PEM_START_MARKER, TEST_PEM_CA_PATH, TEST_PEM_CLIENT_CRT_PATH, TEST_PEM_CLIENT_KEY_PATH,
+    TEST_PEM_CRT_PATH, TEST_PEM_INTERMEDIATE_CA_PATH, TEST_PEM_KEY_PATH,
 };
 
 pub type Result<T> = std::result::Result<T, TlsError>;

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -23,7 +23,7 @@ use super::{
     TlsIdentitySnafu, X509ParseSnafu,
 };
 
-const PEM_START_MARKER: &str = "-----BEGIN ";
+pub const PEM_START_MARKER: &str = "-----BEGIN ";
 
 pub const TEST_PEM_CA_PATH: &str = "tests/data/ca/certs/ca.cert.pem";
 pub const TEST_PEM_INTERMEDIATE_CA_PATH: &str =

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -5,7 +5,9 @@ use snafu::Snafu;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 
-use crate::{internal_events::KafkaStatisticsReceived, tls::PEM_START_MARKER, tls::TlsEnableableConfig};
+use crate::{
+    internal_events::KafkaStatisticsReceived, tls::TlsEnableableConfig, tls::PEM_START_MARKER,
+};
 
 #[derive(Debug, Snafu)]
 enum KafkaError {

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -5,9 +5,7 @@ use snafu::Snafu;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 
-use crate::{internal_events::KafkaStatisticsReceived, tls::TlsEnableableConfig};
-
-const PEM_START_MARKER: &str = "-----BEGIN ";
+use crate::{internal_events::KafkaStatisticsReceived, tls::PEM_START_MARKER, tls::TlsEnableableConfig};
 
 #[derive(Debug, Snafu)]
 enum KafkaError {

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -7,6 +7,8 @@ use vector_config::configurable_component;
 
 use crate::{internal_events::KafkaStatisticsReceived, tls::TlsEnableableConfig};
 
+const PEM_START_MARKER: &str = "-----BEGIN ";
+
 #[derive(Debug, Snafu)]
 enum KafkaError {
     #[snafu(display("invalid path: {:?}", path))]
@@ -100,15 +102,34 @@ impl KafkaAuthConfig {
 
         if tls_enabled {
             let tls = self.tls.as_ref().unwrap();
+
             if let Some(path) = &tls.options.ca_file {
-                client.set("ssl.ca.location", pathbuf_to_string(path)?);
+                let text = pathbuf_to_string(path)?;
+                if text.contains(PEM_START_MARKER) {
+                    client.set("ssl.ca.pem", text);
+                } else {
+                    client.set("ssl.ca.location", text);
+                }
             }
+
             if let Some(path) = &tls.options.crt_file {
-                client.set("ssl.certificate.location", pathbuf_to_string(path)?);
+                let text = pathbuf_to_string(path)?;
+                if text.contains(PEM_START_MARKER) {
+                    client.set("ssl.certificate.pem", text);
+                } else {
+                    client.set("ssl.certificate.location", text);
+                }
             }
+
             if let Some(path) = &tls.options.key_file {
-                client.set("ssl.key.location", pathbuf_to_string(path)?);
+                let text = pathbuf_to_string(path)?;
+                if text.contains(PEM_START_MARKER) {
+                    client.set("ssl.key.pem", text);
+                } else {
+                    client.set("ssl.key.location", text);
+                }
             }
+
             if let Some(pass) = &tls.options.key_pass {
                 client.set("ssl.key.password", pass);
             }


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

### Problem

Vector's documentation states that it supports both inline PEM-encoded certificates and locations to certificate files.

https://vector.dev/docs/reference/configuration/sinks/kafka/#tls.crt_file
> Absolute path to a certificate file used to identify this connection, in DER or PEM format (X.509) or PKCS#12, or an inline certificate in PEM format. If this is set and is not a PKCS#12 archive, key_file must also be set.

However, for Kafka it works only if a location is provided. Otherwise, the following error occurs:
```
x Sink "destination/cluster/test-kafka-dest": creating kafka producer failed: Client creation error: ssl.certificate.location failed: error:140DC002:SSL routines:use_certificate_chain_file:system lib
```

This happens because Kafka source and sink do not utilize the default TLS configuration shared helper and pass options directly to the librdkafka.

### Solution

To align with other providers' behavior, I propose adding an ability to specify inline PEM certificates for Kafka. It can be achieved by passing proper arguments for librdkafka. 