### PR TITLE
chore(docs): fix up some of the generated descriptions of various shared config types

### DIFF
--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -242,13 +242,17 @@ pub enum DeserializerConfig {
 
     /// Decodes the raw bytes as [JSON][json].
     ///
-    /// [json]: https://en.wikipedia.org/wiki/JSON
+    /// [json]: https://www.json.org/
     Json,
 
     #[cfg(feature = "syslog")]
-    /// Decodes the raw bytes as a [Syslog][syslog] message.
+    /// Decodes the raw bytes as a Syslog message.
     ///
-    /// [syslog]: https://en.wikipedia.org/wiki/Syslog
+    /// Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+    /// [RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+    ///
+    /// [rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+    /// [rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
     Syslog,
 
     /// Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -67,24 +67,32 @@ impl StreamDecodingError for Error {
     }
 }
 
-/// Configuration for building a `Framer`.
+/// Framing configuration.
+///
+/// Framing deals with how events are separated when encoded in a raw byte form, where each event is
+/// a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+/// ends within the byte stream.
 // Unfortunately, copying options of the nested enum variants is necessary
 // since `serde` doesn't allow `flatten`ing these:
 // https://github.com/serde-rs/serde/issues/1402.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "method", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The framing method."))]
 pub enum FramingConfig {
-    /// Configures the `BytesDecoder`.
+    /// Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments).
     Bytes,
-    /// Configures the `CharacterDelimitedDecoder`.
+
+    /// Byte frames which are delimited by a chosen character.
     CharacterDelimited {
         /// Options for the character delimited decoder.
         character_delimited: CharacterDelimitedDecoderOptions,
     },
-    /// Configures the `LengthDelimitedDecoder`.
+
+    /// Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length.
     LengthDelimited,
-    /// Configures the `NewlineDelimitedDecoder`.
+
+    /// Byte frames which are delimited by a newline character.
     NewlineDelimited {
         #[serde(
             default,
@@ -93,7 +101,10 @@ pub enum FramingConfig {
         /// Options for the newline delimited decoder.
         newline_delimited: NewlineDelimitedDecoderOptions,
     },
-    /// Configures the `OctetCountingDecoder`.
+
+    /// Byte frames according to the [octet counting][octet_counting] format.
+    ///
+    /// [octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
     OctetCounting {
         #[serde(
             default,
@@ -216,26 +227,45 @@ impl tokio_util::codec::Decoder for Framer {
     }
 }
 
-/// Configuration for building a `Deserializer`.
+/// Deserializer configuration.
 // Unfortunately, copying options of the nested enum variants is necessary
 // since `serde` doesn't allow `flatten`ing these:
 // https://github.com/serde-rs/serde/issues/1402.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "codec", rename_all = "snake_case")]
+#[configurable(description = "Configures how events are decoded from raw bytes.")]
+#[configurable(metadata(docs::enum_tag_description = "The codec to use for decoding events."))]
 pub enum DeserializerConfig {
-    /// Configures the `BytesDeserializer`.
+    /// Uses the raw bytes as-is.
     Bytes,
-    /// Configures the `JsonDeserializer`.
+
+    /// Decodes the raw bytes as [JSON][json].
+    ///
+    /// [json]: https://en.wikipedia.org/wiki/JSON
     Json,
+
     #[cfg(feature = "syslog")]
-    /// Configures the `SyslogDeserializer`.
+    /// Decodes the raw bytes as a [Syslog][syslog] message.
+    ///
+    /// [syslog]: https://en.wikipedia.org/wiki/Syslog
     Syslog,
-    /// Configures the `NativeDeserializer`.
+
+    /// Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+    ///
+    /// [vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+    /// [experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
     Native,
-    /// Configures the `NativeJsonDeserializer`.
+
+    /// Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+    ///
+    /// [vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+    /// [experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
     NativeJson,
-    /// Configures the `GelfDeserializer`.
+
+    /// Decodes the raw bytes as a [GELF][gelf] message.
+    ///
+    /// [gelf]: https://docs.graylog.org/docs/gelf
     Gelf,
 }
 

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -182,46 +182,64 @@ impl tokio_util::codec::Encoder<()> for Framer {
     }
 }
 
-/// Configuration for building a `Serializer`.
+/// Serializer configuration.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "codec", rename_all = "snake_case")]
+#[configurable(description = "Configures how events are encoded into raw bytes.")]
+#[configurable(metadata(docs::enum_tag_description = "The codec to use for encoding events."))]
 pub enum SerializerConfig {
-    /// Apache Avro serialization.
+    /// Encodes an event as an [Apache Avro][apache_avro] message.
+    ///
+    /// [apache_avro]: https://avro.apache.org/
     Avro {
-        /// Apache Avro serializer options.
+        /// Apache Avro-specific encoder options.
         avro: AvroSerializerOptions,
     },
 
-    /// GELF serialization.
+    /// Encodes an event as a [GELF][gelf] message.
+    ///
+    /// [gelf]: https://docs.graylog.org/docs/gelf
     Gelf,
 
-    /// JSON serialization.
+    /// Encodes an event as [JSON][json].
+    ///
+    /// [json]: https://en.wikipedia.org/wiki/JSON
     Json,
 
-    /// Logfmt serialization.
+    /// Encodes an event as a [logfmt][logfmt] message.
+    ///
+    /// [logfmt]:
     Logfmt,
 
-    /// Native Vector serialization based on Protocol Buffers.
+    /// Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+    ///
+    /// [vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+    /// [experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
     Native,
 
-    /// Native Vector serialization based on JSON.
+    /// Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+    ///
+    /// [vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+    /// [experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
     NativeJson,
 
-    /// No serialization.
+    /// No encoding.
     ///
-    /// This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-    /// they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-    /// while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-    /// event.
+    /// This "encoding" simply uses the `message` field of a log event.
+    ///
+    /// Users should take care if they're modifying their log events (such as by using a `remap`
+    /// transform, etc) and removing the message field while doing additional parsing on it, as this
+    /// could lead to the encoding emitting empty strings for the given event.
     RawMessage,
 
-    /// Plaintext serialization.
+    /// Plaintext encoding.
     ///
-    /// This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-    /// they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-    /// while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-    /// event.
+    /// This "encoding" simply uses the `message` field of a log event.
+    ///
+    /// Users should take care if they're modifying their log events (such as by using a `remap`
+    /// transform, etc) and removing the message field while doing additional parsing on it, as this
+    /// could lead to the encoding emitting empty strings for the given event.
     Text,
 }
 

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -204,12 +204,12 @@ pub enum SerializerConfig {
 
     /// Encodes an event as [JSON][json].
     ///
-    /// [json]: https://en.wikipedia.org/wiki/JSON
+    /// [json]: https://www.json.org/
     Json,
 
     /// Encodes an event as a [logfmt][logfmt] message.
     ///
-    /// [logfmt]:
+    /// [logfmt]: https://brandur.org/logfmt
     Logfmt,
 
     /// Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -193,6 +193,7 @@ impl DiskUsage {
 #[configurable_component(no_deser)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "type")]
+#[configurable(metadata(docs::enum_tag_description = "The type of buffer to use."))]
 pub enum BufferType {
     /// A buffer stage backed by an in-memory channel provided by `tokio`.
     ///

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -45,6 +45,7 @@ pub struct TlsEnableableConfig {
     /// When enabled and used for incoming connections, an identity certificate is also required. See `tls.crt_file` for
     /// more information.
     pub enabled: Option<bool>,
+
     #[serde(flatten)]
     pub options: TlsConfig,
 }
@@ -71,11 +72,12 @@ impl TlsEnableableConfig {
 pub struct TlsSourceConfig {
     /// Event field for client certificate metadata.
     pub client_metadata_key: Option<String>,
+
     #[serde(flatten)]
     pub tls_config: TlsEnableableConfig,
 }
 
-/// Standard TLS options.
+/// TLS configuration.
 #[configurable_component]
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -235,10 +235,13 @@ impl<B> fmt::Debug for HttpClient<B> {
 #[configurable_component]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", tag = "strategy")]
+#[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
 pub enum Auth {
     /// Basic authentication.
     ///
-    /// The username and password are concatenated and encoded via base64.
+    /// The username and password are concatenated and encoded via [base64][base64].
+    ///
+    /// [base64]: https://en.wikipedia.org/wiki/Base64
     Basic {
         /// The username to send.
         user: String,
@@ -249,7 +252,7 @@ pub enum Auth {
 
     /// Bearer authentication.
     ///
-    /// A bearer token (OAuth2, JWT, etc) is passed as-is.
+    /// The bearer token value (OAuth2, JWT, etc) is passed as-is.
     Bearer {
         /// The bearer token to send.
         token: SensitiveString,

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -41,7 +41,7 @@ base: components: sinks: amqp: configuration: {
 				type: string: syntax: "literal"
 			}
 			tls: {
-				description: "Standard TLS options."
+				description: "TLS configuration."
 				required:    false
 				type: object: options: {
 					alpn_protocols: {
@@ -132,7 +132,7 @@ base: components: sinks: amqp: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -144,27 +144,55 @@ base: components: sinks: amqp: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -157,12 +157,12 @@ base: components: sinks: amqp: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -183,12 +183,12 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -158,7 +158,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -170,27 +170,55 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -378,7 +406,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 		type: string: syntax: "template"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -274,7 +274,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -128,7 +128,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -140,27 +140,55 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -325,7 +353,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 		type: string: syntax: "literal"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -153,12 +153,12 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -128,7 +128,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -140,27 +140,55 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -334,7 +362,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 		type: string: syntax: "literal"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -153,12 +153,12 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -230,7 +230,7 @@ base: components: sinks: aws_s3: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -242,27 +242,55 @@ base: components: sinks: aws_s3: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -606,7 +634,7 @@ base: components: sinks: aws_s3: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -255,12 +255,12 @@ base: components: sinks: aws_s3: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -112,12 +112,12 @@ base: components: sinks: aws_sqs: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -87,7 +87,7 @@ base: components: sinks: aws_sqs: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -99,27 +99,55 @@ base: components: sinks: aws_sqs: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -301,7 +329,7 @@ base: components: sinks: aws_sqs: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -195,7 +195,7 @@ base: components: sinks: axiom: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -171,12 +171,12 @@ base: components: sinks: azure_blob: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -146,7 +146,7 @@ base: components: sinks: azure_blob: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -158,27 +158,55 @@ base: components: sinks: azure_blob: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -249,7 +249,7 @@ base: components: sinks: azure_monitor_logs: configuration: {
 		type: string: syntax: "literal"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -48,12 +48,14 @@ base: components: sinks: clickhouse: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}
@@ -287,7 +289,7 @@ base: components: sinks: clickhouse: configuration: {
 		type: string: syntax: "literal"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -32,7 +32,7 @@ base: components: sinks: console: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -44,27 +44,55 @@ base: components: sinks: console: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -57,12 +57,12 @@ base: components: sinks: console: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -548,7 +548,7 @@ base: components: sinks: elasticsearch: configuration: {
 		type: bool: {}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -44,7 +44,7 @@ base: components: sinks: file: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -56,27 +56,55 @@ base: components: sinks: file: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -69,12 +69,12 @@ base: components: sinks: file: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -91,7 +91,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -103,27 +103,55 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -300,7 +328,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 		type: bool: default: false
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -116,12 +116,12 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -195,12 +195,12 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -170,7 +170,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -182,27 +182,55 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -475,7 +503,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -111,12 +111,12 @@ base: components: sinks: gcp_pubsub: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -86,7 +86,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -98,27 +98,55 @@ base: components: sinks: gcp_pubsub: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -279,7 +307,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 		type: bool: default: false
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -316,7 +316,7 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 		type: bool: default: false
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -252,7 +252,7 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 		type: bool: default: false
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -48,12 +48,14 @@ base: components: sinks: http: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}
@@ -126,7 +128,7 @@ base: components: sinks: http: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -138,27 +140,55 @@ base: components: sinks: http: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -368,7 +398,7 @@ base: components: sinks: http: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -153,12 +153,12 @@ base: components: sinks: http: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -107,12 +107,12 @@ base: components: sinks: humio_logs: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -82,7 +82,7 @@ base: components: sinks: humio_logs: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -94,27 +94,55 @@ base: components: sinks: humio_logs: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -354,7 +382,7 @@ base: components: sinks: humio_logs: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -296,7 +296,7 @@ base: components: sinks: humio_metrics: configuration: {
 		type: string: examples: ["local", "America/New_York", "EST5EDT"]
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -282,7 +282,7 @@ base: components: sinks: influxdb_logs: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -261,7 +261,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -106,12 +106,12 @@ base: components: sinks: kafka: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -81,7 +81,7 @@ base: components: sinks: kafka: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -93,27 +93,55 @@ base: components: sinks: kafka: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -157,12 +157,12 @@ base: components: sinks: loki: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -48,12 +48,14 @@ base: components: sinks: loki: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}
@@ -130,7 +132,7 @@ base: components: sinks: loki: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -142,27 +144,55 @@ base: components: sinks: loki: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -414,7 +444,7 @@ base: components: sinks: loki: configuration: {
 		type: string: syntax: "template"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -129,7 +129,7 @@ base: components: sinks: nats: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -141,27 +141,55 @@ base: components: sinks: nats: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -154,12 +154,12 @@ base: components: sinks: nats: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -32,7 +32,7 @@ base: components: sinks: papertrail: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -44,27 +44,55 @@ base: components: sinks: papertrail: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -57,12 +57,12 @@ base: components: sinks: papertrail: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_exporter.cue
@@ -60,12 +60,14 @@ base: components: sinks: prometheus_exporter: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -328,7 +328,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 		type: string: syntax: "template"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -113,12 +113,12 @@ base: components: sinks: pulsar: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -88,7 +88,7 @@ base: components: sinks: pulsar: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -100,27 +100,55 @@ base: components: sinks: pulsar: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -79,7 +79,7 @@ base: components: sinks: redis: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -91,27 +91,55 @@ base: components: sinks: redis: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -104,12 +104,12 @@ base: components: sinks: redis: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -42,7 +42,7 @@ base: components: sinks: socket: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -54,27 +54,55 @@ base: components: sinks: socket: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -67,12 +67,12 @@ base: components: sinks: socket: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -126,7 +126,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -138,27 +138,55 @@ base: components: sinks: splunk_hec_logs: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}
@@ -405,7 +433,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		}
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -151,12 +151,12 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -290,7 +290,7 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 		type: string: syntax: "template"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -103,12 +103,12 @@ base: components: sinks: websocket: configuration: {
 					json: """
 						Encodes an event as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					logfmt: """
 						Encodes an event as a [logfmt][logfmt] message.
 
-						[logfmt]:
+						[logfmt]: https://brandur.org/logfmt
 						"""
 					native: """
 						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -48,12 +48,14 @@ base: components: sinks: websocket: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}
@@ -76,7 +78,7 @@ base: components: sinks: websocket: configuration: {
 		required:    true
 		type: object: options: {
 			avro: {
-				description:   "Apache Avro serializer options."
+				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
 				type: object: options: schema: {
@@ -88,27 +90,55 @@ base: components: sinks: websocket: configuration: {
 			codec: {
 				required: true
 				type: string: enum: {
-					avro:        "Apache Avro serialization."
-					gelf:        "GELF serialization."
-					json:        "JSON serialization."
-					logfmt:      "Logfmt serialization."
-					native:      "Native Vector serialization based on Protocol Buffers."
-					native_json: "Native Vector serialization based on JSON."
-					raw_message: """
-						No serialization.
+					avro: """
+						Encodes an event as an [Apache Avro][apache_avro] message.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						[apache_avro]: https://avro.apache.org/
+						"""
+					gelf: """
+						Encodes an event as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Encodes an event as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					logfmt: """
+						Encodes an event as a [logfmt][logfmt] message.
+
+						[logfmt]:
+						"""
+					native: """
+						Encodes an event in Vector’s [native Protocol Buffers format][vector_native_protobuf]([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Encodes an event in Vector’s [native JSON format][vector_native_json]([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					raw_message: """
+						No encoding.
+
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 					text: """
-						Plaintext serialization.
+						Plaintext encoding.
 
-						This encoding, specifically, will only encode the `message` field of a log event. Users should take care if
-						they're modifying their log events (such as by using a `remap` transform, etc) and removing the message field
-						while doing additional parsing on it, as this could lead to the encoding emitting empty strings for the given
-						event.
+						This "encoding" simply uses the `message` field of a log event.
+
+						Users should take care if they're modifying their log events (such as by using a `remap`
+						transform, etc) and removing the message field while doing additional parsing on it, as this
+						could lead to the encoding emitting empty strings for the given event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -33,7 +33,7 @@ base: components: sources: amqp: configuration: {
 				type: string: syntax: "literal"
 			}
 			tls: {
-				description: "Standard TLS options."
+				description: "TLS configuration."
 				required:    false
 				type: object: options: {
 					alpn_protocols: {
@@ -128,19 +128,41 @@ base: components: sources: amqp: configuration: {
 		}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -154,8 +176,14 @@ base: components: sources: amqp: configuration: {
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -183,11 +211,15 @@ base: components: sources: amqp: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -144,7 +144,7 @@ base: components: sources: amqp: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -159,9 +159,13 @@ base: components: sources: amqp: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -35,26 +35,54 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 		type: string: syntax: "literal"
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -82,11 +110,15 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -51,7 +51,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -66,9 +66,13 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -224,7 +224,7 @@ base: components: sources: aws_s3: configuration: {
 				type: string: syntax: "literal"
 			}
 			tls_options: {
-				description: "Standard TLS options."
+				description: "TLS configuration."
 				required:    false
 				type: object: options: {
 					alpn_protocols: {
@@ -335,7 +335,7 @@ base: components: sources: aws_s3: configuration: {
 		}
 	}
 	tls_options: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -80,19 +80,41 @@ base: components: sources: aws_sqs: configuration: {
 		type: uint: {}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -112,8 +134,14 @@ base: components: sources: aws_sqs: configuration: {
 		type: string: syntax: "literal"
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -141,11 +169,15 @@ base: components: sources: aws_sqs: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}
@@ -196,7 +228,7 @@ base: components: sources: aws_sqs: configuration: {
 		type: string: syntax: "literal"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -96,7 +96,7 @@ base: components: sources: aws_sqs: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -111,9 +111,13 @@ base: components: sources: aws_sqs: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -45,7 +45,7 @@ base: components: sources: datadog_agent: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -60,9 +60,13 @@ base: components: sources: datadog_agent: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -29,19 +29,41 @@ base: components: sources: datadog_agent: configuration: {
 		type: string: syntax: "literal"
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -62,8 +84,14 @@ base: components: sources: datadog_agent: configuration: {
 		type: bool: default: false
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -91,11 +119,15 @@ base: components: sources: datadog_agent: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -11,19 +11,41 @@ base: components: sources: demo_logs: configuration: {
 		type: uint: default: 9223372036854775807
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: {
 			default: codec: "bytes"
 			options: codec: {
 				required: true
 				type: string: enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -43,8 +65,14 @@ base: components: sources: demo_logs: configuration: {
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: {
 			default: method: "bytes"
 			options: {
@@ -72,11 +100,15 @@ base: components: sources: demo_logs: configuration: {
 				method: {
 					required: true
 					type: string: enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 				newline_delimited: {

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -27,7 +27,7 @@ base: components: sources: demo_logs: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -42,9 +42,13 @@ base: components: sources: demo_logs: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -28,7 +28,7 @@ base: components: sources: exec: configuration: {
 						json: """
 															Decodes the raw bytes as [JSON][json].
 
-															[json]: https://en.wikipedia.org/wiki/JSON
+															[json]: https://www.json.org/
 															"""
 						native: """
 															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -43,9 +43,13 @@ base: components: sources: exec: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						syslog: """
-															Decodes the raw bytes as a [Syslog][syslog] message.
+															Decodes the raw bytes as a Syslog message.
 
-															[syslog]: https://en.wikipedia.org/wiki/Syslog
+															Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 					}
 				}

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -10,7 +10,7 @@ base: components: sources: exec: configuration: {
 		}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: {
 			default: codec: "bytes"
@@ -19,20 +19,48 @@ base: components: sources: exec: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:       "Configures the `BytesDeserializer`."
-						gelf:        "Configures the `GelfDeserializer`."
-						json:        "Configures the `JsonDeserializer`."
-						native:      "Configures the `NativeDeserializer`."
-						native_json: "Configures the `NativeJsonDeserializer`."
-						syslog:      "Configures the `SyslogDeserializer`."
+						bytes: "Uses the raw bytes as-is."
+						gelf: """
+															Decodes the raw bytes as a [GELF][gelf] message.
+
+															[gelf]: https://docs.graylog.org/docs/gelf
+															"""
+						json: """
+															Decodes the raw bytes as [JSON][json].
+
+															[json]: https://en.wikipedia.org/wiki/JSON
+															"""
+						native: """
+															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+															[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+															"""
+						native_json: """
+															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+															[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+															"""
+						syslog: """
+															Decodes the raw bytes as a [Syslog][syslog] message.
+
+															[syslog]: https://en.wikipedia.org/wiki/Syslog
+															"""
 					}
 				}
 			}
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -58,11 +86,15 @@ base: components: sources: exec: configuration: {
 			method: {
 				required: true
 				type: string: enum: {
-					bytes:               "Configures the `BytesDecoder`."
-					character_delimited: "Configures the `CharacterDelimitedDecoder`."
-					length_delimited:    "Configures the `LengthDelimitedDecoder`."
-					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-					octet_counting:      "Configures the `OctetCountingDecoder`."
+					bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+					character_delimited: "Byte frames which are delimited by a chosen character."
+					length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+					newline_delimited:   "Byte frames which are delimited by a newline character."
+					octet_counting: """
+						Byte frames according to the [octet counting][octet_counting] format.
+
+						[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+						"""
 				}
 			}
 			newline_delimited: {

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -2,19 +2,41 @@ package metadata
 
 base: components: sources: file_descriptor: configuration: {
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -25,8 +47,14 @@ base: components: sources: file_descriptor: configuration: {
 		type: uint: {}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -52,11 +80,15 @@ base: components: sources: file_descriptor: configuration: {
 			method: {
 				required: true
 				type: string: enum: {
-					bytes:               "Configures the `BytesDecoder`."
-					character_delimited: "Configures the `CharacterDelimitedDecoder`."
-					length_delimited:    "Configures the `LengthDelimitedDecoder`."
-					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-					octet_counting:      "Configures the `OctetCountingDecoder`."
+					bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+					character_delimited: "Byte frames which are delimited by a chosen character."
+					length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+					newline_delimited:   "Byte frames which are delimited by a newline character."
+					octet_counting: """
+						Byte frames according to the [octet counting][octet_counting] format.
+
+						[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+						"""
 				}
 			}
 			newline_delimited: {

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -18,7 +18,7 @@ base: components: sources: file_descriptor: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -33,9 +33,13 @@ base: components: sources: file_descriptor: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -62,19 +62,41 @@ base: components: sources: gcp_pubsub: configuration: {
 		type: string: syntax: "literal"
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -85,8 +107,14 @@ base: components: sources: gcp_pubsub: configuration: {
 		type: string: syntax: "literal"
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -114,11 +142,15 @@ base: components: sources: gcp_pubsub: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}
@@ -205,7 +237,7 @@ base: components: sources: gcp_pubsub: configuration: {
 		type: string: syntax: "literal"
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -78,7 +78,7 @@ base: components: sources: gcp_pubsub: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -93,9 +93,13 @@ base: components: sources: gcp_pubsub: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -57,7 +57,7 @@ base: components: sources: heroku_logs: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -72,9 +72,13 @@ base: components: sources: heroku_logs: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -41,26 +41,54 @@ base: components: sources: heroku_logs: configuration: {
 		}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -88,11 +116,15 @@ base: components: sources: heroku_logs: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -55,7 +55,7 @@ base: components: sources: http: configuration: {
 				json: """
 					Decodes the raw bytes as [JSON][json].
 
-					[json]: https://en.wikipedia.org/wiki/JSON
+					[json]: https://www.json.org/
 					"""
 				native: """
 					Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -70,9 +70,13 @@ base: components: sources: http: configuration: {
 					[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 					"""
 				syslog: """
-					Decodes the raw bytes as a [Syslog][syslog] message.
+					Decodes the raw bytes as a Syslog message.
 
-					[syslog]: https://en.wikipedia.org/wiki/Syslog
+					Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+					[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+					[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+					[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 					"""
 			}
 		}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -41,17 +41,39 @@ base: components: sources: http: configuration: {
 		}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: true
 			type: string: enum: {
-				bytes:       "Configures the `BytesDeserializer`."
-				gelf:        "Configures the `GelfDeserializer`."
-				json:        "Configures the `JsonDeserializer`."
-				native:      "Configures the `NativeDeserializer`."
-				native_json: "Configures the `NativeJsonDeserializer`."
-				syslog:      "Configures the `SyslogDeserializer`."
+				bytes: "Uses the raw bytes as-is."
+				gelf: """
+					Decodes the raw bytes as a [GELF][gelf] message.
+
+					[gelf]: https://docs.graylog.org/docs/gelf
+					"""
+				json: """
+					Decodes the raw bytes as [JSON][json].
+
+					[json]: https://en.wikipedia.org/wiki/JSON
+					"""
+				native: """
+					Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+					[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+					[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+					"""
+				native_json: """
+					Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+					[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+					[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+					"""
+				syslog: """
+					Decodes the raw bytes as a [Syslog][syslog] message.
+
+					[syslog]: https://en.wikipedia.org/wiki/Syslog
+					"""
 			}
 		}
 	}
@@ -70,8 +92,14 @@ base: components: sources: http: configuration: {
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -97,11 +125,15 @@ base: components: sources: http: configuration: {
 			method: {
 				required: true
 				type: string: enum: {
-					bytes:               "Configures the `BytesDecoder`."
-					character_delimited: "Configures the `CharacterDelimitedDecoder`."
-					length_delimited:    "Configures the `LengthDelimitedDecoder`."
-					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-					octet_counting:      "Configures the `OctetCountingDecoder`."
+					bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+					character_delimited: "Byte frames which are delimited by a chosen character."
+					length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+					newline_delimited:   "Byte frames which are delimited by a newline character."
+					octet_counting: """
+						Byte frames according to the [octet counting][octet_counting] format.
+
+						[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+						"""
 				}
 			}
 			newline_delimited: {

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -59,7 +59,7 @@ base: components: sources: http_client: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -74,9 +74,13 @@ base: components: sources: http_client: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -17,12 +17,14 @@ base: components: sources: http_client: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}
@@ -48,12 +50,34 @@ base: components: sources: http_client: configuration: {
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -96,11 +120,15 @@ base: components: sources: http_client: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -41,17 +41,39 @@ base: components: sources: http_server: configuration: {
 		}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: true
 			type: string: enum: {
-				bytes:       "Configures the `BytesDeserializer`."
-				gelf:        "Configures the `GelfDeserializer`."
-				json:        "Configures the `JsonDeserializer`."
-				native:      "Configures the `NativeDeserializer`."
-				native_json: "Configures the `NativeJsonDeserializer`."
-				syslog:      "Configures the `SyslogDeserializer`."
+				bytes: "Uses the raw bytes as-is."
+				gelf: """
+					Decodes the raw bytes as a [GELF][gelf] message.
+
+					[gelf]: https://docs.graylog.org/docs/gelf
+					"""
+				json: """
+					Decodes the raw bytes as [JSON][json].
+
+					[json]: https://en.wikipedia.org/wiki/JSON
+					"""
+				native: """
+					Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+					[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+					[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+					"""
+				native_json: """
+					Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+					[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+					[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+					"""
+				syslog: """
+					Decodes the raw bytes as a [Syslog][syslog] message.
+
+					[syslog]: https://en.wikipedia.org/wiki/Syslog
+					"""
 			}
 		}
 	}
@@ -70,8 +92,14 @@ base: components: sources: http_server: configuration: {
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -97,11 +125,15 @@ base: components: sources: http_server: configuration: {
 			method: {
 				required: true
 				type: string: enum: {
-					bytes:               "Configures the `BytesDecoder`."
-					character_delimited: "Configures the `CharacterDelimitedDecoder`."
-					length_delimited:    "Configures the `LengthDelimitedDecoder`."
-					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-					octet_counting:      "Configures the `OctetCountingDecoder`."
+					bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+					character_delimited: "Byte frames which are delimited by a chosen character."
+					length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+					newline_delimited:   "Byte frames which are delimited by a newline character."
+					octet_counting: """
+						Byte frames according to the [octet counting][octet_counting] format.
+
+						[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+						"""
 				}
 			}
 			newline_delimited: {

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -55,7 +55,7 @@ base: components: sources: http_server: configuration: {
 				json: """
 					Decodes the raw bytes as [JSON][json].
 
-					[json]: https://en.wikipedia.org/wiki/JSON
+					[json]: https://www.json.org/
 					"""
 				native: """
 					Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -70,9 +70,13 @@ base: components: sources: http_server: configuration: {
 					[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 					"""
 				syslog: """
-					Decodes the raw bytes as a [Syslog][syslog] message.
+					Decodes the raw bytes as a Syslog message.
 
-					[syslog]: https://en.wikipedia.org/wiki/Syslog
+					Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+					[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+					[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+					[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 					"""
 			}
 		}

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -65,7 +65,7 @@ base: components: sources: kafka: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -80,9 +80,13 @@ base: components: sources: kafka: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -49,19 +49,41 @@ base: components: sources: kafka: configuration: {
 		type: uint: default: 5000
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
@@ -72,8 +94,14 @@ base: components: sources: kafka: configuration: {
 		type: uint: default: 100
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -101,11 +129,15 @@ base: components: sources: kafka: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -112,7 +112,7 @@ base: components: sources: nats: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -127,9 +127,13 @@ base: components: sources: nats: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -96,26 +96,54 @@ base: components: sources: nats: configuration: {
 		type: string: syntax: "literal"
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -143,11 +171,15 @@ base: components: sources: nats: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/base/nginx_metrics.cue
@@ -22,12 +22,14 @@ base: components: sources: nginx_metrics: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}
@@ -75,7 +77,7 @@ base: components: sources: nginx_metrics: configuration: {
 		type: uint: default: 15
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -22,12 +22,14 @@ base: components: sources: prometheus_scrape: configuration: {
 					basic: """
 						Basic authentication.
 
-						The username and password are concatenated and encoded via base64.
+						The username and password are concatenated and encoded via [base64][base64].
+
+						[base64]: https://en.wikipedia.org/wiki/Base64
 						"""
 					bearer: """
 						Bearer authentication.
 
-						A bearer token (OAuth2, JWT, etc) is passed as-is.
+						The bearer token value (OAuth2, JWT, etc) is passed as-is.
 						"""
 				}
 			}
@@ -111,7 +113,7 @@ base: components: sources: prometheus_scrape: configuration: {
 		type: uint: default: 15
 	}
 	tls: {
-		description: "Standard TLS options."
+		description: "TLS configuration."
 		required:    false
 		type: object: options: {
 			alpn_protocols: {

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -33,7 +33,7 @@ base: components: sources: redis: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -48,9 +48,13 @@ base: components: sources: redis: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -17,26 +17,54 @@ base: components: sources: redis: configuration: {
 		}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -64,11 +92,15 @@ base: components: sources: redis: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:               "Configures the `BytesDecoder`."
-						character_delimited: "Configures the `CharacterDelimitedDecoder`."
-						length_delimited:    "Configures the `LengthDelimitedDecoder`."
-						newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-						octet_counting:      "Configures the `OctetCountingDecoder`."
+						bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+						character_delimited: "Byte frames which are delimited by a chosen character."
+						length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+						newline_delimited:   "Byte frames which are delimited by a newline character."
+						octet_counting: """
+															Byte frames according to the [octet counting][octet_counting] format.
+
+															[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -33,7 +33,7 @@ base: components: sources: socket: configuration: {
 					json: """
 						Decodes the raw bytes as [JSON][json].
 
-						[json]: https://en.wikipedia.org/wiki/JSON
+						[json]: https://www.json.org/
 						"""
 					native: """
 						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -48,9 +48,13 @@ base: components: sources: socket: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					syslog: """
-						Decodes the raw bytes as a [Syslog][syslog] message.
+						Decodes the raw bytes as a Syslog message.
 
-						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -17,26 +17,54 @@ base: components: sources: socket: configuration: {
 		type: uint: {}
 	}
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: options: codec: {
 			required: false
 			type: string: {
 				default: "bytes"
 				enum: {
-					bytes:       "Configures the `BytesDeserializer`."
-					gelf:        "Configures the `GelfDeserializer`."
-					json:        "Configures the `JsonDeserializer`."
-					native:      "Configures the `NativeDeserializer`."
-					native_json: "Configures the `NativeJsonDeserializer`."
-					syslog:      "Configures the `SyslogDeserializer`."
+					bytes: "Uses the raw bytes as-is."
+					gelf: """
+						Decodes the raw bytes as a [GELF][gelf] message.
+
+						[gelf]: https://docs.graylog.org/docs/gelf
+						"""
+					json: """
+						Decodes the raw bytes as [JSON][json].
+
+						[json]: https://en.wikipedia.org/wiki/JSON
+						"""
+					native: """
+						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					native_json: """
+						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+						[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+						"""
+					syslog: """
+						Decodes the raw bytes as a [Syslog][syslog] message.
+
+						[syslog]: https://en.wikipedia.org/wiki/Syslog
+						"""
 				}
 			}
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -62,11 +90,15 @@ base: components: sources: socket: configuration: {
 			method: {
 				required: true
 				type: string: enum: {
-					bytes:               "Configures the `BytesDecoder`."
-					character_delimited: "Configures the `CharacterDelimitedDecoder`."
-					length_delimited:    "Configures the `LengthDelimitedDecoder`."
-					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-					octet_counting:      "Configures the `OctetCountingDecoder`."
+					bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+					character_delimited: "Byte frames which are delimited by a chosen character."
+					length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+					newline_delimited:   "Byte frames which are delimited by a newline character."
+					octet_counting: """
+						Byte frames according to the [octet counting][octet_counting] format.
+
+						[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+						"""
 				}
 			}
 			newline_delimited: {

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -20,7 +20,7 @@ base: components: sources: stdin: configuration: {
 						json: """
 															Decodes the raw bytes as [JSON][json].
 
-															[json]: https://en.wikipedia.org/wiki/JSON
+															[json]: https://www.json.org/
 															"""
 						native: """
 															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
@@ -35,9 +35,13 @@ base: components: sources: stdin: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						syslog: """
-															Decodes the raw bytes as a [Syslog][syslog] message.
+															Decodes the raw bytes as a Syslog message.
 
-															[syslog]: https://en.wikipedia.org/wiki/Syslog
+															Will decode either as the [RFC 3164][rfc3164]-style format ("old" style) or the more modern
+															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+
+															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
+															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 					}
 				}

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -2,7 +2,7 @@ package metadata
 
 base: components: sources: stdin: configuration: {
 	decoding: {
-		description: "Configuration for building a `Deserializer`."
+		description: "Configures how events are decoded from raw bytes."
 		required:    false
 		type: object: {
 			default: codec: "bytes"
@@ -11,20 +11,48 @@ base: components: sources: stdin: configuration: {
 				type: string: {
 					default: "bytes"
 					enum: {
-						bytes:       "Configures the `BytesDeserializer`."
-						gelf:        "Configures the `GelfDeserializer`."
-						json:        "Configures the `JsonDeserializer`."
-						native:      "Configures the `NativeDeserializer`."
-						native_json: "Configures the `NativeJsonDeserializer`."
-						syslog:      "Configures the `SyslogDeserializer`."
+						bytes: "Uses the raw bytes as-is."
+						gelf: """
+															Decodes the raw bytes as a [GELF][gelf] message.
+
+															[gelf]: https://docs.graylog.org/docs/gelf
+															"""
+						json: """
+															Decodes the raw bytes as [JSON][json].
+
+															[json]: https://en.wikipedia.org/wiki/JSON
+															"""
+						native: """
+															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf] ([EXPERIMENTAL][experimental]).
+
+															[vector_native_protobuf]: https://github.com/vectordotdev/vector/blob/master/lib/vector-core/proto/event.proto
+															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+															"""
+						native_json: """
+															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json] ([EXPERIMENTAL][experimental]).
+
+															[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
+															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
+															"""
+						syslog: """
+															Decodes the raw bytes as a [Syslog][syslog] message.
+
+															[syslog]: https://en.wikipedia.org/wiki/Syslog
+															"""
 					}
 				}
 			}
 		}
 	}
 	framing: {
-		description: "Configuration for building a `Framer`."
-		required:    false
+		description: """
+			Framing configuration.
+
+			Framing deals with how events are separated when encoded in a raw byte form, where each event is
+			a "frame" that must be prefixed, or delimited, in a way that marks where an event begins and
+			ends within the byte stream.
+			"""
+		required: false
 		type: object: options: {
 			character_delimited: {
 				description:   "Options for the character delimited decoder."
@@ -50,11 +78,15 @@ base: components: sources: stdin: configuration: {
 			method: {
 				required: true
 				type: string: enum: {
-					bytes:               "Configures the `BytesDecoder`."
-					character_delimited: "Configures the `CharacterDelimitedDecoder`."
-					length_delimited:    "Configures the `LengthDelimitedDecoder`."
-					newline_delimited:   "Configures the `NewlineDelimitedDecoder`."
-					octet_counting:      "Configures the `OctetCountingDecoder`."
+					bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+					character_delimited: "Byte frames which are delimited by a chosen character."
+					length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
+					newline_delimited:   "Byte frames which are delimited by a newline character."
+					octet_counting: """
+						Byte frames according to the [octet counting][octet_counting] format.
+
+						[octet_counting]: https://tools.ietf.org/html/rfc6587#section-3.4.1
+						"""
 				}
 			}
 			newline_delimited: {


### PR DESCRIPTION
This PR is an incremental chunk of work needed before moving over sources and sinks to the new machine-generated Cue documentation.

Generally, it's simply rewording and porting over user-facing descriptions of types/enums/etc to generate more user-friendly documentation for shared Rust types that show up often in sources/sinks.