### PR TITLE
docs(unit tests): Document the use of hyphens in key names in input data

### DIFF
--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -345,6 +345,17 @@ code = 200
 id = "38c5b0d0-5e7e-42aa-ae86-2b642ad2d1b8"
 ```
 
+If there are hyphens in the field name, you will need to quote this part (at least in YAML):
+
+```
+  - name: hypens
+    inputs:
+      - insert_at: hypens
+        type: log
+        log_fields:
+          labels."this-has-hypens": "this is a test"
+```
+
 ##### Raw string value
 
 To specify a raw string value for a log event, use `value`:

--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -348,12 +348,12 @@ id = "38c5b0d0-5e7e-42aa-ae86-2b642ad2d1b8"
 If there are hyphens in the field name, you will need to quote this part (at least in YAML):
 
 ```
-  - name: hypens
+  - name: hyphens
     inputs:
-      - insert_at: hypens
+      - insert_at: hyphens
         type: log
         log_fields:
-          labels."this-has-hypens": "this is a test"
+          labels."this-has-hyphens": "this is a test"
 ```
 
 ##### Raw string value

--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -347,7 +347,7 @@ id = "38c5b0d0-5e7e-42aa-ae86-2b642ad2d1b8"
 
 If there are hyphens in the field name, you will need to quote this part (at least in YAML):
 
-```
+```yaml
   - name: hyphens
     inputs:
       - insert_at: hyphens


### PR DESCRIPTION
Document how hyphens can be used in unit test input data with an example.
